### PR TITLE
feat(dashboard): add plugin PWA metadata support

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10955,6 +10955,21 @@ def cmd_dashboard(args):
     # backend is the desktop's primary entrypoint and needs the same.
     _sync_bundled_skills_quietly()
 
+    # The packaged Hermes Desktop app launches its own backend with
+    # HERMES_DESKTOP=1 + HERMES_WEB_DIST=<asar-unpacked dist> and also injects
+    # HERMES_DASHBOARD_SESSION_TOKEN so the backend trusts the renderer. When a
+    # user launches `hermes dashboard` from inside a desktop-managed shell (or,
+    # as here, from the Hermes desktop chat's terminal tool environment), those
+    # desktop-only env vars can leak into an ordinary browser dashboard launch.
+    # The result is a poisoned server that serves the packaged desktop bundle
+    # instead of hermes_cli/web_dist, booting into "Desktop IPC bridge is
+    # unavailable" because the browser has no Electron bridge. Only honor the
+    # desktop bundle override when the caller also provided the desktop session
+    # token — that is the reliable marker for a real Electron-managed backend.
+    if os.environ.get("HERMES_WEB_DIST") and not os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN"):
+        os.environ.pop("HERMES_WEB_DIST", None)
+        os.environ.pop("HERMES_DESKTOP", None)
+
     if "HERMES_WEB_DIST" not in os.environ and not getattr(args, "skip_build", False):
         if not _build_web_ui(PROJECT_ROOT / "web", fatal=True):
             sys.exit(1)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12008,6 +12008,32 @@ async def set_dashboard_font(body: FontSetBody):
 # Dashboard plugin system
 # ---------------------------------------------------------------------------
 
+def _safe_plugin_dashboard_relpath(path_field: Any, *, dashboard_dir: Path) -> Optional[str]:
+    """Validate a manifest-declared relative file path inside ``dashboard/``.
+
+    Used for backend ``api`` modules as well as browser-fetchable assets like
+    plugin-declared manifests, icons, and service-worker scripts. Returns the
+    original string when it resolves under ``dashboard_dir``; otherwise returns
+    ``None`` so the caller can ignore the unsafe field while still loading the
+    rest of the plugin manifest.
+    """
+    if not isinstance(path_field, str) or not path_field.strip():
+        return None
+    candidate = Path(path_field)
+    if candidate.is_absolute():
+        return None
+    try:
+        resolved = (dashboard_dir / candidate).resolve()
+        base = dashboard_dir.resolve()
+    except (OSError, RuntimeError):
+        return None
+    try:
+        resolved.relative_to(base)
+    except ValueError:
+        return None
+    return path_field
+
+
 def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional[str]:
     """Validate the manifest's ``api`` field for the plugin loader.
 
@@ -12028,21 +12054,7 @@ def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional
     call site) otherwise so the plugin still loads its static JS/CSS
     but its backend ``api`` is rejected.
     """
-    if not isinstance(api_field, str) or not api_field.strip():
-        return None
-    candidate = Path(api_field)
-    if candidate.is_absolute():
-        return None
-    try:
-        resolved = (dashboard_dir / candidate).resolve()
-        base = dashboard_dir.resolve()
-    except (OSError, RuntimeError):
-        return None
-    try:
-        resolved.relative_to(base)
-    except ValueError:
-        return None
-    return api_field
+    return _safe_plugin_dashboard_relpath(api_field, dashboard_dir=dashboard_dir)
 
 
 def _discover_dashboard_plugins() -> list:
@@ -12117,8 +12129,8 @@ def _discover_dashboard_plugins() -> list:
                 # any absolute path or ``..`` traversal here — the
                 # web server then imports that file as a Python module
                 # (RCE, GHSA-5qr3-c538-wm9j).
-                raw_api = data.get("api")
                 dashboard_dir = child / "dashboard"
+                raw_api = data.get("api")
                 safe_api = _safe_plugin_api_relpath(raw_api, dashboard_dir=dashboard_dir)
                 if raw_api and safe_api is None:
                     _log.warning(
@@ -12128,6 +12140,55 @@ def _discover_dashboard_plugins() -> list:
                         "not be mounted",
                         name, raw_api,
                     )
+                raw_web_manifest = data.get("web_manifest")
+                safe_web_manifest = _safe_plugin_dashboard_relpath(
+                    raw_web_manifest, dashboard_dir=dashboard_dir
+                )
+                if raw_web_manifest and safe_web_manifest is None:
+                    _log.warning(
+                        "Plugin %s: refusing unsafe web_manifest path %r",
+                        name, raw_web_manifest,
+                    )
+
+                raw_apple_touch_icon = data.get("apple_touch_icon")
+                safe_apple_touch_icon = _safe_plugin_dashboard_relpath(
+                    raw_apple_touch_icon, dashboard_dir=dashboard_dir
+                )
+                if raw_apple_touch_icon and safe_apple_touch_icon is None:
+                    _log.warning(
+                        "Plugin %s: refusing unsafe apple_touch_icon path %r",
+                        name, raw_apple_touch_icon,
+                    )
+
+                raw_service_worker = data.get("service_worker")
+                safe_service_worker = _safe_plugin_dashboard_relpath(
+                    raw_service_worker, dashboard_dir=dashboard_dir
+                )
+                if raw_service_worker and safe_service_worker is None:
+                    _log.warning(
+                        "Plugin %s: refusing unsafe service_worker path %r",
+                        name, raw_service_worker,
+                    )
+
+                raw_theme_color = data.get("theme_color")
+                theme_color = raw_theme_color.strip() if isinstance(raw_theme_color, str) else None
+                if not theme_color:
+                    theme_color = None
+
+                raw_service_worker_scope = data.get("service_worker_scope")
+                service_worker_scope = (
+                    raw_service_worker_scope.strip()
+                    if isinstance(raw_service_worker_scope, str)
+                    else None
+                )
+                if service_worker_scope and not service_worker_scope.startswith("/"):
+                    _log.warning(
+                        "Plugin %s: refusing unsafe service_worker_scope %r "
+                        "(must start with '/')",
+                        name, raw_service_worker_scope,
+                    )
+                    service_worker_scope = None
+
                 plugins.append({
                     "name": name,
                     "label": data.get("label", name),
@@ -12138,6 +12199,11 @@ def _discover_dashboard_plugins() -> list:
                     "slots": slots,
                     "entry": data.get("entry", "dist/index.js"),
                     "css": data.get("css"),
+                    "web_manifest": safe_web_manifest,
+                    "apple_touch_icon": safe_apple_touch_icon,
+                    "theme_color": theme_color,
+                    "service_worker": safe_service_worker,
+                    "service_worker_scope": service_worker_scope,
                     "has_api": bool(safe_api),
                     "source": source,
                     "_dir": str(dashboard_dir),
@@ -12462,7 +12528,7 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
     Path traversal is blocked by checking ``resolve().is_relative_to()``.
 
     Restricted to a browser-fetchable suffix allowlist (JS/CSS/JSON/HTML/
-    SVG/PNG/JPG/WOFF). The dashboard loads plugin JS via ``<script src>``
+    SVG/PNG/JPG/WOFF/webmanifest). The dashboard loads plugin JS via ``<script src>``
     and CSS via ``<link href>``, neither of which can attach a custom
     auth header — so this route stays unauthenticated to keep the SPA
     working. But user-installed plugins ship a ``plugin_api.py``
@@ -12496,6 +12562,7 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
         ".mjs": "application/javascript",
         ".css": "text/css",
         ".json": "application/json",
+        ".webmanifest": "application/manifest+json",
         ".html": "text/html",
         ".svg": "image/svg+xml",
         ".png": "image/png",
@@ -12516,10 +12583,15 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
             detail="File not found",
         )
     media_type = content_types[suffix]
+    headers = {"Cache-Control": "no-store, no-cache, must-revalidate"}
+    declared_service_worker = str(plugin.get("service_worker") or "").strip()
+    declared_scope = str(plugin.get("service_worker_scope") or "").strip()
+    if declared_service_worker and declared_scope and file_path == declared_service_worker:
+        headers["Service-Worker-Allowed"] = declared_scope
     return FileResponse(
         target,
         media_type=media_type,
-        headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
+        headers=headers,
     )
 
 

--- a/tests/fixtures/plugins/example-dashboard/dashboard/app.webmanifest
+++ b/tests/fixtures/plugins/example-dashboard/dashboard/app.webmanifest
@@ -1,0 +1,8 @@
+{
+  "name": "Example Dashboard",
+  "short_name": "Example",
+  "start_url": "/example",
+  "display": "standalone",
+  "background_color": "#101114",
+  "theme_color": "#101114"
+}

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -232,3 +232,48 @@ class TestUnifiedDashboardRouting:
                 "thread_name": "dashboard-mcp-discovery",
             }
         ]
+
+    def test_dashboard_ignores_leaked_desktop_web_dist_without_session_token(self, main_mod, monkeypatch):
+        """Launching `hermes dashboard` from a desktop-managed shell must not
+        accidentally serve the packaged Electron bundle unless the real desktop
+        session token is also present."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+        )
+        monkeypatch.setenv("HERMES_WEB_DIST", "/tmp/desktop-bundle-dist")
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        monkeypatch.delenv("HERMES_DASHBOARD_SESSION_TOKEN", raising=False)
+        monkeypatch.setattr(main_mod, "_sync_bundled_skills_quietly", lambda: None)
+        build_calls = []
+        monkeypatch.setattr(
+            main_mod,
+            "_build_web_ui",
+            lambda *_a, **_k: build_calls.append(True) or True,
+        )
+        monkeypatch.setitem(sys.modules, "fastapi", types.SimpleNamespace())
+        monkeypatch.setitem(sys.modules, "uvicorn", types.SimpleNamespace())
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_logging",
+            types.SimpleNamespace(setup_logging=lambda **_k: None),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_cli.plugins",
+            types.SimpleNamespace(discover_plugins=lambda: None),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.mcp_startup.start_background_mcp_discovery",
+            lambda **_kwargs: None,
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_cli.web_server",
+            types.SimpleNamespace(start_server=lambda **_kwargs: None),
+        )
+
+        main_mod.cmd_dashboard(_args())
+
+        assert build_calls == [True]
+        assert "HERMES_WEB_DIST" not in main_mod.os.environ
+        assert "HERMES_DESKTOP" not in main_mod.os.environ

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5144,6 +5144,76 @@ class TestDashboardPluginManifestExtensions:
             "chat:top",
         ]
 
+    def test_pwa_fields_round_trip_when_safe(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(tmp_path, "mobilepilot-ish", {
+            "name": "mobilepilot-ish",
+            "label": "MobilePilot-ish",
+            "tab": {"path": "/chat", "override": "/chat"},
+            "entry": "dist/index.js",
+            "web_manifest": "mobilepilot.webmanifest",
+            "apple_touch_icon": "pwa-icons/apple-touch-icon.png",
+            "theme_color": "#101114",
+            "service_worker": "sw.js",
+            "service_worker_scope": "/chat",
+        })
+        from hermes_cli import web_server
+        web_server._dashboard_plugins_cache = None
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "mobilepilot-ish")
+        assert entry["web_manifest"] == "mobilepilot.webmanifest"
+        assert entry["apple_touch_icon"] == "pwa-icons/apple-touch-icon.png"
+        assert entry["theme_color"] == "#101114"
+        assert entry["service_worker"] == "sw.js"
+        assert entry["service_worker_scope"] == "/chat"
+
+    def test_pwa_fields_drop_unsafe_paths_and_bad_scope(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(tmp_path, "unsafe-mobilepilot-ish", {
+            "name": "unsafe-mobilepilot-ish",
+            "label": "Unsafe MobilePilot-ish",
+            "tab": {"path": "/chat"},
+            "entry": "dist/index.js",
+            "web_manifest": "../../outside.webmanifest",
+            "apple_touch_icon": "/tmp/icon.png",
+            "service_worker": "../sw.js",
+            "service_worker_scope": "chat",
+            "theme_color": "   ",
+        })
+        from hermes_cli import web_server
+        web_server._dashboard_plugins_cache = None
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "unsafe-mobilepilot-ish")
+        assert entry["web_manifest"] is None
+        assert entry["apple_touch_icon"] is None
+        assert entry["service_worker"] is None
+        assert entry["service_worker_scope"] is None
+        assert entry["theme_color"] is None
+
+    def test_service_worker_asset_emits_allowed_scope_header(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(tmp_path, "mobilepilot-ish", {
+            "name": "mobilepilot-ish",
+            "label": "MobilePilot-ish",
+            "tab": {"path": "/chat", "override": "/chat"},
+            "entry": "dist/index.js",
+            "service_worker": "sw.js",
+            "service_worker_scope": "/chat",
+        })
+        sw_path = tmp_path / "plugins" / "mobilepilot-ish" / "dashboard" / "sw.js"
+        sw_path.write_text("self.addEventListener('fetch', () => {});", encoding="utf-8")
+
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        ws._dashboard_plugins_cache = None
+        client = TestClient(ws.app)
+        resp = client.get("/dashboard-plugins/mobilepilot-ish/sw.js")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/javascript")
+        assert resp.headers["service-worker-allowed"] == "/chat"
+
 
 # ---------------------------------------------------------------------------
 # /api/pty WebSocket — terminal bridge for the dashboard "Chat" tab.
@@ -5686,6 +5756,15 @@ class TestDashboardPluginStaticAssetAllowlist:
         # And the body is actually the manifest, not the SPA fallback.
         body = resp.json()
         assert body.get("name") == "example"
+
+    def test_webmanifest_still_served(self):
+        """PWA manifests use the dedicated ``.webmanifest`` suffix and must be
+        browser-fetchable just like ``manifest.json``."""
+        resp = self.client.get("/dashboard-plugins/example/app.webmanifest")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/manifest+json")
+        body = resp.json()
+        assert body.get("name") == "Example Dashboard"
 
     def test_unknown_plugin_is_404(self):
         """Existing behaviour preserved: nonexistent plugin name → 404."""

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -99,11 +99,55 @@ import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
 import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
-import { api } from "@/lib/api";
+import { api, HERMES_BASE_PATH } from "@/lib/api";
 import type { StatusResponse } from "@/lib/api";
 
+function normalizeRoutePath(path: string): string {
+  const trimmed = path.replace(/\/$/, "");
+  return trimmed || "/";
+}
+
+function pluginOwnsPath(pluginPath: string, currentPath: string): boolean {
+  const owner = normalizeRoutePath(pluginPath);
+  const current = normalizeRoutePath(currentPath);
+  return current === owner || current.startsWith(`${owner}/`);
+}
+
+function pluginAssetUrl(manifest: PluginManifest, relativePath: string): string {
+  return `${HERMES_BASE_PATH}/dashboard-plugins/${manifest.name}/${relativePath}`;
+}
+
+function withHermesBasePath(routePath: string): string {
+  if (!routePath.startsWith("/")) return routePath;
+  if (!HERMES_BASE_PATH) return routePath;
+  if (routePath === "/") return `${HERMES_BASE_PATH}/`;
+  if (routePath.startsWith(`${HERMES_BASE_PATH}/`) || routePath === HERMES_BASE_PATH) {
+    return routePath;
+  }
+  return `${HERMES_BASE_PATH}${routePath}`;
+}
+
+function selectActivePwaManifest(
+  manifests: PluginManifest[],
+  pathname: string,
+): PluginManifest | null {
+  const active = manifests.find((manifest) =>
+    pluginOwnsPath(manifest.tab.override ?? manifest.tab.path, pathname),
+  );
+  if (!active) return null;
+  if (
+    !active.web_manifest
+    && !active.apple_touch_icon
+    && !active.theme_color
+    && !active.service_worker
+  ) {
+    return null;
+  }
+  return active;
+}
+
 function RootRedirect() {
-  return <Navigate to="/sessions" replace />;
+  return <Navigate to={isDashboardEmbeddedChatEnabled() ? "/chat" : "/sessions"} replace />;
 }
 
 function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
@@ -111,7 +155,7 @@ function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
     // Render nothing during the plugin-load window — a spinner here would just flash.
     return null;
   }
-  return <Navigate to="/sessions" replace />;
+  return <Navigate to={isDashboardEmbeddedChatEnabled() ? "/chat" : "/sessions"} replace />;
 }
 
 const CHAT_NAV_ITEM: NavItem = {
@@ -120,6 +164,8 @@ const CHAT_NAV_ITEM: NavItem = {
   label: "Chat",
   icon: Terminal,
 };
+
+const MOBILE_PRIMARY_NAV_PATHS = ["/chat", "/sessions", "/files"] as const;
 
 /**
  * Built-in routes except /chat.  Chat is rendered persistently (outside
@@ -417,6 +463,11 @@ export default function App() {
     () => manifests.some((m) => m.tab.override === "/chat"),
     [manifests],
   );
+  const activePwaManifest = useMemo(
+    () => selectActivePwaManifest(manifests, pathname),
+    [manifests, pathname],
+  );
+  const registeredServiceWorkers = useRef<Set<string>>(new Set());
 
   const builtinRoutes = useMemo(
     () => ({
@@ -438,6 +489,15 @@ export default function App() {
   const sidebarNav = useMemo(
     () => partitionSidebarNav(builtinNav, manifests),
     [builtinNav, manifests],
+  );
+  const mobilePrimaryNav = useMemo(
+    () =>
+      builtinNav.filter((item) =>
+        MOBILE_PRIMARY_NAV_PATHS.includes(
+          item.path as (typeof MOBILE_PRIMARY_NAV_PATHS)[number],
+        ),
+      ),
+    [builtinNav],
   );
   const routes = useMemo(
     () => buildRoutes(builtinRoutes, manifests),
@@ -478,6 +538,102 @@ export default function App() {
     mql.addEventListener("change", onChange);
     return () => mql.removeEventListener("change", onChange);
   }, []);
+
+  useEffect(() => {
+    const head = document.head;
+    const existingManifest = head.querySelector<HTMLLinkElement>('link[rel="manifest"]');
+    const existingAppleTouch = head.querySelector<HTMLLinkElement>('link[rel="apple-touch-icon"]');
+    const existingThemeColor = head.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+
+    const prevManifestHref = existingManifest?.getAttribute("href") ?? null;
+    const prevAppleTouchHref = existingAppleTouch?.getAttribute("href") ?? null;
+    const prevThemeColorContent = existingThemeColor?.getAttribute("content") ?? null;
+
+    const manifestLink = existingManifest ?? document.createElement("link");
+    const appleTouchLink = existingAppleTouch ?? document.createElement("link");
+    const themeColorMeta = existingThemeColor ?? document.createElement("meta");
+
+    let createdManifest = false;
+    let createdAppleTouch = false;
+    let createdThemeColor = false;
+
+    if (activePwaManifest?.web_manifest) {
+      manifestLink.rel = "manifest";
+      manifestLink.href = pluginAssetUrl(activePwaManifest, activePwaManifest.web_manifest);
+      if (!existingManifest) {
+        head.appendChild(manifestLink);
+        createdManifest = true;
+      }
+    }
+
+    if (activePwaManifest?.apple_touch_icon) {
+      appleTouchLink.rel = "apple-touch-icon";
+      appleTouchLink.href = pluginAssetUrl(activePwaManifest, activePwaManifest.apple_touch_icon);
+      if (!existingAppleTouch) {
+        head.appendChild(appleTouchLink);
+        createdAppleTouch = true;
+      }
+    }
+
+    if (activePwaManifest?.theme_color) {
+      themeColorMeta.setAttribute("name", "theme-color");
+      themeColorMeta.setAttribute("content", activePwaManifest.theme_color);
+      if (!existingThemeColor) {
+        head.appendChild(themeColorMeta);
+        createdThemeColor = true;
+      }
+    }
+
+    return () => {
+      if (activePwaManifest?.web_manifest) {
+        if (createdManifest) {
+          manifestLink.remove();
+        } else if (prevManifestHref !== null) {
+          manifestLink.href = prevManifestHref;
+        } else {
+          manifestLink.removeAttribute("href");
+        }
+      }
+      if (activePwaManifest?.apple_touch_icon) {
+        if (createdAppleTouch) {
+          appleTouchLink.remove();
+        } else if (prevAppleTouchHref !== null) {
+          appleTouchLink.href = prevAppleTouchHref;
+        } else {
+          appleTouchLink.removeAttribute("href");
+        }
+      }
+      if (activePwaManifest?.theme_color) {
+        if (createdThemeColor) {
+          themeColorMeta.remove();
+        } else if (prevThemeColorContent !== null) {
+          themeColorMeta.setAttribute("content", prevThemeColorContent);
+        } else {
+          themeColorMeta.removeAttribute("content");
+        }
+      }
+    };
+  }, [activePwaManifest]);
+
+  useEffect(() => {
+    if (!activePwaManifest?.service_worker) return;
+    if (!("serviceWorker" in navigator)) return;
+
+    const serviceWorkerUrl = pluginAssetUrl(activePwaManifest, activePwaManifest.service_worker);
+    const serviceWorkerScope = activePwaManifest.service_worker_scope
+      ? withHermesBasePath(activePwaManifest.service_worker_scope)
+      : undefined;
+    const registrationKey = `${serviceWorkerUrl}::${serviceWorkerScope ?? ""}`;
+    if (registeredServiceWorkers.current.has(registrationKey)) return;
+    registeredServiceWorkers.current.add(registrationKey);
+
+    void navigator.serviceWorker
+      .register(serviceWorkerUrl, serviceWorkerScope ? { scope: serviceWorkerScope } : undefined)
+      .catch((error) => {
+        registeredServiceWorkers.current.delete(registrationKey);
+        console.warn(`[plugins] Failed to register service worker for ${activePwaManifest.name}`, error);
+      });
+  }, [activePwaManifest]);
 
   return (
     <ProfileProvider>
@@ -731,8 +887,11 @@ export default function App() {
               <div
                 className={cn(
                   "w-full min-w-0",
-                  !isChatRoute &&
-                    "pb-[calc(2rem+env(safe-area-inset-bottom,0px))] lg:pb-8",
+                  isMobile
+                    ? "pb-[calc(5.5rem+env(safe-area-inset-bottom,0px))]"
+                    : !isChatRoute
+                      ? "lg:pb-8"
+                      : "",
                   (isDocsRoute || isChatRoute) &&
                     "min-h-0 flex flex-1 flex-col",
                 )}
@@ -784,6 +943,65 @@ export default function App() {
           </PageHeaderProvider>
         </div>
       </div>
+
+      {isMobile && mobilePrimaryNav.length > 0 && (
+        <div
+          className={cn(
+            "lg:hidden fixed inset-x-0 bottom-0 z-40",
+            "border-t border-current/20 bg-background-base/95 backdrop-blur-md",
+            "px-2 pb-[max(env(safe-area-inset-bottom,0px),0.35rem)] pt-2",
+          )}
+          style={{
+            background: "var(--component-header-background)",
+            borderImage: "var(--component-header-border-image)",
+          }}
+        >
+          <div className="mx-auto grid max-w-screen-sm grid-cols-4 gap-1">
+            {mobilePrimaryNav.map((item) => {
+              const Icon = item.icon;
+              const navLabel = item.labelKey
+                ? ((t.app.nav as Record<string, string>)[item.labelKey] ?? item.label)
+                : item.label;
+              return (
+                <NavLink
+                  key={item.path}
+                  to={item.path}
+                  end={item.path === "/sessions"}
+                  onClick={closeMobile}
+                  className={({ isActive }) =>
+                    cn(
+                      "flex min-w-0 flex-col items-center justify-center gap-1 rounded-md px-1 py-2",
+                      "text-[0.65rem] font-medium uppercase tracking-[0.08em]",
+                      isActive
+                        ? "text-midground bg-midground/10"
+                        : "text-text-secondary hover:text-midground hover:bg-midground/5",
+                    )
+                  }
+                >
+                  <Icon className="h-4 w-4 shrink-0" />
+                  <span className="truncate">{navLabel}</span>
+                </NavLink>
+              );
+            })}
+
+            <Button
+              ghost
+              onClick={() => setMobileOpen(true)}
+              aria-label={t.app.openNavigation}
+              aria-expanded={mobileOpen}
+              aria-controls="app-sidebar"
+              className={cn(
+                "flex h-auto min-w-0 flex-col items-center justify-center gap-1 rounded-md px-1 py-2",
+                "text-[0.65rem] font-medium uppercase tracking-[0.08em] text-text-secondary",
+                "hover:text-midground hover:bg-midground/5",
+              )}
+            >
+              <Menu className="h-4 w-4 shrink-0" />
+              <span className="truncate">More</span>
+            </Button>
+          </div>
+        </div>
+      )}
 
       <PluginSlot name="overlay" />
     </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -147,7 +147,7 @@ function selectActivePwaManifest(
 }
 
 function RootRedirect() {
-  return <Navigate to={isDashboardEmbeddedChatEnabled() ? "/chat" : "/sessions"} replace />;
+  return <Navigate to="/sessions" replace />;
 }
 
 function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
@@ -155,7 +155,7 @@ function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
     // Render nothing during the plugin-load window — a spinner here would just flash.
     return null;
   }
-  return <Navigate to={isDashboardEmbeddedChatEnabled() ? "/chat" : "/sessions"} replace />;
+  return <Navigate to="/sessions" replace />;
 }
 
 const CHAT_NAV_ITEM: NavItem = {
@@ -164,8 +164,6 @@ const CHAT_NAV_ITEM: NavItem = {
   label: "Chat",
   icon: Terminal,
 };
-
-const MOBILE_PRIMARY_NAV_PATHS = ["/chat", "/sessions", "/files"] as const;
 
 /**
  * Built-in routes except /chat.  Chat is rendered persistently (outside
@@ -489,15 +487,6 @@ export default function App() {
   const sidebarNav = useMemo(
     () => partitionSidebarNav(builtinNav, manifests),
     [builtinNav, manifests],
-  );
-  const mobilePrimaryNav = useMemo(
-    () =>
-      builtinNav.filter((item) =>
-        MOBILE_PRIMARY_NAV_PATHS.includes(
-          item.path as (typeof MOBILE_PRIMARY_NAV_PATHS)[number],
-        ),
-      ),
-    [builtinNav],
   );
   const routes = useMemo(
     () => buildRoutes(builtinRoutes, manifests),
@@ -887,11 +876,8 @@ export default function App() {
               <div
                 className={cn(
                   "w-full min-w-0",
-                  isMobile
-                    ? "pb-[calc(5.5rem+env(safe-area-inset-bottom,0px))]"
-                    : !isChatRoute
-                      ? "lg:pb-8"
-                      : "",
+                  !isChatRoute &&
+                    "pb-[calc(2rem+env(safe-area-inset-bottom,0px))] lg:pb-8",
                   (isDocsRoute || isChatRoute) &&
                     "min-h-0 flex flex-1 flex-col",
                 )}
@@ -943,66 +929,6 @@ export default function App() {
           </PageHeaderProvider>
         </div>
       </div>
-
-      {isMobile && mobilePrimaryNav.length > 0 && (
-        <div
-          className={cn(
-            "lg:hidden fixed inset-x-0 bottom-0 z-40",
-            "border-t border-current/20 bg-background-base/95 backdrop-blur-md",
-            "px-2 pb-[max(env(safe-area-inset-bottom,0px),0.35rem)] pt-2",
-          )}
-          style={{
-            background: "var(--component-header-background)",
-            borderImage: "var(--component-header-border-image)",
-          }}
-        >
-          <div className="mx-auto grid max-w-screen-sm grid-cols-4 gap-1">
-            {mobilePrimaryNav.map((item) => {
-              const Icon = item.icon;
-              const navLabel = item.labelKey
-                ? ((t.app.nav as Record<string, string>)[item.labelKey] ?? item.label)
-                : item.label;
-              return (
-                <NavLink
-                  key={item.path}
-                  to={item.path}
-                  end={item.path === "/sessions"}
-                  onClick={closeMobile}
-                  className={({ isActive }) =>
-                    cn(
-                      "flex min-w-0 flex-col items-center justify-center gap-1 rounded-md px-1 py-2",
-                      "text-[0.65rem] font-medium uppercase tracking-[0.08em]",
-                      isActive
-                        ? "text-midground bg-midground/10"
-                        : "text-text-secondary hover:text-midground hover:bg-midground/5",
-                    )
-                  }
-                >
-                  <Icon className="h-4 w-4 shrink-0" />
-                  <span className="truncate">{navLabel}</span>
-                </NavLink>
-              );
-            })}
-
-            <Button
-              ghost
-              onClick={() => setMobileOpen(true)}
-              aria-label={t.app.openNavigation}
-              aria-expanded={mobileOpen}
-              aria-controls="app-sidebar"
-              className={cn(
-                "flex h-auto min-w-0 flex-col items-center justify-center gap-1 rounded-md px-1 py-2",
-                "text-[0.65rem] font-medium uppercase tracking-[0.08em] text-text-secondary",
-                "hover:text-midground hover:bg-midground/5",
-              )}
-            >
-              <Menu className="h-4 w-4 shrink-0" />
-              <span className="truncate">More</span>
-            </Button>
-          </div>
-        </div>
-      )}
-
       <PluginSlot name="overlay" />
     </div>
     </ProfileProvider>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2179,6 +2179,11 @@ export interface PluginManifestResponse {
   slots?: string[];
   entry: string;
   css?: string | null;
+  web_manifest?: string | null;
+  apple_touch_icon?: string | null;
+  theme_color?: string | null;
+  service_worker?: string | null;
+  service_worker_scope?: string | null;
   has_api: boolean;
   source: string;
 }

--- a/web/src/plugins/types.ts
+++ b/web/src/plugins/types.ts
@@ -21,6 +21,11 @@ export interface PluginManifest {
   slots?: string[];
   entry: string;
   css?: string | null;
+  web_manifest?: string | null;
+  apple_touch_icon?: string | null;
+  theme_color?: string | null;
+  service_worker?: string | null;
+  service_worker_scope?: string | null;
   has_api: boolean;
   /**
    * Optional Subresource Integrity hash (e.g. "sha384-..."). When set,


### PR DESCRIPTION
## Summary
- add safe plugin manifest fields for PWA-related assets and metadata
- serve plugin `.webmanifest` assets and emit `Service-Worker-Allowed` for declared plugin service workers
- ignore leaked desktop-only `HERMES_WEB_DIST` / `HERMES_DESKTOP` env when `hermes dashboard` is launched without a desktop session token
- wire the dashboard app to consume plugin-declared manifest/icon/theme/service-worker metadata

## Verification
- `uv run --python 3.11 pytest tests/hermes_cli/test_dashboard_unified_launch.py -o addopts='' -q -k "desktop_web_dist_without_session_token"`
- `uv run --python 3.11 pytest tests/hermes_cli/test_web_server.py -o addopts='' -q -k "pwa_fields_round_trip_when_safe or pwa_fields_drop_unsafe_paths_and_bad_scope or service_worker_asset_emits_allowed_scope_header or webmanifest_still_served"`
- `cd web && npm run typecheck`
- `cd web && npm run build`

## Notes
- plugin-declared file paths are validated to stay under the plugin `dashboard/` directory before being exposed to the browser or backend loader
- the planning confidence gate change was split into a separate follow-up PR to keep this PR focused on dashboard/PWA behavior
