### PR TITLE
fix(desktop): use app.exit(0) after updater handoff to prevent EBUSY (#48854)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1837,11 +1837,14 @@ async function applyUpdates(opts = {}) {
 
     rememberLog(`[updates] launched updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release venv shim`)
 
-    // Give the OS a beat to register the new process, then quit. The updater
-    // rebuilds and relaunches us when it's done.
-    setTimeout(() => {
-      app.quit()
-    }, 600)
+    // Force-exit immediately.  releaseBackendLockForUpdate() above already
+    // killed every backend and waited for the venv shim to unlock, so there
+    // is nothing left for a graceful shutdown to do.  Using app.quit()
+    // instead races the updater: on Windows app.quit() drains window-close
+    // handlers and can take seconds, during which the updater starts
+    // `npm ci` which needs to wipe node_modules/electron — still locked by
+    // our live process — causing EBUSY (#48854).
+    app.exit(0)
 
     return { ok: true, handedOff: true, updater }
   } finally {
@@ -1880,9 +1883,8 @@ async function handOffWindowsBootstrapRecovery(reason) {
   child.unref()
 
   rememberLog(`[bootstrap] handed off ${reason} recovery to updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release app.asar`)
-  setTimeout(() => {
-    app.quit()
-  }, 600)
+  // Force-exit immediately — see applyUpdates() rationale above.
+  app.exit(0)
 
   return true
 }
@@ -2086,7 +2088,8 @@ fi
   child.unref()
   rememberLog(`[updates] launched mac swap+relaunch: ${scriptPath} (${rebuiltApp} -> ${targetApp})`)
 
-  setTimeout(() => app.quit(), 600)
+  // Force-exit immediately — see applyUpdates() rationale above.
+  app.exit(0)
   return { ok: true, handedOff: true, rebuiltApp, targetApp }
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2288,6 +2288,49 @@ function Try-RestoreElectronDist {
     return Restore-ElectronDist -InstallDir $InstallDir -Mirror $script:DesktopElectronFallbackMirror
 }
 
+# Wait for the Hermes Desktop (Electron) process to exit before proceeding
+# with npm ci / npm run pack.  On Windows, a still-running Electron process
+# holds an exclusive lock on node_modules\electron, causing npm to fail with
+# EBUSY when it tries to rmdir or rename that directory (#48854).  The
+# Desktop's own app.exit(0) path should release the lock promptly, but
+# this belt-and-suspenders loop covers any lag.
+function Wait-ForDesktopExit {
+    param(
+        [string]$InstallDir,
+        [int]$TimeoutSec = 30
+    )
+    if ($env:OS -ne 'Windows_NT') { return }
+
+    # Hermes.exe is the packaged Electron binary produced by `npm run pack`.
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSec)
+    $waited = $false
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $procs = Get-Process -Name 'Hermes' -ErrorAction SilentlyContinue
+        if (-not $procs -or $procs.Count -eq 0) { break }
+        # Only match processes whose path is inside our install tree.
+        $ours = $procs | Where-Object {
+            try { $_.Path -like "$InstallDir*" } catch { $false }
+        }
+        if (-not $ours -or $ours.Count -eq 0) { break }
+        if (-not $waited) {
+            Write-Info "Waiting for Hermes Desktop to exit (EBUSY guard)..."
+            $waited = $true
+        }
+        Start-Sleep -Milliseconds 500
+    }
+    if ($waited) {
+        # Final check — log if it didn't exit in time so the subsequent
+        # npm error can be attributed to the lock rather than a mystery.
+        $stale = Get-Process -Name 'Hermes' -ErrorAction SilentlyContinue |
+            Where-Object { try { $_.Path -like "$InstallDir*" } catch { $false } }
+        if ($stale -and $stale.Count -gt 0) {
+            Write-Warn "Hermes Desktop still running after ${TimeoutSec}s — npm may hit EBUSY on node_modules\electron"
+        } else {
+            Write-Success "Hermes Desktop exited cleanly"
+        }
+    }
+}
+
 function Install-Desktop {
     # Build apps/desktop into a launchable Hermes.exe. Only called from
     # Stage-Desktop, which is itself only included in the manifest when
@@ -2343,6 +2386,11 @@ function Install-Desktop {
     # the SAME `npm install` Install-NodeDeps does for browser tools,
     # but at the root rather than the browser-tools workspace, so all
     # apps/* workspaces resolve.
+    #
+    # Wait for the Hermes Desktop (Electron) process to exit first: it
+    # holds an exclusive lock on node_modules\electron on Windows, which
+    # causes npm ci to fail with EBUSY (#48854).
+    Wait-ForDesktopExit -InstallDir $InstallDir
     Write-Info "Installing desktop workspace dependencies (this includes Electron ~150MB, takes 1-3min)..."
     Push-Location $InstallDir
     $prevEAP = $ErrorActionPreference


### PR DESCRIPTION
Fixes #48854. After spawning the updater, the Desktop used app.quit() which waits for graceful window-close handlers. On Windows this can take seconds, during which the updater starts npm ci which needs to wipe node_modules/electron - still locked by our live Electron process, causing EBUSY. releaseBackendLockForUpdate() already killed all backends and unlocked the venv shim before spawning the updater, so the graceful shutdown adds no value. Switch to app.exit(0) for immediate termination. Also adds a Wait-ForDesktopExit guard in install.ps1 that polls for stale Hermes processes before running npm ci / npm run pack, as a belt-and-suspenders safety net.