### PR TITLE
fix: use pythonw.exe for Windows gateway post-update restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -613,7 +613,16 @@ def find_profile_gateway_processes(
 
 
 def _gateway_run_args_for_profile(profile: str) -> list[str]:
-    args = [get_python_path(), "-m", "hermes_cli.main"]
+    python_path = get_python_path()
+    if is_windows():
+        # On Windows, use pythonw.exe (windowless GUI subsystem) instead of
+        # python.exe (console subsystem) so the post-update gateway restart
+        # does not leave a visible console window open on the user's desktop.
+        p = Path(python_path)
+        pythonw_path = str(p.with_name(p.stem + "w" + p.suffix))
+        if Path(pythonw_path).exists():
+            python_path = pythonw_path
+    args = [python_path, "-m", "hermes_cli.main"]
     if profile != "default":
         args.extend(["--profile", profile])
     args.extend(["gateway", "run", "--replace"])


### PR DESCRIPTION
## Summary

On Windows, after running `hermes update`, a black console window (python.exe) stays open on the desktop. The gateway works fine, but the window is visual noise and closing it kills the gateway.

## Root cause

`_gateway_run_args_for_profile()` used `get_python_path()` which returns `venv/Scripts/python.exe` (console subsystem). The post-update gateway restart watcher spawned `python.exe` instead of `pythonw.exe` (windowless GUI subsystem).

## Fix

On Windows, resolve the sibling `pythonw.exe` from the `python.exe` path returned by `get_python_path()`. This mirrors what `Hermes_Gateway.cmd` (generated by `gateway_windows._build_gateway_cmd_script()`) already does via `_derive_venv_pythonw()`.

## Notes

- The fix is minimal and scoped: only `_gateway_run_args_for_profile()` was changed (5 lines added).
- The change is gated by `is_windows()` — no impact on POSIX platforms.
- Falls back to `python.exe` if `pythonw.exe` doesn't exist (defensive).

## Testing

Tested locally on Windows 10 (git-bash). Before: console window visible after `hermes update`. After: no window — gateway runs cleanly in the background via pythonw.exe.