### PR TITLE
fix(api_server): let strict OpenAI clients opt out of tool.progress SSE frames

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2084,6 +2084,18 @@ class APIServerAdapter(BasePlatformAdapter):
         response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
 
+        # Strict OpenAI-compatible clients (the `openai` SDK, LiveKit's voice
+        # plugin, etc.) parse every SSE frame as a `chat.completion.chunk` and
+        # crash on our custom `event: hermes.tool.progress` frames — they have no
+        # `choices` field, so `chunk.choices` is None and iterating it raises
+        # "NoneType object is not iterable". Such clients can opt out by sending
+        # `X-Hermes-Tool-Progress: off`; the tools still run server-side and the
+        # full answer still streams, only the UI-only progress frames are skipped.
+        # Default keeps progress frames (chat frontends rely on them).
+        suppress_tool_progress = request.headers.get(
+            "X-Hermes-Tool-Progress", ""
+        ).strip().lower() in ("off", "false", "0", "none", "no")
+
         try:
             last_activity = time.monotonic()
 
@@ -2108,6 +2120,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 #16588 for the ``toolCallId``/``status`` lifecycle fields.
                 """
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
+                    if suppress_tool_progress:
+                        # Client opted out (strict OpenAI parser) — skip the
+                        # UI-only frame; the tool already ran server-side.
+                        return time.monotonic()
                     event_data = json.dumps(item[1])
                     await response.write(
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()

--- a/tests/gateway/test_api_server_tool_progress.py
+++ b/tests/gateway/test_api_server_tool_progress.py
@@ -1,0 +1,77 @@
+"""Tests for the ``X-Hermes-Tool-Progress: off`` opt-out on /v1/chat/completions.
+
+The API server emits custom ``event: hermes.tool.progress`` SSE frames so chat
+frontends can show live tool activity. Strict OpenAI-compatible clients (the
+``openai`` SDK, LiveKit's voice plugin, etc.) parse every frame as a
+``chat.completion.chunk`` and crash on these custom frames (no ``choices`` field
+-> ``chunk.choices`` is None -> "NoneType object is not iterable"). Such clients
+send ``X-Hermes-Tool-Progress: off`` to suppress the UI-only frames; the tools
+still run server-side and the full answer still streams.
+"""
+
+import asyncio
+import queue
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _make_adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True))
+
+
+async def _collect_sse(suppress: bool) -> str:
+    """Drive ``_write_sse_chat_completion`` through a real aiohttp request and
+    return the raw SSE body. The stream yields one tool-progress frame, one
+    content chunk, then the end sentinel."""
+    adapter = _make_adapter()
+
+    async def handler(request: web.Request) -> web.StreamResponse:
+        stream_q: "queue.Queue" = queue.Queue()
+        stream_q.put(("__tool_progress__", {"tool_name": "terminal", "delta": "running"}))
+        stream_q.put("hello world")
+        stream_q.put(None)  # end-of-stream sentinel
+
+        async def _agent():
+            return (None, {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2})
+
+        agent_task = asyncio.create_task(_agent())
+        return await adapter._write_sse_chat_completion(
+            request,
+            completion_id="cmpl-test",
+            model="test-model",
+            created=0,
+            stream_q=stream_q,
+            agent_task=agent_task,
+        )
+
+    app = web.Application()
+    app.router.add_get("/sse", handler)
+    async with TestClient(TestServer(app)) as client:
+        headers = {"X-Hermes-Tool-Progress": "off"} if suppress else {}
+        resp = await client.get("/sse", headers=headers)
+        assert resp.status == 200
+        return await resp.text()
+
+
+@pytest.mark.asyncio
+async def test_tool_progress_emitted_by_default():
+    """Without the header, the custom progress frame is present (chat frontends)."""
+    body = await _collect_sse(suppress=False)
+    assert "event: hermes.tool.progress" in body
+    assert "hello world" in body  # content still streams
+    assert "data: [DONE]" in body
+
+
+@pytest.mark.asyncio
+async def test_tool_progress_suppressed_with_header():
+    """With ``X-Hermes-Tool-Progress: off`` the custom frame is gone, but the
+    answer (and the standard chunks a strict OpenAI client expects) still stream."""
+    body = await _collect_sse(suppress=True)
+    assert "event: hermes.tool.progress" not in body
+    assert "hello world" in body  # answer still streams; only the UI frame is skipped
+    assert "data: [DONE]" in body


### PR DESCRIPTION
## What does this PR do?

The `/v1/chat/completions` SSE stream emits custom `event: hermes.tool.progress`
frames so chat frontends can render live tool activity. **Strict
OpenAI-compatible clients crash on these frames.** Libraries like the official
`openai` SDK and LiveKit's voice plugin parse *every* SSE frame as a
`chat.completion.chunk`. Our custom event frame has no `choices` field, so
`chunk.choices` is `None` and iterating it raises `"'NoneType' object is not
iterable"`, aborting the whole stream — the user gets nothing back.

This adds a header opt-out: a client that sends `X-Hermes-Tool-Progress: off`
no longer receives the custom progress frames. The tools still run server-side
and the full answer still streams as standard `chat.completion.chunk`s — only
the UI-only progress frames are skipped. **Default behavior is unchanged**
(progress frames are still sent), so existing chat frontends are unaffected.

This is the minimal, backwards-compatible way for a non-streaming-UI client to
consume the OpenAI-compatible endpoint without crashing.

## Related Issue

Fixes # <!-- no issue filed yet; happy to open one if preferred -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` — in `_write_sse_chat_completion`, read
  `X-Hermes-Tool-Progress` from the request headers; when it is
  `off`/`false`/`0`/`none`/`no`, the `_emit` helper skips the
  `event: hermes.tool.progress` frames (returns without writing). Everything
  else (content chunks, role chunk, finish chunk, `[DONE]`) is untouched.
- `tests/gateway/test_api_server_tool_progress.py` — new test: progress frame
  present by default, absent with the header; the answer still streams in both.

## How to Test

1. Without the header: `curl -N -H 'Content-Type: application/json' \
   -d '{"model":"...","stream":true,"messages":[{"role":"user","content":"run ls"}]}' \
   http://localhost:PORT/v1/chat/completions` → response contains
   `event: hermes.tool.progress` frames.
2. With `-H 'X-Hermes-Tool-Progress: off'` → no `event: hermes.tool.progress`
   frames, but the assistant's answer still streams and `data: [DONE]` arrives.
3. `pytest tests/gateway/test_api_server_tool_progress.py -q` → 2 passed.
4. Regression: `pytest tests/gateway/test_api_server_multimodal.py -q` → still green.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(api_server): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 6.17)

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing config key; opt-in request header)
- [x] `cli-config.yaml.example` — N/A (no config key added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure header parse, no platform-specific code)
- [x] Tool descriptions/schemas — N/A
