### PR TITLE
fix: guard shutil.which() calls against platform mock AttributeError in doctor command

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -409,7 +409,13 @@ def run_doctor(args):
     except Exception as e:
         check_warn("Auth provider status", f"(could not check: {e})")
 
-    if shutil.which("codex"):
+    try:
+        _has_codex = shutil.which("codex")
+    except AttributeError:
+        # shutil.which can raise AttributeError when sys.platform is
+        # mocked to "win32" on a non-Windows host (missing _winapi).
+        _has_codex = None
+    if _has_codex:
         check_ok("codex CLI")
     else:
         check_warn("codex CLI not found", "(required for openai-codex login)")
@@ -620,13 +626,21 @@ def run_doctor(args):
     print(color("◆ External Tools", Colors.CYAN, Colors.BOLD))
     
     # Git
-    if shutil.which("git"):
+    try:
+        _has_git = shutil.which("git")
+    except AttributeError:
+        _has_git = None
+    if _has_git:
         check_ok("git")
     else:
         check_warn("git not found", "(optional)")
     
     # ripgrep (optional, for faster file search)
-    if shutil.which("rg"):
+    try:
+        _has_rg = shutil.which("rg")
+    except AttributeError:
+        _has_rg = None
+    if _has_rg:
         check_ok("ripgrep (rg)", "(faster file search)")
     else:
         check_warn("ripgrep (rg) not found", "(file search uses grep fallback)")
@@ -635,7 +649,11 @@ def run_doctor(args):
     # Docker (optional)
     terminal_env = os.getenv("TERMINAL_ENV", "local")
     if terminal_env == "docker":
-        if shutil.which("docker"):
+        try:
+            _has_docker = shutil.which("docker")
+        except AttributeError:
+            _has_docker = None
+        if _has_docker:
             # Check if docker daemon is running
             try:
                 result = subprocess.run(["docker", "info"], capture_output=True, timeout=10)
@@ -650,7 +668,11 @@ def run_doctor(args):
             check_fail("docker not found", "(required for TERMINAL_ENV=docker)")
             issues.append("Install Docker or change TERMINAL_ENV")
     else:
-        if shutil.which("docker"):
+        try:
+            _has_docker2 = shutil.which("docker")
+        except AttributeError:
+            _has_docker2 = None
+        if _has_docker2:
             check_ok("docker", "(optional)")
         else:
             if _is_termux():
@@ -697,7 +719,11 @@ def run_doctor(args):
             issues.append("Install daytona SDK: pip install daytona")
 
     # Node.js + agent-browser (for browser automation tools)
-    if shutil.which("node"):
+    try:
+        _has_node = shutil.which("node")
+    except AttributeError:
+        _has_node = None
+    if _has_node:
         check_ok("Node.js")
         # Check if agent-browser is installed
         agent_browser_path = PROJECT_ROOT / "node_modules" / "agent-browser"
@@ -723,7 +749,11 @@ def run_doctor(args):
             check_warn("Node.js not found", "(optional, needed for browser tools)")
     
     # npm audit for all Node.js packages
-    if shutil.which("npm"):
+    try:
+        _has_npm = shutil.which("npm")
+    except AttributeError:
+        _has_npm = None
+    if _has_npm:
         npm_dirs = [
             (PROJECT_ROOT, "Browser tools (agent-browser)"),
             (PROJECT_ROOT / "scripts" / "whatsapp-bridge", "WhatsApp bridge"),


### PR DESCRIPTION
## Problem

`hermes doctor` crashes with `AttributeError: 'NoneType' object has no attribute 'NeedCurrentDirectoryForExePath'` when `sys.platform` is mocked to `"win32"` on a non-Windows host. This breaks the `test_windows_skips_check` test.

The root cause: `shutil.which()` internally checks `sys.platform == "win32"` and, when true, tries to call `_winapi.NeedCurrentDirectoryForExePath()`. On Linux/macOS, `_winapi` is `None`, causing the `AttributeError`.

## Changes

Wrap all 7 `shutil.which()` calls in `hermes_cli/doctor.py` with `try/except AttributeError`:

- `shutil.which("codex")` (line ~413)
- `shutil.which("git")` (line ~629)
- `shutil.which("rg")` (line ~635)
- `shutil.which("docker")` (line ~648)
- `shutil.which("docker")` (line ~663)
- `shutil.which("node")` (line ~710)
- `shutil.which("npm")` (line ~736)

Each call is wrapped in:
```python
try:
    _has_X = shutil.which("X")
except AttributeError:
    _has_X = None
```

## Test Results

```
tests/hermes_cli/test_doctor_command_install.py: 10 passed
```