### PR TITLE
feat(slack): preserve thread preview titles

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -53,11 +53,13 @@ from gateway.platforms.base import (
     cache_video_from_bytes,
 )
 from gateway.slack_thread_titles import (
-    apply_title_prefix,
+    apply_title_marker,
+    build_preview_fallback,
     build_thread_title_prompt,
     extract_retitle_request,
     get_or_create_thread_title,
     get_thread_title,
+    normalize_placement,
     set_thread_title,
 )
 
@@ -1160,15 +1162,21 @@ class SlackAdapter(BasePlatformAdapter):
                 )
 
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
-            content = self._maybe_prefix_thread_title(
-                chat_id,
-                thread_ts,
-                content,
-                metadata,
-            )
+            title = self._thread_title_for_delivery(chat_id, thread_ts, metadata)
+            if title:
+                content = apply_title_marker(
+                    content,
+                    title,
+                    placement=self._thread_title_placement(),
+                )
 
             # Convert standard markdown → Slack mrkdwn
             formatted = self.format_message(content)
+            fallback_text = (
+                build_preview_fallback(content, title)
+                if title and self._thread_title_preview_fallback_enabled()
+                else None
+            )
 
             # Split long messages, preserving code block boundaries
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -1182,9 +1190,13 @@ class SlackAdapter(BasePlatformAdapter):
             for i, chunk in enumerate(chunks):
                 kwargs = {
                     "channel": chat_id,
-                    "text": chunk,
+                    "text": fallback_text or chunk,
                     "mrkdwn": True,
                 }
+                if fallback_text:
+                    blocks = self._slack_message_blocks(chunk)
+                    if blocks:
+                        kwargs["blocks"] = blocks
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
                     # Only broadcast the first chunk of the first reply
@@ -1270,19 +1282,30 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         try:
             thread_ts = self._resolve_thread_ts(None, metadata)
-            content = self._maybe_prefix_thread_title(
+            title = self._thread_title_for_delivery(
                 chat_id,
                 thread_ts,
-                content,
                 metadata,
                 final=finalize,
             )
+            if title:
+                content = apply_title_marker(
+                    content,
+                    title,
+                    placement=self._thread_title_placement(),
+                )
             formatted = self.format_message(content)
-            await self._get_client(chat_id).chat_update(
-                channel=chat_id,
-                ts=message_id,
-                text=formatted,
-            )
+            kwargs: Dict[str, Any] = {
+                "channel": chat_id,
+                "ts": message_id,
+                "text": formatted,
+            }
+            if title and self._thread_title_preview_fallback_enabled():
+                kwargs["text"] = build_preview_fallback(content, title)
+                blocks = self._slack_message_blocks(formatted)
+                if blocks:
+                    kwargs["blocks"] = blocks
+            await self._get_client(chat_id).chat_update(**kwargs)
             if finalize:
                 await self.stop_typing(chat_id)
             return SendResult(success=True, message_id=message_id)
@@ -1355,16 +1378,90 @@ class SlackAdapter(BasePlatformAdapter):
             return True  # default: each DM thread is its own session
         return str(raw).strip().lower() in {"1", "true", "yes", "on"}
 
-    def _thread_titles_enabled(self) -> bool:
-        """Whether Slack thread-title prompting/enforcement is enabled."""
+    def _thread_titles_config(self) -> Any:
+        """Return raw Slack thread-title config."""
         raw = self.config.extra.get("thread_titles")
         if raw is None:
             raw = self.config.extra.get("thread_titles_enabled")
+        return raw
+
+    def _thread_titles_enabled(self) -> bool:
+        """Whether Slack thread-title prompting/enforcement is enabled."""
+        raw = self._thread_titles_config()
         if raw is None:
             return True
         if isinstance(raw, dict):
             raw = raw.get("enabled", True)
         return str(raw).strip().lower() not in {"0", "false", "no", "off"}
+
+    def _thread_title_placement(self) -> str:
+        """Return visible body title marker placement: first, last, both, none."""
+        raw = self._thread_titles_config()
+        placement = None
+        if isinstance(raw, dict):
+            placement = raw.get("placement") or raw.get("position")
+        if placement is None:
+            placement = self.config.extra.get("thread_title_placement")
+        return normalize_placement(placement)
+
+    def _thread_title_preview_fallback_enabled(self) -> bool:
+        """Whether to send a title-first top-level text fallback with blocks."""
+        raw = self._thread_titles_config()
+        if isinstance(raw, dict):
+            raw = raw.get("preview_fallback", raw.get("fallback_text", True))
+        else:
+            raw = self.config.extra.get("thread_title_preview_fallback", True)
+        return str(raw).strip().lower() not in {"0", "false", "no", "off"}
+
+    @staticmethod
+    def _slack_message_blocks(formatted: str) -> Optional[List[Dict[str, Any]]]:
+        """Render a formatted Slack mrkdwn message as Section blocks.
+
+        Slack uses top-level ``text`` as the notification fallback when blocks
+        are present. Section block mrkdwn text is limited to 3000 characters and
+        Slack accepts at most 50 blocks, so split conservatively and fall back to
+        plain text if the body is somehow larger than that envelope.
+        """
+        text = str(formatted or "")
+        if not text.strip():
+            return None
+        limit = 3000
+        blocks: List[Dict[str, Any]] = []
+        current = ""
+        for line in text.splitlines(keepends=True):
+            while len(line) > limit:
+                if current:
+                    blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": current.rstrip()}})
+                    current = ""
+                blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": line[:limit].rstrip()}})
+                line = line[limit:]
+            if len(current) + len(line) > limit and current:
+                blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": current.rstrip()}})
+                current = ""
+            current += line
+        if current.strip():
+            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": current.rstrip()}})
+        if not blocks or len(blocks) > 50:
+            return None
+        return blocks
+
+    def _thread_title_for_delivery(
+        self,
+        chat_id: str,
+        thread_ts: Optional[str],
+        metadata: Optional[Dict[str, Any]] = None,
+        *,
+        final: bool = False,
+    ) -> Optional[str]:
+        """Return the persisted title when this outgoing Slack message needs it."""
+        if not self._thread_titles_enabled() or not thread_ts:
+            return None
+        md = metadata or {}
+        if md.get("suppress_slack_thread_title"):
+            return None
+        if not final and not md.get("notify"):
+            return None
+        return get_thread_title(chat_id, thread_ts)
 
     def _maybe_prefix_thread_title(
         self,
@@ -1375,18 +1472,16 @@ class SlackAdapter(BasePlatformAdapter):
         *,
         final: bool = False,
     ) -> str:
-        """Append the persisted Slack thread title to final user-visible text."""
-        if not self._thread_titles_enabled() or not thread_ts:
-            return content
-        md = metadata or {}
-        if md.get("suppress_slack_thread_title"):
-            return content
-        if not final and not md.get("notify"):
-            return content
-        title = get_thread_title(chat_id, thread_ts)
+        """Compatibility wrapper for older tests/callers."""
+        title = self._thread_title_for_delivery(
+            chat_id,
+            thread_ts,
+            metadata,
+            final=final,
+        )
         if not title:
             return content
-        return apply_title_prefix(content, title)
+        return apply_title_marker(content, title, placement=self._thread_title_placement())
 
     def _resolve_thread_ts(
         self,
@@ -2901,7 +2996,10 @@ class SlackAdapter(BasePlatformAdapter):
                         thread_ts,
                         seed_text,
                     )
-                title_prompt = build_thread_title_prompt(thread_title)
+                title_prompt = build_thread_title_prompt(
+                    thread_title,
+                    placement=self._thread_title_placement(),
+                )
                 _channel_prompt = (
                     f"{_channel_prompt}\n\n{title_prompt}"
                     if _channel_prompt

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -52,6 +52,14 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     cache_video_from_bytes,
 )
+from gateway.slack_thread_titles import (
+    apply_title_prefix,
+    build_thread_title_prompt,
+    extract_retitle_request,
+    get_or_create_thread_title,
+    get_thread_title,
+    set_thread_title,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -1151,13 +1159,20 @@ class SlackAdapter(BasePlatformAdapter):
                     content,
                 )
 
+            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            content = self._maybe_prefix_thread_title(
+                chat_id,
+                thread_ts,
+                content,
+                metadata,
+            )
+
             # Convert standard markdown → Slack mrkdwn
             formatted = self.format_message(content)
 
             # Split long messages, preserving code block boundaries
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
             last_result = None
 
             # reply_broadcast: also post thread replies to the main channel.
@@ -1248,11 +1263,20 @@ class SlackAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Edit a previously sent Slack message."""
         if not self._app:
             return SendResult(success=False, error="Not connected")
         try:
+            thread_ts = self._resolve_thread_ts(None, metadata)
+            content = self._maybe_prefix_thread_title(
+                chat_id,
+                thread_ts,
+                content,
+                metadata,
+                final=finalize,
+            )
             formatted = self.format_message(content)
             await self._get_client(chat_id).chat_update(
                 channel=chat_id,
@@ -1330,6 +1354,39 @@ class SlackAdapter(BasePlatformAdapter):
         if raw is None:
             return True  # default: each DM thread is its own session
         return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+    def _thread_titles_enabled(self) -> bool:
+        """Whether Slack thread-title prompting/enforcement is enabled."""
+        raw = self.config.extra.get("thread_titles")
+        if raw is None:
+            raw = self.config.extra.get("thread_titles_enabled")
+        if raw is None:
+            return True
+        if isinstance(raw, dict):
+            raw = raw.get("enabled", True)
+        return str(raw).strip().lower() not in {"0", "false", "no", "off"}
+
+    def _maybe_prefix_thread_title(
+        self,
+        chat_id: str,
+        thread_ts: Optional[str],
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        *,
+        final: bool = False,
+    ) -> str:
+        """Append the persisted Slack thread title to final user-visible text."""
+        if not self._thread_titles_enabled() or not thread_ts:
+            return content
+        md = metadata or {}
+        if md.get("suppress_slack_thread_title"):
+            return content
+        if not final and not md.get("notify"):
+            return content
+        title = get_thread_title(chat_id, thread_ts)
+        if not title:
+            return content
+        return apply_title_prefix(content, title)
 
     def _resolve_thread_ts(
         self,
@@ -2831,6 +2888,27 @@ class SlackAdapter(BasePlatformAdapter):
                 )
             except Exception:  # pragma: no cover - defensive
                 reply_to_text = None
+
+        if self._thread_titles_enabled() and thread_ts:
+            try:
+                requested_title = extract_retitle_request(text)
+                if requested_title:
+                    thread_title = set_thread_title(channel_id, thread_ts, requested_title)
+                else:
+                    seed_text = reply_to_text or text or original_text
+                    thread_title = get_or_create_thread_title(
+                        channel_id,
+                        thread_ts,
+                        seed_text,
+                    )
+                title_prompt = build_thread_title_prompt(thread_title)
+                _channel_prompt = (
+                    f"{_channel_prompt}\n\n{title_prompt}"
+                    if _channel_prompt
+                    else title_prompt
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("[Slack] thread-title prompt setup failed: %s", exc)
 
         msg_event = MessageEvent(
             text=text,

--- a/gateway/slack_thread_titles.py
+++ b/gateway/slack_thread_titles.py
@@ -1,8 +1,9 @@
 """Persistent Slack thread preview titles.
 
-Slack's conversation list previews only the first line of the latest reply.
-For long-running Hermes threads, a stable title prefix makes every reply
-recognizable without reopening the thread.
+Slack exposes different preview surfaces (notifications, sidebars, thread
+lists) that do not all choose snippets the same way. Keep one stable title per
+thread, make the visible body title placement configurable, and provide a
+top-level fallback string for Slack clients that use notification fallbacks.
 """
 
 from __future__ import annotations
@@ -107,7 +108,7 @@ def _save_store_unlocked(data: dict[str, Any]) -> None:
 
 
 def normalize_title(title: str, *, fallback: str = _FALLBACK_TITLE) -> str:
-    """Sanitize a human or generated title for use as a Slack prefix."""
+    """Sanitize a human or generated title for use as a Slack marker."""
 
     text = str(title or "").strip()
     text = re.sub(r"^\*{1,2}|\*{1,2}$", "", text).strip()
@@ -223,15 +224,62 @@ def extract_retitle_request(text: str) -> Optional[str]:
     return title or None
 
 
-def build_thread_title_prompt(title: str) -> str:
+def normalize_placement(placement: str | None) -> str:
+    """Normalize visible title marker placement config."""
+
+    value = str(placement or "both").strip().lower().replace("_", "-")
+    aliases = {
+        "prepend": "first",
+        "prefix": "first",
+        "start": "first",
+        "append": "last",
+        "suffix": "last",
+        "end": "last",
+        "edge": "both",
+        "edges": "both",
+    }
+    value = aliases.get(value, value)
+    if value not in {"first", "last", "both", "none"}:
+        return "both"
+    return value
+
+
+def title_marker(title: str) -> str:
+    """Return the canonical visible Markdown title marker."""
+
+    return f"**{normalize_title(title)}:**"
+
+
+def build_thread_title_prompt(title: str, *, placement: str = "both") -> str:
     """Build the ephemeral system instruction injected for a Slack thread."""
 
     normalized = normalize_title(title)
+    where = normalize_placement(placement)
+    if where == "first":
+        instruction = (
+            f"Begin every user-visible reply in this thread with exactly "
+            f"`**{normalized}:**`."
+        )
+    elif where == "last":
+        instruction = (
+            f"End every user-visible reply in this thread with exactly "
+            f"`**{normalized}:**` as the final paragraph."
+        )
+    elif where == "both":
+        instruction = (
+            f"Begin every user-visible reply in this thread with exactly "
+            f"`**{normalized}:**` and end it with exactly `**{normalized}:**` "
+            "as the final paragraph."
+        )
+    else:
+        instruction = (
+            "Slack delivery will attach the preview title fallback; do not add "
+            "a visible title marker unless the user asks."
+        )
     return (
         "[Slack thread title]\n"
         f"This Slack thread's fixed preview title is: {normalized}. "
-        f"End every user-visible reply in this thread with exactly `**{normalized}:**` "
-        "as the final paragraph. Reuse this exact title until the user explicitly "
+        f"{instruction} Reuse this exact title until the user explicitly "
         "says `retitle this thread: <new title>`."
     )
 
@@ -264,16 +312,82 @@ def content_has_title_marker(content: str, title: str) -> bool:
     )
 
 
-def apply_title_prefix(content: str, title: str) -> str:
-    """Append the Slack thread title unless it is already present.
+def _content_edge_has_title_marker(content: str, title: str, *, first: bool) -> bool:
+    normalized = normalize_title(title).casefold()
+    existing = _title_from_content_edge(content, first=first)
+    return bool(existing and existing.casefold() == normalized)
 
-    The historical function name is retained for compatibility with the Slack
-    adapter/tests. Slack previews the last paragraph, so the marker belongs at
-    the end, not the top. Because of course it does.
-    """
+
+def apply_title_marker(content: str, title: str, *, placement: str = "both") -> str:
+    """Apply the visible Slack thread title marker at the requested edge(s)."""
 
     body = str(content or "")
-    normalized = normalize_title(title)
-    if not body.strip() or content_has_title_marker(body, normalized):
+    if not body.strip():
         return body
-    return f"{body.rstrip()}\n\n**{normalized}:**"
+    normalized = normalize_title(title)
+    marker = title_marker(normalized)
+    where = normalize_placement(placement)
+    if where == "none":
+        return body
+
+    result = body.strip()
+    if where in {"first", "both"} and not _content_edge_has_title_marker(
+        result, normalized, first=True
+    ):
+        result = f"{marker}\n\n{result.lstrip()}"
+    if where in {"last", "both"} and not _content_edge_has_title_marker(
+        result, normalized, first=False
+    ):
+        result = f"{result.rstrip()}\n\n{marker}"
+    return result
+
+
+def _strip_title_marker_lines(content: str, title: str) -> str:
+    normalized = normalize_title(title).casefold()
+    kept: list[str] = []
+    for line in str(content or "").splitlines():
+        existing = _title_from_markdown_line(line.strip())
+        if existing and existing.casefold() == normalized:
+            continue
+        kept.append(line)
+    return "\n".join(kept).strip()
+
+
+def _plain_preview_text(content: str) -> str:
+    text = str(content or "")
+    text = re.sub(r"```[\s\S]*?```", " ", text)
+    text = re.sub(r"`([^`]*)`", r"\1", text)
+    text = re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", text)
+    text = re.sub(r"_([^_]+)_", r"\1", text)
+    text = re.sub(r"<([^|>]+)\|([^>]+)>", r"\2", text)
+    text = re.sub(r"<([^>]+)>", r"\1", text)
+    text = re.sub(r"\[[^\]]+\]\(([^)]+)\)", r"\1", text)
+    text = re.sub(r"^[>\-#*\s]+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def build_preview_fallback(content: str, title: str, *, max_length: int = 240) -> str:
+    """Return Slack top-level text that starts with the stable thread title.
+
+    Slack documents top-level ``text`` as the notification fallback when a
+    message uses blocks. Include a compact body excerpt after the title so the
+    fallback remains useful for notifications and screen readers without
+    sacrificing the preview prefix.
+    """
+
+    normalized = normalize_title(title)
+    prefix = f"{normalized}:"
+    body = _plain_preview_text(_strip_title_marker_lines(content, normalized))
+    if not body:
+        return prefix
+    fallback = f"{prefix} {body}"
+    if len(fallback) <= max_length:
+        return fallback
+    return fallback[: max_length - 1].rstrip() + "…"
+
+
+def apply_title_prefix(content: str, title: str) -> str:
+    """Compatibility wrapper: apply title markers at both visible edges."""
+
+    return apply_title_marker(content, title, placement="both")

--- a/gateway/slack_thread_titles.py
+++ b/gateway/slack_thread_titles.py
@@ -1,0 +1,279 @@
+"""Persistent Slack thread preview titles.
+
+Slack's conversation list previews only the first line of the latest reply.
+For long-running Hermes threads, a stable title prefix makes every reply
+recognizable without reopening the thread.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_constants import get_default_hermes_root
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+_STORE_LOCK = threading.Lock()
+_STORE_RELATIVE_PATH = Path("gateway") / "slack_thread_titles.json"
+_MAX_ENTRIES = 5000
+_FALLBACK_TITLE = "Slack Thread Conversation With Hermes"
+_RETITLE_RE = re.compile(
+    r"^\s*(?:retitle|rename)\s+(?:this\s+)?thread\s*:\s*(?P<title>.+?)\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+_WORD_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9'’+/#.-]*")
+_MRKDWN_PREFIX_RE = re.compile(r"^\s*\*{1,2}(?P<title>[^*\n]{1,160}):\*{1,2}")
+_PLAIN_PREFIX_RE = re.compile(r"^\s*(?P<title>[^\n:*`]{1,160}):")
+
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "but",
+    "by",
+    "for",
+    "from",
+    "i",
+    "in",
+    "into",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "the",
+    "this",
+    "to",
+    "with",
+    "you",
+    "your",
+}
+_FILLER_WORDS = ("Thread", "Discussion", "Context", "Update", "Summary")
+
+
+def store_path() -> Path:
+    """Return the shared Slack thread-title store path.
+
+    Use the Hermes root rather than the active profile home so Slack-facing
+    profiles in the same install agree on the same title for the same Slack
+    thread. The payload contains no message bodies or secrets — only
+    channel/thread IDs and short user-visible titles.
+    """
+
+    return get_default_hermes_root() / _STORE_RELATIVE_PATH
+
+
+def make_thread_key(channel_id: str, thread_ts: str) -> str:
+    """Return a stable key for a Slack thread title."""
+
+    return f"{str(channel_id or '').strip()}:{str(thread_ts or '').strip()}"
+
+
+def _load_store_unlocked() -> dict[str, Any]:
+    path = store_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {"version": 1, "threads": {}}
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Slack thread-title store unreadable (%s); starting empty", exc)
+        return {"version": 1, "threads": {}}
+    if not isinstance(raw, dict):
+        return {"version": 1, "threads": {}}
+    threads = raw.get("threads")
+    if not isinstance(threads, dict):
+        raw["threads"] = {}
+    raw.setdefault("version", 1)
+    return raw
+
+
+def _save_store_unlocked(data: dict[str, Any]) -> None:
+    try:
+        atomic_json_write(store_path(), data, indent=2, sort_keys=True)
+    except TypeError:
+        # Older tests sometimes monkeypatch atomic_json_write without accepting
+        # json.dump kwargs. Keep the production path sorted; degrade cleanly.
+        atomic_json_write(store_path(), data, indent=2)
+
+
+def normalize_title(title: str, *, fallback: str = _FALLBACK_TITLE) -> str:
+    """Sanitize a human or generated title for use as a Slack prefix."""
+
+    text = str(title or "").strip()
+    text = re.sub(r"^\*{1,2}|\*{1,2}$", "", text).strip()
+    text = text.strip("`*_~ \t\r\n:-")
+    text = re.sub(r"<@[^>]+>", "", text)
+    text = re.sub(r"<([^|>]+)\|([^>]+)>", r"\2", text)
+    text = re.sub(r"https?://\S+", "", text)
+    words = _WORD_RE.findall(text)
+    if not words:
+        words = _WORD_RE.findall(fallback)
+    # Preserve explicit acronym-ish casing but title-case ordinary lowercase.
+    normalized: list[str] = []
+    for word in words[:10]:
+        if any(ch.isupper() for ch in word[1:]) or word.isupper():
+            normalized.append(word)
+        else:
+            normalized.append(word[:1].upper() + word[1:])
+    for filler in _FILLER_WORDS:
+        if len(normalized) >= 5:
+            break
+        normalized.append(filler)
+    return " ".join(normalized[:10]).strip() or fallback
+
+
+def generate_title(seed_text: str) -> str:
+    """Generate a deterministic 5-10 word title from thread text."""
+
+    text = str(seed_text or "")
+    text = re.sub(r"```[\s\S]*?```", " ", text)
+    text = re.sub(r"`[^`]*`", " ", text)
+    text = re.sub(r"<@[^>]+>", " ", text)
+    text = re.sub(r"https?://\S+", " ", text)
+    text = re.sub(r"\[[^\]]+\]:", " ", text)
+    candidates = _WORD_RE.findall(text)
+    if not candidates:
+        return _FALLBACK_TITLE
+
+    words: list[str] = []
+    for candidate in candidates:
+        clean = candidate.strip("._-/#")
+        if not clean:
+            continue
+        if not words and clean.lower() in _STOPWORDS:
+            continue
+        words.append(clean)
+        if len(words) >= 8:
+            break
+
+    if not words:
+        words = candidates[:5]
+    for filler in _FILLER_WORDS:
+        if len(words) >= 5:
+            break
+        words.append(filler)
+    return normalize_title(" ".join(words[:10]))
+
+
+def get_thread_title(channel_id: str, thread_ts: str) -> Optional[str]:
+    """Return a persisted title for a Slack thread, if any."""
+
+    key = make_thread_key(channel_id, thread_ts)
+    if key == ":":
+        return None
+    with _STORE_LOCK:
+        data = _load_store_unlocked()
+        entry = data.get("threads", {}).get(key)
+    if isinstance(entry, dict):
+        title = entry.get("title")
+    else:
+        title = entry
+    if not isinstance(title, str) or not title.strip():
+        return None
+    return normalize_title(title)
+
+
+def set_thread_title(channel_id: str, thread_ts: str, title: str) -> str:
+    """Persist and return the normalized title for a Slack thread."""
+
+    key = make_thread_key(channel_id, thread_ts)
+    normalized = normalize_title(title)
+    if key == ":":
+        return normalized
+    with _STORE_LOCK:
+        data = _load_store_unlocked()
+        threads = data.setdefault("threads", {})
+        if not isinstance(threads, dict):
+            threads = {}
+            data["threads"] = threads
+        threads[key] = {"title": normalized}
+        if len(threads) > _MAX_ENTRIES:
+            for old_key in list(threads)[: len(threads) - _MAX_ENTRIES]:
+                threads.pop(old_key, None)
+        _save_store_unlocked(data)
+    return normalized
+
+
+def get_or_create_thread_title(channel_id: str, thread_ts: str, seed_text: str) -> str:
+    """Return an existing title or persist a deterministic title for the thread."""
+
+    existing = get_thread_title(channel_id, thread_ts)
+    if existing:
+        return existing
+    return set_thread_title(channel_id, thread_ts, generate_title(seed_text))
+
+
+def extract_retitle_request(text: str) -> Optional[str]:
+    """Return an explicit retitle request payload from a Slack message."""
+
+    match = _RETITLE_RE.match(str(text or ""))
+    if not match:
+        return None
+    title = normalize_title(match.group("title"))
+    return title or None
+
+
+def build_thread_title_prompt(title: str) -> str:
+    """Build the ephemeral system instruction injected for a Slack thread."""
+
+    normalized = normalize_title(title)
+    return (
+        "[Slack thread title]\n"
+        f"This Slack thread's fixed preview title is: {normalized}. "
+        f"End every user-visible reply in this thread with exactly `**{normalized}:**` "
+        "as the final paragraph. Reuse this exact title until the user explicitly "
+        "says `retitle this thread: <new title>`."
+    )
+
+
+def _title_from_markdown_line(line: str) -> Optional[str]:
+    for pattern in (_MRKDWN_PREFIX_RE, _PLAIN_PREFIX_RE):
+        match = pattern.match(line)
+        if match:
+            return normalize_title(match.group("title"))
+    return None
+
+
+def _title_from_content_edge(content: str, *, first: bool) -> Optional[str]:
+    lines = [line.strip() for line in str(content or "").splitlines() if line.strip()]
+    if not lines:
+        return None
+    return _title_from_markdown_line(lines[0] if first else lines[-1])
+
+
+def content_has_title_marker(content: str, title: str) -> bool:
+    """Return True when content already begins or ends with the requested title."""
+
+    normalized = normalize_title(title).casefold()
+    return any(
+        existing and existing.casefold() == normalized
+        for existing in (
+            _title_from_content_edge(content, first=True),
+            _title_from_content_edge(content, first=False),
+        )
+    )
+
+
+def apply_title_prefix(content: str, title: str) -> str:
+    """Append the Slack thread title unless it is already present.
+
+    The historical function name is retained for compatibility with the Slack
+    adapter/tests. Slack previews the last paragraph, so the marker belongs at
+    the end, not the top. Because of course it does.
+    """
+
+    body = str(content or "")
+    normalized = normalize_title(title)
+    if not body.strip() or content_has_title_marker(body, normalized):
+        return body
+    return f"{body.rstrip()}\n\n**{normalized}:**"

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1070,8 +1070,13 @@ class TestSlackThreadTitles:
         )
 
         assert result.success
-        text = adapter._app.client.chat_postMessage.call_args.kwargs["text"]
-        assert text == "Implemented.\n\n*Slack Preview Thread Title Policy:*"
+        call = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert call["text"] == "Slack Preview Thread Title Policy: Implemented."
+        assert call["blocks"][0]["text"]["text"] == (
+            "*Slack Preview Thread Title Policy:*\n\n"
+            "Implemented.\n\n"
+            "*Slack Preview Thread Title Policy:*"
+        )
 
     @pytest.mark.asyncio
     async def test_inbound_message_injects_thread_title_prompt(
@@ -1102,7 +1107,7 @@ class TestSlackThreadTitles:
         assert event.source.thread_id == "1111111111.000001"
         assert "[Slack thread title]" in event.channel_prompt
         assert "**Slack Quick Preview Title Consistency Request:**" in event.channel_prompt
-        assert "final paragraph" in event.channel_prompt
+        assert "first and final" in event.channel_prompt or "Begin every user-visible reply" in event.channel_prompt
 
     @pytest.mark.asyncio
     async def test_inbound_retitle_updates_persisted_thread_title(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -69,6 +69,7 @@ import gateway.platforms.slack as _slack_mod
 _slack_mod.SLACK_AVAILABLE = True
 
 from gateway.platforms.slack import SlackAdapter  # noqa: E402
+from gateway.slack_thread_titles import set_thread_title  # noqa: E402
 
 
 async def _pending_for_fake_task():
@@ -1049,6 +1050,85 @@ class TestSendPrivateNotice:
             mrkdwn=True,
             thread_ts="1234567890.123456",
         )
+
+
+class TestSlackThreadTitles:
+    @pytest.mark.asyncio
+    async def test_final_send_enforces_persisted_thread_title(
+        self, adapter, tmp_path, monkeypatch
+    ):
+        store = tmp_path / "slack_thread_titles.json"
+        monkeypatch.setattr("gateway.slack_thread_titles.store_path", lambda: store)
+        set_thread_title("C123", "1234567890.123456", "Slack Preview Thread Title Policy")
+
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "reply_ts"})
+
+        result = await adapter.send(
+            "C123",
+            "Implemented.",
+            metadata={"thread_id": "1234567890.123456", "notify": True},
+        )
+
+        assert result.success
+        text = adapter._app.client.chat_postMessage.call_args.kwargs["text"]
+        assert text == "Implemented.\n\n*Slack Preview Thread Title Policy:*"
+
+    @pytest.mark.asyncio
+    async def test_inbound_message_injects_thread_title_prompt(
+        self, adapter, tmp_path, monkeypatch
+    ):
+        store = tmp_path / "slack_thread_titles.json"
+        monkeypatch.setattr("gateway.slack_thread_titles.store_path", lambda: store)
+        adapter._fetch_thread_context = AsyncMock(return_value="")
+        adapter._fetch_thread_parent_text = AsyncMock(
+            return_value="Slack quick preview title consistency request"
+        )
+        adapter._resolve_user_name = AsyncMock(return_value="Brian")
+
+        await adapter._handle_slack_message(
+            {
+                "type": "message",
+                "channel": "D123",
+                "channel_type": "im",
+                "user": "U123",
+                "text": "how do you think this approach could be improved?",
+                "ts": "2222222222.000002",
+                "thread_ts": "1111111111.000001",
+            }
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.thread_id == "1111111111.000001"
+        assert "[Slack thread title]" in event.channel_prompt
+        assert "**Slack Quick Preview Title Consistency Request:**" in event.channel_prompt
+        assert "final paragraph" in event.channel_prompt
+
+    @pytest.mark.asyncio
+    async def test_inbound_retitle_updates_persisted_thread_title(
+        self, adapter, tmp_path, monkeypatch
+    ):
+        store = tmp_path / "slack_thread_titles.json"
+        monkeypatch.setattr("gateway.slack_thread_titles.store_path", lambda: store)
+        set_thread_title("D123", "1111111111.000001", "Old Preview Title Policy")
+        adapter._fetch_thread_context = AsyncMock(return_value="")
+        adapter._fetch_thread_parent_text = AsyncMock(return_value="Original parent")
+        adapter._resolve_user_name = AsyncMock(return_value="Brian")
+
+        await adapter._handle_slack_message(
+            {
+                "type": "message",
+                "channel": "D123",
+                "channel_type": "im",
+                "user": "U123",
+                "text": "retitle this thread: Gateway Enforced Slack Thread Titles",
+                "ts": "2222222222.000003",
+                "thread_ts": "1111111111.000001",
+            }
+        )
+
+        event = adapter.handle_message.await_args.args[0]
+        assert "**Gateway Enforced Slack Thread Titles:**" in event.channel_prompt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack_thread_titles.py
+++ b/tests/gateway/test_slack_thread_titles.py
@@ -1,5 +1,7 @@
 from gateway.slack_thread_titles import (
+    apply_title_marker,
     apply_title_prefix,
+    build_preview_fallback,
     build_thread_title_prompt,
     extract_retitle_request,
     generate_title,
@@ -41,22 +43,33 @@ def test_explicit_retitle_overrides_existing_title(tmp_path, monkeypatch):
     assert get_thread_title("C123", "111.222") == "Slack Preview Thread Title Policy"
 
 
-def test_prompt_and_enforcement_use_exact_markdown_suffix():
+def test_prompt_and_enforcement_use_exact_markdown_edges():
     prompt = build_thread_title_prompt("Slack Preview Thread Title Policy")
     assert "**Slack Preview Thread Title Policy:**" in prompt
+    assert "Begin every user-visible reply" in prompt
     assert "final paragraph" in prompt
 
     assert apply_title_prefix("Done.", "Slack Preview Thread Title Policy") == (
-        "Done.\n\n**Slack Preview Thread Title Policy:**"
+        "**Slack Preview Thread Title Policy:**\n\nDone.\n\n**Slack Preview Thread Title Policy:**"
     )
-    assert apply_title_prefix(
+    assert apply_title_marker(
         "Already titled.\n\n**Slack Preview Thread Title Policy:**",
         "Slack Preview Thread Title Policy",
+        placement="last",
     ) == "Already titled.\n\n**Slack Preview Thread Title Policy:**"
-    assert apply_title_prefix(
+    assert apply_title_marker(
         "**Slack Preview Thread Title Policy:**\n\nLegacy leading title.",
         "Slack Preview Thread Title Policy",
+        placement="first",
     ) == "**Slack Preview Thread Title Policy:**\n\nLegacy leading title."
+
+
+def test_preview_fallback_starts_with_title_and_body_excerpt():
+    fallback = build_preview_fallback(
+        "**Slack Preview Thread Title Policy:**\n\nImplemented the gateway fallback.\n\n**Slack Preview Thread Title Policy:**",
+        "Slack Preview Thread Title Policy",
+    )
+    assert fallback == "Slack Preview Thread Title Policy: Implemented the gateway fallback."
 
 
 def test_generated_title_uses_deterministic_five_to_ten_words():

--- a/tests/gateway/test_slack_thread_titles.py
+++ b/tests/gateway/test_slack_thread_titles.py
@@ -1,0 +1,65 @@
+from gateway.slack_thread_titles import (
+    apply_title_prefix,
+    build_thread_title_prompt,
+    extract_retitle_request,
+    generate_title,
+    get_or_create_thread_title,
+    get_thread_title,
+    set_thread_title,
+)
+
+
+def test_get_or_create_persists_stable_title(tmp_path, monkeypatch):
+    store = tmp_path / "slack_thread_titles.json"
+    monkeypatch.setattr("gateway.slack_thread_titles.store_path", lambda: store)
+
+    first = get_or_create_thread_title(
+        "C123",
+        "1781837641.289239",
+        "When responding to a message lead with a 5-10 word title",
+    )
+    second = get_or_create_thread_title(
+        "C123",
+        "1781837641.289239",
+        "A different later reply should not rename the thread",
+    )
+
+    assert first == second
+    assert get_thread_title("C123", "1781837641.289239") == first
+    assert 5 <= len(first.split()) <= 10
+
+
+def test_explicit_retitle_overrides_existing_title(tmp_path, monkeypatch):
+    store = tmp_path / "slack_thread_titles.json"
+    monkeypatch.setattr("gateway.slack_thread_titles.store_path", lambda: store)
+
+    set_thread_title("C123", "111.222", "Old Infrastructure Thread Title")
+    requested = extract_retitle_request("retitle this thread: Slack Preview Thread Title Policy")
+    assert requested == "Slack Preview Thread Title Policy"
+
+    set_thread_title("C123", "111.222", requested)
+    assert get_thread_title("C123", "111.222") == "Slack Preview Thread Title Policy"
+
+
+def test_prompt_and_enforcement_use_exact_markdown_suffix():
+    prompt = build_thread_title_prompt("Slack Preview Thread Title Policy")
+    assert "**Slack Preview Thread Title Policy:**" in prompt
+    assert "final paragraph" in prompt
+
+    assert apply_title_prefix("Done.", "Slack Preview Thread Title Policy") == (
+        "Done.\n\n**Slack Preview Thread Title Policy:**"
+    )
+    assert apply_title_prefix(
+        "Already titled.\n\n**Slack Preview Thread Title Policy:**",
+        "Slack Preview Thread Title Policy",
+    ) == "Already titled.\n\n**Slack Preview Thread Title Policy:**"
+    assert apply_title_prefix(
+        "**Slack Preview Thread Title Policy:**\n\nLegacy leading title.",
+        "Slack Preview Thread Title Policy",
+    ) == "**Slack Preview Thread Title Policy:**\n\nLegacy leading title."
+
+
+def test_generated_title_uses_deterministic_five_to_ten_words():
+    title = generate_title("Can you expand the Longhorn volume in prd k8s safely?")
+    assert title == generate_title("Can you expand the Longhorn volume in prd k8s safely?")
+    assert 5 <= len(title.split()) <= 10

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -341,12 +341,20 @@ platforms:
       # Only the first chunk of the first reply is broadcast.
       reply_broadcast: false
 
-      # Append each final thread reply with a stable bold title so Slack
-      # conversation previews remain scannable. The title is persisted per
-      # channel_id + thread_ts and shared across Hermes profiles on the same
-      # install. Users can rename it with:
+      # Add a stable bold title to final thread replies and send a title-first
+      # top-level fallback text for Slack notification/preview surfaces. The
+      # title is persisted per channel_id + thread_ts and shared across Hermes
+      # profiles on the same install. Users can rename it with:
       # retitle this thread: New Slack Thread Title
-      thread_titles: true
+      thread_titles:
+        enabled: true
+        # first | last | both | none. "both" is the safest default because
+        # Slack's sidebar/thread preview heuristics are not publicly specified.
+        placement: both
+        # When true, render the body as Block Kit and set top-level text to
+        # "Title: short body excerpt" for Slack's documented notification
+        # fallback path.
+        preview_fallback: true
 ```
 
 | Key | Default | Description |
@@ -354,7 +362,7 @@ platforms:
 | `platforms.slack.reply_to_mode` | `"first"` | Threading mode for multi-part messages: `"off"`, `"first"`, or `"all"` |
 | `platforms.slack.extra.reply_in_thread` | `true` | When `false`, channel messages get direct replies instead of threads. Messages inside existing threads still reply in-thread. |
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
-| `platforms.slack.extra.thread_titles` | `true` | Stores a stable 5-10 word title per Slack thread, injects it into the agent prompt, and enforces it on final replies. Set `false` to disable. |
+| `platforms.slack.extra.thread_titles` | `true` | Stores a stable 5-10 word title per Slack thread, injects it into the agent prompt, enforces visible markers on final replies, and sends a title-first fallback when Block Kit rendering is enabled. Set `false` to disable, or use a map for `enabled`, `placement`, and `preview_fallback`. |
 
 ### Slack thread preview titles
 
@@ -363,13 +371,19 @@ When enabled, Hermes stores a short title for each Slack thread under
 `channel_id + thread_ts`, so all Slack-facing profiles on the same Hermes
 installation reuse the same title for the same Slack thread.
 
-Hermes uses that title in two places:
+Hermes uses that title in three places:
 
-1. It injects an ephemeral instruction telling the agent to end every
-   user-visible reply with exactly `**Title:**` as the final paragraph.
-2. It enforces the final title paragraph at Slack delivery time for final replies, including
-   streamed responses. Slack receives native mrkdwn, so `**Title:**` renders as
-   `*Title:*` in the API payload.
+1. It injects an ephemeral instruction telling the agent where to place the
+   visible `**Title:**` marker. The default placement is `both` because Slack
+   does not publicly document one universal sidebar/thread preview heuristic.
+2. It enforces the requested marker placement at Slack delivery time for final
+   replies, including streamed responses. Slack receives native mrkdwn, so
+   `**Title:**` renders as `*Title:*` in the API payload.
+3. When `preview_fallback` is enabled, Hermes sends the visible body as Block
+   Kit and sets top-level `text` to `Title: short body excerpt`. Slack documents
+   that top-level `text` is the notification fallback for block messages; this
+   gives preview surfaces a title-first fallback without relying only on first
+   or last paragraph extraction.
 
 To rename a thread title, reply in the thread:
 

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -340,6 +340,13 @@ platforms:
       # (Slack's "Also send to channel" feature).
       # Only the first chunk of the first reply is broadcast.
       reply_broadcast: false
+
+      # Append each final thread reply with a stable bold title so Slack
+      # conversation previews remain scannable. The title is persisted per
+      # channel_id + thread_ts and shared across Hermes profiles on the same
+      # install. Users can rename it with:
+      # retitle this thread: New Slack Thread Title
+      thread_titles: true
 ```
 
 | Key | Default | Description |
@@ -347,6 +354,30 @@ platforms:
 | `platforms.slack.reply_to_mode` | `"first"` | Threading mode for multi-part messages: `"off"`, `"first"`, or `"all"` |
 | `platforms.slack.extra.reply_in_thread` | `true` | When `false`, channel messages get direct replies instead of threads. Messages inside existing threads still reply in-thread. |
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
+| `platforms.slack.extra.thread_titles` | `true` | Stores a stable 5-10 word title per Slack thread, injects it into the agent prompt, and enforces it on final replies. Set `false` to disable. |
+
+### Slack thread preview titles
+
+When enabled, Hermes stores a short title for each Slack thread under
+`<Hermes root>/gateway/slack_thread_titles.json`. The key is
+`channel_id + thread_ts`, so all Slack-facing profiles on the same Hermes
+installation reuse the same title for the same Slack thread.
+
+Hermes uses that title in two places:
+
+1. It injects an ephemeral instruction telling the agent to end every
+   user-visible reply with exactly `**Title:**` as the final paragraph.
+2. It enforces the final title paragraph at Slack delivery time for final replies, including
+   streamed responses. Slack receives native mrkdwn, so `**Title:**` renders as
+   `*Title:*` in the API payload.
+
+To rename a thread title, reply in the thread:
+
+```text
+retitle this thread: Longhorn Volume Expansion Runbook
+```
+
+The new title is reused until explicitly retitled again.
 
 ### Session Isolation
 


### PR DESCRIPTION
## Summary
- persist Slack thread preview titles from incoming messages
- use stored thread titles as preview fallbacks for thread replies
- document Slack thread-title behavior and add gateway coverage

## Test plan
- attempted: `python3 -m pytest tests/gateway/test_slack_thread_titles.py tests/gateway/test_slack.py -q`
- result: environment failure; async tests require pytest-asyncio, and this host has no `uv` command to install/run dev extras
