### PR TITLE
fix(agent): inherit main runtime connection fields for auto vision

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2222,6 +2222,25 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     return normalized
 
 
+def _main_runtime_with_connection_fallback(
+    main_runtime: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Return main runtime with process-local connection fields filled in.
+
+    ``set_runtime_main()`` persists base_url/api_key/api_mode in process-local
+    globals so auxiliary routing can inherit the live main-session endpoint
+    even when the caller does not pass ``main_runtime`` explicitly.
+    """
+    runtime = _normalize_main_runtime(main_runtime)
+    if not runtime.get("base_url") and _RUNTIME_MAIN_BASE_URL:
+        runtime["base_url"] = _RUNTIME_MAIN_BASE_URL
+    if not runtime.get("api_key") and _RUNTIME_MAIN_API_KEY:
+        runtime["api_key"] = _RUNTIME_MAIN_API_KEY
+    if not runtime.get("api_mode") and _RUNTIME_MAIN_API_MODE:
+        runtime["api_mode"] = _RUNTIME_MAIN_API_MODE
+    return runtime
+
+
 def _get_provider_chain() -> List[tuple]:
     """Return the ordered provider detection chain.
 
@@ -2797,6 +2816,7 @@ def _retry_same_provider_sync(
             model=final_model,
             base_url=resolved_base_url,
             api_key=resolved_api_key,
+            main_runtime=main_runtime,
             async_mode=False,
         )
     else:
@@ -2840,6 +2860,7 @@ async def _retry_same_provider_async(
     resolved_base_url: Optional[str],
     resolved_api_key: Optional[str],
     resolved_api_mode: Optional[str],
+    main_runtime: Optional[Dict[str, Any]],
     final_model: Optional[str],
     messages: list,
     temperature: Optional[float],
@@ -2854,6 +2875,7 @@ async def _retry_same_provider_async(
             model=final_model,
             base_url=resolved_base_url,
             api_key=resolved_api_key,
+            main_runtime=main_runtime,
             async_mode=True,
         )
     else:
@@ -2864,6 +2886,7 @@ async def _retry_same_provider_async(
             base_url=resolved_base_url,
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
+            main_runtime=main_runtime,
         )
     if retry_client is None:
         raise RuntimeError(
@@ -3238,24 +3261,12 @@ def _resolve_auto(
     """
     global auxiliary_is_nous, _stale_base_url_warned
     auxiliary_is_nous = False  # Reset — _try_nous() will set True if it wins
-    runtime = _normalize_main_runtime(main_runtime)
+    runtime = _main_runtime_with_connection_fallback(main_runtime)
     runtime_provider = runtime.get("provider", "")
     runtime_model = str(runtime.get("model") or "")
     runtime_base_url = str(runtime.get("base_url") or "")
     runtime_api_key = runtime.get("api_key", "")
     runtime_api_mode = str(runtime.get("api_mode") or "")
-
-    # Fall back to process-local globals when main_runtime dict was not
-    # provided or was incomplete.  ``set_runtime_main()`` now records
-    # base_url/api_key/api_mode alongside provider/model, so custom:
-    # providers get the full credential surface in Step 1 of the
-    # auto-detect chain.
-    if not runtime_base_url and _RUNTIME_MAIN_BASE_URL:
-        runtime_base_url = _RUNTIME_MAIN_BASE_URL
-    if not runtime_api_key and _RUNTIME_MAIN_API_KEY:
-        runtime_api_key = _RUNTIME_MAIN_API_KEY
-    if not runtime_api_mode and _RUNTIME_MAIN_API_MODE:
-        runtime_api_mode = _RUNTIME_MAIN_API_MODE
 
     # ── Warn once if OPENAI_BASE_URL is set but config.yaml uses a named
     #    provider (not 'custom').  This catches the common "env poisoning"
@@ -4244,6 +4255,7 @@ def resolve_vision_provider_client(
     *,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
     async_mode: bool = False,
 ) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
     """Resolve the client actually used for vision tasks.
@@ -4257,6 +4269,12 @@ def resolve_vision_provider_client(
         "vision", provider, model, base_url, api_key
     )
     requested = _normalize_vision_provider(requested)
+    runtime = _main_runtime_with_connection_fallback(main_runtime)
+    runtime_provider = runtime.get("provider", "")
+    runtime_model = str(runtime.get("model") or "")
+    runtime_base_url = str(runtime.get("base_url") or "")
+    runtime_api_key = runtime.get("api_key", "")
+    runtime_api_mode = str(runtime.get("api_mode") or "")
 
     def _finalize(resolved_provider: str, sync_client: Any, default_model: Optional[str]):
         if sync_client is None:
@@ -4295,8 +4313,8 @@ def resolve_vision_provider_client(
         #   2. OpenRouter  (vision-capable aggregator fallback)
         #   3. Nous Portal (vision-capable aggregator fallback)
         #   4. Stop
-        main_provider = _read_main_provider()
-        main_model = _read_main_model()
+        main_provider = str(runtime_provider or _read_main_provider() or "")
+        main_model = str(runtime_model or _read_main_model() or "")
         if main_provider and main_provider not in {"auto", ""}:
             vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
             if main_provider == "nous":
@@ -4340,10 +4358,26 @@ def resolve_vision_provider_client(
                     main_provider,
                 )
             else:
+                resolved_provider = main_provider
+                explicit_base_url = runtime_base_url or None
+                explicit_api_key = None
+                if runtime_base_url and (
+                    main_provider == "custom" or main_provider.startswith("custom:")
+                ):
+                    resolved_provider = "custom"
+                    explicit_base_url = runtime_base_url
+                    explicit_api_key = runtime_api_key or None
+                elif runtime_api_key:
+                    explicit_api_key = runtime_api_key
                 rpc_client, rpc_model = resolve_provider_client(
-                    main_provider, vision_model,
-                    api_mode=resolved_api_mode,
-                    is_vision=True)
+                    resolved_provider,
+                    vision_model,
+                    explicit_base_url=explicit_base_url,
+                    explicit_api_key=explicit_api_key,
+                    api_mode=runtime_api_mode or resolved_api_mode,
+                    main_runtime=runtime,
+                    is_vision=True,
+                )
                 if rpc_client is not None:
                     logger.info(
                         "Vision auto-detect: using main provider %s (%s)",
@@ -5215,6 +5249,7 @@ def call_llm(
             model=resolved_model or model,
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
+            main_runtime=main_runtime,
             async_mode=False,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
@@ -5225,6 +5260,7 @@ def call_llm(
             effective_provider, client, final_model = resolve_vision_provider_client(
                 provider="auto",
                 model=resolved_model,
+                main_runtime=main_runtime,
                 async_mode=False,
             )
         if client is None:
@@ -5724,6 +5760,7 @@ async def async_call_llm(
             model=resolved_model or model,
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
+            main_runtime=main_runtime,
             async_mode=True,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
@@ -5734,6 +5771,7 @@ async def async_call_llm(
             effective_provider, client, final_model = resolve_vision_provider_client(
                 provider="auto",
                 model=resolved_model,
+                main_runtime=main_runtime,
                 async_mode=True,
             )
         if client is None:
@@ -5951,6 +5989,7 @@ async def async_call_llm(
                     resolved_base_url=resolved_base_url,
                     resolved_api_key=resolved_api_key,
                     resolved_api_mode=resolved_api_mode,
+                    main_runtime=main_runtime,
                     final_model=final_model,
                     messages=messages,
                     temperature=temperature,
@@ -5988,6 +6027,7 @@ async def async_call_llm(
                         resolved_base_url=resolved_base_url,
                         resolved_api_key=resolved_api_key,
                         resolved_api_mode=resolved_api_mode,
+                        main_runtime=main_runtime,
                         final_model=final_model,
                         messages=messages,
                         temperature=temperature,

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -355,6 +355,43 @@ class TestResolveVisionMainFirst:
         assert mock_resolve.call_args.args[1] == "mimo-v2.5"
         assert mock_resolve.call_args.kwargs.get("is_vision") is True
 
+    def test_custom_main_vision_inherits_runtime_endpoint(self):
+        """Vision auto must inherit base_url/api_key from the live main runtime."""
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="openrouter",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="config-model",
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client"
+        ) as mock_resolve, patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ):
+            mock_resolve.return_value = (MagicMock(), "qwen-vl-max")
+
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client(
+                main_runtime={
+                    "provider": "custom:qwen",
+                    "model": "qwen-vl-max",
+                    "base_url": "https://qwen.example.com/v1",
+                    "api_key": "sk-qwen",
+                    "api_mode": "chat_completions",
+                },
+            )
+
+        assert provider == "custom:qwen"
+        assert client is not None
+        assert model == "qwen-vl-max"
+        assert mock_resolve.call_args.args[0] == "custom"
+        assert mock_resolve.call_args.args[1] == "qwen-vl-max"
+        assert mock_resolve.call_args.kwargs["explicit_base_url"] == "https://qwen.example.com/v1"
+        assert mock_resolve.call_args.kwargs["explicit_api_key"] == "sk-qwen"
+        assert mock_resolve.call_args.kwargs["api_mode"] == "chat_completions"
+        assert mock_resolve.call_args.kwargs["is_vision"] is True
+
     def test_copilot_vision_sets_vision_header(self, monkeypatch):
         """Copilot vision requests include the header required for vision routing."""
         monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "ghu_test-token")

--- a/tests/agent/test_set_runtime_main_custom_provider.py
+++ b/tests/agent/test_set_runtime_main_custom_provider.py
@@ -112,6 +112,40 @@ class TestSetRuntimeMainCustomProvider:
         finally:
             mod.clear_runtime_main()
 
+    def test_resolve_vision_uses_globals_for_custom_provider(self):
+        """Vision auto also reads base_url/api_key from globals when main_runtime is None."""
+        import agent.auxiliary_client as mod
+
+        mod.clear_runtime_main()
+        try:
+            mod.set_runtime_main(
+                "custom:test-router",
+                "qwen-vl-max",
+                base_url="https://vision-endpoint.example.com/v1",
+                api_key="sk-vision",
+                api_mode="chat_completions",
+            )
+
+            with patch.object(mod, "_resolve_task_provider_model", return_value=("auto", None, None, None, None)), patch.object(
+                mod, "resolve_provider_client"
+            ) as mock_resolve:
+                mock_resolve.return_value = (MagicMock(), "qwen-vl-max")
+
+                provider, client, resolved = mod.resolve_vision_provider_client(main_runtime=None)
+
+                assert provider == "custom:test-router"
+                assert client is not None
+                assert resolved == "qwen-vl-max"
+                mock_resolve.assert_called_once()
+                call_args = mock_resolve.call_args
+                assert call_args[0][0] == "custom"
+                assert call_args[1]["explicit_base_url"] == "https://vision-endpoint.example.com/v1"
+                assert call_args[1]["explicit_api_key"] == "sk-vision"
+                assert call_args[1]["api_mode"] == "chat_completions"
+                assert call_args[1]["is_vision"] is True
+        finally:
+            mod.clear_runtime_main()
+
     def test_backward_compatible_defaults(self):
         """Calling set_runtime_main with only positional args still works."""
         import agent.auxiliary_client as mod

--- a/tests/agent/test_vision_resolved_args.py
+++ b/tests/agent/test_vision_resolved_args.py
@@ -1,6 +1,8 @@
 """Test that call_llm vision path passes resolved provider args, not raw ones."""
 
-from unittest.mock import patch, MagicMock
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock, AsyncMock
 
 
 def test_vision_call_uses_resolved_provider_args():
@@ -35,6 +37,172 @@ def test_vision_call_uses_resolved_provider_args():
     assert call_args.kwargs["model"] == "my-resolved-model"
     assert call_args.kwargs["base_url"] == "http://resolved"
     assert call_args.kwargs["api_key"] == "resolved-key"
+
+
+def test_vision_call_passes_main_runtime():
+    """Vision call_llm should forward main_runtime into auto vision resolution."""
+    from agent.auxiliary_client import call_llm
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="description"))],
+        usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+    )
+    main_runtime = {
+        "provider": "custom:qwen",
+        "model": "qwen-vl-max",
+        "base_url": "https://qwen.example.com/v1",
+        "api_key": "sk-qwen",
+        "api_mode": "chat_completions",
+    }
+
+    with patch(
+        "agent.auxiliary_client._resolve_task_provider_model",
+        return_value=("auto", None, None, None, None),
+    ), patch(
+        "agent.auxiliary_client.resolve_vision_provider_client",
+        return_value=("custom:qwen", fake_client, "qwen-vl-max"),
+    ) as mock_vision:
+        call_llm(
+            "vision",
+            main_runtime=main_runtime,
+            messages=[{"role": "user", "content": "describe this"}],
+        )
+
+    assert mock_vision.call_args.kwargs["main_runtime"] == main_runtime
+
+
+def test_async_vision_call_passes_main_runtime():
+    """Async vision path should forward main_runtime into auto vision resolution."""
+
+    async def _run():
+        from agent.auxiliary_client import async_call_llm
+
+        fake_create = AsyncMock(
+            return_value=MagicMock(
+                choices=[MagicMock(message=MagicMock(content="description"))],
+                usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+            ),
+        )
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        )
+        main_runtime = {
+            "provider": "custom:qwen",
+            "model": "qwen-vl-max",
+            "base_url": "https://qwen.example.com/v1",
+            "api_key": "sk-qwen",
+            "api_mode": "chat_completions",
+        }
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            return_value=("custom:qwen", fake_client, "qwen-vl-max"),
+        ) as mock_vision:
+            await async_call_llm(
+                "vision",
+                main_runtime=main_runtime,
+                messages=[{"role": "user", "content": "describe this"}],
+            )
+
+        assert mock_vision.call_args.kwargs["main_runtime"] == main_runtime
+
+    asyncio.run(_run())
+
+
+def test_vision_retry_sync_passes_main_runtime():
+    """Sync same-provider retry must rebuild vision clients with main_runtime."""
+    from agent.auxiliary_client import _retry_same_provider_sync
+
+    response = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="description"))],
+        usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+    )
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = response
+    main_runtime = {
+        "provider": "custom:qwen",
+        "model": "qwen-vl-max",
+        "base_url": "https://qwen.example.com/v1",
+        "api_key": "sk-qwen",
+        "api_mode": "chat_completions",
+    }
+
+    with patch(
+        "agent.auxiliary_client.resolve_vision_provider_client",
+        return_value=("custom:qwen", fake_client, "qwen-vl-max"),
+    ) as mock_vision:
+        result = _retry_same_provider_sync(
+            task="vision",
+            resolved_provider="auto",
+            resolved_model=None,
+            resolved_base_url=None,
+            resolved_api_key=None,
+            resolved_api_mode=None,
+            main_runtime=main_runtime,
+            final_model="qwen-vl-max",
+            messages=[{"role": "user", "content": "describe this"}],
+            temperature=None,
+            max_tokens=None,
+            tools=None,
+            effective_timeout=30.0,
+            effective_extra_body={},
+        )
+
+    assert result is response
+    assert mock_vision.call_args.kwargs["main_runtime"] == main_runtime
+
+
+def test_vision_retry_async_passes_main_runtime():
+    """Async same-provider retry must rebuild vision clients with main_runtime."""
+
+    async def _run():
+        from agent.auxiliary_client import _retry_same_provider_async
+
+        response = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="description"))],
+            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+        )
+        fake_create = AsyncMock(return_value=response)
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        )
+        main_runtime = {
+            "provider": "custom:qwen",
+            "model": "qwen-vl-max",
+            "base_url": "https://qwen.example.com/v1",
+            "api_key": "sk-qwen",
+            "api_mode": "chat_completions",
+        }
+
+        with patch(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            return_value=("custom:qwen", fake_client, "qwen-vl-max"),
+        ) as mock_vision:
+            result = await _retry_same_provider_async(
+                task="vision",
+                resolved_provider="auto",
+                resolved_model=None,
+                resolved_base_url=None,
+                resolved_api_key=None,
+                resolved_api_mode=None,
+                main_runtime=main_runtime,
+                final_model="qwen-vl-max",
+                messages=[{"role": "user", "content": "describe this"}],
+                temperature=None,
+                max_tokens=None,
+                tools=None,
+                effective_timeout=30.0,
+                effective_extra_body={},
+            )
+
+        assert result is response
+        assert mock_vision.call_args.kwargs["main_runtime"] == main_runtime
+
+    asyncio.run(_run())
 
 
 def test_vision_base_url_override_keeps_explicit_provider():


### PR DESCRIPTION
## What does this PR do?

Fixes `auxiliary.vision.provider=auto` so the vision auto path inherits the active main runtime connection fields (`base_url`, `api_key`, `api_mode`) instead of only the provider/model names. This keeps custom main providers working for vision tasks and closes the sibling sync/async retry paths that were dropping the same runtime context.

## Related Issue

Fixes #48991

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `agent/auxiliary_client.py` so vision auto resolution uses the same runtime connection fallback as text auto resolution.
- Pass `main_runtime` through `resolve_vision_provider_client()` from `call_llm()`, `async_call_llm()`, and the same-provider sync/async retry helpers.
- Add regression tests for explicit `main_runtime`, `set_runtime_main()` globals fallback, and vision sync/async entry + retry forwarding.

## How to Test

1. Run `env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q tests/agent/test_auxiliary_main_first.py tests/agent/test_set_runtime_main_custom_provider.py tests/agent/test_vision_resolved_args.py tests/agent/test_auxiliary_named_custom_providers.py tests/agent/test_vision_routing_31179.py`
2. Confirm all 74 targeted tests pass.
3. Verify `auxiliary.vision.provider=auto` now resolves a client when the main runtime uses a `custom:*` provider with runtime `base_url` / `api_key`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation:

- `tests/agent/test_auxiliary_main_first.py`
- `tests/agent/test_set_runtime_main_custom_provider.py`
- `tests/agent/test_vision_resolved_args.py`
- `tests/agent/test_auxiliary_named_custom_providers.py`
- `tests/agent/test_vision_routing_31179.py`

Result: `74 passed in 5.44s`
