### PR TITLE
feat(gateway): add .sql document and MEDIA delivery support

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1144,6 +1144,7 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".ts": "text/plain",
     ".py": "text/plain",
     ".sh": "text/plain",
+    ".sql": "application/sql",
 }
 
 
@@ -1208,6 +1209,7 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     ".pptx", ".ppt", ".odp", ".key",
     # Archives
     ".zip", ".tar", ".gz", ".tgz", ".bz2", ".xz", ".7z", ".rar", ".apk", ".ipa",
+    ".sql",
     # Web / rendered output
     ".html", ".htm",
 )


### PR DESCRIPTION
.sql files are common in agent workflows (migrations, schema dumps, query results) but the gateway rejects them as an unsupported type.

Two additions to base.py:
- SUPPORTED_DOCUMENT_TYPES gets .sql mapped to application/sql
- MEDIA_DELIVERY_EXTS gets .sql so MEDIA:.sql tags can be used