### PR TITLE
fix(openviking): gate memory writes and add viking_forget

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout
+from agent.memory_write_bridge import collect_memory_write_notifications
 from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
@@ -1849,29 +1850,24 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 operations=operations,
                 store=agent._memory_store,
             )
-            # Bridge: notify external memory provider of built-in memory writes.
-            # Covers both the single-op shape and each add/replace inside a batch.
+            # Bridge: notify external memory providers of successful built-in
+            # memory writes. Covers the single-op shape and each mutating op
+            # inside a successful batch.
             if agent._memory_manager:
-                if operations:
-                    _mem_ops = [
-                        op for op in operations
-                        if isinstance(op, dict) and op.get("action") in {"add", "replace"}
-                    ]
-                else:
-                    _mem_ops = (
-                        [{"action": next_args.get("action"), "content": next_args.get("content")}]
-                        if next_args.get("action") in {"add", "replace"} else []
-                    )
+                _mem_ops = collect_memory_write_notifications(result, next_args)
                 for _op in _mem_ops:
                     try:
+                        metadata = agent._build_memory_write_metadata(
+                            task_id=effective_task_id,
+                            tool_call_id=tool_call_id,
+                        )
+                        if _op.get("old_text"):
+                            metadata["old_text"] = _op["old_text"]
                         agent._memory_manager.on_memory_write(
                             _op.get("action", ""),
-                            target,
+                            _op.get("target", target),
                             _op.get("content", "") or "",
-                            metadata=agent._build_memory_write_metadata(
-                                task_id=effective_task_id,
-                                tool_call_id=tool_call_id,
-                            ),
+                            metadata=metadata,
                         )
                     except Exception:
                         pass

--- a/agent/memory_write_bridge.py
+++ b/agent/memory_write_bridge.py
@@ -15,15 +15,10 @@ def _memory_tool_result_succeeded(result: Any) -> bool:
         except Exception:
             return False
 
-    if isinstance(result, dict):
-        if result.get("success") is False:
-            return False
-        if result.get("staged") is True:
-            return False
-        if "error" in result and result.get("success") is not True:
-            return False
+    if not isinstance(result, dict):
+        return False
 
-    return True
+    return result.get("success") is True and result.get("staged") is not True
 
 
 def collect_memory_write_notifications(

--- a/agent/memory_write_bridge.py
+++ b/agent/memory_write_bridge.py
@@ -1,0 +1,61 @@
+"""Helpers for mirroring built-in memory writes to external providers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+_MIRRORED_MEMORY_ACTIONS = {"add", "replace", "remove"}
+
+
+def _memory_tool_result_succeeded(result: Any) -> bool:
+    if isinstance(result, str):
+        try:
+            result = json.loads(result)
+        except Exception:
+            return False
+
+    if isinstance(result, dict):
+        if result.get("success") is False:
+            return False
+        if result.get("staged") is True:
+            return False
+        if "error" in result and result.get("success") is not True:
+            return False
+
+    return True
+
+
+def collect_memory_write_notifications(
+    tool_result: Any,
+    tool_args: Dict[str, Any],
+) -> List[Dict[str, str]]:
+    """Return provider notifications for a successful built-in memory write."""
+    if not _memory_tool_result_succeeded(tool_result):
+        return []
+
+    target = str(tool_args.get("target") or "memory")
+    operations = tool_args.get("operations")
+    if isinstance(operations, list) and operations:
+        raw_operations = operations
+    else:
+        raw_operations = [{
+            "action": tool_args.get("action"),
+            "content": tool_args.get("content"),
+            "old_text": tool_args.get("old_text"),
+        }]
+
+    notifications: List[Dict[str, str]] = []
+    for op in raw_operations:
+        if not isinstance(op, dict):
+            continue
+        action = str(op.get("action") or "")
+        if action not in _MIRRORED_MEMORY_ACTIONS:
+            continue
+        notifications.append({
+            "action": action,
+            "target": target,
+            "content": str(op.get("content") or ""),
+            "old_text": str(op.get("old_text") or ""),
+        })
+    return notifications

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -29,6 +29,7 @@ from agent.display import (
     _detect_tool_failure,
 )
 from agent.tool_guardrails import ToolGuardrailDecision
+from agent.memory_write_bridge import collect_memory_write_notifications
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
     _is_multimodal_tool_result,
@@ -1022,29 +1023,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     operations=operations,
                     store=agent._memory_store,
                 )
-                # Bridge: notify external memory provider of built-in memory writes.
-                # Covers both the single-op shape and each add/replace inside a batch.
+                # Bridge: notify external memory providers of successful built-in
+                # memory writes. Covers the single-op shape and each mutating op
+                # inside a successful batch.
                 if agent._memory_manager:
-                    if operations:
-                        _mem_ops = [
-                            op for op in operations
-                            if isinstance(op, dict) and op.get("action") in {"add", "replace"}
-                        ]
-                    else:
-                        _mem_ops = (
-                            [{"action": next_args.get("action"), "content": next_args.get("content")}]
-                            if next_args.get("action") in {"add", "replace"} else []
-                        )
+                    _mem_ops = collect_memory_write_notifications(result, next_args)
                     for _op in _mem_ops:
                         try:
+                            metadata = agent._build_memory_write_metadata(
+                                task_id=effective_task_id,
+                                tool_call_id=getattr(tool_call, "id", None),
+                            )
+                            if _op.get("old_text"):
+                                metadata["old_text"] = _op["old_text"]
                             agent._memory_manager.on_memory_write(
                                 _op.get("action", ""),
-                                target,
+                                _op.get("target", target),
                                 _op.get("content", "") or "",
-                                metadata=agent._build_memory_write_metadata(
-                                    task_id=effective_task_id,
-                                    tool_call_id=getattr(tool_call, "id", None),
-                                ),
+                                metadata=metadata,
                             )
                         except Exception:
                             pass

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -47,5 +47,37 @@ Hermes sends `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` as identity headers.
 | `viking_search` | Semantic search with fast/deep/auto modes |
 | `viking_read` | Read content at a viking:// URI (abstract/overview/full) |
 | `viking_browse` | Filesystem-style navigation (list/tree/stat) |
-| `viking_remember` | Store a fact for extraction on session commit |
+| `viking_remember` | Store a fact directly with OpenViking `content/write` |
+| `viking_forget` | Delete one exact `viking://` memory file URI |
 | `viking_add_resource` | Ingest URLs/docs into the knowledge base |
+
+## Memory Writes And Deletes
+
+`viking_remember` writes directly to OpenViking with `POST /api/v1/content/write`
+and `mode=create`. It creates peer-scoped memory files under
+`viking://user/peers/${OPENVIKING_AGENT}/memories/...`; OpenViking may return a
+canonical user-scoped form such as
+`viking://user/default/peers/${OPENVIKING_AGENT}/memories/...` in API-key mode.
+Explicit remembers do not depend on session commit extraction.
+
+Hermes built-in `memory` tool additions are mirrored to OpenViking after the
+local memory operation succeeds:
+
+| Hermes action | OpenViking operation |
+|---------------|----------------------|
+| `add` | `content/write` with `mode=create` under the configured peer memory namespace |
+
+Built-in `replace` and `remove` operations are not mirrored because Hermes
+native memory entries do not yet carry stable OpenViking file URIs. Use
+`viking_forget` when the user explicitly asks to delete a specific OpenViking
+memory URI.
+
+`viking_forget` is intentionally narrow. It only accepts concrete user memory
+file URIs, such as
+`viking://user/peers/hermes/memories/preferences/mem_abc123.md` or the canonical
+`viking://user/default/peers/hermes/memories/preferences/mem_abc123.md`. Files
+directly under `memories/`, such as `viking://user/default/memories/profile.md`,
+are also allowed because OpenViking supports them. The tool rejects directories,
+resources, skills, sessions, generated summary files, and URIs with query
+strings or fragments. Use OpenViking's MCP, CLI, or admin APIs for broader
+resource and directory cleanup.

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -91,6 +91,13 @@ _MEMORY_WRITE_TARGET_SUBDIR_MAP = {
     "user": "preferences",
     "memory": "patterns",
 }
+_DERIVED_MEMORY_FILENAMES = {
+    ".abstract.md",
+    ".overview.md",
+    ".read.md",
+    ".full.md",
+    ".relations.json",
+}
 _LOCAL_OPENVIKING_HOSTS = {"localhost", "127.0.0.1", "::1"}
 _LOCAL_OPENVIKING_AUTOSTART_TIMEOUT = 60.0
 _OPENVIKING_SERVER_LOG_RELATIVE_PATH = Path("logs") / "openviking-server.log"
@@ -320,6 +327,13 @@ class _VikingClient:
             )
         )
 
+    def delete(self, path: str, **kwargs) -> dict:
+        return self._send_with_trusted_identity_retry(
+            lambda headers: self._httpx.delete(
+                self._url(path), headers=headers, timeout=_TIMEOUT, **kwargs
+            )
+        )
+
     def upload_temp_file(self, file_path: Path) -> str:
         mime_type = mimetypes.guess_type(file_path.name)[0] or "application/octet-stream"
 
@@ -460,6 +474,26 @@ REMEMBER_SCHEMA = {
     },
 }
 
+FORGET_SCHEMA = {
+    "name": "viking_forget",
+    "description": (
+        "Delete one OpenViking memory file by exact viking:// URI. "
+        "Use only when the user explicitly asks to forget or delete a specific "
+        "memory and you have the exact memory file URI. Resources, skills, "
+        "sessions, directories, generated summaries, and broad deletes are rejected."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "uri": {
+                "type": "string",
+                "description": "Exact viking:// memory file URI ending in .md.",
+            },
+        },
+        "required": ["uri"],
+    },
+}
+
 ADD_RESOURCE_SCHEMA = {
     "name": "viking_add_resource",
     "description": (
@@ -550,6 +584,46 @@ def _is_windows_absolute_path(value: str) -> bool:
 
 def _is_remote_resource_source(value: str) -> bool:
     return value.startswith(_REMOTE_RESOURCE_PREFIXES)
+
+
+def _memory_segment_index(parts: List[str]) -> Optional[int]:
+    if len(parts) >= 2 and parts[0] == "user" and parts[1] == "memories":
+        return 1
+    if len(parts) >= 3 and parts[0] == "user" and parts[2] == "memories":
+        return 2
+    if len(parts) >= 4 and parts[0] == "user" and parts[1] == "peers" and parts[3] == "memories":
+        return 3
+    if len(parts) >= 5 and parts[0] == "user" and parts[2] == "peers" and parts[4] == "memories":
+        return 4
+    return None
+
+
+def _validate_forget_memory_uri(raw_uri: Any) -> tuple[Optional[str], Optional[str]]:
+    if not isinstance(raw_uri, str):
+        return None, "uri is required"
+
+    uri = raw_uri.strip()
+    if not uri:
+        return None, "uri is required"
+
+    parsed = urlparse(uri)
+    if parsed.scheme != "viking" or not uri.startswith("viking://"):
+        return None, "viking_forget only accepts viking:// memory file URIs"
+    if parsed.query or parsed.fragment:
+        return None, "viking_forget requires an exact URI without query or fragment"
+    if uri.endswith("/") or not uri.endswith(".md"):
+        return None, "viking_forget only deletes concrete .md memory files"
+
+    parts = [part for part in uri[len("viking://") :].split("/") if part]
+    memories_idx = _memory_segment_index(parts)
+    if memories_idx is None or len(parts) < memories_idx + 2:
+        return None, "viking_forget only deletes user memory file URIs"
+
+    filename = uri.rsplit("/", 1)[-1]
+    if filename in _DERIVED_MEMORY_FILENAMES:
+        return None, "viking_forget cannot delete generated memory summary files"
+
+    return uri, None
 
 
 def _is_local_path_reference(value: str) -> bool:
@@ -2034,7 +2108,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 f"Active. Endpoint: {self._endpoint}\n"
                 "Use viking_search to find information, viking_read for details "
                 "(abstract/overview/full), viking_browse to explore.\n"
-                "Use viking_remember to store facts, viking_add_resource to index URLs/docs."
+                "Use viking_remember to store facts, viking_forget to delete exact memory "
+                "file URIs, and viking_add_resource to index URLs/docs."
             )
         except Exception as e:
             logger.warning("OpenViking system_prompt_block failed: %s", e)
@@ -2042,7 +2117,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 "# OpenViking Knowledge Base\n"
                 f"Active. Endpoint: {self._endpoint}\n"
                 "Use viking_search, viking_read, viking_browse, "
-                "viking_remember, viking_add_resource."
+                "viking_remember, viking_forget, viking_add_resource."
             )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
@@ -2793,7 +2868,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         content: str,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Mirror built-in memory writes to OpenViking via content/write."""
+        """Mirror successful built-in memory additions to OpenViking."""
         if not self._client or action != "add" or not content:
             return
 
@@ -2818,7 +2893,14 @@ class OpenVikingMemoryProvider(MemoryProvider):
         t.start()
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        return [SEARCH_SCHEMA, READ_SCHEMA, BROWSE_SCHEMA, REMEMBER_SCHEMA, ADD_RESOURCE_SCHEMA]
+        return [
+            SEARCH_SCHEMA,
+            READ_SCHEMA,
+            BROWSE_SCHEMA,
+            REMEMBER_SCHEMA,
+            FORGET_SCHEMA,
+            ADD_RESOURCE_SCHEMA,
+        ]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if not self._client:
@@ -2833,6 +2915,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 return self._tool_browse(args)
             elif tool_name == "viking_remember":
                 return self._tool_remember(args)
+            elif tool_name == "viking_forget":
+                return self._tool_forget(args)
             elif tool_name == "viking_add_resource":
                 return self._tool_add_resource(args)
             return tool_error(f"Unknown tool: {tool_name}")
@@ -3083,6 +3167,31 @@ class OpenVikingMemoryProvider(MemoryProvider):
         except Exception as e:
             logger.error("OpenViking content/write failed: %s", e)
             return tool_error(f"Failed to store memory: {e}")
+
+    def _tool_forget(self, args: dict) -> str:
+        uri, error = _validate_forget_memory_uri(args.get("uri"))
+        if error:
+            return tool_error(error)
+
+        resp = self._client.delete(
+            "/api/v1/fs",
+            params={"uri": uri, "recursive": False},
+        )
+        result = self._unwrap_result(resp)
+        payload: Dict[str, Any] = {"status": "deleted", "uri": uri}
+        if isinstance(result, dict):
+            payload["uri"] = result.get("uri") or uri
+            for key in (
+                "estimated_deleted_count",
+                "memory_cleanup",
+                "semantic_root_uri",
+                "semantic_status",
+                "queue_status",
+            ):
+                if key in result:
+                    payload[key] = result[key]
+
+        return json.dumps(payload, ensure_ascii=False)
 
     def _tool_add_resource(self, args: dict) -> str:
         url = args.get("url", "")

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1780,6 +1780,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._prefetch_thread: Optional[threading.Thread] = None
         self._runtime_start_lock = threading.Lock()
         self._runtime_start_thread: Optional[threading.Thread] = None
+        self._memory_write_lock = threading.Lock()
+        self._memory_write_threads: Set[threading.Thread] = set()
         # All prefetch threads ever spawned (daemon, short-lived). Tracked so
         # shutdown() can drain them and rapid re-queues don't orphan a still-
         # running thread by overwriting the single _prefetch_thread slot.
@@ -2888,9 +2890,20 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 })
             except Exception as e:
                 logger.debug("OpenViking memory mirror failed: %s", e)
+            finally:
+                with self._memory_write_lock:
+                    self._memory_write_threads.discard(threading.current_thread())
 
         t = threading.Thread(target=_write, daemon=True, name="openviking-memwrite")
-        t.start()
+        with self._memory_write_lock:
+            if self._shutting_down:
+                return
+            self._memory_write_threads.add(t)
+            try:
+                t.start()
+            except Exception as e:
+                self._memory_write_threads.discard(t)
+                logger.debug("OpenViking memory mirror worker failed to start: %s", e)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         return [
@@ -2936,6 +2949,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
             deferred_workers = list(self._deferred_commit_threads)
         with self._prefetch_lock:
             prefetch_workers = list(self._prefetch_threads)
+        with self._memory_write_lock:
+            memory_write_workers = list(self._memory_write_threads)
         for t in all_workers:
             if t.is_alive():
                 t.join(timeout=5.0)
@@ -2943,6 +2958,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
             if t.is_alive():
                 t.join(timeout=5.0)
         for t in prefetch_workers:
+            if t.is_alive():
+                t.join(timeout=5.0)
+        for t in memory_write_workers:
             if t.is_alive():
                 t.join(timeout=5.0)
         # Clear atexit reference so it doesn't double-commit.

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -91,12 +91,11 @@ _MEMORY_WRITE_TARGET_SUBDIR_MAP = {
     "user": "preferences",
     "memory": "patterns",
 }
-_DERIVED_MEMORY_FILENAMES = {
+# OpenViking-generated markdown summaries. Non-.md sidecars such as
+# .relations.json are rejected earlier by the exact memory-file check.
+_GENERATED_MEMORY_SUMMARY_FILENAMES = {
     ".abstract.md",
     ".overview.md",
-    ".read.md",
-    ".full.md",
-    ".relations.json",
 }
 _LOCAL_OPENVIKING_HOSTS = {"localhost", "127.0.0.1", "::1"}
 _LOCAL_OPENVIKING_AUTOSTART_TIMEOUT = 60.0
@@ -620,7 +619,7 @@ def _validate_forget_memory_uri(raw_uri: Any) -> tuple[Optional[str], Optional[s
         return None, "viking_forget only deletes user memory file URIs"
 
     filename = uri.rsplit("/", 1)[-1]
-    if filename in _DERIVED_MEMORY_FILENAMES:
+    if filename in _GENERATED_MEMORY_SUMMARY_FILENAMES:
         return None, "viking_forget cannot delete generated memory summary files"
 
     return uri, None

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1172,16 +1172,12 @@ class TestOnMemoryWriteBridge:
         mgr.on_memory_write("replace", "user", "updated pref")
         assert p.memory_writes == [("replace", "user", "updated pref")]
 
-    def test_on_memory_write_remove_not_bridged(self):
-        """The bridge intentionally skips 'remove' — only add/replace notify."""
-        # This tests the contract that run_agent.py checks:
-        #   function_args.get("action") in ("add", "replace")
+    def test_on_memory_write_remove_supported_by_manager(self):
+        """The manager forwards remove actions when a caller elects to bridge them."""
         mgr = MemoryManager()
         p = FakeMemoryProvider("ext")
         mgr.add_provider(p)
 
-        # Manager itself doesn't filter — run_agent.py does.
-        # But providers should handle remove gracefully.
         mgr.on_memory_write("remove", "memory", "old fact")
         assert p.memory_writes == [("remove", "memory", "old fact")]
 

--- a/tests/agent/test_memory_write_bridge.py
+++ b/tests/agent/test_memory_write_bridge.py
@@ -1,0 +1,84 @@
+import json
+
+from agent.memory_write_bridge import collect_memory_write_notifications
+
+
+def test_collect_notifications_includes_remove_with_old_text_after_success():
+    notifications = collect_memory_write_notifications(
+        json.dumps({"success": True}),
+        {
+            "action": "remove",
+            "target": "memory",
+            "old_text": "stale preference entry",
+        },
+    )
+
+    assert notifications == [
+        {
+            "action": "remove",
+            "target": "memory",
+            "content": "",
+            "old_text": "stale preference entry",
+        }
+    ]
+
+
+def test_collect_notifications_skips_failed_memory_write():
+    notifications = collect_memory_write_notifications(
+        json.dumps({"success": False, "error": "No entry matched"}),
+        {
+            "action": "remove",
+            "target": "memory",
+            "old_text": "stale preference entry",
+        },
+    )
+
+    assert notifications == []
+
+
+def test_collect_notifications_skips_staged_memory_write():
+    notifications = collect_memory_write_notifications(
+        json.dumps({"success": True, "staged": True, "pending_id": "abc123"}),
+        {
+            "action": "remove",
+            "target": "memory",
+            "old_text": "stale preference entry",
+        },
+    )
+
+    assert notifications == []
+
+
+def test_collect_notifications_preserves_old_text_for_replace_and_remove_batch():
+    notifications = collect_memory_write_notifications(
+        json.dumps({"success": True}),
+        {
+            "target": "user",
+            "operations": [
+                {"action": "replace", "old_text": "old preference", "content": "updated"},
+                {"action": "remove", "old_text": "obsolete preference"},
+                {"action": "add", "content": "new fact"},
+            ],
+        },
+    )
+
+    assert notifications == [
+        {
+            "action": "replace",
+            "target": "user",
+            "content": "updated",
+            "old_text": "old preference",
+        },
+        {
+            "action": "remove",
+            "target": "user",
+            "content": "",
+            "old_text": "obsolete preference",
+        },
+        {
+            "action": "add",
+            "target": "user",
+            "content": "new fact",
+            "old_text": "",
+        },
+    ]

--- a/tests/agent/test_memory_write_bridge.py
+++ b/tests/agent/test_memory_write_bridge.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from agent.memory_write_bridge import collect_memory_write_notifications
 
 
@@ -43,6 +45,20 @@ def test_collect_notifications_skips_staged_memory_write():
             "action": "remove",
             "target": "memory",
             "old_text": "stale preference entry",
+        },
+    )
+
+    assert notifications == []
+
+
+@pytest.mark.parametrize("tool_result", [None, [], object()])
+def test_collect_notifications_skips_unrecognized_tool_result_shape(tool_result):
+    notifications = collect_memory_write_notifications(
+        tool_result,
+        {
+            "action": "add",
+            "target": "memory",
+            "content": "new fact",
         },
     )
 

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1459,6 +1459,115 @@ def test_tool_add_resource_sends_git_remote_sources_as_path(url):
     })
 
 
+def test_get_tool_schemas_includes_narrow_forget_tool():
+    provider = OpenVikingMemoryProvider()
+
+    names = [schema["name"] for schema in provider.get_tool_schemas()]
+
+    assert "viking_forget" in names
+
+
+def test_handle_tool_call_forget_deletes_exact_memory_file_uri():
+    uri = "viking://user/peers/hermes/memories/preferences/mem_abc123.md"
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.delete.return_value = {
+        "status": "ok",
+        "result": {"uri": uri, "estimated_deleted_count": 1},
+    }
+
+    result = json.loads(provider.handle_tool_call("viking_forget", {"uri": uri}))
+
+    provider._client.delete.assert_called_once_with(
+        "/api/v1/fs",
+        params={"uri": uri, "recursive": False},
+    )
+    assert result == {
+        "status": "deleted",
+        "uri": uri,
+        "estimated_deleted_count": 1,
+    }
+
+
+def test_handle_tool_call_forget_deletes_exact_memory_file_under_memories_root():
+    uri = "viking://user/default/memories/profile.md"
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.delete.return_value = {
+        "status": "ok",
+        "result": {"uri": uri, "estimated_deleted_count": 1},
+    }
+
+    result = json.loads(provider.handle_tool_call("viking_forget", {"uri": uri}))
+
+    provider._client.delete.assert_called_once_with(
+        "/api/v1/fs",
+        params={"uri": uri, "recursive": False},
+    )
+    assert result == {
+        "status": "deleted",
+        "uri": uri,
+        "estimated_deleted_count": 1,
+    }
+
+
+@pytest.mark.parametrize("uri", [
+    "",
+    "https://example.com/mem.md",
+    "viking:/user/memories/preferences/mem_abc123.md",
+    "viking://resources/project/doc.md",
+    "viking://resources/project/memories/mem_abc123.md",
+    "viking://memories/preferences/mem_abc123.md",
+    "viking://agent/hermes/memories/preferences/mem_abc123.md",
+    "viking://user/skills/example/SKILL.md",
+    "viking://user/sessions/session-1/messages.jsonl",
+    "viking://user/memories/preferences/",
+    "viking://user/memories/preferences/.overview.md",
+    "viking://user/memories/preferences/.abstract.md",
+    "viking://user/memories/preferences/mem_abc123.md?recursive=true",
+])
+def test_handle_tool_call_forget_rejects_non_memory_file_uris(uri):
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+
+    result = json.loads(provider.handle_tool_call("viking_forget", {"uri": uri}))
+
+    assert "error" in result
+    provider._client.delete.assert_not_called()
+
+
+def test_viking_client_delete_uses_identity_headers(monkeypatch):
+    client = _VikingClient(
+        "https://example.com",
+        api_key="test-key",
+        account="acct",
+        user="alice",
+        agent="hermes",
+    )
+    captured = {}
+
+    def capture_delete(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(
+            status_code=200,
+            text="",
+            json=lambda: {"status": "ok", "result": {"uri": "viking://user/memories/x.md"}},
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr(client._httpx, "delete", capture_delete)
+
+    assert client.delete("/api/v1/fs", params={"uri": "viking://user/memories/x.md"}) == {
+        "status": "ok",
+        "result": {"uri": "viking://user/memories/x.md"},
+    }
+    assert captured["url"] == "https://example.com/api/v1/fs"
+    assert captured["kwargs"]["params"] == {"uri": "viking://user/memories/x.md"}
+    assert captured["kwargs"]["headers"]["Authorization"] == "Bearer test-key"
+    assert captured["kwargs"]["headers"]["X-OpenViking-Actor-Peer"] == "hermes"
+
+
 def test_viking_client_upload_temp_file_uses_multipart_identity_headers(tmp_path, monkeypatch):
     sample = tmp_path / "sample.md"
     sample.write_text("# Local resource\n", encoding="utf-8")
@@ -2635,6 +2744,46 @@ def test_on_memory_write_uses_content_write_independent_of_session_rotation():
     assert captured_payloads[0]["uri"].startswith(
         "viking://user/peers/hermes/memories/preferences/mem_"
     )
+
+
+@pytest.mark.parametrize(
+    ("action", "content"),
+    [
+        ("replace", "updated memory"),
+        ("remove", ""),
+        ("forget", ""),
+        ("delete", ""),
+    ],
+)
+def test_on_memory_write_ignores_non_add_actions(action, content, monkeypatch):
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._endpoint = "http://test"
+    provider._api_key = ""
+    provider._account = "acct"
+    provider._user = "usr"
+    provider._agent = "hermes"
+    uri = "viking://user/peers/hermes/memories/preferences/mem_abc123.md"
+    spawned = []
+
+    class StubThread:
+        def __init__(self, *args, **kwargs):
+            spawned.append((args, kwargs))
+
+        def start(self):
+            raise AssertionError("non-URI remove should not spawn a mirror thread")
+
+    import plugins.memory.openviking as _mod
+    monkeypatch.setattr(_mod.threading, "Thread", StubThread)
+
+    provider.on_memory_write(
+        action,
+        "memory",
+        content,
+        metadata={"uri": uri, "old_text": "stale fact"},
+    )
+
+    assert spawned == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1511,6 +1511,28 @@ def test_handle_tool_call_forget_deletes_exact_memory_file_under_memories_root()
     }
 
 
+def test_handle_tool_call_forget_allows_non_generated_dot_md_memory_file():
+    uri = "viking://user/default/memories/preferences/.full.md"
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.delete.return_value = {
+        "status": "ok",
+        "result": {"uri": uri, "estimated_deleted_count": 1},
+    }
+
+    result = json.loads(provider.handle_tool_call("viking_forget", {"uri": uri}))
+
+    provider._client.delete.assert_called_once_with(
+        "/api/v1/fs",
+        params={"uri": uri, "recursive": False},
+    )
+    assert result == {
+        "status": "deleted",
+        "uri": uri,
+        "estimated_deleted_count": 1,
+    }
+
+
 @pytest.mark.parametrize("uri", [
     "",
     "https://example.com/mem.md",

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -2746,6 +2746,54 @@ def test_on_memory_write_uses_content_write_independent_of_session_rotation():
     )
 
 
+def test_shutdown_waits_for_memory_write_worker(monkeypatch):
+    import threading
+
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._endpoint = "http://test"
+    provider._api_key = ""
+    provider._account = "acct"
+    provider._user = "usr"
+    provider._agent = "hermes"
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    worker_finished = threading.Event()
+    shutdown_returned = threading.Event()
+
+    class StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def post(self, path, payload=None, **kwargs):
+            assert path == "/api/v1/content/write"
+            worker_started.set()
+            release_worker.wait(timeout=2.0)
+            worker_finished.set()
+            return {}
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", StubClient)
+
+    provider.on_memory_write("add", "user", "remember this")
+    assert worker_started.wait(timeout=2.0), "worker never entered post()"
+
+    shutdown_thread = threading.Thread(
+        target=lambda: (provider.shutdown(), shutdown_returned.set()),
+        daemon=True,
+    )
+    shutdown_thread.start()
+
+    returned_before_worker_finished = shutdown_returned.wait(timeout=0.1)
+    release_worker.set()
+    assert shutdown_returned.wait(timeout=2.0), "shutdown did not return after worker finished"
+    shutdown_thread.join(timeout=2.0)
+
+    assert not returned_before_worker_finished
+    assert worker_finished.is_set()
+    assert provider._memory_write_threads == set()
+
+
 @pytest.mark.parametrize(
     ("action", "content"),
     [

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2082,6 +2082,41 @@ class TestExecuteToolCalls:
         assert messages[0]["role"] == "tool"
         assert "search result" in messages[0]["content"]
 
+    def test_sequential_memory_remove_notifies_provider_with_tool_result(self, agent):
+        old_text = "stale preference entry"
+        tc = _mock_tool_call(
+            name="memory",
+            arguments=json.dumps({
+                "action": "remove",
+                "target": "memory",
+                "old_text": old_text,
+            }),
+            call_id="mem-1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        calls = []
+
+        class FakeMemoryManager:
+            def has_tool(self, name):
+                return False
+
+            def on_memory_write(self, action, target, content, metadata=None):
+                calls.append((action, target, content, metadata or {}))
+
+        agent._memory_manager = FakeMemoryManager()
+        agent._memory_store = object()
+
+        with patch("tools.memory_tool.memory_tool", return_value=json.dumps({"success": True})):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert len(calls) == 1
+        action, target, content, metadata = calls[0]
+        assert (action, target, content) == ("remove", "memory", "")
+        assert metadata["old_text"] == old_text
+        assert metadata["tool_call_id"] == "mem-1"
+        assert messages[-1]["tool_call_id"] == "mem-1"
+
     def test_keyboard_interrupt_emits_cancelled_post_tool_hook(self, agent, monkeypatch):
         tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
@@ -2796,6 +2831,63 @@ class TestConcurrentToolExecution:
 
         assert json.loads(result) == {"error": "Blocked"}
         assert agent._turns_since_memory == 5
+
+    def test_invoke_tool_memory_remove_notifies_provider_with_old_text(self, agent, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: None,
+        )
+        calls = []
+
+        class FakeMemoryManager:
+            def has_tool(self, name):
+                return False
+
+            def on_memory_write(self, action, target, content, metadata=None):
+                calls.append((action, target, content, metadata or {}))
+
+        old_text = "stale preference entry"
+        agent._memory_manager = FakeMemoryManager()
+        agent._memory_store = object()
+
+        with patch("tools.memory_tool.memory_tool", return_value=json.dumps({"success": True})):
+            agent._invoke_tool(
+                "memory",
+                {"action": "remove", "target": "memory", "old_text": old_text},
+                "task-1",
+                tool_call_id="mem-1",
+            )
+
+        assert len(calls) == 1
+        action, target, content, metadata = calls[0]
+        assert (action, target, content) == ("remove", "memory", "")
+        assert metadata["old_text"] == old_text
+        assert metadata["tool_call_id"] == "mem-1"
+
+    def test_invoke_tool_memory_failed_remove_skips_provider_notification(self, agent, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: None,
+        )
+        manager = SimpleNamespace(
+            has_tool=lambda name: False,
+            on_memory_write=MagicMock(side_effect=AssertionError("should not notify")),
+        )
+        agent._memory_manager = manager
+        agent._memory_store = object()
+
+        with patch(
+            "tools.memory_tool.memory_tool",
+            return_value=json.dumps({"success": False, "error": "No entry matched"}),
+        ):
+            agent._invoke_tool(
+                "memory",
+                {"action": "remove", "target": "memory", "old_text": "missing"},
+                "task-1",
+                tool_call_id="mem-1",
+            )
+
+        manager.on_memory_write.assert_not_called()
 
     def test_concurrent_blocked_write_skips_checkpoint(self, agent, monkeypatch):
         """Concurrent path: blocked write_file should not trigger checkpoint."""


### PR DESCRIPTION
## What does this PR do?

Keeps Hermes native memory semantics unchanged while making the external memory-provider bridge safer and adding a narrow OpenViking deletion tool.

The built-in `memory` tool now notifies external memory providers only after a write actually succeeds and is not staged for approval. The generic bridge still forwards successful `add`, `replace`, and `remove` notifications so providers that can handle those actions may do so, but the OpenViking provider only mirrors built-in `add` writes because Hermes native memory entries do not yet carry stable OpenViking file URIs.

This PR also adds `viking_forget`, an exact-URI delete tool for one OpenViking user memory file. It rejects broad deletion surfaces: resources, skills, sessions, directories, generated summary files, query/fragment URIs, and deprecated `viking://agent/...` memory paths.

The OpenViking provider now also tracks and drains the add-mirroring workers it starts for built-in `memory add` writes, so `content/write` HTTP workers are not left as untracked daemon threads during provider shutdown.

## Related PRs

If merged, this PR closes the following overlapping prior PRs:

- Supersedes and closes #49256 by adding a shared `memory_write_bridge` and applying the success/staged gating across both memory execution paths.
- Supersedes and closes #37351 by replacing broad `viking_delete` with the narrower exact-memory-file `viking_forget` tool.
- Closes #12792 because local file upload support is already present on `main`, while this PR intentionally keeps deletion limited to exact OpenViking memory files instead of broad resource deletion.
- Closes #31006 by keeping OpenViking built-in memory mirroring intentionally add-only; built-in `replace` and `remove` are not mirrored without stable OpenViking file URIs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `agent/memory_write_bridge.py` to collect external-provider notifications only after the built-in memory tool succeeds.
- Updated both agent tool-execution paths to use the bridge and skip failed, malformed, unrecognized, or approval-staged memory-write results.
- Kept OpenViking built-in memory mirroring add-only via `POST /api/v1/content/write` with `mode=create`.
- Tracked and drained OpenViking built-in memory add-mirror workers during provider shutdown.
- Added `_VikingClient.delete()` and a narrow `viking_forget` tool for exact user memory file deletion.
- Aligned generated-summary rejection with OpenViking's actual generated markdown summary files.
- Updated OpenViking plugin docs with current add mirroring and forget behavior.
- Added regression coverage for bridge gating, realistic prose `old_text`, unrecognized memory-tool result shapes, OpenViking add-only mirroring, exact-URI `viking_forget`, URI validation, and shutdown draining for memory add-mirror workers.

## How to Test

1. Focused unit/regression suites:

```bash
scripts/run_tests.sh tests/agent/test_memory_write_bridge.py tests/plugins/memory/test_openviking_provider.py tests/openviking_plugin/test_openviking.py -- -o addopts=
scripts/run_tests.sh tests/run_agent/test_run_agent.py -- -o addopts= -k "sequential_memory_remove_notifies or memory_remove_notifies or failed_remove_skips"
scripts/run_tests.sh tests/agent/test_memory_provider.py tests/tools/test_write_approval.py -- -o addopts= -k "OnMemoryWriteBridge or memory_gate_on_no_interactive_stages or handle_approve_all"
```

2. Static checks:

```bash
UV_NATIVE_TLS=true uv run ruff check agent/memory_write_bridge.py agent/tool_executor.py agent/agent_runtime_helpers.py plugins/memory/openviking/__init__.py tests/agent/test_memory_write_bridge.py tests/agent/test_memory_provider.py tests/plugins/memory/test_openviking_provider.py tests/run_agent/test_run_agent.py tests/tools/test_write_approval.py
git diff --check
```

3. Live local OpenViking integration probe:

- Started a local OpenViking server in API-key mode.
- Verified server health in API-key mode.
- Exercised real Hermes plugin calls for:
  - `on_memory_write(add)`
  - `viking_forget` for peer-scoped memory URI
  - `viking_forget` for canonical `viking://user/default/memories/*.md` URI
  - rejection of a resource URI
- Stopped the server and verified the test listener was cleaned up.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested with a local Hermes worktree and local OpenViking server

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

No UI screenshots. The focused tests and live OpenViking probe above cover the affected behavior.
