### PR TITLE
fix(footer): show actual backend model in runtime footer via response_model

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -977,6 +977,15 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     if codex_message_items:
         msg["codex_message_items"] = codex_message_items
 
+    # Preserve the actual backend model (response.model) through to the
+    # result dict so the runtime footer can display it alongside the
+    # user-facing alias (agent.model). Providers like Failover Assistant
+    # and OpenRouter return the routing alias in agent.model but the
+    # actual backend model in response.model.
+    resp_model = getattr(assistant_message, "response_model", None)
+    if resp_model:
+        msg["response_model"] = resp_model
+
     if assistant_tool_calls:
         tool_calls = []
         for tool_call in assistant_tool_calls:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3528,6 +3528,14 @@ def run_conversation(
                 _normalize_kwargs["strip_tool_prefix"] = agent._is_anthropic_oauth
             normalized = _transport.normalize_response(response, **_normalize_kwargs)
             assistant_message = normalized
+            # Attach response.model so build_assistant_message can copy it
+            # to the message dict for the runtime footer to display.
+            _response_model = getattr(response, "model", None)
+            if _response_model:
+                try:
+                    setattr(assistant_message, "response_model", _response_model)
+                except Exception:
+                    pass
             finish_reason = normalized.finish_reason
             
             # Normalize content to string — some OpenAI-compatible servers

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -322,6 +322,15 @@ def finalize_turn(
             last_reasoning = msg["reasoning"]
             break
 
+    # Extract response_model from the last assistant message
+    response_model = None
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            break
+        if msg.get("role") == "assistant" and msg.get("response_model"):
+            response_model = msg.get("response_model")
+            break
+
     # Build result with interrupt info if applicable
     result = {
         "final_response": final_response,
@@ -336,6 +345,7 @@ def finalize_turn(
         "response_transformed": _response_transformed,
         "response_previewed": getattr(agent, "_response_was_previewed", False),
         "model": agent.model,
+        "response_model": response_model,
         "provider": agent.provider,
         "base_url": agent.base_url,
         "input_tokens": agent.session_input_tokens,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9178,10 +9178,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _footer_line = ""
             try:
                 from gateway.runtime_footer import build_footer_line as _bfl
+                _footer_model = agent_result.get("model")
+                # If the response_model is in the agent result, use it directly.
+                # Otherwise fall back to scanning the last assistant message in
+                # the messages list (for code paths that don't set it on the result).
+                _footer_response_model = agent_result.get("response_model")
+                if not _footer_response_model:
+                    for _msg in reversed(agent_result.get("messages") or []):
+                        if not isinstance(_msg, dict) or _msg.get("role") != "assistant":
+                            continue
+                        _candidate = _msg.get("response_model")
+                        if _candidate:
+                            _footer_response_model = _candidate
+                            break
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
-                    model=agent_result.get("model"),
+                    model=_footer_model,
+                    response_model=_footer_response_model,
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -95,6 +95,7 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    response_model: Optional[str] = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
@@ -107,6 +108,10 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field in ("response_model", "backend_model", "actual_model"):
+            rm = _model_short(response_model)
+            if rm and response_model != model:
+                parts.append(rm)
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
@@ -130,6 +135,7 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    response_model: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -146,4 +152,5 @@ def build_footer_line(
         context_length=context_length,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        response_model=response_model,
     )


### PR DESCRIPTION
The runtime footer shows agent.model (the routing alias/FA proxy), not the actual model generating responses. If you use a router like Failover Assistant or OpenRouter, the footer says 'free' or 'auto' regardless of which backend model is answering.

This wires response.model from the API response through the message dict into the agent result, and adds a 'response_model' field to the footer. When it differs from model, both are shown so you can see : free -> deepseek-v4-flash.