### PR TITLE
fix(kanban): auto-scroll worker log and refresh it on live events

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3028,6 +3028,7 @@
         err ? h("div", { className: "p-4 text-sm text-destructive" }, err) :
         data ? h(TaskDetail, {
           data, editing, setEditing,
+          eventTick: props.eventTick,
           renderMarkdown: props.renderMarkdown,
           allTasks: props.allTasks,
           assignees: props.assignees || [],
@@ -3328,7 +3329,7 @@
           );
         }),
       ),
-      h(WorkerLogSection, { taskId: t.id, boardSlug: props.boardSlug }),
+      h(WorkerLogSection, { taskId: t.id, boardSlug: props.boardSlug, eventTick: props.eventTick }),
       h(RunHistorySection, { runs: props.data.runs || [] }),
     );
   }
@@ -3409,30 +3410,55 @@
     const { t } = useI18n();
     const [state, setState] = useState({ loading: false, data: null, err: null });
     const load = useCallback(function () {
-      setState({ loading: true, data: null, err: null });
+      // Keep the current content visible while a refresh is in flight so live
+      // re-fetches don't blink the log back to a spinner on every event; the
+      // spinner only shows on the first load, when there's nothing yet.
+      setState(function (prev) { return { loading: true, data: prev.data, err: null }; });
       SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/log?tail=100000`, props.boardSlug))
         .then(function (d) { setState({ loading: false, data: d, err: null }); })
-        .catch(function (e) { setState({ loading: false, data: null, err: String(e.message || e) }); });
+        .catch(function (e) {
+          // Preserve stale content on a failed refresh rather than wiping it.
+          setState(function (prev) { return { loading: false, data: prev.data, err: String(e.message || e) }; });
+        });
     }, [props.taskId, props.boardSlug]);
 
-    // Auto-load when the section mounts; the user opened the drawer so the
-    // cost is one small HTTP round-trip.
-    useEffect(function () { load(); }, [load]);
+    // Auto-load on mount and re-fetch on every live task event so the log
+    // tracks the worker as it writes. eventTick bumps on each WS event for
+    // this task; load identity is stable (deps are taskId/boardSlug).
+    useEffect(function () { load(); }, [load, props.eventTick]);
+
+    // Pin the log to the bottom so the newest line stays visible as content
+    // grows. stickRef tracks whether the user is at the bottom; if they
+    // scroll up to read earlier output we stop yanking them back down.
+    const logRef = useRef(null);
+    const stickRef = useRef(true);
+    const onLogScroll = useCallback(function () {
+      const el = logRef.current;
+      if (!el) return;
+      stickRef.current = el.scrollHeight - el.clientHeight - el.scrollTop < 40;
+    }, []);
+    useEffect(function () {
+      const el = logRef.current;
+      if (el && stickRef.current) el.scrollTop = el.scrollHeight;
+    }, [state.data && state.data.content]);
 
     const data = state.data;
     let body;
-    if (state.loading) {
+    if (state.loading && !data) {
       body = h("div", { className: "text-xs text-muted-foreground" },
         tx(t, "loadingLog", "Loading log…"));
-    } else if (state.err) {
+    } else if (state.err && !data) {
       body = h("div", { className: "text-xs text-destructive" }, state.err);
     } else if (!data || !data.exists) {
       body = h("div", { className: "text-xs text-muted-foreground italic" },
         tx(t, "noWorkerLog",
           "— no worker log yet (task hasn't spawned or log was rotated away) —"));
     } else {
-      body = h("pre", { className: "hermes-kanban-pre hermes-kanban-log" },
-        data.content || "(empty)");
+      body = h("pre", {
+        className: "hermes-kanban-pre hermes-kanban-log",
+        ref: logRef,
+        onScroll: onLogScroll,
+      }, data.content || "(empty)");
     }
 
     return h("div", { className: "hermes-kanban-section" },

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2252,3 +2252,37 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+
+def test_dashboard_worker_log_auto_scrolls_to_bottom():
+    """Worker log must pin to the newest line as content grows, unless the
+    user has scrolled up to read earlier output (stick-to-bottom guard)."""
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+
+    # The pre carries a ref and a scroll handler that tracks pinned state.
+    assert "ref: logRef" in js
+    assert "onScroll: onLogScroll" in js
+    # Effect scrolls to the bottom when the log content changes.
+    assert "el.scrollTop = el.scrollHeight" in js
+    assert "}, [state.data && state.data.content]);" in js
+    # Stick-to-bottom guard: only auto-scroll when the user is at the bottom.
+    assert "stickRef.current = el.scrollHeight - el.clientHeight - el.scrollTop < 40" in js
+    assert "if (el && stickRef.current)" in js
+
+
+def test_dashboard_worker_log_refetches_on_live_events():
+    """The log must re-fetch on each live task event (eventTick) and refresh
+    silently — keeping the current content instead of blinking a spinner."""
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+
+    # eventTick is threaded down to the log section and drives re-fetch.
+    assert "h(WorkerLogSection, { taskId: t.id, boardSlug: props.boardSlug, eventTick: props.eventTick })" in js
+    assert "}, [load, props.eventTick]);" in js
+    # Background refresh keeps prior content (no blink to "Loading…" / no wipe).
+    assert "return { loading: true, data: prev.data, err: null };" in js
+    assert "return { loading: false, data: prev.data, err: String(e.message || e) };" in js
+    # Spinner/error only when there is nothing to show yet.
+    assert "if (state.loading && !data)" in js
+    assert "} else if (state.err && !data)" in js


### PR DESCRIPTION
## What & why

The dashboard **Worker log** section only fetched its content on mount and on manual *refresh*, so it never tracked a running worker, and the `<pre>` had no scroll handling — new lines appeared below the fold and the user had to scroll down manually.

## Changes (`plugins/kanban/dashboard/dist/index.js`, `WorkerLogSection`)

- **Live updates:** thread `eventTick` down through `TaskDetail` into `WorkerLogSection` and add it to the load-effect deps, so the log re-fetches on every live task event (same WS-driven tick the rest of the drawer already uses).
- **Silent refresh:** background re-fetches keep the current content (and scroll position) instead of blinking back to a "Loading…" spinner; a failed refresh preserves the stale log rather than wiping it. The spinner/error now only show when there is nothing to display yet.
- **Auto-scroll:** the `<pre>` pins to the bottom when content changes, with a 40px stick-to-bottom guard so a user who scrolls up to read earlier output isn't yanked back down.

## How to test

1. Open the Kanban dashboard, open a task with a running worker.
2. Watch the Worker log grow as the worker writes — it stays pinned to the newest line, no spinner flicker.
3. Scroll up mid-stream → it stops auto-scrolling; scroll back to the bottom → auto-scroll resumes.

Automated: `scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py` — adds `test_dashboard_worker_log_auto_scrolls_to_bottom` and `test_dashboard_worker_log_refetches_on_live_events` (97 passed locally).

## Platforms

Frontend JS only (no file I/O / process / shell). `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)