### PR TITLE
feat(model-picker): show google-gemini-cli as authenticated when OAuth creds exist

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1520,6 +1520,14 @@ def list_authenticated_providers(
                     has_creds = True
             except Exception as exc:
                 logger.debug("Credential pool check failed for %s: %s", hermes_slug, exc)
+        # Google Gemini OAuth stores its real credentials in
+        # ~/.hermes/auth/google_oauth.json instead of the generic auth store.
+        if not has_creds and hermes_slug == "google-gemini-cli":
+            try:
+                from hermes_cli.auth import get_gemini_oauth_auth_status
+                has_creds = bool((get_gemini_oauth_auth_status() or {}).get("logged_in"))
+            except Exception as exc:
+                logger.debug("Gemini OAuth status check failed: %s", exc)
         # Fallback: check external credential files directly.
         # The credential pool gates anthropic behind
         # is_provider_explicitly_configured() to prevent auxiliary tasks


### PR DESCRIPTION
## What does this PR do?

The `/model` picker (`list_authenticated_providers`) marks `google-gemini-cli` as **not authenticated** even when the user is logged in via Gemini OAuth, because Gemini OAuth credentials live in `~/.hermes/auth/google_oauth.json` rather than the generic auth store or credential pool that the function checks. As a result, Gemini models cannot be selected from the picker after logging in.

This adds a `google-gemini-cli` special-case that consults the real OAuth store via `get_gemini_oauth_auth_status().logged_in`. It is **pattern-identical to the existing `anthropic` special-case** a few lines below in the same function, which reads Claude Code / Hermes OAuth credential files directly for the same discovery-oriented reason.

## Related Issue

No existing issue — standalone fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py` — in `list_authenticated_providers()`, after the credential-pool check, mark `google-gemini-cli` as having credentials when `get_gemini_oauth_auth_status()` reports `logged_in`. Wrapped in try/except with a debug log on failure, mirroring the adjacent `anthropic` block.

## How to Test

1. Log in to Gemini via Google OAuth in Hermes.
2. **Before:** open the `/model` picker → `google-gemini-cli` shows as unauthenticated and Gemini models aren't selectable.
3. **After:** `google-gemini-cli` appears as authenticated and its models are selectable.

## Checklist

- [x] Self-contained, non-breaking change
- [x] Mirrors an existing reviewed pattern in the same function (`anthropic`)
- [x] `python -m py_compile hermes_cli/model_switch.py` passes
