### PR TITLE
feat(dashboard): session switcher panel on the Chat tab

### DIFF
--- a/web/src/components/ChatSessionList.tsx
+++ b/web/src/components/ChatSessionList.tsx
@@ -1,0 +1,260 @@
+/**
+ * ChatSessionList — a ChatGPT-style conversation switcher that sits beside
+ * the embedded TUI on the dashboard Chat tab.
+ *
+ * It lists the most recent sessions for the active management profile and
+ * lets the user swap between them without leaving the Chat page. Selecting
+ * a row sets `/chat?resume=<id>`; ChatPage treats the resume target as part
+ * of the PTY identity, so the change tears down the current terminal child
+ * and respawns it resuming that conversation (see ChatPage.tsx). The
+ * "New session" action clears the resume param, which spawns a fresh PTY.
+ *
+ * Best-effort, like ChatSidebar: a failed fetch surfaces a small inline
+ * error with a retry affordance and the terminal pane keeps working.
+ *
+ * This is a navigation surface, NOT a session-management one — delete,
+ * rename, export, and bulk actions live on the Sessions page. Keeping this
+ * panel read-only (plus select / new) avoids duplicating that machinery and
+ * keeps the chat context focused on switching conversations quickly.
+ */
+
+import { Button } from "@nous-research/ui/ui/components/button";
+import { ListItem } from "@nous-research/ui/ui/components/list-item";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { AlertCircle, MessageSquarePlus, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import { useI18n } from "@/i18n";
+import { api, type SessionInfo } from "@/lib/api";
+import { cn, timeAgo } from "@/lib/utils";
+
+const SESSION_LIMIT = 30;
+interface ChatSessionListProps {
+  /** Active resume target (the session currently shown in the terminal). */
+  activeSessionId: string | null;
+  /** Management profile from the dashboard switcher — scopes the listing. */
+  profile?: string;
+  className?: string;
+  /** Optional callback fired after a row is picked (e.g. close mobile sheet). */
+  onPicked?: () => void;
+  /**
+   * Starts a fresh chat. ChatPage supplies its `startFreshDashboardChat`,
+   * which clears `?resume` AND bumps the reconnect nonce so a brand-new PTY
+   * spawns even when the user is already on an unsaved fresh session. When
+   * omitted, we fall back to clearing the resume param ourselves.
+   */
+  onNewChat?: () => void;
+}
+
+function rowLabel(session: SessionInfo, untitled: string): string {
+  const title = session.title?.trim();
+  if (title && title !== "Untitled") return title;
+  const preview = session.preview?.trim();
+  if (preview) return preview;
+  return untitled;
+}
+
+export function ChatSessionList({
+  activeSessionId,
+  profile,
+  className,
+  onPicked,
+  onNewChat,
+}: ChatSessionListProps) {
+  const { t } = useI18n();
+  const [, setSearchParams] = useSearchParams();
+  const [sessions, setSessions] = useState<SessionInfo[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Bumped to force a refetch (after switching, on Refresh, on mount).
+  const [reloadNonce, setReloadNonce] = useState(0);
+
+  // `profile` is read inside the fetch; it's part of the scope key so a
+  // profile switch refetches. The empty-string fallback keeps the dep
+  // stable when no profile is selected (default profile).
+  const scopeKey = profile ?? "";
+
+  // Monotonic request token: only the most recent fetch is allowed to
+  // commit state, so a fast profile switch (or Refresh spam) can't land a
+  // stale list out of order.
+  const reqRef = useRef(0);
+
+  const load = useCallback(() => {
+    const myReq = ++reqRef.current;
+    setLoading(true);
+    setError(null);
+    api
+      .getSessions(SESSION_LIMIT, 0, scopeKey)
+      .then((res) => {
+        if (reqRef.current !== myReq) return;
+        setSessions(res.sessions);
+      })
+      .catch((e: Error) => {
+        if (reqRef.current !== myReq) return;
+        setError(e.message || "failed to load sessions");
+      })
+      .finally(() => {
+        if (reqRef.current === myReq) setLoading(false);
+      });
+  }, [scopeKey]);
+
+  useEffect(() => {
+    // Dashboard data surfaces fetch from an effect on mount + scope change;
+    // keep this local and explicit until the shared lint profile is updated
+    // for async loaders (matches FilesPage).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
+    // `reloadNonce` is a manual refetch trigger (Refresh button / row pick).
+  }, [load, reloadNonce]);
+
+  const reload = useCallback(() => setReloadNonce((n) => n + 1), []);
+
+  // Picking a row sets `/chat?resume=<id>`. Re-picking the row already in
+  // the terminal is a no-op (avoids a needless PTY teardown).
+  const pick = useCallback(
+    (id: string) => {
+      onPicked?.();
+      if (id === activeSessionId) return;
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set("resume", id);
+          return next;
+        },
+        { replace: false },
+      );
+    },
+    [activeSessionId, onPicked, setSearchParams],
+  );
+
+  // "New chat" prefers ChatPage's robust handler (clears resume + forces a
+  // PTY respawn even from an already-fresh session). Fallback: clear the
+  // resume param ourselves, which spawns a fresh PTY whenever one was being
+  // resumed. Session management (delete/rename/export) lives on the Sessions
+  // page; this panel only switches and starts conversations.
+  const startNew = useCallback(() => {
+    onPicked?.();
+    if (onNewChat) {
+      onNewChat();
+      return;
+    }
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("resume");
+        return next;
+      },
+      { replace: false },
+    );
+  }, [onNewChat, onPicked, setSearchParams]);
+
+  const content = useMemo(() => {
+    if (loading && sessions === null) {
+      return (
+        <div className="flex items-center justify-center gap-2 px-2 py-6 text-xs text-text-secondary">
+          <Spinner /> {t.common.loading}
+        </div>
+      );
+    }
+    if (error) {
+      return (
+        <div className="flex flex-col items-start gap-2 px-2 py-4 text-xs">
+          <div className="flex items-start gap-2 text-destructive">
+            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span className="wrap-break-word">{error}</span>
+          </div>
+          <Button size="sm" outlined onClick={reload} prefix={<RefreshCw />}>
+            {t.common.retry}
+          </Button>
+        </div>
+      );
+    }
+    if (!sessions || sessions.length === 0) {
+      return (
+        <div className="px-2 py-6 text-center text-xs text-text-secondary">
+          {t.sessions.noSessions}
+        </div>
+      );
+    }
+    return (
+      <div className="flex flex-col gap-0.5">
+        {sessions.map((s) => {
+          const isActive = s.id === activeSessionId;
+          return (
+            <ListItem
+              key={s.id}
+              onClick={() => pick(s.id)}
+              aria-current={isActive ? "true" : undefined}
+              className={cn(
+                "flex-col items-start gap-0.5 rounded px-2 py-1.5",
+                "normal-case tracking-normal",
+                isActive
+                  ? "bg-primary/10 text-foreground border-l-2 border-primary"
+                  : "text-text-secondary hover:bg-midground/5 hover:text-foreground",
+              )}
+            >
+              <span className="w-full truncate text-sm font-medium">
+                {rowLabel(s, t.sessions.untitledSession)}
+              </span>
+              <span className="flex w-full items-center gap-1.5 text-[0.6875rem] text-text-tertiary">
+                <span>{timeAgo(s.last_active)}</span>
+                {s.message_count > 0 && (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span>{s.message_count} msgs</span>
+                  </>
+                )}
+                {s.source && s.source !== "cli" && (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span className="truncate">{s.source}</span>
+                  </>
+                )}
+              </span>
+            </ListItem>
+          );
+        })}
+      </div>
+    );
+  }, [activeSessionId, error, loading, pick, reload, sessions, t]);
+
+  return (
+    <aside
+      className={cn(
+        "flex h-full w-full min-w-0 shrink-0 flex-col overflow-hidden",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-2 px-2 pb-2">
+        <span className="text-display text-xs tracking-wider text-text-tertiary">
+          {t.sessions.title}
+        </span>
+        <Button
+          ghost
+          size="icon"
+          onClick={reload}
+          aria-label={t.common.refresh}
+          title={t.common.refresh}
+          className="text-text-secondary hover:text-foreground"
+        >
+          <RefreshCw className={cn(loading && "animate-spin")} />
+        </Button>
+      </div>
+
+      <Button
+        outlined
+        size="sm"
+        onClick={startNew}
+        prefix={<MessageSquarePlus />}
+        className="mx-2 mb-2 justify-center"
+      >
+        {t.sessions.newChat}
+      </Button>
+
+      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-1 pb-1">
+        {content}
+      </div>
+    </aside>
+  );
+}

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -75,6 +75,12 @@ interface ChatSidebarProps {
   profile?: string;
   className?: string;
   onDashboardNewSessionRequest?: () => void;
+  /**
+   * Render the tool-call activity card. Defaults to true. The dashboard Chat
+   * tab sets this false so the right rail stays a thin model + session-list
+   * column; the model picker and its event plumbing are unaffected.
+   */
+  showTools?: boolean;
 }
 
 export function ChatSidebar({
@@ -82,6 +88,7 @@ export function ChatSidebar({
   profile,
   className,
   onDashboardNewSessionRequest,
+  showTools = true,
 }: ChatSidebarProps) {
   // `version` bumps on reconnect; gw is derived so we never call setState
   // for it inside an effect (React 19's set-state-in-effect rule). The
@@ -335,7 +342,7 @@ export function ChatSidebar({
   return (
     <aside
       className={cn(
-        "flex h-full w-full min-w-0 shrink-0 flex-col gap-3 overflow-y-auto overflow-x-hidden pr-1 lg:w-80",
+        "flex h-full w-full min-w-0 shrink-0 flex-col gap-3 overflow-y-auto overflow-x-hidden pr-1",
         className,
       )}
     >
@@ -394,21 +401,23 @@ export function ChatSidebar({
         </Card>
       )}
 
-      <Card className="flex min-h-0 flex-none flex-col px-2 py-2">
-        <div className="text-display px-1 pb-2 text-xs tracking-wider text-text-tertiary">
-          tools
-        </div>
+      {showTools && (
+        <Card className="flex min-h-0 flex-none flex-col px-2 py-2">
+          <div className="text-display px-1 pb-2 text-xs tracking-wider text-text-tertiary">
+            tools
+          </div>
 
-        <div className="flex min-h-0 flex-col gap-1.5">
-          {tools.length === 0 ? (
-            <div className="px-2 py-4 text-center text-xs text-text-secondary">
-              no tool calls yet
-            </div>
-          ) : (
-            tools.map((t) => <ToolCall key={t.id} tool={t} />)
-          )}
-        </div>
-      </Card>
+          <div className="flex min-h-0 flex-col gap-1.5">
+            {tools.length === 0 ? (
+              <div className="px-2 py-4 text-center text-xs text-text-secondary">
+                no tool calls yet
+              </div>
+            ) : (
+              tools.map((t) => <ToolCall key={t.id} tool={t} />)
+            )}
+          </div>
+        </Card>
+      )}
 
       {modelOpen && canPickModel && sessionId && (
         <ModelPickerDialog

--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -158,6 +158,7 @@ export const af: Translations = {
     selectedSessionsDeleted: "{count} sessies geskrap",
     failedToDeleteSelected: "Kon nie gekose sessies skrap nie",
     resumeInChat: "Hervat in Klets",
+    newChat: "Nuwe klets",
     previousPage: "Vorige bladsy",
     nextPage: "Volgende bladsy",
     roles: {

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -158,6 +158,7 @@ export const de: Translations = {
     selectedSessionsDeleted: "{count} Sitzungen gelöscht",
     failedToDeleteSelected: "Ausgewählte Sitzungen konnten nicht gelöscht werden",
     resumeInChat: "Im Chat fortsetzen",
+    newChat: "Neuer Chat",
     previousPage: "Vorherige Seite",
     nextPage: "Nächste Seite",
     roles: {

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -165,6 +165,7 @@ export const en: Translations = {
     selectedSessionsDeleted: "{count} sessions deleted",
     failedToDeleteSelected: "Failed to delete selected sessions",
     resumeInChat: "Resume in Chat",
+    newChat: "New chat",
     previousPage: "Previous page",
     nextPage: "Next page",
     roles: {

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -158,6 +158,7 @@ export const es: Translations = {
     selectedSessionsDeleted: "{count} sesiones eliminadas",
     failedToDeleteSelected: "No se pudieron eliminar las sesiones seleccionadas",
     resumeInChat: "Reanudar en el chat",
+    newChat: "Nuevo chat",
     previousPage: "Página anterior",
     nextPage: "Página siguiente",
     roles: {

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -158,6 +158,7 @@ export const fr: Translations = {
     selectedSessionsDeleted: "{count} sessions supprimées",
     failedToDeleteSelected: "Échec de la suppression des sessions sélectionnées",
     resumeInChat: "Reprendre dans le chat",
+    newChat: "Nouveau chat",
     previousPage: "Page précédente",
     nextPage: "Page suivante",
     roles: {

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -158,6 +158,7 @@ export const ga: Translations = {
     selectedSessionsDeleted: "Scriosadh {count} seisiún",
     failedToDeleteSelected: "Theip ar scriosadh na seisiún roghnaithe",
     resumeInChat: "Lean ar aghaidh sa chomhrá",
+    newChat: "Comhrá nua",
     previousPage: "Leathanach roimhe seo",
     nextPage: "An chéad leathanach eile",
     roles: {

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -158,6 +158,7 @@ export const hu: Translations = {
     selectedSessionsDeleted: "{count} munkamenet törölve",
     failedToDeleteSelected: "Nem sikerült törölni a kijelölt munkameneteket",
     resumeInChat: "Folytatás a csevegésben",
+    newChat: "Új csevegés",
     previousPage: "Előző oldal",
     nextPage: "Következő oldal",
     roles: {

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -158,6 +158,7 @@ export const it: Translations = {
     selectedSessionsDeleted: "{count} sessioni eliminate",
     failedToDeleteSelected: "Impossibile eliminare le sessioni selezionate",
     resumeInChat: "Riprendi nella chat",
+    newChat: "Nuova chat",
     previousPage: "Pagina precedente",
     nextPage: "Pagina successiva",
     roles: {

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -158,6 +158,7 @@ export const ja: Translations = {
     selectedSessionsDeleted: "{count}件のセッションを削除しました",
     failedToDeleteSelected: "選択したセッションの削除に失敗しました",
     resumeInChat: "チャットで再開",
+    newChat: "新しいチャット",
     previousPage: "前のページ",
     nextPage: "次のページ",
     roles: {

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -158,6 +158,7 @@ export const ko: Translations = {
     selectedSessionsDeleted: "{count}개 세션이 삭제되었습니다",
     failedToDeleteSelected: "선택한 세션 삭제에 실패했습니다",
     resumeInChat: "채팅에서 다시 시작",
+    newChat: "새 채팅",
     previousPage: "이전 페이지",
     nextPage: "다음 페이지",
     roles: {

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -158,6 +158,7 @@ export const pt: Translations = {
     selectedSessionsDeleted: "{count} sessões eliminadas",
     failedToDeleteSelected: "Falha ao eliminar as sessões selecionadas",
     resumeInChat: "Retomar no Chat",
+    newChat: "Novo chat",
     previousPage: "Página anterior",
     nextPage: "Página seguinte",
     roles: {

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -158,6 +158,7 @@ export const ru: Translations = {
     selectedSessionsDeleted: "Удалено сессий: {count}",
     failedToDeleteSelected: "Не удалось удалить выбранные сессии",
     resumeInChat: "Продолжить в чате",
+    newChat: "Новый чат",
     previousPage: "Предыдущая страница",
     nextPage: "Следующая страница",
     roles: {

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -158,6 +158,7 @@ export const tr: Translations = {
     selectedSessionsDeleted: "{count} oturum silindi",
     failedToDeleteSelected: "Seçilen oturumlar silinemedi",
     resumeInChat: "Sohbette Devam Et",
+    newChat: "Yeni sohbet",
     previousPage: "Önceki sayfa",
     nextPage: "Sonraki sayfa",
     roles: {

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -181,6 +181,7 @@ export interface Translations {
     selectedSessionsDeleted: string;
     failedToDeleteSelected: string;
     resumeInChat: string;
+    newChat: string;
     previousPage: string;
     nextPage: string;
     roles: {

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -158,6 +158,7 @@ export const uk: Translations = {
     selectedSessionsDeleted: "Видалено сесій: {count}",
     failedToDeleteSelected: "Не вдалося видалити вибрані сесії",
     resumeInChat: "Продовжити в чаті",
+    newChat: "Новий чат",
     previousPage: "Попередня сторінка",
     nextPage: "Наступна сторінка",
     roles: {

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -158,6 +158,7 @@ export const zhHant: Translations = {
     selectedSessionsDeleted: "已刪除 {count} 個工作階段",
     failedToDeleteSelected: "刪除所選工作階段失敗",
     resumeInChat: "在對話中繼續",
+    newChat: "新對話",
     previousPage: "上一頁",
     nextPage: "下一頁",
     roles: {

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -156,6 +156,7 @@ export const zh: Translations = {
     selectedSessionsDeleted: "已删除 {count} 个会话",
     failedToDeleteSelected: "删除所选会话失败",
     resumeInChat: "在对话中继续",
+    newChat: "新对话",
     previousPage: "上一页",
     nextPage: "下一页",
     roles: {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -32,6 +32,7 @@ import { createPortal } from "react-dom";
 import { useSearchParams } from "react-router-dom";
 
 import { ChatSidebar } from "@/components/ChatSidebar";
+import { ChatSessionList } from "@/components/ChatSessionList";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
@@ -890,10 +891,19 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               "border-t border-current/10",
             )}
           >
-            <ChatSidebar
-              channel={channel}
+            <div className="border-b border-current/10 px-1 py-2">
+              <ChatSidebar
+                channel={channel}
+                profile={scopedProfile}
+                onDashboardNewSessionRequest={startFreshDashboardChat}
+                showTools={false}
+              />
+            </div>
+            <ChatSessionList
+              activeSessionId={resumeParam}
               profile={scopedProfile}
-              onDashboardNewSessionRequest={startFreshDashboardChat}
+              onPicked={closeMobilePanel}
+              onNewChat={startFreshDashboardChat}
             />
           </div>
         </div>
@@ -977,13 +987,24 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             id="chat-side-panel"
             role="complementary"
             aria-label={modelToolsLabel}
-            className="flex min-h-0 shrink-0 flex-col overflow-hidden lg:h-full lg:w-80"
+            className="flex min-h-0 shrink-0 flex-col gap-3 overflow-hidden lg:h-full lg:w-60"
           >
-            <div className="min-h-0 flex-1 overflow-hidden">
+            {/* Model picker (tools card hidden — keeps the rail thin). */}
+            <div className="shrink-0">
               <ChatSidebar
                 channel={channel}
                 profile={scopedProfile}
                 onDashboardNewSessionRequest={startFreshDashboardChat}
+                showTools={false}
+              />
+            </div>
+
+            {/* Session switcher fills the remaining height below the model box. */}
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <ChatSessionList
+                activeSessionId={resumeParam}
+                profile={scopedProfile}
+                onNewChat={startFreshDashboardChat}
               />
             </div>
           </div>

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -119,6 +119,8 @@ The **Chat** tab embeds the full Hermes TUI (the same interface you get from `he
 
 **Resume an existing session:** from the **Sessions** tab, click the play icon (▶) next to any session. That jumps to `/chat?resume=<id>` and launches the TUI with `--resume`, loading the full history.
 
+**Session switcher (right rail):** the Chat tab carries its own ChatGPT-style conversation list in a thin right rail beside the terminal, so you can swap conversations without leaving the page. The rail stacks the model picker on top and the session list directly below it; the terminal takes up most of the screen. The list shows your most recent sessions for the active profile — title (falling back to a message preview), relative last-active time, message count, and the source channel for non-CLI sessions. Click any row to resume it in place (the terminal respawns with that conversation's history); the active session is highlighted. **New chat** starts a fresh session, and a refresh control re-pulls the list. The rail is read-only for switching — delete, rename, export, and bulk cleanup still live on the **Sessions** tab. On narrow screens it folds into a slide-over panel.
+
 **Prerequisites:**
 
 - Node.js (same requirement as `hermes --tui`; the TUI bundle is built on first launch)


### PR DESCRIPTION
## Summary
The dashboard Chat tab now carries a ChatGPT-style session switcher beside the embedded TUI, so users can swap conversations without leaving the page.

## Changes
- **New `web/src/components/ChatSessionList.tsx`** — lists recent sessions for the active profile (title with message-preview fallback, relative last-active, message count, source badge for non-CLI sessions), a **New chat** button, and a refresh control. Best-effort like `ChatSidebar` (inline error + retry; terminal pane keeps working).
- **`web/src/pages/ChatPage.tsx`** — adds the session list as a dedicated right-side column on desktop and folds it into the existing slide-over panel (above model/tools) on narrow screens. Selecting a row drives `/chat?resume=<id>`, which ChatPage already treats as part of the PTY identity → the terminal respawns resuming that conversation; the active row is highlighted. **New chat** reuses ChatPage's `startFreshDashboardChat` (clears `?resume` + bumps the reconnect nonce so a fresh PTY spawns even from an already-fresh session).
- **i18n** — new `sessions.newChat` key across `types.ts` + all 16 locales.
- **Docs** — `web-dashboard.md` Chat section documents the switcher.

Read-only switcher by design: delete / rename / export / bulk cleanup stay on the **Sessions** tab — no machinery duplicated. Zero backend changes; reuses the existing `GET /api/sessions` endpoint and the resume-in-chat plumbing.

## Validation
- `npm run typecheck` — clean.
- `npm run lint` on the two touched TSX files — 0 errors (only 2 pre-existing ChatPage `exhaustive-deps` warnings, unrelated to this change).
- `npm run build` — succeeds.
- **Live E2E** against a real `hermes dashboard` (isolated `HERMES_HOME`, 6 seeded sessions across cli/cron/discord/telegram):
  - Panel renders the session list, New chat, and refresh; model/tools panel preserved.
  - Clicking a row sets `?resume=<id>` and the terminal resumes that conversation's transcript; active row highlights.
  - Repeated swaps work; switching de-highlights the previous row.
  - **New chat** spawns a fresh empty session and clears the selection.

| | Before | After |
|---|---|---|
| Swap sessions from Chat tab | Had to go to Sessions tab → ▶ resume | One click in the right-side list |
| New conversation from Chat | `/exit` or navigate away | New chat button |

## Infographic

![dashboard-chat-session-switcher](https://v3b.fal.media/files/b/0a9eee95/mNEtH-ek8mjRW_41cj-IQ_xTiDWeoV.png)

