### PR TITLE
fix(desktop): resume stored session id on notification click

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -20,6 +20,7 @@ import {
   MESSAGING_SESSION_SOURCE_IDS,
   normalizeSessionSource
 } from '../lib/session-source'
+import { storedSessionIdForNotification } from '../lib/session-ids'
 import { latestSessionTodos } from '../lib/todos'
 import { setCronFocusJobId, setCronJobs } from '../store/cron'
 import {
@@ -276,16 +277,20 @@ export function DesktopController() {
     }
   }, [])
 
-  // Notification click: the main process already focused the window; jump to its session.
+  // Notification click: the main process already focused the window; jump to its
+  // session. Notifications are tagged with the gateway *runtime* session id, but
+  // the chat route is keyed by the *stored* id — navigating with the runtime id
+  // resumes a non-existent stored session ("session not found") and strands the
+  // user. Translate runtime -> stored before navigating.
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onFocusSession?.(sessionId => {
       if (sessionId) {
-        navigate(sessionRoute(sessionId))
+        navigate(sessionRoute(storedSessionIdForNotification(sessionId, runtimeIdByStoredSessionIdRef.current)))
       }
     })
 
     return () => unsubscribe?.()
-  }, [navigate])
+  }, [navigate, runtimeIdByStoredSessionIdRef])
 
   // Notification action button (Approve/Reject) — resolve in place, no navigation.
   useEffect(() => {

--- a/apps/desktop/src/lib/session-ids.test.ts
+++ b/apps/desktop/src/lib/session-ids.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { storedSessionIdForNotification } from './session-ids'
+
+describe('storedSessionIdForNotification', () => {
+  it('translates a runtime id back to its stored id', () => {
+    // The route is keyed by the stored id, but notifications carry the runtime
+    // id. Resolving runtime -> stored keeps notification-click navigation from
+    // resuming a non-existent stored session ("session not found").
+    const map = new Map([['stored-abc', 'runtime-123']])
+
+    expect(storedSessionIdForNotification('runtime-123', map)).toBe('stored-abc')
+  })
+
+  it('returns the id unchanged when no mapping is known', () => {
+    // A notification for a session this window never opened may already carry a
+    // stored id; let the resume/REST lookup handle it as-is.
+    const map = new Map([['stored-abc', 'runtime-123']])
+
+    expect(storedSessionIdForNotification('stored-xyz', map)).toBe('stored-xyz')
+  })
+
+  it('returns the id unchanged for an empty map', () => {
+    expect(storedSessionIdForNotification('runtime-123', new Map())).toBe('runtime-123')
+  })
+
+  it('resolves the correct stored id among several sessions', () => {
+    const map = new Map([
+      ['stored-1', 'runtime-1'],
+      ['stored-2', 'runtime-2'],
+      ['stored-3', 'runtime-3']
+    ])
+
+    expect(storedSessionIdForNotification('runtime-2', map)).toBe('stored-2')
+  })
+
+  it('does not treat a stored id as a runtime id (keys are not matched)', () => {
+    // The map is stored -> runtime. A value that only appears as a *key* must
+    // not be rewritten, otherwise an already-stored id could be mangled.
+    const map = new Map([['stored-1', 'runtime-1']])
+
+    expect(storedSessionIdForNotification('stored-1', map)).toBe('stored-1')
+  })
+})

--- a/apps/desktop/src/lib/session-ids.ts
+++ b/apps/desktop/src/lib/session-ids.ts
@@ -1,0 +1,26 @@
+// The gateway tags every event — and therefore every native notification —
+// with the *runtime* session id (the key under which the session lives in the
+// gateway's in-memory `_sessions` map). The chat route, however, is keyed by
+// the *stored* session id (`stored_session_id`), which is a different value:
+// a brand-new chat gets a runtime id immediately but its stored id is assigned
+// when the first turn persists. Navigating to a runtime id therefore tries to
+// resume a stored session that does not exist ("session not found") and
+// strands the user, who experiences it as the running session being destroyed.
+//
+// `runtimeIdByStoredSessionId` maps stored -> runtime; this resolves the
+// reverse so notification-click navigation lands on the real route. The id is
+// returned unchanged when no mapping is known — it may already be a stored id
+// (e.g. a notification for a session this window never opened), in which case
+// the normal resume/REST lookup handles it.
+export function storedSessionIdForNotification(
+  id: string,
+  runtimeIdByStoredSessionId: ReadonlyMap<string, string>
+): string {
+  for (const [storedId, runtimeId] of runtimeIdByStoredSessionId) {
+    if (runtimeId === id) {
+      return storedId
+    }
+  }
+
+  return id
+}


### PR DESCRIPTION
## Summary

Clicking a desktop native notification (approval / sudo / secret / clarify) while an agent turn is in flight could destroy the running session and surface **"Resume failed: session not found"**.

Root cause is a runtime-id vs stored-id confusion:

- The gateway tags **every event** — and therefore every native notification — with the **runtime** session id (`tui_gateway/server.py:991` → `_emit("approval.request", sid, …)`, where `sid` is the key in the in-memory `_sessions` map).
- The desktop stream forwards that id verbatim (`use-message-stream.ts:717-723`, `:1011`).
- But the chat **route is keyed by the stored id** (`stored_session_id`), which is a *different* value — see `use-session-actions.ts:483,493` (`activeSessionId = created.session_id`, but `navigate(sessionRoute(created.stored_session_id))`).
- `onFocusSession` navigated straight to `sessionRoute(<runtime id>)` (`desktop-controller.tsx:281-284`). `useRouteResume` then treats the route id as a stored id (`use-route-resume.ts:116,150` → `resumeSession(routedSessionId)`), so it resumes a runtime id as if it were stored → REST `/api/sessions/<runtime id>` **404 "session not found"**, and the user is navigated off the live session (feels like it was destroyed).

### Fix

Translate runtime → stored at the navigation step, using the existing `runtimeIdByStoredSessionId` map (new `storedSessionIdForNotification` helper). Falls back to the id as-is when no mapping is known (it may already be a stored id).

The **Approve/Reject notification button** path is deliberately left untouched: `approval.respond` is routed by the runtime id (`server.py:7547` → `_sess()` → `_sessions[session_id]`), so it must keep carrying the runtime id. Only navigation was wrong.

This fixes the whole notification class (approval, sudo, secret, clarify) since they all flow through the same `onFocusSession` navigation.

## Test plan

- [x] `npx vitest run apps/desktop/src/lib/session-ids.test.ts` — 5 passing
- [x] `npm run typecheck` (apps/desktop) clean
- [ ] Manual: trigger a dangerous-command approval, click the OS notification body → lands on the live session instead of "session not found"