### PR TITLE
feat(desktop): add refresh button for messaging gateway sessions in sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -309,6 +309,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onNewSessionInWorkspace: (path: null | string) => void
   onManageCronJob: (jobId: string) => void
   onTriggerCronJob: (jobId: string) => void
+  onRefreshMessaging?: () => void | Promise<void>
 }
 
 export function ChatSidebar({
@@ -322,7 +323,8 @@ export function ChatSidebar({
   onArchiveSession,
   onNewSessionInWorkspace,
   onManageCronJob,
-  onTriggerCronJob
+  onTriggerCronJob,
+  onRefreshMessaging
 }: ChatSidebarProps) {
   const { t } = useI18n()
   const s = t.sidebar
@@ -365,6 +367,7 @@ export function ChatSidebar({
   const [newSessionKbdFlash, setNewSessionKbdFlash] = useState(false)
   const [profileLoadMorePending, setProfileLoadMorePending] = useState<Record<string, boolean>>({})
   const [messagingLoadMorePending, setMessagingLoadMorePending] = useState<Record<string, boolean>>({})
+  const [messagingRefreshing, setMessagingRefreshing] = useState(false)
   const messagingOpenIds = useStore($sidebarMessagingOpenIds)
   // Per-platform count of rows currently revealed (starts at NON_SESSION_INITIAL_ROWS).
   const [messagingVisible, setMessagingVisible] = useState<Record<string, number>>({})
@@ -612,6 +615,21 @@ export function ChatSidebar({
       loadMoreForMessaging(platform)
     }
   }
+
+  const handleRefreshMessaging = useCallback(async () => {
+    if (!onRefreshMessaging || messagingRefreshing) {
+      return
+    }
+
+    setMessagingRefreshing(true)
+
+    try {
+      await onRefreshMessaging()
+      setMessagingVisible({})
+    } finally {
+      setMessagingRefreshing(false)
+    }
+  }, [messagingRefreshing, onRefreshMessaging])
 
   // Each messaging platform is its own self-managed section: split the
   // separately-fetched messaging slice by source, newest platform first, rows
@@ -1037,6 +1055,27 @@ export function ChatSidebar({
                           step={Math.min(NON_SESSION_LOAD_STEP, Math.max(0, group.total - shownSessions.length))}
                         />
                       ) : null
+                    }
+                    headerAction={
+                      onRefreshMessaging ? (
+                        <div className="grid size-6 shrink-0 place-items-center">
+                          <Tip label={messagingRefreshing ? s.refreshingMessaging : s.refreshMessaging}>
+                            <Button
+                              aria-label={messagingRefreshing ? s.refreshingMessaging : s.refreshMessaging}
+                              title={messagingRefreshing ? s.refreshingMessaging : s.refreshMessaging}
+                              disabled={messagingRefreshing}
+                              onClick={event => {
+                                event.stopPropagation()
+                                void handleRefreshMessaging()
+                              }}
+                              size="icon-xs"
+                              variant="ghost"
+                            >
+                              <Codicon name="refresh" size="0.75rem" spinning={messagingRefreshing} />
+                            </Button>
+                          </Tip>
+                        </div>
+                      ) : undefined
                     }
                     key={group.sourceId}
                     label={group.label}

--- a/apps/desktop/src/app/chat/sidebar/messaging-refresh.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/messaging-refresh.test.tsx
@@ -1,0 +1,153 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarProvider } from '@/components/ui/sidebar'
+import { I18nProvider } from '@/i18n'
+import { $sidebarMessagingOpenIds } from '@/store/layout'
+import { $profiles } from '@/store/profile'
+import {
+  $messagingSessions,
+  $sessions,
+  $sessionsLoading,
+  setMessagingSessions,
+  setSessions,
+  setSessionsLoading
+} from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+vi.mock('@/hermes', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hermes')>()
+
+  return {
+    ...actual,
+    searchSessions: vi.fn().mockResolvedValue({ results: [] })
+  }
+})
+
+import { ChatSidebar } from './index'
+
+function mockSession(id: string, source: string): SessionInfo {
+  const now = Date.now()
+
+  return {
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: now,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: 'hello',
+    source,
+    started_at: now,
+    title: 'Test chat',
+    tool_call_count: 0
+  }
+}
+
+function noop() {
+  return undefined
+}
+
+function renderSidebar(onRefreshMessaging?: () => void | Promise<void>) {
+  return render(
+    <MemoryRouter>
+      <I18nProvider configClient={null}>
+        <SidebarProvider>
+          <ChatSidebar
+            currentView="chat"
+            onArchiveSession={noop}
+            onDeleteSession={noop}
+            onLoadMoreSessions={noop}
+            onManageCronJob={noop}
+            onNavigate={noop}
+            onNewSessionInWorkspace={noop}
+            onRefreshMessaging={onRefreshMessaging}
+            onResumeSession={noop}
+            onTriggerCronJob={noop}
+          />
+        </SidebarProvider>
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  $profiles.set([])
+  setSessions([mockSession('local-1', 'desktop')])
+  setSessionsLoading(false)
+  setMessagingSessions([mockSession('tg-1', 'telegram')])
+  $sidebarMessagingOpenIds.set([])
+})
+
+afterEach(() => {
+  cleanup()
+  $profiles.set([])
+  setSessions([])
+  setMessagingSessions([])
+  setSessionsLoading(false)
+  $sidebarMessagingOpenIds.set([])
+  $sessions.set([])
+  $messagingSessions.set([])
+})
+
+describe('ChatSidebar messaging refresh', () => {
+  it('renders a refresh button on each messaging platform section', () => {
+    setMessagingSessions([mockSession('tg-1', 'telegram'), mockSession('dc-1', 'discord')])
+
+    renderSidebar(noop)
+
+    expect(screen.getAllByRole('button', { name: 'Refresh gateway sessions' })).toHaveLength(2)
+  })
+
+  it('calls onRefreshMessaging once when the refresh button is clicked', async () => {
+    const onRefreshMessaging = vi.fn().mockResolvedValue(undefined)
+
+    renderSidebar(onRefreshMessaging)
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Refresh gateway sessions' })[0]!)
+
+    await waitFor(() => expect(onRefreshMessaging).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not render refresh buttons when onRefreshMessaging is omitted', () => {
+    renderSidebar()
+
+    expect(screen.queryByRole('button', { name: 'Refresh gateway sessions' })).toBeNull()
+  })
+
+  it('disables refresh buttons while onRefreshMessaging is in flight', async () => {
+    let resolveRefresh: (() => void) | undefined
+    const onRefreshMessaging = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveRefresh = resolve
+        })
+    )
+
+    setMessagingSessions([mockSession('tg-1', 'telegram'), mockSession('dc-1', 'discord')])
+    renderSidebar(onRefreshMessaging)
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Refresh gateway sessions' })[0]!)
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Refreshing gateway sessions' })).toHaveLength(2)
+      for (const button of screen.getAllByRole('button', { name: 'Refreshing gateway sessions' })) {
+        expect((button as HTMLButtonElement).disabled).toBe(true)
+      }
+    })
+    expect(onRefreshMessaging).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveRefresh?.()
+    })
+
+    await waitFor(() => {
+      for (const button of screen.getAllByRole('button', { name: 'Refresh gateway sessions' })) {
+        expect((button as HTMLButtonElement).disabled).toBe(false)
+      }
+    })
+  })
+})

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -379,6 +379,7 @@ export function DesktopController() {
       // sources) — those stay in local recents, not a platform section.
       const rows = result.sessions.filter(s => isMessagingSource(s.source))
 
+      setMessagingPlatformTotals({})
       setMessagingSessions(prev => (sameCronSignature(prev, rows) ? prev : rows))
       // Hit the cap → at least one platform may have more on disk than loaded,
       // so platform sections offer their own per-platform "load more".
@@ -939,6 +940,7 @@ export function DesktopController() {
           .then(() => refreshCronJobs())
           .catch(() => undefined)
       }}
+      onRefreshMessaging={() => refreshMessagingSessions()}
     />
   )
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1170,6 +1170,8 @@ export const en: Translations = {
     showMoreIn: (count, label) => `Show ${count} more in ${label}`,
     loading: 'Loading…',
     loadMore: 'Load more',
+    refreshMessaging: 'Refresh gateway sessions',
+    refreshingMessaging: 'Refreshing gateway sessions',
     loadCount: step => `Load ${step} more`,
     row: {
       pin: 'Pin',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1299,6 +1299,8 @@ export const ja = defineLocale({
     showMoreIn: (count, label) => `${label} でさらに ${count} 件を表示`,
     loading: '読み込み中…',
     loadMore: 'さらに読み込む',
+    refreshMessaging: 'ゲートウェイセッションを更新',
+    refreshingMessaging: 'ゲートウェイセッションを更新中',
     loadCount: step => `さらに ${step} 件を読み込む`,
     row: {
       pin: 'ピン留め',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -898,6 +898,8 @@ export interface Translations {
     showMoreIn: (count: number, label: string) => string
     loading: string
     loadMore: string
+    refreshMessaging: string
+    refreshingMessaging: string
     loadCount: (step: number) => string
     row: {
       pin: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1253,6 +1253,8 @@ export const zhHant = defineLocale({
     showMoreIn: (count, label) => `在 ${label} 中再顯示 ${count} 個`,
     loading: '載入中…',
     loadMore: '載入更多',
+    refreshMessaging: '重新整理閘道工作階段',
+    refreshingMessaging: '正在重新整理閘道工作階段',
     loadCount: step => `再載入 ${step} 個`,
     row: {
       pin: '釘選',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1357,6 +1357,8 @@ export const zh: Translations = {
     showMoreIn: (count, label) => `在 ${label} 中再显示 ${count} 个`,
     loading: '加载中…',
     loadMore: '加载更多',
+    refreshMessaging: '刷新网关会话',
+    refreshingMessaging: '正在刷新网关会话',
     loadCount: step => `再加载 ${step} 个`,
     row: {
       pin: '置顶',


### PR DESCRIPTION
# feat(desktop): add refresh button for messaging gateway sessions in sidebar

## Summary

Adds a manual **refresh control** to each messaging-platform section in the desktop chat sidebar (Telegram, Discord, Slack, etc.). When the desktop app is already running and a new conversation starts on an external platform, the sidebar no longer stays stale until gateway reconnect, an agent turn completes, or a cross-window sync fires — the user can pull the latest gateway sessions on demand.

This is a **client-only** change. It wires an existing fetch path (`refreshMessagingSessions()` → `GET /api/profiles/sessions`) to a sidebar action. No backend, gateway, `tui_gateway`, or config changes — the REST aggregator already returns fresh rows on every request.

The control appears on **each** platform section header, but the action refreshes **all** messaging gateway sessions at once. Copy is intentionally generic ("Refresh gateway sessions") so the label matches the global behavior.

## What changed

### Sidebar (`apps/desktop/src/app/chat/sidebar/index.tsx`)

- Optional `onRefreshMessaging` prop on `ChatSidebar`
- Per-platform `headerAction` refresh button (codicon spinner, disabled-while-in-flight, `stopPropagation` so the click doesn't collapse the section)
- Resets `messagingVisible` after refresh so newly fetched rows aren't hidden behind the per-platform row cap

### Controller (`apps/desktop/src/app/desktop-controller.tsx`)

- Wires `onRefreshMessaging={() => refreshMessagingSessions()}`
- Clears `$messagingPlatformTotals` on refresh so per-platform "Load more" counts stay accurate after a full re-fetch

### i18n (`en`, `zh`, `zh-hant`, `ja`, `types.ts`)

- `sidebar.refreshMessaging` / `sidebar.refreshingMessaging` — generic gateway copy, not per-platform strings

### Tests (`apps/desktop/src/app/chat/sidebar/messaging-refresh.test.tsx`)

- 4 vitest cases: render per section, click handler, omitted-prop guard, in-flight disable/spinner

## Problem / context

The desktop sidebar splits sessions into two slices:

| Slice | Atom | When it updates today |
|-------|------|------------------------|
| Local recents | `$sessions` | Profile switch, load-more, agent turn, session sync |
| Messaging platforms | `$messagingSessions` | Same triggers **plus** gateway connect |

There was no user-triggered path to re-pull messaging rows while the app stayed open. A new Telegram DM created on the gateway while desktop was running would not appear until one of the passive refresh triggers fired. This PR closes that gap with an explicit refresh affordance.

## Test plan

```bash
npm run test:ui -- src/app/chat/sidebar/messaging-refresh.test.tsx
npm run typecheck
```

Coverage:

- [x] Refresh button renders on each messaging platform section when `onRefreshMessaging` is provided
- [x] Click invokes `onRefreshMessaging` exactly once
- [x] No button when prop is omitted (embed / secondary surfaces)
- [x] All platform refresh buttons disable and show in-flight label while the promise is pending

Manual:

- [x] Desktop + gateway running; existing Telegram sessions visible under **Telegram**
- [x] New Telegram chat started while desktop stays open → click refresh → new session appears
- [ ] Multi-platform setup (e.g. Telegram + Discord) → refresh on either section updates both

## Platforms tested

- [x] Windows 11 (primary dev environment)
- [x] macOS (not run in this PR — Electron + React only; no platform-specific APIs)
- [ ] Linux (not run in this PR)

## Compatibility

- **No behavior change** when the button isn't used — passive refresh paths are untouched.
- **No new dependencies**, env vars, or `config.yaml` keys.
- **No Python / gateway surface** — safe to merge without a pytest run; desktop vitest + typecheck are the relevant gates.
- Refresh is **read-only** against each profile's `state.db` via the existing dashboard REST route.

## Notes for reviewers

- Deliberately reuses `refreshMessagingSessions()` rather than adding a new RPC or per-platform endpoint — the combined fetch already seeds every platform section; duplicating it per header would add complexity without benefit.
- `$messagingPlatformTotals` is cleared on refresh because the seed fetch doesn't resolve per-platform exact totals; stale totals would mislead the "Load more" footer until the user pages again.
- Open to splitting into per-platform refresh later if maintainers prefer narrower scope; the current UX matches the existing combined-fetch architecture.

---

## Checklist

### Code

- [x] Read [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(desktop): …`)
- [x] Searched [open PRs](https://github.com/NousResearch/hermes-agent/pulls) for duplicates
- [x] PR contains only changes related to this feature
- [x] Added tests (4 vitest cases)
- [x] `scripts/run_tests.sh` — N/A (desktop-only; no Python changes)
- [x] Tested manually on Windows 11

### Documentation & housekeeping

- [x] README / docs — N/A (UI affordance, no new user-facing CLI or config)
- [x] `cli-config.yaml.example` — N/A
- [x] `AGENTS.md` / `CONTRIBUTING.md` — N/A
- [x] Cross-platform impact considered — standard Electron/React; no OS-specific APIs
- [x] Tool schemas — N/A

---

Happy to iterate on copy, per-platform vs global refresh scope, or whether this should be filed against an issue first.