### PR TITLE
fix(desktop): reap Windows backend trees on quit

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1667,11 +1667,10 @@ function isShimLocked(shimPath) {
 // Force-kill the entire process TREE rooted at each PID. Node's child.kill()
 // only signals the direct child, so on Windows a backend `hermes.exe` that
 // spawned its own grandchildren (a `hermes` REPL, a pty terminal session, the
-// gateway) would survive and keep the venv shim locked. taskkill /T /F reaps
-// the whole tree synchronously. Windows-only: this is called solely from the
-// Windows shim-unlock path, and the backend is NOT spawned detached (so it's
-// not a process-group leader — a POSIX negative-pgid kill would be meaningless
-// here anyway). POSIX teardown stays with the existing before-quit SIGTERM.
+// gateway) would survive and keep the venv shim / Electron tree locked.
+// taskkill /T /F reaps the whole tree synchronously. Windows-only: the backend
+// is NOT spawned detached (so it's not a process-group leader — a POSIX
+// negative-pgid kill would be meaningless here anyway).
 function forceKillProcessTree(pid) {
   if (!IS_WINDOWS) return
   if (!Number.isInteger(pid) || pid <= 0) return
@@ -6534,7 +6533,32 @@ function configureSpellChecker() {
   }
 }
 
-app.on('before-quit', () => {
+let quitBackendTeardownInProgress = false
+let quitBackendTeardownComplete = false
+
+function collectBackendChildrenForQuit() {
+  const children = []
+  if (hermesProcess) children.push(hermesProcess)
+  for (const entry of backendPool.values()) {
+    if (entry.process) children.push(entry.process)
+  }
+  return children
+}
+
+function isBackendChildRunning(child) {
+  return child && child.exitCode === null && child.signalCode === null
+}
+
+function forceKillWindowsBackendTrees(children) {
+  if (!IS_WINDOWS) return
+  for (const child of children) {
+    if (isBackendChildRunning(child) && Number.isInteger(child.pid)) {
+      forceKillProcessTree(child.pid)
+    }
+  }
+}
+
+function runBeforeQuitCleanup() {
   // Quitting mid-install should stop the installer, not orphan it.
   if (bootstrapAbortController) {
     try {
@@ -6561,6 +6585,31 @@ app.on('before-quit', () => {
     hermesProcess.kill('SIGTERM')
   }
   stopAllPoolBackends()
+}
+
+app.on('before-quit', event => {
+  const backendChildren = collectBackendChildrenForQuit()
+  runBeforeQuitCleanup()
+
+  if (
+    IS_WINDOWS &&
+    !quitBackendTeardownComplete &&
+    backendChildren.some(isBackendChildRunning)
+  ) {
+    event.preventDefault()
+    if (quitBackendTeardownInProgress) return
+
+    quitBackendTeardownInProgress = true
+    rememberLog('[quit] waiting for Windows backend process trees to exit')
+    // SIGTERM was sent above. Follow with taskkill while the direct backend PID
+    // still identifies its descendants; if the parent exits first, Windows can
+    // leave node/python grandchildren alive and holding update-time locks.
+    forceKillWindowsBackendTrees(backendChildren)
+    Promise.allSettled(backendChildren.map(child => waitForBackendExit(child))).finally(() => {
+      quitBackendTeardownComplete = true
+      app.quit()
+    })
+  }
 })
 
 app.on('window-all-closed', () => {

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -28,14 +28,38 @@ test('desktop background child processes opt into hidden Windows consoles', () =
   assert.match(source, /function hiddenWindowsChildOptions\(options = \{\}\)/)
 
   requireHiddenChildOptions(source, "execFileSync(\n          'reg'")
-  requireHiddenChildOptions(source, 'execFileSync(pyExe')
-  requireHiddenChildOptions(source, 'spawn(resolveGitBinary()')
+  requireHiddenChildOptions(source, 'execFileSync(\n          pyExe')
+  requireHiddenChildOptions(source, 'spawn(\n      resolveGitBinary()')
   requireHiddenChildOptions(source, "execFileSync('taskkill'")
-  requireHiddenChildOptions(source, 'spawn(command, args')
+  requireHiddenChildOptions(source, 'spawn(\n        command')
   requireHiddenChildOptions(source, "spawn('curl'")
-  requireHiddenChildOptions(source, 'spawn(backend.command, backend.args')
-  requireHiddenChildOptions(source, 'hermesProcess = spawn(backend.command, backend.args')
-  requireHiddenChildOptions(source, "spawn(py, ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")
+  requireHiddenChildOptions(source, 'spawn(\n    backend.command')
+  requireHiddenChildOptions(source, 'hermesProcess = spawn(\n      backend.command')
+  requireHiddenChildOptions(source, "spawn(\n        py,\n        ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")
+})
+
+test('Windows before-quit waits for backend process trees before exiting', () => {
+  const source = readElectronFile('main.cjs')
+  const index = source.indexOf("app.on('before-quit', event =>")
+  assert.notEqual(index, -1, 'missing before-quit lifecycle handler')
+
+  const helperIndex = source.indexOf('function forceKillWindowsBackendTrees(children)')
+  assert.notEqual(helperIndex, -1, 'missing Windows backend tree-kill helper')
+  const helper = source.slice(helperIndex, helperIndex + 500)
+  assert.match(helper, /isBackendChildRunning\(child\)/)
+  assert.match(helper, /forceKillProcessTree\(child\.pid\)/)
+
+  const snippet = source.slice(index, index + 1400)
+  assert.match(snippet, /collectBackendChildrenForQuit\(\)/)
+  assert.match(snippet, /event\.preventDefault\(\)/)
+  assert.match(snippet, /forceKillWindowsBackendTrees\(backendChildren\)/)
+  assert.match(snippet, /waitForBackendExit\(child\)/)
+  assert.ok(
+    snippet.indexOf('forceKillWindowsBackendTrees(backendChildren)') < snippet.indexOf('waitForBackendExit(child)'),
+    'backend trees must be killed while parent PIDs still identify descendants'
+  )
+  assert.match(snippet, /quitBackendTeardownComplete = true/)
+  assert.match(snippet, /app\.quit\(\)/)
 })
 
 test('intentional or interactive desktop child processes stay documented', () => {


### PR DESCRIPTION
## Summary
- fix Windows Desktop normal quit so it does not leave Hermes backend child process trees alive
- send the existing graceful SIGTERM cleanup, then force-kill collected backend trees on Windows while parent PIDs still identify descendants
- add regression coverage for the before-quit path and refresh stale child-process test call-site needles

Fixes #48854.

## Validation
- npm run --workspace apps/desktop test:desktop:platforms
- npm run --workspace apps/desktop typecheck
- node --test apps/desktop/electron/windows-child-process.test.cjs
- node -c apps/desktop/electron/main.cjs && node -c apps/desktop/electron/windows-child-process.test.cjs
- npx eslint electron/windows-child-process.test.cjs --quiet
- npx eslint electron/main.cjs --quiet --rule 'no-unused-vars: off'
- git diff --check

## Review
- Subagent review initially found that fast direct-child exit could skip tree-killing grandchildren; fixed by force-killing Windows backend trees before waiting for child exit.
- Second subagent review found no blockers.