### PR TITLE
fix(auxiliary): treat 403 subscription and session-usage-limit errors as payment errors for fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2408,7 +2408,7 @@ def _is_payment_error(exc: Exception) -> bool:
     # but sometimes wrap them in 429 or other codes.
     # Daily quota exhaustion from Bedrock, Vertex AI, and similar providers
     # uses different language but is semantically identical to credit exhaustion.
-    if status in {402, 404, 429, None}:
+    if status in {402, 403, 404, 429, None}:
         if any(kw in err_lower for kw in (
             "credits", "insufficient funds",
             "can only afford", "billing",
@@ -2417,6 +2417,8 @@ def _is_payment_error(exc: Exception) -> bool:
             "balance_depleted", "no usable credits",
             "model_not_supported_on_free_tier",
             "not available on the free tier",
+            "requires a subscription", "upgrade for access",
+            "upgrade for higher limits", "reached your session usage limit",
             # Daily / monthly / weekly quota exhaustion keywords
             "quota exceeded", "quota_exceeded",
             "too many tokens per day", "daily limit",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1323,6 +1323,21 @@ class TestIsPaymentError:
         exc.status_code = 404
         assert _is_payment_error(exc) is True
 
+    def test_403_subscription_required_is_payment(self):
+        exc = Exception(
+            "this model requires a subscription, upgrade for access: "
+            "https://ollama.com/upgrade"
+        )
+        setattr(exc, "status_code", 403)
+        assert _is_payment_error(exc) is True
+
+    def test_429_session_usage_limit_is_payment(self):
+        exc = Exception(
+            "you have reached your session usage limit, upgrade for higher limits"
+        )
+        setattr(exc, "status_code", 429)
+        assert _is_payment_error(exc) is True
+
     def test_404_generic_not_found_is_not_payment(self):
         exc = Exception("Not Found")
         exc.status_code = 404


### PR DESCRIPTION
## Problem

When an Ollama Cloud subscription runs out of quota, the API returns a `403` with messages like "this model requires a subscription, upgrade for access" or "you have reached your session usage limit, upgrade for higher limits". These are semantically identical to credit exhaustion / payment errors, but `_is_payment_error()` did not recognize them:

- `403` was not in the status code set (`{402, 404, 429, None}`)
- The subscription/session-usage keywords were not in the keyword list

As a result, `should_fallback` stayed `False` and the configured `fallback_chain` was never tried. The auxiliary task (typically context compression) failed outright, dropping middle turns without a summary and showing:

> ⚠ Configured auxiliary compression provider 'ollama-cloud' is unavailable — context compression will drop middle turns without a summary.

## Fix

Two minimal changes to `_is_payment_error()` in `agent/auxiliary_client.py`:

1. **Add `403` to the status code set**: Subscription-gated access is a billing/capacity condition, not an auth or request validation error. Including it allows the payment-error fallback path to trigger.

2. **Add 4 new keywords**: `"requires a subscription"`, `"upgrade for access"`, `"upgrade for higher limits"`, `"reached your session usage limit"` — these match the actual error strings returned by Ollama Cloud when subscription quota is exhausted.

## Tests

Two new test cases in `tests/agent/test_auxiliary_client.py::TestIsPaymentError`:

- `test_403_subscription_required_is_payment`: 403 with "requires a subscription, upgrade for access" → `True`
- `test_429_session_usage_limit_is_payment`: 429 with "reached your session usage limit, upgrade for higher limits" → `True`

Existing `test_404_generic_not_found_is_not_payment` continues to pass, confirming the keyword gate still rejects generic 404s.

All tests pass: `17 passed in 0.36s`

## Impact

With this fix, when the primary auxiliary provider returns a subscription/quota error, the `fallback_chain` configured in `auxiliary.<task>.fallback_chain` (e.g. `openai-codex` / `gpt-5.4-mini` for compression) is now tried instead of failing immediately.

## Files changed

- `agent/auxiliary_client.py` (+3/-1) — add 403 status + 4 keywords to `_is_payment_error`
- `tests/agent/test_auxiliary_client.py` (+15) — 2 new test cases