### PR TITLE
fix(gateway): handle CREATE_BREAKAWAY_FROM_JOB rejection on Windows /restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4530,7 +4530,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # that triggered the /restart command closing its console.
         if sys.platform == "win32":
             import textwrap
-            from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+            from hermes_cli._subprocess_compat import (
+                windows_detach_flags_without_breakaway,
+                windows_detach_popen_kwargs,
+            )
 
             cmd_argv = [*hermes_cmd, "gateway", "restart"]
             watcher = textwrap.dedent(
@@ -4596,13 +4599,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if watcher_env.get("PYTHONPATH"):
                     pythonpath.append(watcher_env["PYTHONPATH"])
                 watcher_env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
-            subprocess.Popen(
-                [sys.executable, "-c", watcher, str(current_pid), *cmd_argv],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                env=watcher_env,
-                **windows_detach_popen_kwargs(),
-            )
+            try:
+                subprocess.Popen(
+                    [sys.executable, "-c", watcher, str(current_pid), *cmd_argv],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=watcher_env,
+                    **windows_detach_popen_kwargs(),
+                )
+            except OSError:
+                # Windows Scheduled Tasks put the process in a job object
+                # without JOB_OBJECT_LIMIT_BREAKAWAY_OK, causing
+                # CREATE_BREAKAWAY_FROM_JOB to fail with ERROR_ACCESS_DENIED
+                # (WinError 5). Retry without the breakaway flag —
+                # DETACHED_PROCESS alone is sufficient to survive console
+                # closure in the Scheduled Task / pythonw.exe scenario.
+                subprocess.Popen(
+                    [sys.executable, "-c", watcher, str(current_pid), *cmd_argv],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=watcher_env,
+                    creationflags=windows_detach_flags_without_breakaway(),
+                    close_fds=True,
+                )
             return
 
         cmd = " ".join(shlex.quote(part) for part in hermes_cmd)


### PR DESCRIPTION
## Problem

When the Hermes gateway is run via **Windows Scheduled Task**, running `/restart` on Telegram causes the gateway to exit cleanly with no auto-restart — the bot goes silent until the watchdog cycle (up to 5 minutes) detects the outage and respawns the gateway.

The root cause is in `_launch_detached_restart_command()` (`gateway/run.py`): it spawns a Python watcher subprocess using `windows_detach_popen_kwargs()`, which includes the `CREATE_BREAKAWAY_FROM_JOB` (0x01000000) creation flag.

When the gateway runs inside a job object that does **not** have `JOB_OBJECT_LIMIT_BREAKAWAY_OK` set — which is the case for Windows Scheduled Tasks — `CreateProcess` returns `ERROR_ACCESS_DENIED` (WinError 5). The watcher never starts, the gateway exits, and nothing respawns it until the watchdog kicks in minutes later.

## Fix

Wrap the watcher `subprocess.Popen` in a `try/except OSError` block. On failure:

1. Retry using `windows_detach_flags_without_breakaway()` — which omits `CREATE_BREAKAWAY_FROM_JOB` but retains `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW`.
2. `DETACHED_PROCESS` alone is sufficient to survive the parent console closure in the Scheduled Task / `pythonw.exe` scenario — `BREAKAWAY` is only needed when the parent is in an Electron/Tauri job object that tears down children on exit.

## Changes

- **`gateway/run.py`** — `_launch_detached_restart_command()`:
  - Import `windows_detach_flags_without_breakaway` alongside `windows_detach_popen_kwargs`
  - Wrap the watcher `subprocess.Popen` in `try/except OSError` with a BREAKAWAY-less fallback

## Testing

- **Manual verification**: on a Windows machine with gateway running via Scheduled Task, `/restart` on Telegram now successfully restarts the gateway within seconds instead of going silent for 5 minutes. Confirmed by gateway log: the watcher PID appears after the shutdown sequence.

## Related

The same pattern (try `BREAKAWAY` first, fall back without) already exists in `hermes_cli/gateway.py` and `gateway_windows.py:_spawn_detached` — this fix brings `_launch_detached_restart_command` in line with the rest of the codebase.