### PR TITLE
fix(cron): accept float and numeric-string scores in classify_items

### DIFF
--- a/cron/scripts/classify_items.py
+++ b/cron/scripts/classify_items.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from typing import Any, Dict, List, Optional
 
@@ -115,17 +116,27 @@ def _coerce_score(value: Any) -> Optional[float]:
     float and models frequently emit ``"8"`` as a string. Accept any numeric
     form; return None for anything non-numeric. ``bool`` is rejected explicitly
     (it is an int subclass that must not be read as a score).
+
+    Non-finite results (``NaN``/``inf``/``-inf``) are rejected too: ``float()``
+    happily parses JSON ``1e309`` -> ``inf`` and strings like ``"nan"`` /
+    ``"inf"``, and a non-finite score silently corrupts the threshold gate
+    (``NaN`` is never ``>=`` the threshold so the item is dropped; ``inf`` is
+    always ``>=`` so it is always surfaced as spam). Treat them as non-numeric.
     """
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
+        score = float(value)
+    elif isinstance(value, str):
         try:
-            return float(value.strip())
+            score = float(value.strip())
         except ValueError:
             return None
-    return None
+    else:
+        return None
+    if not math.isfinite(score):
+        return None
+    return score
 
 
 def _parse_scores(content: str, n_items: int) -> Dict[int, Dict[str, Any]]:

--- a/cron/scripts/classify_items.py
+++ b/cron/scripts/classify_items.py
@@ -108,6 +108,26 @@ def _build_prompt(items: List[Dict[str, Any]], criteria: str) -> str:
     return "\n".join(lines)
 
 
+def _coerce_score(value: Any) -> Optional[float]:
+    """Coerce an LLM-returned score to a float for threshold comparison.
+
+    The classifier is asked for an int 0-10, but JSON ``8.0`` deserializes to a
+    float and models frequently emit ``"8"`` as a string. Accept any numeric
+    form; return None for anything non-numeric. ``bool`` is rejected explicitly
+    (it is an int subclass that must not be read as a score).
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
 def _parse_scores(content: str, n_items: int) -> Dict[int, Dict[str, Any]]:
     text = (content or "").strip()
     # Tolerate accidental markdown fences.
@@ -182,8 +202,9 @@ def main() -> int:
     surfaced = []
     for i, item in enumerate(items):
         s = scores.get(i)
-        score = s.get("score") if isinstance(s, dict) else None
-        if isinstance(score, int) and score >= args.threshold:
+        raw_score = s.get("score") if isinstance(s, dict) else None
+        score = _coerce_score(raw_score)
+        if score is not None and score >= args.threshold:
             surfaced.append((i, item, s))
 
     if not surfaced:

--- a/tests/cron/test_classify_items.py
+++ b/tests/cron/test_classify_items.py
@@ -1,0 +1,100 @@
+"""``classify_items`` must surface items whose score arrives as a JSON float or
+a numeric string, not only as a Python ``int``.
+
+The threshold gate used ``isinstance(score, int)``. LLM classifiers routinely
+return the score as a JSON float (``8.0`` -> ``float``) or a numeric string
+(``"8"``); both failed the strict ``int`` check, so a genuinely urgent item was
+silently dropped -> empty stdout -> the cron monitor treats it as "nothing to
+report" and suppresses delivery. That is the silent-swallow failure the
+script's own docstring warns against.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from cron.scripts import classify_items
+
+
+def _fake_response(score_payload):
+    """Build an object shaped like the auxiliary-client response.
+
+    ``main()`` reads ``resp.choices[0].message.content`` and expects a JSON
+    array string of ``{"index", "score", "reason"}`` objects.
+    """
+    content = json.dumps([{"index": 0, "score": score_payload, "reason": "x"}])
+    message = SimpleNamespace(content=content)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
+
+
+def _run(monkeypatch, capsys, tmp_path, *, score_payload, threshold=7):
+    """Drive ``classify_items.main()`` with one item and a stubbed classifier."""
+    items_file = tmp_path / "items.json"
+    items_file.write_text(json.dumps([{"title": "Server on fire"}]))
+
+    def _fake_call_llm(*args, **kwargs):
+        return _fake_response(score_payload)
+
+    # main() lazily does ``from agent.auxiliary_client import call_llm``.
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", _fake_call_llm)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "classify_items.py",
+            "--criteria",
+            "urgent",
+            "--threshold",
+            str(threshold),
+            "--input-file",
+            str(items_file),
+        ],
+    )
+    rc = classify_items.main()
+    return rc, capsys.readouterr().out
+
+
+def test_float_score_surfaced(monkeypatch, capsys, tmp_path):
+    rc, out = _run(monkeypatch, capsys, tmp_path, score_payload=8.0)
+    assert rc == 0
+    assert "Server on fire" in out
+
+
+def test_string_score_surfaced(monkeypatch, capsys, tmp_path):
+    rc, out = _run(monkeypatch, capsys, tmp_path, score_payload="8")
+    assert rc == 0
+    assert "Server on fire" in out
+
+
+def test_int_score_surfaced(monkeypatch, capsys, tmp_path):
+    # Guards against regressing the already-working int path.
+    rc, out = _run(monkeypatch, capsys, tmp_path, score_payload=8)
+    assert rc == 0
+    assert "Server on fire" in out
+
+
+def test_below_threshold_silent(monkeypatch, capsys, tmp_path):
+    # Threshold semantics must still hold: a 3.0 stays silent (empty stdout).
+    rc, out = _run(monkeypatch, capsys, tmp_path, score_payload=3.0)
+    assert rc == 0
+    assert out.strip() == ""
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (8, 8.0),
+        (8.0, 8.0),
+        ("8", 8.0),
+        (" 8 ", 8.0),
+        (True, None),
+        (False, None),
+        ("not-a-number", None),
+        (None, None),
+    ],
+)
+def test_coerce_score(value, expected):
+    assert classify_items._coerce_score(value) == expected

--- a/tests/cron/test_classify_items.py
+++ b/tests/cron/test_classify_items.py
@@ -94,6 +94,17 @@ def test_below_threshold_silent(monkeypatch, capsys, tmp_path):
         (False, None),
         ("not-a-number", None),
         (None, None),
+        # Non-finite results must be rejected: a NaN score never clears the
+        # threshold (silent drop) and an inf score always clears it (spam).
+        # float() parses all of these, so an explicit isfinite guard is needed.
+        ("nan", None),
+        ("inf", None),
+        ("-inf", None),
+        ("Infinity", None),
+        ("1e309", None),  # overflows to inf
+        (float("nan"), None),
+        (float("inf"), None),
+        (float("-inf"), None),
     ],
 )
 def test_coerce_score(value, expected):


### PR DESCRIPTION
## What does this PR do?

`classify_items.py` filters items with `isinstance(score, int) and score >= threshold`. LLM classifiers routinely return the score as a JSON float (`8.0`) or a numeric string (`"8"`); both fail the strict `int` check, so a genuinely urgent item is silently dropped — producing empty stdout, which the cron monitor treats as "nothing to report" and suppresses. This is the silent-swallow failure the script's own docstring warns against. This PR coerces the score to a number (accepting int/float/numeric-string, rejecting `bool`) before the threshold test.

> Audited siblings: `_coerce_score` is applied at the single threshold gate; the `--format json`/text output paths read `s.get("score")` verbatim for display, which is correct. No widening needed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scripts/classify_items.py`: add `_coerce_score` (accepts int/float/numeric-string, rejects `bool`, returns None for non-numeric); the threshold loop coerces the raw score before comparing to `--threshold`.
- `tests/cron/test_classify_items.py` (new): float/string scores surface; below-threshold and the int path stay correct; `_coerce_score` unit table including bool rejection.

## How to Test

1. Feed one item and stub the classifier to return `{"index":0,"score":8.0,...}` (a JSON float) with `--threshold 7` — before this PR the item is dropped (empty stdout); after, it surfaces.
2. Same with `"score":"8"` (numeric string) — surfaced after the fix.
3. `"score":3.0` stays silent (below threshold); `"score":true` is not read as a score.
4. `pytest tests/cron/test_classify_items.py` — the float/string cases fail before the prod hunk and pass after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/test_classify_items.py` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A