### PR TITLE
chore: add tt-a1i to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -415,6 +415,7 @@ AUTHOR_MAP = {
     "androidhtml@yandex.com": "hllqkb",
     "25840394+Bongulielmi@users.noreply.github.com": "Bongulielmi",
     "jonathan.troyer@overmatch.com": "JTroyerOvermatch",
+    "53142663+tt-a1i@users.noreply.github.com": "tt-a1i",  # PR #48933 (SSE-only Anthropic stream aggregation, #48923)
     "harryykyle1@gmail.com": "hharry11",
     "wysie@users.noreply.github.com": "wysie",
     "ronhi@buildabear1.localdomain": "RonHillDev",  # PR #29523 salvage (machine-local commit email)


### PR DESCRIPTION
Adds @tt-a1i to `AUTHOR_MAP` so the contributor audit passes for #48933 (SSE-only Anthropic stream aggregation, fixes #48923).

Prereq for landing #48933 — `check-attribution` reads AUTHOR_MAP from the PR's own HEAD tree, so this needs to be on main first, then #48933 gets `update-branch`ed to pick it up.