### PR TITLE
fix(desktop): render send/prefill directive notices (/goal, /undo)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -32,6 +32,7 @@ import {
   clearComposerAttachments,
   type ComposerAttachment,
   setComposerAttachmentUploadState,
+  setComposerDraft,
   terminalContextBlocksFromDraft,
   updateComposerAttachment
 } from '@/store/composer'
@@ -951,7 +952,25 @@ export function usePromptActions({
             return
           }
 
+          // send / prefill carry an optional `notice` (e.g. "⊙ Goal set …")
+          // that the backend wants shown as a system line before the message
+          // is acted on. Mirrors the TUI's createSlashHandler — without it a
+          // `/goal <text>` looked like it did nothing.
+          if ((dispatch.type === 'send' || dispatch.type === 'prefill') && dispatch.notice?.trim()) {
+            renderSlashOutput(dispatch.notice.trim())
+          }
+
           const message = ('message' in dispatch ? dispatch.message : '')?.trim() ?? ''
+
+          // /undo returns a prefill directive: drop the backed-up message into
+          // the composer for editing instead of submitting it immediately.
+          if (dispatch.type === 'prefill') {
+            if (message) {
+              setComposerDraft(message)
+            }
+
+            return
+          }
 
           if (!message) {
             renderSlashOutput(

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -106,6 +106,13 @@ export interface SkillCommandDispatchResponse {
 export interface SendCommandDispatchResponse {
   type: 'send'
   message: string
+  notice?: string
+}
+
+export interface PrefillCommandDispatchResponse {
+  type: 'prefill'
+  message: string
+  notice?: string
 }
 
 export type CommandDispatchResponse =
@@ -113,6 +120,7 @@ export type CommandDispatchResponse =
   | AliasCommandDispatchResponse
   | SkillCommandDispatchResponse
   | SendCommandDispatchResponse
+  | PrefillCommandDispatchResponse
 
 export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills'
 

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
 
-import { coerceThinkingText, optimisticAttachmentRef } from './chat-runtime'
+import { coerceThinkingText, optimisticAttachmentRef, parseCommandDispatch } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
 
@@ -50,5 +50,33 @@ describe('coerceThinkingText', () => {
         "◉_◉ processing... I don't see any current rewritten thinking or next thinking to process. Could you provide the thinking content you'd like me to rewrite?"
       )
     ).toBe('')
+  })
+})
+
+describe('parseCommandDispatch', () => {
+  it('keeps the notice on a send directive (e.g. /goal set)', () => {
+    // The backend's /goal set returns {type:send, notice:"⊙ Goal set …", message}.
+    // Dropping the notice made /goal look like it did nothing in the desktop app.
+    const parsed = parseCommandDispatch({ type: 'send', notice: '⊙ Goal set', message: 'do the thing' })
+
+    expect(parsed).toEqual({ type: 'send', message: 'do the thing', notice: '⊙ Goal set' })
+  })
+
+  it('keeps message-only send directives working (no notice)', () => {
+    expect(parseCommandDispatch({ type: 'send', message: 'hi' })).toEqual({
+      type: 'send',
+      message: 'hi',
+      notice: undefined
+    })
+  })
+
+  it('parses a prefill directive with its notice (e.g. /undo)', () => {
+    const parsed = parseCommandDispatch({ type: 'prefill', notice: 'backed up 1 turn', message: 'edit me' })
+
+    expect(parsed).toEqual({ type: 'prefill', message: 'edit me', notice: 'backed up 1 turn' })
+  })
+
+  it('rejects a prefill directive missing its message', () => {
+    expect(parseCommandDispatch({ type: 'prefill', notice: 'x' })).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -238,7 +238,12 @@ export function parseCommandDispatch(raw: unknown): CommandDispatchResponse | nu
       return typeof row.name === 'string' ? { type: 'skill', name: row.name, message: str(row.message) } : null
 
     case 'send':
-      return typeof row.message === 'string' ? { type: 'send', message: row.message } : null
+      return typeof row.message === 'string' ? { type: 'send', message: row.message, notice: str(row.notice) } : null
+
+    case 'prefill':
+      return typeof row.message === 'string'
+        ? { type: 'prefill', message: row.message, notice: str(row.notice) }
+        : null
 
     default:
       return null


### PR DESCRIPTION
## Summary
`/goal <text>` now shows its "⊙ Goal set …" notice and `/undo` prefills the composer in the desktop app — both were silently broken because the desktop slash dispatcher dropped directive `notice`s and never handled `prefill`.

Root cause: the backend's `command.dispatch` returns `{type: "send", notice, message}` for `/goal <text>` and `{type: "prefill", notice, message}` for `/undo`. The desktop's `parseCommandDispatch` kept only `message` on `send` (dropping the notice) and returned `null` for `prefill` ("invalid response"). So setting a goal looked like it did nothing — the goal text just got submitted as a plain prompt with zero feedback. The TUI (`createSlashHandler.ts`) renders the notice as a system line and handles prefill; the desktop didn't.

## Changes
- `app/types.ts`: add `notice?` to `SendCommandDispatchResponse`; add `PrefillCommandDispatchResponse` to the union.
- `lib/chat-runtime.ts` `parseCommandDispatch`: keep `notice` on `send`, parse `prefill`.
- `session/hooks/use-prompt-actions.ts` `runExec`: render the notice as a system line before acting; handle `prefill` by dropping the message into the composer for editing (mirrors the TUI).
- Tests for the new parser cases.

## Validation
| | Before | After |
|---|---|---|
| `/goal do X` | goal text submitted silently, no notice | "⊙ Goal set …" system line shown, then goal kicks off |
| `/undo` | "error: invalid response: command.dispatch" | backed-up text dropped into composer to edit |

- `tsc -p apps/desktop --noEmit`: clean
- `vitest` (jsdom): chat-runtime.test.ts 10/10, use-prompt-actions.test.tsx 32/32
- eslint: no new problems (3 pre-existing, unchanged)

## Infographic

![hermes-deco-chrome](https://v3b.fal.media/files/b/0a9eee06/6q43kUgMCCoX5WNTbXLiw_CDRRXNG6.png)
