### PR TITLE
fix(computer_use): route CUA capture through get_window_state

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -416,6 +416,7 @@ AUTHOR_MAP = {
     "25840394+Bongulielmi@users.noreply.github.com": "Bongulielmi",
     "jonathan.troyer@overmatch.com": "JTroyerOvermatch",
     "53142663+tt-a1i@users.noreply.github.com": "tt-a1i",  # PR #48933 (SSE-only Anthropic stream aggregation, #48923)
+    "jeevesassistant00@gmail.com": "jeeves-assistant",
     "harryykyle1@gmail.com": "hharry11",
     "wysie@users.noreply.github.com": "wysie",
     "ronhi@buildabear1.localdomain": "RonHillDev",  # PR #29523 salvage (machine-local commit email)

--- a/tests/tools/test_cua_backend_capture.py
+++ b/tests/tools/test_cua_backend_capture.py
@@ -1,0 +1,150 @@
+"""Regression tests for cua-driver 0.5.x capture routing.
+
+cua-driver no longer exposes the old standalone ``screenshot`` MCP tool.
+Hermes must request screenshots through ``get_window_state`` with the
+appropriate ``capture_mode`` instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+
+_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42m"
+    "NkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+)
+
+
+def _window_list() -> Dict[str, Any]:
+    return {
+        "data": "",
+        "images": [],
+        "structuredContent": {
+            "windows": [
+                {
+                    "app_name": "Safari",
+                    "pid": 1234,
+                    "window_id": 5678,
+                    "is_on_screen": True,
+                    "title": "Test Page",
+                    "z_index": 0,
+                }
+            ]
+        },
+        "isError": False,
+    }
+
+
+def _make_backend(get_window_state_response: Dict[str, Any]):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    backend._session = MagicMock()
+
+    responses = {
+        "list_windows": _window_list(),
+        "get_window_state": get_window_state_response,
+    }
+
+    def _call_tool(name, args):
+        if name in responses:
+            return responses[name]
+        return {
+            "data": f"Unknown tool: {name}",
+            "images": [],
+            "structuredContent": None,
+            "isError": True,
+        }
+
+    backend._session.call_tool.side_effect = _call_tool
+    return backend
+
+
+def _tool_call_names(backend):
+    return [call.args[0] for call in backend._session.call_tool.call_args_list]
+
+
+def _get_window_state_args(backend):
+    for call in backend._session.call_tool.call_args_list:
+        if call.args[0] == "get_window_state":
+            return call.args[1]
+    raise AssertionError("get_window_state was not called")
+
+
+class TestCuaVisionCapture:
+    def test_vision_uses_get_window_state_not_screenshot(self):
+        backend = _make_backend({
+            "data": "",
+            "images": [_PNG_B64],
+            "structuredContent": {
+                "screenshot_width": 1920,
+                "screenshot_height": 1080,
+            },
+            "isError": False,
+        })
+
+        result = backend.capture(mode="vision")
+
+        tool_names = _tool_call_names(backend)
+        assert "screenshot" not in tool_names
+        assert "get_window_state" in tool_names
+        assert _get_window_state_args(backend)["capture_mode"] == "vision"
+        assert result.png_b64 == _PNG_B64
+        assert result.width == 1920
+        assert result.height == 1080
+        assert result.png_bytes_len > 0
+
+
+class TestCuaSomCapture:
+    def test_som_passes_capture_mode_and_returns_png_plus_elements(self):
+        backend = _make_backend({
+            "data": "✅ Safari — 2 elements\n[1] AXButton \"Go\"\n[2] AXTextField \"Search\"",
+            "images": [_PNG_B64],
+            "structuredContent": {
+                "screenshot_width": 1280,
+                "screenshot_height": 800,
+            },
+            "isError": False,
+        })
+
+        result = backend.capture(mode="som")
+
+        assert _get_window_state_args(backend)["capture_mode"] == "som"
+        assert result.png_b64 == _PNG_B64
+        assert result.width == 1280
+        assert result.height == 800
+        assert [element.index for element in result.elements] == [1, 2]
+
+
+class TestCuaAxCapture:
+    def test_ax_still_returns_elements_without_png(self):
+        backend = _make_backend({
+            "data": "✅ Safari — 2 elements\n[1] AXButton \"OK\"\n[2] AXStaticText \"Hello\"",
+            "images": [],
+            "structuredContent": None,
+            "isError": False,
+        })
+
+        result = backend.capture(mode="ax")
+
+        assert _get_window_state_args(backend)["capture_mode"] == "ax"
+        assert result.png_b64 is None
+        assert result.png_bytes_len == 0
+        assert result.width == 0
+        assert result.height == 0
+        assert [element.label for element in result.elements] == ["OK", "Hello"]
+
+    def test_missing_structured_content_keeps_dimensions_zero(self):
+        backend = _make_backend({
+            "data": "✅ Safari — 0 elements\n",
+            "images": [],
+            "structuredContent": None,
+            "isError": False,
+        })
+
+        result = backend.capture(mode="ax")
+
+        assert result.width == 0
+        assert result.height == 0

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -427,7 +427,7 @@ class CuaDriverBackend(ComputerUseBackend):
         """Capture the frontmost on-screen window (optionally filtered by app name).
 
         Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
-        `get_window_state` (ax/som) or `screenshot` (vision).
+        `get_window_state` with capture_mode set for the requested capture.
         """
         # Step 1: enumerate on-screen windows to find target pid/window_id.
         lw_out = self._session.call_tool("list_windows", {"on_screen_only": True})
@@ -497,29 +497,40 @@ class CuaDriverBackend(ComputerUseBackend):
         width = height = 0
         window_title = ""
 
+        # cua-driver 0.5.x no longer exposes the old standalone `screenshot`
+        # MCP tool. Screenshots now come from `get_window_state` when the
+        # requested capture_mode is `vision` or `som`.
+        gws_args: Dict[str, Any] = {
+            "pid": self._active_pid,
+            "window_id": self._active_window_id,
+        }
+        if mode in {"ax", "som", "vision"}:
+            gws_args["capture_mode"] = mode
+
+        gws_out = self._session.call_tool("get_window_state", gws_args)
+
+        gws_sc = gws_out.get("structuredContent") or {}
+        if isinstance(gws_sc, dict):
+            if gws_sc.get("screenshot_width"):
+                width = int(gws_sc["screenshot_width"])
+            if gws_sc.get("screenshot_height"):
+                height = int(gws_sc["screenshot_height"])
+
         if mode == "vision":
-            # screenshot tool: just the PNG, no AX walk.
-            sc_out = self._session.call_tool(
-                "screenshot",
-                {"window_id": self._active_window_id, "format": "jpeg", "quality": 85},
-            )
-            if sc_out["images"]:
-                png_b64 = sc_out["images"][0]
+            # Vision mode: just the PNG, no AX walk.
+            if gws_out.get("images"):
+                png_b64 = gws_out["images"][0]
         else:
-            # get_window_state: AX tree + optional screenshot.
-            gws_out = self._session.call_tool(
-                "get_window_state",
-                {"pid": self._active_pid, "window_id": self._active_window_id},
-            )
+            # ax/som mode: AX tree + optional screenshot.
             text = gws_out["data"] if isinstance(gws_out["data"], str) else ""
             summary, tree = _split_tree_text(text)
 
             # Parse element count from summary e.g. "✅ AppName — 42 elements, turn 3..."
             m = re.search(r'(\d+)\s+elements?', summary)
-            if tree and not gws_out["images"]:
+            if tree and not gws_out.get("images"):
                 # ax mode — no screenshot
                 elements = _parse_elements_from_tree(tree)
-            elif gws_out["images"]:
+            elif gws_out.get("images"):
                 png_b64 = gws_out["images"][0]
                 elements = _parse_elements_from_tree(tree)
 
@@ -534,7 +545,7 @@ class CuaDriverBackend(ComputerUseBackend):
                 raw = base64.b64decode(png_b64, validate=False)
                 png_bytes_len = len(raw)
                 detected_width, detected_height = _image_dimensions_from_bytes(raw)
-                if detected_width and detected_height:
+                if not (width and height) and detected_width and detected_height:
                     width = detected_width
                     height = detected_height
             except Exception:


### PR DESCRIPTION
## Summary
- Routes CUA vision/SOM/AX captures through `get_window_state` instead of the stale standalone `screenshot` MCP tool.
- Passes `capture_mode="vision"` / `"som"` / `"ax"` so cua-driver 0.5.x returns the expected payload shape.
- Preserves AX no-image behavior and prefers `structuredContent` screenshot dimensions when cua-driver provides them.
- Adds the Jeeves Assistant author-map entry required by CI attribution checks.

## Verification
- `python -m pytest tests/tools/test_cua_backend_capture.py tests/tools/test_computer_use.py tests/tools/test_computer_use_capture_routing.py tests/tools/test_computer_use_vision_routing.py -q -o 'addopts='` → 128 passed, 1 warning
- `python -m py_compile scripts/release.py tools/computer_use/cua_backend.py tests/tools/test_cua_backend_capture.py`
- `git diff --check`

Related: #39242. This is intentionally the narrow reversible seam described in the field notes; it mirrors the existing upstream fix direction without adding new runtime surface.
