### PR TITLE
docs(cli): fix broken terminal-backend guide link in setup wizard

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1137,7 +1137,7 @@ def setup_terminal_backend(config: dict):
     print_header("Terminal Backend")
     print_info("Choose where Hermes runs shell commands and code.")
     print_info("This affects tool execution, file access, and isolation.")
-    print_info(f"   Guide: {_DOCS_BASE}/developer-guide/environments")
+    print_info(f"   Guide: {_DOCS_BASE}/user-guide/configuration#terminal-backend-configuration")
     print()
 
     current_backend = cfg_get(config, "terminal", "backend", default="local")


### PR DESCRIPTION
## What does this PR do?

The Terminal Backend step of the interactive setup wizard prints a "Guide" link that points at `https://hermes-agent.nousresearch.com/docs/developer-guide/environments`, which no longer exists. This updates it to the live docs location, `https://hermes-agent.nousresearch.com/docs/user-guide/configuration#terminal-backend-configuration`, so users onboarding through `hermes setup` land on a real page.

## Related Issue

<!-- No tracking issue; trivial dead-link fix. -->

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/setup.py` (`setup_terminal_backend`): point the printed guide link from `{_DOCS_BASE}/developer-guide/environments` to `{_DOCS_BASE}/user-guide/configuration#terminal-backend-configuration`.

## How to Test

1. Run `hermes setup` and advance to the **Terminal Backend** step (or call `setup_terminal_backend()` directly).
2. Confirm the printed `Guide:` URL is `https://hermes-agent.nousresearch.com/docs/user-guide/configuration#terminal-backend-configuration`.
3. Open the URL and confirm it resolves to the Terminal Backend Configuration section.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- string-only change; verified via py_compile of hermes_cli/setup.py -->
- [ ] I've added tests for my changes <!-- N/A: no test exercises the printed onboarding URL; this is a literal string fix -->
- [x] I've tested on my platform: macOS 15 (Darwin 25.3.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — one-line link fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
