### PR TITLE
fix(image_gen): gate openai-codex image generation on Codex tool support

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.image_gen_provider import (
@@ -79,6 +81,10 @@ _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation requests by "
     "using the image_generation tool when provided."
 )
+_CODEX_IMAGE_TOOL = "image_generation"
+_CODEX_MODELS_CLIENT_VERSION = "1.0.0"
+_CODEX_IMAGE_CAPABILITY_CACHE_TTL = 3600  # 1 hour
+_codex_image_capability_cache: Optional[Tuple[float, bool, str]] = None
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +149,113 @@ def _read_codex_access_token() -> Optional[str]:
         return None
 
 
+def _codex_image_generation_unavailable_message() -> str:
+    """Explain the current Codex OAuth image-generation limitation."""
+    return (
+        "ChatGPT/Codex OAuth currently does not expose the Responses "
+        "`image_generation` tool on the Codex backend. Use the API-key-backed "
+        "`openai` image provider instead."
+    )
+
+
+def _read_cached_codex_supported_tools() -> Optional[List[str]]:
+    """Read experimental_supported_tools for the current Codex chat model."""
+    from pathlib import Path
+
+    codex_home = Path(os.getenv("CODEX_HOME", "") or (Path.home() / ".codex")).expanduser()
+    cache_path = codex_home / "models_cache.json"
+    if not cache_path.exists():
+        return None
+    try:
+        raw = json.loads(cache_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.debug("Could not read Codex models cache: %s", exc)
+        return None
+
+    entries = raw.get("models", []) if isinstance(raw, dict) else []
+    for item in entries:
+        if not isinstance(item, dict):
+            continue
+        if item.get("slug") != _CODEX_CHAT_MODEL:
+            continue
+        tools = item.get("experimental_supported_tools")
+        if not isinstance(tools, list):
+            return None
+        return [tool.strip() for tool in tools if isinstance(tool, str) and tool.strip()]
+    return None
+
+
+def _probe_codex_supported_tools(token: str) -> Optional[List[str]]:
+    """Return the live Codex model's advertised experimental tools."""
+    import httpx
+    from agent.auxiliary_client import _codex_cloudflare_headers
+
+    headers = _codex_cloudflare_headers(token)
+    headers["Authorization"] = f"Bearer {token}"
+
+    with httpx.Client(timeout=10.0, headers=headers) as http:
+        response = http.get(
+            f"{_CODEX_BASE_URL}/models?client_version={_CODEX_MODELS_CLIENT_VERSION}"
+        )
+        response.raise_for_status()
+
+    data = response.json()
+    entries = data.get("models", []) if isinstance(data, dict) else []
+    for item in entries:
+        if not isinstance(item, dict):
+            continue
+        if item.get("slug") != _CODEX_CHAT_MODEL:
+            continue
+        tools = item.get("experimental_supported_tools")
+        if not isinstance(tools, list):
+            return None
+        return [tool.strip() for tool in tools if isinstance(tool, str) and tool.strip()]
+    return None
+
+
+def _codex_image_generation_support(
+    token: Optional[str] = None,
+    *,
+    allow_live: bool = False,
+) -> Tuple[Optional[bool], str]:
+    """Return whether the current Codex OAuth surface supports image generation.
+
+    ``False`` means we have direct evidence that the current backend does not
+    expose the ``image_generation`` tool. ``None`` means the capability could
+    not be confirmed cheaply and callers may need to rely on the request path
+    for a definitive answer.
+    """
+    global _codex_image_capability_cache
+
+    cached = _codex_image_capability_cache
+    now = time.time()
+    if cached and now - cached[0] < _CODEX_IMAGE_CAPABILITY_CACHE_TTL:
+        return cached[1], cached[2]
+
+    tools = _read_cached_codex_supported_tools()
+    if tools is not None:
+        supported = _CODEX_IMAGE_TOOL in tools
+        message = "" if supported else _codex_image_generation_unavailable_message()
+        _codex_image_capability_cache = (now, supported, message)
+        return supported, message
+
+    if allow_live and token:
+        try:
+            tools = _probe_codex_supported_tools(token)
+        except Exception as exc:
+            logger.debug("Could not probe Codex image-generation capability: %s", exc)
+        else:
+            if tools is not None:
+                supported = _CODEX_IMAGE_TOOL in tools
+                message = "" if supported else _codex_image_generation_unavailable_message()
+                _codex_image_capability_cache = (now, supported, message)
+                return supported, message
+
+    if cached:
+        return cached[1], cached[2]
+    return None, _codex_image_generation_unavailable_message()
+
+
 def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[str, Any]:
     """Build the Codex Responses request body for an image_generation call."""
     return {
@@ -166,7 +279,7 @@ def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[st
         "tool_choice": {
             "type": "allowed_tools",
             "mode": "required",
-            "tools": [{"type": "image_generation"}],
+            "tools": [{"type": _CODEX_IMAGE_TOOL}],
         },
         "stream": True,
     }
@@ -275,6 +388,16 @@ def _collect_image_b64(token: str, *, prompt: str, size: str, quality: str) -> O
     return image_b64
 
 
+def _looks_like_unsupported_image_generation_error(exc: Exception) -> bool:
+    """Detect the Codex backend's unsupported-image-generation failure."""
+    text = str(exc).lower()
+    return (
+        _CODEX_IMAGE_TOOL in text
+        and "tool choice" in text
+        and "not found" in text
+    )
+
+
 # ---------------------------------------------------------------------------
 # Provider
 # ---------------------------------------------------------------------------
@@ -298,7 +421,8 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             import httpx  # noqa: F401
         except ImportError:
             return False
-        return True
+        supported, _message = _codex_image_generation_support()
+        return supported is True
 
     def list_models(self) -> List[Dict[str, Any]]:
         return [
@@ -323,7 +447,9 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             "env_vars": [],
             "post_setup_hint": (
                 "Sign in with `hermes auth codex` (or `hermes setup` → Codex) "
-                "if you haven't already. No API key needed."
+                "if you haven't already. If this backend stays unavailable, "
+                "your current Codex surface likely does not expose "
+                "`image_generation` yet."
             ),
         }
 
@@ -333,6 +459,8 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
         **kwargs: Any,
     ) -> Dict[str, Any]:
+        global _codex_image_capability_cache
+
         prompt = (prompt or "").strip()
         aspect = resolve_aspect_ratio(aspect_ratio)
 
@@ -382,6 +510,20 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
+        supported, capability_message = _codex_image_generation_support(
+            token,
+            allow_live=True,
+        )
+        if supported is False:
+            return error_response(
+                error=capability_message,
+                error_type="capability_unsupported",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
         try:
             b64 = _collect_image_b64(
                 token,
@@ -391,6 +533,20 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             )
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)
+            if _looks_like_unsupported_image_generation_error(exc):
+                _codex_image_capability_cache = (
+                    time.time(),
+                    False,
+                    _codex_image_generation_unavailable_message(),
+                )
+                return error_response(
+                    error=_codex_image_generation_unavailable_message(),
+                    error_type="capability_unsupported",
+                    provider="openai-codex",
+                    model=tier_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
             return error_response(
                 error=f"OpenAI image generation via Codex auth failed: {exc}",
                 error_type="api_error",

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -45,6 +45,13 @@ def provider(monkeypatch):
     return codex_plugin.OpenAICodexImageGenProvider()
 
 
+@pytest.fixture(autouse=True)
+def _reset_capability_cache():
+    codex_plugin._codex_image_capability_cache = None
+    yield
+    codex_plugin._codex_image_capability_cache = None
+
+
 # ── Metadata ────────────────────────────────────────────────────────────────
 
 
@@ -77,10 +84,31 @@ class TestAvailability:
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: None)
         assert codex_plugin.OpenAICodexImageGenProvider().is_available() is False
 
-    def test_available_with_codex_token(self, monkeypatch):
+    def test_unavailable_with_codex_token_when_capability_unknown(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(codex_plugin, "_read_cached_codex_supported_tools", lambda: None)
+        assert codex_plugin.OpenAICodexImageGenProvider().is_available() is False
+
+    def test_available_with_cached_image_generation_capability(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_read_cached_codex_supported_tools",
+            lambda: ["image_generation"],
+        )
         assert codex_plugin.OpenAICodexImageGenProvider().is_available() is True
+
+    def test_unavailable_with_cached_non_image_tools(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_read_cached_codex_supported_tools",
+            lambda: [],
+        )
+        assert codex_plugin.OpenAICodexImageGenProvider().is_available() is False
 
     def test_openai_api_key_alone_is_not_enough(self, monkeypatch):
         # Codex plugin is intentionally orthogonal to the API-key plugin —
@@ -106,8 +134,26 @@ class TestGenerate:
         assert result["success"] is False
         assert result["error_type"] == "invalid_argument"
 
+    def test_returns_capability_error_when_live_probe_says_unsupported(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_codex_image_generation_support",
+            lambda *a, **k: (False, codex_plugin._codex_image_generation_unavailable_message()),
+        )
+
+        result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "capability_unsupported"
+        assert "does not expose" in result["error"]
+
     def test_generate_uses_codex_stream_path(self, provider, monkeypatch, tmp_path):
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_codex_image_generation_support",
+            lambda *a, **k: (True, ""),
+        )
         monkeypatch.setattr(codex_plugin, "_collect_image_b64", lambda *a, **kw: _b64_png())
 
         result = provider.generate("a cat", aspect_ratio="landscape")
@@ -126,6 +172,11 @@ class TestGenerate:
 
     def test_codex_stream_request_shape(self, provider, monkeypatch):
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_codex_image_generation_support",
+            lambda *a, **k: (True, ""),
+        )
 
         captured = {}
 
@@ -200,6 +251,11 @@ class TestGenerate:
 
     def test_empty_response_returns_error(self, provider, monkeypatch):
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_codex_image_generation_support",
+            lambda *a, **k: (True, ""),
+        )
         monkeypatch.setattr(codex_plugin, "_collect_image_b64", lambda *a, **kw: None)
 
         result = provider.generate("a cat")
@@ -208,6 +264,11 @@ class TestGenerate:
 
     def test_stream_exception_returns_api_error(self, provider, monkeypatch):
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_codex_image_generation_support",
+            lambda *a, **k: (True, ""),
+        )
 
         def _boom(*args, **kwargs):
             raise RuntimeError("cloudflare 403")
@@ -218,6 +279,26 @@ class TestGenerate:
         assert result["success"] is False
         assert result["error_type"] == "api_error"
         assert "cloudflare 403" in result["error"]
+
+    def test_unsupported_stream_error_is_mapped_to_capability_error(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_codex_image_generation_support",
+            lambda *a, **k: (None, codex_plugin._codex_image_generation_unavailable_message()),
+        )
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("Tool choice 'image_generation' not found in 'tools' parameter.")
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _boom)
+
+        result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "capability_unsupported"
+        assert "does not expose" in result["error"]
+        assert codex_plugin._codex_image_capability_cache is not None
+        assert codex_plugin._codex_image_capability_cache[1] is False
 
 
 # ── Plugin entry point ──────────────────────────────────────────────────────

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -30,6 +30,24 @@ class _FakeCodexProvider(ImageGenProvider):
         }
 
 
+class _FakeUnsupportedCodexProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "openai-codex"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        return {
+            "success": False,
+            "image": None,
+            "error": "ChatGPT/Codex OAuth currently does not expose image_generation.",
+            "error_type": "capability_unsupported",
+            "model": "gpt-image-2-medium",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "provider": "openai-codex",
+        }
+
+
 class TestPluginDispatch:
     def test_dispatch_routes_to_codex_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool
@@ -97,3 +115,30 @@ class TestPluginDispatch:
         assert payload["success"] is True
         assert payload["provider"] == "codex"
         assert payload["aspect_ratio"] == "portrait"
+
+    def test_dispatch_preserves_capability_unsupported_error(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent import image_gen_registry as registry_module
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: openai-codex\n")
+
+        monkeypatch.setattr(
+            image_generation_tool,
+            "_read_configured_image_provider",
+            lambda: "openai-codex",
+        )
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(
+            registry_module,
+            "get_provider",
+            lambda name: _FakeUnsupportedCodexProvider() if name == "openai-codex" else None,
+        )
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw cat", "landscape")
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is False
+        assert payload["error_type"] == "capability_unsupported"
+        assert payload["provider"] == "openai-codex"


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive availability bug in the `openai-codex` image generation provider.

Before this change, the provider could appear available as soon as Codex auth credentials were present, even when the current Codex backend did not actually expose the `image_generation` tool. That led to confusing runtime failures when Hermes tried to force the tool through the Responses API.

This patch makes the provider capability-aware so unsupported Codex surfaces are treated as unavailable or reported with an explicit capability error instead of a generic API failure.

## Related Issue

Fixes #49008

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added Codex image-generation capability detection to the `openai-codex` image provider.
- Used cached/local Codex model metadata as the cheap availability signal.
- Added a live model-capability probe during generation when a definitive answer is needed.
- Mapped the known unsupported-tool backend failure into `capability_unsupported`.
- Updated provider availability behavior so unknown or unsupported Codex surfaces no longer report as available.
- Added regression coverage for cached support, unknown capability, unsupported capability, and plugin dispatch behavior.

## How to Test

1. Run:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_image_gen_picker.py tests/tools/test_image_generation_plugin_dispatch.py tests/plugins/image_gen/test_openai_codex_provider.py -- -q
   ```

2. Confirm the targeted suite passes.
3. Verify that `openai-codex` availability now depends on confirmed `image_generation` support instead of token presence alone.
4. Verify that unsupported Codex tool surfaces return `capability_unsupported` rather than a generic API error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted tests above and they pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform:

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Remaining Risks

- This change is validated with targeted automated tests.
- I did not run the full Hermes suite for this patch.
- Live backend behavior is inferred through the provider contract and the targeted unsupported-tool regression path rather than broad end-to-end matrix testing.
