### PR TITLE
fix: honor Telegram typing indicator setting

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -41,6 +41,7 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "interim_assistant_messages": True,
     "long_running_notifications": True,
     "busy_ack_detail": True,
+    "typing_indicator": True,
     # When true, delete tool-progress / "⏳ Working — N min" / status bubbles
     # after the final response lands on platforms that support message
     # deletion (e.g. Telegram). Off by default — progress is still shown
@@ -231,6 +232,7 @@ def _normalise(setting: str, value: Any) -> Any:
         "interim_assistant_messages",
         "long_running_notifications",
         "busy_ack_detail",
+        "typing_indicator",
     }:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1904,6 +1904,25 @@ class BasePlatformAdapter(ABC):
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
 
+    def _typing_indicator_enabled(self) -> bool:
+        """Return whether this adapter should send native typing indicators."""
+        raw = getattr(getattr(self, "config", None), "extra", {}).get("typing_indicator")
+        if raw is not None:
+            if isinstance(raw, str):
+                return raw.strip().lower() in {"true", "1", "yes", "on"}
+            return bool(raw)
+        try:
+            from hermes_cli.config import load_config_readonly
+            from gateway.display_config import resolve_display_setting
+            return bool(resolve_display_setting(
+                load_config_readonly(),
+                _platform_name(self.platform),
+                "typing_indicator",
+                True,
+            ))
+        except Exception:
+            return True
+
     @property
     def message_len_fn(self) -> Callable[[str], int]:
         """Return the length function for measuring message size on this platform.
@@ -4171,12 +4190,14 @@ class BasePlatformAdapter(ABC):
             _keep_typing_sig = None
         if _keep_typing_sig is None or "stop_event" in _keep_typing_sig.parameters:
             _keep_typing_kwargs["stop_event"] = interrupt_event
-        typing_task = asyncio.create_task(
-            self._keep_typing(
-                event.source.chat_id,
-                **_keep_typing_kwargs,
+        typing_task = None
+        if self._typing_indicator_enabled():
+            typing_task = asyncio.create_task(
+                self._keep_typing(
+                    event.source.chat_id,
+                    **_keep_typing_kwargs,
+                )
             )
-        )
 
         async def _stop_typing_task() -> None:
             await self._stop_typing_refresh(

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4937,6 +4937,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Send typing indicator."""
+        if not self._typing_indicator_enabled():
+            return
         if self._bot:
             _is_dm_topic: bool = False
             message_thread_id: Optional[int] = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13593,7 +13593,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Send typing indicator
         _adapter = self.adapters.get(source.platform)
-        if _adapter:
+        if _adapter and getattr(_adapter, "_typing_indicator_enabled", lambda: True)():
             try:
                 await _adapter.send_typing(source.chat_id, metadata=_thread_metadata)
             except Exception:
@@ -14337,7 +14337,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if await _roll_progress_overflow_if_needed():
                         _last_edit_ts = time.monotonic()
                         await asyncio.sleep(0.3)
-                        if _run_still_current():
+                        if _run_still_current() and getattr(adapter, "_typing_indicator_enabled", lambda: True)():
                             await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
                         continue
 
@@ -14423,7 +14423,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                     # Restore typing indicator
                     await asyncio.sleep(0.3)
-                    if _run_still_current():
+                    if _run_still_current() and getattr(adapter, "_typing_indicator_enabled", lambda: True)():
                         await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
 
                 except queue.Empty:
@@ -16186,7 +16186,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # the follow-up turn runs.  The outer _process_message_background
                 # typing task is still alive but may be stale.
                 _followup_adapter = self.adapters.get(source.platform)
-                if _followup_adapter:
+                if _followup_adapter and getattr(_followup_adapter, "_typing_indicator_enabled", lambda: True)():
                     try:
                         await _followup_adapter.send_typing(
                             source.chat_id,

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -149,6 +149,36 @@ class TestBasePlatformTopicSessions:
         ]
 
     @pytest.mark.asyncio
+    async def test_process_message_background_skips_typing_when_indicator_disabled(self):
+        adapter = DummyTelegramAdapter()
+        adapter.config.extra["typing_indicator"] = False
+        typing_calls = []
+
+        async def handler(_event):
+            await asyncio.sleep(0)
+            return "ack"
+
+        async def hold_typing(chat_id, interval=2.0, metadata=None, stop_event=None):
+            typing_calls.append({"chat_id": chat_id, "metadata": metadata})
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(handler)
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert typing_calls == []
+        assert adapter.sent == [
+            {
+                "chat_id": "-1001",
+                "content": "ack",
+                "reply_to": None,
+                "metadata": {"thread_id": "17585", "notify": True},
+            }
+        ]
+
+    @pytest.mark.asyncio
     async def test_process_message_background_marks_total_send_failure_unsuccessful(self):
         adapter = DummyTelegramAdapter()
 

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -282,6 +282,23 @@ async def test_send_typing_preserves_general_topic_thread_id():
 
 
 @pytest.mark.asyncio
+async def test_send_typing_respects_disabled_typing_indicator():
+    """Direct Telegram send_typing calls must honor the display toggle."""
+    adapter = _make_adapter()
+    adapter.config.extra["typing_indicator"] = False
+    call_log = []
+
+    async def mock_send_chat_action(**kwargs):
+        call_log.append(dict(kwargs))
+
+    adapter._bot = SimpleNamespace(send_chat_action=mock_send_chat_action)
+
+    await adapter.send_typing("12345")
+
+    assert call_log == []
+
+
+@pytest.mark.asyncio
 async def test_send_typing_does_not_fall_back_to_root_for_dm_topic():
     """Typing failures in DM topics should not show an indicator in All Messages."""
     adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- honor the existing `typing_indicator` display setting before starting background typing loops
- gate direct Telegram typing calls and progress/follow-up typing pings on the same setting
- add regression coverage for disabled Telegram typing indicators in both the base gateway flow and direct Telegram adapter calls

## Testing
- `python -m pytest tests/gateway/test_base_topic_sessions.py tests/gateway/test_display_config.py tests/gateway/test_telegram_thread_fallback.py -q`
