### PR TITLE
fix(telegram): bump MAX_COMMANDS_PER_SCOPE from 30 to 75

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -106,7 +106,7 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
 }
 
 
-MAX_COMMANDS_PER_SCOPE = 30
+MAX_COMMANDS_PER_SCOPE = 75
 
 
 def check_telegram_requirements() -> bool:


### PR DESCRIPTION
At 30, the BotCommand menu fills up with core commands and nothing else fits. Skills that register slash commands (like /buy, /kb, /micro) never show up in the Telegram menu because all 30 slots are taken by built-ins.

75 is enough breathing room for all built-in + plugin commands plus skill-derived ones. Still well within Telegram's own limit of 100.