### PR TITLE
fix(ssl): tolerate truststore get_ca_certs gaps

### DIFF
--- a/agent/ssl_guard.py
+++ b/agent/ssl_guard.py
@@ -54,7 +54,12 @@ def _validate_bundle_path(label: str, value: str, *, require_substantial: bool =
         ctx = ssl.create_default_context(cafile=str(path))
     except Exception as exc:
         raise _ssl_err(f"{label} CA bundle at {value} cannot be loaded: {exc}") from exc
-    if not ctx.get_ca_certs():
+    try:
+        ca_certs = ctx.get_ca_certs()
+    except NotImplementedError:
+        logger.debug("%s CA bundle loaded but get_ca_certs() is unavailable", label)
+        return
+    if not ca_certs:
         raise _ssl_err(f"{label} CA bundle at {value} did not load any certificates")
 
 

--- a/tests/agent/test_ssl_ca_guard.py
+++ b/tests/agent/test_ssl_ca_guard.py
@@ -41,6 +41,16 @@ def test_empty_certifi_bundle_raises_ssl_error(monkeypatch, tmp_path):
     assert "too small" in str(exc.value).lower()
 
 
+def test_large_invalid_certifi_bundle_still_raises_ssl_error(monkeypatch, tmp_path):
+    """The truststore workaround must not bypass bundle loading failures."""
+    fake = tmp_path / "invalid.pem"
+    fake.write_bytes(b"not a cert bundle\n" * 128)
+    monkeypatch.setattr(certifi, "where", lambda: str(fake))
+    with pytest.raises(SSLConfigurationError) as exc:
+        verify_ca_bundle()
+    assert "cannot be loaded" in str(exc.value)
+
+
 @pytest.mark.parametrize("env_var", ["HERMES_CA_BUNDLE", "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"])
 def test_missing_explicit_ca_bundle_env_raises_before_httpx(monkeypatch, tmp_path, env_var):
     """Bad CA-bundle env vars should be reported before OpenAI/httpx init."""
@@ -62,6 +72,33 @@ def test_invalid_explicit_ca_bundle_env_raises(monkeypatch, tmp_path):
     with pytest.raises(SSLConfigurationError) as exc:
         verify_ca_bundle()
     assert "cannot be loaded" in str(exc.value)
+
+
+def test_truststore_get_ca_certs_not_implemented_does_not_fail(monkeypatch, tmp_path):
+    """Windows truststore can load the bundle but not expose get_ca_certs()."""
+    for key in ("HERMES_CA_BUNDLE", "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"):
+        monkeypatch.delenv(key, raising=False)
+    fake = tmp_path / "cacert.pem"
+    fake.write_bytes(b"-" * 2048)
+    monkeypatch.setattr(certifi, "where", lambda: str(fake))
+
+    class TruststoreContext:
+        def get_ca_certs(self):
+            raise NotImplementedError()
+
+    seen_cafiles = []
+
+    def fake_create_default_context(*, cafile):
+        seen_cafiles.append(cafile)
+        return TruststoreContext()
+
+    monkeypatch.setattr(
+        "agent.ssl_guard.ssl.create_default_context",
+        fake_create_default_context,
+    )
+
+    verify_ca_bundle()
+    assert seen_cafiles == [str(fake)]
 
 
 def test_verify_ca_bundle_with_fallback_keeps_same_contract(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- tolerate truststore-backed SSL contexts that raise NotImplementedError from get_ca_certs() after the CA bundle has loaded
- keep missing, too-small, and unloadable CA bundles failing with the existing SSLConfigurationError path
- add regression coverage for the truststore NotImplementedError path and for large invalid certifi bundles

Fixes #49014

## Tests
- pytest tests/agent/test_ssl_ca_guard.py
- git diff --check

## Review
- Subagent review: no blocking findings after review of the ssl_guard/test diff
