### PR TITLE
feat(webhook): add per-subscription model override

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -641,6 +641,32 @@ class WebhookAdapter(BasePlatformAdapter):
             user_id=f"webhook:{route_name}",
             user_name=route_name,
         )
+
+        # Apply model override if configured on this subscription.
+        # The gateway runner reads _session_model_overrides when creating
+        # the agent for a session, so we register the override here before
+        # spawning the agent task.  The override is scoped to this exact
+        # session_chat_id (unique per delivery) so it cannot leak.
+        route_model = route_config.get("model")
+        if route_model and self.gateway_runner:
+            try:
+                from gateway.run import GatewayRunner
+                if isinstance(self.gateway_runner, GatewayRunner):
+                    if isinstance(route_model, dict):
+                        override = {
+                            "model": route_model.get("model", ""),
+                            "provider": route_model.get("provider", ""),
+                        }
+                    else:
+                        override = {"model": str(route_model)}
+                    self.gateway_runner._session_model_overrides[session_chat_id] = override
+                    logger.info(
+                        "[webhook] Model override applied: session=%s -> %s",
+                        session_chat_id, override,
+                    )
+            except Exception as e:
+                logger.warning("[webhook] Failed to apply model override: %s", e)
+
         event = MessageEvent(
             text=prompt,
             message_type=MessageType.TEXT,

--- a/hermes_cli/subcommands/webhook.py
+++ b/hermes_cli/subcommands/webhook.py
@@ -55,6 +55,12 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
         "message. Zero LLM cost. Requires --deliver to be a real target "
         "(not 'log').",
     )
+    wh_sub.add_argument(
+        "--model",
+        default="",
+        help="Model override for agent runs (e.g. 'anthropic/claude-sonnet-4' "
+        "or 'openai/gpt-4o'). Supports 'provider/model' format.",
+    )
 
     webhook_subparsers.add_parser(
         "list", aliases=["ls"], help="List all dynamic subscriptions"

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -180,6 +180,15 @@ def _cmd_subscribe(args):
         "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
 
+    # Model override: supports "provider:model" or bare "model"
+    model_arg = getattr(args, "model", "") or ""
+    if model_arg:
+        if "/" in model_arg:
+            parts = model_arg.split("/", 1)
+            route["model"] = {"provider": parts[0], "model": parts[1]}
+        else:
+            route["model"] = model_arg
+
     if getattr(args, "deliver_only", False):
         if route["deliver"] == "log":
             print(
@@ -206,6 +215,13 @@ def _cmd_subscribe(args):
     else:
         print("  Events: (all)")
     print(f"  Deliver: {route['deliver']}")
+    if route.get("model"):
+        model_cfg = route["model"]
+        if isinstance(model_cfg, dict):
+            model_str = f"{model_cfg.get('provider', '')}/{model_cfg.get('model', '')}"
+        else:
+            model_str = str(model_cfg)
+        print(f"  Model:  {model_str}")
     if route.get("deliver_only"):
         print("  Mode: direct delivery (no agent, zero LLM cost)")
     if route.get("prompt"):
@@ -238,6 +254,13 @@ def _cmd_list(args):
         print(f"    URL:     {base_url}/webhooks/{name}")
         print(f"    Events:  {events}")
         print(f"    Deliver: {deliver}")
+        model_cfg = route.get("model")
+        if model_cfg:
+            if isinstance(model_cfg, dict):
+                model_str = f"{model_cfg.get('provider', '')}/{model_cfg.get('model', '')}"
+            else:
+                model_str = str(model_cfg)
+            print(f"    Model:   {model_str}")
         print()
 
 


### PR DESCRIPTION
## Summary

Allow webhook subscriptions to specify a model override, bringing them to parity with cron jobs (which already support `--model`).

## What this adds

- **CLI**: `hermes webhook subscribe <name> --model 'provider/model'`
- **JSON**: `"model": "provider/model"` or `"model": {"provider": "x", "model": "y"}`
- **Display**: Model shown in `hermes webhook list` output

## How it works

The webhook adapter reads the `model` field from the route config and registers it in `GatewayRunner._session_model_overrides` before spawning the agent task. The key is scoped to the unique `delivery_id` so the override cannot leak across sessions.

## Changes

| File | Change |
|------|--------|
| `hermes_cli/main.py` | Add `--model` argument to subscribe subparser |
| `hermes_cli/webhook.py` | Save model to subscription JSON + display in list/create |
| `gateway/platforms/webhook.py` | Inject model override into `_session_model_overrides` |

## Use case

Run a more powerful model for complex webhook-driven workflows (e.g. GitHub PR automation) while keeping a faster/cheaper default for everything else.