### PR TITLE
fix(dump): respect WHATSAPP_ENABLED boolean toggle in platform list

### DIFF
--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -164,7 +164,19 @@ def _configured_platforms() -> list[str]:
         "weixin": "WEIXIN_ACCOUNT_ID",
         "qqbot": "QQ_APP_ID",
     }
-    return [name for name, env in checks.items() if os.getenv(env)]
+    truthy = {"true", "1", "yes"}
+    configured: list[str] = []
+    for name, env in checks.items():
+        val = os.getenv(env)
+        if not val:
+            continue
+        # WHATSAPP_ENABLED is a boolean toggle, not a credential. Mirror the
+        # runtime parser (gateway/config.py) so an explicit WHATSAPP_ENABLED=false
+        # / 0 / no is not reported as a configured platform.
+        if name == "whatsapp" and val.strip().lower() not in truthy:
+            continue
+        configured.append(name)
+    return configured
 
 
 def _memory_provider(config: dict) -> str:

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -171,9 +171,12 @@ def _configured_platforms() -> list[str]:
         if not val:
             continue
         # WHATSAPP_ENABLED is a boolean toggle, not a credential. Mirror the
-        # runtime parser (gateway/config.py) so an explicit WHATSAPP_ENABLED=false
-        # / 0 / no is not reported as a configured platform.
-        if name == "whatsapp" and val.strip().lower() not in truthy:
+        # runtime parser EXACTLY: gateway/config.py enables WhatsApp iff
+        # os.getenv("WHATSAPP_ENABLED", "").lower() in {"true", "1", "yes"} —
+        # note it does NOT .strip(), so a padded value like " true " is
+        # disabled at runtime. Stripping here would over-report it as
+        # configured, so we match the runtime (no .strip()).
+        if name == "whatsapp" and val.lower() not in truthy:
             continue
         configured.append(name)
     return configured

--- a/tests/hermes_cli/test_dump_platforms_whatsapp.py
+++ b/tests/hermes_cli/test_dump_platforms_whatsapp.py
@@ -1,0 +1,91 @@
+"""`hermes dump` must report the EFFECTIVE WhatsApp platform state.
+
+``WHATSAPP_ENABLED`` is a boolean toggle, not a credential.  The runtime
+(``gateway/config.py``) enables WhatsApp only when ``WHATSAPP_ENABLED.lower()``
+is in ``{"true", "1", "yes"}`` and treats ``false`` / ``0`` / ``no`` as an
+explicit disable.  ``_configured_platforms`` used a bare presence check, so an
+explicit ``WHATSAPP_ENABLED=false`` (a documented, runtime-honored disable
+value) was still listed under ``platforms:`` — the opposite of the effective
+state.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+# Env vars that, if set in the ambient environment, would add other platforms
+# to the dump output and confuse the assertions below.
+_PLATFORM_ENV_VARS = (
+    "TELEGRAM_BOT_TOKEN",
+    "DISCORD_BOT_TOKEN",
+    "SLACK_BOT_TOKEN",
+    "WHATSAPP_ENABLED",
+    "SIGNAL_HTTP_URL",
+    "EMAIL_ADDRESS",
+    "TWILIO_ACCOUNT_SID",
+    "MATRIX_HOMESERVER_URL",
+    "MATTERMOST_URL",
+    "HASS_TOKEN",
+    "DINGTALK_CLIENT_ID",
+    "FEISHU_APP_ID",
+    "WECOM_BOT_ID",
+    "WECOM_CALLBACK_CORP_ID",
+    "WEIXIN_ACCOUNT_ID",
+    "QQ_APP_ID",
+)
+
+
+def _platforms_line(out: str) -> str:
+    for line in out.splitlines():
+        if line.startswith("  platforms:"):
+            return line
+    raise AssertionError(f"no 'platforms:' line in dump output:\n{out}")
+
+
+def _isolate(monkeypatch, home: Path, tmp_path: Path) -> None:
+    """Clear ambient platform env and stop .env fallbacks from leaking in."""
+    for var in _PLATFORM_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("")
+
+
+def test_whatsapp_disabled_not_listed(monkeypatch, capsys, tmp_path):
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+    _isolate(monkeypatch, get_hermes_home(), tmp_path)
+    monkeypatch.setenv("WHATSAPP_ENABLED", "false")
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _platforms_line(capsys.readouterr().out)
+    assert "whatsapp" not in line
+
+
+def test_whatsapp_enabled_listed(monkeypatch, capsys, tmp_path):
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+    _isolate(monkeypatch, get_hermes_home(), tmp_path)
+    monkeypatch.setenv("WHATSAPP_ENABLED", "true")
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _platforms_line(capsys.readouterr().out)
+    assert "whatsapp" in line
+
+
+def test_whatsapp_zero_not_listed(monkeypatch, capsys, tmp_path):
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+    _isolate(monkeypatch, get_hermes_home(), tmp_path)
+    monkeypatch.setenv("WHATSAPP_ENABLED", "0")
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _platforms_line(capsys.readouterr().out)
+    assert "whatsapp" not in line

--- a/tests/hermes_cli/test_dump_platforms_whatsapp.py
+++ b/tests/hermes_cli/test_dump_platforms_whatsapp.py
@@ -41,7 +41,7 @@ def _platforms_line(out: str) -> str:
     raise AssertionError(f"no 'platforms:' line in dump output:\n{out}")
 
 
-def _isolate(monkeypatch, home: Path, tmp_path: Path) -> None:
+def _isolate(monkeypatch, home: Path, _tmp_path: Path) -> None:
     """Clear ambient platform env and stop .env fallbacks from leaking in."""
     for var in _PLATFORM_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
@@ -84,6 +84,23 @@ def test_whatsapp_zero_not_listed(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
     _isolate(monkeypatch, get_hermes_home(), tmp_path)
     monkeypatch.setenv("WHATSAPP_ENABLED", "0")
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _platforms_line(capsys.readouterr().out)
+    assert "whatsapp" not in line
+
+
+def test_whatsapp_padded_true_not_listed(monkeypatch, capsys, tmp_path):
+    # Runtime-mirror: gateway/config.py does NOT .strip() WHATSAPP_ENABLED, so
+    # a padded " true " is disabled at runtime. The dump must report the same
+    # effective state — it must NOT strip and over-report it as configured.
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+    _isolate(monkeypatch, get_hermes_home(), tmp_path)
+    monkeypatch.setenv("WHATSAPP_ENABLED", " true ")
 
     dump.run_dump(SimpleNamespace(show_keys=False))
 


### PR DESCRIPTION
## What does this PR do?

`hermes dump` (and `hermes debug share`) lists `whatsapp` under `platforms:` whenever `WHATSAPP_ENABLED` is set to **any** non-empty value — including the documented explicit-disable values `false` / `0` / `no`. The runtime treats `WHATSAPP_ENABLED` as a boolean (`gateway/config.py`: enabled only when `.lower()` is in `{"true","1","yes"}`), so the diagnostic reports the opposite of the effective state and misdirects support triage. This mirrors the runtime parser for the WhatsApp toggle while leaving the credential-style entries' presence check unchanged.

> Mirrors the runtime resolver in `gateway/config.py` **exactly**: WhatsApp is enabled iff `os.getenv("WHATSAPP_ENABLED", "").lower() in {"true", "1", "yes"}` — note the runtime does **NOT** `.strip()`, so a padded value like `" true "` is disabled at runtime. The dump matches this precedence byte-for-byte (no `.strip()`, same truthy set), so it never over-reports a padded toggle as configured.

> Audited siblings: the other entries in `_configured_platforms` are credentials / IDs / URLs where non-empty == configured (correct); `WHATSAPP_ENABLED` is the only boolean toggle in the dict. No widening needed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dump.py`: in `_configured_platforms`, special-case the `whatsapp` boolean toggle so an explicit `WHATSAPP_ENABLED=false`/`0`/`no` is not reported as configured; credential-style entries keep their presence check.
- `tests/hermes_cli/test_dump_platforms_whatsapp.py` (new): regression coverage for disabled / enabled / zero.

## How to Test

1. `WHATSAPP_ENABLED=false hermes dump` — before this PR, `platforms:` lists `whatsapp`; after, it does not.
2. `WHATSAPP_ENABLED=true hermes dump` — `whatsapp` is listed (no over-correction).
3. `pytest tests/hermes_cli/test_dump_platforms_whatsapp.py` — the disabled/zero cases fail before the prod hunk and pass after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_dump_platforms_whatsapp.py` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
