### PR TITLE
feat(honcho): expose filterable memory toolset

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -45,22 +45,68 @@ logger = logging.getLogger(__name__)
 _SYNC_DRAIN_TIMEOUT_S = 5.0
 
 
-def memory_provider_tools_enabled(enabled_toolsets: Optional[List[str]]) -> bool:
-    """Return whether external memory-provider tools should be exposed."""
-    if enabled_toolsets is None:
-        return True
-    if not enabled_toolsets:
-        return False
-    if "memory" in enabled_toolsets:
-        return True
-
+def _resolve_toolset_safely(name: str) -> set[str]:
     try:
         from toolsets import resolve_toolset
 
-        return any("memory" in resolve_toolset(name) for name in enabled_toolsets)
+        return set(resolve_toolset(name))
+    except Exception:
+        logger.debug("Failed to resolve toolset '%s' for memory-provider tools", name, exc_info=True)
+        return set()
+
+
+def _enabled_memory_provider_tool_names(
+    enabled_toolsets: Optional[List[str]],
+    provider_tool_names: set[str],
+) -> Optional[set[str]]:
+    """Return enabled provider tool names, or None when all provider tools are enabled."""
+    if enabled_toolsets is None:
+        return None
+    if not enabled_toolsets:
+        return set()
+    if "memory" in enabled_toolsets:
+        return None
+
+    try:
+        enabled_names: set[str] = set()
+        for name in enabled_toolsets:
+            resolved = _resolve_toolset_safely(name)
+            if "memory" in resolved:
+                return None
+            enabled_names.update(provider_tool_names & resolved)
+        return enabled_names
     except Exception:
         logger.debug("Failed to resolve enabled toolsets for memory-provider tools", exc_info=True)
-        return False
+        return set()
+
+
+def memory_provider_tools_enabled(
+    enabled_toolsets: Optional[List[str]],
+    provider_tool_names: Optional[set[str]] = None,
+) -> bool:
+    """Return whether external memory-provider tools should be exposed."""
+    enabled_names = _enabled_memory_provider_tool_names(
+        enabled_toolsets,
+        provider_tool_names or set(),
+    )
+    return enabled_names is None or bool(enabled_names)
+
+
+def _disabled_memory_provider_tool_names(
+    disabled_toolsets: Optional[List[str]],
+    provider_tool_names: set[str],
+) -> Optional[set[str]]:
+    """Return disabled provider tool names, or None when all memory tools are disabled."""
+    if not disabled_toolsets:
+        return set()
+
+    disabled_names: set[str] = set()
+    for toolset_name in disabled_toolsets:
+        resolved = _resolve_toolset_safely(toolset_name)
+        if toolset_name in {"memory", "*", "all"}:
+            return None
+        disabled_names.update(provider_tool_names & resolved)
+    return disabled_names
 
 
 def inject_memory_provider_tools(agent: Any) -> int:
@@ -70,19 +116,34 @@ def inject_memory_provider_tools(agent: Any) -> int:
     if not memory_manager or tools is None:
         return 0
 
+    get_schemas = getattr(memory_manager, "get_all_tool_schemas", None)
+    if not callable(get_schemas):
+        return 0
+
+    provider_schemas = [
+        schema for schema in get_schemas()
+        if isinstance(schema, dict) and schema.get("name", "")
+    ]
+    provider_tool_names = {schema["name"] for schema in provider_schemas}
+    enabled_tool_names = _enabled_memory_provider_tool_names(
+        getattr(agent, "enabled_toolsets", None),
+        provider_tool_names,
+    )
     existing_tool_names = {
         tool.get("function", {}).get("name")
         for tool in tools
         if isinstance(tool, dict)
     }
-    if (
-        "memory" not in existing_tool_names
-        and not memory_provider_tools_enabled(getattr(agent, "enabled_toolsets", None))
-    ):
+    if "memory" in existing_tool_names:
+        enabled_tool_names = None
+    elif enabled_tool_names == set():
         return 0
 
-    get_schemas = getattr(memory_manager, "get_all_tool_schemas", None)
-    if not callable(get_schemas):
+    disabled_tool_names = _disabled_memory_provider_tool_names(
+        getattr(agent, "disabled_toolsets", None),
+        provider_tool_names,
+    )
+    if disabled_tool_names is None:
         return 0
 
     valid_tool_names = getattr(agent, "valid_tool_names", None)
@@ -91,10 +152,12 @@ def inject_memory_provider_tools(agent: Any) -> int:
         agent.valid_tool_names = valid_tool_names
 
     added = 0
-    for schema in get_schemas():
-        if not isinstance(schema, dict):
+    for schema in provider_schemas:
+        tool_name = schema["name"]
+        if enabled_tool_names is not None and tool_name not in enabled_tool_names:
             continue
-        tool_name = schema.get("name", "")
+        if tool_name in disabled_tool_names:
+            continue
         if not tool_name or tool_name in existing_tool_names:
             continue
         tools.append({"type": "function", "function": schema})

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -107,6 +107,41 @@ class CoreShadowProvider:
         ]
 
 
+class HonchoToolProvider:
+    """Provider exposing the Honcho tool names without importing Honcho SDK."""
+
+    name = "honcho"
+
+    def get_tool_schemas(self):
+        return [
+            {"name": "honcho_search", "description": "Search Honcho memory"},
+            {"name": "honcho_conclude", "description": "Save a Honcho conclusion"},
+        ]
+
+
+class OtherMemoryToolProvider:
+    """Non-Honcho provider used to prove the honcho toolset is provider-specific."""
+
+    name = "other-memory"
+
+    def get_tool_schemas(self):
+        return [
+            {"name": "other_memory_search", "description": "Search another memory backend"},
+        ]
+
+
+class OverbroadHonchoToolProvider:
+    """Honcho-like provider that reports a non-Honcho tool too."""
+
+    name = "honcho"
+
+    def get_tool_schemas(self):
+        return [
+            {"name": "honcho_search", "description": "Search Honcho memory"},
+            {"name": "other_memory_search", "description": "Search another memory backend"},
+        ]
+
+
 def test_core_tool_names_rejected_from_memory_routing_table():
     """Memory tools shadowing core tool names are rejected at registration (#40466).
 
@@ -134,6 +169,165 @@ def test_core_tool_names_rejected_from_memory_routing_table():
     assert "clarify" not in schema_names
     assert "delegate_task" not in schema_names
     assert "honcho_search" in schema_names
+
+
+def test_honcho_toolset_enables_memory_provider_tool_injection():
+    """Restricted sessions can opt into Honcho tools by naming the honcho toolset."""
+    from agent.memory_manager import MemoryManager, inject_memory_provider_tools
+
+    mm = MemoryManager()
+    mm.add_provider(HonchoToolProvider())
+    agent = SimpleNamespace(
+        _memory_manager=mm,
+        tools=[],
+        enabled_toolsets=["honcho"],
+        valid_tool_names=set(),
+    )
+
+    added = inject_memory_provider_tools(agent)
+    tool_names = {tool["function"]["name"] for tool in agent.tools}
+
+    assert added == 2
+    assert tool_names == {"honcho_search", "honcho_conclude"}
+    assert agent.valid_tool_names == tool_names
+
+
+def test_honcho_toolset_only_injects_matching_provider_tool_names():
+    from agent.memory_manager import MemoryManager, inject_memory_provider_tools
+
+    mm = MemoryManager()
+    mm.add_provider(OverbroadHonchoToolProvider())
+    agent = SimpleNamespace(
+        _memory_manager=mm,
+        tools=[],
+        enabled_toolsets=["honcho"],
+        valid_tool_names=set(),
+    )
+
+    added = inject_memory_provider_tools(agent)
+    tool_names = {tool["function"]["name"] for tool in agent.tools}
+
+    assert added == 1
+    assert tool_names == {"honcho_search"}
+    assert agent.valid_tool_names == tool_names
+
+
+def test_existing_core_memory_tool_keeps_provider_injection_compatible():
+    from agent.memory_manager import MemoryManager, inject_memory_provider_tools
+
+    mm = MemoryManager()
+    mm.add_provider(OverbroadHonchoToolProvider())
+    agent = SimpleNamespace(
+        _memory_manager=mm,
+        tools=[{"type": "function", "function": {"name": "memory"}}],
+        enabled_toolsets=["terminal"],
+        valid_tool_names=set(),
+    )
+
+    added = inject_memory_provider_tools(agent)
+    tool_names = {tool["function"]["name"] for tool in agent.tools}
+
+    assert added == 2
+    assert tool_names == {"memory", "honcho_search", "other_memory_search"}
+    assert agent.valid_tool_names == {"honcho_search", "other_memory_search"}
+
+
+def test_honcho_toolset_does_not_enable_other_memory_provider_tools():
+    from agent.memory_manager import MemoryManager, inject_memory_provider_tools
+
+    mm = MemoryManager()
+    mm.add_provider(OtherMemoryToolProvider())
+    agent = SimpleNamespace(
+        _memory_manager=mm,
+        tools=[],
+        enabled_toolsets=["honcho"],
+        valid_tool_names=set(),
+    )
+
+    added = inject_memory_provider_tools(agent)
+
+    assert added == 0
+    assert agent.tools == []
+    assert agent.valid_tool_names == set()
+
+
+def test_unrelated_restricted_toolset_does_not_inject_memory_provider_tools():
+    from agent.memory_manager import MemoryManager, inject_memory_provider_tools
+
+    mm = MemoryManager()
+    mm.add_provider(HonchoToolProvider())
+    agent = SimpleNamespace(
+        _memory_manager=mm,
+        tools=[],
+        enabled_toolsets=["terminal"],
+        valid_tool_names=set(),
+    )
+
+    added = inject_memory_provider_tools(agent)
+
+    assert added == 0
+    assert agent.tools == []
+    assert agent.valid_tool_names == set()
+
+
+def test_disabled_honcho_toolset_suppresses_provider_tool_injection():
+    from agent.memory_manager import MemoryManager, inject_memory_provider_tools
+
+    mm = MemoryManager()
+    mm.add_provider(HonchoToolProvider())
+    agent = SimpleNamespace(
+        _memory_manager=mm,
+        tools=[],
+        enabled_toolsets=["honcho"],
+        disabled_toolsets=["honcho"],
+        valid_tool_names=set(),
+    )
+
+    added = inject_memory_provider_tools(agent)
+
+    assert added == 0
+    assert agent.tools == []
+    assert agent.valid_tool_names == set()
+
+
+def test_disabled_memory_toolset_suppresses_provider_tool_injection():
+    from agent.memory_manager import MemoryManager, inject_memory_provider_tools
+
+    mm = MemoryManager()
+    mm.add_provider(HonchoToolProvider())
+    agent = SimpleNamespace(
+        _memory_manager=mm,
+        tools=[],
+        enabled_toolsets=None,
+        disabled_toolsets=["memory"],
+        valid_tool_names=set(),
+    )
+
+    added = inject_memory_provider_tools(agent)
+
+    assert added == 0
+    assert agent.tools == []
+    assert agent.valid_tool_names == set()
+
+
+def test_disabled_all_toolsets_suppresses_provider_tool_injection():
+    from agent.memory_manager import MemoryManager, inject_memory_provider_tools
+
+    mm = MemoryManager()
+    mm.add_provider(HonchoToolProvider())
+    agent = SimpleNamespace(
+        _memory_manager=mm,
+        tools=[],
+        enabled_toolsets=None,
+        disabled_toolsets=["*"],
+        valid_tool_names=set(),
+    )
+
+    added = inject_memory_provider_tools(agent)
+
+    assert added == 0
+    assert agent.tools == []
+    assert agent.valid_tool_names == set()
 
 
 def test_aiagent_forwards_warning_callback_to_cli_memory_provider():

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -229,6 +229,18 @@ class TestToolsetConsistency:
         # silently let a platform diverge so far that nothing is shared).
         assert len(core) > 20, f"Suspiciously small shared core: {len(core)} tools"
 
+    def test_honcho_toolset_exposes_provider_tools_without_core_memory_tool(self):
+        tools = set(resolve_toolset("honcho"))
+
+        assert {
+            "honcho_conclude",
+            "honcho_search",
+            "honcho_profile",
+            "honcho_reasoning",
+            "honcho_context",
+        }.issubset(tools)
+        assert "memory" not in tools
+
 
 class TestPluginToolsets:
     def test_get_all_toolsets_includes_plugin_toolset(self, monkeypatch):

--- a/toolsets.py
+++ b/toolsets.py
@@ -241,8 +241,21 @@ TOOLSETS = {
         "includes": []
     },
 
-    # "honcho" toolset removed — Honcho is now a memory provider plugin.
-    # Tools are injected via MemoryManager, not the toolset system.
+    "honcho": {
+        "description": "Honcho memory provider tools (available when Honcho is the configured memory provider)",
+        "tools": [
+            "honcho_conclude",
+            "honcho_search",
+            "honcho_profile",
+            "honcho_reasoning",
+            "honcho_context",
+        ],
+        # Memory provider tools are injected by MemoryManager after built-in
+        # schemas are assembled. Keeping this leaf toolset free of the core
+        # ``memory`` tool lets restricted cron/subagent runs opt into Honcho
+        # without also granting local MEMORY.md writes.
+        "includes": [],
+    },
 
     "homeassistant": {
         "description": "Home Assistant smart home control and monitoring",


### PR DESCRIPTION
## Summary

Expose Honcho memory provider tools as a named, filterable `honcho` toolset for restricted sessions such as cron jobs and delegated subagents.

- add a leaf `honcho` toolset containing the Honcho tool names without also granting the built-in `memory` tool
- teach `MemoryManager` to inject provider schemas when enabled toolsets explicitly match provider tool names
- keep existing compatibility for unrestricted sessions and sessions that already include the core `memory` tool
- respect disabled toolsets, including `honcho`, `memory`, `*`, and `all`

Fixes #48432

## Testing

- `scripts/run_tests.sh tests/test_toolsets.py tests/run_agent/test_memory_provider_init.py tests/agent/test_memory_provider.py tests/run_agent/test_background_review_toolset_restriction.py`
- `python -m ruff check agent/memory_manager.py toolsets.py tests/test_toolsets.py tests/run_agent/test_memory_provider_init.py tests/agent/test_memory_provider.py`
- `git diff --check`

## Review

Read-only subagent review completed on the final diff with no blocking findings.