### PR TITLE
fix(feishu): tolerate broken lark_oapi imports

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -84,36 +84,70 @@ try:
 except ImportError:
     websockets = None  # type: ignore[assignment]
 
-try:
-    import lark_oapi as lark
-    from lark_oapi.api.application.v6 import GetApplicationRequest
-    from lark_oapi.api.im.v1 import (
-        CreateFileRequest,
-        CreateFileRequestBody,
-        CreateImageRequest,
-        CreateImageRequestBody,
-        CreateMessageRequest,
-        CreateMessageRequestBody,
-        GetChatRequest,
-        GetMessageRequest,
-        GetMessageResourceRequest,
-        P2ImMessageMessageReadV1,
-        ReplyMessageRequest,
-        ReplyMessageRequestBody,
-        UpdateMessageRequest,
-        UpdateMessageRequestBody,
-    )
-    from lark_oapi.core import AccessTokenType, HttpMethod
-    from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
-    from lark_oapi.core.model import BaseRequest
-    from lark_oapi.event.callback.model.p2_card_action_trigger import (
-        CallBackCard,
-        P2CardActionTriggerResponse,
-    )
-    from lark_oapi.event.dispatcher_handler import EventDispatcherHandler
-    from lark_oapi.ws import Client as FeishuWSClient
+def _load_feishu_sdk() -> dict[str, Any]:
+    try:
+        import lark_oapi as lark
+        from lark_oapi.api.application.v6 import GetApplicationRequest
+        from lark_oapi.api.im.v1 import (
+            CreateFileRequest,
+            CreateFileRequestBody,
+            CreateImageRequest,
+            CreateImageRequestBody,
+            CreateMessageRequest,
+            CreateMessageRequestBody,
+            GetChatRequest,
+            GetMessageRequest,
+            GetMessageResourceRequest,
+            P2ImMessageMessageReadV1,
+            ReplyMessageRequest,
+            ReplyMessageRequestBody,
+            UpdateMessageRequest,
+            UpdateMessageRequestBody,
+        )
+        from lark_oapi.core import AccessTokenType, HttpMethod
+        from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
+        from lark_oapi.core.model import BaseRequest
+        from lark_oapi.event.callback.model.p2_card_action_trigger import (
+            CallBackCard,
+            P2CardActionTriggerResponse,
+        )
+        from lark_oapi.event.dispatcher_handler import EventDispatcherHandler
+        from lark_oapi.ws import Client as FeishuWSClient
+    except (ImportError, AttributeError) as exc:
+        raise ImportError("Feishu/Lark SDK is unavailable") from exc
 
-    FEISHU_AVAILABLE = True
+    return {
+        "lark": lark,
+        "GetApplicationRequest": GetApplicationRequest,
+        "CreateFileRequest": CreateFileRequest,
+        "CreateFileRequestBody": CreateFileRequestBody,
+        "CreateImageRequest": CreateImageRequest,
+        "CreateImageRequestBody": CreateImageRequestBody,
+        "CreateMessageRequest": CreateMessageRequest,
+        "CreateMessageRequestBody": CreateMessageRequestBody,
+        "GetChatRequest": GetChatRequest,
+        "GetMessageRequest": GetMessageRequest,
+        "GetMessageResourceRequest": GetMessageResourceRequest,
+        "P2ImMessageMessageReadV1": P2ImMessageMessageReadV1,
+        "ReplyMessageRequest": ReplyMessageRequest,
+        "ReplyMessageRequestBody": ReplyMessageRequestBody,
+        "UpdateMessageRequest": UpdateMessageRequest,
+        "UpdateMessageRequestBody": UpdateMessageRequestBody,
+        "AccessTokenType": AccessTokenType,
+        "HttpMethod": HttpMethod,
+        "FEISHU_DOMAIN": FEISHU_DOMAIN,
+        "LARK_DOMAIN": LARK_DOMAIN,
+        "BaseRequest": BaseRequest,
+        "CallBackCard": CallBackCard,
+        "P2CardActionTriggerResponse": P2CardActionTriggerResponse,
+        "EventDispatcherHandler": EventDispatcherHandler,
+        "FeishuWSClient": FeishuWSClient,
+        "FEISHU_AVAILABLE": True,
+    }
+
+
+try:
+    globals().update(_load_feishu_sdk())
 except ImportError:
     FEISHU_AVAILABLE = False
     lark = None  # type: ignore[assignment]
@@ -1353,57 +1387,8 @@ def check_feishu_requirements() -> bool:
     if FEISHU_AVAILABLE:
         return True
 
-    def _import():
-        import lark_oapi as lark
-        from lark_oapi.api.application.v6 import GetApplicationRequest
-        from lark_oapi.api.im.v1 import (
-            CreateFileRequest, CreateFileRequestBody,
-            CreateImageRequest, CreateImageRequestBody,
-            CreateMessageRequest, CreateMessageRequestBody,
-            GetChatRequest, GetMessageRequest, GetMessageResourceRequest,
-            P2ImMessageMessageReadV1,
-            ReplyMessageRequest, ReplyMessageRequestBody,
-            UpdateMessageRequest, UpdateMessageRequestBody,
-        )
-        from lark_oapi.core import AccessTokenType, HttpMethod
-        from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
-        from lark_oapi.core.model import BaseRequest
-        from lark_oapi.event.callback.model.p2_card_action_trigger import (
-            CallBackCard, P2CardActionTriggerResponse,
-        )
-        from lark_oapi.event.dispatcher_handler import EventDispatcherHandler
-        from lark_oapi.ws import Client as FeishuWSClient
-        return {
-            "lark": lark,
-            "GetApplicationRequest": GetApplicationRequest,
-            "CreateFileRequest": CreateFileRequest,
-            "CreateFileRequestBody": CreateFileRequestBody,
-            "CreateImageRequest": CreateImageRequest,
-            "CreateImageRequestBody": CreateImageRequestBody,
-            "CreateMessageRequest": CreateMessageRequest,
-            "CreateMessageRequestBody": CreateMessageRequestBody,
-            "GetChatRequest": GetChatRequest,
-            "GetMessageRequest": GetMessageRequest,
-            "GetMessageResourceRequest": GetMessageResourceRequest,
-            "P2ImMessageMessageReadV1": P2ImMessageMessageReadV1,
-            "ReplyMessageRequest": ReplyMessageRequest,
-            "ReplyMessageRequestBody": ReplyMessageRequestBody,
-            "UpdateMessageRequest": UpdateMessageRequest,
-            "UpdateMessageRequestBody": UpdateMessageRequestBody,
-            "AccessTokenType": AccessTokenType,
-            "HttpMethod": HttpMethod,
-            "FEISHU_DOMAIN": FEISHU_DOMAIN,
-            "LARK_DOMAIN": LARK_DOMAIN,
-            "BaseRequest": BaseRequest,
-            "CallBackCard": CallBackCard,
-            "P2CardActionTriggerResponse": P2CardActionTriggerResponse,
-            "EventDispatcherHandler": EventDispatcherHandler,
-            "FeishuWSClient": FeishuWSClient,
-            "FEISHU_AVAILABLE": True,
-        }
-
     from tools.lazy_deps import ensure_and_bind
-    return ensure_and_bind("platform.feishu", _import, globals(), prompt=False)
+    return ensure_and_bind("platform.feishu", _load_feishu_sdk, globals(), prompt=False)
 
 
 class FeishuAdapter(BasePlatformAdapter):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -3,6 +3,8 @@
 import asyncio
 import json
 import os
+import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -31,6 +33,65 @@ def _mock_event_dispatcher_builder(mock_handler_class):
     mock_builder.build = Mock(return_value=object())
     mock_handler_class.builder = Mock(return_value=mock_builder)
     return mock_builder
+
+
+class TestFeishuSdkImportAvailability(unittest.TestCase):
+    def test_load_feishu_sdk_converts_sdk_attribute_error_to_import_error(self):
+        import builtins
+        from gateway.platforms import feishu
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "lark_oapi":
+                raise AttributeError(
+                    "module 'pkg_resources' has no attribute 'declare_namespace'"
+                )
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            with self.assertRaises(ImportError):
+                feishu._load_feishu_sdk()
+
+    def test_module_import_survives_sdk_attribute_error(self):
+        script = r"""
+import builtins
+real_import = builtins.__import__
+
+def fake_import(name, *args, **kwargs):
+    if name == "lark_oapi":
+        raise AttributeError(
+            "module 'pkg_resources' has no attribute 'declare_namespace'"
+        )
+    return real_import(name, *args, **kwargs)
+
+builtins.__import__ = fake_import
+from gateway.platforms import feishu
+assert feishu.FEISHU_AVAILABLE is False
+assert feishu.lark is None
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=Path(__file__).resolve().parents[2],
+            text=True,
+            capture_output=True,
+            timeout=15,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_check_requirements_returns_false_when_sdk_import_is_broken(self):
+        from gateway.platforms import feishu
+
+        with (
+            patch("gateway.platforms.feishu.FEISHU_AVAILABLE", False),
+            patch("tools.lazy_deps.ensure", return_value=None),
+            patch(
+                "gateway.platforms.feishu._load_feishu_sdk",
+                side_effect=ImportError("Feishu/Lark SDK is unavailable"),
+            ),
+        ):
+            self.assertFalse(feishu.check_feishu_requirements())
 
 
 class TestConfigEnvOverrides(unittest.TestCase):


### PR DESCRIPTION
## Summary
- treat Feishu/Lark SDK import-time AttributeError as an unavailable optional dependency
- reuse the same SDK loader for startup imports and lazy requirement checks
- add regression coverage for broken lark_oapi imports, module import survival, and requirements fallback

Fixes #49034

## Tests
- `.venv/bin/python -m pytest tests/gateway/test_feishu.py::TestFeishuSdkImportAvailability tests/gateway/test_feishu.py tests/gateway/test_feishu_onboard.py tests/gateway/test_setup_feishu.py`
- `git diff --check`