### PR TITLE
fix(auth): add platform.claude.com fallback to Anthropic OAuth token exchange

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1349,18 +1349,33 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "code_verifier": verifier,
         }).encode()
 
-        req = urllib.request.Request(
+        token_endpoints = [
+            "https://platform.claude.com/v1/oauth/token",
             _OAUTH_TOKEN_URL,
-            data=exchange_data,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
-            },
-            method="POST",
-        )
+        ]
 
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
+        result = None
+        last_error = None
+        for endpoint in token_endpoints:
+            try:
+                req = urllib.request.Request(
+                    endpoint,
+                    data=exchange_data,
+                    headers={
+                        "Content-Type": "application/json",
+                        "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    result = json.loads(resp.read().decode())
+                    break
+            except Exception as e:
+                last_error = e
+                continue
+
+        if result is None:
+            raise last_error or RuntimeError("All token endpoints failed")
     except Exception as e:
         print(f"Token exchange failed: {e}")
         return None


### PR DESCRIPTION
## Problem

`hermes auth add anthropic` fails with:
```
Token exchange failed: HTTP Error 404: Not Found
Anthropic OAuth login did not return credentials.
```

The initial authorization code exchange in `run_hermes_oauth_login_pure()` only tries `console.anthropic.com/v1/oauth/token`, which returns 404.

## Root cause

`refresh_anthropic_oauth_pure()` already has a two-endpoint fallback:
```python
token_endpoints = [
    "https://platform.claude.com/v1/oauth/token",
    "https://console.anthropic.com/v1/oauth/token",
]
```

But the initial code exchange in `run_hermes_oauth_login_pure()` used only `_OAUTH_TOKEN_URL` (`console.anthropic.com`), missing the same fallback.

## Fix

Apply the same fallback order to the initial token exchange — try `platform.claude.com` first, then `console.anthropic.com`.

## Testing

Verified manually: `hermes auth add anthropic` now completes successfully with a Claude Max subscription.