### PR TITLE
feat(compression): in-place compaction option, single session id (#38763) [1/2]

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1325,6 +1325,14 @@ def init_agent(
     compression_abort_on_summary_failure = str(
         _compression_cfg.get("abort_on_summary_failure", False)
     ).lower() in {"true", "1", "yes"}
+    # In-place compaction: when True, compress_context() rewrites the message
+    # list + rebuilds the system prompt WITHOUT rotating the session id (no
+    # parent_session_id chain, no `name #N` renumber). See #38763 and
+    # agent/conversation_compression.py. Consumed by compress_context(), not the
+    # compressor, so it rides on the agent.
+    compression_in_place = str(
+        _compression_cfg.get("in_place", False)
+    ).lower() in {"true", "1", "yes"}
 
     # Read optional explicit context_length override for the auxiliary
     # compression model. Custom endpoints often cannot report this via
@@ -1544,6 +1552,7 @@ def init_agent(
             abort_on_summary_failure=compression_abort_on_summary_failure,
         )
     agent.compression_enabled = compression_enabled
+    agent.compression_in_place = compression_in_place
 
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -50,7 +50,7 @@ from agent.tool_guardrails import (
 from hermes_cli.config import cfg_get
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
-from utils import base_url_host_matches
+from utils import base_url_host_matches, is_truthy_value
 
 # Use the same logger name as run_agent so tests patching ``run_agent.logger``
 # capture our warnings.  (run_agent.py also does
@@ -1330,9 +1330,9 @@ def init_agent(
     # parent_session_id chain, no `name #N` renumber). See #38763 and
     # agent/conversation_compression.py. Consumed by compress_context(), not the
     # compressor, so it rides on the agent.
-    compression_in_place = str(
-        _compression_cfg.get("in_place", False)
-    ).lower() in {"true", "1", "yes"}
+    compression_in_place = is_truthy_value(
+        _compression_cfg.get("in_place"), default=False
+    )
 
     # Read optional explicit context_length override for the auxiliary
     # compression model. Custom endpoints often cannot report this via

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -328,6 +328,13 @@ def compress_context(
         agent._compression_feasibility_checked = True
 
     _pre_msg_count = len(messages)
+    # In-place compaction (config: compression.in_place, see #38763). When True,
+    # this compaction rewrites the message list + rebuilds the system prompt but
+    # keeps the SAME session_id — no end_session, no parent_session_id child, no
+    # `name #N` renumber, no contextvar/env/logging re-sync, no memory/context-
+    # engine session-switch. The conversation keeps one durable id for life,
+    # eliminating the session-rotation bug cluster. Default False during rollout.
+    in_place = bool(getattr(agent, "compression_in_place", False))
     logger.info(
         "context compression started: session=%s messages=%d tokens=~%s model=%s focus=%r",
         agent.session_id or "none", _pre_msg_count,
@@ -508,65 +515,82 @@ def compress_context(
 
     if agent._session_db:
         try:
-            # Propagate title to the new session with auto-numbering
-            old_title = agent._session_db.get_session_title(agent.session_id)
-            # Trigger memory extraction on the old session before it rotates.
+            # Trigger memory extraction on the current session before the
+            # transcript is rewritten (runs in BOTH modes — the logical
+            # conversation's pre-compaction turns are about to be summarized
+            # away regardless of whether the id rotates).
             agent.commit_memory_session(messages)
-            # Flush any un-persisted messages from the current turn to the
-            # old session *before* rotating.  compress_context() can be
-            # called mid-turn (auto-compress when context exceeds threshold)
-            # at a point when _flush_messages_to_session_db() has not yet
-            # run.  Without this, messages generated during the current turn
-            # are silently lost on session rotation (#47202).
+            # Flush any un-persisted messages from the current turn *before*
+            # the rewrite.  compress_context() can be called mid-turn
+            # (auto-compress when context exceeds threshold) at a point when
+            # _flush_messages_to_session_db() has not yet run.  Without this,
+            # messages generated during the current turn are silently lost
+            # (#47202). In-place mode flushes to the SAME session; rotation
+            # mode flushes to the old session before ending it.
             try:
                 agent._flush_messages_to_session_db(messages)
             except Exception:
                 pass  # best-effort — don't block compression on a flush error
-            agent._session_db.end_session(agent.session_id, "compression")
-            old_session_id = agent.session_id
-            agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
-            # Ordering contract: the agent thread updates the contextvar here;
-            # the gateway propagates to SessionEntry after run_in_executor returns.
-            try:
-                from gateway.session_context import set_current_session_id
 
-                set_current_session_id(agent.session_id)
-            except Exception:
-                os.environ["HERMES_SESSION_ID"] = agent.session_id
-            # The gateway/tools session context (ContextVar + env) and the
-            # logging session context are SEPARATE mechanisms. The call above
-            # moves the former; the ``[session_id]`` tag on log lines comes
-            # from ``hermes_logging._session_context`` (set once per turn in
-            # conversation_loop.py). Without this, post-rotation log lines in
-            # the same turn keep the STALE old id while the message/DB/gateway
-            # state carry the new one — breaking log correlation exactly at the
-            # compaction boundary (see #34089). Guarded separately so a logging
-            # failure can never regress the routing update above.
-            try:
-                from hermes_logging import set_session_context
-
-                set_session_context(agent.session_id)
-            except Exception:
-                pass
-            agent._session_db_created = False
-            agent._session_db.create_session(
-                session_id=agent.session_id,
-                source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
-                model=agent.model,
-                model_config=agent._session_init_model_config,
-                parent_session_id=old_session_id,
-            )
-            agent._session_db_created = True
-            # Auto-number the title for the continuation session
-            if old_title:
+            if in_place:
+                # ── In-place compaction: keep the same session_id ──────────
+                # No end_session, no new row, no parent_session_id, no title
+                # renumber, no contextvar/env/logging re-sync. Just refresh
+                # the stored system prompt on the existing row. The session's
+                # id, title, cwd, /goal, FTS-indexed history, and gateway
+                # routing all stay put. See #38763.
+                agent._session_db.update_system_prompt(
+                    agent.session_id, new_system_prompt
+                )
+            else:
+                # ── Rotation (legacy): end this session, fork a continuation ─
+                # Propagate title to the new session with auto-numbering
+                old_title = agent._session_db.get_session_title(agent.session_id)
+                agent._session_db.end_session(agent.session_id, "compression")
+                old_session_id = agent.session_id
+                agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+                # Ordering contract: the agent thread updates the contextvar here;
+                # the gateway propagates to SessionEntry after run_in_executor returns.
                 try:
-                    new_title = agent._session_db.get_next_title_in_lineage(old_title)
-                    agent._session_db.set_session_title(agent.session_id, new_title)
-                except (ValueError, Exception) as e:
-                    logger.debug("Could not propagate title on compression: %s", e)
-            agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
-            # Reset flush cursor — new session starts with no messages written
-            agent._last_flushed_db_idx = 0
+                    from gateway.session_context import set_current_session_id
+
+                    set_current_session_id(agent.session_id)
+                except Exception:
+                    os.environ["HERMES_SESSION_ID"] = agent.session_id
+                # The gateway/tools session context (ContextVar + env) and the
+                # logging session context are SEPARATE mechanisms. The call above
+                # moves the former; the ``[session_id]`` tag on log lines comes
+                # from ``hermes_logging._session_context`` (set once per turn in
+                # conversation_loop.py). Without this, post-rotation log lines in
+                # the same turn keep the STALE old id while the message/DB/gateway
+                # state carry the new one — breaking log correlation exactly at the
+                # compaction boundary (see #34089). Guarded separately so a logging
+                # failure can never regress the routing update above.
+                try:
+                    from hermes_logging import set_session_context
+
+                    set_session_context(agent.session_id)
+                except Exception:
+                    pass
+                agent._session_db_created = False
+                agent._session_db.create_session(
+                    session_id=agent.session_id,
+                    source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                    model=agent.model,
+                    model_config=agent._session_init_model_config,
+                    parent_session_id=old_session_id,
+                )
+                agent._session_db_created = True
+                # Auto-number the title for the continuation session
+                if old_title:
+                    try:
+                        new_title = agent._session_db.get_next_title_in_lineage(old_title)
+                        agent._session_db.set_session_title(agent.session_id, new_title)
+                    except (ValueError, Exception) as e:
+                        logger.debug("Could not propagate title on compression: %s", e)
+                agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+                # Reset flush cursor — new session starts with no messages written
+                agent._last_flushed_db_idx = 0
         except Exception as e:
             logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -530,18 +530,20 @@ def compress_context(
                 # renumber, no contextvar/env/logging re-sync. The session's
                 # id, title, cwd, /goal, and gateway routing all stay put.
                 #
-                # Durable replace: the persisted transcript MUST become the
-                # compacted set, not "original history + summary". `compressed`
-                # already carries the surviving tail (current-turn messages the
-                # compressor kept via protect_last_n), so we DON'T pre-flush
-                # here — a flush would INSERT current-turn rows that the
-                # replace_messages DELETE immediately discards (wasted writes).
-                # Atomically replace ALL rows with `compressed` so a resume
-                # reloads the compacted transcript (lossy by design — the
-                # pre-compaction turns are summarized away). Without this the
-                # row keeps the full history and compaction never durably
-                # shrinks anything (the next turn just re-compacts). See #38763.
-                agent._session_db.replace_messages(agent.session_id, compressed)
+                # Durable, NON-DESTRUCTIVE replace: soft-archive the
+                # pre-compaction turns (active=0, kept on disk + FTS-searchable +
+                # recoverable) and insert `compressed` as the new live (active=1)
+                # set, atomically. `compressed` already carries the surviving
+                # tail (current-turn messages the compressor kept via
+                # protect_last_n), so we DON'T pre-flush here — a flush would
+                # INSERT current-turn rows that archive_and_compact would then
+                # archive alongside the rest (harmless but wasted writes). The
+                # live-context load filters active=1, so a resume reloads ONLY
+                # the compacted set; the original turns remain under the SAME id
+                # for search/recovery (Teknium review — keep one durable id
+                # WITHOUT destroying history, unlike a hard replace_messages).
+                # See #38763.
+                agent._session_db.archive_and_compact(agent.session_id, compressed)
                 # Reset the flush identity set so the next turn's appends are
                 # diffed against the COMPACTED transcript: the compacted dicts
                 # are passed as conversation_history next turn and skipped by

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -535,13 +535,34 @@ def compress_context(
             if in_place:
                 # ── In-place compaction: keep the same session_id ──────────
                 # No end_session, no new row, no parent_session_id, no title
-                # renumber, no contextvar/env/logging re-sync. Just refresh
-                # the stored system prompt on the existing row. The session's
-                # id, title, cwd, /goal, FTS-indexed history, and gateway
-                # routing all stay put. See #38763.
+                # renumber, no contextvar/env/logging re-sync. The session's
+                # id, title, cwd, /goal, and gateway routing all stay put.
+                #
+                # Durable replace: the persisted transcript MUST become the
+                # compacted set, not "original history + summary". The flush
+                # above wrote any un-persisted current-turn messages onto the
+                # row; now atomically replace ALL rows with `compressed` so a
+                # resume reloads the compacted transcript (lossy by design —
+                # the pre-compaction turns are summarized away). Without this
+                # the row keeps the full history and compaction never durably
+                # shrinks anything (the next turn just re-compacts). See #38763.
+                agent._session_db.replace_messages(agent.session_id, compressed)
                 agent._session_db.update_system_prompt(
                     agent.session_id, new_system_prompt
                 )
+                # Reset the flush identity/cursor so the next turn's appends are
+                # diffed against the COMPACTED transcript, not the pre-compaction
+                # one. _flush_messages_to_session_db rebuilds its identity set
+                # when _last_flushed_db_idx == 0; the compacted dicts are passed
+                # as conversation_history next turn and skipped by identity, so
+                # only genuinely new turn messages get appended (no dup of the
+                # summary, no resurrection of dropped turns).
+                agent._last_flushed_db_idx = 0
+                agent._flushed_db_message_ids = set()
+                # Rotation-independent signal: the conversation was compacted in
+                # place (id unchanged). The caller / gateway uses this instead of
+                # an id-change diff to re-baseline transcript handling.
+                compacted_in_place = True
             else:
                 # ── Rotation (legacy): end this session, fork a continuation ─
                 # Propagate title to the new session with auto-numbering
@@ -594,34 +615,37 @@ def compress_context(
         except Exception as e:
             logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 
-    # Notify the context engine that the session_id rotated because of
-    # compression (not a fresh /new). Plugin engines (e.g. hermes-lcm) use
-    # boundary_reason="compression" to preserve DAG lineage across the
-    # rollover instead of re-initializing fresh per-session state.
-    # See hermes-lcm#68. Built-in ContextCompressor ignores kwargs.
+    # Notify the context engine that a compaction boundary occurred. Plugin
+    # engines (e.g. hermes-lcm) use boundary_reason="compression" to preserve
+    # DAG lineage / checkpoint per-session state across the boundary instead of
+    # re-initializing fresh. See hermes-lcm#68. Built-in ContextCompressor
+    # ignores kwargs. Fires in BOTH modes: rotation passes old→new ids; in-place
+    # passes the SAME id (the boundary is real even though the id didn't move).
     try:
         _old_sid = locals().get("old_session_id")
-        if _old_sid and hasattr(agent.context_compressor, "on_session_start"):
+        _boundary = bool(_old_sid) or in_place
+        if _boundary and hasattr(agent.context_compressor, "on_session_start"):
             agent.context_compressor.on_session_start(
                 agent.session_id or "",
                 boundary_reason="compression",
-                old_session_id=_old_sid,
+                old_session_id=_old_sid or agent.session_id or "",
                 conversation_id=getattr(agent, "_gateway_session_key", None),
             )
     except Exception as _ce_err:
         logger.debug("context engine on_session_start (compression): %s", _ce_err)
 
-    # Notify memory providers of the compression-driven session_id rotation
-    # so provider-cached per-session state (Hindsight's _document_id,
-    # accumulated turn buffers, counters) refreshes. reset=False because
-    # the logical conversation continues; only the id and DB row rolled
-    # over. See #6672.
+    # Notify memory providers of the compaction boundary so provider-cached
+    # per-session state (Hindsight's _document_id, accumulated turn buffers,
+    # counters) refreshes. reset=False because the logical conversation
+    # continues. See #6672. Fires in BOTH modes: in-place uses the same id as
+    # parent (the conversation didn't fork, but the buffer must still be told
+    # the transcript was compacted so it doesn't double-count dropped turns).
     try:
         _old_sid = locals().get("old_session_id")
-        if _old_sid and agent._memory_manager:
+        if (_old_sid or in_place) and agent._memory_manager:
             agent._memory_manager.on_session_switch(
                 agent.session_id or "",
-                parent_session_id=_old_sid,
+                parent_session_id=_old_sid or agent.session_id or "",
                 reset=False,
                 reason="compression",
             )
@@ -638,7 +662,9 @@ def compress_context(
         )
 
     # Emit session:compress event so hooks (e.g. MemPalace sync) can ingest
-    # the completed old session before its details are lost.
+    # the completed old session before its details are lost. In in-place mode
+    # there is no old id (same session); ``in_place=True`` tells hooks the
+    # transcript was compacted on the same id rather than rotated.
     _old_sid_for_event = locals().get("old_session_id")
     if getattr(agent, "event_callback", None):
         try:
@@ -646,10 +672,17 @@ def compress_context(
                 "platform": agent.platform or "",
                 "session_id": agent.session_id,
                 "old_session_id": _old_sid_for_event or "",
+                "in_place": in_place,
                 "compression_count": agent.context_compressor.compression_count,
             })
         except Exception as e:
             logger.debug("event_callback error on session:compress: %s", e)
+
+    # Surface the compaction mode to the caller (run_conversation / gateway)
+    # via a rotation-independent flag. The gateway uses this — NOT an
+    # id-change diff — to re-baseline transcript handling (history_offset=0 +
+    # rewrite on the same id) when compaction happened in place. See #38763.
+    agent._last_compaction_in_place = bool(locals().get("compacted_in_place", False))
 
     # Keep the post-compression rough estimate for diagnostics, but do not
     # treat it as provider-reported prompt usage. Schema-heavy rough estimates

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -335,6 +335,9 @@ def compress_context(
     # engine session-switch. The conversation keeps one durable id for life,
     # eliminating the session-rotation bug cluster. Default False during rollout.
     in_place = bool(getattr(agent, "compression_in_place", False))
+    # Set True once the in-place DB write actually completes (the DB block can
+    # raise and skip it). Surfaced to the gateway via agent._last_compaction_in_place.
+    compacted_in_place = False
     logger.info(
         "context compression started: session=%s messages=%d tokens=~%s model=%s focus=%r",
         agent.session_id or "none", _pre_msg_count,
@@ -520,17 +523,6 @@ def compress_context(
             # conversation's pre-compaction turns are about to be summarized
             # away regardless of whether the id rotates).
             agent.commit_memory_session(messages)
-            # Flush any un-persisted messages from the current turn *before*
-            # the rewrite.  compress_context() can be called mid-turn
-            # (auto-compress when context exceeds threshold) at a point when
-            # _flush_messages_to_session_db() has not yet run.  Without this,
-            # messages generated during the current turn are silently lost
-            # (#47202). In-place mode flushes to the SAME session; rotation
-            # mode flushes to the old session before ending it.
-            try:
-                agent._flush_messages_to_session_db(messages)
-            except Exception:
-                pass  # best-effort — don't block compression on a flush error
 
             if in_place:
                 # ── In-place compaction: keep the same session_id ──────────
@@ -539,32 +531,36 @@ def compress_context(
                 # id, title, cwd, /goal, and gateway routing all stay put.
                 #
                 # Durable replace: the persisted transcript MUST become the
-                # compacted set, not "original history + summary". The flush
-                # above wrote any un-persisted current-turn messages onto the
-                # row; now atomically replace ALL rows with `compressed` so a
-                # resume reloads the compacted transcript (lossy by design —
-                # the pre-compaction turns are summarized away). Without this
-                # the row keeps the full history and compaction never durably
+                # compacted set, not "original history + summary". `compressed`
+                # already carries the surviving tail (current-turn messages the
+                # compressor kept via protect_last_n), so we DON'T pre-flush
+                # here — a flush would INSERT current-turn rows that the
+                # replace_messages DELETE immediately discards (wasted writes).
+                # Atomically replace ALL rows with `compressed` so a resume
+                # reloads the compacted transcript (lossy by design — the
+                # pre-compaction turns are summarized away). Without this the
+                # row keeps the full history and compaction never durably
                 # shrinks anything (the next turn just re-compacts). See #38763.
                 agent._session_db.replace_messages(agent.session_id, compressed)
-                agent._session_db.update_system_prompt(
-                    agent.session_id, new_system_prompt
-                )
-                # Reset the flush identity/cursor so the next turn's appends are
-                # diffed against the COMPACTED transcript, not the pre-compaction
-                # one. _flush_messages_to_session_db rebuilds its identity set
-                # when _last_flushed_db_idx == 0; the compacted dicts are passed
-                # as conversation_history next turn and skipped by identity, so
-                # only genuinely new turn messages get appended (no dup of the
-                # summary, no resurrection of dropped turns).
-                agent._last_flushed_db_idx = 0
+                # Reset the flush identity set so the next turn's appends are
+                # diffed against the COMPACTED transcript: the compacted dicts
+                # are passed as conversation_history next turn and skipped by
+                # identity, so only genuinely new turn messages get appended
+                # (no dup of the summary, no resurrection of dropped turns).
                 agent._flushed_db_message_ids = set()
                 # Rotation-independent signal: the conversation was compacted in
-                # place (id unchanged). The caller / gateway uses this instead of
-                # an id-change diff to re-baseline transcript handling.
+                # place (id unchanged). The gateway reads this (NOT an id-change
+                # diff) to re-baseline transcript handling.
                 compacted_in_place = True
             else:
                 # ── Rotation (legacy): end this session, fork a continuation ─
+                # Flush any un-persisted current-turn messages to the OLD
+                # session before ending it, so they survive in the preserved
+                # parent transcript (#47202). (In-place skips this — see above.)
+                try:
+                    agent._flush_messages_to_session_db(messages)
+                except Exception:
+                    pass  # best-effort — don't block compression on a flush error
                 # Propagate title to the new session with auto-numbering
                 old_title = agent._session_db.get_session_title(agent.session_id)
                 agent._session_db.end_session(agent.session_id, "compression")
@@ -609,11 +605,23 @@ def compress_context(
                         agent._session_db.set_session_title(agent.session_id, new_title)
                     except (ValueError, Exception) as e:
                         logger.debug("Could not propagate title on compression: %s", e)
-                agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
-                # Reset flush cursor — new session starts with no messages written
-                agent._last_flushed_db_idx = 0
+
+            # Shared post-write steps (both modes target agent.session_id, which
+            # in-place keeps and rotation has already reassigned to the new id):
+            # refresh the stored system prompt and reset the flush cursor so the
+            # next turn re-bases its append diff.
+            agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+            agent._last_flushed_db_idx = 0
         except Exception as e:
             logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
+
+    # Compaction-boundary bookkeeping, computed once. `old_session_id` is only
+    # bound in the rotation branch; in-place leaves it unset. `_boundary_parent`
+    # is the id the boundary notifications attribute the prior state to: the old
+    # id on rotation, the (unchanged) current id in-place.
+    _old_sid = locals().get("old_session_id")
+    _is_boundary = bool(_old_sid) or in_place
+    _boundary_parent = _old_sid or agent.session_id or ""
 
     # Notify the context engine that a compaction boundary occurred. Plugin
     # engines (e.g. hermes-lcm) use boundary_reason="compression" to preserve
@@ -622,13 +630,11 @@ def compress_context(
     # ignores kwargs. Fires in BOTH modes: rotation passes old→new ids; in-place
     # passes the SAME id (the boundary is real even though the id didn't move).
     try:
-        _old_sid = locals().get("old_session_id")
-        _boundary = bool(_old_sid) or in_place
-        if _boundary and hasattr(agent.context_compressor, "on_session_start"):
+        if _is_boundary and hasattr(agent.context_compressor, "on_session_start"):
             agent.context_compressor.on_session_start(
                 agent.session_id or "",
                 boundary_reason="compression",
-                old_session_id=_old_sid or agent.session_id or "",
+                old_session_id=_boundary_parent,
                 conversation_id=getattr(agent, "_gateway_session_key", None),
             )
     except Exception as _ce_err:
@@ -641,11 +647,10 @@ def compress_context(
     # parent (the conversation didn't fork, but the buffer must still be told
     # the transcript was compacted so it doesn't double-count dropped turns).
     try:
-        _old_sid = locals().get("old_session_id")
-        if (_old_sid or in_place) and agent._memory_manager:
+        if _is_boundary and agent._memory_manager:
             agent._memory_manager.on_session_switch(
                 agent.session_id or "",
-                parent_session_id=_old_sid or agent.session_id or "",
+                parent_session_id=_boundary_parent,
                 reset=False,
                 reason="compression",
             )
@@ -665,13 +670,12 @@ def compress_context(
     # the completed old session before its details are lost. In in-place mode
     # there is no old id (same session); ``in_place=True`` tells hooks the
     # transcript was compacted on the same id rather than rotated.
-    _old_sid_for_event = locals().get("old_session_id")
     if getattr(agent, "event_callback", None):
         try:
             agent.event_callback("session:compress", {
                 "platform": agent.platform or "",
                 "session_id": agent.session_id,
-                "old_session_id": _old_sid_for_event or "",
+                "old_session_id": _old_sid or "",
                 "in_place": in_place,
                 "compression_count": agent.context_compressor.compression_count,
             })
@@ -682,7 +686,7 @@ def compress_context(
     # via a rotation-independent flag. The gateway uses this — NOT an
     # id-change diff — to re-baseline transcript handling (history_offset=0 +
     # rewrite on the same id) when compaction happened in place. See #38763.
-    agent._last_compaction_in_place = bool(locals().get("compacted_in_place", False))
+    agent._last_compaction_in_place = compacted_in_place
 
     # Keep the post-compression rough estimate for diagnostics, but do not
     # treat it as provider-reported prompt usage. Schema-heavy rough estimates

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15349,6 +15349,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # below must still point the gateway at the compressed child.
             agent = agent_holder[0]
             _session_was_split = False
+            # In-place compaction (compression.in_place / #38763) compacts the
+            # transcript WITHOUT rotating the id, so the id-change diff below
+            # can't detect it. compress_context() sets this rotation-independent
+            # flag on the agent; the gateway uses it to re-baseline transcript
+            # handling (history_offset=0 + rewrite the JSONL transcript) the
+            # same way a split would, even though the session_id is unchanged.
+            _compacted_in_place = bool(getattr(agent, "_last_compaction_in_place", False)) if agent else False
             agent_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
             if agent and session_key and agent_session_id != session_id:
                 _session_was_split = True
@@ -15397,7 +15404,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
 
             effective_session_id = agent_session_id
-            _effective_history_offset = 0 if _session_was_split else len(agent_history)
+            # history_offset=0 whenever the agent's message list no longer has
+            # the original history prefix — i.e. on rotation (split) OR in-place
+            # compaction. In both cases the returned `messages` is the compacted
+            # set, so the gateway must persist all of it (offset 0), not slice
+            # past the pre-compaction length (which would drop everything).
+            _effective_history_offset = (
+                0 if (_session_was_split or _compacted_in_place) else len(agent_history)
+            )
 
             if not final_response:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
@@ -15414,6 +15428,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "compression_exhausted": result.get("compression_exhausted", False),
                     "tools": tools_holder[0] or [],
                     "history_offset": _effective_history_offset,
+                    "compacted_in_place": _compacted_in_place,
                     "session_id": effective_session_id,
                     "last_prompt_tokens": _last_prompt_toks,
                     "input_tokens": _input_toks,
@@ -15514,6 +15529,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "interrupt_message": result_holder[0].get("interrupt_message") if result_holder[0] else None,
                 "tools": tools_holder[0] or [],
                 "history_offset": _effective_history_offset,
+                "compacted_in_place": _compacted_in_place,
                 "last_prompt_tokens": _last_prompt_toks,
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2583,12 +2583,14 @@ class GatewaySlashCommandsMixin:
                 if partial and tail:
                     compressed = rejoin_compressed_head_and_tail(compressed, tail)
 
-                # _compress_context already calls end_session() on the old session
-                # (preserving its full transcript in SQLite) and creates a new
-                # session_id for the continuation.  Write the compressed messages
-                # into the NEW session so the original history stays searchable.
+                # _compress_context either rotated (legacy: ended the old
+                # session, created a continuation id — write compressed messages
+                # into the NEW session so the original stays searchable) or
+                # compacted in place (compression.in_place / #38763: same id,
+                # transcript replaced with the compacted set).
                 new_session_id = tmp_agent.session_id
                 rotated = new_session_id != session_entry.session_id
+                _in_place = bool(getattr(tmp_agent, "compression_in_place", False))
                 if rotated:
                     session_entry.session_id = new_session_id
                     self.session_store._save()
@@ -2596,20 +2598,27 @@ class GatewaySlashCommandsMixin:
                         source, session_entry, reason="compress-command",
                     )
 
-                # Only rewrite the transcript when rotation actually produced a
-                # NEW session id. If _compress_context could not rotate (e.g.
-                # _session_db unavailable, or the DB split raised), session_id
-                # is unchanged and rewrite_transcript() would DELETE the
-                # original messages and replace them with only the compressed
-                # summary — permanent data loss (#44794, #39704). In that case
-                # leave the original transcript intact.
-                if rotated:
-                    self.session_store.rewrite_transcript(new_session_id, compressed)
+                # Rewrite the transcript when EITHER rotation produced a new id
+                # OR in-place compaction succeeded. The danger this guards
+                # against is the THIRD case: _compress_context could NOT rotate
+                # AND was not in-place (e.g. legacy mode but _session_db
+                # unavailable / the DB split raised) — there session_id is
+                # unchanged for a FAILURE reason, and rewrite_transcript() would
+                # DELETE the original messages and replace them with only the
+                # compressed summary (permanent data loss #44794, #39704). In
+                # in-place mode the unchanged id is SUCCESS, so the rewrite is
+                # exactly right (and is the durable write when the throwaway
+                # /compress agent has no _session_db of its own).
+                if rotated or _in_place:
+                    self.session_store.rewrite_transcript(
+                        new_session_id, compressed
+                    )
                 else:
                     logger.warning(
                         "Manual /compress: session rotation did not occur "
-                        "(session_id unchanged) — preserving original transcript "
-                        "instead of overwriting it (#44794)."
+                        "(session_id unchanged) and in-place mode is off — "
+                        "preserving original transcript instead of overwriting "
+                        "it (#44794)."
                     )
                 # Reset stored token count — transcript changed, old value is stale
                 self.session_store.update_session(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1269,6 +1269,19 @@ DEFAULT_CONFIG = {
                                       # exact route is affected — gpt-5.5 on OpenAI's
                                       # direct API, OpenRouter, and Copilot keep the
                                       # global threshold regardless.
+        "in_place": False,            # When True, compaction rewrites the message
+                                      # list and rebuilds the system prompt WITHOUT
+                                      # rotating the session id — the conversation
+                                      # keeps one durable id for its whole life
+                                      # (no parent_session_id chain, no `name #N`
+                                      # renumbering). Eliminates the session-rotation
+                                      # bug cluster (#33618 /goal loss, #14238 lost
+                                      # response, #33907 orphans, #45117 search gaps,
+                                      # #42228 null cwd) — see #38763. Compaction is
+                                      # lossy: the pre-compaction transcript is
+                                      # discarded, matching Claude Code / Codex.
+                                      # Default False during rollout; will flip on
+                                      # after live validation.
     },
 
     # Kanban subsystem (orchestrator workers + dispatcher-driven child tasks).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1277,9 +1277,12 @@ DEFAULT_CONFIG = {
                                       # renumbering). Eliminates the session-rotation
                                       # bug cluster (#33618 /goal loss, #14238 lost
                                       # response, #33907 orphans, #45117 search gaps,
-                                      # #42228 null cwd) — see #38763. Compaction is
-                                      # lossy: the pre-compaction transcript is
-                                      # discarded, matching Claude Code / Codex.
+                                      # #42228 null cwd) — see #38763. Non-destructive:
+                                      # the live context is compacted (lossy for what
+                                      # the model reloads), but the pre-compaction
+                                      # turns are soft-archived under the same id
+                                      # (active=0, compacted=1) — still searchable via
+                                      # session_search and recoverable, not deleted.
                                       # Default False during rollout; will flip on
                                       # after live validation.
     },

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -566,7 +566,8 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_message_items TEXT,
     platform_message_id TEXT,
     observed INTEGER DEFAULT 0,
-    active INTEGER NOT NULL DEFAULT 1
+    active INTEGER NOT NULL DEFAULT 1,
+    compacted INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS state_meta (
@@ -2709,11 +2710,14 @@ class SessionDB:
         - The live-context load (:meth:`get_messages_as_conversation`,
           :meth:`get_messages`) filters ``active = 1`` by default, so the model
           reloads ONLY the compacted set.
-        - The archived pre-compaction turns stay on disk and remain
-          FTS-searchable (the ``messages_fts*`` triggers index on INSERT / drop
-          on DELETE and do NOT key on ``active``; flipping to ``active = 0`` is a
-          content-preserving UPDATE), and are recoverable via
-          ``get_messages(..., include_inactive=True)`` / ``restore_rewound``.
+        - The archived pre-compaction turns stay on disk (active=0) and stay
+          DISCOVERABLE: they are marked compacted=1, and search_messages()
+          includes compacted=1 rows by default — so session_search still finds
+          them, unlike rewind/undo rows (active=0, compacted=0) which stay
+          hidden. They remain in the FTS index (the messages_fts* triggers
+          index on INSERT / drop on DELETE and don't key on active/compacted;
+          flipping to active=0 is a content-preserving UPDATE) and are
+          recoverable via get_messages(..., include_inactive=True).
 
         This is the durability-preserving alternative to :meth:`replace_messages`
         for compaction. ``message_count`` is set to the ACTIVE (compacted) count,
@@ -2721,8 +2725,15 @@ class SessionDB:
         """
 
         def _do(conn):
+            # Soft-archive the live turns: active=0 hides them from the live
+            # context load, compacted=1 marks them as "summarized away" (vs
+            # rewind/undo's active=0+compacted=0, which means "user took it
+            # back"). search_messages includes compacted=1 rows by default so
+            # the pre-compaction transcript stays discoverable; live-context
+            # loads (active=1 only) still exclude them.
             conn.execute(
-                "UPDATE messages SET active = 0 WHERE session_id = ? AND active = 1",
+                "UPDATE messages SET active = 0, compacted = 1 "
+                "WHERE session_id = ? AND active = 1",
                 (session_id,),
             )
             inserted, tool_calls_total = self._insert_message_rows(
@@ -3475,8 +3486,12 @@ class SessionDB:
         ignores ``sort``. The trigram CJK path honours ``sort`` like the main
         FTS5 path.
 
-        Rewound (``active=0``) rows are excluded by default. Pass
-        ``include_inactive=True`` to search every row.
+        Rewound (``active=0``, ``compacted=0``) rows are excluded by default —
+        the user took those back. Compaction-archived rows (``active=0``,
+        ``compacted=1``) ARE included by default: they were summarized away from
+        the live context but remain part of the conversation's record, so the
+        pre-compaction transcript stays discoverable after in-place compaction
+        (#38763). Pass ``include_inactive=True`` to search every row regardless.
         """
         if not self._fts_enabled:
             return []
@@ -3511,7 +3526,10 @@ class SessionDB:
         where_clauses = ["messages_fts MATCH ?"]
         params: list = [query]
         if not include_inactive:
-            where_clauses.append("m.active = 1")
+            # Live rows (active=1) AND compaction-archived rows (compacted=1)
+            # are discoverable; only rewind/undo rows (active=0, compacted=0)
+            # are hidden. See archive_and_compact() / #38763.
+            where_clauses.append("(m.active = 1 OR m.compacted = 1)")
 
         if source_filter is not None:
             source_placeholders = ",".join("?" for _ in source_filter)
@@ -3593,7 +3611,7 @@ class SessionDB:
                 tri_where = ["messages_fts_trigram MATCH ?"]
                 tri_params: list = [trigram_query]
                 if not include_inactive:
-                    tri_where.append("m.active = 1")
+                    tri_where.append("(m.active = 1 OR m.compacted = 1)")
                 if source_filter is not None:
                     tri_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                     tri_params.extend(source_filter)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2585,12 +2585,97 @@ class SessionDB:
 
         return self._execute_write(_do)
 
+    def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
+        """Insert *messages* as fresh active rows for *session_id*.
+
+        Shared by :meth:`replace_messages` (delete-then-insert) and
+        :meth:`archive_and_compact` (soft-archive-then-insert). Runs inside the
+        caller's write transaction (takes the live ``conn``). Returns
+        ``(inserted_count, tool_call_count)``. Does NOT touch sessions.* counters
+        — the caller owns that, since the two flows reconcile counts differently.
+        """
+        now_ts = time.time()
+        inserted = 0
+        tool_calls_total = 0
+        for msg in messages:
+            role = msg.get("role", "unknown")
+            tool_calls = msg.get("tool_calls")
+            message_timestamp = now_ts
+            if msg.get("timestamp") is not None:
+                try:
+                    ts_value = msg.get("timestamp")
+                    if hasattr(ts_value, "timestamp"):
+                        message_timestamp = float(ts_value.timestamp())
+                    else:
+                        message_timestamp = float(ts_value)
+                except (TypeError, ValueError):
+                    logger.debug("Ignoring invalid explicit message timestamp: %r", msg.get("timestamp"))
+            reasoning_details = msg.get("reasoning_details") if role == "assistant" else None
+            codex_reasoning_items = (
+                msg.get("codex_reasoning_items") if role == "assistant" else None
+            )
+            codex_message_items = (
+                msg.get("codex_message_items") if role == "assistant" else None
+            )
+            reasoning_details_json = (
+                json.dumps(reasoning_details) if reasoning_details else None
+            )
+            codex_items_json = (
+                json.dumps(codex_reasoning_items) if codex_reasoning_items else None
+            )
+            codex_message_items_json = (
+                json.dumps(codex_message_items) if codex_message_items else None
+            )
+            tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+            # Accept either `platform_message_id` (new explicit name) or
+            # `message_id` (yuanbao's existing convention on message dicts).
+            platform_msg_id = (
+                msg.get("platform_message_id") or msg.get("message_id")
+            )
+
+            conn.execute(
+                """INSERT INTO messages (session_id, role, content, tool_call_id,
+                   tool_calls, tool_name, timestamp, token_count, finish_reason,
+                   reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
+                   codex_message_items, platform_message_id, observed)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    role,
+                    self._encode_content(msg.get("content")),
+                    msg.get("tool_call_id"),
+                    tool_calls_json,
+                    msg.get("tool_name"),
+                    message_timestamp,
+                    msg.get("token_count"),
+                    msg.get("finish_reason"),
+                    msg.get("reasoning") if role == "assistant" else None,
+                    msg.get("reasoning_content") if role == "assistant" else None,
+                    reasoning_details_json,
+                    codex_items_json,
+                    codex_message_items_json,
+                    platform_msg_id,
+                    1 if msg.get("observed") else 0,
+                ),
+            )
+            inserted += 1
+            if tool_calls is not None:
+                tool_calls_total += (
+                    len(tool_calls) if isinstance(tool_calls, list) else 1
+                )
+            now_ts = max(now_ts + 1e-6, message_timestamp + 1e-6)
+        return inserted, tool_calls_total
+
     def replace_messages(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Atomically replace every message for a session.
 
         Used by transcript-rewrite flows such as /retry, /undo, and /compress.
         The delete + reinsert sequence must commit as one transaction so a
         mid-rewrite failure does not leave SQLite with a partial transcript.
+
+        DESTRUCTIVE: the prior rows are DELETEd (and drop out of the FTS index).
+        For compaction that must preserve the pre-compaction transcript under
+        the same id, use :meth:`archive_and_compact` instead.
         """
 
         def _do(conn):
@@ -2601,85 +2686,58 @@ class SessionDB:
                 "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
                 (session_id,),
             )
-
-            now_ts = time.time()
-            total_messages = 0
-            total_tool_calls = 0
-            for msg in messages:
-                role = msg.get("role", "unknown")
-                tool_calls = msg.get("tool_calls")
-                message_timestamp = now_ts
-                if msg.get("timestamp") is not None:
-                    try:
-                        ts_value = msg.get("timestamp")
-                        if hasattr(ts_value, "timestamp"):
-                            message_timestamp = float(ts_value.timestamp())
-                        else:
-                            message_timestamp = float(ts_value)
-                    except (TypeError, ValueError):
-                        logger.debug("Ignoring invalid explicit message timestamp: %r", msg.get("timestamp"))
-                reasoning_details = msg.get("reasoning_details") if role == "assistant" else None
-                codex_reasoning_items = (
-                    msg.get("codex_reasoning_items") if role == "assistant" else None
-                )
-                codex_message_items = (
-                    msg.get("codex_message_items") if role == "assistant" else None
-                )
-
-                reasoning_details_json = (
-                    json.dumps(reasoning_details) if reasoning_details else None
-                )
-                codex_items_json = (
-                    json.dumps(codex_reasoning_items) if codex_reasoning_items else None
-                )
-                codex_message_items_json = (
-                    json.dumps(codex_message_items) if codex_message_items else None
-                )
-                tool_calls_json = json.dumps(tool_calls) if tool_calls else None
-                # Accept either `platform_message_id` (new explicit name) or
-                # `message_id` (yuanbao's existing convention on message dicts).
-                platform_msg_id = (
-                    msg.get("platform_message_id") or msg.get("message_id")
-                )
-
-                conn.execute(
-                    """INSERT INTO messages (session_id, role, content, tool_call_id,
-                       tool_calls, tool_name, timestamp, token_count, finish_reason,
-                       reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                       codex_message_items, platform_message_id, observed)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (
-                        session_id,
-                        role,
-                        self._encode_content(msg.get("content")),
-                        msg.get("tool_call_id"),
-                        tool_calls_json,
-                        msg.get("tool_name"),
-                        message_timestamp,
-                        msg.get("token_count"),
-                        msg.get("finish_reason"),
-                        msg.get("reasoning") if role == "assistant" else None,
-                        msg.get("reasoning_content") if role == "assistant" else None,
-                        reasoning_details_json,
-                        codex_items_json,
-                        codex_message_items_json,
-                        platform_msg_id,
-                        1 if msg.get("observed") else 0,
-                    ),
-                )
-                total_messages += 1
-                if tool_calls is not None:
-                    total_tool_calls += (
-                        len(tool_calls) if isinstance(tool_calls, list) else 1
-                    )
-                now_ts = max(now_ts + 1e-6, message_timestamp + 1e-6)
-
+            total_messages, total_tool_calls = self._insert_message_rows(
+                conn, session_id, messages
+            )
             conn.execute(
                 "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
                 (total_messages, total_tool_calls, session_id),
             )
 
         self._execute_write(_do)
+
+    def archive_and_compact(
+        self, session_id: str, compacted_messages: List[Dict[str, Any]]
+    ) -> int:
+        """Non-destructive in-place compaction for a single durable session id.
+
+        Soft-archives every currently-active message (``active = 0``) and
+        inserts *compacted_messages* as fresh active rows — atomically, in one
+        write transaction. The conversation keeps ONE session id for life
+        (#38763) WITHOUT destroying history:
+
+        - The live-context load (:meth:`get_messages_as_conversation`,
+          :meth:`get_messages`) filters ``active = 1`` by default, so the model
+          reloads ONLY the compacted set.
+        - The archived pre-compaction turns stay on disk and remain
+          FTS-searchable (the ``messages_fts*`` triggers index on INSERT / drop
+          on DELETE and do NOT key on ``active``; flipping to ``active = 0`` is a
+          content-preserving UPDATE), and are recoverable via
+          ``get_messages(..., include_inactive=True)`` / ``restore_rewound``.
+
+        This is the durability-preserving alternative to :meth:`replace_messages`
+        for compaction. ``message_count`` is set to the ACTIVE (compacted) count,
+        matching what the live load returns. Returns the new active count.
+        """
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE messages SET active = 0 WHERE session_id = ? AND active = 1",
+                (session_id,),
+            )
+            inserted, tool_calls_total = self._insert_message_rows(
+                conn, session_id, compacted_messages
+            )
+            # message_count / tool_call_count reflect the LIVE (active) set —
+            # the archived rows are still on disk but not part of the live count.
+            conn.execute(
+                "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
+                (inserted, tool_calls_total, session_id),
+            )
+            return inserted
+
+        return self._execute_write(_do)
+
 
     def get_messages(
         self, session_id: str, include_inactive: bool = False

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -87,24 +87,41 @@ class TestInPlaceCompaction:
             row = db.get_session(sid)
             assert row["end_reason"] is None
             assert row["title"] == "my-research"
-            # DURABLE REPLACE (the core invariant): the persisted transcript is
-            # now the COMPACTED set, not "full history + summary". A resume must
-            # reload the compacted transcript so compaction actually shrinks the
-            # session and doesn't immediately re-compact (#38763).
+            # DURABLE, NON-DESTRUCTIVE compaction (the core invariant, per
+            # Teknium's review): the LIVE context is the compacted set, but the
+            # pre-compaction turns are PRESERVED on disk (active=0), not deleted
+            # — searchable + recoverable under the SAME id. A resume reloads the
+            # compacted set so compaction actually shrinks the live session and
+            # doesn't immediately re-compact (#38763).
             reloaded = db.get_messages_as_conversation(sid)
             assert len(reloaded) == 2
             assert [m.get("content") for m in reloaded] == [
                 "[CONTEXT COMPACTION] summary of prior turns",
                 "recent reply",
             ]
-            assert row["message_count"] == 2
+            assert row["message_count"] == 2  # live (active) count
+            # NON-DESTRUCTIVE: the 8 seeded originals survive at active=0
+            # alongside the 2 compacted rows — nothing was DELETEd.
+            all_rows = db.get_messages(sid, include_inactive=True)
+            assert len(all_rows) == 10
+            archived = [m for m in all_rows if not m.get("active", 1)]
+            assert len(archived) == 8
+            # The originals remain FTS-searchable (active=0 is a content-
+            # preserving UPDATE; the fts triggers don't key on active).
+            hit = db._conn.execute(
+                "SELECT 1 FROM messages_fts f JOIN messages m ON m.id = f.rowid "
+                "WHERE m.session_id = ? AND messages_fts MATCH 'msg' AND m.active = 0 "
+                "LIMIT 1",
+                (sid,),
+            ).fetchone()
+            assert hit is not None
             # Flush identity/cursor reset so next-turn appends diff against the
             # compacted transcript (rebuilds the identity set on next flush).
             assert agent._last_flushed_db_idx == 0
             assert agent._flushed_db_message_ids == set()
             # Rotation-independent in-place signal set for the gateway.
             assert agent._last_compaction_in_place is True
-            # Transcript actually shrank.
+            # Live transcript actually shrank.
             assert len(compressed) == 2
 
     def test_in_place_alternation_preserved(self):

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -1,0 +1,152 @@
+"""Tests for in-place context compaction (config: compression.in_place, #38763).
+
+When ``compression.in_place`` is True, ``compress_context()`` rewrites the
+message list and rebuilds the system prompt but keeps the SAME ``session_id``:
+no ``end_session``, no ``parent_session_id`` child row, no ``name #N`` title
+renumber, no flush-cursor reset. This eliminates the session-rotation bug
+cluster (#33618 /goal loss, #14238 lost response, #33907 orphans, #45117 search
+gaps, #42228 null cwd). When the flag is False (default), rotation behaves
+exactly as before.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_agent(session_db, session_id, *, in_place):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.compression_in_place = in_place
+    # Mock the compressor to return a deterministic shrunk transcript so the
+    # test exercises the DB-mutation path, not summarization quality.
+    def _fake_compress(messages, current_tokens=None, focus_topic=None, force=False):
+        return [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary of prior turns"},
+            {"role": "assistant", "content": "recent reply"},
+        ]
+
+    agent.context_compressor.compress = _fake_compress
+    agent.context_compressor._last_compress_aborted = False
+    agent.context_compressor._last_summary_error = None
+    agent.context_compressor.compression_count = 1
+    return agent
+
+
+def _seed(db, sid, title, n=8):
+    db.create_session(sid, "cli", model="test/model")
+    db.set_session_title(sid, title)
+    for i in range(n):
+        db.append_message(
+            session_id=sid,
+            role="user" if i % 2 == 0 else "assistant",
+            content=f"msg {i}",
+        )
+
+
+class TestInPlaceCompaction:
+    def test_in_place_keeps_same_session_id(self):
+        """In-place mode: id unchanged, no child row, no rename, history kept."""
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260619_120000_aaaaaa"
+            _seed(db, sid, "my-research")
+            agent = _make_agent(db, sid, in_place=True)
+            agent._last_flushed_db_idx = 5
+
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(8)]
+            compressed, _sp = compress_context(
+                agent, messages, approx_tokens=100_000, system_message="sys"
+            )
+
+            # Identity never moved.
+            assert agent.session_id == sid
+            # No continuation row forked.
+            child = db._conn.execute(
+                "SELECT id FROM sessions WHERE parent_session_id = ?", (sid,)
+            ).fetchall()
+            assert child == []
+            # Session not ended; title untouched (no "#2").
+            row = db.get_session(sid)
+            assert row["end_reason"] is None
+            assert row["title"] == "my-research"
+            # Pre-compaction messages remain under the one id (FTS continuity).
+            assert row["message_count"] >= 8
+            # Flush cursor must NOT be reset to 0. Rotation resets it (a fresh
+            # row starts empty); in-place keeps writing to the same row, so the
+            # cursor only ever advances as current-turn messages are persisted.
+            assert agent._last_flushed_db_idx != 0
+            # Transcript actually shrank.
+            assert len(compressed) == 2
+
+    def test_in_place_alternation_preserved(self):
+        """The compacted list must not introduce consecutive same-role messages."""
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260619_120500_cccccc"
+            _seed(db, sid, "alt")
+            agent = _make_agent(db, sid, in_place=True)
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(8)]
+            compressed, _ = compress_context(
+                agent, messages, approx_tokens=100_000, system_message="sys"
+            )
+            roles = [m["role"] for m in compressed if m.get("role") != "system"]
+            assert all(roles[i] != roles[i + 1] for i in range(len(roles) - 1))
+
+
+class TestRotationStillDefault:
+    def test_rotation_when_flag_off(self):
+        """Regression guard: flag off => legacy rotation is unchanged."""
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260619_130000_bbbbbb"
+            _seed(db, sid, "my-research")
+            agent = _make_agent(db, sid, in_place=False)
+            agent._last_flushed_db_idx = 5
+
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(8)]
+            compress_context(
+                agent, messages, approx_tokens=100_000, system_message="sys"
+            )
+
+            # Identity rotated to a fresh id.
+            assert agent.session_id != sid
+            # Old session ended via compression; continuation forked + renamed.
+            assert db.get_session(sid)["end_reason"] == "compression"
+            child = db._conn.execute(
+                "SELECT id, title FROM sessions WHERE parent_session_id = ?", (sid,)
+            ).fetchall()
+            assert len(child) == 1
+            assert child[0]["title"] == "my-research #2"
+            # Flush cursor reset for the new row.
+            assert agent._last_flushed_db_idx == 0
+
+
+class TestInPlaceConfigDefault:
+    def test_flag_defaults_off(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["compression"].get("in_place") is False

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -87,12 +87,23 @@ class TestInPlaceCompaction:
             row = db.get_session(sid)
             assert row["end_reason"] is None
             assert row["title"] == "my-research"
-            # Pre-compaction messages remain under the one id (FTS continuity).
-            assert row["message_count"] >= 8
-            # Flush cursor must NOT be reset to 0. Rotation resets it (a fresh
-            # row starts empty); in-place keeps writing to the same row, so the
-            # cursor only ever advances as current-turn messages are persisted.
-            assert agent._last_flushed_db_idx != 0
+            # DURABLE REPLACE (the core invariant): the persisted transcript is
+            # now the COMPACTED set, not "full history + summary". A resume must
+            # reload the compacted transcript so compaction actually shrinks the
+            # session and doesn't immediately re-compact (#38763).
+            reloaded = db.get_messages_as_conversation(sid)
+            assert len(reloaded) == 2
+            assert [m.get("content") for m in reloaded] == [
+                "[CONTEXT COMPACTION] summary of prior turns",
+                "recent reply",
+            ]
+            assert row["message_count"] == 2
+            # Flush identity/cursor reset so next-turn appends diff against the
+            # compacted transcript (rebuilds the identity set on next flush).
+            assert agent._last_flushed_db_idx == 0
+            assert agent._flushed_db_message_ids == set()
+            # Rotation-independent in-place signal set for the gateway.
+            assert agent._last_compaction_in_place is True
             # Transcript actually shrank.
             assert len(compressed) == 2
 
@@ -143,6 +154,37 @@ class TestRotationStillDefault:
             assert child[0]["title"] == "my-research #2"
             # Flush cursor reset for the new row.
             assert agent._last_flushed_db_idx == 0
+            # Rotation mode does NOT set the in-place signal.
+            assert getattr(agent, "_last_compaction_in_place", False) is False
+
+
+class TestInPlaceSignalForGateway:
+    """compress_context must expose a rotation-independent flag the gateway can
+    read (instead of an id-change diff) to re-baseline transcript handling."""
+
+    def test_signal_set_on_in_place_unset_on_rotation(self):
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            # in-place → flag True
+            _seed(db, "s_ip", "ip")
+            a_ip = _make_agent(db, "s_ip", in_place=True)
+            compress_context(
+                a_ip, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+            assert a_ip._last_compaction_in_place is True
+
+            # rotation → flag False
+            _seed(db, "s_rot", "rot")
+            a_rot = _make_agent(db, "s_rot", in_place=False)
+            compress_context(
+                a_rot, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+            assert a_rot._last_compaction_in_place is False
 
 
 class TestInPlaceConfigDefault:

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -251,3 +251,66 @@ class TestInPlaceConfigDefault:
         from hermes_cli.config import DEFAULT_CONFIG
 
         assert DEFAULT_CONFIG["compression"].get("in_place") is False
+
+
+class TestCompactedTurnsStaySearchable:
+    """Teknium's review hinges on the pre-compaction transcript staying
+    DISCOVERABLE after in-place compaction. Compaction-archived rows
+    (active=0, compacted=1) must surface in session_search by default, while
+    rewind/undo rows (active=0, compacted=0) must stay hidden. The two share
+    the active flag but are distinguished by the compacted flag."""
+
+    def test_compacted_turns_found_by_default_search(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260619_search"
+            db.create_session(sid, "cli", model="test/model")
+            for r, c in [
+                ("user", "configure the HMAC secret"),
+                ("assistant", "set it in config.yaml"),
+                ("user", "deploy returns 403"),
+                ("assistant", "rotate the HMAC"),
+                ("user", "works now"),
+                ("assistant", "great"),
+            ]:
+                db.append_message(session_id=sid, role=r, content=c)
+
+            before = db.search_messages("HMAC", role_filter=["user", "assistant"])
+            assert len(before) == 2
+
+            db.archive_and_compact(
+                sid,
+                [
+                    {"role": "user", "content": "[SUMMARY] earlier setup"},
+                    {"role": "assistant", "content": "ok"},
+                ],
+            )
+
+            # The archived originals (active=0, compacted=1) are still found by
+            # the DEFAULT search — this is the durability requirement.
+            after = db.search_messages("HMAC", role_filter=["user", "assistant"])
+            assert {m["id"] for m in after} == {1, 4}
+            # Live context still excludes them.
+            assert len(db.get_messages_as_conversation(sid)) == 2
+
+    def test_rewound_turns_stay_hidden(self):
+        """Rewind/undo (active=0, compacted=0) must NOT leak into default
+        search — the distinction the compacted flag preserves."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260619_undo"
+            db.create_session(sid, "cli", model="test/model")
+            db.append_message(session_id=sid, role="user", content="ZEBRAWORD remember this")
+            db.append_message(session_id=sid, role="assistant", content="noted")
+            db.rewind_to_message(sid, db.get_messages(sid)[0]["id"])
+
+            assert db.search_messages("ZEBRAWORD", role_filter=["user", "assistant"]) == []
+            recovered = db.search_messages(
+                "ZEBRAWORD", role_filter=["user", "assistant"], include_inactive=True
+            )
+            assert len(recovered) == 1
+

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -124,6 +124,48 @@ class TestInPlaceCompaction:
             roles = [m["role"] for m in compressed if m.get("role") != "system"]
             assert all(roles[i] != roles[i + 1] for i in range(len(roles) - 1))
 
+    def test_in_place_skips_redundant_preflush(self):
+        """In-place must NOT pre-flush current-turn messages: replace_messages
+        rewrites the whole row, so a flush would INSERT rows it immediately
+        deletes (wasted writes). The current-turn tail survives via the
+        compressor's `compressed` output, not the flush."""
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            _seed(db, "ip_flush", "f")
+            agent = _make_agent(db, "ip_flush", in_place=True)
+            calls = {"n": 0}
+            agent._flush_messages_to_session_db = lambda *a, **k: calls.__setitem__(
+                "n", calls["n"] + 1
+            )
+            compress_context(
+                agent, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+            assert calls["n"] == 0
+
+    def test_rotation_still_preflushes(self):
+        """Rotation MUST pre-flush so current-turn messages survive in the
+        preserved old (parent) session before it is ended (#47202)."""
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            _seed(db, "rot_flush", "f")
+            agent = _make_agent(db, "rot_flush", in_place=False)
+            calls = {"n": 0}
+            agent._flush_messages_to_session_db = lambda *a, **k: calls.__setitem__(
+                "n", calls["n"] + 1
+            )
+            compress_context(
+                agent, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+            assert calls["n"] == 1
+
 
 class TestRotationStillDefault:
     def test_rotation_when_flag_off(self):


### PR DESCRIPTION
## Summary
Adds an in-place context-compaction mode that keeps **one durable session id** for a conversation's entire life, instead of rotating the id every time context is compressed — and does it **non-destructively**: the pre-compaction turns are preserved (searchable + recoverable), not deleted. Default **off**; first of two staged PRs for #38763.

Today compression rewrites the message list (necessary) **and** rotates `agent.session_id` — ending the session, forking a `parent_session_id` child, renumbering the title (`name` → `name #2`). That moving identity key is the root cause of a whole bug cluster:

- #33618 — persistent `/goal` lost after rotation (P2)
- #14238 — pending response lost at the split boundary (P1)
- #33907 — orphan sessions missing from state.db (P2)
- #36777 — TUI `ctx.sid` not updated after the fork (P2)
- #45117 — pre-compaction history undiscoverable; FTS gaps + duplicate `#N` sidebar entries (P3)
- #42228 — continuation row's cwd is null → "No workspace" (P3)
- #48989 — title rename dead-ends on the hidden ended ancestor (fixed separately)

## Durability model (the important part)
Rotation today is **non-destructive** — the old session's full transcript survives under the old id (FTS-searchable, resumable, recoverable); the new id holds the compacted continuation. In-place compaction must match that contract, not weaken it. So compaction here **soft-archives** rather than deletes, with a `compacted` flag that keeps the archived turns discoverable:

- New `SessionDB.archive_and_compact(session_id, compacted)`: in one atomic write, flip the live turns to `active=0, compacted=1` and insert the compacted set as fresh `active=1` rows. **Nothing is deleted.**
- Live-context load (`get_messages_as_conversation` / `get_messages`) filters `active=1` → a resume reloads ONLY the compacted set (compaction still shrinks the live session).
- The pre-compaction turns stay on disk and **stay discoverable in `session_search`**: a `compacted` flag distinct from `active` gives a 3-way state, and `search_messages` includes `compacted=1` rows by default —

  | state | meaning | live context | session_search |
  |---|---|---|---|
  | `active=1, compacted=0` | live turn | ✅ in | ✅ found |
  | `active=0, compacted=1` | compaction-archived | ❌ out | ✅ **found** |
  | `active=0, compacted=0` | rewind/undo | ❌ out | ❌ hidden |

  This distinction matters: rewind/undo turns are intentionally hidden (the user took them back), but compaction-archived turns must stay findable. Reusing `active=0` alone would have hidden them — the `compacted` flag fixes that. They also remain recoverable via `get_messages(include_inactive=True)`.
- Verified across **two** successive compactions: the 1st compaction's originals are still recoverable + searchable after the 2nd. There is always a recovery path.

> **Note on search:** `session_search` is FTS5 keyword/BM25 (with a trigram path for CJK), not semantic — there are no embeddings over the session transcript. Semantic retrieval lives in the optional memory-provider layer, a separate subsystem.

The insert loop is extracted into a shared `_insert_message_rows()` helper so `archive_and_compact` and `replace_messages` don't duplicate the column/encoding block. `replace_messages` keeps its DELETE semantics (correct for `/retry`, `/undo`) with a docstring note pointing compaction at the non-destructive method.

## End-to-end wiring
**Config** (`hermes_cli/config.py`): `compression.in_place` (default `False`), documented. Deep-merge gives existing installs the default — no version bump.

**Agent** (`agent/conversation_compression.py`): on in-place, `archive_and_compact` + rebuild system prompt + reset the flush identity so next-turn appends diff against the compacted set; expose a rotation-independent `agent._last_compaction_in_place` signal + `in_place=True` on the `session:compress` event; fire the compaction-boundary hooks (context-engine `on_session_start`, memory `on_session_switch`) in **both** modes. No `end_session`, child row, title renumber, or contextvar/logging re-sync. Rotation path moved verbatim into the `else` branch (unchanged when off).

**Gateway auto-compress** (`gateway/run.py`): read the signal → `history_offset=0` on rotation **or** in-place. The agent shares the gateway's `SessionDB`, so its `archive_and_compact` already updated the canonical store.

**Manual `/compress`** (`gateway/slash_commands.py`): rewrites the transcript on `rotated OR in_place`; the #44794 data-loss guard still fires only for the genuine no-rotation-AND-not-in-place failure.

## Why staged
Ships default-off so it can be validated live (CLI / gateway / TUI / ACP) before anything changes for existing users. The follow-up PR flips the default, adds a read shim so legacy `parent_session_id` chains still display/resume, deletes the now-redundant rotation machinery, and supersedes the 14 open rotation band-aid PRs (closing each with credit). #42814 (on-demand compression API endpoint) is independent and stays open.

## Invariants preserved
- **Non-destructive:** pre-compaction turns survive at `active=0`, searchable + recoverable (the core of the durability review).
- **Prompt cache:** rebuilds the system prompt exactly once per compaction — the same single sanctioned invalidation. No *new* invalidation.
- **No boundary data loss:** the current-turn tail survives via `compressed` (protect_last_n); rotation still pre-flushes its preserved old session.
- **Message alternation:** the compacted list introduces no consecutive same-role messages.

## Validation
| | flag off (default) | flag on (in-place) |
|---|---|---|
| session_id | rotates | unchanged |
| continuation row | child via `parent_session_id` | none |
| title | `name #2` | unchanged |
| live transcript | old preserved under old id; compacted under new | compacted set is live |
| pre-compaction history | preserved under old id | **preserved at `active=0`, searchable + recoverable** |
| gateway history_offset | 0 (via split) | 0 (via in-place signal) |

- 285 `hermes_state` + in-place tests green (in-place suite strengthened to assert the originals survive at `active=0` and stay FTS-searchable); rotation/persistence/boundary/compress-command/cli suites green.
- Mutation check: swapping `archive_and_compact` back to a hard DELETE fails the non-destructive test → the contract is bound.
- E2E both modes against a real shared `SessionDB`, including two successive in-place compactions with full recovery.
- ruff clean.
