### PR TITLE
feat(telegram): interactive resume session picker with inline keyboard

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -22,7 +22,6 @@ import {
   MESSAGING_SESSION_SOURCE_IDS,
   normalizeSessionSource
 } from '../lib/session-source'
-import { storedSessionIdForNotification } from '../lib/session-ids'
 import { latestSessionTodos } from '../lib/todos'
 import { setCronFocusJobId, setCronJobs } from '../store/cron'
 import {

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -22,6 +22,7 @@ import {
   MESSAGING_SESSION_SOURCE_IDS,
   normalizeSessionSource
 } from '../lib/session-source'
+import { storedSessionIdForNotification } from '../lib/session-ids'
 import { latestSessionTodos } from '../lib/todos'
 import { setCronFocusJobId, setCronJobs } from '../store/cron'
 import {

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2941,6 +2941,22 @@ class GatewaySlashCommandsMixin:
             else:
                 return t("gateway.title.current_no_title", session_id=session_id)
 
+    async def _resume_session_by_id(self, chat_id: str, session_id: str, session_key: str) -> str:
+        """Switch to a specific session by ID (called from resume picker callback)."""
+        if not self._session_db:
+            return "Session database not available."
+        self._release_running_agent_state(session_key)
+        new_entry = self.session_store.switch_session(session_key, session_id)
+        if not new_entry:
+            return "Failed to switch session."
+        self._clear_session_boundary_security_state(session_key)
+        self._evict_cached_agent(session_key)
+        title = self._session_db.get_session_title(session_id) or session_id[:8]
+        history = self.session_store.load_transcript(session_id)
+        msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
+        msg_part = f" ({msg_count} message{'s' if msg_count != 1 else ''})" if msg_count else ""
+        return f"\u21bb Resumed session **{title}**{msg_part}. Conversation restored."
+
     async def _handle_resume_command(self, event: MessageEvent) -> str:
         """Handle /resume command — list or switch to a previous session."""
         if not self._session_db:
@@ -2970,8 +2986,8 @@ class GatewaySlashCommandsMixin:
 
         def _list_titled_sessions() -> list[dict]:
             user_source = source.platform.value if source.platform else None
-            sessions = self._session_db.list_sessions_rich(source=user_source, limit=10)
-            return [s for s in sessions if s.get("title")][:10]
+            sessions = self._session_db.list_sessions_rich(source=user_source, limit=50)
+            return [s for s in sessions if s.get("title")]
 
         if not name:
             # List recent titled sessions for this user/platform
@@ -2988,6 +3004,17 @@ class GatewaySlashCommandsMixin:
                     if source.platform == Platform.MATRIX and not allow_all:
                         return t("gateway.resume.matrix_no_named_sessions")
                     return t("gateway.resume.no_named_sessions")
+                # Platforms with interactive pickers get inline buttons
+                # instead of a numbered text list (e.g. Telegram bot API).
+                adapter = self.adapters.get(source.platform) if hasattr(self, 'adapters') else None
+                if adapter is not None and hasattr(adapter, "send_resume_picker"):
+                    await adapter.send_resume_picker(
+                        chat_id=source.chat_id,
+                        sessions=titled[:24],
+                        on_session_selected=self._resume_session_by_id,
+                        metadata=getattr(source, "metadata", None),
+                    )
+                    return ""
                 lines = [t("gateway.resume.list_header")]
                 for idx, s in enumerate(titled[:10], start=1):
                     title = s["title"]

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -581,6 +581,8 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
+        # Interactive resume session picker state per chat
+        self._resume_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
@@ -3603,6 +3605,153 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    def _build_resume_keyboard(self, sessions: list, page: int) -> tuple:
+        """Build paginated resume-session buttons. Returns (keyboard, page_info_text)."""
+        page_size = self._RESUME_PAGE_SIZE
+        total = len(sessions)
+        total_pages = max(1, (total + page_size - 1) // page_size)
+        page = max(0, min(page, total_pages - 1))
+        start = page * page_size
+        end = min(start + page_size, total)
+        page_sessions = sessions[start:end]
+
+        rows = []
+        for i, session in enumerate(page_sessions):
+            abs_idx = start + i
+            title = str(session.get("title") or session.get("id") or "Untitled")
+            label = title if len(title) <= 38 else title[:35] + "..."
+            rows.append([InlineKeyboardButton(label, callback_data=f"rs:{abs_idx}")])
+
+        if total_pages > 1:
+            nav = []
+            if page > 0:
+                nav.append(InlineKeyboardButton("◀ Prev", callback_data=f"rg:{page - 1}"))
+            nav.append(InlineKeyboardButton(f"{page + 1}/{total_pages}", callback_data="rx:noop"))
+            if page < total_pages - 1:
+                nav.append(InlineKeyboardButton("Next ▶", callback_data=f"rg:{page + 1}"))
+            rows.append(nav)
+
+        rows.append([InlineKeyboardButton("✗ Cancel", callback_data="rx")])
+        page_info = f" ({start + 1}-{end} of {total})" if total_pages > 1 else ""
+        return InlineKeyboardMarkup(rows), page_info
+
+    async def send_resume_picker(
+        self,
+        chat_id: str,
+        sessions: list,
+        on_session_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive inline-keyboard session resume picker."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            chat_key = str(chat_id)
+            keyboard, page_info = self._build_resume_keyboard(sessions, 0)
+            thread_id = metadata.get("thread_id") if metadata else None
+            text = f"📋 *Named Sessions*{page_info}\n\nSelect a session to resume:"
+            msg = await self._bot.send_message(
+                chat_id=int(chat_id),
+                text=text,
+                parse_mode=ParseMode.MARKDOWN,
+                reply_markup=keyboard,
+                message_thread_id=int(thread_id) if thread_id else None,
+                **self._link_preview_kwargs(),
+            )
+            self._resume_picker_state[chat_key] = {
+                "msg_id": msg.message_id,
+                "sessions": sessions,
+                "on_session_selected": on_session_selected,
+                "page": 0,
+            }
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_resume_picker failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def _handle_resume_picker_callback(self, query, data: str, chat_id: str) -> None:
+        """Handle resume picker callbacks (rs:/rg:/rx)."""
+        state = self._resume_picker_state.get(chat_id)
+        if not state:
+            await query.answer(text="Resume picker expired — use /resume again.")
+            return
+
+        if data == "rx:noop":
+            await query.answer()
+            return
+
+        if data.startswith("rg:"):
+            try:
+                page = int(data[3:])
+            except ValueError:
+                await query.answer(text="Invalid page.")
+                return
+            sessions = state.get("sessions", [])
+            state["page"] = page
+            keyboard, page_info = self._build_resume_keyboard(sessions, page)
+            await query.edit_message_text(
+                text=f"📋 *Named Sessions*{page_info}\n\nSelect a session to resume:",
+                parse_mode=ParseMode.MARKDOWN,
+                reply_markup=keyboard,
+            )
+            await query.answer()
+            return
+
+        if data.startswith("rs:"):
+            try:
+                idx = int(data[3:])
+            except ValueError:
+                await query.answer(text="Invalid selection.")
+                return
+            sessions = state.get("sessions", [])
+            if idx < 0 or idx >= len(sessions):
+                await query.answer(text="Invalid session index.")
+                return
+            session = sessions[idx]
+            session_id = session.get("id")
+            callback = state.get("on_session_selected")
+            if not callable(callback):
+                await query.answer(text="Picker expired.")
+                return
+            try:
+                from gateway.session import build_session_key, SessionSource
+                source = SessionSource(
+                    platform=Platform.TELEGRAM,
+                    user_id=str(getattr(query.from_user, "id", "")),
+                    chat_id=str(query.message.chat_id),
+                    user_name=getattr(query.from_user, "username", None),
+                )
+                session_key = build_session_key(source)
+            except Exception:
+                session_key = f"agent:main:telegram:{chat_id}"
+            try:
+                result_text = await callback(chat_id, session_id, session_key)
+            except Exception as exc:
+                logger.error("Resume picker switch failed: %s", exc)
+                result_text = f"Error resuming session: {exc}"
+            try:
+                await query.edit_message_text(
+                    text=result_text,
+                    parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=None,
+                )
+            except Exception:
+                try:
+                    await query.edit_message_text(text=result_text, parse_mode=None, reply_markup=None)
+                except Exception:
+                    pass
+            await query.answer(text="Session resumed.")
+            self._resume_picker_state.pop(chat_id, None)
+            return
+
+        # rx (cancel)
+        self._resume_picker_state.pop(chat_id, None)
+        try:
+            await query.edit_message_text(text="Resume cancelled.", reply_markup=None)
+        except Exception:
+            pass
+        await query.answer()
+
     async def send_model_picker(
         self,
         chat_id: str,
@@ -3675,6 +3824,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(e))
 
     _MODEL_PAGE_SIZE = 8
+    _RESUME_PAGE_SIZE = 8
 
     def _build_provider_keyboard(self, providers: list):
         """Build the top-level provider keyboard, folding provider groups.
@@ -4081,6 +4231,13 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # --- Resume picker callbacks ---
+        if data.startswith(("rs:", "rg:", "rx")):
+            chat_id = str(query.message.chat_id) if query.message else None
+            if chat_id:
+                await self._handle_resume_picker_callback(query, data, chat_id)
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mm:", "mc:", "mb", "mx", "mg:")):


### PR DESCRIPTION
## What

Replaces the static numbered text list on Telegram `/resume` with an interactive inline-keyboard picker. Tapping a session name resumes it immediately -- no typing numbers.

## Why

The current text list is fine for CLI but clunky on mobile. Three taps (type number, send, wait) vs one tap with the picker. This matters when you have 20+ named sessions.

## How

- `TelegramAdapter` gains `send_resume_picker`, `_handle_resume_picker_callback`, `_build_resume_keyboard` with pagination (8 per page, Prev/Next nav)
- `GatewaySlashCommandsMixin` gets `_resume_session_by_id` -- does the actual session switch and returns the confirmation text
- `_handle_resume_command` checks for `send_resume_picker` on the adapter before falling back to the text list
- Session query expanded from 10 to 50 for wider coverage (picker shows up to 24)

## Backward compatibility

Platforms without `send_resume_picker` (Discord, Slack, Matrix, CLI) keep the existing numbered text response. Zero impact.

## Testing

Manual on running gateway with 30+ named sessions. Picker appears on bare `/resume`, navigating pages works, tapping a session switches correctly, cancel dismisses the keyboard, expired state shows a hint to run `/resume` again.