### PR TITLE
fix(gateway): suppress 4 more noisy agent status patterns on Telegram

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -112,6 +112,10 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
     r"|stream\s+(?:drop|drop\s+mid\s+tool-call).+retry\s+\d"
     r"|stale\s+connections\s+from\s+a\s+previous\s+provider\s+issue"
+    r"|iteration\s+budget\s+exhausted"
+    r"|asking\s+model\s+to\s+summarise"
+    r"|model\s+returned\s+empty\s+after\s+tool\s+calls"
+    r"|nudging\s+to\s+continue"
     r")",
     re.IGNORECASE | re.DOTALL,
 )

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -65,6 +65,9 @@ NOISY_STATUS_MESSAGES = [
         "⚠ Skipping concurrent compression — another path is already "
         "compressing this session. Will retry after it finishes."
     ),
+    # Iteration-budget and empty-response retry chatter.
+    "⚠️ Iteration budget exhausted (50/50) — asking model to summarise",
+    "⚠️ Model returned empty after tool calls — nudging to continue",
 ]
 
 # Messages that must NEVER be swallowed by the compression-noise filter:


### PR DESCRIPTION
Adds 4 additional patterns to the _TELEGRAM_NOISY_STATUS_RE regex in gateway/run.py:

- iteration budget exhausted
- asking model to summarise
- model returned empty after tool calls
- nudging to continue

These are internal agent-loop states that are useful in logs but add no value in Telegram chat. They appear as transient status callbacks that distract from actual conversation.