### PR TITLE
fix(migration): read Slack tokens from named OpenClaw accounts

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -1410,7 +1410,7 @@ class Migrator:
 
     @staticmethod
     def _get_channel_field(ch_cfg: Dict[str, Any], field: str) -> Any:
-        """Get a field from channel config, checking both flat and accounts.default layout."""
+        """Get a field from channel config, checking flat and account-scoped layouts."""
         val = ch_cfg.get(field)
         if val is not None:
             return val
@@ -1418,7 +1418,14 @@ class Migrator:
         if isinstance(accounts, dict):
             default = accounts.get("default")
             if isinstance(default, dict):
-                return default.get(field)
+                val = default.get(field)
+                if val is not None:
+                    return val
+            for account in accounts.values():
+                if isinstance(account, dict):
+                    val = account.get(field)
+                    if val is not None:
+                        return val
         return None
 
     def migrate_discord_settings(self, config: Optional[Dict[str, Any]] = None) -> None:

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -547,6 +547,43 @@ def test_slack_settings_migrated(tmp_path: Path):
     assert "SLACK_ALLOWED_USERS=U111,U222" in env_text
 
 
+def test_slack_settings_migrated_from_named_account(tmp_path: Path):
+    """Slack settings fall back to the first named account when no flat/default exists."""
+    mod = load_module()
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    target.mkdir()
+    source.mkdir()
+
+    (source / "openclaw.json").write_text(
+        json.dumps({
+            "channels": {
+                "slack": {
+                    "accounts": {
+                        "workspace-prod": {
+                            "botToken": "xoxb-named-bot",
+                            "appToken": "xapp-named-app",
+                            "allowFrom": ["U999"],
+                        }
+                    }
+                }
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    migrator = mod.Migrator(
+        source_root=source, target_root=target, execute=True,
+        workspace_target=None, overwrite=False, migrate_secrets=False, output_dir=None,
+        selected_options={"slack-settings"},
+    )
+    migrator.migrate()
+    env_text = (target / ".env").read_text(encoding="utf-8")
+    assert "SLACK_BOT_TOKEN=xoxb-named-bot" in env_text
+    assert "SLACK_APP_TOKEN=xapp-named-app" in env_text
+    assert "SLACK_ALLOWED_USERS=U999" in env_text
+
+
 def test_signal_settings_migrated(tmp_path: Path):
     """Signal account, HTTP URL, and allowlist migrate to .env."""
     mod = load_module()


### PR DESCRIPTION
## Summary
- migrate Slack bot/app tokens from named `channels.slack.accounts.*` entries when flat fields and `accounts.default` are absent
- keep existing flat/default precedence and only fall back to named accounts as a last resort
- cover the regression with a targeted OpenClaw migration test

## Testing
- pytest tests/skills/test_openclaw_migration.py -q -k slack_settings_migrated
- ruff check optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py tests/skills/test_openclaw_migration.py
- python -m py_compile optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py tests/skills/test_openclaw_migration.py
- git diff --check

Fixes #5191