### PR TITLE
fix(agent): preserve provider prompt-cache session across compression rotation

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1452,6 +1452,14 @@ def init_agent(
         short_uuid = uuid.uuid4().hex[:6]
         agent.session_id = f"{timestamp_str}_{short_uuid}"
 
+    # Provider-side cache scope is intentionally separate from the durable
+    # Hermes session row.  Compression rotates ``agent.session_id`` so the old
+    # DB row can be finalized, but Codex/OpenAI prompt caching benefits from a
+    # stable routing key across that rotation.  New /new sessions still get a
+    # fresh scope because this attribute is initialized with the initial
+    # session id and then preserved only inside a continuing agent instance.
+    agent.provider_cache_session_id = agent.session_id
+
     # Expose session ID to tools (terminal, execute_code) so agents can
     # reference their own session for --resume commands, cross-session
     # coordination, and logging. Keep the ContextVar and os.environ

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1076,6 +1076,11 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             tools=tools_for_api,
             reasoning_config=agent.reasoning_config,
             session_id=getattr(agent, "session_id", None),
+            cache_scope_id=getattr(
+                agent,
+                "provider_cache_session_id",
+                getattr(agent, "session_id", None),
+            ),
             base_url=agent.base_url,
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -166,9 +166,10 @@ class ResponsesApiTransport(ProviderTransport):
             instructions: str — system prompt (extracted from messages[0] if not given)
             reasoning_config: dict | None — {effort, enabled}
             session_id: str | None — transcript/session id; drives the xAI
-                x-grok-conv-id header and the Codex cache-scope headers, and is
-                the fallback prompt_cache_key when there is no static prefix to
-                content-address
+                x-grok-conv-id header and remains provider-visible metadata
+            cache_scope_id: str | None — stable provider cache-routing scope;
+                drives Codex cache headers and is the fallback prompt_cache_key
+                when there is no static prefix to content-address
             max_tokens: int | None — max_output_tokens
             timeout: float | None — per-request timeout forwarded to the SDK
             request_overrides: dict | None — extra kwargs merged in
@@ -316,13 +317,14 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs["parallel_tool_calls"] = True
 
         session_id = params.get("session_id")
+        cache_scope_id = params.get("cache_scope_id") or session_id
         # prompt_cache_key is content-addressed from the static prefix
         # (instructions + tools), NOT session_id — recurring cron jobs carry a
         # per-fire timestamp in session_id (cron_<id>_<ts>) that made every run
-        # cache-cold. session_id is left untouched for transcript isolation and
-        # the cache-scope routing headers below. Falls back to session_id when
+        # cache-cold. session_id remains logical provider metadata; the separate
+        # cache_scope_id drives cache routing. Falls back to that scope when
         # there is no static content to hash.
-        cache_key = _content_cache_key(instructions, response_tools) or session_id
+        cache_key = _content_cache_key(instructions, response_tools) or cache_scope_id
         # xAI Responses takes prompt_cache_key in extra_body (set further
         # down); GitHub Models opts out of cache-key routing entirely.
         if not is_github_responses and not is_xai_responses and cache_key:
@@ -409,8 +411,8 @@ class ResponsesApiTransport(ProviderTransport):
             # remain high.  Send session_id / x-client-request-id as HTTP
             # headers while keeping ``prompt_cache_key`` in the body for
             # standard OpenAI routing as a belt-and-braces fallback.
-            cache_scope_id = _bounded_prompt_cache_key(session_id)
-            if cache_scope_id:
+            normalized_cache_scope_id = _bounded_prompt_cache_key(cache_scope_id)
+            if normalized_cache_scope_id:
                 existing_extra_headers = kwargs.get("extra_headers")
                 merged_extra_headers: Dict[str, str] = {}
                 if isinstance(existing_extra_headers, dict):
@@ -421,8 +423,8 @@ class ResponsesApiTransport(ProviderTransport):
                             if key and value is not None
                         }
                     )
-                merged_extra_headers["session_id"] = cache_scope_id
-                merged_extra_headers["x-client-request-id"] = cache_scope_id
+                merged_extra_headers["session_id"] = normalized_cache_scope_id
+                merged_extra_headers["x-client-request-id"] = normalized_cache_scope_id
                 kwargs["extra_headers"] = merged_extra_headers
 
         max_tokens = params.get("max_tokens")

--- a/tests/agent/test_provider_cache_scope.py
+++ b/tests/agent/test_provider_cache_scope.py
@@ -1,0 +1,82 @@
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import build_api_kwargs
+from agent.transports import get_transport
+import agent.transports.codex  # noqa: F401 - register transport
+
+
+def _make_codex_agent():
+    agent = SimpleNamespace()
+    agent.api_mode = "codex_responses"
+    agent.model = "gpt-5.5"
+    agent.tools = []
+    agent.reasoning_config = {}
+    agent.session_id = "rotated-session"
+    agent.provider_cache_session_id = "original-cache-scope"
+    agent.max_tokens = None
+    agent.request_overrides = {}
+    agent.base_url = "https://chatgpt.com/backend-api/codex"
+    agent.provider = "openai-codex"
+    agent._base_url_hostname = "chatgpt.com"
+    agent._base_url_lower = "https://chatgpt.com/backend-api/codex"
+    agent._get_transport = lambda: get_transport("codex_responses")
+    agent._prepare_messages_for_non_vision_model = lambda messages: messages
+    agent._resolved_api_call_timeout = lambda: 120
+    agent._github_models_reasoning_extra_body = lambda: None
+    return agent
+
+
+def test_codex_build_api_kwargs_uses_stable_provider_cache_scope_after_session_rotation():
+    """Compression rotates Hermes session_id for DB lineage, but Codex cache
+    routing should keep the original provider-side scope for the continuing
+    in-memory conversation so prompt-cache buckets survive compaction.
+    """
+    agent = _make_codex_agent()
+
+    kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+
+    assert kwargs["prompt_cache_key"].startswith("pck_")
+    assert kwargs["extra_headers"]["session_id"] == "original-cache-scope"
+    assert kwargs["extra_headers"]["x-client-request-id"] == "original-cache-scope"
+
+
+def test_codex_build_api_kwargs_falls_back_to_session_id_for_older_agents():
+    agent = _make_codex_agent()
+    delattr(agent, "provider_cache_session_id")
+
+    kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+
+    assert kwargs["prompt_cache_key"].startswith("pck_")
+    assert kwargs["extra_headers"]["session_id"] == "rotated-session"
+    assert kwargs["extra_headers"]["x-client-request-id"] == "rotated-session"
+
+
+def test_codex_cache_scope_does_not_replace_logical_provider_session_id():
+    agent = _make_codex_agent()
+
+    class CapturingTransport:
+        def build_kwargs(self, **kwargs):
+            return kwargs
+
+    agent.api_mode = "chat_completions"
+    agent.provider = "openrouter"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent._base_url_lower = agent.base_url
+    agent._base_url_hostname = "openrouter.ai"
+    agent._get_transport = lambda: CapturingTransport()
+    agent._is_qwen_portal = lambda: False
+    agent._is_openrouter_url = lambda: True
+    agent._max_tokens_param = lambda *_args, **_kwargs: "max_tokens"
+    agent._ollama_num_ctx = None
+    agent._supports_reasoning_extra_body = lambda: False
+    agent.providers_allowed = []
+    agent.providers_ignored = []
+    agent.providers_order = []
+    agent.provider_sort = None
+    agent.provider_require_parameters = False
+    agent.provider_data_collection = None
+    agent.openrouter_min_coding_score = None
+
+    kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+
+    assert kwargs["session_id"] == "rotated-session"

--- a/tests/agent/test_provider_cache_session_rotation.py
+++ b/tests/agent/test_provider_cache_session_rotation.py
@@ -1,0 +1,81 @@
+"""Regression: provider prompt-cache scope must survive session rotation.
+
+Compaction rotates ``agent.session_id`` so the old durable session DB row can
+be finalized (``conversation_compression.py`` reassigns it to a fresh id). But
+Codex/OpenAI prompt caching keys off ``agent.provider_cache_session_id``, which
+is initialized once per agent instance and must NOT rotate — otherwise every
+compaction silently drops the provider-side cache bucket for the continuing
+in-memory conversation. This asserts the cache scope is left untouched across a
+real ``_compress_context`` rotation.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hermes_state import SessionDB
+
+
+def _build_agent_with_db(db: SessionDB, session_id: str):
+    """Mirror tests/agent/test_compression_logging_session_context.py's harness."""
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    compressor = MagicMock()
+    compressor.compress.return_value = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "user", "content": "tail"},
+    ]
+    compressor.compression_count = 1
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    agent.context_compressor = compressor
+    # The default is in-place compaction, which deliberately preserves the
+    # durable session id. Pin the legacy rotation path this regression covers.
+    agent.compression_in_place = False
+    return agent
+
+
+def test_provider_cache_scope_survives_compression_rotation(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "PARENT_PROVIDER_CACHE_SESSION"
+    db.create_session(parent_sid, source="cli")
+
+    agent = _build_agent_with_db(db, parent_sid)
+
+    # init_agent seeds the provider cache scope from the initial session id.
+    assert agent.provider_cache_session_id == parent_sid
+    initial_cache_scope = agent.provider_cache_session_id
+
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+    agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    # The durable session id actually rotated (sanity — otherwise the
+    # invariant assertion below would be vacuous).
+    assert agent.session_id != parent_sid
+
+    # The provider-side cache scope must NOT have followed the rotation: it is
+    # the stable routing key for Codex/OpenAI prompt caching.
+    assert agent.provider_cache_session_id == initial_cache_scope, (
+        "provider_cache_session_id rotated with the session id; provider "
+        "prompt-cache buckets would be dropped on every compaction "
+        f"(scope was {initial_cache_scope!r}, now "
+        f"{agent.provider_cache_session_id!r})."
+    )


### PR DESCRIPTION
Compression rotates agent.session_id so the old DB row can be finalized, but Codex/OpenAI prompt caching needs a stable routing key across that rotation.

This adds provider_cache_session_id, initialized once with the initial session id on every new agent instance. When the session_id is rotated by compression, the provider cache key stays stable — avoiding re-billing the full prompt on every rotation.

**Rebased Jul 25:** Caught up to current main (267 commits). Resolved conflict in chat_completion_helpers.py (base_url param added upstream). Addressed @teknium1 review feedback:
- `session_id` preserved as-is for non-Codex provider profiles (OpenRouter `extra_body.session_id` unaffected); `cache_scope_id` threaded only to cache-routing fields.
- `compression_in_place = False` pinned in rotation test harness.
- `prompt_cache_key` remains content-addressed (`pck_` hash); `cache_scope_id` only affects the fallback path.

/alt-glitch