### PR TITLE
feat(desktop): enable composer spellcheck

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -40,6 +40,7 @@ import {
   isBrowsingHistory,
   resetBrowseState
 } from '@/store/composer-input-history'
+import { $composerEditorPreferences } from '@/store/composer-preferences'
 import {
   $queuedPromptsBySession,
   enqueueQueuedPrompt,
@@ -182,6 +183,7 @@ export function ChatBar({
   const aui = useAui()
   const draft = useAuiState(s => s.composer.text)
   const attachments = useStore($composerAttachments)
+  const editorPreferences = useStore($composerEditorPreferences)
   const queuedPromptsBySession = useStore($queuedPromptsBySession)
   const statusItemsBySession = useStore($statusItemsBySession)
   const scrolledUp = useStore($threadScrolledUp)
@@ -1759,6 +1761,7 @@ export function ChatBar({
         contentEditable={!inputDisabled}
         data-placeholder={placeholder}
         data-slot={RICH_INPUT_SLOT}
+        lang={editorPreferences.language}
         onBlur={() => window.setTimeout(closeTrigger, 80)}
         onCompositionEnd={event => {
           composingRef.current = false
@@ -1785,7 +1788,7 @@ export function ChatBar({
         onPaste={handlePaste}
         ref={editorRef}
         role="textbox"
-        spellCheck={false}
+        spellCheck={editorPreferences.spellcheck}
         suppressContentEditableWarning
       />
       {/* assistant-ui requires ComposerPrimitive.Input somewhere in the tree

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -2,6 +2,7 @@ import { type MutableRefObject, useCallback, useState } from 'react'
 
 import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
+import { setComposerEditorPreferencesFromConfig } from '@/store/composer-preferences'
 import {
   $currentCwd,
   setAvailablePersonalities,
@@ -32,6 +33,8 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
   const refreshHermesConfig = useCallback(async () => {
     try {
       const [config, defaults] = await Promise.all([getHermesConfig(), getHermesConfigDefaults().catch(() => ({}))])
+
+      setComposerEditorPreferencesFromConfig(config)
 
       const personality = normalizePersonalityValue(
         typeof config.display?.personality === 'string' ? config.display.personality : ''

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -13,8 +13,8 @@ import {
 } from '@/lib/icons'
 import type { ThemeMode } from '@/themes/context'
 
-import type { DesktopConfigSection } from './types'
 import { defineFieldCopy } from './field-copy'
+import type { DesktopConfigSection } from './types'
 
 // Provider group definitions used to fold raw env-var names like
 // ``XAI_API_KEY`` into a single "xAI" card with a friendly label, short
@@ -284,6 +284,12 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     personality: 'Personality',
     showReasoning: 'Reasoning Blocks'
   },
+  desktop: {
+    editor: {
+      spellcheck: 'Enable Spellcheck',
+      language: 'Spellcheck Language'
+    }
+  },
   agent: {
     maxTurns: 'Max Agent Steps',
     imageInputMode: 'Image Attachments',
@@ -435,6 +441,12 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     personality: 'Default assistant style for new sessions.',
     showReasoning: 'Show reasoning sections when the backend provides them.'
   },
+  desktop: {
+    editor: {
+      spellcheck: 'Underline misspellings and enable native suggestions in the chat composer.',
+      language: 'BCP 47 language tag for composer spellcheck. Leave blank to follow your system language.'
+    }
+  },
   timezone: 'Used when Hermes needs local time context. Blank uses the system timezone.',
   agent: {
     imageInputMode: 'Controls how image attachments are sent to the model.',
@@ -509,7 +521,14 @@ export const SECTIONS: DesktopConfigSection[] = [
     id: 'chat',
     label: 'Chat',
     icon: MessageCircle,
-    keys: ['display.personality', 'timezone', 'display.show_reasoning', 'agent.image_input_mode']
+    keys: [
+      'display.personality',
+      'timezone',
+      'display.show_reasoning',
+      'agent.image_input_mode',
+      'desktop.editor.spellcheck',
+      'desktop.editor.language'
+    ]
   },
   {
     id: 'appearance',

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -98,6 +98,7 @@ import { cn } from '@/lib/utils'
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
 import { $compactionActive } from '@/store/compaction'
 import type { ComposerAttachment } from '@/store/composer'
+import { $composerEditorPreferences } from '@/store/composer-preferences'
 import { notifyError } from '@/store/notifications'
 import { $connection } from '@/store/session'
 import { notifyThreadEditClose, notifyThreadEditOpen } from '@/store/thread-scroll'
@@ -1195,6 +1196,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   const [staging, setStaging] = useState(false)
   const expanded = draft.includes('\n')
   const canSubmit = draft.trim().length > 0
+  const editorPreferences = useStore($composerEditorPreferences)
   const at = useAtCompletions({ cwd, gateway, sessionId })
   const slash = useSlashCompletions({ gateway })
 
@@ -1734,6 +1736,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
               contentEditable
               data-placeholder={copy.editMessage}
               data-slot={RICH_INPUT_SLOT}
+              lang={editorPreferences.language}
               onBlur={() => window.setTimeout(closeTrigger, 80)}
               onDragOver={handleDragOver}
               onDrop={handleDrop}
@@ -1745,7 +1748,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
               onPaste={handlePaste}
               ref={editorRef}
               role="textbox"
-              spellCheck={false}
+              spellCheck={editorPreferences.spellcheck}
               suppressContentEditableWarning
             />
             <ComposerPrimitive.Input

--- a/apps/desktop/src/components/assistant-ui/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/user-message-edit.test.tsx
@@ -9,9 +9,10 @@ import { ExportedMessageRepository } from '@assistant-ui/core/internal'
 // carve-out in thread.tsx.
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
+import { setComposerEditorPreferencesFromConfig } from '@/store/composer-preferences'
 
 import { Thread } from './thread'
 
@@ -30,6 +31,10 @@ vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
 vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
 
 Element.prototype.scrollTo = function scrollTo() {}
+
+afterEach(() => {
+  setComposerEditorPreferencesFromConfig({})
+})
 
 function stubOffsetDimension(
   prop: 'offsetHeight' | 'offsetWidth',
@@ -137,5 +142,29 @@ describe('click-to-edit user message', () => {
     await waitFor(() => {
       expect(container.querySelector('[data-slot="aui_edit-composer-root"]')).toBeTruthy()
     })
+  })
+
+  it('applies composer spellcheck preferences to the visible edit editor only', async () => {
+    setComposerEditorPreferencesFromConfig({
+      desktop: { editor: { language: 'en-GB', spellcheck: false } }
+    })
+
+    const { container } = render(<IncrementalHarness onEdit={async () => {}} />)
+
+    const bubble = await screen.findByRole('button', { name: 'Edit message' })
+
+    fireEvent.click(bubble)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-slot="aui_edit-composer-root"]')).toBeTruthy()
+    })
+
+    const editor = container.querySelector('[data-slot="composer-rich-input"][contenteditable="true"]') as HTMLElement | null
+    const hiddenInput = container.querySelector('textarea.sr-only')
+
+    expect(editor?.lang).toBe('en-GB')
+    expect(editor?.getAttribute('spellcheck')).toBe('false')
+
+    expect(hiddenInput?.getAttribute('spellcheck')).toBe('false')
   })
 })

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -371,6 +371,12 @@ export const zh: Translations = {
         personality: '人格',
         showReasoning: '推理过程块'
       },
+      desktop: {
+        editor: {
+          spellcheck: '启用拼写检查',
+          language: '拼写检查语言'
+        }
+      },
       agent: {
         maxTurns: '最大智能体步数',
         imageInputMode: '图片附件',
@@ -520,6 +526,12 @@ export const zh: Translations = {
       display: {
         personality: '新会话的默认助手风格。',
         showReasoning: '当后端提供推理内容时予以显示。'
+      },
+      desktop: {
+        editor: {
+          spellcheck: '在聊天输入框中标出拼写错误，并启用原生候选建议。',
+          language: '用于输入框拼写检查的 BCP 47 语言标签。留空则跟随系统语言。'
+        }
       },
       timezone: '当 Hermes 需要本地时间上下文时使用。留空则使用系统时区。',
       agent: {

--- a/apps/desktop/src/store/composer-preferences.test.ts
+++ b/apps/desktop/src/store/composer-preferences.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $composerEditorPreferences,
+  composerEditorPreferencesFromConfig,
+  setComposerEditorPreferencesFromConfig
+} from './composer-preferences'
+
+const originalLanguage = navigator.language
+
+function setNavigatorLanguage(language: string) {
+  Object.defineProperty(navigator, 'language', { configurable: true, value: language })
+}
+
+describe('composer editor preferences', () => {
+  beforeEach(() => {
+    setNavigatorLanguage('fr-CA')
+    setComposerEditorPreferencesFromConfig({})
+  })
+
+  afterEach(() => {
+    setNavigatorLanguage(originalLanguage)
+    setComposerEditorPreferencesFromConfig({})
+  })
+
+  it('defaults spellcheck on and follows the system language', () => {
+    expect(composerEditorPreferencesFromConfig({})).toEqual({
+      language: 'fr-CA',
+      spellcheck: true
+    })
+  })
+
+  it('honors explicit desktop editor spellcheck and language settings', () => {
+    expect(
+      composerEditorPreferencesFromConfig({
+        desktop: { editor: { language: 'en-GB', spellcheck: false } }
+      })
+    ).toEqual({
+      language: 'en-GB',
+      spellcheck: false
+    })
+  })
+
+  it('normalizes blank language back to the system language', () => {
+    expect(
+      composerEditorPreferencesFromConfig({
+        desktop: { editor: { language: '   ', spellcheck: true } }
+      })
+    ).toEqual({
+      language: 'fr-CA',
+      spellcheck: true
+    })
+  })
+
+  it('updates the shared atom from config refreshes', () => {
+    setComposerEditorPreferencesFromConfig({
+      desktop: { editor: { language: 'de-DE', spellcheck: false } }
+    })
+
+    expect($composerEditorPreferences.get()).toEqual({
+      language: 'de-DE',
+      spellcheck: false
+    })
+  })
+})

--- a/apps/desktop/src/store/composer-preferences.ts
+++ b/apps/desktop/src/store/composer-preferences.ts
@@ -1,0 +1,35 @@
+import { atom } from 'nanostores'
+
+export interface ComposerEditorPreferences {
+  language: string
+  spellcheck: boolean
+}
+
+export function systemComposerLanguage(): string {
+  if (typeof navigator === 'undefined') {
+    return 'en-US'
+  }
+
+  return navigator.language?.trim() || 'en-US'
+}
+
+export function normalizeComposerLanguage(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : systemComposerLanguage()
+}
+
+export function composerEditorPreferencesFromConfig(config: unknown): ComposerEditorPreferences {
+  const desktop = config && typeof config === 'object' ? (config as { desktop?: unknown }).desktop : null
+  const editor = desktop && typeof desktop === 'object' ? (desktop as { editor?: unknown }).editor : null
+  const settings = editor && typeof editor === 'object' ? (editor as { language?: unknown; spellcheck?: unknown }) : null
+
+  return {
+    language: normalizeComposerLanguage(settings?.language),
+    spellcheck: settings?.spellcheck !== false
+  }
+}
+
+export const $composerEditorPreferences = atom<ComposerEditorPreferences>(composerEditorPreferencesFromConfig({}))
+
+export function setComposerEditorPreferencesFromConfig(config: unknown): void {
+  $composerEditorPreferences.set(composerEditorPreferencesFromConfig(config))
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -203,6 +203,12 @@ export interface HermesConfig {
     personality?: string
     skin?: string
   }
+  desktop?: {
+    editor?: {
+      language?: string
+      spellcheck?: boolean
+    }
+  }
   terminal?: {
     cwd?: string
   }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1635,6 +1635,20 @@ DEFAULT_CONFIG = {
         "copy_shortcut": "auto",  # "auto" (platform default) | "ctrl_c" | "ctrl_shift_c" | "disabled"
     },
 
+    # Desktop-app-only preferences. Keep these out of ``display`` so CLI/TUI
+    # rendering config does not absorb renderer-specific editor behavior.
+    "desktop": {
+        "editor": {
+            # Enable Chromium/native spellcheck on chat composer contenteditable
+            # surfaces. The browser spellchecker ignores IME preedit text and
+            # only checks committed text, so CJK composition stays untouched.
+            "spellcheck": True,
+            # BCP 47 language tag for composer spellcheck. Blank follows the
+            # renderer's ``navigator.language``.
+            "language": "",
+        },
+    },
+
     # Web dashboard settings
     "dashboard": {
         "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -579,6 +579,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "approvals": "security",
     "human_delay": "display",
     "dashboard": "display",
+    "desktop": "display",
     "code_execution": "agent",
     "prompt_caching": "agent",
     "goals": "agent",

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -73,6 +73,12 @@ class TestLoadConfigDefaults:
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
 
+    def test_desktop_editor_spellcheck_defaults(self):
+        editor = DEFAULT_CONFIG["desktop"]["editor"]
+
+        assert editor["spellcheck"] is True
+        assert editor["language"] == ""
+
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             config_path = tmp_path / "config.yaml"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2619,6 +2619,17 @@ class TestBuildSchemaFromConfig:
         if "agent.max_turns" in CONFIG_SCHEMA:
             assert CONFIG_SCHEMA["agent.max_turns"]["category"] == "agent"
 
+    def test_desktop_editor_spellcheck_schema_is_display_scoped(self):
+        from hermes_cli.web_server import CONFIG_SCHEMA
+
+        spellcheck = CONFIG_SCHEMA["desktop.editor.spellcheck"]
+        language = CONFIG_SCHEMA["desktop.editor.language"]
+
+        assert spellcheck["type"] == "boolean"
+        assert spellcheck["category"] == "display"
+        assert language["type"] == "string"
+        assert language["category"] == "display"
+
     def test_category_merge_applied(self):
         """Small categories should be merged into larger ones."""
         from hermes_cli.web_server import CONFIG_SCHEMA


### PR DESCRIPTION
## What does this PR do?

Enables native Chromium/Electron spellcheck for the visible Hermes Desktop chat composer surfaces. The main composer and inline edit composer now receive config-backed `spellCheck` and `lang` props, while hidden assistant-ui binding textareas stay spellcheck-disabled to avoid duplicate work.

This adds `desktop.editor.spellcheck` (default `true`) and `desktop.editor.language` (blank = renderer `navigator.language`) to `config.yaml`, surfaces both controls under Settings -> Chat, and keeps the generic config schema from creating a separate desktop-only category.

Collision check: #48375 has no comments or directly linked open PRs. The open spellcheck-related PR #45988 only changes the dashboard/xterm right-click overlay, not the Desktop React composer.

Fixes #48375

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added desktop composer editor preferences and config normalization in `apps/desktop/src/store/composer-preferences.ts`.
- Enabled native spellcheck/lang on visible main and edit composer contenteditable inputs.
- Added Settings -> Chat controls for spellcheck enablement and language.
- Added default config/schema coverage for `desktop.editor.*`.
- Added Vitest coverage for preference normalization and edit composer DOM props.

## How to Test

1. `npm run --workspace apps/desktop test:ui -- src/components/assistant-ui/user-message-edit.test.tsx src/store/composer-preferences.test.ts src/app/chat/composer/ime-composition-dom-repro.test.tsx src/app/chat/composer/enter-submit-dom-race.test.tsx src/i18n/runtime.test.ts`
2. `npm run --workspace apps/desktop typecheck`
3. `npm --workspace apps/desktop exec eslint -- src/store/composer-preferences.ts src/store/composer-preferences.test.ts src/app/session/hooks/use-hermes-config.ts src/app/chat/composer/index.tsx src/components/assistant-ui/thread.tsx src/components/assistant-ui/user-message-edit.test.tsx src/app/settings/constants.ts src/i18n/zh.ts src/types/hermes.ts`
4. `.venv/bin/python -m pytest tests/hermes_cli/test_config.py::TestLoadConfigDefaults::test_desktop_editor_spellcheck_defaults tests/hermes_cli/test_web_server.py::TestBuildSchemaFromConfig::test_desktop_editor_spellcheck_schema_is_display_scoped -q`
5. `git diff --check`

## Checklist

### Code

- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this feature
- [x] I added tests for my changes
- [x] I tested on my platform: macOS

### Documentation & Housekeeping

- [x] N/A - no docs update required
- [x] N/A - no `cli-config.yaml.example` change required
- [x] N/A - no architecture/workflow docs changed
- [x] Cross-platform impact considered: uses Chromium/Electron native spellcheck and existing IME composition behavior remains covered
- [x] N/A - no tool schemas changed
