### PR TITLE
fix(tui): disable fast-echo bypass inside tmux to prevent cursor drift

### DIFF
--- a/ui-tui/src/__tests__/textInputFastEcho.test.ts
+++ b/ui-tui/src/__tests__/textInputFastEcho.test.ts
@@ -178,6 +178,26 @@ describe('supportsFastEchoTerminal', () => {
     expect(supportsFastEchoTerminal({ TERM_PROGRAM: 'Apple_Terminal' } as NodeJS.ProcessEnv)).toBe(false)
   })
 
+  it('disables fast-echo inside tmux', () => {
+    expect(supportsFastEchoTerminal({ TMUX: '/tmp/tmux-1000/default,1234,0' } as NodeJS.ProcessEnv)).toBe(false)
+    expect(supportsFastEchoTerminal({ TMUX: '/private/tmp/tmux-501/default' } as NodeJS.ProcessEnv)).toBe(false)
+  })
+
+  it('tmux wins over Termux fast-echo opt-in', () => {
+    expect(
+      supportsFastEchoTerminal({
+        TMUX: '/tmp/tmux-1000/default,1234,0',
+        HERMES_TUI_TERMUX_FAST_ECHO: '1',
+        TERMUX_VERSION: '0.118.0'
+      } as NodeJS.ProcessEnv)
+    ).toBe(false)
+  })
+
+  it('keeps fast-echo enabled when TMUX is empty or unset', () => {
+    expect(supportsFastEchoTerminal({ TMUX: '' } as NodeJS.ProcessEnv)).toBe(true)
+    expect(supportsFastEchoTerminal({ TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv)).toBe(true)
+  })
+
   it('disables fast-echo by default in Termux mode', () => {
     expect(
       supportsFastEchoTerminal({ TERMUX_VERSION: '0.118.0', PREFIX: '/data/data/com.termux/files/usr' } as NodeJS.ProcessEnv)

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -359,6 +359,13 @@ export function supportsFastEchoTerminal(env: NodeJS.ProcessEnv = process.env): 
     return false
   }
 
+  // tmux adds a PTY multiplexing layer that desyncs stdout.write() cursor
+  // advances from its internal cursor model, causing cursor drift and ghost
+  // whitespace under the fast-echo bypass path.
+  if ((env.TMUX ?? '').trim().length > 0) {
+    return false
+  }
+
   // Termux terminals are especially sensitive to bypass-path cursor drift and
   // stale paints at soft-wrap boundaries on tall/narrow viewports. Keep this
   // off by default in Termux mode; allow explicit opt-in for local debugging.


### PR DESCRIPTION
## What does this PR do?

Disables the TUI fast-echo bypass path when running inside tmux. The fast-echo path writes characters directly to `stdout` bypassing Ink's renderer for speed, then notifies Ink's cursor tracker via `noteCursorAdvance()`. tmux's PTY multiplexing layer buffers and redraws independently, desyncing the physical cursor from Ink's model — causing a visible whitespace gap between typed text and the cursor block, and backspace deleting characters instead of closing the gap.

This is the same class of cursor drift bug that led to the existing Apple Terminal and Termux exclusions in `supportsFastEchoTerminal()`.

## Related Issue

N/A — discovered via user report; no existing issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/components/textInput.tsx`: Added `TMUX` env var check to `supportsFastEchoTerminal()` — returns `false` when `TMUX` is set (non-empty), disabling the fast-echo bypass inside tmux sessions.
- `ui-tui/src/__tests__/textInputFastEcho.test.ts`: Added 3 test cases:
  - `disables fast-echo inside tmux` — verifies `false` with real tmux socket paths
  - `tmux wins over Termux fast-echo opt-in` — precedence guard against future reordering
  - `keeps fast-echo enabled when TMUX is empty or unset` — no false positives

## How to Test

1. Open a tmux session: `tmux new`
2. Launch Hermes TUI: `hermes --tui`
3. Type rapidly in the composer input — without this fix, extra whitespace appears between text and cursor; with the fix, cursor tracks correctly
4. Press backspace — without the fix, characters vanish instead of the gap closing; with the fix, normal backspace behavior
5. Run tests: `cd ui-tui && npx vitest run src/__tests__/textInputFastEcho.test.ts` — all 31 pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tui): disable fast-echo bypass inside tmux to prevent cursor drift`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (3 new test cases, 31 total pass)
- [x] I've tested on my platform: macOS 15.7.3, tmux inside iTerm2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing docs change needed)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture change)
- [x] I've considered cross-platform impact — tmux runs on macOS/Linux only; `TMUX` env var is the standard detection method on both
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

**Test output:**
```
 ✓ src/__tests__/textInputFastEcho.test.ts (31 tests) 4ms

 Test Files  1 passed (1)
      Tests  31 passed (31)
```

**Not in scope:** GNU screen (`STY`) and zellij (`ZELLIJ`) are not covered — no evidence of the same drift there. Can be follow-up PRs if reproduced.
