### PR TITLE
fix(tui): disable fast-echo bypass inside tmux to prevent cursor drift

### DIFF
--- a/ui-tui/src/__tests__/textInputFastEcho.test.ts
+++ b/ui-tui/src/__tests__/textInputFastEcho.test.ts
@@ -178,6 +178,26 @@ describe('supportsFastEchoTerminal', () => {
     expect(supportsFastEchoTerminal({ TERM_PROGRAM: 'Apple_Terminal' } as NodeJS.ProcessEnv)).toBe(false)
   })
 
+  it('disables fast-echo inside tmux', () => {
+    expect(supportsFastEchoTerminal({ TMUX: '/tmp/tmux-1000/default,1234,0' } as NodeJS.ProcessEnv)).toBe(false)
+    expect(supportsFastEchoTerminal({ TMUX: '/private/tmp/tmux-501/default' } as NodeJS.ProcessEnv)).toBe(false)
+  })
+
+  it('tmux wins over Termux fast-echo opt-in', () => {
+    expect(
+      supportsFastEchoTerminal({
+        TMUX: '/tmp/tmux-1000/default,1234,0',
+        HERMES_TUI_TERMUX_FAST_ECHO: '1',
+        TERMUX_VERSION: '0.118.0'
+      } as NodeJS.ProcessEnv)
+    ).toBe(false)
+  })
+
+  it('keeps fast-echo enabled when TMUX is empty or unset', () => {
+    expect(supportsFastEchoTerminal({ TMUX: '' } as NodeJS.ProcessEnv)).toBe(true)
+    expect(supportsFastEchoTerminal({ TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv)).toBe(true)
+  })
+
   it('disables fast-echo by default in Termux mode', () => {
     expect(
       supportsFastEchoTerminal({ TERMUX_VERSION: '0.118.0', PREFIX: '/data/data/com.termux/files/usr' } as NodeJS.ProcessEnv)

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -359,6 +359,13 @@ export function supportsFastEchoTerminal(env: NodeJS.ProcessEnv = process.env): 
     return false
   }
 
+  // tmux adds a PTY multiplexing layer that desyncs stdout.write() cursor
+  // advances from its internal cursor model, causing cursor drift and ghost
+  // whitespace under the fast-echo bypass path.
+  if ((env.TMUX ?? '').trim().length > 0) {
+    return false
+  }
+
   // Termux terminals are especially sensitive to bypass-path cursor drift and
   // stale paints at soft-wrap boundaries on tall/narrow viewports. Keep this
   // off by default in Termux mode; allow explicit opt-in for local debugging.


### PR DESCRIPTION
## Problem

The TUI's fast-echo bypass path writes characters directly to `stdout` (bypassing Ink's renderer for speed), then notifies Ink's cursor tracker via `noteCursorAdvance()`. Inside **tmux**, this desyncs because tmux's PTY multiplexing layer buffers and redraws independently from the inner terminal's cursor state.

**Symptoms:** extra whitespace gap between typed text and the cursor block; pressing backspace deletes characters instead of closing the gap.

Same class of bug that led to the existing Apple Terminal and Termux exclusions.

## Fix

Add tmux detection to `supportsFastEchoTerminal()` — when `TMUX` env var is set (non-empty), disable the fast-echo bypass and fall through to Ink's normal render path.

- `TMUX` is the authoritative signal (set by tmux to its socket path); covers nested tmux sessions too
- No opt-in override added (would conflict with AGENTS.md guidance against new `HERMES_*` env vars for non-secret config)
- Hard-disable is the safer fix, matching the Apple Terminal precedent

## Tests

- `disables fast-echo inside tmux` — verifies `false` with real tmux socket paths
- `tmux wins over Termux fast-echo opt-in` — precedence guard against future reordering
- `keeps fast-echo enabled when TMUX is empty or unset` — no false positives
- All 31 tests pass (28 existing + 3 new)

## Not in scope

GNU screen (`STY`) and zellij (`ZELLIJ`) are not covered — no evidence of the same drift there. Can be follow-up PRs if reproduced.