### PR TITLE
fix(desktop): harden external file preview opens

### DIFF
--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -8,11 +8,13 @@ import { pathToFileURL } from 'node:url'
 import {
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret,
+  openOrRevealExternalFilePath,
   resolveDirectoryForIpc,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
-  sensitiveFileBlockReason
+  sensitiveFileBlockReason,
+  shouldRevealExternalFilePath
 } from './hardening'
 
 async function rejectsWithCode(promise, code: string) {
@@ -59,6 +61,47 @@ test('sensitiveFileBlockReason blocks obvious secret file patterns', () => {
   assert.equal(sensitiveFileBlockReason('/tmp/.env.example'), null)
   assert.match(String(sensitiveFileBlockReason('/Users/me/.ssh/id_ed25519')), /SSH/)
   assert.match(String(sensitiveFileBlockReason('/tmp/server-cert.pem')), /\.pem/)
+})
+
+test('openOrRevealExternalFilePath reveals executable-like file URLs instead of launching them', async () => {
+  const filePath = 'C:\\Users\\me\\Downloads\\setup.EXE'
+  const opened: string[] = []
+  const revealed: string[] = []
+
+  assert.equal(shouldRevealExternalFilePath(filePath), true)
+
+  const outcome = await openOrRevealExternalFilePath(filePath, {
+    open: async target => {
+      opened.push(target)
+    },
+    reveal: target => {
+      revealed.push(target)
+    }
+  })
+
+  assert.deepEqual(opened, [])
+  assert.deepEqual(revealed, [filePath])
+  assert.deepEqual(outcome, { action: 'revealed', reason: 'unsafe-file-type' })
+})
+
+test('openOrRevealExternalFilePath handles a rejected openExternal by revealing the file', async () => {
+  const filePath = '/tmp/report.html'
+  const openError = new Error('browser unavailable')
+  const revealed: string[] = []
+
+  const outcome = await openOrRevealExternalFilePath(filePath, {
+    open: async () => {
+      throw openError
+    },
+    reveal: target => {
+      revealed.push(target)
+    }
+  })
+
+  assert.deepEqual(revealed, [filePath])
+  assert.equal(outcome.action, 'revealed')
+  assert.equal(outcome.reason, 'open-failed')
+  assert.equal(outcome.openError, openError)
 })
 
 test('path helpers reject blank non-string NUL and Windows device syntax', async () => {

--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -10,6 +10,38 @@ const TEXT_PREVIEW_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 const SAFE_ENV_SUFFIXES = new Set(['dist', 'example', 'sample', 'template'])
 const SENSITIVE_EXTENSIONS = new Set(['.kdbx', '.p12', '.pem', '.pfx'])
 
+const EXTERNAL_FILE_REVEAL_EXTENSIONS = new Set([
+  '.app',
+  '.appimage',
+  '.bat',
+  '.bash',
+  '.cmd',
+  '.com',
+  '.command',
+  '.desktop',
+  '.dmg',
+  '.exe',
+  '.fish',
+  '.jar',
+  '.js',
+  '.jse',
+  '.lnk',
+  '.msc',
+  '.msi',
+  '.msp',
+  '.pkg',
+  '.ps1',
+  '.psm1',
+  '.run',
+  '.scr',
+  '.sh',
+  '.vbe',
+  '.vbs',
+  '.wsf',
+  '.wsh',
+  '.zsh'
+])
+
 function resolveTimeoutMs(timeoutMs, fallbackMs = DEFAULT_FETCH_TIMEOUT_MS) {
   const fallback =
     Number.isFinite(fallbackMs) && Number(fallbackMs) > 0 ? Math.round(Number(fallbackMs)) : DEFAULT_FETCH_TIMEOUT_MS
@@ -108,6 +140,27 @@ function sensitiveFileBlockReason(filePath) {
   }
 
   return null
+}
+
+function shouldRevealExternalFilePath(filePath) {
+  const basename = path.basename(String(filePath || '')).toLowerCase()
+
+  return Boolean(basename) && EXTERNAL_FILE_REVEAL_EXTENSIONS.has(path.extname(basename))
+}
+
+async function openOrRevealExternalFilePath(filePath, actions) {
+  if (shouldRevealExternalFilePath(filePath)) {
+    actions.reveal(filePath)
+    return { action: 'revealed', reason: 'unsafe-file-type' }
+  }
+
+  try {
+    await actions.open(filePath)
+    return { action: 'opened' }
+  } catch (openError) {
+    actions.reveal(filePath)
+    return { action: 'revealed', reason: 'open-failed', openError }
+  }
 }
 
 function ipcPathError(code: any, message: string): Error & { code: any } {
@@ -306,11 +359,13 @@ export {
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret,
+  openOrRevealExternalFilePath,
   rejectUnsafePathSyntax,
   resolveDirectoryForIpc,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
   sensitiveFileBlockReason,
+  shouldRevealExternalFilePath,
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -88,6 +88,7 @@ import {
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret as encryptDesktopSecretStrict,
+  openOrRevealExternalFilePath,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
@@ -1036,22 +1037,22 @@ function openExternalUrl(rawUrl) {
       return false
     }
 
-    void shell
-      .openPath(localPath)
-      .then(error => {
-        if (!error) {
-          return
+    void openOrRevealExternalFilePath(localPath, {
+      open: async target => {
+        const error = await shell.openPath(target)
+
+        if (error) {
+          throw new Error(error)
         }
-
-        rememberLog(`[file] openPath failed: ${error}; revealing in folder instead`)
-
-        try {
-          shell.showItemInFolder(localPath)
-        } catch (revealError) {
-          rememberLog(`[file] showItemInFolder failed: ${revealError.message}`)
+      },
+      reveal: target => shell.showItemInFolder(target)
+    })
+      .then(outcome => {
+        if ('reason' in outcome) {
+          rememberLog(`[file] ${outcome.reason}; revealed in folder instead`)
         }
       })
-      .catch(error => rememberLog(`[file] openPath rejected: ${error.message}`))
+      .catch(error => rememberLog(`[file] open/reveal failed: ${error.message}`))
 
     return true
   }
@@ -1109,7 +1110,20 @@ async function openPreviewInBrowser(rawUrl) {
       return false
     }
 
-    await shell.openExternal(pathToFileURL(localPath).toString())
+    try {
+      const outcome = await openOrRevealExternalFilePath(localPath, {
+        open: target => shell.openExternal(pathToFileURL(target).toString()),
+        reveal: target => shell.showItemInFolder(target)
+      })
+
+      if ('reason' in outcome) {
+        rememberLog(`[preview] ${outcome.reason}; revealed in folder instead`)
+      }
+    } catch (error) {
+      rememberLog(`[preview] open/reveal failed: ${error.message}`)
+
+      return false
+    }
 
     return true
   }


### PR DESCRIPTION
## Summary

- Route executable-like file URLs to Reveal in Folder instead of OS execution.
- Apply the same policy to both artifact/openExternal and Preview in Browser paths.
- Fall back to revealing the file when shell.openPath or shell.openExternal fails.
- Keep normal document and HTML preview workflows intact.

## Why this PR changed

The earlier version combined several unrelated Desktop hardening and UX fixes and had drifted far behind main. This revision deliberately replaces that broad diff with one current, reviewable file-open boundary fix. The current scan also found that openPreviewInBrowser(file:) bypassed the executable-file policy entirely, so both sibling call paths now share one tested helper.

## Security behavior

Agent-controlled output can surface file URLs. Passing scripts, installers, launchers, or application bundles directly to OS file associations can execute them on click. The change recognizes executable-like extensions case-insensitively and reveals those files without launching them. It does not block the feature: inert documents and browser previews still open normally.

## Duplicate review

Checked the current open PR queue and related preview protocol PR #47689. #47689 constrains navigation from inside an attached webview; this PR governs local file URLs handed from the Electron main process to OS open APIs. No open PR covers the openPreviewInBrowser bypass or rejected-open fallback.

## Validation

- npm --workspace apps/desktop exec -- tsx --test electron/hardening.test.ts (13 passed, 1 Windows symlink skip)
- npm --workspace apps/desktop run typecheck
- npm --workspace apps/desktop exec -- eslint electron/hardening.ts electron/hardening.test.ts electron/main.ts --quiet
- git diff upstream/main...HEAD --check
- Rebased on upstream 97e9c64664

## Scope

Three upstream Desktop files, one commit. No custom features or _docs content.

## Agent disclosure

Prepared with Codex and narrowed from the prior PR after a fresh code-path and duplicate review.