### PR TITLE
fix(terminal): Ctrl+C now copies mouse selection instead of sending interrupt signal

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -545,6 +545,14 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
 
     cleanup.push(() => dataDisposable.dispose())
 
+    term.attachCustomKeyEventHandler(ev => {
+      if (ev.type === 'keydown' && ev.ctrlKey && ev.key === 'c' && selectionRef.current) {
+        void navigator.clipboard.writeText(selectionRef.current)
+        term.clearSelection()
+        return false
+      }
+      return true
+    })
     const selectionDisposable = term.onSelectionChange(() => {
       const next = term.getSelection()
       selectionRef.current = next


### PR DESCRIPTION
## Problem
In the built-in terminal (PowerShell, opened via Ctrl+~), selecting text 
with the mouse and pressing Ctrl+C did not copy the text to clipboard. 
Instead, it sent `\x03` (interrupt signal) to the PTY, showing:

PS C:\Users\Aleksandr> test test^C

Keyboard selection (Shift+Home) worked correctly with Ctrl+C.
Right-click → Copy worked in both cases.

## Root Cause
xterm.js intercepts all keyboard input before it reaches `onData`. 
When using mouse selection, the selected text is stored in `selectionRef` 
(updated via `onSelectionChange`), but nothing intercepted Ctrl+C to use it.
`term.hasSelection()` returned false at the time of the keypress because 
the selection was already cleared by the time `onData` fired.

## Fix
Added `attachCustomKeyEventHandler` which fires before any other keyboard 
handler. If Ctrl+C is pressed and `selectionRef.current` contains selected 
text — copy it to clipboard and block the event from reaching PTY. 
If nothing is selected — return true so Ctrl+C works normally as interrupt.

## Testing
- Manually patched the minified JS in the installed app via asar
- Verified: mouse selection + Ctrl+C now copies text correctly
- Verified: Ctrl+C without selection still works as interrupt signal  
- Verified: Shift+Home selection + Ctrl+C still works correctly
- Video attached showing before/after behavior

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts` added `term.attachCustomKeyEventHandler` before `term.onSelectionChange` to intercept Ctrl+C when text is selected via mouse

## How to Test
1. Open Hermes Desktop and open the terminal with Ctrl+~
2. Type `test test` and select it with the mouse (blue highlight appears)
3. Press Ctrl+C
4. Open any text editor or input field and press Ctrl+V
5. Verify that `test test` is pasted correctly
6. Also verify: pressing Ctrl+C without any selection still works as interrupt (shows `^C` in terminal)

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(terminal): intercept Ctrl+C to copy mouse selection to clipboard`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [ ] I've updated relevant documentation — N/A
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — fix uses standard Web APIs (`navigator.clipboard`, `attachCustomKeyEventHandler`) that work on Windows, macOS, Linux
- [ ] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Before

https://github.com/user-attachments/assets/46d2c4e2-26d7-442d-89e5-966340777b47

After


https://github.com/user-attachments/assets/f7f5d007-b6f9-4d30-af87-84bfa0c02783


