### PR TITLE
fix(cli): default cli_refresh_interval to 1.0 to keep status bar alive

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1582,11 +1582,13 @@ DEFAULT_CONFIG = {
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.
         "tui_status_indicator": "kaomoji",
         # Seconds between prompt_toolkit redraws in the classic CLI when idle.
-        # 0 = disabled (no background refresh — the pre-0.15.2 behaviour).
-        # Positive values e.g. 1.0 keep wall-clock status-bar read-outs
-        # (idle-since-last-turn) ticking but may fight terminal auto-scroll in
-        # non-fullscreen mode on some emulators (Xshell, iTerm2, etc.).
-        "cli_refresh_interval": 0,
+        # Default 1.0 keeps the wall-clock status-bar read-outs (idle-since-
+        # last-turn) ticking and keeps the bottom chrome alive during idle —
+        # without it prompt_toolkit stops repainting the status bar after a
+        # turn and it can go stale/disappear (#45592).
+        # Set 0 to disable the background refresh if it fights terminal
+        # auto-scroll in non-fullscreen mode on some emulators (#48309).
+        "cli_refresh_interval": 1.0,
         "user_message_preview": {  # CLI: how many submitted user-message lines to echo back in scrollback
             "first_lines": 2,
             "last_lines": 2,

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -956,13 +956,14 @@ class TestInterimAssistantMessageConfig:
 
 
 class TestCliRefreshIntervalConfig:
-    """Test the CLI refresh_interval config default (#48309)."""
+    """Test the CLI refresh_interval config default (#45592 / #48309)."""
 
-    def test_default_config_disables_cli_refresh_interval(self):
-        """cli_refresh_interval defaults to 0 (disabled) to avoid
-        background redraws that fight terminal auto-scroll-on-output
-        in non-fullscreen mode (Xshell, iTerm2, Windows Terminal)."""
-        assert DEFAULT_CONFIG["display"]["cli_refresh_interval"] == 0
+    def test_default_config_enables_cli_refresh_interval(self):
+        """cli_refresh_interval defaults to 1.0 so the idle status-bar
+        clock keeps ticking and the bottom chrome stays alive during
+        idle (#45592). Users on emulators where the periodic redraw
+        fights auto-scroll can set it to 0 (#48309)."""
+        assert DEFAULT_CONFIG["display"]["cli_refresh_interval"] == 1.0
 
 
 class TestDiscordChannelPromptsConfig:


### PR DESCRIPTION
## Summary
The classic CLI status bar stays alive during idle again. `display.cli_refresh_interval` now defaults to `1.0`, restoring the #45592 idle-clock fix.

PR #49056 set the default to `0`, which reverted #45592: without a periodic invalidate, prompt_toolkit stops repainting the bottom chrome after a turn completes, so the status bar goes stale and disappears during idle.

## Changes
- `hermes_cli/config.py`: `display.cli_refresh_interval` default `0` → `1.0`.
- `tests/hermes_cli/test_config.py`: assert the default is `1.0`.

## Validation
| | Before (#49056) | After |
|---|---|---|
| Idle status bar | goes stale / disappears after a turn | keeps ticking, stays painted |
| Opt-out (`cli_refresh_interval: 0`) | n/a (was the default) | still available for auto-scroll emulators |
| `tests/hermes_cli/test_config.py` | — | 101/101 pass |

The config knob from #49056 stays — users on emulators where the per-second redraw fights auto-scroll (#48309) can set `display.cli_refresh_interval: 0`. The default just optimizes for the common case: a live, present status bar.

## Infographic

![status-bar-stays-alive](https://v3b.fal.media/files/b/0a9eee5f/c3vsLc_SxcJP9aLh3u2wk_lDUdTsxn.png)
