### PR TITLE
feat(desktop): unify provider list — one source for hermes model + Providers tabs (salvage #48800)

### DIFF
--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -36,6 +36,22 @@ function provider(id: string, loggedIn: boolean, patch: Partial<OAuthProvider> =
   }
 }
 
+// A backend-tagged provider env var (category=provider) for the API-keys view.
+function keyVar(label: string, slug: string) {
+  return {
+    advanced: false,
+    category: 'provider',
+    description: `${label} direct API`,
+    is_password: true,
+    is_set: false,
+    provider: slug,
+    provider_label: label,
+    redacted_value: null,
+    tools: [],
+    url: ''
+  }
+}
+
 beforeEach(() => {
   onboarding.set({ manual: false })
   getEnvVars.mockResolvedValue({})
@@ -123,5 +139,37 @@ describe('ProvidersSettings', () => {
     render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="keys" />)
 
     expect(await screen.findByText('WidgetAI')).toBeTruthy()
+  })
+
+  it('orders API-key providers by priority then name, and filters them via search', async () => {
+    // These three providers have no curated PROVIDER_GROUPS priority, so they
+    // share the default priority and fall back to alphabetical among themselves
+    // (Acme, Middle, Zebra) — exercising the name tiebreak of the priority sort.
+    getEnvVars.mockResolvedValue({
+      ZEBRA_API_KEY: keyVar('Zebra', 'zebra'),
+      ACME_API_KEY: keyVar('Acme', 'acme'),
+      MIDDLE_API_KEY: keyVar('Middle', 'middle')
+    })
+    listOAuthProviders.mockResolvedValue({ providers: [] })
+
+    const { ProvidersSettings } = await import('./providers-settings')
+    render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="keys" />)
+
+    // Equal priority → alphabetical tiebreak: Acme, Middle, Zebra.
+    await screen.findByText('Acme')
+    const labels = screen.getAllByText(/Acme|Middle|Zebra/).map(el => el.textContent)
+    expect(labels).toEqual(['Acme', 'Middle', 'Zebra'])
+
+    // Typing narrows the list to matching providers only.
+    const search = screen.getByPlaceholderText('Search providers…')
+    fireEvent.change(search, { target: { value: 'mid' } })
+
+    await waitFor(() => expect(screen.queryByText('Acme')).toBeNull())
+    expect(screen.getByText('Middle')).toBeTruthy()
+    expect(screen.queryByText('Zebra')).toBeNull()
+
+    // A non-matching query shows the empty-state copy.
+    fireEvent.change(search, { target: { value: 'nonesuch-xyz' } })
+    expect(await screen.findByText('No providers match your search.')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -97,4 +97,31 @@ describe('ProvidersSettings', () => {
     expect(screen.queryByRole('button', { name: 'Remove Qwen Code' })).toBeNull()
     expect(screen.getByText(/managed by its own CLI/)).toBeTruthy()
   })
+
+  it('renders a Keys card for a backend-tagged provider with no PROVIDER_GROUPS prefix', async () => {
+    // A provider the backend catalog tags (provider/provider_label) but that has
+    // no desktop PROVIDER_GROUPS prefix row must still render its own card —
+    // this is the GUI/CLI drift fix: membership comes from the backend, not
+    // from the hand-maintained prefix list.
+    getEnvVars.mockResolvedValue({
+      WIDGETAI_API_KEY: {
+        advanced: false,
+        category: 'provider',
+        description: 'WidgetAI direct API',
+        is_password: true,
+        is_set: false,
+        provider: 'widgetai',
+        provider_label: 'WidgetAI',
+        redacted_value: null,
+        tools: [],
+        url: 'https://widgetai.example/keys'
+      }
+    })
+    listOAuthProviders.mockResolvedValue({ providers: [] })
+
+    const { ProvidersSettings } = await import('./providers-settings')
+    render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="keys" />)
+
+    expect(await screen.findByText('WidgetAI')).toBeTruthy()
+  })
 })

--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { OAuthProvider } from '@/types/hermes'
+import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
 const listOAuthProviders = vi.fn()
 const disconnectOAuthProvider = vi.fn()
@@ -36,19 +36,22 @@ function provider(id: string, loggedIn: boolean, patch: Partial<OAuthProvider> =
   }
 }
 
-// A backend-tagged provider env var (category=provider) for the API-keys view.
-function keyVar(label: string, slug: string) {
+// One `/api/env` row (an EnvVarInfo) for the API-keys view. Mirrors the
+// `provider()` factory above: a valid base + per-test overrides, typed against
+// the real response shape so it can't drift from EnvVarInfo.
+function keyVar(patch: Partial<EnvVarInfo> = {}): EnvVarInfo {
   return {
     advanced: false,
     category: 'provider',
-    description: `${label} direct API`,
+    description: '',
     is_password: true,
     is_set: false,
-    provider: slug,
-    provider_label: label,
+    provider: '',
+    provider_label: '',
     redacted_value: null,
     tools: [],
-    url: ''
+    url: '',
+    ...patch
   }
 }
 
@@ -120,18 +123,11 @@ describe('ProvidersSettings', () => {
     // this is the GUI/CLI drift fix: membership comes from the backend, not
     // from the hand-maintained prefix list.
     getEnvVars.mockResolvedValue({
-      WIDGETAI_API_KEY: {
-        advanced: false,
-        category: 'provider',
-        description: 'WidgetAI direct API',
-        is_password: true,
-        is_set: false,
+      WIDGETAI_API_KEY: keyVar({
         provider: 'widgetai',
         provider_label: 'WidgetAI',
-        redacted_value: null,
-        tools: [],
         url: 'https://widgetai.example/keys'
-      }
+      })
     })
     listOAuthProviders.mockResolvedValue({ providers: [] })
 
@@ -146,9 +142,9 @@ describe('ProvidersSettings', () => {
     // share the default priority and fall back to alphabetical among themselves
     // (Acme, Middle, Zebra) — exercising the name tiebreak of the priority sort.
     getEnvVars.mockResolvedValue({
-      ZEBRA_API_KEY: keyVar('Zebra', 'zebra'),
-      ACME_API_KEY: keyVar('Acme', 'acme'),
-      MIDDLE_API_KEY: keyVar('Middle', 'middle')
+      ZEBRA_API_KEY: keyVar({ provider: 'zebra', provider_label: 'Zebra' }),
+      ACME_API_KEY: keyVar({ provider: 'acme', provider_label: 'Acme' }),
+      MIDDLE_API_KEY: keyVar({ provider: 'middle', provider_label: 'Middle' })
     })
     listOAuthProviders.mockResolvedValue({ providers: [] })
 

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -12,6 +12,7 @@ import {
   sortProviders
 } from '@/components/desktop-onboarding-overlay'
 import { Button } from '@/components/ui/button'
+import { SearchField } from '@/components/ui/search-field'
 import { disconnectOAuthProvider, listOAuthProviders } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { Check, ChevronDown, ChevronRight, KeyRound, Loader2, Terminal, Trash2 } from '@/lib/icons'
@@ -145,6 +146,7 @@ function OAuthPicker({
   const rest = featured ? ordered.filter(p => p.id !== FEATURED_ID) : ordered
   // Keep connected accounts grouped and always visible; only the unconnected
   // providers hide behind the disclosure, so the page leads with what's set up.
+  // Both lists preserve `sortProviders` order (curated priority, then name).
   const connected = rest.filter(p => p.status?.logged_in)
   const others = rest.filter(p => !p.status?.logged_in)
   const collapsible = others.length > 0
@@ -298,6 +300,8 @@ export function ProvidersSettings({ onClose, onViewChange, view }: ProvidersSett
   const [oauthProviders, setOauthProviders] = useState<OAuthProvider[]>([])
   const [openProvider, setOpenProvider] = useState<null | string>(null)
   const [disconnecting, setDisconnecting] = useState<null | string>(null)
+  // Free-text filter for the API-keys view (provider name / env-var key / desc).
+  const [keyQuery, setKeyQuery] = useState('')
   // The onboarding overlay owns the OAuth flow. Watch its `manual` flag so we
   // re-read connection state when the user finishes (or dismisses) a sign-in
   // they launched from this page — otherwise the cards keep their stale status.
@@ -386,20 +390,49 @@ export function ProvidersSettings({ onClose, onViewChange, view }: ProvidersSett
   const keyGroups = buildProviderKeyGroups(vars)
 
   if (showApiKeys) {
+    const q = keyQuery.trim().toLowerCase()
+    const visibleGroups = q
+      ? keyGroups.filter(group => {
+          const haystack = [
+            group.name,
+            group.description ?? '',
+            group.primary[0],
+            ...group.advanced.map(([k]) => k)
+          ]
+
+          return haystack.some(s => s.toLowerCase().includes(q))
+        })
+      : keyGroups
+
     return (
       <SettingsContent>
         {keyGroups.length > 0 ? (
-          <div className="grid gap-2">
-            {keyGroups.map(group => (
-              <ProviderKeyRows
-                expanded={openProvider === group.name}
-                group={group}
-                key={group.name}
-                onExpand={() => setOpenProvider(group.name)}
-                onToggle={() => setOpenProvider(prev => (prev === group.name ? null : group.name))}
-                rowProps={rowProps}
-              />
-            ))}
+          <div className="grid gap-3">
+            <SearchField
+              aria-label={t.settings.providers.searchKeys}
+              containerClassName="w-full"
+              onChange={setKeyQuery}
+              placeholder={t.settings.providers.searchKeys}
+              value={keyQuery}
+            />
+            {visibleGroups.length > 0 ? (
+              <div className="grid gap-2">
+                {visibleGroups.map(group => (
+                  <ProviderKeyRows
+                    expanded={openProvider === group.name}
+                    group={group}
+                    key={group.name}
+                    onExpand={() => setOpenProvider(group.name)}
+                    onToggle={() => setOpenProvider(prev => (prev === group.name ? null : group.name))}
+                    rowProps={rowProps}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="grid min-h-24 place-items-center px-4 py-6 text-center text-[length:var(--conversation-caption-font-size)] text-muted-foreground">
+                {t.settings.providers.noKeysMatch}
+              </div>
+            )}
           </div>
         ) : (
           <NoProviderKeys />

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -45,8 +45,17 @@ export const PROVIDER_VIEWS = ['accounts', 'keys'] as const
 export type ProviderView = (typeof PROVIDER_VIEWS)[number]
 
 // Group the env catalog by provider — one ListRow per vendor plus optional
-// advanced overrides (base URL, region, etc.). Groups without a key field and
-// the "Other" bucket are skipped.
+// advanced overrides (base URL, region, etc.). Groups without a key field are
+// skipped.
+//
+// Grouping key precedence:
+//   1. Backend `provider_label` / `provider` (from the unified provider catalog
+//      in hermes_cli/provider_catalog.py) — the SAME provider identity
+//      `hermes model` uses. This is authoritative: a provider tagged by the
+//      backend always renders a card, even with no PROVIDER_GROUPS row.
+//   2. Desktop prefix match (`providerGroup`) — legacy fallback for provider
+//      env vars that predate the backend tagging.
+// Only entries that resolve to neither (the "Other" bucket) are skipped.
 function buildProviderKeyGroups(vars: Record<string, EnvVarInfo>): ProviderKeyGroup[] {
   const buckets = new Map<string, [string, EnvVarInfo][]>()
 
@@ -55,7 +64,9 @@ function buildProviderKeyGroups(vars: Record<string, EnvVarInfo>): ProviderKeyGr
       continue
     }
 
-    const name = providerGroup(key)
+    // Prefer the backend-supplied provider label/id so the Keys tab groups by
+    // the same identity the CLI picker uses; fall back to the prefix guess.
+    const name = info.provider_label?.trim() || info.provider?.trim() || providerGroup(key)
 
     if (name === 'Other') {
       continue
@@ -73,6 +84,9 @@ function buildProviderKeyGroups(vars: Record<string, EnvVarInfo>): ProviderKeyGr
       continue
     }
 
+    // Presentation overlay (priority, blurb, docs) is keyed by the prefix-based
+    // group name; when the backend introduced this provider it may have no
+    // overlay entry, so fall back to the backend/env metadata for display.
     const meta = providerMeta(name)
 
     groups.push({

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -581,6 +581,8 @@ export const en: Translations = {
       removedMessage: provider => `${provider} was removed.`,
       failedRemove: provider => `Could not remove ${provider}`,
       noProviderKeys: 'No provider API keys available.',
+      searchKeys: 'Search providers…',
+      noKeysMatch: 'No providers match your search.',
       loading: 'Loading providers...'
     },
     sessions: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -700,6 +700,8 @@ export const ja = defineLocale({
       removedMessage: provider => `${provider} を削除しました。`,
       failedRemove: provider => `${provider} を削除できませんでした`,
       noProviderKeys: '利用可能なプロバイダー API キーがありません。',
+      searchKeys: 'プロバイダーを検索…',
+      noKeysMatch: '一致するプロバイダーがありません。',
       loading: 'プロバイダーを読み込み中...'
     },
     sessions: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -462,6 +462,8 @@ export interface Translations {
       removedMessage: (provider: string) => string
       failedRemove: (provider: string) => string
       noProviderKeys: string
+      searchKeys: string
+      noKeysMatch: string
       loading: string
     }
     sessions: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -677,6 +677,8 @@ export const zhHant = defineLocale({
       removedMessage: provider => `${provider} 已移除。`,
       failedRemove: provider => `無法移除 ${provider}`,
       noProviderKeys: '沒有可用的提供方 API 金鑰。',
+      searchKeys: '搜尋提供方…',
+      noKeysMatch: '沒有符合的提供方。',
       loading: '正在載入提供方...'
     },
     sessions: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -774,6 +774,8 @@ export const zh: Translations = {
       removedMessage: provider => `${provider} 已移除。`,
       failedRemove: provider => `无法移除 ${provider}`,
       noProviderKeys: '没有可用的提供方 API 密钥。',
+      searchKeys: '搜索提供方…',
+      noKeysMatch: '没有匹配的提供方。',
       loading: '正在加载提供方...'
     },
     sessions: {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -108,6 +108,12 @@ export interface EnvVarInfo {
   description: string
   is_password: boolean
   is_set: boolean
+  // Backend-derived provider grouping hints (from the unified provider catalog
+  // in hermes_cli/provider_catalog.py). When present, the Keys tab groups by
+  // this provider identity — the SAME one `hermes model` uses — instead of
+  // desktop-only env-var prefix guesses. Empty for non-provider env vars.
+  provider?: string
+  provider_label?: string
   redacted_value: null | string
   tools: string[]
   url: null | string

--- a/hermes_cli/provider_catalog.py
+++ b/hermes_cli/provider_catalog.py
@@ -1,0 +1,170 @@
+"""Unified provider catalog — one source of truth for the provider universe.
+
+The provider list shown by ``hermes model`` (CLI/TUI) and the desktop Settings
+→ Providers tabs (Accounts + API keys) **must be the same set**.  Historically
+they were not: the CLI picker read :data:`hermes_cli.models.CANONICAL_PROVIDERS`
+(which auto-extends from ``plugins/model-providers/<name>/``), while the desktop
+tabs read separate hand-maintained lists (``_OAUTH_PROVIDER_CATALOG``,
+``OPTIONAL_ENV_VARS`` + ``PROVIDER_GROUPS``) that nobody kept in sync.  Every
+provider added after those lists were written silently went missing from the
+GUI — e.g. GitHub Copilot showing up only under "tools", or ``openai-api`` being
+configurable from the CLI but not the desktop app.
+
+This module fixes that at the root: it derives ONE descriptor per provider from
+the same universe ``hermes model`` renders (``CANONICAL_PROVIDERS``), joining:
+
+* ``auth_type`` / ``api_key_env_vars`` / ``base_url_env_var`` from
+  :data:`hermes_cli.auth.PROVIDER_REGISTRY` (credential truth), and
+* ``display_name`` / ``description`` / ``signup_url`` from the provider's
+  :class:`providers.base.ProviderProfile` when one exists, falling back to the
+  ``CANONICAL_PROVIDERS`` entry's ``label`` / ``tui_desc`` and the
+  ``OPTIONAL_ENV_VARS`` signup URL otherwise (many profiles leave these blank,
+  and four canonical providers have no profile at all — lmstudio, openai-api,
+  tencent-tokenhub, xai-oauth — so the fallbacks are load-bearing).
+
+Each descriptor is tagged with the ``tab`` it belongs on (``keys`` vs
+``accounts``) based purely on how the provider authenticates.  The desktop
+``/api/env`` and ``/api/providers/oauth`` endpoints derive their MEMBERSHIP from
+this catalog; the old hand lists are demoted to presentation/override overlays
+(bespoke OAuth flow + status resolvers, richer copy, icons, ordering) and no
+longer decide which providers exist.
+
+Parity contract (locked by tests): the union of the two tabs equals the
+``CANONICAL_PROVIDERS`` universe, i.e. exactly what ``hermes model`` shows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Auth types that authenticate via an account / sign-in flow rather than a
+# pasted API key.  These route to the desktop "Accounts" tab; everything else
+# (api_key, and aws_sdk which is configured via AWS_REGION/AWS_PROFILE) routes
+# to the "API keys" tab.  Mirrors the auth_type strings used in
+# hermes_cli.auth.PROVIDER_REGISTRY and providers.base.ProviderProfile.
+_ACCOUNTS_AUTH_TYPES: frozenset[str] = frozenset(
+    {
+        "oauth_device_code",
+        "oauth_external",
+        "oauth_minimax",
+        "external_process",  # copilot-acp: spawns `copilot --acp --stdio`
+        "copilot",           # GitHub Copilot token / gh auth
+    }
+)
+
+
+@dataclass(frozen=True)
+class ProviderDescriptor:
+    """One provider, as seen by every surface (CLI picker + both GUI tabs)."""
+
+    slug: str                      # canonical id, e.g. "google-gemini-cli"
+    label: str                     # human display name
+    description: str               # one-line description
+    auth_type: str                 # api_key | oauth_* | external_process | copilot | aws_sdk
+    tab: str                       # "keys" | "accounts"
+    api_key_env_vars: tuple[str, ...]  # credential env vars (may be empty)
+    base_url_env_var: str          # base-URL override env var (may be "")
+    signup_url: str                # signup / console URL (may be "")
+    order: int                     # CANONICAL_PROVIDERS index — mirrors `hermes model`
+
+
+def tab_for_auth_type(auth_type: str) -> str:
+    """Return the desktop tab ("keys"|"accounts") a provider's auth maps to."""
+    return "accounts" if auth_type in _ACCOUNTS_AUTH_TYPES else "keys"
+
+
+def _split_env_vars(env_vars: tuple[str, ...]) -> tuple[tuple[str, ...], str]:
+    """Split a profile's ``env_vars`` into (api_key_vars, base_url_var)."""
+    keys = tuple(v for v in env_vars if not (v.endswith("_BASE_URL") or v.endswith("_URL")))
+    base = next((v for v in env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), "")
+    return keys, base
+
+
+def provider_catalog() -> list[ProviderDescriptor]:
+    """Return one descriptor per provider in the ``hermes model`` universe.
+
+    Membership is :data:`CANONICAL_PROVIDERS` (the list the CLI/TUI picker
+    renders, which auto-extends from provider plugins).  Auth + env come from
+    ``PROVIDER_REGISTRY``; display metadata from ``ProviderProfile`` with
+    canonical/env fallbacks so providers without a profile (or with blank
+    profile metadata) still resolve sensibly.
+    """
+    from hermes_cli.models import CANONICAL_PROVIDERS
+
+    # PROVIDER_REGISTRY / list_providers are imported lazily and defensively:
+    # this module is on the import path of the web server and the CLI, and we
+    # never want a provider-plugin import error to blank the whole catalog.
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+    except Exception:
+        PROVIDER_REGISTRY = {}
+
+    try:
+        from providers import list_providers
+
+        profiles = {p.name: p for p in list_providers()}
+    except Exception:
+        profiles = {}
+
+    try:
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+    except Exception:
+        OPTIONAL_ENV_VARS = {}
+
+    out: list[ProviderDescriptor] = []
+    for order, entry in enumerate(CANONICAL_PROVIDERS):
+        slug = entry.slug
+        cfg = PROVIDER_REGISTRY.get(slug)
+        prof = profiles.get(slug)
+
+        # auth_type: registry is authoritative; fall back to profile, then api_key.
+        auth_type = (
+            (getattr(cfg, "auth_type", "") if cfg else "")
+            or (getattr(prof, "auth_type", "") if prof else "")
+            or "api_key"
+        )
+
+        # Credential env vars: registry first (it already normalizes these),
+        # else derive from the profile's env_vars tuple.
+        if cfg and getattr(cfg, "api_key_env_vars", ()):
+            api_key_vars = tuple(cfg.api_key_env_vars)
+            base_url_var = getattr(cfg, "base_url_env_var", "") or ""
+        elif prof and getattr(prof, "env_vars", ()):
+            api_key_vars, base_url_var = _split_env_vars(tuple(prof.env_vars))
+        else:
+            api_key_vars, base_url_var = (), ""
+
+        label = (
+            (getattr(prof, "display_name", "") if prof else "")
+            or entry.label
+            or slug
+        )
+        description = (
+            (getattr(prof, "description", "") if prof else "")
+            or entry.tui_desc
+            or label
+        )
+        signup_url = (getattr(prof, "signup_url", "") if prof else "") or ""
+        if not signup_url and api_key_vars:
+            info = OPTIONAL_ENV_VARS.get(api_key_vars[0]) or {}
+            signup_url = info.get("url") or ""
+
+        out.append(
+            ProviderDescriptor(
+                slug=slug,
+                label=label,
+                description=description,
+                auth_type=auth_type,
+                tab=tab_for_auth_type(auth_type),
+                api_key_env_vars=api_key_vars,
+                base_url_env_var=base_url_var,
+                signup_url=signup_url,
+                order=order,
+            )
+        )
+    return out
+
+
+def provider_catalog_by_slug() -> dict[str, ProviderDescriptor]:
+    """Convenience: the catalog keyed by slug."""
+    return {d.slug: d for d in provider_catalog()}

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5550,6 +5550,40 @@ def _claude_code_only_status() -> Dict[str, Any]:
     return {"logged_in": False, "source": None}
 
 
+def _gemini_cli_status() -> Dict[str, Any]:
+    """Status for the google-gemini-cli OAuth provider (Code Assist login)."""
+    try:
+        from hermes_cli import auth as hauth
+        raw = hauth.get_gemini_oauth_auth_status()
+    except Exception as e:
+        return {"logged_in": False, "error": str(e)}
+    return {
+        "logged_in": bool(raw.get("logged_in")),
+        "source": raw.get("source") or "google_oauth",
+        "source_label": raw.get("email") or raw.get("auth_file") or "Google Code Assist",
+        "token_preview": _truncate_token(raw.get("api_key")),
+        "expires_at": None,
+        "has_refresh_token": True,
+    }
+
+
+def _copilot_acp_status() -> Dict[str, Any]:
+    """Status for copilot-acp — credentials are owned by the Copilot CLI.
+
+    There is no cheap programmatic credential probe for the ACP subprocess, so
+    this is a read-only "managed by the Copilot CLI" card (like claude-code):
+    Hermes never claims a login state it can't verify.
+    """
+    return {
+        "logged_in": False,
+        "source": "copilot_cli",
+        "source_label": "Managed by the GitHub Copilot CLI",
+        "token_preview": None,
+        "expires_at": None,
+        "has_refresh_token": False,
+    }
+
+
 # Provider catalog. The order matters — it's how we render the UI list.
 # ``cli_command`` is what the dashboard surfaces as the copy-to-clipboard
 # fallback while Phase 2 (in-browser flows) isn't built yet.
@@ -5605,6 +5639,22 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "cli_command": "hermes auth add xai-oauth",
         "docs_url": "https://hermes-agent.nousresearch.com/docs/guides/xai-grok-oauth",
         "status_fn": None,  # dispatched via auth.get_xai_oauth_auth_status
+    },
+    {
+        "id": "google-gemini-cli",
+        "name": "Google Gemini (OAuth + Code Assist)",
+        "flow": "external",
+        "cli_command": "hermes auth add google-gemini-cli",
+        "docs_url": "https://ai.google.dev/gemini-api/docs",
+        "status_fn": _gemini_cli_status,
+    },
+    {
+        "id": "copilot-acp",
+        "name": "GitHub Copilot (ACP)",
+        "flow": "external",
+        "cli_command": "copilot /login",
+        "docs_url": "https://docs.github.com/en/copilot",
+        "status_fn": _copilot_acp_status,
     },
     # ── Anthropic / Claude entries sit at the bottom: the API-key path
     # first, then the subscription OAuth path (which only works with extra
@@ -5735,6 +5785,56 @@ def _oauth_provider_disconnect_hint(provider: Dict[str, Any], status: Dict[str, 
     return None
 
 
+def _build_oauth_catalog() -> list[Dict[str, Any]]:
+    """Build the Accounts-tab provider list.
+
+    MEMBERSHIP is the union of:
+      1. ``_OAUTH_PROVIDER_CATALOG`` — the explicit, hand-tuned cards that carry
+         bespoke flow / status_fn / cli_command (including the api-key Anthropic
+         PKCE card and the synthetic claude-code subscription row, which are not
+         catalog providers), and
+      2. every accounts-tab provider in the unified ``provider_catalog()`` (the
+         ``hermes model`` universe) — so any OAuth/external provider added as a
+         plugin appears automatically, with sensible defaults, even if no
+         explicit card was written for it.
+
+    The explicit catalog wins on metadata; the unified catalog guarantees we
+    never silently drop a provider the CLI picker offers. Order: explicit cards
+    first (their curated order), then any catalog-only providers appended in
+    ``hermes model`` order.
+    """
+    rows: list[Dict[str, Any]] = []
+    seen: set[str] = set()
+
+    # 1. Explicit hand-tuned cards (authoritative metadata + curated order).
+    for entry in _OAUTH_PROVIDER_CATALOG:
+        if entry["id"] in seen:
+            continue
+        seen.add(entry["id"])
+        rows.append(dict(entry))
+
+    # 2. Catalog accounts-providers not already covered — keeps the Accounts tab
+    #    in lockstep with the `hermes model` universe (zero-edit for new plugins).
+    try:
+        from hermes_cli.provider_catalog import provider_catalog
+        for d in provider_catalog():
+            if d.tab != "accounts" or d.slug in seen:
+                continue
+            seen.add(d.slug)
+            rows.append({
+                "id": d.slug,
+                "name": d.label,
+                "flow": "external",
+                "cli_command": f"hermes auth add {d.slug}",
+                "docs_url": d.signup_url or "",
+                "status_fn": None,
+            })
+    except Exception:
+        pass
+
+    return rows
+
+
 @app.get("/api/providers/oauth")
 async def list_oauth_providers(profile: Optional[str] = None):
     """Enumerate every OAuth-capable LLM provider with current status.
@@ -5754,10 +5854,14 @@ async def list_oauth_providers(profile: Optional[str] = None):
           token_preview    last N chars of the token, never the full token
           expires_at       ISO timestamp string or null
           has_refresh_token bool
+
+    Membership is derived from the unified provider_catalog() so this stays in
+    sync with the `hermes model` picker; _OAUTH_OVERRIDES supplies per-provider
+    flow/status/cli metadata.
     """
     with _profile_scope(profile):
         providers = []
-        for p in _OAUTH_PROVIDER_CATALOG:
+        for p in _build_oauth_catalog():
             status = _resolve_provider_status(p["id"], p.get("status_fn"))
             disconnect_hint = _oauth_provider_disconnect_hint(p, status)
             providers.append({
@@ -5784,7 +5888,7 @@ async def disconnect_oauth_provider(
     _require_token(request)
 
     with _profile_scope(profile):
-        catalog_by_id = {p["id"]: p for p in _OAUTH_PROVIDER_CATALOG}
+        catalog_by_id = {p["id"]: p for p in _build_oauth_catalog()}
         provider = catalog_by_id.get(provider_id)
         if provider is None:
             raise HTTPException(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4038,6 +4038,24 @@ def _catalog_provider_env_metadata() -> dict:
                     "category": "provider",
                 },
             )
+
+        # AWS-SDK providers (Bedrock) authenticate via the AWS credential chain
+        # rather than a pasted API key, so they have no api_key_env_vars. Tag
+        # their AWS_* settings to the provider card so they still appear on the
+        # Keys tab (otherwise Bedrock — a `hermes model` provider — would be
+        # invisible in the desktop app).
+        if d.auth_type == "aws_sdk":
+            for aws_var in ("AWS_REGION", "AWS_PROFILE"):
+                existing = meta.get(aws_var, {})
+                meta[aws_var] = {
+                    "provider": d.slug,
+                    "provider_label": d.label,
+                    "description": existing.get("description") or f"{d.label} ({aws_var})",
+                    "url": existing.get("url"),
+                    "is_password": False,
+                    "advanced": existing.get("advanced", True),
+                    "category": "provider",
+                }
     return meta
 
 
@@ -5584,13 +5602,19 @@ def _copilot_acp_status() -> Dict[str, Any]:
     }
 
 
-# Provider catalog. The order matters — it's how we render the UI list.
-# ``cli_command`` is what the dashboard surfaces as the copy-to-clipboard
-# fallback while Phase 2 (in-browser flows) isn't built yet.
-# ``flow`` describes the OAuth shape so the future modal can pick the
-# right UI: ``pkce`` = open URL + paste callback code, ``device_code`` =
-# show code + verification URL + poll, ``external`` = read-only (delegated
-# to a third-party CLI like Claude Code or Qwen).
+# Explicit, hand-tuned OAuth/account provider cards. These carry the bits that
+# can't be derived from the unified provider catalog: the OAuth ``flow`` shape,
+# the per-provider ``status_fn``, the ``cli_command`` fallback, and curated
+# display order. They are the OVERRIDE BASE for ``_build_oauth_catalog()``,
+# which unions them with every accounts-tab provider in ``provider_catalog()``
+# so newly-added OAuth/external providers appear automatically (no hand edit).
+# This tuple also still includes two entries that are NOT catalog providers but
+# must show on the Accounts tab: the api-key Anthropic PKCE card and the
+# synthetic ``claude-code`` subscription row.
+# ``flow`` describes the OAuth shape so the modal can pick the right UI:
+# ``pkce`` = open URL + paste callback code, ``device_code`` = show code +
+# verification URL + poll, ``external`` = read-only (delegated to a third-party
+# CLI like Claude Code or Qwen), ``loopback`` = 127.0.0.1 callback listener.
 _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
     {
         "id": "nous",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5766,6 +5766,31 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
                 "has_refresh_token": True,
                 "last_refresh": raw.get("last_refresh"),
             }
+        # No hand-written branch for this provider id: fall through to the
+        # canonical slug-driven dispatcher so accounts-tab providers derived
+        # from the unified catalog (which carry status_fn=None) still reflect
+        # real login state instead of rendering permanently logged-out. This
+        # closes the membership-auto-extends-but-status-doesn't gap: add an
+        # OAuth/account provider plugin and its card shows the right state.
+        raw = hauth.get_auth_status(provider_id)
+        if isinstance(raw, dict) and "logged_in" in raw:
+            return {
+                "logged_in": bool(raw.get("logged_in")),
+                "source": raw.get("source") or raw.get("provider") or provider_id,
+                "source_label": (
+                    raw.get("source_label")
+                    or raw.get("auth_store")
+                    or raw.get("auth_store_path")
+                    or raw.get("base_url")
+                    or raw.get("name")
+                    or ""
+                ),
+                "token_preview": _truncate_token(
+                    raw.get("access_token") or raw.get("api_key")
+                ),
+                "expires_at": raw.get("expires_at") or raw.get("access_expires_at"),
+                "has_refresh_token": bool(raw.get("has_refresh_token")),
+            }
     except Exception as e:
         return {"logged_in": False, "error": str(e)}
     return {"logged_in": False}

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3971,28 +3971,117 @@ async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+def _catalog_provider_env_metadata() -> dict:
+    """Map provider env vars → desktop card metadata, derived from the catalog.
+
+    Returns ``{env_var: {provider, provider_label, description, url, is_password,
+    advanced}}`` for every API-key provider in the unified ``provider_catalog()``
+    (i.e. the ``hermes model`` universe). This is what lets the desktop Keys tab
+    render a card for a provider even when its env var was never hand-added to
+    ``OPTIONAL_ENV_VARS`` — closing the drift where CLI-configurable providers
+    (openai-api, kilocode, novita, tencent-tokenhub, copilot, …) were missing
+    from the GUI.
+
+    Hand ``OPTIONAL_ENV_VARS`` prose is layered ON TOP of this in the endpoint;
+    this only supplies membership + grouping + sensible fallbacks.
+    """
+    try:
+        from hermes_cli.provider_catalog import provider_catalog
+    except Exception:
+        return {}
+
+    # Env vars already declared with a NON-provider category (e.g. the shared
+    # GITHUB_TOKEN, which is a Skills-Hub "tool" credential) must not be
+    # promoted into a provider card. Copilot lists GITHUB_TOKEN among its auth
+    # aliases, but its provider card uses the provider-owned COPILOT_GITHUB_TOKEN.
+    try:
+        from hermes_cli.config import OPTIONAL_ENV_VARS as _OPT
+    except Exception:
+        _OPT = {}
+    _non_provider_keys = {
+        k for k, v in _OPT.items()
+        if (v or {}).get("category") and (v or {}).get("category") != "provider"
+    }
+
+    meta: dict = {}
+    for d in provider_catalog():
+        if d.tab != "keys":
+            continue
+        # API-key vars: the first is the primary (password) field; any aliases
+        # are kept as additional password fields so users can clear them too.
+        for env_var in d.api_key_env_vars:
+            if env_var in _non_provider_keys:
+                continue  # don't hijack a shared tool/messaging credential
+            meta.setdefault(
+                env_var,
+                {
+                    "provider": d.slug,
+                    "provider_label": d.label,
+                    "description": d.description,
+                    "url": d.signup_url or None,
+                    "is_password": True,
+                    "advanced": False,
+                    "category": "provider",
+                },
+            )
+        # Base-URL override is an advanced, non-secret field for the same card.
+        if d.base_url_env_var:
+            meta.setdefault(
+                d.base_url_env_var,
+                {
+                    "provider": d.slug,
+                    "provider_label": d.label,
+                    "description": f"{d.label} base URL override",
+                    "url": None,
+                    "is_password": False,
+                    "advanced": True,
+                    "category": "provider",
+                },
+            )
+    return meta
+
+
 @app.get("/api/env")
 async def get_env_vars(profile: Optional[str] = None):
     with _profile_scope(profile):
         env_on_disk = load_env()
     channel_keys = _channel_managed_env_keys()
-    result = {}
-    for var_name, info in OPTIONAL_ENV_VARS.items():
+    catalog_meta = _catalog_provider_env_metadata()
+
+    def _row(var_name: str, info: dict) -> dict:
         value = env_on_disk.get(var_name)
-        result[var_name] = {
+        cat_meta = catalog_meta.get(var_name) or {}
+        # Hand OPTIONAL_ENV_VARS prose wins where present; the catalog fills any
+        # gaps (description/url) and always supplies provider grouping hints.
+        return {
             "is_set": bool(value),
             "redacted_value": redact_key(value) if value else None,
-            "description": info.get("description", ""),
-            "url": info.get("url"),
-            "category": info.get("category", ""),
-            "is_password": info.get("password", False),
+            "description": info.get("description") or cat_meta.get("description", ""),
+            "url": info.get("url") if info.get("url") is not None else cat_meta.get("url"),
+            "category": info.get("category") or cat_meta.get("category", ""),
+            "is_password": info.get("password", cat_meta.get("is_password", False)),
             "tools": info.get("tools", []),
-            "advanced": info.get("advanced", False),
+            "advanced": info.get("advanced", cat_meta.get("advanced", False)),
             # True when this var is a messaging-platform credential owned by a
             # Channels page card. The Keys/Env page uses this to hide it and
             # avoid duplicating the (richer) Channels configuration UI.
             "channel_managed": var_name in channel_keys,
+            # Provider grouping hints derived from the unified provider catalog
+            # so the desktop Keys tab groups by the SAME provider identity the
+            # CLI `hermes model` picker uses (not desktop-only prefix guesses).
+            "provider": cat_meta.get("provider", ""),
+            "provider_label": cat_meta.get("provider_label", ""),
         }
+
+    result = {}
+    for var_name, info in OPTIONAL_ENV_VARS.items():
+        result[var_name] = _row(var_name, info)
+    # Synthesize rows for catalog provider env vars that have no hand entry in
+    # OPTIONAL_ENV_VARS — these are the providers that were CLI-configurable but
+    # invisible in the desktop app until now.
+    for var_name in catalog_meta:
+        if var_name not in result:
+            result[var_name] = _row(var_name, {})
     return result
 
 

--- a/tests/hermes_cli/test_provider_catalog.py
+++ b/tests/hermes_cli/test_provider_catalog.py
@@ -1,0 +1,127 @@
+"""Tests for the unified provider catalog (hermes_cli.provider_catalog).
+
+These are invariant tests, not snapshots: they assert the parity *contract*
+between what ``hermes model`` shows (``CANONICAL_PROVIDERS``) and what the
+catalog exposes, plus how each provider's ``auth_type`` maps to a desktop tab —
+never a specific provider count or a frozen vendor list (both change over time).
+"""
+
+from hermes_cli.models import CANONICAL_PROVIDERS
+from hermes_cli.provider_catalog import (
+    ProviderDescriptor,
+    provider_catalog,
+    provider_catalog_by_slug,
+    tab_for_auth_type,
+)
+
+
+def test_catalog_covers_every_hermes_model_provider():
+    """PARITY CONTRACT: the catalog == the `hermes model` universe."""
+    slugs = {d.slug for d in provider_catalog()}
+    for entry in CANONICAL_PROVIDERS:
+        assert entry.slug in slugs, (
+            f"{entry.slug} is shown in `hermes model` but missing from provider_catalog()"
+        )
+
+
+def test_catalog_has_no_providers_outside_hermes_model():
+    """The catalog must not invent providers `hermes model` doesn't show."""
+    canonical = {e.slug for e in CANONICAL_PROVIDERS}
+    for d in provider_catalog():
+        assert d.slug in canonical, f"{d.slug} in catalog but not in CANONICAL_PROVIDERS"
+
+
+def test_every_descriptor_lands_on_exactly_one_known_tab():
+    for d in provider_catalog():
+        assert d.tab in {"keys", "accounts"}, f"{d.slug} has bad tab {d.tab!r}"
+
+
+def test_descriptor_count_matches_canonical():
+    """One descriptor per canonical entry (no dupes, no drops)."""
+    cat = provider_catalog()
+    assert len(cat) == len(CANONICAL_PROVIDERS)
+    assert len({d.slug for d in cat}) == len(cat)
+
+
+def test_profileless_providers_still_present():
+    """Providers without a ProviderProfile must still resolve via fallbacks.
+
+    lmstudio / openai-api / tencent-tokenhub / xai-oauth have no profile on
+    main; they exist only as registry + canonical entries. The catalog must
+    not require a profile to include a provider.
+    """
+    by = provider_catalog_by_slug()
+    for slug in ("lmstudio", "openai-api", "tencent-tokenhub", "xai-oauth"):
+        assert slug in by, f"{slug} dropped from catalog (profile-less provider)"
+        assert by[slug].label, f"{slug} has empty label despite canonical fallback"
+        assert by[slug].description, f"{slug} has empty description despite fallback"
+
+
+def test_api_key_providers_route_to_keys_oauth_to_accounts():
+    by = provider_catalog_by_slug()
+    # api_key → keys
+    assert by["kilocode"].tab == "keys"
+    assert by["openai-api"].tab == "keys"
+    # account / sign-in flows → accounts
+    assert by["google-gemini-cli"].tab == "accounts"
+    assert by["copilot-acp"].tab == "accounts"
+
+
+def test_copilot_surfaces_as_a_provider_with_its_own_token_var():
+    """Regression for the reported bug: a GitHub Copilot login showed up under
+    tools, never as a provider, because the shared GITHUB_TOKEN is tool-category.
+
+    Copilot authenticates via the `copilot`/api_key path, so it belongs on the
+    keys tab — but its PRIMARY credential var must be the provider-owned
+    COPILOT_GITHUB_TOKEN, not the shared tool-category GITHUB_TOKEN. That is what
+    lets the desktop render Copilot as its own provider card.
+    """
+    by = provider_catalog_by_slug()
+    assert "copilot" in by
+    d = by["copilot"]
+    assert d.tab == "keys"
+    assert d.api_key_env_vars, "Copilot must expose a credential env var"
+    assert d.api_key_env_vars[0] == "COPILOT_GITHUB_TOKEN", (
+        "Copilot's primary var must be the provider-owned token, not shared GITHUB_TOKEN"
+    )
+
+
+def test_bedrock_routes_to_keys():
+    """Bedrock is aws_sdk (AWS_REGION/AWS_PROFILE), configured on the keys tab."""
+    by = provider_catalog_by_slug()
+    assert by["bedrock"].tab == "keys"
+
+
+def test_api_key_providers_expose_a_credential_env_var():
+    """Every keys-tab provider that authenticates via a pasted API key must
+    surface at least one env var to write the key into (otherwise the GUI can't
+    configure it).
+
+    Exemptions: ``aws_sdk`` (bedrock — uses AWS_REGION/AWS_PROFILE) and the
+    ``custom`` bring-your-own-endpoint pseudo-provider, which is configured
+    inline via the local-endpoint flow rather than a fixed env var.
+    """
+    exempt = {"custom"}
+    for d in provider_catalog():
+        if d.auth_type == "api_key" and d.slug not in exempt:
+            assert d.api_key_env_vars, f"{d.slug} is api_key but exposes no env var"
+
+
+def test_order_mirrors_canonical_declaration():
+    cat = provider_catalog()
+    assert [d.order for d in cat] == list(range(len(cat)))
+    assert [d.slug for d in cat] == [e.slug for e in CANONICAL_PROVIDERS]
+
+
+def test_descriptors_are_provider_descriptor_instances():
+    for d in provider_catalog():
+        assert isinstance(d, ProviderDescriptor)
+
+
+def test_tab_for_auth_type_helper():
+    assert tab_for_auth_type("api_key") == "keys"
+    assert tab_for_auth_type("aws_sdk") == "keys"
+    assert tab_for_auth_type("oauth_external") == "accounts"
+    assert tab_for_auth_type("oauth_device_code") == "accounts"
+    assert tab_for_auth_type("copilot") == "accounts"
+    assert tab_for_auth_type("external_process") == "accounts"

--- a/tests/hermes_cli/test_provider_parity.py
+++ b/tests/hermes_cli/test_provider_parity.py
@@ -1,0 +1,90 @@
+"""End-to-end provider parity contract: the desktop Providers tabs must show
+the SAME provider universe as ``hermes model`` (the CLI/TUI picker).
+
+This is the single load-bearing invariant of the unified provider catalog:
+
+    keys(/api/env provider rows) ∪ ids(/api/providers/oauth) ⊇ CANONICAL_PROVIDERS
+
+i.e. every provider the CLI picker offers is configurable from the desktop app,
+on one of the two Providers sub-tabs (API keys or Accounts). It is asserted as
+an invariant against the real FastAPI endpoints (not a snapshot / count), so it
+can never silently drift again when a provider plugin is added.
+"""
+
+from fastapi.testclient import TestClient
+
+from hermes_cli.models import CANONICAL_PROVIDERS
+from hermes_cli.provider_catalog import provider_catalog
+from hermes_cli.web_server import _SESSION_TOKEN, app
+
+client = TestClient(app)
+HEADERS = {"X-Hermes-Session-Token": _SESSION_TOKEN}
+
+# `custom` is the bring-your-own-endpoint pseudo-provider configured inline via
+# the model picker's local-endpoint flow, not a fixed credential card. It is in
+# the CLI picker's universe but intentionally has no dedicated Providers-tab
+# card. Exempt it from the union check.
+_EXEMPT = {"custom"}
+
+# Providers that legitimately offer BOTH auth methods and so intentionally
+# appear on both desktop tabs (an API-key card AND an account sign-in card).
+# Anthropic supports a direct API key (Keys tab) and a subscription OAuth /
+# Claude Code login (Accounts tab); surfacing both is correct, not a bug.
+_DUAL_TAB = {"anthropic"}
+
+
+def _keys_tab_providers() -> set[str]:
+    """Provider slugs that have at least one card on the desktop API-keys tab."""
+    data = client.get("/api/env", headers=HEADERS).json()
+    return {
+        info.get("provider")
+        for info in data.values()
+        if info.get("category") == "provider" and info.get("provider")
+    }
+
+
+def _accounts_tab_providers() -> set[str]:
+    """Provider slugs offered on the desktop Accounts tab."""
+    data = client.get("/api/providers/oauth", headers=HEADERS).json()
+    return {p["id"] for p in data["providers"]}
+
+
+def test_every_hermes_model_provider_is_configurable_in_desktop():
+    """PARITY CONTRACT: GUI (keys ∪ accounts) ⊇ `hermes model` universe."""
+    gui = _keys_tab_providers() | _accounts_tab_providers()
+    missing = [
+        e.slug
+        for e in CANONICAL_PROVIDERS
+        if e.slug not in _EXEMPT and e.slug not in gui
+    ]
+    assert not missing, (
+        "providers shown in `hermes model` but not configurable in the desktop "
+        f"Providers tabs: {missing}"
+    )
+
+
+def test_each_provider_lands_on_the_tab_its_auth_type_dictates():
+    """A keys-tab provider must surface under /api/env; an accounts-tab provider
+    under /api/providers/oauth. Cross-checks the catalog's tab routing against
+    where each provider actually renders.
+    """
+    keys = _keys_tab_providers()
+    accounts = _accounts_tab_providers()
+    for d in provider_catalog():
+        if d.slug in _EXEMPT:
+            continue
+        if d.tab == "keys" and d.api_key_env_vars:
+            assert d.slug in keys, f"{d.slug} (keys tab) missing from /api/env"
+        elif d.tab == "accounts":
+            assert d.slug in accounts, f"{d.slug} (accounts tab) missing from /api/providers/oauth"
+
+
+def test_no_provider_appears_on_both_tabs():
+    """A provider should be configured exactly one way — not duplicated across
+    both tabs (which would confuse users about where to put credentials).
+
+    Exception: genuinely dual-auth providers (see ``_DUAL_TAB``) intentionally
+    appear on both tabs.
+    """
+    overlap = (_keys_tab_providers() & _accounts_tab_providers()) - _EXEMPT - _DUAL_TAB
+    assert not overlap, f"providers appearing on BOTH desktop tabs: {sorted(overlap)}"

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -470,6 +470,39 @@ def test_xai_oauth_listed_as_loopback_flow():
     assert "grok" in providers["xai-oauth"]["name"].lower()
 
 
+def test_accounts_offers_every_oauth_provider_from_catalog():
+    """PARITY CONTRACT: every accounts-tab provider in the unified catalog (the
+    `hermes model` universe) must be offered by /api/providers/oauth. This keeps
+    the desktop Accounts tab in lockstep with the CLI picker — no provider the
+    CLI can sign into may be missing from the GUI.
+    """
+    from hermes_cli.provider_catalog import provider_catalog
+
+    resp = client.get("/api/providers/oauth", headers=HEADERS)
+    assert resp.status_code == 200, resp.text
+    offered = {p["id"] for p in resp.json()["providers"]}
+    for d in provider_catalog():
+        if d.tab == "accounts":
+            assert d.slug in offered, (
+                f"{d.slug} is an accounts-tab provider in `hermes model` but is "
+                f"missing from the desktop Accounts tab (/api/providers/oauth)"
+            )
+
+
+def test_gemini_cli_and_copilot_acp_now_in_accounts():
+    """Regression: google-gemini-cli and copilot-acp were canonical providers the
+    CLI could configure, but had no Accounts card (the reported GUI/CLI drift).
+    """
+    resp = client.get("/api/providers/oauth", headers=HEADERS)
+    assert resp.status_code == 200, resp.text
+    providers = {p["id"]: p for p in resp.json()["providers"]}
+    assert "google-gemini-cli" in providers
+    assert "copilot-acp" in providers
+    # copilot-acp is managed by an external CLI: read-only card, not auto-removable.
+    assert providers["copilot-acp"]["flow"] == "external"
+    assert providers["copilot-acp"]["disconnectable"] is False
+
+
 def test_oauth_catalog_marks_external_providers_not_disconnectable():
     """External CLI credentials are visible in Accounts but cannot be removed by Hermes."""
     resp = client.get("/api/providers/oauth", headers=HEADERS)

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -837,3 +837,56 @@ def test_unknown_pkce_provider_rejected_cleanly():
     # 4xx — what we MUST NOT see is a 200 with claude.ai in the body.
     assert resp.status_code >= 400, resp.text
     assert "claude.ai" not in resp.text.lower()
+
+
+def test_status_falls_through_to_generic_dispatcher_for_catalog_only_provider():
+    """Accounts-tab providers with no hardcoded branch reflect REAL status.
+
+    Providers appended to the Accounts tab from the unified provider_catalog()
+    carry status_fn=None and may have no explicit branch in
+    _resolve_provider_status. Before the fallthrough they rendered permanently
+    logged-out; now they dispatch to hermes_cli.auth.get_auth_status (the
+    canonical slug dispatcher) so membership AND status both auto-extend.
+    """
+    import hermes_cli.web_server as ws
+
+    fake_status = {
+        "logged_in": True,
+        "provider": "some-future-oauth",
+        "name": "Future OAuth Provider",
+        "access_token": "sk-future-secret-token-xyz",
+        "expires_at": "2026-12-01T00:00:00Z",
+        "has_refresh_token": True,
+    }
+    with patch("hermes_cli.auth.get_auth_status", return_value=fake_status):
+        out = ws._resolve_provider_status("some-future-oauth", None)
+
+    assert out["logged_in"] is True
+    assert out["source"] == "some-future-oauth"
+    assert out["source_label"] == "Future OAuth Provider"
+    # Token is previewed, never returned whole.
+    assert out["token_preview"] and "sk-future-secret-token-xyz" not in out["token_preview"]
+    assert out["expires_at"] == "2026-12-01T00:00:00Z"
+    assert out["has_refresh_token"] is True
+
+
+def test_status_hardcoded_branch_wins_over_generic_fallback():
+    """An existing hardcoded branch (nous) is unaffected by the fallthrough."""
+    import hermes_cli.web_server as ws
+
+    with patch(
+        "hermes_cli.auth.get_nous_auth_status",
+        return_value={"logged_in": True, "portal_base_url": "https://portal.test"},
+    ):
+        out = ws._resolve_provider_status("nous", None)
+    assert out["source"] == "nous_portal"
+    assert out["source_label"] == "https://portal.test"
+
+
+def test_status_unknown_provider_degrades_to_logged_out():
+    """A provider the generic dispatcher can't resolve stays logged-out cleanly."""
+    import hermes_cli.web_server as ws
+
+    with patch("hermes_cli.auth.get_auth_status", return_value={"logged_in": False}):
+        out = ws._resolve_provider_status("totally-unknown", None)
+    assert out["logged_in"] is False

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1299,6 +1299,48 @@ class TestWebServerEndpoints:
         for key, info in data.items():
             assert info["channel_managed"] is (key in channel_keys)
 
+    def test_get_env_vars_surfaces_catalog_providers(self):
+        """Every keys-tab provider in the unified catalog must appear in /api/env
+        as a provider card, even when it has no hand entry in OPTIONAL_ENV_VARS.
+
+        Regression for the GUI⇄CLI drift: openai-api, kilocode, novita,
+        tencent-tokenhub, copilot were configurable via `hermes model` but
+        invisible in the desktop Providers → API keys tab.
+        """
+        from hermes_cli.provider_catalog import provider_catalog
+
+        data = self.client.get("/api/env").json()
+        for d in provider_catalog():
+            if d.tab != "keys" or not d.api_key_env_vars:
+                continue
+            # The PRIMARY credential var must surface as this provider's card.
+            # (Shared aliases like GITHUB_TOKEN are intentionally left on their
+            # existing tool category and not hijacked — see the copilot test.)
+            primary = d.api_key_env_vars[0]
+            assert primary in data, f"{primary} ({d.slug}) missing from /api/env"
+            info = data[primary]
+            assert info["category"] == "provider"
+            assert info["provider"] == d.slug
+            assert info["provider_label"] == d.label
+
+    def test_get_env_vars_provider_rows_carry_grouping_hints(self):
+        """Provider env rows expose the backend `provider`/`provider_label` the
+        desktop Keys tab groups by (so it no longer relies on prefix guesses)."""
+        data = self.client.get("/api/env").json()
+        # OPENAI_API_KEY is a hand-listed protected var AND a catalog provider;
+        # it must come back tagged to the openai-api provider.
+        assert data["OPENAI_API_KEY"]["provider"] == "openai-api"
+        assert data["OPENAI_API_KEY"]["category"] == "provider"
+
+    def test_get_env_vars_copilot_uses_provider_token_not_shared_github_token(self):
+        """Copilot surfaces as its own provider card via COPILOT_GITHUB_TOKEN;
+        the shared GITHUB_TOKEN keeps its existing (tool) category."""
+        data = self.client.get("/api/env").json()
+        assert data["COPILOT_GITHUB_TOKEN"]["provider"] == "copilot"
+        assert data["COPILOT_GITHUB_TOKEN"]["category"] == "provider"
+        # Shared GITHUB_TOKEN must NOT be hijacked into the copilot provider card.
+        assert data.get("GITHUB_TOKEN", {}).get("provider", "") != "copilot"
+
     def test_platform_scoped_messaging_env_vars_are_channel_managed(self):
         from hermes_cli.web_server import (
             _MESSAGING_KEYS_PAGE_KEYS,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1341,6 +1341,15 @@ class TestWebServerEndpoints:
         # Shared GITHUB_TOKEN must NOT be hijacked into the copilot provider card.
         assert data.get("GITHUB_TOKEN", {}).get("provider", "") != "copilot"
 
+    def test_get_env_vars_bedrock_aws_vars_tagged_to_provider(self):
+        """Bedrock (aws_sdk, no api-key) must still appear on the Keys tab: its
+        AWS_REGION/AWS_PROFILE settings are tagged to the bedrock provider card.
+        """
+        data = self.client.get("/api/env").json()
+        assert data["AWS_REGION"]["provider"] == "bedrock"
+        assert data["AWS_REGION"]["category"] == "provider"
+        assert data["AWS_PROFILE"]["provider"] == "bedrock"
+
     def test_platform_scoped_messaging_env_vars_are_channel_managed(self):
         from hermes_cli.web_server import (
             _MESSAGING_KEYS_PAGE_KEYS,


### PR DESCRIPTION
## Summary

The desktop **Settings → Providers** tabs now show the same provider universe as `hermes model`, derived from one source — and OAuth/account providers reflect real login state automatically, not just membership.

Salvage of #48800 (@austinpickett) onto current `main`, plus a follow-up that closes the status-side of the auto-extend gap.

## What it fixes

The desktop Providers tabs read three hand-maintained lists (`_OAUTH_PROVIDER_CATALOG`, `OPTIONAL_ENV_VARS` provider entries, `PROVIDER_GROUPS`) that were never wired to `CANONICAL_PROVIDERS` — the list `hermes model` renders. Every provider added since those lists were written was invisible in the GUI: **openai-api, kilocode, novita, tencent-tokenhub, copilot** (Keys) and **google-gemini-cli, copilot-acp** (Accounts).

## Changes

- **`hermes_cli/provider_catalog.py`** (new) — `provider_catalog()` / `ProviderDescriptor`, one descriptor per provider derived from `CANONICAL_PROVIDERS`, joining auth/env from `PROVIDER_REGISTRY` and display metadata from `ProviderProfile` (with canonical/env fallbacks). Each descriptor is tagged `keys` vs `accounts` by `auth_type`.
- **`hermes_cli/web_server.py`** — `/api/env` and `/api/providers/oauth` derive *membership* from the catalog; the hand lists are demoted to presentation/override overlays (bespoke flow + `status_fn`, prose, icons, order).
- **`apps/desktop/src/app/settings/providers-settings.tsx`** + `types/hermes.ts` — group by backend `provider`/`provider_label`; API-keys search; priority-sorted lists.

### Follow-up (teknium1): OAuth status auto-extends too

The contributor's catalog auto-extends Accounts-tab *membership*, but catalog-only cards carried `status_fn=None` and had no hardcoded branch in `_resolve_provider_status` — so a future OAuth provider plugin would render permanently logged-out. Fixed by falling through to the canonical `hermes_cli.auth.get_auth_status(provider_id)` slug dispatcher and adapting its shape. Existing hardcoded branches (nous, codex, qwen, minimax, xai) still win; unknown providers degrade cleanly to logged-out.

## Parity contract (locked by tests)

```
keys(/api/env provider rows) ∪ ids(/api/providers/oauth) ⊇ CANONICAL_PROVIDERS
```

Asserted as an invariant against the live endpoints (not a snapshot/count) — add a provider plugin and it appears on the right tab, with correct status, automatically.

## Validation

| | Result |
|---|---|
| `test_provider_catalog` + `test_provider_parity` + `test_web_oauth_dispatch` + `test_web_server` | 346 passed |
| desktop vitest (`providers-settings`, `helpers`) | 24 passed |
| `npm run typecheck` | clean |
| Live: 37/37 canonical providers covered, 0 missing | ✓ |
| Live: generic OAuth fallthrough resolves real status for catalog-only providers | ✓ |

Supersedes #48800 and #48722. Contributor authorship preserved across 7 cherry-picked commits.

## Infographic

![one-provider-source](https://v3b.fal.media/files/b/0a9eee35/tQMmIcSla5PYhM0pKYShR_ZiuPbEbz.png)
