### PR TITLE
fix(cli): make idle refresh_interval configurable, default 0 (no auto-scroll)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13527,13 +13527,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             style=style,
             full_screen=False,
             mouse_support=False,
-            # The status bar contains wall-clock read-outs (live prompt elapsed
-            # and idle-since-last-turn). Once a turn finishes there may be no
-            # further events to invalidate the app, so prompt_toolkit would keep
-            # rendering the first post-turn value (usually ``✓ 0s``) forever.
-            # A low-rate refresh keeps the clock honest without reintroducing a
-            # custom repaint thread or touching conversation state.
-            refresh_interval=1.0,
+            # Read from display.cli_refresh_interval (default 0 = disabled).
+            # When non-zero, prompt_toolkit redraws the UI on this cadence
+            # during idle, keeping wall-clock status-bar read-outs ticking.
+            # Set to 0 to suppress background redraws entirely — avoids
+            # fighting terminal auto-scroll in non-fullscreen mode (Xshell,
+            # iTerm2, Windows Terminal). See #48309.
+            refresh_interval=float(CLI_CONFIG.get("display", {}).get("cli_refresh_interval", 0)),
             # Erase the live bottom chrome (status bar, input box, separator
             # rules) on exit instead of freezing a final copy into scrollback.
             # Without this, prompt_toolkit's render_as_done teardown repaints

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1581,6 +1581,12 @@ DEFAULT_CONFIG = {
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.
         "tui_status_indicator": "kaomoji",
+        # Seconds between prompt_toolkit redraws in the classic CLI when idle.
+        # 0 = disabled (no background refresh — the pre-0.15.2 behaviour).
+        # Positive values e.g. 1.0 keep wall-clock status-bar read-outs
+        # (idle-since-last-turn) ticking but may fight terminal auto-scroll in
+        # non-fullscreen mode on some emulators (Xshell, iTerm2, etc.).
+        "cli_refresh_interval": 0,
         "user_message_preview": {  # CLI: how many submitted user-message lines to echo back in scrollback
             "first_lines": 2,
             "last_lines": 2,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1531,6 +1531,7 @@ AUTHOR_MAP = {
     "erik.engervall@gmail.com": "erikengervall",  # PR #28774 (firecrawl integration tag)
     "egilewski@egilewski.com": "egilewski",  # PR #30432 (MEDIA path traversal fix, GHSA-jmf9-9729-7pp8)
     "edison@mcclean.codes": "McClean-Edison",  # PR #29817 (register_auxiliary_task plugin API)
+    "OYLFLMH@users.noreply.github.com": "OYLFLMH",  # PR #48312 salvage (cli_refresh_interval config, #48309)
     "zhangsamuel12@gmail.com": "SamuelZ12",  # PR #7480 (show recap after in-session resume)
     "490408354@qq.com": "daizhonggeng",  # PR #9020 (numbered /resume selection)
     "claw@openclaw.ai": "wanwan2qq",  # PR #10215 (strip brackets/quotes from /resume; gateway session-ID lookup)

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -955,6 +955,16 @@ class TestInterimAssistantMessageConfig:
         assert raw["display"]["interim_assistant_messages"] is True
 
 
+class TestCliRefreshIntervalConfig:
+    """Test the CLI refresh_interval config default (#48309)."""
+
+    def test_default_config_disables_cli_refresh_interval(self):
+        """cli_refresh_interval defaults to 0 (disabled) to avoid
+        background redraws that fight terminal auto-scroll-on-output
+        in non-fullscreen mode (Xshell, iTerm2, Windows Terminal)."""
+        assert DEFAULT_CONFIG["display"]["cli_refresh_interval"] == 0
+
+
 class TestDiscordChannelPromptsConfig:
     def test_default_config_includes_discord_channel_prompts(self):
         assert DEFAULT_CONFIG["discord"]["channel_prompts"] == {}


### PR DESCRIPTION
## Summary
The classic CLI no longer fights terminal auto-scroll-on-output during idle. `display.cli_refresh_interval` now drives prompt_toolkit's `refresh_interval`, defaulting to `0` (disabled).

Root cause: commit `6724daa2c` hardcoded `refresh_interval=1.0` to keep the idle clock ticking. In non-fullscreen mode that repaints the UI every second, and emulators with "auto-scroll on output" (Xshell, iTerm2, Windows Terminal) snap the viewport to the bottom — so scrolling up to read history gets yanked back down.

Salvages #48312 by @OYLFLMH (the issue reporter), with the config-default test ported from @Elshayib's #48319. Fixes #48309.

## Changes
- `cli.py`: `refresh_interval` reads `display.cli_refresh_interval` (default `0`).
- `hermes_cli/config.py`: new `display.cli_refresh_interval` default `0`.
- `tests/hermes_cli/test_config.py`: assert the default is `0`.
- `scripts/release.py`: AUTHOR_MAP entry for the salvaged commit.

## Validation
| | Before | After |
|---|---|---|
| Default idle behavior (non-fullscreen) | repaint every 1s → auto-scroll snaps to bottom | no background repaint, viewport stays put |
| Opt back in (`cli_refresh_interval: 1.0`) | n/a | idle clock ticks again |
| `tests/hermes_cli/test_config.py` | — | 101/101 pass |
| E2E (both loaders) | — | default `0`, opt-in `1.0` honored |

Default `0` restores the pre-`6724daa2c` behavior for everyone; users who want the live idle clock set `display.cli_refresh_interval: 1.0` in `config.yaml`.

## Infographic

![cli-idle-refresh-no-auto-scroll](https://v3b.fal.media/files/b/0a9eed99/sOBvcWyYtURo7Z3Pmqd-p_EETNnP0F.png)
