### PR TITLE
fix(desktop): clear subagent and todo state when a session is deleted

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -49,6 +49,8 @@ import {
   workspaceCwdForNewSession
 } from '@/store/session'
 import { broadcastSessionsChanged } from '@/store/session-sync'
+import { clearSessionSubagents } from '@/store/subagents'
+import { clearSessionTodos } from '@/store/todos'
 import { reportBackendContract } from '@/store/updates'
 import { isWatchWindow } from '@/store/windows'
 import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, SessionRuntimeInfo, UsageStats } from '@/types/hermes'
@@ -989,9 +991,13 @@ export function useSessionActions({
 
         await deleteSession(storedSessionId, removed?.profile)
         clearQueuedPrompts(storedSessionId)
+        clearSessionSubagents(storedSessionId)
+        clearSessionTodos(storedSessionId)
 
         if (closingRuntimeId) {
           clearQueuedPrompts(closingRuntimeId)
+          clearSessionSubagents(closingRuntimeId)
+          clearSessionTodos(closingRuntimeId)
         }
       } catch (err) {
         if (removed) {


### PR DESCRIPTION
## Summary

- `removeSession` already calls `clearQueuedPrompts` for both the stored and runtime session ids, but the parallel per-session stores (`$subagentsBySession`, `$todosBySession`) were never pruned on the delete path
- Because neither store is cleared by a subsequent turn — deleted sessions have no next turn — the orphaned entries accumulate for the lifetime of the renderer process
- Mirror the existing `clearQueuedPrompts` pattern so both stores are released alongside the queued-prompt cleanup

## Test plan

- [ ] Delete a session that had active subagents or a todo list
- [ ] Verify `$subagentsBySession` and `$todosBySession` no longer retain the deleted session's key
- [ ] Confirm session-delete rollback (catch branch) still restores the session correctly
- [ ] `npm --workspace apps/desktop run typecheck` passes