### PR TITLE
fix(tui): guard /update against hosted dashboard mode (salvage #48904)

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createSlashHandler } from '../app/createSlashHandler.js'
 import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
-import { DASHBOARD_EXIT_DISABLED_MESSAGE } from '../app/slash/commands/core.js'
+import { DASHBOARD_EXIT_DISABLED_MESSAGE, DASHBOARD_UPDATE_DISABLED_MESSAGE } from '../app/slash/commands/core.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
 
@@ -114,6 +114,22 @@ describe('createSlashHandler', () => {
     // Advance past the 100ms setTimeout
     vi.advanceTimersByTime(150)
     expect(ctx.session.dieWithCode).toHaveBeenCalledWith(42)
+
+    vi.useRealTimers()
+  })
+
+  it('refuses /update in hosted dashboard chat instead of killing the PTY', () => {
+    vi.useFakeTimers()
+    envState.dashboardTuiMode = true
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/update')).toBe(true)
+    expect(ctx.session.dieWithCode).not.toHaveBeenCalled()
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith(DASHBOARD_UPDATE_DISABLED_MESSAGE)
+
+    vi.advanceTimersByTime(150)
+    expect(ctx.session.dieWithCode).not.toHaveBeenCalled()
 
     vi.useRealTimers()
   })

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -81,6 +81,9 @@ const DETAILS_SECTION_USAGE = 'usage: /details <section> [hidden|collapsed|expan
 export const DASHBOARD_EXIT_DISABLED_MESSAGE =
   'exit is disabled in hosted dashboard chat — use /new to start a fresh session'
 
+export const DASHBOARD_UPDATE_DISABLED_MESSAGE =
+  'update is disabled in hosted dashboard chat — the hosted environment is managed separately'
+
 export const coreCommands: SlashCommand[] = [
   {
     help: 'list commands + hotkeys',
@@ -140,6 +143,12 @@ export const coreCommands: SlashCommand[] = [
     help: 'update Hermes Agent to the latest version (exits TUI)',
     name: 'update',
     run: (_arg, ctx) => {
+      if (DASHBOARD_TUI_MODE) {
+        ctx.transcript.sys(DASHBOARD_UPDATE_DISABLED_MESSAGE)
+
+        return
+      }
+
       ctx.transcript.sys('exiting TUI to run update...')
       // Exit code 42 signals the Python wrapper to exec `hermes update`.
       // Use dieWithCode for proper cleanup (gateway kill + Ink unmount).


### PR DESCRIPTION
## Summary

`/update` in the hosted dashboard chat killed the PTY and bricked the tab — and could never work there anyway. This guards it the same way #48882 guarded `/exit` and `/quit`.

`/update` calls `setTimeout(() => ctx.session.dieWithCode(42), 100)`. Exit code 42 is the signal the **native CLI launch path** (`hermes_cli/main.py`) catches to relaunch as `hermes update`. The hosted dashboard runs the TUI through the PTY bridge (`hermes_cli/pty_bridge.py`), which only streams bytes — it never runs that exit-42 handler. So in hosted mode `/update` can't trigger an update, and the PTY death leaves the tab dead until a browser refresh. Same bug class as #48882.

## Changes
- `ui-tui/src/app/slash/commands/core.ts`: `/update` returns early with `DASHBOARD_UPDATE_DISABLED_MESSAGE` when `DASHBOARD_TUI_MODE` is set, before reaching `dieWithCode(42)`. New exported constant mirrors the existing `DASHBOARD_EXIT_DISABLED_MESSAGE`.
- `ui-tui/src/__tests__/createSlashHandler.test.ts`: regression test — asserts `dieWithCode` is never called (even after advancing the fake timer past the 100ms `setTimeout`) and the refusal message matches the exported constant.

## Validation
| Scenario | Before | After |
|---|---|---|
| `/update` in hosted dashboard | `dieWithCode(42)` → PTY killed → tab bricked | refused with message, tab stays alive |
| `/update` outside hosted mode | exits 42 → `hermes update` relaunch | unchanged |

`vitest run createSlashHandler.test.ts` → 61/61 pass. `tsc --noEmit` clean.

Salvage of #48904 by @srojk34 — cherry-picked onto current `main` with authorship preserved.

## Infographic

![update-guarded](https://v3b.fal.media/files/b/0a9eeda5/Wb1BKhikYDc7uU6Xw-CmZ_L4HucpYE.png)
