### PR TITLE
fix(desktop): allow selecting slash output and shell logs in thread

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -859,7 +859,10 @@ const ProcessNotificationNote: FC<{ text: string }> = ({ text }) => {
           <summary className="cursor-pointer select-none text-muted-foreground/45 hover:text-muted-foreground/70">
             output
           </summary>
-          <pre className="mt-0.5 max-h-48 overflow-auto whitespace-pre-wrap font-mono text-[0.625rem] leading-4 text-muted-foreground/55">
+          <pre
+            className="mt-0.5 max-h-48 overflow-auto whitespace-pre-wrap font-mono text-[0.625rem] leading-4 text-muted-foreground/55"
+            data-selectable-text="true"
+          >
             {detail}
           </pre>
         </details>

--- a/apps/desktop/src/components/chat/terminal-output.tsx
+++ b/apps/desktop/src/components/chat/terminal-output.tsx
@@ -41,7 +41,11 @@ export function TerminalOutput({ className, text }: TerminalOutputProps) {
   }, [text])
 
   return (
-    <div className={cn('max-h-16 overflow-auto overscroll-contain', className)} ref={ref}>
+    <div
+      className={cn('max-h-16 overflow-auto overscroll-contain', className)}
+      data-selectable-text="true"
+      ref={ref}
+    >
       <pre className="w-max min-w-full font-mono text-[0.5625rem] leading-[0.85rem] whitespace-pre text-muted-foreground/70">
         {text}
       </pre>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -680,6 +680,7 @@ textarea,
 [contenteditable]:not([contenteditable='false']),
 [data-slot='aui_user-message-root'],
 [data-slot='aui_assistant-message-content'],
+[data-slot='aui_system-message-root'],
 [data-selectable-text='true'],
 [data-selectable-text='true'] * {
   -webkit-user-select: text;


### PR DESCRIPTION
## Summary
- Opt `aui_system-message-root` into the desktop text-selection allowlist so slash command output (`/debug`, `/status`, catalogs, etc.) can be highlighted and copied
- Mark `TerminalOutput` and background-process log `<pre>` blocks as selectable for the same reason

## Root cause
The Electron shell sets `user-select: none` on `body` and only re-enables selection on explicit slots (user/assistant bubbles, inputs). Slash output renders as a system message (`data-slot="aui_system-message-root"`), which was missing from that list — not a pointer-events issue.

## Test plan
- [x] Desktop app: run `/debug`, select/copy multiline paste URLs and log tails from the thread
- [x] Run a background terminal job with output, expand the status-stack log, copy text
- [x] Confirm user/assistant message selection still works