### PR TITLE
feat(msteams): Microsoft Teams voice (CVI) + video + chat + governance

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -720,6 +720,10 @@ class TeamsAdapter(BasePlatformAdapter):
             str(extra.get("audit_channel") or "").strip()
             or os.getenv("TEAMS_AUDIT_CHANNEL", "").strip()
         )
+        self._transcribe_voice = str(
+            extra.get("transcribe_voice_messages", "")
+            or os.getenv("TEAMS_TRANSCRIBE_VOICE_MESSAGES", "")
+        ).strip().lower() in ("1", "true", "yes", "on")
 
     async def connect(self) -> bool:
         # Lazy-install the Teams SDK on demand (parity with Slack/Discord/etc.),
@@ -772,6 +776,13 @@ class TeamsAdapter(BasePlatformAdapter):
                 ctx: ActivityContext[AdaptiveCardInvokeActivity],
             ) -> InvokeResponse[AdaptiveCardActionMessageResponse]:
                 return await self._on_card_action(ctx)
+
+            # "Ask Hermes about this" message command (composeExtension submit on a
+            # selected message). Requires the Teams app manifest to declare a
+            # composeExtensions command id "askHermes" with context ["message"].
+            @self._app.on_message_ext_submit
+            async def _handle_msg_ext(ctx):
+                return await self._on_message_action(ctx)
 
             # initialize() calls register_route() on the bridge, which adds
             # POST /api/messages to aiohttp_app automatically
@@ -975,7 +986,9 @@ class TeamsAdapter(BasePlatformAdapter):
         elif "video" in media_kinds:
             msg_type = MessageType.VIDEO
         elif "audio" in media_kinds:
-            msg_type = MessageType.AUDIO
+            # Opt-in: treat audio clips as VOICE so the gateway's STT transcribes
+            # them and folds the transcript into the agent's turn.
+            msg_type = MessageType.VOICE if self._transcribe_voice else MessageType.AUDIO
         else:
             msg_type = MessageType.TEXT
 
@@ -988,6 +1001,65 @@ class TeamsAdapter(BasePlatformAdapter):
             message_id=msg_id,
         )
         await self.handle_message(event)
+
+    @staticmethod
+    def _extract_message_action(value: "Any") -> tuple[str, str]:
+        """Pull ``(command_id, quoted_text)`` from a message-ext submit value.
+
+        Defensive across dict / object payload shapes; strips HTML from the
+        selected message body.
+        """
+        import re
+
+        data = value if isinstance(value, dict) else (getattr(value, "__dict__", None) or {})
+        command_id = str(data.get("commandId") or data.get("command_id") or "")
+        payload = data.get("messagePayload") or data.get("message_payload") or {}
+        if not isinstance(payload, dict):
+            payload = getattr(payload, "__dict__", None) or {}
+        quoted = ""
+        body = payload.get("body")
+        if isinstance(body, dict):
+            quoted = body.get("content") or ""
+        quoted = quoted or payload.get("text") or ""
+        if "<" in quoted:
+            quoted = re.sub(r"<[^>]+>", " ", quoted)
+        return command_id, re.sub(r"\s+", " ", quoted).strip()
+
+    async def _on_message_action(self, ctx: "Any") -> None:
+        """Handle the "Ask Hermes about this" message command — dispatch the
+        quoted message through the normal message path so the answer posts back."""
+        try:
+            activity = getattr(ctx, "activity", None)
+            command_id, quoted = self._extract_message_action(getattr(activity, "value", None))
+            if command_id and command_id != "askHermes":
+                return None
+            if not quoted:
+                return None
+            conv = getattr(activity, "conversation", None)
+            from_account = getattr(activity, "from_", None)
+            conv_type = getattr(conv, "conversation_type", None) or ""
+            chat_type = (
+                "dm" if conv_type == "personal"
+                else "channel" if conv_type == "channel"
+                else "group"
+            )
+            source = self.build_source(
+                chat_id=getattr(conv, "id", "") or "",
+                chat_name=getattr(conv, "name", None) or "",
+                chat_type=chat_type,
+                user_id=str(getattr(from_account, "aad_object_id", None) or getattr(from_account, "id", "")),
+                user_name=getattr(from_account, "name", None) or "",
+                guild_id=getattr(conv, "tenant_id", None) or self._tenant_id,
+            )
+            event = MessageEvent(
+                text=f"Regarding this Teams message:\n\n> {quoted}\n\nPlease help with it.",
+                source=source,
+                message_type=MessageType.TEXT,
+            )
+            await self.handle_message(event)
+        except Exception as e:  # noqa: BLE001 — never crash the invoke path
+            logger.warning("[teams] message action failed: %s", e)
+        return None
 
     async def _send_card(self, chat_id: str, card: "AdaptiveCard") -> "Any":
         """Send an AdaptiveCard, using a stored ConversationReference when available."""

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -521,10 +521,11 @@ async def _standalone_send(
     env var.  ``chat_id`` is validated to match the documented Bot
     Framework ID character set so it cannot escape the URL path.
 
-    ``media_files`` and ``force_document`` are accepted for signature
-    parity but not implemented for the standalone path; messages with
-    attachments will send as text-only.  The live adapter handles
-    attachments via the SDK.
+    ``media_files`` are uploaded to SharePoint (OneDrive) and attached as native
+    Teams file cards when ``sharePointSiteId`` + the bot's Graph
+    ``Sites.ReadWrite.All`` permission are configured; otherwise (or on upload
+    failure) the message sends as text-only.  ``force_document`` is accepted for
+    signature parity.  The live adapter handles attachments via the SDK.
     """
     extra = getattr(pconfig, "extra", {}) or {}
     client_id = os.getenv("TEAMS_CLIENT_ID") or extra.get("client_id", "")
@@ -588,13 +589,31 @@ async def _standalone_send(
             if not access_token:
                 return {"error": "Teams standalone send: token response missing access_token"}
 
+            # Upload any media_files to SharePoint and attach them as file cards
+            # (best-effort; needs sharePointSiteId + Graph Sites.ReadWrite.All).
+            all_attachments = list(attachments or [])
+            if media_files:
+                from . import graph_files
+
+                creds = graph_files.resolve_sharepoint(extra)
+                if creds:
+                    for f in media_files:
+                        try:
+                            with open(f, "rb") as fh:
+                                data = fh.read()
+                        except OSError:
+                            continue
+                        up = await graph_files.upload_and_build_card(creds, os.path.basename(str(f)), data)
+                        if up:
+                            all_attachments.append(up["card"])
+
             activity = {
                 "type": "message",
                 "text": message,
                 "textFormat": "markdown",
             }
-            if attachments:
-                activity["attachments"] = attachments
+            if all_attachments:
+                activity["attachments"] = all_attachments
             async with session.post(
                 activities_url,
                 json=activity,

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -707,6 +707,19 @@ class TeamsAdapter(BasePlatformAdapter):
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
         self._conv_refs: Dict[str, Any] = {}
+        # Governance: DLP outbound redaction + audit-log channel mirror (opt-in).
+        from .dlp import DlpConfig
+
+        dlp_raw = extra.get("dlp")
+        if dlp_raw is None and os.getenv("TEAMS_DLP_ENABLED", "").strip().lower() in (
+            "1", "true", "yes", "on",
+        ):
+            dlp_raw = {"enabled": True}
+        self._dlp_cfg = DlpConfig.from_dict(dlp_raw if isinstance(dlp_raw, dict) else None)
+        self._audit_channel = (
+            str(extra.get("audit_channel") or "").strip()
+            or os.getenv("TEAMS_AUDIT_CHANNEL", "").strip()
+        )
 
     async def connect(self) -> bool:
         # Lazy-install the Teams SDK on demand (parity with Slack/Discord/etc.),
@@ -1156,6 +1169,12 @@ class TeamsAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Teams app not initialized")
 
         formatted = self.format_message(content)
+        # DLP: redact secrets/PII on every outbound reply before it hits Teams.
+        # (Redact before truncation so a secret can't be sliced into a fragment.)
+        if self._dlp_cfg.enabled:
+            from .dlp import redact
+
+            formatted, _n = redact(formatted, self._dlp_cfg)
         chunks = self.truncate_message(formatted)
         last_message_id = None
 
@@ -1179,7 +1198,27 @@ class TeamsAdapter(BasePlatformAdapter):
             except Exception as e:
                 return SendResult(success=False, error=str(e), retryable=True)
 
+        # Audit: mirror the (already redacted) reply to the audit channel. Fires
+        # at the delivery choke point, so streamed/threaded replies are covered.
+        await self._mirror_to_audit(chat_id, formatted)
         return SendResult(success=True, message_id=last_message_id)
+
+    async def _mirror_to_audit(self, chat_id: str, redacted_text: str) -> None:
+        """Mirror an outbound reply to the audit-log channel (best-effort).
+
+        The text is already DLP-redacted by ``send()``. A loop guard skips the
+        audit channel's own traffic so it doesn't mirror itself.
+        """
+        if not self._audit_channel or not self._app:
+            return
+        if chat_id == self._audit_channel:  # loop guard
+            return
+        excerpt = redacted_text if len(redacted_text) <= 1500 else redacted_text[:1500] + "…"
+        line = f"🧾 Reply in {chat_id}:\n{excerpt}"
+        try:
+            await self._app.send(self._audit_channel, line)
+        except Exception as e:  # noqa: BLE001 — auditing must never break delivery
+            logger.debug("[teams] audit mirror failed: %s", e)
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         if not self._app:

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -502,6 +502,7 @@ async def _standalone_send(
     thread_id: Optional[str] = None,
     media_files: Optional[list] = None,
     force_document: bool = False,
+    attachments: Optional[list] = None,
 ) -> Dict[str, Any]:
     """Acquire a Bot Framework bearer token and POST a single message activity.
 
@@ -592,6 +593,8 @@ async def _standalone_send(
                 "text": message,
                 "textFormat": "markdown",
             }
+            if attachments:
+                activity["attachments"] = attachments
             async with session.post(
                 activities_url,
                 json=activity,
@@ -614,6 +617,35 @@ async def _standalone_send(
     except Exception as e:
         logger.debug("Teams standalone send raised", exc_info=True)
         return {"error": f"Teams standalone send failed: {e}"}
+
+
+async def _standalone_send_file(
+    pconfig,
+    chat_id: str,
+    content: bytes,
+    filename: str,
+    *,
+    content_type: str = "application/octet-stream",
+    caption: str = "",
+) -> Dict[str, Any]:
+    """Upload ``content`` to SharePoint and post it to a Teams chat as a file card.
+
+    Requires ``sharePointSiteId`` (+ the Bot Framework app creds, which must hold the
+    Graph ``Sites.ReadWrite.All`` application permission). Falls back to a text-only
+    message with a markdown link when the native card can't be built; returns an
+    error dict when SharePoint isn't configured so callers can degrade to text."""
+    from . import graph_files
+
+    extra = getattr(pconfig, "extra", {}) or {}
+    creds = graph_files.resolve_sharepoint(extra)
+    if creds is None:
+        return {"error": "Teams file send: sharePointSiteId / app credentials not configured"}
+    uploaded = await graph_files.upload_and_build_card(creds, filename, content, content_type)
+    if uploaded is None:
+        return {"error": "Teams file send: SharePoint upload failed"}
+    link = f"📎 [{uploaded['name']}]({uploaded['share_url']})" if uploaded.get("share_url") else ""
+    text = f"{caption}\n\n{link}".strip() if caption else (link or uploaded["name"])
+    return await _standalone_send(pconfig, chat_id=chat_id, message=text, attachments=[uploaded["card"]])
 
 
 # Keep the old name as an alias so existing test imports don't break.

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1181,10 +1181,14 @@ class TeamsAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Teams app not initialized")
 
         cmd_preview = command[:2000] + "..." if len(command) > 2000 else command
+        # DLP: redact secrets in the command/reason shown on the approval card.
+        cmd_preview = self._dlp_text(cmd_preview)
+        description = self._dlp_text(description)
         # Truncated for button data payload — just enough to reconstruct the card body.
+        btn_cmd = command[:200] + "..." if len(command) > 200 else command
         btn_data_base = {
             "session_key": session_key,
-            "cmd": command[:200] + "..." if len(command) > 200 else command,
+            "cmd": self._dlp_text(btn_cmd),
             "desc": description,
         }
 
@@ -1292,6 +1296,17 @@ class TeamsAdapter(BasePlatformAdapter):
         except Exception as e:  # noqa: BLE001 — auditing must never break delivery
             logger.debug("[teams] audit mirror failed: %s", e)
 
+    def _dlp_text(self, text: str) -> str:
+        """Redact a string with the configured DLP policy (no-op when disabled).
+
+        Used for card / caption text that doesn't pass through ``send()``."""
+        if not text or not self._dlp_cfg.enabled:
+            return text
+        from .dlp import redact
+
+        out, _ = redact(text, self._dlp_cfg)
+        return out
+
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         if not self._app:
             return
@@ -1329,7 +1344,7 @@ class TeamsAdapter(BasePlatformAdapter):
             attachment = Attachment(content_type=mime_type, content_url=content_url)
             activity = MessageActivityInput().add_attachments(attachment)
             if caption:
-                activity = activity.add_text(caption)
+                activity = activity.add_text(self._dlp_text(caption))
 
             conv_ref = self._conv_refs.get(chat_id)
             if conv_ref:

--- a/plugins/platforms/teams/dlp.py
+++ b/plugins/platforms/teams/dlp.py
@@ -14,7 +14,7 @@ progress when DLP is on (handled adapter-side; this module is the scrubber).
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 # ── built-in detectors ───────────────────────────────────────────────────────
 
@@ -56,11 +56,6 @@ class DlpConfig:
             custom_patterns=tuple(str(p) for p in custom),
             placeholder=str(raw.get("placeholder") or "[REDACTED:{label}]"),
         )
-
-
-@dataclass
-class _Compiled:
-    custom: list[re.Pattern] = field(default_factory=list)
 
 
 def _ph(config: DlpConfig, label: str) -> str:

--- a/plugins/platforms/teams/dlp.py
+++ b/plugins/platforms/teams/dlp.py
@@ -1,0 +1,99 @@
+"""DLP redaction for outbound Teams messages.
+
+Scrubs secrets / PII from every outbound surface before it reaches Teams
+(mirrors openclaw #92081's DLP). Pure logic — the adapter calls :func:`redact`
+at its delivery choke point (block sends, streamed replies, edits, card strings).
+
+Built-in categories: ``email``, ``secret`` (API keys / tokens). Operators can add
+``custom_patterns`` (regexes). Each hit becomes a configurable placeholder, e.g.
+``[REDACTED:email]``. Because per-token streaming can't retract a secret that
+completes across chunk boundaries, the adapter downgrades partial streaming to
+progress when DLP is on (handled adapter-side; this module is the scrubber).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# ── built-in detectors ───────────────────────────────────────────────────────
+
+_EMAIL = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+
+# Secrets: known-prefixed tokens (full-match redaction).
+_SECRET_PATTERNS = (
+    re.compile(r"\bsk-(?:proj|ant|live|test)-[A-Za-z0-9_-]{8,}\b"),  # OpenAI/Anthropic/Stripe
+    re.compile(r"\bsk-[A-Za-z0-9]{20,}\b"),  # generic sk- key
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),  # AWS access key id
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),  # Slack token
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"),  # GitHub token
+    re.compile(r"\bBearer\s+[A-Za-z0-9._\-]{16,}\b"),  # bearer header value
+    re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{6,}\b"),  # JWT
+)
+# "api_key: <value>" / "password=<value>" — redact the VALUE only.
+_SECRET_ASSIGN = re.compile(
+    r"(?i)\b(api[_-]?key|secret|token|password|passwd|pwd)\b(\s*[:=]\s*)(\S{6,})"
+)
+
+_BUILTIN = ("email", "secret")
+
+
+@dataclass(frozen=True)
+class DlpConfig:
+    enabled: bool = False
+    categories: tuple[str, ...] = _BUILTIN
+    custom_patterns: tuple[str, ...] = ()
+    placeholder: str = "[REDACTED:{label}]"
+
+    @classmethod
+    def from_dict(cls, raw: dict | None) -> "DlpConfig":
+        raw = raw or {}
+        cats = raw.get("categories")
+        custom = raw.get("custom_patterns") or raw.get("customPatterns") or []
+        return cls(
+            enabled=bool(raw.get("enabled", False)),
+            categories=tuple(cats) if cats else _BUILTIN,
+            custom_patterns=tuple(str(p) for p in custom),
+            placeholder=str(raw.get("placeholder") or "[REDACTED:{label}]"),
+        )
+
+
+@dataclass
+class _Compiled:
+    custom: list[re.Pattern] = field(default_factory=list)
+
+
+def _ph(config: DlpConfig, label: str) -> str:
+    try:
+        return config.placeholder.format(label=label)
+    except (KeyError, IndexError, ValueError):
+        return f"[REDACTED:{label}]"
+
+
+def redact(text: str, config: DlpConfig) -> tuple[str, int]:
+    """Return ``(redacted_text, num_redactions)``. No-op when disabled/empty."""
+    if not config.enabled or not text:
+        return text, 0
+    count = 0
+
+    if "secret" in config.categories:
+        for pat in _SECRET_PATTERNS:
+            text, n = pat.subn(_ph(config, "secret"), text)
+            count += n
+        text, n = _SECRET_ASSIGN.subn(
+            lambda m: f"{m.group(1)}{m.group(2)}{_ph(config, 'secret')}", text
+        )
+        count += n
+
+    if "email" in config.categories:
+        text, n = _EMAIL.subn(_ph(config, "email"), text)
+        count += n
+
+    for raw in config.custom_patterns:
+        try:
+            text, n = re.subn(raw, _ph(config, "custom"), text)
+            count += n
+        except re.error:
+            continue  # skip a malformed operator pattern rather than crash
+
+    return text, count

--- a/plugins/platforms/teams/dlp.py
+++ b/plugins/platforms/teams/dlp.py
@@ -1,7 +1,7 @@
 """DLP redaction for outbound Teams messages.
 
-Scrubs secrets / PII from every outbound surface before it reaches Teams
-(mirrors openclaw #92081's DLP). Pure logic — the adapter calls :func:`redact`
+Scrubs secrets / PII from every outbound surface before it reaches Teams.
+Pure logic — the adapter calls :func:`redact`
 at its delivery choke point (block sends, streamed replies, edits, card strings).
 
 Built-in categories: ``email``, ``secret`` (API keys / tokens). Operators can add

--- a/plugins/platforms/teams/graph_files.py
+++ b/plugins/platforms/teams/graph_files.py
@@ -8,7 +8,8 @@ a link + a native Teams file card. The flow mirrors the Graph contract:
 
 Requires the bot's AAD app to hold the Graph **application** permission
 ``Sites.ReadWrite.All`` (admin-consented). When unconfigured, callers fall back to
-text-only delivery.
+text-only delivery. Uses Graph *simple* upload (≤4 MB) — fine for minutes/cards;
+larger files would need an upload session (follow-up).
 """
 
 from __future__ import annotations

--- a/plugins/platforms/teams/graph_files.py
+++ b/plugins/platforms/teams/graph_files.py
@@ -1,4 +1,4 @@
-"""Microsoft Graph → SharePoint file upload, for sending files into Teams chats.
+"""Microsoft Graph → SharePoint (OneDrive) file upload, for sending files into Teams chats.
 
 Bots can't post files via ``/me/drive``; group chats and channels need the file
 uploaded to a SharePoint site (configured via ``sharePointSiteId``) and shared with

--- a/plugins/platforms/teams/graph_files.py
+++ b/plugins/platforms/teams/graph_files.py
@@ -1,0 +1,141 @@
+"""Microsoft Graph → SharePoint file upload, for sending files into Teams chats.
+
+Bots can't post files via ``/me/drive``; group chats and channels need the file
+uploaded to a SharePoint site (configured via ``sharePointSiteId``) and shared with
+a link + a native Teams file card. The flow mirrors the Graph contract:
+
+    upload → sharing link → driveItem (eTag/webDavUrl) → file-info card
+
+Requires the bot's AAD app to hold the Graph **application** permission
+``Sites.ReadWrite.All`` (admin-consented). When unconfigured, callers fall back to
+text-only delivery.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+from urllib.parse import quote
+
+logger = logging.getLogger(__name__)
+
+GRAPH_ROOT = "https://graph.microsoft.com/v1.0"
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+FILE_INFO_CARD_TYPE = "application/vnd.microsoft.teams.card.file.info"
+UPLOAD_FOLDER = "HermesShared"  # organizes bot-uploaded files in the site drive
+
+
+def resolve_sharepoint(extra: Optional[dict] = None) -> Optional[dict]:
+    """Resolve ``{site_id, client_id, client_secret, tenant_id}`` or ``None``.
+
+    Site id from ``TEAMS_SHAREPOINT_SITE_ID`` / config ``share_point_site_id``
+    (``sharePointSiteId`` accepted too); credentials reuse the Bot Framework app."""
+    extra = extra or {}
+    site_id = (
+        os.getenv("TEAMS_SHAREPOINT_SITE_ID")
+        or extra.get("share_point_site_id")
+        or extra.get("sharePointSiteId")
+        or ""
+    ).strip()
+    client_id = (os.getenv("TEAMS_CLIENT_ID") or extra.get("client_id") or "").strip()
+    client_secret = (os.getenv("TEAMS_CLIENT_SECRET") or extra.get("client_secret") or "").strip()
+    tenant_id = (os.getenv("TEAMS_TENANT_ID") or extra.get("tenant_id") or "").strip()
+    if not (site_id and client_id and client_secret and tenant_id):
+        return None
+    return {"site_id": site_id, "client_id": client_id, "client_secret": client_secret, "tenant_id": tenant_id}
+
+
+def build_file_info_card(props: dict) -> dict:
+    """Build a native Teams file-info card attachment from driveItem properties."""
+    raw_etag = str(props.get("eTag") or "")
+    unique_id = raw_etag.strip("\"'").replace("{", "").replace("}", "").split(",")[0] or raw_etag
+    name = str(props.get("name") or "file")
+    dot = name.rfind(".")
+    file_type = name[dot + 1:].lower() if dot >= 0 else ""
+    return {
+        "contentType": FILE_INFO_CARD_TYPE,
+        "contentUrl": props.get("webDavUrl"),
+        "name": name,
+        "content": {"uniqueId": unique_id, "fileType": file_type},
+    }
+
+
+async def _graph_token(session, creds: dict) -> Optional[str]:
+    url = f"https://login.microsoftonline.com/{creds['tenant_id']}/oauth2/v2.0/token"
+    async with session.post(
+        url,
+        data={
+            "grant_type": "client_credentials",
+            "client_id": creds["client_id"],
+            "client_secret": creds["client_secret"],
+            "scope": GRAPH_SCOPE,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    ) as r:
+        if r.status >= 400:
+            logger.warning("[teams] graph token failed (%s): %s", r.status, (await r.text())[:200])
+            return None
+        return (await r.json()).get("access_token")
+
+
+async def _upload(session, token: str, site_id: str, filename: str, content: bytes, content_type: str) -> Optional[dict]:
+    path = f"/{UPLOAD_FOLDER}/{quote(filename)}"
+    url = f"{GRAPH_ROOT}/sites/{site_id}/drive/root:{path}:/content"
+    async with session.put(
+        url, data=content,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": content_type},
+    ) as r:
+        if r.status >= 400:
+            logger.warning("[teams] sharepoint upload failed (%s): %s", r.status, (await r.text())[:200])
+            return None
+        return await r.json()
+
+
+async def _sharing_link(session, token: str, site_id: str, item_id: str) -> Optional[str]:
+    url = f"{GRAPH_ROOT}/sites/{site_id}/drive/items/{item_id}/createLink"
+    async with session.post(
+        url, json={"type": "view", "scope": "organization"},
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+    ) as r:
+        if r.status >= 400:
+            return None
+        return ((await r.json()).get("link") or {}).get("webUrl")
+
+
+async def _drive_item_props(session, token: str, site_id: str, item_id: str) -> Optional[dict]:
+    url = f"{GRAPH_ROOT}/sites/{site_id}/drive/items/{item_id}?$select=eTag,webDavUrl,name"
+    async with session.get(url, headers={"Authorization": f"Bearer {token}"}) as r:
+        if r.status >= 400:
+            return None
+        return await r.json()
+
+
+async def upload_and_build_card(
+    creds: dict, filename: str, content: bytes, content_type: str = "application/octet-stream"
+) -> Optional[dict]:
+    """Upload ``content`` to SharePoint and return ``{card, share_url, name}`` or None.
+
+    Best-effort: any Graph failure returns ``None`` so the caller degrades to text."""
+    try:
+        import aiohttp
+    except ImportError:
+        return None
+    timeout = aiohttp.ClientTimeout(total=30.0)
+    try:
+        async with aiohttp.ClientSession(trust_env=True, timeout=timeout) as session:
+            token = await _graph_token(session, creds)
+            if not token:
+                return None
+            uploaded = await _upload(session, token, creds["site_id"], filename, content, content_type)
+            if not uploaded or not uploaded.get("id"):
+                return None
+            item_id = uploaded["id"]
+            share_url = await _sharing_link(session, token, creds["site_id"], item_id)
+            props = await _drive_item_props(session, token, creds["site_id"], item_id)
+            if not props or not props.get("webDavUrl"):
+                return None
+            return {"card": build_file_info_card(props), "share_url": share_url or uploaded.get("webUrl"), "name": props.get("name") or filename}
+    except Exception:  # noqa: BLE001 — file delivery is best-effort
+        logger.warning("[teams] sharepoint upload_and_build_card failed", exc_info=True)
+        return None

--- a/plugins/platforms/teams/plugin.yaml
+++ b/plugins/platforms/teams/plugin.yaml
@@ -54,3 +54,7 @@ optional_env:
     description: "Conversation ID to mirror (DLP-redacted) agent replies to for compliance"
     prompt: "Audit-log channel conversation ID (or empty)"
     password: false
+  - name: TEAMS_TRANSCRIBE_VOICE_MESSAGES
+    description: "Transcribe inbound Teams voice clips and fold the text into the agent's turn"
+    prompt: "Transcribe voice messages? (true/false)"
+    password: false

--- a/plugins/platforms/teams/plugin.yaml
+++ b/plugins/platforms/teams/plugin.yaml
@@ -46,3 +46,11 @@ optional_env:
     description: "Display name for the Teams home channel"
     prompt: "Home channel display name"
     password: false
+  - name: TEAMS_DLP_ENABLED
+    description: "Redact secrets/PII (emails, API keys, tokens) from every outbound reply"
+    prompt: "Enable DLP redaction? (true/false)"
+    password: false
+  - name: TEAMS_AUDIT_CHANNEL
+    description: "Conversation ID to mirror (DLP-redacted) agent replies to for compliance"
+    prompt: "Audit-log channel conversation ID (or empty)"
+    password: false

--- a/plugins/platforms/teams/plugin.yaml
+++ b/plugins/platforms/teams/plugin.yaml
@@ -31,7 +31,7 @@ optional_env:
     prompt: "Webhook port"
     password: false
   - name: TEAMS_SHAREPOINT_SITE_ID
-    description: "SharePoint site id (host,siteGuid,webGuid) for sending files into chats; needs the bot app's Graph Sites.ReadWrite.All permission"
+    description: "SharePoint (OneDrive) site id (host,siteGuid,webGuid) for sending files into chats; needs the bot app's Graph Sites.ReadWrite.All permission"
     prompt: "SharePoint site id"
     password: false
   - name: TEAMS_ALLOWED_USERS

--- a/plugins/platforms/teams/plugin.yaml
+++ b/plugins/platforms/teams/plugin.yaml
@@ -30,6 +30,10 @@ optional_env:
     description: "Webhook listen port (Bot Framework default: 3978)"
     prompt: "Webhook port"
     password: false
+  - name: TEAMS_SHAREPOINT_SITE_ID
+    description: "SharePoint site id (host,siteGuid,webGuid) for sending files into chats; needs the bot app's Graph Sites.ReadWrite.All permission"
+    prompt: "SharePoint site id"
+    password: false
   - name: TEAMS_ALLOWED_USERS
     description: "Comma-separated Teams user IDs / UPNs allowed to talk to the bot"
     prompt: "Allowed users (comma-separated)"

--- a/plugins/platforms/teams/tests/test_dlp.py
+++ b/plugins/platforms/teams/tests/test_dlp.py
@@ -1,0 +1,60 @@
+"""Tests for the Teams DLP redaction engine."""
+
+from __future__ import annotations
+
+from plugins.platforms.teams.dlp import DlpConfig, redact
+
+ON = DlpConfig(enabled=True)
+
+
+def test_disabled_is_noop():
+    cfg = DlpConfig(enabled=False)
+    out, n = redact("my key is sk-proj-abcdefghijklmnop and a@b.com", cfg)
+    assert n == 0 and "sk-proj-" in out and "a@b.com" in out
+
+
+def test_redacts_email():
+    out, n = redact("contact me at alaa.h@example.com please", ON)
+    assert "alaa.h@example.com" not in out
+    assert "[REDACTED:email]" in out and n == 1
+
+
+def test_redacts_openai_anthropic_keys():
+    out, n = redact("key sk-proj-ABCDEFGH12345678ZZ and sk-ant-api03-aaaaaaaaaa", ON)
+    assert "sk-proj-" not in out and "sk-ant-" not in out
+    assert out.count("[REDACTED:secret]") == 2 and n == 2
+
+
+def test_redacts_aws_and_github_and_jwt():
+    out, _ = redact("AKIAIOSFODNN7EXAMPLE ghp_abcdefghijklmnopqrstuvwxyz0123", ON)
+    assert "AKIA" not in out and "ghp_" not in out
+
+
+def test_redacts_assignment_value_keeps_key():
+    out, n = redact("password = hunter2supersecret", ON)
+    assert "hunter2supersecret" not in out
+    assert "password" in out and "[REDACTED:secret]" in out and n == 1
+
+
+def test_custom_pattern():
+    cfg = DlpConfig(enabled=True, custom_patterns=(r"PROJ-\d{4}",))
+    out, n = redact("ticket PROJ-1234 is internal", cfg)
+    assert "PROJ-1234" not in out and "[REDACTED:custom]" in out and n == 1
+
+
+def test_malformed_custom_pattern_skipped():
+    cfg = DlpConfig(enabled=True, custom_patterns=(r"[unclosed",))
+    out, n = redact("nothing to redact here", cfg)  # must not raise
+    assert out == "nothing to redact here" and n == 0
+
+
+def test_category_selection_email_only():
+    cfg = DlpConfig(enabled=True, categories=("email",))
+    out, _ = redact("sk-proj-ABCDEFGH12345678 and a@b.com", cfg)
+    assert "[REDACTED:email]" in out
+    assert "sk-proj-" in out  # secret category off → key untouched
+
+
+def test_from_dict_camel_and_snake():
+    cfg = DlpConfig.from_dict({"enabled": True, "customPatterns": [r"X-\d+"]})
+    assert cfg.enabled and cfg.custom_patterns == (r"X-\d+",)

--- a/plugins/platforms/teams/tests/test_governance.py
+++ b/plugins/platforms/teams/tests/test_governance.py
@@ -1,0 +1,66 @@
+"""Integration tests for the Teams adapter governance wiring (DLP + audit)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from plugins.platforms.teams.adapter import TeamsAdapter
+from plugins.platforms.teams.dlp import DlpConfig
+
+
+class _FakeApp:
+    def __init__(self):
+        self.sent: list[tuple[str, str]] = []
+
+    async def send(self, chat_id, text):
+        self.sent.append((chat_id, text))
+        return type("R", (), {"id": "m1"})()
+
+    async def reply(self, *_a, **_k):
+        raise RuntimeError("no threading in test")
+
+
+def _adapter(*, dlp: bool, audit: str | None) -> TeamsAdapter:
+    """Construct an adapter without the heavy gateway __init__."""
+    a = TeamsAdapter.__new__(TeamsAdapter)
+    a._dlp_cfg = DlpConfig(enabled=dlp)
+    a._audit_channel = audit or ""
+    a._app = _FakeApp()
+    a.format_message = lambda c: c  # identity for the test
+    a.truncate_message = lambda c: [c]
+    return a
+
+
+def test_send_redacts_outbound():
+    a = _adapter(dlp=True, audit=None)
+    asyncio.run(a.send("CHAT1", "mail me at a.b@example.com, key sk-proj-ABCDEFGH12345678"))
+    chat, text = a._app.sent[0]
+    assert chat == "CHAT1"
+    assert "a.b@example.com" not in text and "sk-proj-" not in text
+    assert "[REDACTED:email]" in text and "[REDACTED:secret]" in text
+
+
+def test_audit_mirror_sends_redacted_copy():
+    a = _adapter(dlp=True, audit="AUDIT")
+    asyncio.run(a.send("CHAT1", "secret sk-ant-api03-zzzzzzzzzz here"))
+    # two sends: the reply to CHAT1 + the audit mirror to AUDIT
+    targets = [c for c, _ in a._app.sent]
+    assert "CHAT1" in targets and "AUDIT" in targets
+    audit_text = next(t for c, t in a._app.sent if c == "AUDIT")
+    assert "sk-ant-" not in audit_text and "[REDACTED:secret]" in audit_text
+    assert audit_text.startswith("🧾 Reply in CHAT1")
+
+
+def test_audit_loop_guard_skips_own_channel():
+    a = _adapter(dlp=False, audit="AUDIT")
+    asyncio.run(a.send("AUDIT", "a message posted into the audit channel itself"))
+    # only the direct send, no self-mirror
+    assert [c for c, _ in a._app.sent] == ["AUDIT"]
+
+
+def test_no_audit_when_unconfigured():
+    a = _adapter(dlp=True, audit=None)
+    asyncio.run(a.send("CHAT1", "hello"))
+    assert len(a._app.sent) == 1  # reply only, no mirror

--- a/plugins/platforms/teams/tests/test_governance.py
+++ b/plugins/platforms/teams/tests/test_governance.py
@@ -64,3 +64,12 @@ def test_no_audit_when_unconfigured():
     a = _adapter(dlp=True, audit=None)
     asyncio.run(a.send("CHAT1", "hello"))
     assert len(a._app.sent) == 1  # reply only, no mirror
+
+
+def test_dlp_text_helper_for_cards():
+    a = TeamsAdapter.__new__(TeamsAdapter)
+    a._dlp_cfg = DlpConfig(enabled=True)
+    out = a._dlp_text("approve: curl -H 'Authorization: Bearer abcdef0123456789xyz' x")
+    assert "Bearer abcdef" not in out and "[REDACTED:secret]" in out
+    a._dlp_cfg = DlpConfig(enabled=False)
+    assert a._dlp_text("sk-proj-ABCDEFGH12345678") == "sk-proj-ABCDEFGH12345678"

--- a/plugins/platforms/teams/tests/test_graph_files.py
+++ b/plugins/platforms/teams/tests/test_graph_files.py
@@ -1,0 +1,44 @@
+"""Tests for the SharePoint Graph file-send helpers (pure parts)."""
+
+from __future__ import annotations
+
+from plugins.platforms.teams.graph_files import (
+    FILE_INFO_CARD_TYPE,
+    build_file_info_card,
+    resolve_sharepoint,
+)
+
+
+def test_build_file_info_card_parses_etag_and_type():
+    card = build_file_info_card({
+        "eTag": '"{ABC-123-DEF},5"',  # quoted, braces, version suffix
+        "webDavUrl": "https://contoso.sharepoint.com/sites/x/Doc.docx",
+        "name": "Meeting minutes.docx",
+    })
+    assert card["contentType"] == FILE_INFO_CARD_TYPE
+    assert card["contentUrl"].endswith("Doc.docx")
+    assert card["name"] == "Meeting minutes.docx"
+    assert card["content"]["uniqueId"] == "ABC-123-DEF"  # stripped to the GUID
+    assert card["content"]["fileType"] == "docx"
+
+
+def test_build_file_info_card_no_extension():
+    card = build_file_info_card({"eTag": "GUID", "webDavUrl": "u", "name": "README"})
+    assert card["content"]["fileType"] == ""
+    assert card["content"]["uniqueId"] == "GUID"
+
+
+def test_resolve_sharepoint_none_without_config(monkeypatch):
+    for k in ("TEAMS_SHAREPOINT_SITE_ID", "TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"):
+        monkeypatch.delenv(k, raising=False)
+    assert resolve_sharepoint({}) is None
+
+
+def test_resolve_sharepoint_from_config(monkeypatch):
+    for k in ("TEAMS_SHAREPOINT_SITE_ID", "TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"):
+        monkeypatch.delenv(k, raising=False)
+    cfg = resolve_sharepoint({
+        "sharePointSiteId": "host,site-guid,web-guid",
+        "client_id": "c", "client_secret": "s", "tenant_id": "t",
+    })
+    assert cfg == {"site_id": "host,site-guid,web-guid", "client_id": "c", "client_secret": "s", "tenant_id": "t"}

--- a/plugins/platforms/teams/tests/test_message_action.py
+++ b/plugins/platforms/teams/tests/test_message_action.py
@@ -1,0 +1,43 @@
+"""Tests for the 'Ask Hermes about this' message-action extraction."""
+
+from __future__ import annotations
+
+from plugins.platforms.teams.adapter import TeamsAdapter
+
+extract = TeamsAdapter._extract_message_action
+
+
+def test_extract_html_body_and_command():
+    value = {
+        "commandId": "askHermes",
+        "messagePayload": {"body": {"content": "<div>What is <b>this</b>?</div>"}},
+    }
+    cmd, quoted = extract(value)
+    assert cmd == "askHermes"
+    assert quoted == "What is this ?".replace("  ", " ") or "this" in quoted
+    assert "<" not in quoted
+
+
+def test_extract_plain_text_payload():
+    cmd, quoted = extract({"command_id": "askHermes", "messagePayload": {"text": "hello world"}})
+    assert cmd == "askHermes" and quoted == "hello world"
+
+
+def test_extract_object_shaped_value():
+    class V:
+        def __init__(self):
+            self.commandId = "askHermes"
+            self.messagePayload = {"text": "from object"}
+
+    cmd, quoted = extract(V())
+    assert cmd == "askHermes" and quoted == "from object"
+
+
+def test_extract_empty_when_no_text():
+    cmd, quoted = extract({"commandId": "askHermes", "messagePayload": {}})
+    assert cmd == "askHermes" and quoted == ""
+
+
+def test_extract_handles_none():
+    cmd, quoted = extract(None)
+    assert cmd == "" and quoted == ""

--- a/plugins/teams_voice/README.md
+++ b/plugins/teams_voice/README.md
@@ -24,26 +24,25 @@ The worker is the **WebSocket client**; this plugin is the **server**
 actions, meeting-recap posting) are handled by the existing
 `plugins/platforms/teams` adapter (the `microsoft-teams-apps` SDK), **not** here.
 
-## Status
+## Status — implemented
 
 | Layer | File | Status |
 |---|---|---|
-| Bridge WS server (HMAC, lifecycle, dispatch, ping/pong) | `bridge_server.py` | ✅ scaffolded |
+| Bridge WS server (HMAC, replay guard, lifecycle, ping/pong, conn caps) | `bridge_server.py` | ✅ |
 | Wire protocol (mirrors worker `Protocol.cs`) | `protocol.py` | ✅ |
-| HMAC handshake + single-use replay guard | `hmac_auth.py` | ✅ |
-| Config resolution | `config.py` | ✅ |
-| Expression heuristic (port) | `expression.py` | ✅ + tests |
-| Viseme estimator (port; Latin) | `viseme_estimate.py` | ✅ + tests · Arabic TODO |
-| Group-call gate (port) | `group_call_gate.py` | ✅ + tests |
-| Status tool + CLI | `tools.py`, `cli.py` | ✅ minimal |
-| **Realtime speech-to-speech brain** | `realtime/openai_client.py` | 🚧 **stub** |
-| Streaming STT→agent→TTS path | — | ⬜ not started |
-| Vision store / `look_at_screen` / `show_to_caller` | — | ⬜ not started |
-| Outbound "call me back" | — | ⬜ not started |
+| Config (config.yaml + env, allowlist, vision cap, recap, …) | `config.py` | ✅ |
+| **Realtime mode** (OpenAI/Azure speech-to-speech) | `realtime/openai_client.py`, `handlers.py` | ✅ |
+| **Streaming mode** (STT→agent→TTS; needs `ffmpeg` on PATH) | `streaming_audio.py`, `handlers.py` | ✅ |
+| Echo guard · group gate · verbal interrupts (EN/AR) · DTMF · bilingual | `echo_guard.py`, `group_call_gate.py`, `verbal_interrupts.py` | ✅ + tests |
+| Vision (`look_at_screen` live/history) · ambient push · budget cap | `vision_store.py`, `vision_budget.py` | ✅ + tests |
+| Tools: consult, agent_task, show_to_caller, call_me_back, post_meeting_minutes | `realtime_tools.py`, `handlers.py` | ✅ |
+| Visemes (estimator; Latin) | `viseme_estimate.py` | ✅ + tests · Arabic + real ElevenLabs alignment = follow-up |
+| Meeting recap/minutes (text; posts via Bot Framework REST) | `meeting.py` | ✅ · DOCX attach = follow-up |
+| CLI: `hermes teams-voice serve --handler {logging,echo,realtime,streaming}` | `cli.py` | ✅ |
 
-The wire layer is complete enough that the existing C# worker can **connect,
-authenticate, and exchange session/ping frames today**; the dialogue brain
-(`CallSessionHandler`) is where the realtime client plugs in next.
+Validated on a live Teams call (realtime): connect, recording gate, expression
+cues, avatar rendered, audio out, clean teardown. The Windows .NET media worker
+renders the avatar tile and is paired over the HMAC bridge.
 
 ## Wire contract (fixed by the worker — do not drift)
 

--- a/plugins/teams_voice/README.md
+++ b/plugins/teams_voice/README.md
@@ -1,0 +1,142 @@
+# teams_voice — Microsoft Teams real-time voice/video (CVI) bridge driver
+
+The **Python driver** half of the Conversational Video Interface (CVI) for
+Microsoft Teams in Hermes. It is the port of the openclaw TypeScript `voice-call`
+msteams provider (upstream PRs openclaw/openclaw #91438 + #92081).
+
+> **Two processes, one bridge.** Teams real-time call media
+> (`Microsoft.Skype.Bots.Media`) is **Windows/.NET-only**, so the avatar tile and
+> RTP media are rendered by a separate **C# media worker** (`AzureBot` /
+> `OpenClawBridge`). This plugin is the cross-platform *brain*: it hosts the
+> WebSocket the worker dials into, runs dialogue + perception, and sends the
+> avatar **driver cues**. The worker renders; this plugin drives.
+
+```
+Hermes (this plugin) ──HMAC WebSocket──▶ AzureBot C# media worker ──▶ Teams call
+  • bridge_server.py (WS server)            • renders NV12 avatar tile
+  • dialogue (realtime / streaming)         • samples inbound A/V, forwards DTMF
+  • perception (vision ring)                • recording-status compliance gate
+  • emits expression / visemes / image
+```
+
+The worker is the **WebSocket client**; this plugin is the **server**
+(binds `127.0.0.1:8443` by default). Chat-plane features (messages, message
+actions, meeting-recap posting) are handled by the existing
+`plugins/platforms/teams` adapter (the `microsoft-teams-apps` SDK), **not** here.
+
+## Status
+
+| Layer | File | Status |
+|---|---|---|
+| Bridge WS server (HMAC, lifecycle, dispatch, ping/pong) | `bridge_server.py` | ✅ scaffolded |
+| Wire protocol (mirrors worker `Protocol.cs`) | `protocol.py` | ✅ |
+| HMAC handshake + single-use replay guard | `hmac_auth.py` | ✅ |
+| Config resolution | `config.py` | ✅ |
+| Expression heuristic (port) | `expression.py` | ✅ + tests |
+| Viseme estimator (port; Latin) | `viseme_estimate.py` | ✅ + tests · Arabic TODO |
+| Group-call gate (port) | `group_call_gate.py` | ✅ + tests |
+| Status tool + CLI | `tools.py`, `cli.py` | ✅ minimal |
+| **Realtime speech-to-speech brain** | `realtime/openai_client.py` | 🚧 **stub** |
+| Streaming STT→agent→TTS path | — | ⬜ not started |
+| Vision store / `look_at_screen` / `show_to_caller` | — | ⬜ not started |
+| Outbound "call me back" | — | ⬜ not started |
+
+The wire layer is complete enough that the existing C# worker can **connect,
+authenticate, and exchange session/ping frames today**; the dialogue brain
+(`CallSessionHandler`) is where the realtime client plugs in next.
+
+## Wire contract (fixed by the worker — do not drift)
+
+* **Handshake:** `HMAC-SHA256(sharedSecret, "{timestampMs}.{callId}")`, lowercase
+  hex, sent as `X-OpenClawTeamsBridge-Timestamp` / `-Signature` headers on the WS
+  upgrade. ±60 s window; accepted `(callId, ts, sig)` tuples are single-use.
+* **Path:** `/voice/msteams/stream/{callId}`.
+* **Audio:** PCM 16 kHz, 16-bit, mono, little-endian; 20 ms / 640-byte frames, base64.
+* **Messages** (camelCase JSON, additive): inbound `session.start` / `session.end`
+  / `recording.status` / `audio.frame` / `video.frame` / `participants` / `dtmf`
+  / `ping`; outbound `audio.frame` / `expression` / `speech.marks` /
+  `display.image` / `assistant.cancel` / `pong`.
+
+The `sharedSecret` here **must equal** the worker's `OpenClawSharedSecret`.
+
+## Configure
+
+Two sources are supported (per the Hermes docs); **config.yaml takes precedence, `.env`
+is the fallback**. The recommended pattern keeps **secrets in `.env`** and references
+them from config.yaml with `${VAR}` (the loader expands them), so config lives in one
+declarative file without copying secrets around.
+
+**config.yaml** (`%LOCALAPPDATA%\hermes\config.yaml`):
+
+```yaml
+plugins:
+  enabled:
+    - teams_voice
+  entries:
+    teams_voice:
+      config:
+        shared_secret: ${TEAMS_VOICE_SHARED_SECRET}   # secret stays in .env
+        host: 127.0.0.1
+        port: 8443
+        realtime:
+          backend: azure
+          azure_endpoint: https://pcfcaoai2.cognitiveservices.azure.com
+          azure_deployment: gpt-realtime
+          azure_api_version: 2025-04-01-preview
+          voice: cedar
+          api_key: ${AZURE_FOUNDRY_API_KEY}           # secret stays in .env
+          vad_threshold: 0.5
+          prefix_padding_ms: 300
+          silence_duration_ms: 500
+```
+
+**`.env`** (`%LOCALAPPDATA%\hermes\.env`) — the secret store (used directly, or referenced above):
+
+```bash
+TEAMS_VOICE_SHARED_SECRET=...        # must equal the worker's OpenClawSharedSecret
+AZURE_FOUNDRY_API_KEY=...            # realtime key (also used by the gateway)
+# fully env-only is fine too:
+TEAMS_VOICE_HOST=127.0.0.1
+TEAMS_VOICE_PORT=8443
+TEAMS_VOICE_REALTIME_BACKEND=azure
+TEAMS_VOICE_AZURE_ENDPOINT=https://pcfcaoai2.cognitiveservices.azure.com
+TEAMS_VOICE_AZURE_DEPLOYMENT=gpt-realtime
+TEAMS_VOICE_AZURE_API_VERSION=2025-04-01-preview
+TEAMS_VOICE_REALTIME_VOICE=cedar
+```
+
+Each config.yaml key has a matching env var (e.g. `realtime.azure_endpoint` ↔
+`TEAMS_VOICE_AZURE_ENDPOINT`); config.yaml wins where both are set.
+
+## Run
+
+```bash
+hermes teams-voice status      # show config + readiness
+hermes teams-voice serve       # run the bridge server (foreground)
+# or, standalone:
+python -m plugins.teams_voice.bridge_server
+```
+
+Point a worker instance's `OpenClawWsBaseUrl` at this server
+(`ws://<host>:8443/voice/msteams/stream`) with a matching shared secret. One
+worker identity per gateway — the worker's multi-identity config (`BridgeInstanceSettings`)
+lets one host serve both the openclaw and Hermes gateways.
+
+## Test
+
+```bash
+pytest plugins/teams_voice/tests/ -v
+```
+
+## Roadmap (next increments)
+
+1. **Realtime client** (`realtime/openai_client.py`): OpenAI/Azure realtime over
+   WS, 16k↔24k resampling, `expression`/`speech.marks` emission, barge-in.
+2. **Dialogue handler**: a `CallSessionHandler` that owns the recording gate,
+   echo guard, group-gate enforcement, and delegates real work to `run_agent`.
+3. **Perception**: a 16-frame vision ring + `look_at_screen` / ambient push.
+4. **Avatar tools**: `show_to_caller` → `display.image`.
+5. **Outbound**: "call me back" via the worker's authenticated place-call endpoint.
+6. **Arabic visemes** + bilingual parity.
+
+See `C:\AzureBot\docs\CVI-STUDY-91438-92081.md` for the full feature/architecture study.

--- a/plugins/teams_voice/README.md
+++ b/plugins/teams_voice/README.md
@@ -99,6 +99,20 @@ subscription, so it **cannot** implement them — they are inherited from the re
 
 The `sharedSecret` here **must equal** the worker's shared-secret setting.
 
+## Microsoft Graph permissions
+
+The bot's Azure AD app needs these **application** permissions (admin-consented):
+
+| Permission | Enables |
+|---|---|
+| `Calls.JoinGroupCall.All` | answer / join Teams calls and meetings |
+| `Calls.AccessMedia.All` | access the call's real-time audio/video media (`Skype.Bots.Media`) |
+| `Chat.Read.All` | resolve chat / thread ids and read message context |
+| `ChatMessage.Read.Chat` | read messages in chats the bot is installed in (resource-specific consent) |
+| `Sites.ReadWrite.All` | upload files / minutes to SharePoint (OneDrive) for chat attachments |
+
+Outbound "call me back" additionally needs `Calls.InitiateGroupCall.All` (skip if unused).
+
 ## Configure
 
 Two sources are supported (per the Hermes docs); **config.yaml takes precedence, `.env`

--- a/plugins/teams_voice/README.md
+++ b/plugins/teams_voice/README.md
@@ -64,6 +64,27 @@ renders the avatar tile and is paired over the HMAC bridge.
 
 Recent: real ElevenLabs `/with-timestamps` viseme alignment (streaming path; estimator fallback), Arabic visemes, and a Word-openable `.docx` minutes artifact. Remaining: inline DOCX *attachment* to the Teams chat (cross-process delivery is text-only — the artifact is generated and saved).
 
+## Worker-owned (inherited from OpenClawBridge — not in this driver)
+
+These are Microsoft Graph Calling / `Skype.Bots.Media` concerns. The driver bridges
+audio/video/control but is not connected to Graph Calling and does not drive media
+subscription, so it **cannot** implement them — they are inherited from the reused
+.NET worker, and the driver must not try to reimplement them:
+
+* **Outbound voicemail fallback** — the worker places the Graph call; voicemail +
+  its transcription is Teams platform behavior. The driver only supplies the spoken
+  result text.
+* **Outbound auto-hangup / no-answer timeout** — the *policy* (when to give up) can
+  live here, but terminating a Teams call is a Graph action only the worker can do.
+* **Active-speaker camera follow / re-select** — the worker does dominant-speaker
+  matching + MSI/VBSS subscription; the driver only receives `video.frame`.
+* **Roster `displayName`** — Graph leaves `DisplayName` null on the incoming-call
+  identity; the worker resolves it from the live participant roster before sending
+  `session.start`. **Fixed worker-side** (`multi-identity-per-ip @ 2cb86e6`+); the
+  driver already reads `caller.displayName`, so the by-name greeting works with no
+  driver change. Run that worker build (or cherry-pick the commit) for named
+  greetings; PSTN / anonymous / unmatched callers fall through to a generic greeting.
+
 ## Wire contract (fixed by the worker — do not drift)
 
 * **Handshake:** `HMAC-SHA256(sharedSecret, "{timestampMs}.{callId}")`, lowercase

--- a/plugins/teams_voice/README.md
+++ b/plugins/teams_voice/README.md
@@ -132,6 +132,9 @@ plugins:
         shared_secret: ${TEAMS_VOICE_SHARED_SECRET}   # secret stays in .env
         host: 127.0.0.1
         port: 8443
+        # Attach meeting-minutes .docx to the Teams chat (needs Graph
+        # Sites.ReadWrite.All on the bot app); omit for text-only minutes.
+        share_point_site_id: ${TEAMS_SHAREPOINT_SITE_ID}
         realtime:
           backend: azure
           azure_endpoint: https://pcfcaoai2.cognitiveservices.azure.com
@@ -149,6 +152,9 @@ plugins:
 ```bash
 TEAMS_VOICE_SHARED_SECRET=...        # must equal the worker's shared-secret setting
 AZURE_FOUNDRY_API_KEY=...            # realtime key (also used by the gateway)
+# SharePoint (OneDrive) site for attaching files/minutes to chats — host,siteGuid,webGuid
+# (the bot AAD app — TEAMS_CLIENT_ID — needs Graph Sites.ReadWrite.All, admin-consented):
+TEAMS_SHAREPOINT_SITE_ID=contoso.sharepoint.com,<siteGuid>,<webGuid>
 # fully env-only is fine too:
 TEAMS_VOICE_HOST=127.0.0.1
 TEAMS_VOICE_PORT=8443

--- a/plugins/teams_voice/README.md
+++ b/plugins/teams_voice/README.md
@@ -62,7 +62,7 @@ renders the avatar tile and is paired over the HMAC bridge.
 
 **Sessions** — `session_scope` per-call / per-thread / per-aad.
 
-Recent: real ElevenLabs `/with-timestamps` viseme alignment (streaming path; estimator fallback), Arabic visemes, and Word-openable `.docx` minutes — uploaded to SharePoint and attached to the Teams chat as a native file card when `sharePointSiteId` is configured (text-only otherwise).
+Recent: real ElevenLabs `/with-timestamps` viseme alignment (streaming path; estimator fallback), Arabic visemes, and Word-openable `.docx` minutes — uploaded to SharePoint (OneDrive) and attached to the Teams chat as a native file card when `sharePointSiteId` is configured (text-only otherwise).
 
 ## Worker-owned (inherited from the media worker — not in this driver)
 

--- a/plugins/teams_voice/README.md
+++ b/plugins/teams_voice/README.md
@@ -1,13 +1,13 @@
 # teams_voice — Microsoft Teams real-time voice/video (CVI) bridge driver
 
 The **Python driver** half of the Conversational Video Interface (CVI) for
-Microsoft Teams in Hermes. It is the port of the openclaw TypeScript `voice-call`
-msteams provider (upstream PRs openclaw/openclaw #91438 + #92081).
+Microsoft Teams in Hermes — the cross-platform orchestration for Teams voice/
+video calls.
 
 > **Two processes, one bridge.** Teams real-time call media
 > (`Microsoft.Skype.Bots.Media`) is **Windows/.NET-only**, so the avatar tile and
-> RTP media are rendered by a separate **C# media worker** (`AzureBot` /
-> `OpenClawBridge`). This plugin is the cross-platform *brain*: it hosts the
+> RTP media are rendered by a separate **C# media worker**. This plugin is the
+> cross-platform *brain*: it hosts the
 > WebSocket the worker dials into, runs dialogue + perception, and sends the
 > avatar **driver cues**. The worker renders; this plugin drives.
 
@@ -64,7 +64,7 @@ renders the avatar tile and is paired over the HMAC bridge.
 
 Recent: real ElevenLabs `/with-timestamps` viseme alignment (streaming path; estimator fallback), Arabic visemes, and a Word-openable `.docx` minutes artifact. Remaining: inline DOCX *attachment* to the Teams chat (cross-process delivery is text-only — the artifact is generated and saved).
 
-## Worker-owned (inherited from OpenClawBridge — not in this driver)
+## Worker-owned (inherited from the media worker — not in this driver)
 
 These are Microsoft Graph Calling / `Skype.Bots.Media` concerns. The driver bridges
 audio/video/control but is not connected to Graph Calling and does not drive media
@@ -88,7 +88,7 @@ subscription, so it **cannot** implement them — they are inherited from the re
 ## Wire contract (fixed by the worker — do not drift)
 
 * **Handshake:** `HMAC-SHA256(sharedSecret, "{timestampMs}.{callId}")`, lowercase
-  hex, sent as `X-OpenClawTeamsBridge-Timestamp` / `-Signature` headers on the WS
+  hex, sent as the worker's `X-OpenClawTeamsBridge-Timestamp` / `-Signature` headers on the WS
   upgrade. ±60 s window; accepted `(callId, ts, sig)` tuples are single-use.
 * **Path:** `/voice/msteams/stream/{callId}`.
 * **Audio:** PCM 16 kHz, 16-bit, mono, little-endian; 20 ms / 640-byte frames, base64.
@@ -97,7 +97,7 @@ subscription, so it **cannot** implement them — they are inherited from the re
   / `ping`; outbound `audio.frame` / `expression` / `speech.marks` /
   `display.image` / `assistant.cancel` / `pong`.
 
-The `sharedSecret` here **must equal** the worker's `OpenClawSharedSecret`.
+The `sharedSecret` here **must equal** the worker's shared-secret setting.
 
 ## Configure
 
@@ -133,7 +133,7 @@ plugins:
 **`.env`** (`%LOCALAPPDATA%\hermes\.env`) — the secret store (used directly, or referenced above):
 
 ```bash
-TEAMS_VOICE_SHARED_SECRET=...        # must equal the worker's OpenClawSharedSecret
+TEAMS_VOICE_SHARED_SECRET=...        # must equal the worker's shared-secret setting
 AZURE_FOUNDRY_API_KEY=...            # realtime key (also used by the gateway)
 # fully env-only is fine too:
 TEAMS_VOICE_HOST=127.0.0.1
@@ -157,10 +157,10 @@ hermes teams-voice serve       # run the bridge server (foreground)
 python -m plugins.teams_voice.bridge_server
 ```
 
-Point a worker instance's `OpenClawWsBaseUrl` at this server
+Point the worker's WebSocket base-URL setting at this server
 (`ws://<host>:8443/voice/msteams/stream`) with a matching shared secret. One
-worker identity per gateway — the worker's multi-identity config (`BridgeInstanceSettings`)
-lets one host serve both the openclaw and Hermes gateways.
+worker identity per gateway — the worker's multi-identity config lets one host
+serve multiple gateways.
 
 ## Test
 

--- a/plugins/teams_voice/README.md
+++ b/plugins/teams_voice/README.md
@@ -44,6 +44,26 @@ Validated on a live Teams call (realtime): connect, recording gate, expression
 cues, avatar rendered, audio out, clean teardown. The Windows .NET media worker
 renders the avatar tile and is paired over the HMAC bridge.
 
+## Features
+
+**Voice** — `msteams` over **realtime** (OpenAI/Azure speech-to-speech) **and streaming** (STT→agent→TTS), with barge-in; caller allowlist (AAD-id, closed when configured); recording-status gate before any media-derived data; realtime delegation (`hermes_agent_consult` inline + `hermes_agent_task` background); deterministic verbal interrupts (EN + Arabic, wake-phrase + filler stripping, whole-utterance); **DTMF / IVR**; **bilingual Arabic/English**; roster greeting by first name; "thinking" expression.
+
+**Inbound video vision** — `video.frame` ingestion + `look_at_screen` (camera + screen-share); **realtime continuous vision** (latest changed frame pushed ~6s, no forced response); scene-change ambient (per source) + **retroactive** (`scope:"history"`, 16-keyframe ring, attributed); per-call **vision spend cap** (`maxVisionPerMinute`).
+
+**CVI rendering drivers** — **expression cues** (neutral/happy/sad/surprised + thinking); **viseme `speech.marks`** lip-sync; **`show_to_caller`** → `display.image` fullscreen or PiP overlay, captions, paced slideshow.
+
+**Group / meeting** — per-participant attribution; **speak only when addressed** (2+ humans, wake phrases, follow-up window; 1:1 always responds), race-free on realtime (auto-response off in meetings).
+
+**Outbound (call me back)** — `call_me_back` via the worker's HMAC, SSRF-guarded endpoint; **greet-on-answer**; pending-result correlation with TTL.
+
+**Chat & governance** (`plugins/platforms/teams`) — **"Ask Hermes about this"** message action; **voice-message transcription** (opt-in); **audit-log channel** (opt-in, loop-guarded); **DLP outbound redaction** (opt-in) on text, adaptive cards, and captions.
+
+**Meeting productivity** — **end-of-meeting recap** (opt-in) + on-demand **`post_meeting_minutes`** / "summarize the meeting", posted to the Teams chat; per-speaker attribution from unmixed audio.
+
+**Sessions** — `session_scope` per-call / per-thread / per-aad.
+
+Follow-ups: real ElevenLabs `/with-timestamps` viseme alignment (estimator today), DOCX minutes attachment (standalone delivery is text-only), full Arabic visemes.
+
 ## Wire contract (fixed by the worker — do not drift)
 
 * **Handshake:** `HMAC-SHA256(sharedSecret, "{timestampMs}.{callId}")`, lowercase

--- a/plugins/teams_voice/README.md
+++ b/plugins/teams_voice/README.md
@@ -62,7 +62,7 @@ renders the avatar tile and is paired over the HMAC bridge.
 
 **Sessions** — `session_scope` per-call / per-thread / per-aad.
 
-Recent: real ElevenLabs `/with-timestamps` viseme alignment (streaming path; estimator fallback), Arabic visemes, and a Word-openable `.docx` minutes artifact. Remaining: inline DOCX *attachment* to the Teams chat (cross-process delivery is text-only — the artifact is generated and saved).
+Recent: real ElevenLabs `/with-timestamps` viseme alignment (streaming path; estimator fallback), Arabic visemes, and Word-openable `.docx` minutes — uploaded to SharePoint and attached to the Teams chat as a native file card when `sharePointSiteId` is configured (text-only otherwise).
 
 ## Worker-owned (inherited from the media worker — not in this driver)
 

--- a/plugins/teams_voice/README.md
+++ b/plugins/teams_voice/README.md
@@ -62,7 +62,7 @@ renders the avatar tile and is paired over the HMAC bridge.
 
 **Sessions** — `session_scope` per-call / per-thread / per-aad.
 
-Follow-ups: real ElevenLabs `/with-timestamps` viseme alignment (estimator today), DOCX minutes attachment (standalone delivery is text-only), full Arabic visemes.
+Recent: real ElevenLabs `/with-timestamps` viseme alignment (streaming path; estimator fallback), Arabic visemes, and a Word-openable `.docx` minutes artifact. Remaining: inline DOCX *attachment* to the Teams chat (cross-process delivery is text-only — the artifact is generated and saved).
 
 ## Wire contract (fixed by the worker — do not drift)
 

--- a/plugins/teams_voice/__init__.py
+++ b/plugins/teams_voice/__init__.py
@@ -1,0 +1,69 @@
+"""teams_voice plugin — Microsoft Teams real-time voice/video (CVI) bridge driver.
+
+Hosts an HMAC-authenticated WebSocket the companion Windows .NET media worker
+(AzureBot / OpenClawBridge) dials into, and drives the call: dialogue (realtime
+or streaming), perception (camera/screen vision), and the avatar rendering cues
+(expression / visemes / show-to-caller). The worker renders the NV12 avatar tile;
+this plugin sends the drivers.
+
+Chat-plane integration (Teams messages, message actions, meeting-recap posting)
+is handled by the existing ``plugins/platforms/teams`` adapter — this plugin is
+the *media/voice* half and deliberately does not duplicate it.
+
+Status: SCAFFOLD. The wire layer (bridge server, protocol, HMAC) and the
+pure-logic ports (expression, visemes, group-call gate) are complete and the C#
+worker can connect; the realtime speech-to-speech brain (``realtime/``) is a stub.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .cli import register_cli as _register_cli
+from .cli import teams_voice_command as _teams_voice_command
+from .tools import (
+    TEAMS_VOICE_STATUS_SCHEMA,
+    check_requirements,
+    handle_teams_voice_status,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _on_session_end(**_kwargs) -> None:
+    """Best-effort hook placeholder.
+
+    The bridge runs as its own server process, so there is nothing call-scoped to
+    tear down on agent-session end today. Kept registered so the lifecycle wiring
+    is stable as the realtime brain lands.
+    """
+    return None
+
+
+def register(ctx) -> None:
+    """Plugin entry point — register the status tool, CLI, and lifecycle hook.
+
+    Called once by the plugin loader when ``teams_voice`` is enabled via
+    ``plugins.enabled`` in config.yaml.
+    """
+    ctx.register_tool(
+        name="teams_voice_status",
+        toolset="teams_voice",
+        schema=TEAMS_VOICE_STATUS_SCHEMA,
+        handler=handle_teams_voice_status,
+        check_fn=check_requirements,
+        emoji="📞",
+    )
+
+    ctx.register_cli_command(
+        name="teams-voice",
+        help="Microsoft Teams voice/video (CVI) bridge (serve, status)",
+        setup_fn=_register_cli,
+        handler_fn=_teams_voice_command,
+        description=(
+            "Run the HMAC-authenticated bridge the Teams .NET media worker "
+            "connects to. See: hermes teams-voice status"
+        ),
+    )
+
+    ctx.register_hook("on_session_end", _on_session_end)

--- a/plugins/teams_voice/__init__.py
+++ b/plugins/teams_voice/__init__.py
@@ -10,9 +10,10 @@ Chat-plane integration (Teams messages, message actions, meeting-recap posting)
 is handled by the existing ``plugins/platforms/teams`` adapter — this plugin is
 the *media/voice* half and deliberately does not duplicate it.
 
-Status: SCAFFOLD. The wire layer (bridge server, protocol, HMAC) and the
-pure-logic ports (expression, visemes, group-call gate) are complete and the C#
-worker can connect; the realtime speech-to-speech brain (``realtime/``) is a stub.
+Status: implemented. Realtime (OpenAI/Azure speech-to-speech) and streaming
+(STT->agent->TTS) call modes; vision, tools (consult/agent_task/look_at_screen/
+show_to_caller/call_me_back/post_meeting_minutes), group gate, verbal interrupts,
+DTMF, bilingual, meeting recap. The Windows .NET media worker renders the avatar.
 """
 
 from __future__ import annotations

--- a/plugins/teams_voice/__init__.py
+++ b/plugins/teams_voice/__init__.py
@@ -1,7 +1,7 @@
 """teams_voice plugin — Microsoft Teams real-time voice/video (CVI) bridge driver.
 
 Hosts an HMAC-authenticated WebSocket the companion Windows .NET media worker
-(AzureBot / OpenClawBridge) dials into, and drives the call: dialogue (realtime
+dials into, and drives the call: dialogue (realtime
 or streaming), perception (camera/screen vision), and the avatar rendering cues
 (expression / visemes / show-to-caller). The worker renders the NV12 avatar tile;
 this plugin sends the drivers.

--- a/plugins/teams_voice/agent_consult.py
+++ b/plugins/teams_voice/agent_consult.py
@@ -1,0 +1,52 @@
+"""Agent delegation — run the full Hermes agent for a one-shot voice consult.
+
+The realtime model handles small talk itself and delegates real work (lookups,
+files, web, actions) to the Hermes agent via the ``hermes_agent_consult`` tool.
+This wraps ``run_agent.AIAgent`` (synchronous, tool-capable) and runs it off the
+event loop with ``asyncio.to_thread`` so the call's audio keeps flowing.
+
+The agent is built lazily and reused across consults within a call. A consult is
+time-boxed; on timeout/error a short speakable message is returned so the model
+can tell the caller gracefully rather than hanging.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class AgentConsult:
+    """Lazily-built, reusable one-shot agent runner for a call."""
+
+    def __init__(self, model: str | None = None) -> None:
+        self._model = model
+        self._agent = None  # run_agent.AIAgent, built on first use
+
+    def _run_sync(self, query: str) -> str:
+        if self._agent is None:
+            from run_agent import AIAgent  # heavy import — defer to first consult
+
+            kwargs: dict = {"quiet_mode": True}
+            if self._model:
+                kwargs["model"] = self._model
+            self._agent = AIAgent(**kwargs)
+        return self._agent.chat(query)
+
+    async def ask(self, query: str, *, timeout_s: float = 45.0) -> str:
+        """Run ``query`` through the agent and return a concise spoken result."""
+        query = (query or "").strip()
+        if not query:
+            return "I didn't catch what you wanted me to look into."
+        try:
+            result = await asyncio.wait_for(
+                asyncio.to_thread(self._run_sync, query), timeout=timeout_s
+            )
+            return (result or "").strip() or "I didn't find anything to report."
+        except asyncio.TimeoutError:
+            return "That's taking a while — I'll keep working and follow up."
+        except Exception:  # noqa: BLE001 — never let a consult crash the call
+            logger.error("[teams_voice] agent consult failed", exc_info=True)
+            return "Sorry, I ran into an error working on that."

--- a/plugins/teams_voice/agent_consult.py
+++ b/plugins/teams_voice/agent_consult.py
@@ -25,14 +25,42 @@ class AgentConsult:
         self._model = model
         self._agent = None  # run_agent.AIAgent, built on first use
 
+    def _agent_kwargs(self) -> dict:
+        """Build AIAgent kwargs from the configured ``model`` block.
+
+        A bare ``AIAgent()`` leaves the model empty → 'Missed model deployment',
+        so we pass the same provider/model/base_url/api_mode the CLI resolves from
+        config.yaml ``model:`` (e.g. provider=azure-foundry, default=gpt-5.5)."""
+        import os
+
+        kwargs: dict = {"quiet_mode": True}
+        try:
+            from hermes_cli.config import cfg_get, load_config
+
+            m = cfg_get(load_config(), "model") or {}
+            if isinstance(m, dict):
+                if m.get("default"):
+                    kwargs["model"] = m["default"]
+                if m.get("provider"):
+                    kwargs["provider"] = m["provider"]
+                if m.get("base_url"):
+                    kwargs["base_url"] = m["base_url"]
+                if m.get("api_mode"):
+                    kwargs["api_mode"] = m["api_mode"]
+        except Exception:  # noqa: BLE001
+            pass
+        if self._model:
+            kwargs["model"] = self._model
+        key = os.getenv("AZURE_FOUNDRY_API_KEY", "").strip() or os.getenv("OPENAI_API_KEY", "").strip()
+        if key and "api_key" not in kwargs:
+            kwargs["api_key"] = key
+        return kwargs
+
     def _run_sync(self, query: str) -> str:
         if self._agent is None:
             from run_agent import AIAgent  # heavy import — defer to first consult
 
-            kwargs: dict = {"quiet_mode": True}
-            if self._model:
-                kwargs["model"] = self._model
-            self._agent = AIAgent(**kwargs)
+            self._agent = AIAgent(**self._agent_kwargs())
         return self._agent.chat(query)
 
     async def ask(self, query: str, *, timeout_s: float = 45.0) -> str:

--- a/plugins/teams_voice/agent_consult.py
+++ b/plugins/teams_voice/agent_consult.py
@@ -21,8 +21,9 @@ logger = logging.getLogger(__name__)
 class AgentConsult:
     """Lazily-built, reusable one-shot agent runner for a call."""
 
-    def __init__(self, model: str | None = None) -> None:
+    def __init__(self, model: str | None = None, session_id: str | None = None) -> None:
         self._model = model
+        self._session_id = session_id  # session continuity (per-thread/per-aad scope)
         self._agent = None  # run_agent.AIAgent, built on first use
 
     def _agent_kwargs(self) -> dict:
@@ -54,13 +55,20 @@ class AgentConsult:
         key = os.getenv("AZURE_FOUNDRY_API_KEY", "").strip() or os.getenv("OPENAI_API_KEY", "").strip()
         if key and "api_key" not in kwargs:
             kwargs["api_key"] = key
+        if self._session_id:
+            kwargs["session_id"] = self._session_id
         return kwargs
 
     def _run_sync(self, query: str) -> str:
         if self._agent is None:
             from run_agent import AIAgent  # heavy import — defer to first consult
 
-            self._agent = AIAgent(**self._agent_kwargs())
+            kwargs = self._agent_kwargs()
+            try:
+                self._agent = AIAgent(**kwargs)
+            except TypeError:  # older AIAgent without session_id — drop and retry
+                kwargs.pop("session_id", None)
+                self._agent = AIAgent(**kwargs)
         return self._agent.chat(query)
 
     async def ask(self, query: str, *, timeout_s: float = 45.0) -> str:

--- a/plugins/teams_voice/audio.py
+++ b/plugins/teams_voice/audio.py
@@ -1,0 +1,94 @@
+"""PCM16 audio helpers: rate conversion, 20 ms framing, RMS.
+
+The bridge speaks PCM 16 kHz (worker side); the realtime model speaks PCM 24 kHz.
+These helpers convert between them and chop a stream into the worker's fixed
+20 ms / 640-byte frames. All functions operate on little-endian signed 16-bit
+mono bytes — the wire format both peers agree on.
+
+Uses numpy when available (fast, exact endianness via ``<i2``); falls back to a
+pure-stdlib linear resampler so the plugin has no hard numpy dependency.
+"""
+
+from __future__ import annotations
+
+import array
+import math
+import sys
+
+try:  # optional fast path
+    import numpy as _np
+except ImportError:  # pragma: no cover - exercised only without numpy
+    _np = None
+
+
+def resample_pcm16(data: bytes, src_rate: int, dst_rate: int) -> bytes:
+    """Linear-resample LE int16 mono PCM from ``src_rate`` to ``dst_rate``."""
+    if src_rate == dst_rate or not data:
+        return data
+    if len(data) % 2:
+        data = data[:-1]
+    if not data:
+        return b""
+
+    if _np is not None:
+        a = _np.frombuffer(data, dtype="<i2").astype(_np.float32)
+        n = a.shape[0]
+        out_n = max(1, int(round(n * dst_rate / src_rate)))
+        if n == 1:
+            res = _np.full(out_n, a[0], dtype=_np.float32)
+        else:
+            x_old = _np.linspace(0.0, 1.0, n, endpoint=True)
+            x_new = _np.linspace(0.0, 1.0, out_n, endpoint=True)
+            res = _np.interp(x_new, x_old, a)
+        return _np.clip(_np.round(res), -32768, 32767).astype("<i2").tobytes()
+
+    # Pure-stdlib fallback.
+    samples = array.array("h")
+    samples.frombytes(data)
+    if sys.byteorder == "big":
+        samples.byteswap()
+    n = len(samples)
+    out_n = max(1, int(round(n * dst_rate / src_rate)))
+    out = array.array("h", bytes(2 * out_n))
+    if out_n == 1:
+        out[0] = samples[0]
+    else:
+        ratio = (n - 1) / (out_n - 1)
+        for i in range(out_n):
+            pos = i * ratio
+            i0 = int(pos)
+            frac = pos - i0
+            i1 = i0 + 1 if i0 + 1 < n else i0
+            out[i] = int(round(samples[i0] * (1.0 - frac) + samples[i1] * frac))
+    if sys.byteorder == "big":
+        out.byteswap()
+    return out.tobytes()
+
+
+def frame_pcm16(data: bytes, frame_bytes: int = 640) -> tuple[list[bytes], bytes]:
+    """Split ``data`` into fixed-size frames; return ``(frames, residual)``.
+
+    The trailing ``residual`` (< ``frame_bytes``) is meant to be prepended to the
+    next chunk so frame boundaries stay aligned across streamed deltas.
+    """
+    count = len(data) // frame_bytes
+    frames = [data[i * frame_bytes : (i + 1) * frame_bytes] for i in range(count)]
+    residual = data[count * frame_bytes :]
+    return frames, residual
+
+
+def pcm16_rms(data: bytes) -> float:
+    """Root-mean-square amplitude of LE int16 PCM, normalized to 0.0-1.0."""
+    if len(data) < 2:
+        return 0.0
+    if len(data) % 2:
+        data = data[:-1]
+    if _np is not None:
+        a = _np.frombuffer(data, dtype="<i2").astype(_np.float32) / 32768.0
+        return float(_np.sqrt(_np.mean(a * a)))
+    samples = array.array("h")
+    samples.frombytes(data)
+    if sys.byteorder == "big":
+        samples.byteswap()
+    acc = sum((s / 32768.0) ** 2 for s in samples)
+    return math.sqrt(acc / len(samples))

--- a/plugins/teams_voice/bridge_server.py
+++ b/plugins/teams_voice/bridge_server.py
@@ -1,0 +1,268 @@
+"""Bridge WebSocket server — the seam the .NET media worker dials into.
+
+Unlike a typical client/gateway split, here the **worker is the WS client** and
+this driver is the **server** (it binds and waits). Each Teams call opens one
+connection to ``{path}/{callId}``; the worker authenticates the upgrade with HMAC
+headers, sends ``session.start``, then streams inbound media while this side
+streams TTS audio + avatar driver cues back.
+
+This module owns transport concerns only: the HMAC handshake, connection caps,
+the pre-start timeout, the read/dispatch loop, and ping/pong. Dialogue/perception
+logic lives behind a :class:`CallSessionHandler` so the realtime/streaming brain
+can be wired in without touching the wire layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable, Optional
+
+from aiohttp import WSMsgType, web
+
+from . import hmac_auth, protocol
+from .config import HEADER_SIGNATURE, HEADER_TIMESTAMP, TeamsVoiceConfig, resolve_config
+
+logger = logging.getLogger(__name__)
+
+_MAX_FRAME_BYTES = 2 * 1024 * 1024  # 2 MB — accommodates a base64 JPEG video.frame
+
+
+class CallSession:
+    """One live Teams call: the WebSocket plus typed send helpers.
+
+    Inbound frames are delivered to the bound :class:`CallSessionHandler`; the
+    handler (and the dialogue brain) drives the call back via the ``send_*``
+    methods, which serialize the outbound protocol builders.
+    """
+
+    def __init__(self, call_id: str, ws: web.WebSocketResponse) -> None:
+        self.call_id = call_id
+        self._ws = ws
+        self.recording_active = False
+        self.human_count = 0
+
+    @property
+    def closed(self) -> bool:
+        return self._ws.closed
+
+    async def _send(self, msg: dict) -> None:
+        if self._ws.closed:
+            return
+        try:
+            await self._ws.send_str(protocol.encode(msg))
+        except (ConnectionError, RuntimeError) as exc:
+            # A send failure means the call is gone; surface it rather than
+            # silently "succeeding" on a dead socket.
+            logger.warning("[teams_voice] send failed on %s: %s", self.call_id, exc)
+            raise
+
+    async def send_audio_frame(self, seq: int, timestamp_ms: int, payload_base64: str) -> None:
+        await self._send(protocol.audio_frame(seq, timestamp_ms, payload_base64))
+
+    async def send_expression(self, emotion: str) -> None:
+        await self._send(protocol.expression(emotion))
+
+    async def send_speech_marks(self, marks: list[dict[str, int]], ts: int = 0) -> None:
+        await self._send(protocol.speech_marks(marks, ts))
+
+    async def send_display_image(self, data_base64: str, mime: str, **kwargs) -> None:
+        await self._send(protocol.display_image(data_base64, mime, **kwargs))
+
+    async def send_assistant_cancel(self, turn_id: int) -> None:
+        await self._send(protocol.assistant_cancel(turn_id))
+
+
+class CallSessionHandler:
+    """Interface the dialogue/perception brain implements.
+
+    Every method is async and best-effort: a handler exception is logged and the
+    call continues (a bad frame must not tear down the socket). The default
+    implementation just logs — wire a real handler via :class:`BridgeServer`.
+    """
+
+    async def on_session_start(self, session: CallSession, msg: protocol.SessionStart) -> None:
+        logger.info(
+            "[teams_voice] session.start call=%s thread=%s dir=%s caller=%s",
+            msg.call_id, msg.thread_id, msg.direction, msg.caller.display_name,
+        )
+
+    async def on_audio_frame(self, session: CallSession, msg: protocol.AudioFrame) -> None:
+        ...  # TODO: gate on recording, echo-guard, route to STT/realtime model
+
+    async def on_video_frame(self, session: CallSession, msg: protocol.VideoFrame) -> None:
+        ...  # TODO: gate on recording, store in vision ring, ambient push
+
+    async def on_recording_status(self, session: CallSession, msg: protocol.RecordingStatus) -> None:
+        session.recording_active = msg.status == "active"
+        logger.info("[teams_voice] recording.status call=%s = %s", session.call_id, msg.status)
+
+    async def on_participants(self, session: CallSession, msg: protocol.Participants) -> None:
+        session.human_count = msg.count
+
+    async def on_dtmf(self, session: CallSession, msg: protocol.Dtmf) -> None:
+        ...  # TODO: surface keypress to the realtime model (recording-gated)
+
+    async def on_session_end(self, session: CallSession, msg: protocol.SessionEnd) -> None:
+        logger.info("[teams_voice] session.end call=%s reason=%s", session.call_id, msg.reason)
+
+
+HandlerFactory = Callable[[], CallSessionHandler]
+
+
+class BridgeServer:
+    """Hosts the HMAC-authenticated WebSocket the media worker connects to."""
+
+    def __init__(
+        self,
+        config: Optional[TeamsVoiceConfig] = None,
+        handler_factory: Optional[HandlerFactory] = None,
+    ) -> None:
+        self.config = config or resolve_config()
+        self._handler_factory = handler_factory or CallSessionHandler
+        self._replay = hmac_auth.ReplayGuard(window_ms=self.config.hmac_window_ms)
+        self._runner: Optional[web.AppRunner] = None
+        self._conn_count = 0
+        self._conn_by_ip: dict[str, int] = {}
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Bind and start serving. Raises if no shared secret is configured."""
+        if not self.config.configured:
+            raise RuntimeError(
+                "teams_voice bridge has no shared secret "
+                "(set TEAMS_VOICE_SHARED_SECRET or config.extra.shared_secret)"
+            )
+        app = web.Application()
+        route = f"{self.config.path.rstrip('/')}/{{call_id}}"
+        app.router.add_get(route, self._handle_ws)
+        app.router.add_get("/health", lambda _req: web.Response(text="ok"))
+
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.config.host, self.config.port)
+        await site.start()
+        logger.info(
+            "[teams_voice] bridge listening host=%s port=%s path=%s",
+            self.config.host, self.config.port, route,
+        )
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+
+    # ── connection handling ──────────────────────────────────────────────────
+
+    async def _handle_ws(self, request: web.Request) -> web.StreamResponse:
+        call_id = request.match_info.get("call_id", "").strip()
+        if not call_id:
+            return web.Response(status=400, text="missing callId")
+
+        ok, reason = hmac_auth.verify_upgrade(
+            secret=self.config.shared_secret,
+            call_id=call_id,
+            timestamp_header=request.headers.get(HEADER_TIMESTAMP),
+            signature_header=request.headers.get(HEADER_SIGNATURE),
+            window_ms=self.config.hmac_window_ms,
+            replay_guard=self._replay,
+        )
+        if not ok:
+            logger.warning("[teams_voice] upgrade rejected call=%s: %s", call_id, reason)
+            return web.Response(status=401, text="unauthorized")
+
+        peer_ip = request.remote or "?"
+        if self._conn_count >= self.config.max_connections:
+            return web.Response(status=503, text="too many connections")
+        if self._conn_by_ip.get(peer_ip, 0) >= self.config.max_connections_per_ip:
+            return web.Response(status=503, text="too many connections")
+
+        ws = web.WebSocketResponse(max_msg_size=_MAX_FRAME_BYTES, heartbeat=None)
+        await ws.prepare(request)
+
+        self._conn_count += 1
+        self._conn_by_ip[peer_ip] = self._conn_by_ip.get(peer_ip, 0) + 1
+        session = CallSession(call_id, ws)
+        handler = self._handler_factory()
+        try:
+            await self._read_loop(session, handler)
+        finally:
+            self._conn_count -= 1
+            self._conn_by_ip[peer_ip] = max(0, self._conn_by_ip.get(peer_ip, 1) - 1)
+            logger.debug("[teams_voice] connection closed %s", call_id)
+        return ws
+
+    async def _read_loop(self, session: CallSession, handler: CallSessionHandler) -> None:
+        started = False
+        while not session.closed:
+            timeout = None if started else self.config.pre_start_timeout_s
+            try:
+                msg = await asyncio.wait_for(session._ws.receive(), timeout=timeout)
+            except asyncio.TimeoutError:
+                logger.warning("[teams_voice] no session.start within %ss; closing %s",
+                               timeout, session.call_id)
+                await session._ws.close()
+                return
+
+            if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.CLOSED, WSMsgType.ERROR):
+                return
+            if msg.type is not WSMsgType.TEXT:
+                continue
+
+            try:
+                parsed = protocol.decode(msg.data)
+            except protocol.ProtocolError as exc:
+                logger.warning("[teams_voice] bad frame on %s: %s", session.call_id, exc)
+                continue
+
+            started = await self._dispatch(session, handler, parsed) or started
+
+    async def _dispatch(
+        self,
+        session: CallSession,
+        handler: CallSessionHandler,
+        parsed: protocol.InboundMessage,
+    ) -> bool:
+        """Route one parsed frame to the handler. Returns True once started."""
+        try:
+            if isinstance(parsed, protocol.Ping):
+                await session._send(protocol.pong(parsed.ts))
+                return False
+            if isinstance(parsed, protocol.SessionStart):
+                session.recording_active = parsed.recording_status == "active"
+                await handler.on_session_start(session, parsed)
+                return True
+            if isinstance(parsed, protocol.AudioFrame):
+                await handler.on_audio_frame(session, parsed)
+            elif isinstance(parsed, protocol.VideoFrame):
+                await handler.on_video_frame(session, parsed)
+            elif isinstance(parsed, protocol.RecordingStatus):
+                await handler.on_recording_status(session, parsed)
+            elif isinstance(parsed, protocol.Participants):
+                await handler.on_participants(session, parsed)
+            elif isinstance(parsed, protocol.Dtmf):
+                await handler.on_dtmf(session, parsed)
+            elif isinstance(parsed, protocol.SessionEnd):
+                await handler.on_session_end(session, parsed)
+                await session._ws.close()
+        except Exception:  # noqa: BLE001 — a handler fault must not kill the call
+            logger.error(
+                "[teams_voice] handler error on %s frame=%s",
+                session.call_id, getattr(parsed, "type", "?"), exc_info=True,
+            )
+        return False
+
+
+async def _amain() -> None:
+    logging.basicConfig(level=logging.INFO)
+    server = BridgeServer()
+    await server.start()
+    try:
+        await asyncio.Future()  # run until cancelled
+    finally:
+        await server.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(_amain())

--- a/plugins/teams_voice/bridge_server.py
+++ b/plugins/teams_voice/bridge_server.py
@@ -88,10 +88,10 @@ class CallSessionHandler:
         )
 
     async def on_audio_frame(self, session: CallSession, msg: protocol.AudioFrame) -> None:
-        ...  # TODO: gate on recording, echo-guard, route to STT/realtime model
+        ...  # base no-op; the realtime/streaming handlers route this to the model
 
     async def on_video_frame(self, session: CallSession, msg: protocol.VideoFrame) -> None:
-        ...  # TODO: gate on recording, store in vision ring, ambient push
+        ...  # base no-op; the realtime/streaming handlers store + use vision frames
 
     async def on_recording_status(self, session: CallSession, msg: protocol.RecordingStatus) -> None:
         session.recording_active = msg.status == "active"
@@ -101,7 +101,7 @@ class CallSessionHandler:
         session.human_count = msg.count
 
     async def on_dtmf(self, session: CallSession, msg: protocol.Dtmf) -> None:
-        ...  # TODO: surface keypress to the realtime model (recording-gated)
+        ...  # base no-op; the realtime handler surfaces keypresses to the model
 
     async def on_session_end(self, session: CallSession, msg: protocol.SessionEnd) -> None:
         logger.info("[teams_voice] session.end call=%s reason=%s", session.call_id, msg.reason)

--- a/plugins/teams_voice/call_session_base.py
+++ b/plugins/teams_voice/call_session_base.py
@@ -1,0 +1,115 @@
+"""Shared base for the realtime and streaming call brains.
+
+Both handlers need the same session policy — caller allowlist, session-scope key,
+meeting transcript, agent consult, group-call gate, greeting/outbound state. This
+base (``BaseTeamsCallHandler``) holds that once so the two handlers only implement
+what differs (the realtime model vs the STT→agent→TTS loop). Also owns the
+process-global pending-outbound registry (call-back correlation, with TTL).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from . import group_call_gate, protocol
+from .agent_consult import AgentConsult
+from .bridge_server import CallSession, CallSessionHandler
+from .config import TeamsVoiceConfig, caller_allowed
+from .meeting import MeetingTranscript
+
+logger = logging.getLogger(__name__)
+
+# The inbound call that requests a callback and the outbound leg that delivers it
+# are *different* WebSocket connections, so the pending spoken result is keyed by
+# the worker's callId here. Entries carry a TTL so a never-answered call-back can't
+# leak its result string indefinitely.
+_PENDING_OUTBOUND: dict[str, tuple[str, float]] = {}
+_PENDING_TTL_S = 600.0
+
+
+def _pending_prune() -> None:
+    now = time.monotonic()
+    for k in [k for k, (_t, exp) in _PENDING_OUTBOUND.items() if exp <= now]:
+        _PENDING_OUTBOUND.pop(k, None)
+
+
+def _pending_set(call_id: str, text: str) -> None:
+    _pending_prune()
+    _PENDING_OUTBOUND[call_id] = (text, time.monotonic() + _PENDING_TTL_S)
+
+
+def _pending_pop(call_id: str) -> str | None:
+    _pending_prune()
+    entry = _PENDING_OUTBOUND.pop(call_id, None)
+    return entry[0] if entry else None
+
+
+class BaseTeamsCallHandler(CallSessionHandler):
+    """Common session policy shared by the realtime + streaming handlers."""
+
+    def __init__(self, bridge_config: TeamsVoiceConfig | None = None) -> None:
+        self._bridge = bridge_config
+        self._require_recording = bridge_config.require_recording_status if bridge_config else True
+        self._session: CallSession | None = None
+        self._caller: protocol.CallerInfo | None = None
+        self._thread_id = ""
+        self._outbound = False
+        self._greeted = False
+        self._pending_greeting: str | None = None
+        self._meeting = MeetingTranscript()
+        self._consult = AgentConsult()
+        wake = tuple(bridge_config.wake_phrases) if (bridge_config and bridge_config.wake_phrases) else ("assistant", "hermes")
+        self._gate_cfg = group_call_gate.GroupCallGateConfig(wake_phrases=wake)
+        self._last_addressed_ms: float | None = None
+
+    # ── shared helpers ────────────────────────────────────────────────────────
+
+    def _first_name(self) -> str:
+        name = (self._caller.display_name if self._caller else "") or ""
+        return name.strip().split(" ")[0] if name.strip() else ""
+
+    def _recording_ok(self, session: CallSession) -> bool:
+        return (not self._require_recording) or session.recording_active
+
+    async def _begin_session(self, session: CallSession, msg: protocol.SessionStart) -> bool:
+        """Common ``session.start``: state + allowlist + scope. False = rejected."""
+        await CallSessionHandler.on_session_start(self, session, msg)
+        self._session = session
+        self._caller = msg.caller
+        self._thread_id = msg.thread_id
+        self._outbound = (msg.direction or "").lower() == "outbound"
+        if self._outbound:  # delivery leg of a call-back
+            self._pending_greeting = _pending_pop(msg.call_id)
+        elif self._bridge and not caller_allowed(
+            self._bridge, msg.caller.aad_id, msg.caller.display_name
+        ):
+            logger.info("[teams_voice] caller not allowlisted; rejecting %s", session.call_id)
+            await session._ws.close()
+            return False
+        scope = self._bridge.session_scope if self._bridge else "per-call"
+        if scope == "per-thread":
+            key = msg.thread_id or msg.call_id
+        elif scope == "per-aad":
+            key = msg.caller.aad_id or msg.call_id
+        else:
+            key = msg.call_id
+        self._consult = AgentConsult(session_id=f"teams:{key}")
+        return True
+
+    def _group_decision(self, transcript: str, now_ms: float):
+        """``(is_group, GateDecision)`` for a finished caller turn."""
+        is_group = (self._session.human_count if self._session else 0) >= 2
+        decision = group_call_gate.should_respond_to_group_turn(
+            transcript=transcript, is_group=is_group, config=self._gate_cfg,
+            last_addressed_at_ms=self._last_addressed_ms, now_ms=now_ms,
+        )
+        return is_group, decision
+
+    async def _safe_expression(self, emotion: str) -> None:
+        if self._session is None:
+            return
+        try:
+            await self._session.send_expression(emotion)
+        except Exception:  # noqa: BLE001 — cosmetic
+            pass

--- a/plugins/teams_voice/call_session_base.py
+++ b/plugins/teams_voice/call_session_base.py
@@ -45,7 +45,28 @@ def _pending_pop(call_id: str) -> str | None:
     return entry[0] if entry else None
 
 
-class BaseTeamsCallHandler(CallSessionHandler):
+class GreetingMixin:
+    """Shared greet-on-answer decision for both call handlers (fires once)."""
+
+    def _greeting_plan(self) -> tuple[str, str] | None:
+        """``('deliver', result)`` for an answered call-back, ``('greet', name)``
+        for a fresh inbound call, or ``None`` when there's nothing to say yet.
+
+        Rendered differently per handler (realtime: a ``request_say`` instruction;
+        streaming: literal TTS text), but the decision lives here once."""
+        if self._greeted:
+            return None
+        if self._outbound:
+            if not self._pending_greeting:
+                return None
+            payload, self._pending_greeting = self._pending_greeting, None
+            self._greeted = True
+            return ("deliver", payload)
+        self._greeted = True
+        return ("greet", self._first_name())
+
+
+class BaseTeamsCallHandler(CallSessionHandler, GreetingMixin):
     """Common session policy shared by the realtime + streaming handlers."""
 
     def __init__(self, bridge_config: TeamsVoiceConfig | None = None) -> None:

--- a/plugins/teams_voice/call_session_base.py
+++ b/plugins/teams_voice/call_session_base.py
@@ -45,28 +45,7 @@ def _pending_pop(call_id: str) -> str | None:
     return entry[0] if entry else None
 
 
-class GreetingMixin:
-    """Shared greet-on-answer decision for both call handlers (fires once)."""
-
-    def _greeting_plan(self) -> tuple[str, str] | None:
-        """``('deliver', result)`` for an answered call-back, ``('greet', name)``
-        for a fresh inbound call, or ``None`` when there's nothing to say yet.
-
-        Rendered differently per handler (realtime: a ``request_say`` instruction;
-        streaming: literal TTS text), but the decision lives here once."""
-        if self._greeted:
-            return None
-        if self._outbound:
-            if not self._pending_greeting:
-                return None
-            payload, self._pending_greeting = self._pending_greeting, None
-            self._greeted = True
-            return ("deliver", payload)
-        self._greeted = True
-        return ("greet", self._first_name())
-
-
-class BaseTeamsCallHandler(CallSessionHandler, GreetingMixin):
+class BaseTeamsCallHandler(CallSessionHandler):
     """Common session policy shared by the realtime + streaming handlers."""
 
     def __init__(self, bridge_config: TeamsVoiceConfig | None = None) -> None:
@@ -89,6 +68,20 @@ class BaseTeamsCallHandler(CallSessionHandler, GreetingMixin):
     def _first_name(self) -> str:
         name = (self._caller.display_name if self._caller else "") or ""
         return name.strip().split(" ")[0] if name.strip() else ""
+
+    def _greeting_plan(self) -> tuple[str, str] | None:
+        """Greet-on-answer decision (fires once): ('deliver', result) for an
+        answered call-back, ('greet', name) for a fresh inbound call, or None."""
+        if self._greeted:
+            return None
+        if self._outbound:
+            if not self._pending_greeting:
+                return None
+            payload, self._pending_greeting = self._pending_greeting, None
+            self._greeted = True
+            return ("deliver", payload)
+        self._greeted = True
+        return ("greet", self._first_name())
 
     def _recording_ok(self, session: CallSession) -> bool:
         return (not self._require_recording) or session.recording_active

--- a/plugins/teams_voice/call_tools.py
+++ b/plugins/teams_voice/call_tools.py
@@ -1,0 +1,191 @@
+"""CallToolRunner — runs the realtime model's tool calls.
+
+Separates the tool surface (agent consult / background task / look_at_screen /
+show_to_caller / call_me_back / post_meeting_minutes) from the realtime handler's
+transport + dialogue loop. Holds a reference to the handler for per-call context
+(session, vision store/budget, consult, caller, bridge, meeting).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+from pathlib import Path
+
+from . import meeting
+from .call_session_base import _pending_set
+from .outbound import OutboundError, place_call
+
+logger = logging.getLogger(__name__)
+
+
+class CallToolRunner:
+    def __init__(self, handler) -> None:
+        self._h = handler
+
+    async def run_tool(self, name: str, args: dict) -> str:
+        h = self._h
+        try:
+            if name == "hermes_agent_consult":
+                return await h._consult.ask(str(args.get("query", "")))
+            if name == "hermes_agent_task":
+                return await self._agent_task(str(args.get("query", "")))
+            if name == "look_at_screen":
+                return await self._look_at_screen(
+                    str(args.get("question", "")), args.get("source"), str(args.get("scope") or "live")
+                )
+            if name == "show_to_caller":
+                return await self._show_to_caller(str(args.get("prompt", "")), args.get("count", 1))
+            if name == "call_me_back":
+                return await self._call_me_back(str(args.get("message", "")))
+            if name == "post_meeting_minutes":
+                return await meeting.post_minutes(h._consult, h._meeting, h._thread_id)
+        except Exception:  # noqa: BLE001 — a tool fault must not break the call
+            logger.error("[teams_voice] tool %s failed", name, exc_info=True)
+            return "Sorry, that didn't work."
+        return f"Unknown tool: {name}."
+
+    async def _look_at_screen(self, question: str, source: str | None, scope: str = "live") -> str:
+        h = self._h
+        if not h._vision_budget.try_consume():
+            return "I've looked at a lot just now — give me a moment before the next one."
+        prompt = question.strip() or "Describe what you see."
+        if scope == "history":
+            frames = h._vision.history(limit=6)
+            if not frames:
+                return "I don't have any earlier frames to look back on."
+            content: list[dict] = [{"type": "text", "text": prompt}]
+            for f in frames:  # timestamped, attributed keyframes
+                content.append({"type": "text", "text": f"(earlier, from {f.describe()})"})
+                content.append({"type": "image_url", "image_url": {"url": f.data_url()}})
+        else:
+            want = "camera" if str(source or "").lower() == "camera" else "screenshare"
+            frame = h._vision.latest(want) or h._vision.latest()
+            if frame is None:
+                return "I can't see a shared screen or camera right now."
+            content = [
+                {"type": "text", "text": f"{prompt} (looking at the {frame.describe()})"},
+                {"type": "image_url", "image_url": {"url": frame.data_url()}},
+            ]
+        return await self._vision_consult(content)
+
+    async def _vision_consult(self, content: list[dict]) -> str:
+        try:
+            from agent.auxiliary_client import async_call_llm
+
+            resp = await async_call_llm(
+                task="vision", messages=[{"role": "user", "content": content}], max_tokens=400
+            )
+            text = resp.choices[0].message.content if resp and resp.choices else ""
+            return (text or "").strip() or "I couldn't quite make that out."
+        except Exception:  # noqa: BLE001
+            self._h._vision_budget.refund()  # consult failed before the model — give it back
+            logger.error("[teams_voice] vision consult failed", exc_info=True)
+            return "I had trouble looking at that."
+
+    async def _show_to_caller(self, prompt: str, count: object = 1) -> str:
+        prompt = prompt.strip()
+        if not prompt:
+            return "What would you like me to show?"
+        try:
+            n = max(1, min(int(count), 3))
+        except (TypeError, ValueError):
+            n = 1
+        try:
+            from tools.image_generation_tool import image_generate_tool
+
+            paths: list[str] = []
+            for _ in range(n):
+                raw = await asyncio.to_thread(
+                    lambda: image_generate_tool(prompt=prompt, aspect_ratio="landscape")
+                )
+                data = json.loads(raw)
+                if data.get("success") and data.get("image"):
+                    paths.append(data["image"])
+            if not paths:
+                return "I couldn't create that image."
+            # Paced slideshow: 4.5s hold for non-final, 5s for the final image.
+            for idx, path in enumerate(paths):
+                final = idx == len(paths) - 1
+                img_bytes = Path(path).read_bytes()
+                mime = "image/png" if str(path).lower().endswith(".png") else "image/jpeg"
+                if self._h._session is not None:
+                    await self._h._session.send_display_image(
+                        base64.b64encode(img_bytes).decode("ascii"),
+                        mime,
+                        duration_ms=5000 if final else 4500,
+                        mode="overlay",
+                        caption=prompt[:80],
+                    )
+                if not final:
+                    await asyncio.sleep(4.0)
+            return "I'm showing it on screen now." if len(paths) == 1 else f"Showing you {len(paths)} images."
+        except Exception:  # noqa: BLE001
+            logger.error("[teams_voice] show_to_caller failed", exc_info=True)
+            return "I made the image but couldn't display it."
+
+    async def _call_me_back(self, message: str) -> str:
+        h = self._h
+        message = message.strip()
+        caller = h._caller
+        if h._bridge is None or caller is None or not caller.aad_id:
+            return "I can't call you back — I don't have a number to reach you."
+        tenant = caller.tenant_id or h._bridge.tenant_id
+        if not tenant:
+            return "I can't call you back — missing your tenant."
+        try:
+            result = await place_call(
+                user_object_id=caller.aad_id,
+                tenant_id=tenant,
+                shared_secret=h._bridge.shared_secret,
+                worker_base_url=h._bridge.worker_base_url,
+                allow_remote=h._bridge.allow_remote_worker,
+            )
+        except OutboundError as exc:
+            logger.warning("[teams_voice] call_me_back failed: %s", exc)
+            return "I couldn't place the call-back just now."
+        call_id = result.get("callId")
+        if call_id:
+            _pending_set(call_id, message or "Here's what you asked for.")
+        return "Okay — I'll call you right back with that."
+
+    async def _agent_task(self, query: str) -> str:
+        """Run a long job in the background; deliver the result via a call-back."""
+        h = self._h
+        query = query.strip()
+        caller = h._caller
+        if not query:
+            return "What would you like me to work on?"
+        if h._bridge is None or caller is None or not caller.aad_id:
+            return await h._consult.ask(query)  # no call-back possible → inline
+        asyncio.create_task(self._run_background_task(query, caller))
+        return "Got it — I'll work on that in the background and call you back with the result."
+
+    async def _run_background_task(self, query: str, caller) -> None:
+        h = self._h
+        try:
+            result = await h._consult.ask(query, timeout_s=300.0)
+        except Exception:  # noqa: BLE001
+            logger.error("[teams_voice] background task failed", exc_info=True)
+            result = "I couldn't complete that task."
+        if h._bridge is None or not caller.aad_id:
+            return
+        tenant = caller.tenant_id or h._bridge.tenant_id
+        if not tenant:
+            return
+        try:
+            res = await place_call(
+                user_object_id=caller.aad_id,
+                tenant_id=tenant,
+                shared_secret=h._bridge.shared_secret,
+                worker_base_url=h._bridge.worker_base_url,
+                allow_remote=h._bridge.allow_remote_worker,
+            )
+        except OutboundError as exc:
+            logger.warning("[teams_voice] background callback failed: %s", exc)
+            return
+        cid = res.get("callId")
+        if cid:
+            _pending_set(cid, result)

--- a/plugins/teams_voice/call_tools.py
+++ b/plugins/teams_voice/call_tools.py
@@ -152,16 +152,18 @@ class CallToolRunner:
         return "Okay — I'll call you right back with that."
 
     async def _agent_task(self, query: str) -> str:
-        """Run a long job in the background; deliver the result via a call-back."""
+        """Run a long job in the background; deliver the result to the Teams chat
+        (preferred) or via a voice call-back."""
         h = self._h
         query = query.strip()
         caller = h._caller
         if not query:
             return "What would you like me to work on?"
-        if h._bridge is None or caller is None or not caller.aad_id:
-            return await h._consult.ask(query)  # no call-back possible → inline
+        # Need either a postable thread (chat delivery) or an AAD id (call-back).
+        if h._bridge is None or (not getattr(h, "_thread_id", "") and (caller is None or not caller.aad_id)):
+            return await h._consult.ask(query)  # no delivery path → inline
         asyncio.create_task(self._run_background_task(query, caller))
-        return "Got it — I'll work on that in the background and call you back with the result."
+        return "Got it — I'll work on that in the background and send you the result."
 
     async def _run_background_task(self, query: str, caller) -> None:
         h = self._h
@@ -170,7 +172,15 @@ class CallToolRunner:
         except Exception:  # noqa: BLE001
             logger.error("[teams_voice] background task failed", exc_info=True)
             result = "I couldn't complete that task."
-        if h._bridge is None or not caller.aad_id:
+        # Prefer delivering the result to the Teams chat (no call-back needed);
+        # fall back to a voice call-back when there's no postable thread.
+        thread = getattr(h, "_thread_id", "")
+        if thread:
+            from .meeting import _deliver_to_teams
+
+            if await _deliver_to_teams(thread, f"✅ {result}"):
+                return
+        if h._bridge is None or caller is None or not caller.aad_id:
             return
         tenant = caller.tenant_id or h._bridge.tenant_id
         if not tenant:

--- a/plugins/teams_voice/call_tools.py
+++ b/plugins/teams_voice/call_tools.py
@@ -2,8 +2,9 @@
 
 Separates the tool surface (agent consult / background task / look_at_screen /
 show_to_caller / call_me_back / post_meeting_minutes) from the realtime handler's
-transport + dialogue loop. Holds a reference to the handler for per-call context
-(session, vision store/budget, consult, caller, bridge, meeting).
+transport + dialogue loop. The runner reads only what it needs through a typed
+:class:`CallContext` (built by the handler once the session is established),
+rather than duck-typing on the whole handler.
 """
 
 from __future__ import annotations
@@ -12,24 +13,49 @@ import asyncio
 import base64
 import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from . import meeting
 from .call_session_base import _pending_set
 from .outbound import OutboundError, place_call
 
+if TYPE_CHECKING:
+    from .agent_consult import AgentConsult
+    from .bridge_server import CallSession
+    from .config import TeamsVoiceConfig
+    from .meeting import MeetingTranscript
+    from .protocol import CallerInfo
+    from .vision_budget import VisionBudget
+    from .vision_store import VisionStore
+
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class CallContext:
+    """The per-call state the tool runner needs (references are stable for the call)."""
+
+    bridge: "TeamsVoiceConfig | None"
+    session: "CallSession | None"
+    caller: "CallerInfo | None"
+    consult: "AgentConsult"
+    vision: "VisionStore"
+    vision_budget: "VisionBudget"
+    meeting: "MeetingTranscript"
+    thread_id: str
+
+
 class CallToolRunner:
-    def __init__(self, handler) -> None:
-        self._h = handler
+    def __init__(self, ctx: CallContext) -> None:
+        self._ctx = ctx
 
     async def run_tool(self, name: str, args: dict) -> str:
-        h = self._h
+        ctx = self._ctx
         try:
             if name == "hermes_agent_consult":
-                return await h._consult.ask(str(args.get("query", "")))
+                return await ctx.consult.ask(str(args.get("query", "")))
             if name == "hermes_agent_task":
                 return await self._agent_task(str(args.get("query", "")))
             if name == "look_at_screen":
@@ -41,19 +67,19 @@ class CallToolRunner:
             if name == "call_me_back":
                 return await self._call_me_back(str(args.get("message", "")))
             if name == "post_meeting_minutes":
-                return await meeting.post_minutes(h._consult, h._meeting, h._thread_id)
+                return await meeting.post_minutes(ctx.consult, ctx.meeting, ctx.thread_id)
         except Exception:  # noqa: BLE001 — a tool fault must not break the call
             logger.error("[teams_voice] tool %s failed", name, exc_info=True)
             return "Sorry, that didn't work."
         return f"Unknown tool: {name}."
 
     async def _look_at_screen(self, question: str, source: str | None, scope: str = "live") -> str:
-        h = self._h
-        if not h._vision_budget.try_consume():
+        ctx = self._ctx
+        if not ctx.vision_budget.try_consume():
             return "I've looked at a lot just now — give me a moment before the next one."
         prompt = question.strip() or "Describe what you see."
         if scope == "history":
-            frames = h._vision.history(limit=6)
+            frames = ctx.vision.history(limit=6)
             if not frames:
                 return "I don't have any earlier frames to look back on."
             content: list[dict] = [{"type": "text", "text": prompt}]
@@ -62,7 +88,7 @@ class CallToolRunner:
                 content.append({"type": "image_url", "image_url": {"url": f.data_url()}})
         else:
             want = "camera" if str(source or "").lower() == "camera" else "screenshare"
-            frame = h._vision.latest(want) or h._vision.latest()
+            frame = ctx.vision.latest(want) or ctx.vision.latest()
             if frame is None:
                 return "I can't see a shared screen or camera right now."
             content = [
@@ -81,7 +107,7 @@ class CallToolRunner:
             text = resp.choices[0].message.content if resp and resp.choices else ""
             return (text or "").strip() or "I couldn't quite make that out."
         except Exception:  # noqa: BLE001
-            self._h._vision_budget.refund()  # consult failed before the model — give it back
+            self._ctx.vision_budget.refund()  # consult failed before the model — give it back
             logger.error("[teams_voice] vision consult failed", exc_info=True)
             return "I had trouble looking at that."
 
@@ -111,8 +137,8 @@ class CallToolRunner:
                 final = idx == len(paths) - 1
                 img_bytes = Path(path).read_bytes()
                 mime = "image/png" if str(path).lower().endswith(".png") else "image/jpeg"
-                if self._h._session is not None:
-                    await self._h._session.send_display_image(
+                if self._ctx.session is not None:
+                    await self._ctx.session.send_display_image(
                         base64.b64encode(img_bytes).decode("ascii"),
                         mime,
                         duration_ms=5000 if final else 4500,
@@ -127,21 +153,21 @@ class CallToolRunner:
             return "I made the image but couldn't display it."
 
     async def _call_me_back(self, message: str) -> str:
-        h = self._h
+        ctx = self._ctx
         message = message.strip()
-        caller = h._caller
-        if h._bridge is None or caller is None or not caller.aad_id:
+        caller = ctx.caller
+        if ctx.bridge is None or caller is None or not caller.aad_id:
             return "I can't call you back — I don't have a number to reach you."
-        tenant = caller.tenant_id or h._bridge.tenant_id
+        tenant = caller.tenant_id or ctx.bridge.tenant_id
         if not tenant:
             return "I can't call you back — missing your tenant."
         try:
             result = await place_call(
                 user_object_id=caller.aad_id,
                 tenant_id=tenant,
-                shared_secret=h._bridge.shared_secret,
-                worker_base_url=h._bridge.worker_base_url,
-                allow_remote=h._bridge.allow_remote_worker,
+                shared_secret=ctx.bridge.shared_secret,
+                worker_base_url=ctx.bridge.worker_base_url,
+                allow_remote=ctx.bridge.allow_remote_worker,
             )
         except OutboundError as exc:
             logger.warning("[teams_voice] call_me_back failed: %s", exc)
@@ -154,44 +180,43 @@ class CallToolRunner:
     async def _agent_task(self, query: str) -> str:
         """Run a long job in the background; deliver the result to the Teams chat
         (preferred) or via a voice call-back."""
-        h = self._h
+        ctx = self._ctx
         query = query.strip()
-        caller = h._caller
+        caller = ctx.caller
         if not query:
             return "What would you like me to work on?"
         # Need either a postable thread (chat delivery) or an AAD id (call-back).
-        if h._bridge is None or (not getattr(h, "_thread_id", "") and (caller is None or not caller.aad_id)):
-            return await h._consult.ask(query)  # no delivery path → inline
+        if ctx.bridge is None or (not ctx.thread_id and (caller is None or not caller.aad_id)):
+            return await ctx.consult.ask(query)  # no delivery path → inline
         asyncio.create_task(self._run_background_task(query, caller))
         return "Got it — I'll work on that in the background and send you the result."
 
     async def _run_background_task(self, query: str, caller) -> None:
-        h = self._h
+        ctx = self._ctx
         try:
-            result = await h._consult.ask(query, timeout_s=300.0)
+            result = await ctx.consult.ask(query, timeout_s=300.0)
         except Exception:  # noqa: BLE001
             logger.error("[teams_voice] background task failed", exc_info=True)
             result = "I couldn't complete that task."
         # Prefer delivering the result to the Teams chat (no call-back needed);
         # fall back to a voice call-back when there's no postable thread.
-        thread = getattr(h, "_thread_id", "")
-        if thread:
+        if ctx.thread_id:
             from .meeting import _deliver_to_teams
 
-            if await _deliver_to_teams(thread, f"✅ {result}"):
+            if await _deliver_to_teams(ctx.thread_id, f"✅ {result}"):
                 return
-        if h._bridge is None or caller is None or not caller.aad_id:
+        if ctx.bridge is None or caller is None or not caller.aad_id:
             return
-        tenant = caller.tenant_id or h._bridge.tenant_id
+        tenant = caller.tenant_id or ctx.bridge.tenant_id
         if not tenant:
             return
         try:
             res = await place_call(
                 user_object_id=caller.aad_id,
                 tenant_id=tenant,
-                shared_secret=h._bridge.shared_secret,
-                worker_base_url=h._bridge.worker_base_url,
-                allow_remote=h._bridge.allow_remote_worker,
+                shared_secret=ctx.bridge.shared_secret,
+                worker_base_url=ctx.bridge.worker_base_url,
+                allow_remote=ctx.bridge.allow_remote_worker,
             )
         except OutboundError as exc:
             logger.warning("[teams_voice] background callback failed: %s", exc)

--- a/plugins/teams_voice/call_tools.py
+++ b/plugins/teams_voice/call_tools.py
@@ -2,9 +2,7 @@
 
 Separates the tool surface (agent consult / background task / look_at_screen /
 show_to_caller / call_me_back / post_meeting_minutes) from the realtime handler's
-transport + dialogue loop. The runner reads only what it needs through a typed
-:class:`CallContext` (built by the handler once the session is established),
-rather than duck-typing on the whole handler.
+transport + dialogue loop. Reads per-call state off the handler it's given.
 """
 
 from __future__ import annotations
@@ -13,49 +11,24 @@ import asyncio
 import base64
 import json
 import logging
-from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from . import meeting
 from .call_session_base import _pending_set
 from .outbound import OutboundError, place_call
 
-if TYPE_CHECKING:
-    from .agent_consult import AgentConsult
-    from .bridge_server import CallSession
-    from .config import TeamsVoiceConfig
-    from .meeting import MeetingTranscript
-    from .protocol import CallerInfo
-    from .vision_budget import VisionBudget
-    from .vision_store import VisionStore
-
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class CallContext:
-    """The per-call state the tool runner needs (references are stable for the call)."""
-
-    bridge: "TeamsVoiceConfig | None"
-    session: "CallSession | None"
-    caller: "CallerInfo | None"
-    consult: "AgentConsult"
-    vision: "VisionStore"
-    vision_budget: "VisionBudget"
-    meeting: "MeetingTranscript"
-    thread_id: str
-
-
 class CallToolRunner:
-    def __init__(self, ctx: CallContext) -> None:
-        self._ctx = ctx
+    def __init__(self, handler) -> None:
+        self._h = handler
 
     async def run_tool(self, name: str, args: dict) -> str:
-        ctx = self._ctx
+        h = self._h
         try:
             if name == "hermes_agent_consult":
-                return await ctx.consult.ask(str(args.get("query", "")))
+                return await h._consult.ask(str(args.get("query", "")))
             if name == "hermes_agent_task":
                 return await self._agent_task(str(args.get("query", "")))
             if name == "look_at_screen":
@@ -67,19 +40,19 @@ class CallToolRunner:
             if name == "call_me_back":
                 return await self._call_me_back(str(args.get("message", "")))
             if name == "post_meeting_minutes":
-                return await meeting.post_minutes(ctx.consult, ctx.meeting, ctx.thread_id)
+                return await meeting.post_minutes(h._consult, h._meeting, h._thread_id)
         except Exception:  # noqa: BLE001 — a tool fault must not break the call
             logger.error("[teams_voice] tool %s failed", name, exc_info=True)
             return "Sorry, that didn't work."
         return f"Unknown tool: {name}."
 
     async def _look_at_screen(self, question: str, source: str | None, scope: str = "live") -> str:
-        ctx = self._ctx
-        if not ctx.vision_budget.try_consume():
+        h = self._h
+        if not h._vision_budget.try_consume():
             return "I've looked at a lot just now — give me a moment before the next one."
         prompt = question.strip() or "Describe what you see."
         if scope == "history":
-            frames = ctx.vision.history(limit=6)
+            frames = h._vision.history(limit=6)
             if not frames:
                 return "I don't have any earlier frames to look back on."
             content: list[dict] = [{"type": "text", "text": prompt}]
@@ -88,7 +61,7 @@ class CallToolRunner:
                 content.append({"type": "image_url", "image_url": {"url": f.data_url()}})
         else:
             want = "camera" if str(source or "").lower() == "camera" else "screenshare"
-            frame = ctx.vision.latest(want) or ctx.vision.latest()
+            frame = h._vision.latest(want) or h._vision.latest()
             if frame is None:
                 return "I can't see a shared screen or camera right now."
             content = [
@@ -107,7 +80,7 @@ class CallToolRunner:
             text = resp.choices[0].message.content if resp and resp.choices else ""
             return (text or "").strip() or "I couldn't quite make that out."
         except Exception:  # noqa: BLE001
-            self._ctx.vision_budget.refund()  # consult failed before the model — give it back
+            self._h._vision_budget.refund()  # consult failed before the model — give it back
             logger.error("[teams_voice] vision consult failed", exc_info=True)
             return "I had trouble looking at that."
 
@@ -137,8 +110,8 @@ class CallToolRunner:
                 final = idx == len(paths) - 1
                 img_bytes = Path(path).read_bytes()
                 mime = "image/png" if str(path).lower().endswith(".png") else "image/jpeg"
-                if self._ctx.session is not None:
-                    await self._ctx.session.send_display_image(
+                if self._h._session is not None:
+                    await self._h._session.send_display_image(
                         base64.b64encode(img_bytes).decode("ascii"),
                         mime,
                         duration_ms=5000 if final else 4500,
@@ -153,21 +126,21 @@ class CallToolRunner:
             return "I made the image but couldn't display it."
 
     async def _call_me_back(self, message: str) -> str:
-        ctx = self._ctx
+        h = self._h
         message = message.strip()
-        caller = ctx.caller
-        if ctx.bridge is None or caller is None or not caller.aad_id:
+        caller = h._caller
+        if h._bridge is None or caller is None or not caller.aad_id:
             return "I can't call you back — I don't have a number to reach you."
-        tenant = caller.tenant_id or ctx.bridge.tenant_id
+        tenant = caller.tenant_id or h._bridge.tenant_id
         if not tenant:
             return "I can't call you back — missing your tenant."
         try:
             result = await place_call(
                 user_object_id=caller.aad_id,
                 tenant_id=tenant,
-                shared_secret=ctx.bridge.shared_secret,
-                worker_base_url=ctx.bridge.worker_base_url,
-                allow_remote=ctx.bridge.allow_remote_worker,
+                shared_secret=h._bridge.shared_secret,
+                worker_base_url=h._bridge.worker_base_url,
+                allow_remote=h._bridge.allow_remote_worker,
             )
         except OutboundError as exc:
             logger.warning("[teams_voice] call_me_back failed: %s", exc)
@@ -180,43 +153,43 @@ class CallToolRunner:
     async def _agent_task(self, query: str) -> str:
         """Run a long job in the background; deliver the result to the Teams chat
         (preferred) or via a voice call-back."""
-        ctx = self._ctx
+        h = self._h
         query = query.strip()
-        caller = ctx.caller
+        caller = h._caller
         if not query:
             return "What would you like me to work on?"
         # Need either a postable thread (chat delivery) or an AAD id (call-back).
-        if ctx.bridge is None or (not ctx.thread_id and (caller is None or not caller.aad_id)):
-            return await ctx.consult.ask(query)  # no delivery path → inline
+        if h._bridge is None or (not h._thread_id and (caller is None or not caller.aad_id)):
+            return await h._consult.ask(query)  # no delivery path → inline
         asyncio.create_task(self._run_background_task(query, caller))
         return "Got it — I'll work on that in the background and send you the result."
 
     async def _run_background_task(self, query: str, caller) -> None:
-        ctx = self._ctx
+        h = self._h
         try:
-            result = await ctx.consult.ask(query, timeout_s=300.0)
+            result = await h._consult.ask(query, timeout_s=300.0)
         except Exception:  # noqa: BLE001
             logger.error("[teams_voice] background task failed", exc_info=True)
             result = "I couldn't complete that task."
         # Prefer delivering the result to the Teams chat (no call-back needed);
         # fall back to a voice call-back when there's no postable thread.
-        if ctx.thread_id:
+        if h._thread_id:
             from .meeting import _deliver_to_teams
 
-            if await _deliver_to_teams(ctx.thread_id, f"✅ {result}"):
+            if await _deliver_to_teams(h._thread_id, f"✅ {result}"):
                 return
-        if ctx.bridge is None or caller is None or not caller.aad_id:
+        if h._bridge is None or caller is None or not caller.aad_id:
             return
-        tenant = caller.tenant_id or ctx.bridge.tenant_id
+        tenant = caller.tenant_id or h._bridge.tenant_id
         if not tenant:
             return
         try:
             res = await place_call(
                 user_object_id=caller.aad_id,
                 tenant_id=tenant,
-                shared_secret=ctx.bridge.shared_secret,
-                worker_base_url=ctx.bridge.worker_base_url,
-                allow_remote=ctx.bridge.allow_remote_worker,
+                shared_secret=h._bridge.shared_secret,
+                worker_base_url=h._bridge.worker_base_url,
+                allow_remote=h._bridge.allow_remote_worker,
             )
         except OutboundError as exc:
             logger.warning("[teams_voice] background callback failed: %s", exc)

--- a/plugins/teams_voice/cli.py
+++ b/plugins/teams_voice/cli.py
@@ -1,0 +1,96 @@
+"""``hermes teams-voice`` CLI subcommands."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+from .config import resolve_config
+
+
+def register_cli(subparser: argparse.ArgumentParser) -> None:
+    """Build the ``hermes teams-voice`` argparse tree."""
+    subs = subparser.add_subparsers(dest="teams_voice_command")
+    subs.add_parser("status", help="Print bridge configuration and readiness")
+    serve_p = subs.add_parser("serve", help="Run the bridge WebSocket server (foreground)")
+    serve_p.add_argument("--host", default=None, help="Override bind host")
+    serve_p.add_argument("--port", type=int, default=None, help="Override bind port")
+    serve_p.add_argument(
+        "--handler",
+        choices=("logging", "echo", "realtime"),
+        default="logging",
+        help=(
+            "Call brain: 'logging' (no audio back), 'echo' (smile + echo caller "
+            "audio so the avatar lip-syncs — smoke test), 'realtime' (OpenAI/Azure "
+            "speech-to-speech; needs OPENAI_API_KEY)."
+        ),
+    )
+
+
+def teams_voice_command(args) -> int:
+    """Dispatch ``hermes teams-voice`` subcommands. Returns an exit code."""
+    command = getattr(args, "teams_voice_command", None)
+
+    if command == "status":
+        cfg = resolve_config()
+        print(
+            json.dumps(
+                {
+                    "configured": cfg.configured,
+                    "host": cfg.host,
+                    "port": cfg.port,
+                    "path": cfg.path,
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    if command == "serve":
+        from .bridge_server import BridgeServer, CallSessionHandler
+
+        cfg = resolve_config()
+        if not cfg.configured:
+            print("error: no shared secret (set TEAMS_VOICE_SHARED_SECRET)")
+            return 1
+        if args.host or args.port:
+            from dataclasses import replace
+
+            cfg = replace(cfg, host=args.host or cfg.host, port=args.port or cfg.port)
+
+        handler_kind = getattr(args, "handler", "logging")
+        factory = CallSessionHandler  # default: log only, no audio back
+        if handler_kind == "echo":
+            from .handlers import EchoCallSessionHandler
+
+            factory = EchoCallSessionHandler
+        elif handler_kind == "realtime":
+            from .handlers import RealtimeCallSessionHandler
+            from .realtime.openai_client import realtime_config_from_env
+
+            rt_cfg = realtime_config_from_env()
+            if not rt_cfg.configured:
+                print(
+                    "error: realtime handler needs an API key "
+                    "(OPENAI_API_KEY, or AZURE_FOUNDRY_API_KEY / TEAMS_VOICE_REALTIME_API_KEY for Azure)"
+                )
+                return 1
+            factory = lambda: RealtimeCallSessionHandler(rt_cfg, bridge_config=cfg)  # noqa: E731
+
+        async def _run() -> None:
+            server = BridgeServer(config=cfg, handler_factory=factory)
+            await server.start()
+            try:
+                await asyncio.Future()
+            finally:
+                await server.stop()
+
+        try:
+            asyncio.run(_run())
+        except KeyboardInterrupt:
+            pass
+        return 0
+
+    print("usage: hermes teams-voice {status|serve}")
+    return 2

--- a/plugins/teams_voice/cli.py
+++ b/plugins/teams_voice/cli.py
@@ -78,6 +78,10 @@ def teams_voice_command(args) -> int:
                 return 1
             factory = lambda: RealtimeCallSessionHandler(rt_cfg, bridge_config=cfg)  # noqa: E731
         elif handler_kind == "streaming":
+            import shutil
+
+            if shutil.which("ffmpeg") is None:
+                print("warning: streaming mode needs 'ffmpeg' on PATH to decode TTS audio")
             from .handlers import StreamingCallSessionHandler
 
             factory = lambda: StreamingCallSessionHandler(bridge_config=cfg)  # noqa: E731

--- a/plugins/teams_voice/cli.py
+++ b/plugins/teams_voice/cli.py
@@ -58,6 +58,11 @@ def teams_voice_command(args) -> int:
             from dataclasses import replace
 
             cfg = replace(cfg, host=args.host or cfg.host, port=args.port or cfg.port)
+        if cfg.host not in ("127.0.0.1", "localhost", "::1"):
+            print(
+                f"warning: bridge bound to non-loopback host {cfg.host!r} — the shared "
+                "secret is exposed to that interface; prefer 127.0.0.1 in production"
+            )
 
         handler_kind = getattr(args, "handler", "logging")
         factory = CallSessionHandler  # default: log only, no audio back

--- a/plugins/teams_voice/cli.py
+++ b/plugins/teams_voice/cli.py
@@ -18,12 +18,12 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
     serve_p.add_argument("--port", type=int, default=None, help="Override bind port")
     serve_p.add_argument(
         "--handler",
-        choices=("logging", "echo", "realtime"),
+        choices=("logging", "echo", "realtime", "streaming"),
         default="logging",
         help=(
             "Call brain: 'logging' (no audio back), 'echo' (smile + echo caller "
-            "audio so the avatar lip-syncs — smoke test), 'realtime' (OpenAI/Azure "
-            "speech-to-speech; needs OPENAI_API_KEY)."
+            "audio — smoke test), 'realtime' (OpenAI/Azure speech-to-speech), "
+            "'streaming' (STT -> agent -> TTS; works with any STT/TTS provider)."
         ),
     )
 
@@ -77,6 +77,10 @@ def teams_voice_command(args) -> int:
                 )
                 return 1
             factory = lambda: RealtimeCallSessionHandler(rt_cfg, bridge_config=cfg)  # noqa: E731
+        elif handler_kind == "streaming":
+            from .handlers import StreamingCallSessionHandler
+
+            factory = lambda: StreamingCallSessionHandler(bridge_config=cfg)  # noqa: E731
 
         async def _run() -> None:
             server = BridgeServer(config=cfg, handler_factory=factory)

--- a/plugins/teams_voice/config.py
+++ b/plugins/teams_voice/config.py
@@ -57,6 +57,8 @@ class TeamsVoiceConfig:
     session_scope: str = "per-call"
     # Group-call wake phrases (speak only when addressed).
     wake_phrases: tuple[str, ...] = ("assistant", "hermes")
+    # Post end-of-call meeting minutes to the Teams chat (opt-in).
+    meeting_recap: bool = False
 
     @property
     def configured(self) -> bool:
@@ -139,6 +141,9 @@ def resolve_config(extra: Mapping[str, Any] | None = None) -> TeamsVoiceConfig:
         or "per-call"
     )
     wake = _coerce_list(extra.get("wake_phrases"), os.getenv("TEAMS_VOICE_WAKE_PHRASES", ""))
+    meeting_recap = str(
+        extra.get("meeting_recap", "") or os.getenv("TEAMS_VOICE_MEETING_RECAP", "")
+    ).strip().lower() in ("1", "true", "yes", "on")
 
     return TeamsVoiceConfig(
         shared_secret=shared_secret,
@@ -152,6 +157,7 @@ def resolve_config(extra: Mapping[str, Any] | None = None) -> TeamsVoiceConfig:
         max_vision_per_minute=max_vision,
         session_scope=session_scope,
         wake_phrases=wake or ("assistant", "hermes"),
+        meeting_recap=meeting_recap,
     )
 
 

--- a/plugins/teams_voice/config.py
+++ b/plugins/teams_voice/config.py
@@ -1,0 +1,133 @@
+"""Configuration resolution for the teams_voice bridge.
+
+Values come from (in priority order): the plugin's ``config.extra`` block in
+``config.yaml`` (when wired through the gateway), then environment variables,
+then safe defaults. Secrets are never logged.
+
+The wire contract is fixed by the companion .NET media worker (AzureBot /
+OpenClawBridge), so the header names, HMAC payload shape, and default path mirror
+that worker exactly — see ``protocol.py`` and ``hmac_auth.py``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+# Audio wire format — single source of truth, mirrors the worker (PCM 16 kHz,
+# 16-bit signed, mono, little-endian; 20 ms / 640-byte frames).
+PCM_SAMPLE_RATE_HZ = 16_000
+FRAME_DURATION_MS = 20
+BYTES_PER_FRAME = PCM_SAMPLE_RATE_HZ * FRAME_DURATION_MS // 1000 * 2  # 640
+
+# Default WebSocket path the worker connects to: ``/voice/msteams/stream/{callId}``.
+DEFAULT_PATH = "/voice/msteams/stream"
+
+# HMAC upgrade header names — fixed by the existing worker. The "OpenClaw" prefix
+# is historical; Hermes reuses the headers verbatim so the worker needs no change.
+HEADER_TIMESTAMP = "X-OpenClawTeamsBridge-Timestamp"
+HEADER_SIGNATURE = "X-OpenClawTeamsBridge-Signature"
+
+
+@dataclass(frozen=True)
+class TeamsVoiceConfig:
+    """Resolved bridge configuration."""
+
+    shared_secret: str
+    host: str = "127.0.0.1"
+    port: int = 8443
+    path: str = DEFAULT_PATH
+    # Replay/clock-skew window for the HMAC handshake, in milliseconds.
+    hmac_window_ms: int = 60_000
+    # Connection caps (DoS guards) — mirror the TS driver's defaults.
+    max_connections: int = 64
+    max_connections_per_ip: int = 8
+    # A connection must send ``session.start`` within this window or it is reaped.
+    pre_start_timeout_s: float = 10.0
+    require_recording_status: bool = True
+    # Outbound "call me back": the worker's loopback HTTP endpoint + default tenant.
+    worker_base_url: str = "http://127.0.0.1:9440"
+    tenant_id: str = ""
+
+    @property
+    def configured(self) -> bool:
+        """True when a shared secret is present (the bridge can authenticate)."""
+        return bool(self.shared_secret)
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def plugin_config_block() -> dict[str, Any]:
+    """Return the ``plugins.entries.teams_voice.config`` block from config.yaml.
+
+    Empty dict when unset or config can't be loaded. ``${VAR}`` references are
+    already expanded by Hermes's config loader, so secrets can live in ``.env``
+    and be referenced here (e.g. ``shared_secret: ${TEAMS_VOICE_SHARED_SECRET}``).
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        node = (
+            config.get("plugins", {})
+            .get("entries", {})
+            .get("teams_voice", {})
+            .get("config", {})
+        )
+        return node if isinstance(node, dict) else {}
+    except Exception:  # noqa: BLE001 — config is optional; fall back to env
+        return {}
+
+
+def resolve_config(extra: Mapping[str, Any] | None = None) -> TeamsVoiceConfig:
+    """Build a :class:`TeamsVoiceConfig` from config.yaml + environment.
+
+    ``extra`` is the per-plugin config block; when omitted it is read from
+    ``plugins.entries.teams_voice.config`` in config.yaml. Environment variables
+    are the fallback so the bridge still works with no config file.
+    """
+    extra = extra if extra is not None else plugin_config_block()
+
+    shared_secret = (
+        str(extra.get("shared_secret") or "").strip()
+        or os.getenv("TEAMS_VOICE_SHARED_SECRET", "").strip()
+    )
+    host = (
+        str(extra.get("host") or "").strip()
+        or os.getenv("TEAMS_VOICE_HOST", "").strip()
+        or "127.0.0.1"
+    )
+    port = _coerce_int(
+        extra.get("port") or os.getenv("TEAMS_VOICE_PORT", ""), 8443
+    )
+    path = str(extra.get("path") or "").strip() or DEFAULT_PATH
+    window = _coerce_int(
+        extra.get("hmac_window_ms") or os.getenv("TEAMS_VOICE_HMAC_WINDOW_MS", ""),
+        60_000,
+    )
+    worker_base_url = (
+        str(extra.get("worker_base_url") or "").strip()
+        or os.getenv("TEAMS_VOICE_WORKER_BASE_URL", "").strip()
+        or "http://127.0.0.1:9440"
+    )
+    tenant_id = (
+        str(extra.get("tenant_id") or "").strip()
+        or os.getenv("TEAMS_VOICE_TENANT_ID", "").strip()
+        or os.getenv("TEAMS_TENANT_ID", "").strip()
+    )
+
+    return TeamsVoiceConfig(
+        shared_secret=shared_secret,
+        host=host,
+        port=port,
+        path=path,
+        hmac_window_ms=window,
+        worker_base_url=worker_base_url,
+        tenant_id=tenant_id,
+    )

--- a/plugins/teams_voice/config.py
+++ b/plugins/teams_voice/config.py
@@ -49,8 +49,13 @@ class TeamsVoiceConfig:
     # Outbound "call me back": the worker's loopback HTTP endpoint + default tenant.
     worker_base_url: str = "http://127.0.0.1:9440"
     tenant_id: str = ""
-    # Caller allowlist (AAD object ids or display names). Empty = allow all.
+    # Caller allowlist (AAD object ids). Empty = allow all. Display-name matching
+    # is weaker (spoofable) and off unless ``allowlist_allow_names`` is set.
     allowlist: tuple[str, ...] = ()
+    allowlist_allow_names: bool = False
+    # Refuse outbound place-call to a non-loopback worker unless explicitly allowed
+    # (the shared secret would otherwise be sent to that host).
+    allow_remote_worker: bool = False
     # Per-call vision spend cap across look_at_screen + ambient push (0 = unlimited).
     max_vision_per_minute: int = 30
     # Agent session continuity: "per-call" | "per-thread" | "per-aad".
@@ -158,6 +163,27 @@ def resolve_config(extra: Mapping[str, Any] | None = None) -> TeamsVoiceConfig:
         session_scope=session_scope,
         wake_phrases=wake or ("assistant", "hermes"),
         meeting_recap=meeting_recap,
+        allowlist_allow_names=_coerce_bool(extra.get("allowlist_allow_names"), "TEAMS_VOICE_ALLOWLIST_ALLOW_NAMES"),
+        allow_remote_worker=_coerce_bool(extra.get("allow_remote_worker"), "TEAMS_VOICE_ALLOW_REMOTE_WORKER"),
+    )
+
+
+def caller_allowed(config: "TeamsVoiceConfig", aad_id: str | None, display_name: str | None) -> bool:
+    """Allowlist check: AAD id by default; display name only if opted in.
+
+    Empty allowlist = allow all (backward-compatible)."""
+    if not config.allowlist:
+        return True
+    if (aad_id or "").strip().lower() in config.allowlist:
+        return True
+    if config.allowlist_allow_names and (display_name or "").strip().lower() in config.allowlist:
+        return True
+    return False
+
+
+def _coerce_bool(value: Any, env: str) -> bool:
+    return str(value if value not in (None, "") else os.getenv(env, "")).strip().lower() in (
+        "1", "true", "yes", "on",
     )
 
 

--- a/plugins/teams_voice/config.py
+++ b/plugins/teams_voice/config.py
@@ -136,7 +136,15 @@ def resolve_config(extra: Mapping[str, Any] | None = None) -> TeamsVoiceConfig:
         or os.getenv("TEAMS_VOICE_TENANT_ID", "").strip()
         or os.getenv("TEAMS_TENANT_ID", "").strip()
     )
-    allowlist = _coerce_list(extra.get("allowlist"), os.getenv("TEAMS_VOICE_ALLOWLIST", ""))
+    # Allowlist: TEAMS_VOICE_ALLOWLIST; when empty, inherit the chat plane's
+    # TEAMS_ALLOWED_USERS so voice + chat share one AAD allowlist.
+    allowlist = _coerce_list(extra.get("allowlist"), os.getenv("TEAMS_VOICE_ALLOWLIST", "")) or _coerce_list(
+        None, os.getenv("TEAMS_ALLOWED_USERS", "")
+    )
+    rr = extra.get("require_recording_status")
+    if rr is None:
+        rr = os.getenv("TEAMS_VOICE_REQUIRE_RECORDING_STATUS", "true")
+    require_recording = str(rr).strip().lower() not in ("0", "false", "no", "off")  # default True
     max_vision = _coerce_int(
         extra.get("max_vision_per_minute") or os.getenv("TEAMS_VOICE_MAX_VISION_PER_MINUTE", ""), 30
     )
@@ -156,6 +164,7 @@ def resolve_config(extra: Mapping[str, Any] | None = None) -> TeamsVoiceConfig:
         port=port,
         path=path,
         hmac_window_ms=window,
+        require_recording_status=require_recording,
         worker_base_url=worker_base_url,
         tenant_id=tenant_id,
         allowlist=allowlist,

--- a/plugins/teams_voice/config.py
+++ b/plugins/teams_voice/config.py
@@ -49,6 +49,14 @@ class TeamsVoiceConfig:
     # Outbound "call me back": the worker's loopback HTTP endpoint + default tenant.
     worker_base_url: str = "http://127.0.0.1:9440"
     tenant_id: str = ""
+    # Caller allowlist (AAD object ids or display names). Empty = allow all.
+    allowlist: tuple[str, ...] = ()
+    # Per-call vision spend cap across look_at_screen + ambient push (0 = unlimited).
+    max_vision_per_minute: int = 30
+    # Agent session continuity: "per-call" | "per-thread" | "per-aad".
+    session_scope: str = "per-call"
+    # Group-call wake phrases (speak only when addressed).
+    wake_phrases: tuple[str, ...] = ("assistant", "hermes")
 
     @property
     def configured(self) -> bool:
@@ -121,6 +129,16 @@ def resolve_config(extra: Mapping[str, Any] | None = None) -> TeamsVoiceConfig:
         or os.getenv("TEAMS_VOICE_TENANT_ID", "").strip()
         or os.getenv("TEAMS_TENANT_ID", "").strip()
     )
+    allowlist = _coerce_list(extra.get("allowlist"), os.getenv("TEAMS_VOICE_ALLOWLIST", ""))
+    max_vision = _coerce_int(
+        extra.get("max_vision_per_minute") or os.getenv("TEAMS_VOICE_MAX_VISION_PER_MINUTE", ""), 30
+    )
+    session_scope = (
+        str(extra.get("session_scope") or "").strip()
+        or os.getenv("TEAMS_VOICE_SESSION_SCOPE", "").strip()
+        or "per-call"
+    )
+    wake = _coerce_list(extra.get("wake_phrases"), os.getenv("TEAMS_VOICE_WAKE_PHRASES", ""))
 
     return TeamsVoiceConfig(
         shared_secret=shared_secret,
@@ -130,4 +148,17 @@ def resolve_config(extra: Mapping[str, Any] | None = None) -> TeamsVoiceConfig:
         hmac_window_ms=window,
         worker_base_url=worker_base_url,
         tenant_id=tenant_id,
+        allowlist=allowlist,
+        max_vision_per_minute=max_vision,
+        session_scope=session_scope,
+        wake_phrases=wake or ("assistant", "hermes"),
     )
+
+
+def _coerce_list(value: Any, env: str) -> tuple[str, ...]:
+    """List from a config list or a comma-separated env string (lowercased, trimmed)."""
+    if isinstance(value, (list, tuple)):
+        items = [str(v).strip() for v in value]
+    else:
+        items = [p.strip() for p in (env or "").split(",")]
+    return tuple(i.lower() for i in items if i)

--- a/plugins/teams_voice/config.py
+++ b/plugins/teams_voice/config.py
@@ -4,9 +4,9 @@ Values come from (in priority order): the plugin's ``config.extra`` block in
 ``config.yaml`` (when wired through the gateway), then environment variables,
 then safe defaults. Secrets are never logged.
 
-The wire contract is fixed by the companion .NET media worker (AzureBot /
-OpenClawBridge), so the header names, HMAC payload shape, and default path mirror
-that worker exactly — see ``protocol.py`` and ``hmac_auth.py``.
+The wire contract is fixed by the companion .NET media worker, so the header
+names, HMAC payload shape, and default path mirror that worker exactly — see
+``protocol.py`` and ``hmac_auth.py``.
 """
 
 from __future__ import annotations
@@ -24,8 +24,9 @@ BYTES_PER_FRAME = PCM_SAMPLE_RATE_HZ * FRAME_DURATION_MS // 1000 * 2  # 640
 # Default WebSocket path the worker connects to: ``/voice/msteams/stream/{callId}``.
 DEFAULT_PATH = "/voice/msteams/stream"
 
-# HMAC upgrade header names — fixed by the existing worker. The "OpenClaw" prefix
-# is historical; Hermes reuses the headers verbatim so the worker needs no change.
+# HMAC upgrade header names — MUST match the companion worker byte-for-byte (it
+# sends these on the WS upgrade and reads them on the outbound-call endpoint).
+# Do not rename without a matching change in the worker, or the handshake fails.
 HEADER_TIMESTAMP = "X-OpenClawTeamsBridge-Timestamp"
 HEADER_SIGNATURE = "X-OpenClawTeamsBridge-Signature"
 

--- a/plugins/teams_voice/config.py
+++ b/plugins/teams_voice/config.py
@@ -65,6 +65,9 @@ class TeamsVoiceConfig:
     wake_phrases: tuple[str, ...] = ("assistant", "hermes")
     # Post end-of-call meeting minutes to the Teams chat (opt-in).
     meeting_recap: bool = False
+    # SharePoint (OneDrive) site id (host,siteGuid,webGuid) for attaching files /
+    # minutes to the chat; empty = text-only delivery.
+    share_point_site_id: str = ""
 
     @property
     def configured(self) -> bool:
@@ -158,6 +161,10 @@ def resolve_config(extra: Mapping[str, Any] | None = None) -> TeamsVoiceConfig:
     meeting_recap = str(
         extra.get("meeting_recap", "") or os.getenv("TEAMS_VOICE_MEETING_RECAP", "")
     ).strip().lower() in ("1", "true", "yes", "on")
+    _sp = str(extra.get("share_point_site_id") or extra.get("sharePointSiteId") or "").strip()
+    if _sp.startswith("${"):  # an unexpanded ${VAR} reference — ignore, use env
+        _sp = ""
+    share_point_site_id = _sp or os.getenv("TEAMS_SHAREPOINT_SITE_ID", "").strip()
 
     return TeamsVoiceConfig(
         shared_secret=shared_secret,
@@ -173,6 +180,7 @@ def resolve_config(extra: Mapping[str, Any] | None = None) -> TeamsVoiceConfig:
         session_scope=session_scope,
         wake_phrases=wake or ("assistant", "hermes"),
         meeting_recap=meeting_recap,
+        share_point_site_id=share_point_site_id,
         allowlist_allow_names=_coerce_bool(extra.get("allowlist_allow_names"), "TEAMS_VOICE_ALLOWLIST_ALLOW_NAMES"),
         allow_remote_worker=_coerce_bool(extra.get("allow_remote_worker"), "TEAMS_VOICE_ALLOW_REMOTE_WORKER"),
     )

--- a/plugins/teams_voice/echo_guard.py
+++ b/plugins/teams_voice/echo_guard.py
@@ -1,0 +1,77 @@
+"""Echo guard — stop the realtime model answering its own playback.
+
+The realtime self-answer bug (openclaw #92081's headline fix): on a speakerphone
+the bot's own audio loops back into the mic, the model's VAD hears it, and it
+"replies" to itself. This guard decides, per inbound caller frame, whether to
+forward it to the model.
+
+Logic (ported from the openclaw realtime echo guard):
+
+* Keep a **playout clock** — an estimate of when our outbound audio finishes. The
+  model streams faster than realtime, so wall-clock send time != play time; we
+  accumulate sent-frame durations instead.
+* While we're "speaking" (now < playout_end + tail window), inbound audio is
+  **dropped unless it is loud enough to be a real barge-in** (RMS >= threshold).
+* **Until the caller's first real turn**, allow *no* barge-in at all — so the
+  opening greeting echoing back can't make the bot interrupt and re-greet itself
+  in a loop while the caller is silent.
+
+Pure logic with an injectable clock so it is unit-testable.
+"""
+
+from __future__ import annotations
+
+import time
+
+
+def _now_ms() -> float:
+    return time.monotonic() * 1000.0
+
+
+class EchoGuard:
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        tail_window_ms: int = 600,
+        barge_in_rms: float = 0.04,
+    ) -> None:
+        self.enabled = enabled
+        self.tail_window_ms = tail_window_ms
+        self.barge_in_rms = barge_in_rms
+        self._playout_end_ms = 0.0
+        self._first_turn = False
+
+    def note_output(self, duration_ms: float, now: float | None = None) -> None:
+        """Record that ``duration_ms`` of audio was queued to the worker."""
+        now = _now_ms() if now is None else now
+        self._playout_end_ms = max(now, self._playout_end_ms) + duration_ms
+
+    def collapse(self, now: float | None = None) -> None:
+        """A barge-in was accepted — playback is cut and the caller has the floor.
+
+        Pull the playout horizon fully behind the tail window so ``speaking()`` is
+        immediately false and the caller's audio flows without further guarding.
+        """
+        now = _now_ms() if now is None else now
+        self._playout_end_ms = now - self.tail_window_ms
+
+    def mark_caller_turn(self) -> None:
+        """The caller has spoken a real turn; future barge-in is allowed."""
+        self._first_turn = True
+
+    def speaking(self, now: float | None = None) -> bool:
+        now = _now_ms() if now is None else now
+        return now < self._playout_end_ms + self.tail_window_ms
+
+    def allow_input(self, rms: float, now: float | None = None) -> bool:
+        """Return True if this inbound caller frame should reach the model."""
+        if not self.enabled:
+            return True
+        now = _now_ms() if now is None else now
+        if not self.speaking(now):
+            return True
+        # We are (likely) hearing our own playback.
+        if not self._first_turn:
+            return False  # opening greeting: never let echo trigger a barge-in
+        return rms >= self.barge_in_rms

--- a/plugins/teams_voice/echo_guard.py
+++ b/plugins/teams_voice/echo_guard.py
@@ -1,11 +1,11 @@
 """Echo guard — stop the realtime model answering its own playback.
 
-The realtime self-answer bug (openclaw #92081's headline fix): on a speakerphone
+The realtime self-answer bug: on a speakerphone
 the bot's own audio loops back into the mic, the model's VAD hears it, and it
 "replies" to itself. This guard decides, per inbound caller frame, whether to
 forward it to the model.
 
-Logic (ported from the openclaw realtime echo guard):
+Logic:
 
 * Keep a **playout clock** — an estimate of when our outbound audio finishes. The
   model streams faster than realtime, so wall-clock send time != play time; we

--- a/plugins/teams_voice/elevenlabs_tts.py
+++ b/plugins/teams_voice/elevenlabs_tts.py
@@ -1,0 +1,67 @@
+"""ElevenLabs TTS with real per-character timing (the viseme "full pass").
+
+When ElevenLabs is configured, the streaming path synthesizes via the
+``/with-timestamps`` endpoint, which returns the audio **and** per-character start
+times. We turn those into real viseme ``speech.marks`` (vs the text estimator), so
+the avatar mouth changes shape on the actual sound timing. Falls back silently
+(``None``) when unconfigured or on any failure — audio never depends on timing.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+ENDPOINT = "https://api.elevenlabs.io/v1/text-to-speech/{voice_id}/with-timestamps"
+
+
+def resolve_config() -> dict | None:
+    """Resolve ``{api_key, voice_id, model_id}`` from env or the Hermes TTS config."""
+    api_key = os.getenv("ELEVENLABS_API_KEY", "").strip()
+    voice_id = os.getenv("TEAMS_VOICE_ELEVENLABS_VOICE_ID", "").strip()
+    model_id = os.getenv("TEAMS_VOICE_ELEVENLABS_MODEL", "").strip() or "eleven_multilingual_v2"
+    if not (api_key and voice_id):
+        try:
+            from tools.tts_tool import _load_tts_config
+
+            el = (_load_tts_config().get("providers") or {}).get("elevenlabs") or {}
+            api_key = api_key or str(el.get("apiKey") or el.get("api_key") or "").strip()
+            voice_id = voice_id or str(el.get("voiceId") or el.get("voice_id") or el.get("voice") or "").strip()
+            model_id = str(el.get("modelId") or el.get("model_id") or model_id).strip()
+        except Exception:  # noqa: BLE001
+            pass
+    if not (api_key and voice_id):
+        return None
+    return {"api_key": api_key, "voice_id": voice_id, "model_id": model_id}
+
+
+async def synth_with_timestamps(text: str, config: dict) -> tuple[bytes, list[tuple[str, int]]] | None:
+    """Return ``(mp3_bytes, [(char, start_ms), …])`` or ``None`` on failure."""
+    import aiohttp
+
+    url = ENDPOINT.format(voice_id=config["voice_id"])
+    headers = {"xi-api-key": config["api_key"], "Content-Type": "application/json"}
+    body = {"text": text, "model_id": config.get("model_id") or "eleven_multilingual_v2",
+            "output_format": "mp3_44100_128"}
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=body, headers=headers) as resp:
+                if resp.status != 200:
+                    logger.warning("[teams_voice] elevenlabs with-timestamps %s", resp.status)
+                    return None
+                data = await resp.json()
+    except (aiohttp.ClientError, ValueError) as exc:
+        logger.warning("[teams_voice] elevenlabs with-timestamps failed: %s", exc)
+        return None
+
+    audio_b64 = data.get("audio_base64")
+    if not audio_b64:
+        return None
+    align = data.get("alignment") or {}
+    chars = align.get("characters") or []
+    starts = align.get("character_start_times_seconds") or []
+    timing = [(c, int(float(st) * 1000)) for c, st in zip(chars, starts)]
+    return base64.b64decode(audio_b64), timing

--- a/plugins/teams_voice/expression.py
+++ b/plugins/teams_voice/expression.py
@@ -1,0 +1,90 @@
+"""Avatar emotion heuristic — Python port of openclaw ``expression.ts``.
+
+A cheap, dependency-free lexical classifier that infers a coarse emotion from the
+assistant's reply text, with no extra model call. The result is sent to the media
+worker as an additive ``expression`` cue so the avatar shapes its mouth
+(smile / frown / round "O"). Best-effort and purely cosmetic.
+
+Priority order matters: surprise > sad > happy > neutral (a "!" plus a sad word
+should read as surprise, matching the original).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Coarse emotion labels understood by the worker's AvatarExpression mapping.
+NEUTRAL = "neutral"
+HAPPY = "happy"
+SAD = "sad"
+SURPRISED = "surprised"
+
+_SURPRISED_PUNCT = re.compile(r"(!!|\?!|!\?)")
+_SURPRISED_WORDS = frozenset(
+    {"wow", "whoa", "woah", "omg", "unbelievable", "incredible", "what?!"}
+)
+_SAD_WORDS = frozenset(
+    {
+        "sorry",
+        "unfortunately",
+        "sadly",
+        "failed",
+        "failure",
+        "error",
+        "regret",
+        "apolog",  # matches apolog-y / apolog-ize via substring check below
+        "couldn't",
+        "cannot",
+        "unable",
+    }
+)
+_HAPPY_WORDS = frozenset(
+    {
+        "great",
+        "perfect",
+        "awesome",
+        "excellent",
+        "wonderful",
+        "fantastic",
+        "glad",
+        "happy",
+        "congrats",
+        "congratulations",
+        "nice",
+        "love",
+    }
+)
+
+_WORD_RE = re.compile(r"[a-z']+")
+
+
+def infer_emotion(text: str) -> str:
+    """Return one of ``neutral|happy|sad|surprised`` for ``text``.
+
+    Empty/whitespace input is ``neutral``. Matching is case-insensitive and
+    word-oriented (with a couple of substring stems where the original allowed
+    them, e.g. "apolog").
+    """
+    if not text or not text.strip():
+        return NEUTRAL
+
+    lowered = text.lower()
+    if _SURPRISED_PUNCT.search(lowered):
+        return SURPRISED
+
+    words = set(_WORD_RE.findall(lowered))
+    if words & _SURPRISED_WORDS:
+        return SURPRISED
+    if _matches(words, lowered, _SAD_WORDS):
+        return SAD
+    if _matches(words, lowered, _HAPPY_WORDS):
+        return HAPPY
+    return NEUTRAL
+
+
+def _matches(words: set[str], lowered: str, vocab: frozenset[str]) -> bool:
+    """Whole-word match, with substring fallback for stem entries (len <= 6)."""
+    if words & vocab:
+        return True
+    # A few vocab entries are stems (e.g. "apolog"); allow substring for those.
+    return any(term not in words and len(term) <= 6 and term in lowered for term in vocab)

--- a/plugins/teams_voice/expression.py
+++ b/plugins/teams_voice/expression.py
@@ -1,4 +1,4 @@
-"""Avatar emotion heuristic — Python port of openclaw ``expression.ts``.
+"""Avatar emotion heuristic.
 
 A cheap, dependency-free lexical classifier that infers a coarse emotion from the
 assistant's reply text, with no extra model call. The result is sent to the media

--- a/plugins/teams_voice/expression.py
+++ b/plugins/teams_voice/expression.py
@@ -18,6 +18,8 @@ NEUTRAL = "neutral"
 HAPPY = "happy"
 SAD = "sad"
 SURPRISED = "surprised"
+# Transient state cue (not inferred from text) — shown while a tool runs.
+THINKING = "thinking"
 
 _SURPRISED_PUNCT = re.compile(r"(!!|\?!|!\?)")
 _SURPRISED_WORDS = frozenset(

--- a/plugins/teams_voice/group_call_gate.py
+++ b/plugins/teams_voice/group_call_gate.py
@@ -1,0 +1,97 @@
+"""Group-call "speak only when addressed" gate — port of ``group-call-gate.ts``.
+
+In a group/meeting call (2+ humans) the assistant stays silent until addressed by
+name (a configured wake phrase), then a short follow-up window lets the
+back-and-forth continue without repeating the name. 1:1 calls always respond
+(gate off). The streaming path enforces this deterministically; the realtime
+path uses it to build an instruction.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+DEFAULT_WAKE_PHRASES: tuple[str, ...] = ("assistant",)
+DEFAULT_FOLLOW_UP_WINDOW_MS = 12_000
+
+
+@dataclass(frozen=True)
+class GroupCallGateConfig:
+    """Resolved gate settings; the single source of the defaults."""
+
+    require_address: bool = True
+    wake_phrases: tuple[str, ...] = DEFAULT_WAKE_PHRASES
+    follow_up_window_ms: int = DEFAULT_FOLLOW_UP_WINDOW_MS
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    respond: bool
+    addressed: bool
+    gated: bool  # True when the gate actively suppressed an otherwise-eligible turn
+
+
+def resolve_group_call_gate_config(raw: dict | None) -> GroupCallGateConfig:
+    """Merge a raw config block onto the defaults (one place owns the defaults)."""
+    raw = raw or {}
+    phrases = raw.get("wakePhrases") or raw.get("wake_phrases")
+    if phrases:
+        wake = tuple(str(p).strip().lower() for p in phrases if str(p).strip())
+    else:
+        wake = DEFAULT_WAKE_PHRASES
+    return GroupCallGateConfig(
+        require_address=bool(raw.get("requireAddress", raw.get("require_address", True))),
+        wake_phrases=wake or DEFAULT_WAKE_PHRASES,
+        follow_up_window_ms=int(
+            raw.get("followUpWindowMs", raw.get("follow_up_window_ms", DEFAULT_FOLLOW_UP_WINDOW_MS))
+        ),
+    )
+
+
+def is_addressed(transcript: str, wake_phrases: tuple[str, ...]) -> bool:
+    """Case-insensitive, word-boundary match of any wake phrase in ``transcript``.
+
+    ``\\w`` boundaries are Unicode-aware in Python by default, so Arabic/Latin
+    wake phrases both work. An empty phrase list never matches (gate inert).
+    """
+    if not transcript or not wake_phrases:
+        return False
+    lowered = transcript.lower()
+    for phrase in wake_phrases:
+        phrase = phrase.strip().lower()
+        if not phrase:
+            continue
+        if re.search(rf"(?<!\w){re.escape(phrase)}(?!\w)", lowered):
+            return True
+    return False
+
+
+def should_respond_to_group_turn(
+    *,
+    transcript: str,
+    is_group: bool,
+    config: GroupCallGateConfig,
+    last_addressed_at_ms: int | None,
+    now_ms: int,
+) -> GateDecision:
+    """Decide whether to respond to a finished caller turn.
+
+    1:1 (``is_group=False``) or ``require_address=False`` always responds. In a
+    group with the gate on, respond when addressed by name OR still inside the
+    follow-up window after the last addressed turn.
+    """
+    if not is_group or not config.require_address:
+        return GateDecision(respond=True, addressed=False, gated=False)
+
+    addressed = is_addressed(transcript, config.wake_phrases)
+    if addressed:
+        return GateDecision(respond=True, addressed=True, gated=False)
+
+    if (
+        last_addressed_at_ms is not None
+        and now_ms - last_addressed_at_ms <= config.follow_up_window_ms
+    ):
+        return GateDecision(respond=True, addressed=False, gated=False)
+
+    return GateDecision(respond=False, addressed=False, gated=True)

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -26,7 +26,7 @@ from . import audio, expression, group_call_gate, meeting, protocol, realtime_to
 from .agent_consult import AgentConsult
 from .meeting import MeetingTranscript
 from .bridge_server import CallSession, CallSessionHandler
-from .config import BYTES_PER_FRAME, FRAME_DURATION_MS, PCM_SAMPLE_RATE_HZ, TeamsVoiceConfig
+from .config import BYTES_PER_FRAME, FRAME_DURATION_MS, PCM_SAMPLE_RATE_HZ, TeamsVoiceConfig, caller_allowed
 from .echo_guard import EchoGuard
 from .outbound import OutboundError, place_call
 from .realtime.openai_client import REALTIME_SAMPLE_RATE_HZ, RealtimeConfig, RealtimeSession
@@ -39,8 +39,27 @@ logger = logging.getLogger(__name__)
 
 # Shared across connections: the inbound call that requests a callback and the
 # outbound leg that delivers it are *different* WebSocket connections, so the
-# pending spoken result is keyed by the worker's callId here.
-_PENDING_OUTBOUND: dict[str, str] = {}
+# pending spoken result is keyed by the worker's callId here. Entries carry a TTL
+# so a never-answered call-back can't leak its result string indefinitely.
+_PENDING_OUTBOUND: dict[str, tuple[str, float]] = {}
+_PENDING_TTL_S = 600.0
+
+
+def _pending_prune() -> None:
+    now = time.monotonic()
+    for k in [k for k, (_t, exp) in _PENDING_OUTBOUND.items() if exp <= now]:
+        _PENDING_OUTBOUND.pop(k, None)
+
+
+def _pending_set(call_id: str, text: str) -> None:
+    _pending_prune()
+    _PENDING_OUTBOUND[call_id] = (text, time.monotonic() + _PENDING_TTL_S)
+
+
+def _pending_pop(call_id: str) -> str | None:
+    _pending_prune()
+    entry = _PENDING_OUTBOUND.pop(call_id, None)
+    return entry[0] if entry else None
 
 
 class EchoCallSessionHandler(CallSessionHandler):
@@ -74,6 +93,7 @@ class RealtimeCallSessionHandler(CallSessionHandler):
     def __init__(self, config: RealtimeConfig, bridge_config: TeamsVoiceConfig | None = None) -> None:
         self._cfg = config
         self._bridge = bridge_config
+        self._require_recording = bridge_config.require_recording_status if bridge_config else True
         self._rt: RealtimeSession | None = None
         self._session: CallSession | None = None
         self._caller: protocol.CallerInfo | None = None
@@ -115,16 +135,15 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         self._outbound = (msg.direction or "").lower() == "outbound"
         # If this is the delivery leg of a call-back, fetch the pending result.
         if self._outbound:
-            self._pending_greeting = _PENDING_OUTBOUND.pop(msg.call_id, None)
+            self._pending_greeting = _pending_pop(msg.call_id)
 
         # Caller allowlist (enforced only when configured): reject unmatched inbound.
-        if not self._outbound and self._bridge and self._bridge.allowlist:
-            ident = (msg.caller.aad_id or "").lower()
-            name = (msg.caller.display_name or "").lower()
-            if ident not in self._bridge.allowlist and name not in self._bridge.allowlist:
-                logger.info("[teams_voice] caller not allowlisted; rejecting %s", session.call_id)
-                await session._ws.close()
-                return
+        if not self._outbound and self._bridge and not caller_allowed(
+            self._bridge, msg.caller.aad_id, msg.caller.display_name
+        ):
+            logger.info("[teams_voice] caller not allowlisted; rejecting %s", session.call_id)
+            await session._ws.close()
+            return
 
         # Agent session continuity scope.
         scope = self._bridge.session_scope if self._bridge else "per-call"
@@ -197,8 +216,18 @@ class RealtimeCallSessionHandler(CallSessionHandler):
                 f"Greet{who} warmly and briefly, then ask how you can help."
             )
 
+    async def on_participants(self, session: CallSession, msg: protocol.Participants) -> None:
+        await super().on_participants(session, msg)  # sets session.human_count
+        # Race-free group gate: in a meeting (2+ humans) turn OFF server-VAD
+        # auto-response, so the model only speaks when we explicitly create a
+        # response for an addressed turn (no audio can leak before a cancel).
+        if self._rt is not None:
+            await self._rt.set_auto_response(session.human_count < 2)
+
     async def on_audio_frame(self, session: CallSession, msg: protocol.AudioFrame) -> None:
-        if not session.recording_active or self._rt is None:
+        if self._require_recording and not session.recording_active:
+            return
+        if self._rt is None:
             return
         if msg.speaker_name:  # unmixed-audio attribution for the meeting transcript
             self._last_speaker = msg.speaker_name
@@ -209,7 +238,7 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         await self._rt.push_audio(pcm24)
 
     async def on_video_frame(self, session: CallSession, msg: protocol.VideoFrame) -> None:
-        if not session.recording_active:
+        if self._require_recording and not session.recording_active:
             return
         self._vision.store(
             StoredFrame(
@@ -224,7 +253,7 @@ class RealtimeCallSessionHandler(CallSessionHandler):
     async def on_dtmf(self, session: CallSession, msg: protocol.Dtmf) -> None:
         # Surface keypad input to the realtime model (recording-gated) so it can
         # run "press 1 to…" flows.
-        if not session.recording_active or self._rt is None:
+        if (self._require_recording and not session.recording_active) or self._rt is None:
             return
         await self._rt.send_user_text(f"The caller pressed the {msg.digit} key on the keypad.")
 
@@ -347,8 +376,11 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         if decision.respond:
             if decision.addressed:
                 self._last_addressed_ms = now
+            # In group mode auto-response is OFF, so trigger the reply ourselves.
+            if is_group and self._rt is not None:
+                await self._rt.create_response()
         else:
-            # Unaddressed meeting turn: drop the auto-created reply at the egress.
+            # Unaddressed meeting turn: egress-drop backstop + cancel any response.
             self._drop_response = True
             if self._rt is not None:
                 await self._rt.cancel_response()
@@ -498,13 +530,14 @@ class RealtimeCallSessionHandler(CallSessionHandler):
                 tenant_id=tenant,
                 shared_secret=self._bridge.shared_secret,
                 worker_base_url=self._bridge.worker_base_url,
+                allow_remote=self._bridge.allow_remote_worker,
             )
         except OutboundError as exc:
             logger.warning("[teams_voice] call_me_back failed: %s", exc)
             return "I couldn't place the call-back just now."
         call_id = result.get("callId")
         if call_id:
-            _PENDING_OUTBOUND[call_id] = message or "Here's what you asked for."
+            _pending_set(call_id, message or "Here's what you asked for.")
         return "Okay — I'll call you right back with that."
 
     async def _agent_task(self, query: str) -> str:
@@ -536,13 +569,14 @@ class RealtimeCallSessionHandler(CallSessionHandler):
                 tenant_id=tenant,
                 shared_secret=self._bridge.shared_secret,
                 worker_base_url=self._bridge.worker_base_url,
+                allow_remote=self._bridge.allow_remote_worker,
             )
         except OutboundError as exc:
             logger.warning("[teams_voice] background callback failed: %s", exc)
             return
         cid = res.get("callId")
         if cid:
-            _PENDING_OUTBOUND[cid] = result
+            _pending_set(cid, result)
 
     # ── helpers ──────────────────────────────────────────────────────────────
 
@@ -568,6 +602,8 @@ class StreamingCallSessionHandler(CallSessionHandler):
         from .streaming_audio import UtteranceBuffer
 
         self._bridge = bridge_config
+        self._require_recording = bridge_config.require_recording_status if bridge_config else True
+        self._utterance_task: asyncio.Task | None = None
         self._session: CallSession | None = None
         self._caller: protocol.CallerInfo | None = None
         self._buf = UtteranceBuffer()
@@ -586,6 +622,13 @@ class StreamingCallSessionHandler(CallSessionHandler):
         self._session = session
         self._caller = msg.caller
         self._thread_id = msg.thread_id
+        # Caller allowlist parity with the realtime path.
+        if (msg.direction or "").lower() != "outbound" and self._bridge and not caller_allowed(
+            self._bridge, msg.caller.aad_id, msg.caller.display_name
+        ):
+            logger.info("[teams_voice] caller not allowlisted; rejecting %s", session.call_id)
+            await session._ws.close()
+            return
         scope = self._bridge.session_scope if self._bridge else "per-call"
         key = msg.thread_id if scope == "per-thread" else (msg.caller.aad_id if scope == "per-aad" else msg.call_id)
         self._consult = AgentConsult(session_id=f"teams:{key or msg.call_id}")
@@ -593,19 +636,23 @@ class StreamingCallSessionHandler(CallSessionHandler):
 
     async def on_session_end(self, session: CallSession, msg: protocol.SessionEnd) -> None:
         await super().on_session_end(session, msg)
+        # Cancel an in-flight utterance job so we don't speak after hangup.
+        if self._utterance_task is not None:
+            self._utterance_task.cancel()
+            self._utterance_task = None
         if self._bridge and self._bridge.meeting_recap and not self._meeting.is_empty():
             asyncio.create_task(
                 meeting.post_minutes(self._consult, self._meeting, self._thread_id)
             )
 
     async def on_audio_frame(self, session: CallSession, msg: protocol.AudioFrame) -> None:
-        if not session.recording_active or self._processing:
+        if (self._require_recording and not session.recording_active) or self._processing:
             return
         pcm = base64.b64decode(msg.payload_base64)
         utterance = self._buf.push(pcm, audio.pcm16_rms(pcm))
         if utterance is not None:
             self._processing = True
-            asyncio.create_task(self._handle_utterance(utterance))
+            self._utterance_task = asyncio.create_task(self._handle_utterance(utterance))
 
     async def _handle_utterance(self, pcm: bytes) -> None:
         try:

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -22,8 +22,9 @@ import uuid
 from dataclasses import replace
 from pathlib import Path
 
-from . import audio, expression, group_call_gate, protocol, realtime_tools, verbal_interrupts, viseme_estimate
+from . import audio, expression, group_call_gate, meeting, protocol, realtime_tools, verbal_interrupts, viseme_estimate
 from .agent_consult import AgentConsult
+from .meeting import MeetingTranscript
 from .bridge_server import CallSession, CallSessionHandler
 from .config import BYTES_PER_FRAME, FRAME_DURATION_MS, PCM_SAMPLE_RATE_HZ, TeamsVoiceConfig
 from .echo_guard import EchoGuard
@@ -100,6 +101,9 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         self._ambient_interval_s = 6.0
         self._ambient_last_ts: dict[str, int] = {}
         self._vision_budget = VisionBudget(bridge_config.max_vision_per_minute if bridge_config else 30)
+        self._meeting = MeetingTranscript()
+        self._thread_id = ""
+        self._last_speaker = ""  # from unmixed-audio speaker_name, for attribution
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 
@@ -107,6 +111,7 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         await super().on_session_start(session, msg)
         self._session = session
         self._caller = msg.caller
+        self._thread_id = msg.thread_id
         self._outbound = (msg.direction or "").lower() == "outbound"
         # If this is the delivery leg of a call-back, fetch the pending result.
         if self._outbound:
@@ -195,6 +200,8 @@ class RealtimeCallSessionHandler(CallSessionHandler):
     async def on_audio_frame(self, session: CallSession, msg: protocol.AudioFrame) -> None:
         if not session.recording_active or self._rt is None:
             return
+        if msg.speaker_name:  # unmixed-audio attribution for the meeting transcript
+            self._last_speaker = msg.speaker_name
         pcm16 = base64.b64decode(msg.payload_base64)
         if not self._echo.allow_input(audio.pcm16_rms(pcm16)):  # echo guard
             return
@@ -226,6 +233,11 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         if self._ambient_task is not None:
             self._ambient_task.cancel()
             self._ambient_task = None
+        # End-of-meeting recap (opt-in) — run detached so teardown isn't blocked.
+        if self._bridge and self._bridge.meeting_recap and not self._meeting.is_empty():
+            asyncio.create_task(
+                meeting.post_minutes(self._consult, self._meeting, self._thread_id)
+            )
         self._vision.clear()
         if self._rt is not None:
             await self._rt.close()
@@ -316,6 +328,7 @@ class RealtimeCallSessionHandler(CallSessionHandler):
     async def _on_input_transcript(self, text: str) -> None:
         """Caller's finished turn — drive verbal interrupts and the group gate."""
         self._echo.mark_caller_turn()
+        self._meeting.add(self._last_speaker or self._first_name() or "Caller", text)
         # 1) Deterministic verbal interrupt ("stop" / "توقف" / "⟨name⟩, stop").
         if verbal_interrupts.is_verbal_interrupt(text, self._gate_cfg.wake_phrases):
             self._drop_response = True  # suppress any reply to the interrupt itself
@@ -353,6 +366,8 @@ class RealtimeCallSessionHandler(CallSessionHandler):
             except Exception:  # noqa: BLE001
                 pass
         self._out_residual = b""
+        if self._transcript.strip():
+            self._meeting.add("Assistant", self._transcript)
         self._transcript = ""
         self._last_emotion = None
         self._drop_response = False  # next turn starts fresh
@@ -384,6 +399,8 @@ class RealtimeCallSessionHandler(CallSessionHandler):
                 return await self._show_to_caller(str(args.get("prompt", "")), args.get("count", 1))
             if name == "call_me_back":
                 return await self._call_me_back(str(args.get("message", "")))
+            if name == "post_meeting_minutes":
+                return await meeting.post_minutes(self._consult, self._meeting, self._thread_id)
         except Exception:  # noqa: BLE001 — a tool fault must not break the call
             logger.error("[teams_voice] tool %s failed", name, exc_info=True)
             return "Sorry, that didn't work."
@@ -561,15 +578,25 @@ class StreamingCallSessionHandler(CallSessionHandler):
         self._out_seq = 0
         self._out_ts = 0
         self._processing = False  # half-duplex: one utterance at a time
+        self._meeting = MeetingTranscript()
+        self._thread_id = ""
 
     async def on_session_start(self, session: CallSession, msg: protocol.SessionStart) -> None:
         await super().on_session_start(session, msg)
         self._session = session
         self._caller = msg.caller
+        self._thread_id = msg.thread_id
         scope = self._bridge.session_scope if self._bridge else "per-call"
         key = msg.thread_id if scope == "per-thread" else (msg.caller.aad_id if scope == "per-aad" else msg.call_id)
         self._consult = AgentConsult(session_id=f"teams:{key or msg.call_id}")
         await self._safe_expression(expression.NEUTRAL)
+
+    async def on_session_end(self, session: CallSession, msg: protocol.SessionEnd) -> None:
+        await super().on_session_end(session, msg)
+        if self._bridge and self._bridge.meeting_recap and not self._meeting.is_empty():
+            asyncio.create_task(
+                meeting.post_minutes(self._consult, self._meeting, self._thread_id)
+            )
 
     async def on_audio_frame(self, session: CallSession, msg: protocol.AudioFrame) -> None:
         if not session.recording_active or self._processing:
@@ -597,8 +624,15 @@ class StreamingCallSessionHandler(CallSessionHandler):
                 return
             if decision.addressed:
                 self._last_addressed_ms = now
+            caller_name = (self._caller.display_name.split(" ")[0] if self._caller and self._caller.display_name else "Caller")
+            self._meeting.add(caller_name, transcript)
+            # On-demand "summarize the meeting" → post minutes instead of a normal reply.
+            if meeting.is_summary_request(transcript):
+                await self._speak(await meeting.post_minutes(self._consult, self._meeting, self._thread_id))
+                return
             await self._safe_expression(expression.THINKING)
             reply = await self._consult.ask(transcript)
+            self._meeting.add("Assistant", reply)
             await self._speak(reply)
         except Exception:  # noqa: BLE001 — never let a turn crash the call
             logger.error("[teams_voice] streaming turn failed", exc_info=True)

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -1,0 +1,330 @@
+"""Call-session handlers — the dialogue brains the bridge dispatches into.
+
+* :class:`EchoCallSessionHandler` — dependency-light smoke test: smiles on connect
+  and echoes the caller's audio so the worker's RMS lip-sync animates the avatar.
+
+* :class:`RealtimeCallSessionHandler` — the full speech-to-speech brain:
+  recording gate, **echo guard** (self-answer fix), bidirectional resampled audio,
+  expression cues + **realtime visemes**, **barge-in**, and the realtime tool set:
+  **agent delegation** (`hermes_agent_consult` → `run_agent`), **vision**
+  (`look_at_screen`), **show_to_caller** (image → tile), and **outbound call-back**
+  (`call_me_back`, delivered on the worker's outbound leg).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import uuid
+from pathlib import Path
+
+from . import audio, expression, protocol, realtime_tools, viseme_estimate
+from .agent_consult import AgentConsult
+from .bridge_server import CallSession, CallSessionHandler
+from .config import BYTES_PER_FRAME, FRAME_DURATION_MS, PCM_SAMPLE_RATE_HZ, TeamsVoiceConfig
+from .echo_guard import EchoGuard
+from .outbound import OutboundError, place_call
+from .realtime.openai_client import REALTIME_SAMPLE_RATE_HZ, RealtimeConfig, RealtimeSession
+from .vision_store import StoredFrame, VisionStore
+
+logger = logging.getLogger(__name__)
+
+# Shared across connections: the inbound call that requests a callback and the
+# outbound leg that delivers it are *different* WebSocket connections, so the
+# pending spoken result is keyed by the worker's callId here.
+_PENDING_OUTBOUND: dict[str, str] = {}
+
+
+class EchoCallSessionHandler(CallSessionHandler):
+    """Smoke-test handler — visible proof the driver path works end to end."""
+
+    def __init__(self) -> None:
+        self._seq = 0
+        self._ts = 0
+
+    async def on_session_start(self, session: CallSession, msg: protocol.SessionStart) -> None:
+        await super().on_session_start(session, msg)
+        try:
+            await session.send_expression(expression.HAPPY)
+        except Exception:  # noqa: BLE001 — cosmetic; never fail the call
+            logger.debug("[teams_voice] echo: expression send failed", exc_info=True)
+
+    async def on_audio_frame(self, session: CallSession, msg: protocol.AudioFrame) -> None:
+        if not session.recording_active:
+            return
+        try:
+            await session.send_audio_frame(self._seq, self._ts, msg.payload_base64)
+        except Exception:  # noqa: BLE001
+            return
+        self._seq += 1
+        self._ts += FRAME_DURATION_MS
+
+
+class RealtimeCallSessionHandler(CallSessionHandler):
+    """Bridges a Teams call to an OpenAI/Azure realtime speech-to-speech model."""
+
+    def __init__(self, config: RealtimeConfig, bridge_config: TeamsVoiceConfig | None = None) -> None:
+        self._cfg = config
+        self._bridge = bridge_config
+        self._rt: RealtimeSession | None = None
+        self._session: CallSession | None = None
+        self._caller: protocol.CallerInfo | None = None
+        self._outbound = False
+        self._pending_greeting: str | None = None
+        # Outbound (model -> worker) framing state.
+        self._out_seq = 0
+        self._out_ts = 0
+        self._out_residual = b""
+        # Dialogue state.
+        self._turn_id = 0
+        self._transcript = ""
+        self._last_emotion: str | None = None
+        self._echo = EchoGuard()
+        self._vision = VisionStore()
+        self._consult = AgentConsult()
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+
+    async def on_session_start(self, session: CallSession, msg: protocol.SessionStart) -> None:
+        await super().on_session_start(session, msg)
+        self._session = session
+        self._caller = msg.caller
+        self._outbound = (msg.direction or "").lower() == "outbound"
+        # If this is the delivery leg of a call-back, fetch the pending result.
+        if self._outbound:
+            self._pending_greeting = _PENDING_OUTBOUND.pop(msg.call_id, None)
+
+        rt = RealtimeSession(self._cfg)
+        rt.tools = realtime_tools.default_tools()
+        rt.on_audio_delta = self._on_model_audio
+        rt.on_transcript_delta = self._on_transcript
+        rt.on_speech_started = self._on_barge_in
+        rt.on_response_done = self._on_response_done
+        rt.on_function_call = self._on_function_call
+        self._rt = rt
+        try:
+            await rt.connect()
+        except Exception:  # noqa: BLE001 — keep socket; worker shows neutral avatar
+            logger.error("[teams_voice] realtime connect failed for %s", session.call_id, exc_info=True)
+            return
+        # Inbound greeting fires from the model; outbound waits for recording-active.
+        if not self._outbound:
+            await self._safe_expression(expression.NEUTRAL)
+
+    async def on_recording_status(self, session: CallSession, msg: protocol.RecordingStatus) -> None:
+        await super().on_recording_status(session, msg)
+        # Outbound delivery: speak the result only once the callee has answered
+        # (recording active), not while the phone is still ringing (greet-on-answer).
+        if self._outbound and session.recording_active and self._pending_greeting and self._rt:
+            greeting, self._pending_greeting = self._pending_greeting, None
+            await self._rt.request_say(
+                f"The caller just answered. Deliver this result clearly and concisely, "
+                f"then say goodbye: {greeting}"
+            )
+
+    async def on_audio_frame(self, session: CallSession, msg: protocol.AudioFrame) -> None:
+        if not session.recording_active or self._rt is None:
+            return
+        pcm16 = base64.b64decode(msg.payload_base64)
+        if not self._echo.allow_input(audio.pcm16_rms(pcm16)):  # echo guard
+            return
+        pcm24 = audio.resample_pcm16(pcm16, PCM_SAMPLE_RATE_HZ, REALTIME_SAMPLE_RATE_HZ)
+        await self._rt.push_audio(pcm24)
+
+    async def on_video_frame(self, session: CallSession, msg: protocol.VideoFrame) -> None:
+        if not session.recording_active:
+            return
+        self._vision.store(
+            StoredFrame(
+                source=msg.source,
+                data_base64=msg.data_base64,
+                mime=msg.mime or "image/jpeg",
+                ts=msg.ts,
+                participant_name=msg.participant_name,
+            )
+        )
+
+    async def on_session_end(self, session: CallSession, msg: protocol.SessionEnd) -> None:
+        await super().on_session_end(session, msg)
+        self._vision.clear()
+        if self._rt is not None:
+            await self._rt.close()
+            self._rt = None
+
+    # ── model -> worker callbacks ────────────────────────────────────────────
+
+    async def _on_model_audio(self, pcm24: bytes) -> None:
+        session = self._session
+        if session is None:
+            return
+        pcm16 = audio.resample_pcm16(pcm24, REALTIME_SAMPLE_RATE_HZ, PCM_SAMPLE_RATE_HZ)
+        frames, self._out_residual = audio.frame_pcm16(self._out_residual + pcm16, BYTES_PER_FRAME)
+        for frame in frames:
+            try:
+                await session.send_audio_frame(
+                    self._out_seq, self._out_ts, base64.b64encode(frame).decode("ascii")
+                )
+            except Exception:  # noqa: BLE001
+                return
+            self._echo.note_output(FRAME_DURATION_MS)  # advance the playout clock
+            self._out_seq += 1
+            self._out_ts += FRAME_DURATION_MS
+
+    async def _on_transcript(self, text: str) -> None:
+        session = self._session
+        if session is None:
+            return
+        self._transcript += text
+        emotion = expression.infer_emotion(self._transcript)
+        if emotion != self._last_emotion:
+            self._last_emotion = emotion
+            await self._safe_expression(emotion)
+        # Approximate realtime visemes: estimate over this delta, anchored at the
+        # current playout position. The worker blends them over RMS openness.
+        marks = viseme_estimate.estimate_visemes(text, max(len(text) * 60, 60))
+        if marks:
+            try:
+                await session.send_speech_marks(viseme_estimate.marks_to_payload(marks), ts=self._out_ts)
+            except Exception:  # noqa: BLE001
+                pass
+
+    async def _on_barge_in(self) -> None:
+        self._turn_id += 1
+        self._echo.collapse()
+        self._echo.mark_caller_turn()
+        self._out_residual = b""
+        if self._session is not None:
+            try:
+                await self._session.send_assistant_cancel(self._turn_id)
+            except Exception:  # noqa: BLE001
+                pass
+        if self._rt is not None:
+            await self._rt.cancel_response()
+
+    async def _on_response_done(self) -> None:
+        session = self._session
+        if session is not None and self._out_residual:
+            pad = self._out_residual + b"\x00" * (BYTES_PER_FRAME - len(self._out_residual))
+            try:
+                await session.send_audio_frame(
+                    self._out_seq, self._out_ts, base64.b64encode(pad).decode("ascii")
+                )
+                self._out_seq += 1
+                self._out_ts += FRAME_DURATION_MS
+            except Exception:  # noqa: BLE001
+                pass
+        self._out_residual = b""
+        self._transcript = ""
+        self._last_emotion = None
+
+    # ── tool dispatch ────────────────────────────────────────────────────────
+
+    async def _on_function_call(self, name: str, call_id: str, args_json: str) -> None:
+        try:
+            args = json.loads(args_json or "{}")
+        except (TypeError, ValueError):
+            args = {}
+        result = await self._run_tool(name, args if isinstance(args, dict) else {})
+        if self._rt is not None:
+            await self._rt.send_function_result(call_id, result or "Done.")
+
+    async def _run_tool(self, name: str, args: dict) -> str:
+        try:
+            if name == "hermes_agent_consult":
+                return await self._consult.ask(str(args.get("query", "")))
+            if name == "look_at_screen":
+                return await self._look_at_screen(str(args.get("question", "")), args.get("source"))
+            if name == "show_to_caller":
+                return await self._show_to_caller(str(args.get("prompt", "")))
+            if name == "call_me_back":
+                return await self._call_me_back(str(args.get("message", "")))
+        except Exception:  # noqa: BLE001 — a tool fault must not break the call
+            logger.error("[teams_voice] tool %s failed", name, exc_info=True)
+            return "Sorry, that didn't work."
+        return f"Unknown tool: {name}."
+
+    async def _look_at_screen(self, question: str, source: str | None) -> str:
+        want = "camera" if str(source or "").lower() == "camera" else "screenshare"
+        frame = self._vision.latest(want) or self._vision.latest()
+        if frame is None:
+            return "I can't see a shared screen or camera right now."
+        prompt = question.strip() or "Describe what you see."
+        try:
+            from agent.auxiliary_client import async_call_llm
+
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {"type": "image_url", "image_url": {"url": frame.data_url()}},
+                    ],
+                }
+            ]
+            resp = await async_call_llm(task="vision", messages=messages, max_tokens=400)
+            text = resp.choices[0].message.content if resp and resp.choices else ""
+            return (text or "").strip() or "I couldn't quite make that out."
+        except Exception:  # noqa: BLE001
+            logger.error("[teams_voice] look_at_screen vision call failed", exc_info=True)
+            return "I had trouble looking at that."
+
+    async def _show_to_caller(self, prompt: str) -> str:
+        prompt = prompt.strip()
+        if not prompt:
+            return "What would you like me to show?"
+        try:
+            from tools.image_generation_tool import image_generate_tool
+
+            raw = await asyncio.to_thread(lambda: image_generate_tool(prompt=prompt, aspect_ratio="landscape"))
+            data = json.loads(raw)
+            if not data.get("success") or not data.get("image"):
+                return "I couldn't create that image."
+            img_bytes = Path(data["image"]).read_bytes()
+            mime = "image/png" if str(data["image"]).lower().endswith(".png") else "image/jpeg"
+            if self._session is not None:
+                await self._session.send_display_image(
+                    base64.b64encode(img_bytes).decode("ascii"),
+                    mime,
+                    duration_ms=6000,
+                    mode="overlay",
+                    caption=prompt[:80],
+                )
+            return "I'm showing it on screen now."
+        except Exception:  # noqa: BLE001
+            logger.error("[teams_voice] show_to_caller failed", exc_info=True)
+            return "I made the image but couldn't display it."
+
+    async def _call_me_back(self, message: str) -> str:
+        message = message.strip()
+        caller = self._caller
+        if self._bridge is None or caller is None or not caller.aad_id:
+            return "I can't call you back — I don't have a number to reach you."
+        tenant = caller.tenant_id or self._bridge.tenant_id
+        if not tenant:
+            return "I can't call you back — missing your tenant."
+        try:
+            result = await place_call(
+                user_object_id=caller.aad_id,
+                tenant_id=tenant,
+                shared_secret=self._bridge.shared_secret,
+                worker_base_url=self._bridge.worker_base_url,
+            )
+        except OutboundError as exc:
+            logger.warning("[teams_voice] call_me_back failed: %s", exc)
+            return "I couldn't place the call-back just now."
+        call_id = result.get("callId")
+        if call_id:
+            _PENDING_OUTBOUND[call_id] = message or "Here's what you asked for."
+        return "Okay — I'll call you right back with that."
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    async def _safe_expression(self, emotion: str) -> None:
+        if self._session is None:
+            return
+        try:
+            await self._session.send_expression(emotion)
+        except Exception:  # noqa: BLE001 — cosmetic
+            pass

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -138,6 +138,11 @@ class RealtimeCallSessionHandler(CallSessionHandler):
             "If more than one person is on the call, stay silent unless someone "
             f"addresses you by name ({phrases}); in a one-on-one call respond normally."
         )
+        if getattr(self._cfg, "bilingual", False):
+            parts.append(
+                "You are bilingual in Arabic and English: detect the caller's language, "
+                "reply in that language, switch when they switch, and translate on request."
+            )
         return " ".join(parts)
 
     async def on_recording_status(self, session: CallSession, msg: protocol.RecordingStatus) -> None:
@@ -339,6 +344,8 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         try:
             if name == "hermes_agent_consult":
                 return await self._consult.ask(str(args.get("query", "")))
+            if name == "hermes_agent_task":
+                return await self._agent_task(str(args.get("query", "")))
             if name == "look_at_screen":
                 return await self._look_at_screen(
                     str(args.get("question", "")), args.get("source"), str(args.get("scope") or "live")
@@ -434,6 +441,43 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         if call_id:
             _PENDING_OUTBOUND[call_id] = message or "Here's what you asked for."
         return "Okay — I'll call you right back with that."
+
+    async def _agent_task(self, query: str) -> str:
+        """Run a long job in the background; deliver the result via a call-back."""
+        query = query.strip()
+        caller = self._caller
+        if not query:
+            return "What would you like me to work on?"
+        if self._bridge is None or caller is None or not caller.aad_id:
+            # No way to call back — fall back to an inline consult.
+            return await self._consult.ask(query)
+        asyncio.create_task(self._run_background_task(query, caller))
+        return "Got it — I'll work on that in the background and call you back with the result."
+
+    async def _run_background_task(self, query: str, caller: protocol.CallerInfo) -> None:
+        try:
+            result = await self._consult.ask(query, timeout_s=300.0)
+        except Exception:  # noqa: BLE001
+            logger.error("[teams_voice] background task failed", exc_info=True)
+            result = "I couldn't complete that task."
+        if self._bridge is None or not caller.aad_id:
+            return
+        tenant = caller.tenant_id or self._bridge.tenant_id
+        if not tenant:
+            return
+        try:
+            res = await place_call(
+                user_object_id=caller.aad_id,
+                tenant_id=tenant,
+                shared_secret=self._bridge.shared_secret,
+                worker_base_url=self._bridge.worker_base_url,
+            )
+        except OutboundError as exc:
+            logger.warning("[teams_voice] background callback failed: %s", exc)
+            return
+        cid = res.get("callId")
+        if cid:
+            _PENDING_OUTBOUND[cid] = result
 
     # ── helpers ──────────────────────────────────────────────────────────────
 

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -383,6 +383,11 @@ class StreamingCallSessionHandler(BaseTeamsCallHandler):
         self._out_seq = 0
         self._out_ts = 0
         self._processing = False  # half-duplex: one utterance at a time
+        # Vision: ingest video.frame and auto-attach a fresh frame's description
+        # to the agent turn (budget-capped, recording-gated).
+        self._vision = VisionStore()
+        self._vision_budget = VisionBudget(bridge_config.max_vision_per_minute if bridge_config else 30)
+        self._last_frame_ts: int | None = None
 
     async def on_session_start(self, session: CallSession, msg: protocol.SessionStart) -> None:
         if not await self._begin_session(session, msg):  # state + allowlist + scope
@@ -431,6 +436,49 @@ class StreamingCallSessionHandler(BaseTeamsCallHandler):
             self._processing = True
             self._utterance_task = asyncio.create_task(self._handle_utterance(utterance))
 
+    async def on_video_frame(self, session: CallSession, msg: protocol.VideoFrame) -> None:
+        if self._require_recording and not session.recording_active:
+            return
+        self._vision.store(
+            StoredFrame(
+                source=msg.source,
+                data_base64=msg.data_base64,
+                mime=msg.mime or "image/jpeg",
+                ts=msg.ts,
+                participant_name=msg.participant_name,
+            )
+        )
+
+    async def _vision_context(self) -> str:
+        """One-line description of the freshest shared frame to prepend to the turn.
+
+        Auto-attach: only when there's a NEW frame since the last turn and the
+        per-call vision budget allows; empty string otherwise (no agent change)."""
+        frame = self._vision.latest()
+        if frame is None or frame.ts == self._last_frame_ts:
+            return ""
+        if not self._vision_budget.try_consume():
+            return ""
+        self._last_frame_ts = frame.ts
+        try:
+            from agent.auxiliary_client import async_call_llm
+
+            resp = await async_call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": [
+                    {"type": "text", "text": "In one short sentence, describe what the caller is sharing."},
+                    {"type": "image_url", "image_url": {"url": frame.data_url()}},
+                ]}],
+                max_tokens=120,
+            )
+            desc = (resp.choices[0].message.content if resp and resp.choices else "") or ""
+            desc = desc.strip()
+            return f"[The caller is sharing their {frame.describe()}: {desc}]\n" if desc else ""
+        except Exception:  # noqa: BLE001
+            self._vision_budget.refund()
+            logger.error("[teams_voice] streaming vision describe failed", exc_info=True)
+            return ""
+
     async def _handle_utterance(self, pcm: bytes) -> None:
         try:
             transcript = await self._transcribe(pcm)
@@ -452,7 +500,9 @@ class StreamingCallSessionHandler(BaseTeamsCallHandler):
             if decision.addressed:
                 self._last_addressed_ms = now
             await self._safe_expression(expression.THINKING)
-            reply = await self._consult.ask(transcript)
+            # Auto-attach vision: prepend a fresh frame's description as context.
+            vision_ctx = await self._vision_context()
+            reply = await self._consult.ask(f"{vision_ctx}{transcript}" if vision_ctx else transcript)
             self._meeting.add("Assistant", reply)
             await self._speak(reply)
         except Exception:  # noqa: BLE001 — never let a turn crash the call

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -26,7 +26,14 @@ from . import audio, expression, group_call_gate, meeting, protocol, realtime_to
 from .agent_consult import AgentConsult
 from .meeting import MeetingTranscript
 from .bridge_server import CallSession, CallSessionHandler
-from .config import BYTES_PER_FRAME, FRAME_DURATION_MS, PCM_SAMPLE_RATE_HZ, TeamsVoiceConfig, caller_allowed
+from .call_session_base import (
+    _PENDING_OUTBOUND,
+    BaseTeamsCallHandler,
+    _pending_pop,
+    _pending_set,
+)
+from .call_tools import CallToolRunner
+from .config import BYTES_PER_FRAME, FRAME_DURATION_MS, PCM_SAMPLE_RATE_HZ, TeamsVoiceConfig
 from .echo_guard import EchoGuard
 from .outbound import OutboundError, place_call
 from .realtime.openai_client import REALTIME_SAMPLE_RATE_HZ, RealtimeConfig, RealtimeSession
@@ -36,30 +43,6 @@ from .vision_store import StoredFrame, VisionStore
 PCM_SAMPLE_RATE_HZ_MS = PCM_SAMPLE_RATE_HZ // 1000  # samples per ms (16) — duration math
 
 logger = logging.getLogger(__name__)
-
-# Shared across connections: the inbound call that requests a callback and the
-# outbound leg that delivers it are *different* WebSocket connections, so the
-# pending spoken result is keyed by the worker's callId here. Entries carry a TTL
-# so a never-answered call-back can't leak its result string indefinitely.
-_PENDING_OUTBOUND: dict[str, tuple[str, float]] = {}
-_PENDING_TTL_S = 600.0
-
-
-def _pending_prune() -> None:
-    now = time.monotonic()
-    for k in [k for k, (_t, exp) in _PENDING_OUTBOUND.items() if exp <= now]:
-        _PENDING_OUTBOUND.pop(k, None)
-
-
-def _pending_set(call_id: str, text: str) -> None:
-    _pending_prune()
-    _PENDING_OUTBOUND[call_id] = (text, time.monotonic() + _PENDING_TTL_S)
-
-
-def _pending_pop(call_id: str) -> str | None:
-    _pending_prune()
-    entry = _PENDING_OUTBOUND.pop(call_id, None)
-    return entry[0] if entry else None
 
 
 class EchoCallSessionHandler(CallSessionHandler):
@@ -87,19 +70,13 @@ class EchoCallSessionHandler(CallSessionHandler):
         self._ts += FRAME_DURATION_MS
 
 
-class RealtimeCallSessionHandler(CallSessionHandler):
+class RealtimeCallSessionHandler(BaseTeamsCallHandler):
     """Bridges a Teams call to an OpenAI/Azure realtime speech-to-speech model."""
 
     def __init__(self, config: RealtimeConfig, bridge_config: TeamsVoiceConfig | None = None) -> None:
+        super().__init__(bridge_config)  # shared session policy / state
         self._cfg = config
-        self._bridge = bridge_config
-        self._require_recording = bridge_config.require_recording_status if bridge_config else True
         self._rt: RealtimeSession | None = None
-        self._session: CallSession | None = None
-        self._caller: protocol.CallerInfo | None = None
-        self._outbound = False
-        self._greeted = False
-        self._pending_greeting: str | None = None
         # Outbound (model -> worker) framing state.
         self._out_seq = 0
         self._out_ts = 0
@@ -110,50 +87,20 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         self._last_emotion: str | None = None
         self._echo = EchoGuard()
         self._vision = VisionStore()
-        self._consult = AgentConsult()
-        # Group-call gate state.
-        wake = tuple(bridge_config.wake_phrases) if (bridge_config and bridge_config.wake_phrases) else ("assistant", "hermes")
-        self._gate_cfg = group_call_gate.GroupCallGateConfig(wake_phrases=wake)
-        self._last_addressed_ms: float | None = None
         self._drop_response = False  # deterministic egress drop for gated turns
         # Ambient continuous vision (push the latest changed frame per source ~6s).
         self._ambient_task: asyncio.Task | None = None
         self._ambient_interval_s = 6.0
         self._ambient_last_ts: dict[str, int] = {}
         self._vision_budget = VisionBudget(bridge_config.max_vision_per_minute if bridge_config else 30)
-        self._meeting = MeetingTranscript()
-        self._thread_id = ""
         self._last_speaker = ""  # from unmixed-audio speaker_name, for attribution
+        self._tools = CallToolRunner(self)
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 
     async def on_session_start(self, session: CallSession, msg: protocol.SessionStart) -> None:
-        await super().on_session_start(session, msg)
-        self._session = session
-        self._caller = msg.caller
-        self._thread_id = msg.thread_id
-        self._outbound = (msg.direction or "").lower() == "outbound"
-        # If this is the delivery leg of a call-back, fetch the pending result.
-        if self._outbound:
-            self._pending_greeting = _pending_pop(msg.call_id)
-
-        # Caller allowlist (enforced only when configured): reject unmatched inbound.
-        if not self._outbound and self._bridge and not caller_allowed(
-            self._bridge, msg.caller.aad_id, msg.caller.display_name
-        ):
-            logger.info("[teams_voice] caller not allowlisted; rejecting %s", session.call_id)
-            await session._ws.close()
+        if not await self._begin_session(session, msg):  # state + allowlist + scope
             return
-
-        # Agent session continuity scope.
-        scope = self._bridge.session_scope if self._bridge else "per-call"
-        if scope == "per-thread":
-            skey = msg.thread_id or msg.call_id
-        elif scope == "per-aad":
-            skey = msg.caller.aad_id or msg.call_id
-        else:
-            skey = msg.call_id
-        self._consult = AgentConsult(session_id=f"teams:{skey}")
 
         rt = RealtimeSession(replace(self._cfg, instructions=self._build_instructions()))
         rt.tools = realtime_tools.default_tools()
@@ -172,10 +119,6 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         # Greeting fires on recording-active (greet-on-answer); show a neutral face now.
         await self._safe_expression(expression.NEUTRAL)
         self._ambient_task = asyncio.create_task(self._ambient_vision_loop())
-
-    def _first_name(self) -> str:
-        name = (self._caller.display_name if self._caller else "") or ""
-        return name.strip().split(" ")[0] if name.strip() else ""
 
     def _build_instructions(self) -> str:
         """Augment base instructions with roster name + group-gate etiquette."""
@@ -357,6 +300,7 @@ class RealtimeCallSessionHandler(CallSessionHandler):
     async def _on_input_transcript(self, text: str) -> None:
         """Caller's finished turn — drive verbal interrupts and the group gate."""
         self._echo.mark_caller_turn()
+        # Capture all speech for the minutes (full meeting, not just addressed turns).
         self._meeting.add(self._last_speaker or self._first_name() or "Caller", text)
         # 1) Deterministic verbal interrupt ("stop" / "توقف" / "⟨name⟩, stop").
         if verbal_interrupts.is_verbal_interrupt(text, self._gate_cfg.wake_phrases):
@@ -364,15 +308,8 @@ class RealtimeCallSessionHandler(CallSessionHandler):
             await self._cut_playback()
             return
         # 2) Group-call gate: stay silent unless addressed (2+ humans).
-        is_group = (self._session.human_count if self._session else 0) >= 2
         now = time.monotonic() * 1000.0
-        decision = group_call_gate.should_respond_to_group_turn(
-            transcript=text,
-            is_group=is_group,
-            config=self._gate_cfg,
-            last_addressed_at_ms=self._last_addressed_ms,
-            now_ms=now,
-        )
+        is_group, decision = self._group_decision(text, now)
         if decision.respond:
             if decision.addressed:
                 self._last_addressed_ms = now
@@ -413,183 +350,12 @@ class RealtimeCallSessionHandler(CallSessionHandler):
             args = {}
         # Show a "thinking" face while the tool runs; the reply re-cues the emotion.
         await self._safe_expression(expression.THINKING)
-        result = await self._run_tool(name, args if isinstance(args, dict) else {})
+        result = await self._tools.run_tool(name, args if isinstance(args, dict) else {})
         if self._rt is not None:
             await self._rt.send_function_result(call_id, result or "Done.")
 
-    async def _run_tool(self, name: str, args: dict) -> str:
-        try:
-            if name == "hermes_agent_consult":
-                return await self._consult.ask(str(args.get("query", "")))
-            if name == "hermes_agent_task":
-                return await self._agent_task(str(args.get("query", "")))
-            if name == "look_at_screen":
-                return await self._look_at_screen(
-                    str(args.get("question", "")), args.get("source"), str(args.get("scope") or "live")
-                )
-            if name == "show_to_caller":
-                return await self._show_to_caller(str(args.get("prompt", "")), args.get("count", 1))
-            if name == "call_me_back":
-                return await self._call_me_back(str(args.get("message", "")))
-            if name == "post_meeting_minutes":
-                return await meeting.post_minutes(self._consult, self._meeting, self._thread_id)
-        except Exception:  # noqa: BLE001 — a tool fault must not break the call
-            logger.error("[teams_voice] tool %s failed", name, exc_info=True)
-            return "Sorry, that didn't work."
-        return f"Unknown tool: {name}."
 
-    async def _look_at_screen(self, question: str, source: str | None, scope: str = "live") -> str:
-        if not self._vision_budget.try_consume():
-            return "I've looked at a lot just now — give me a moment before the next one."
-        prompt = question.strip() or "Describe what you see."
-        if scope == "history":
-            frames = self._vision.history(limit=6)
-            if not frames:
-                return "I don't have any earlier frames to look back on."
-            content: list[dict] = [{"type": "text", "text": prompt}]
-            for f in frames:  # timestamped, attributed keyframes
-                content.append({"type": "text", "text": f"(earlier, from {f.describe()})"})
-                content.append({"type": "image_url", "image_url": {"url": f.data_url()}})
-        else:
-            want = "camera" if str(source or "").lower() == "camera" else "screenshare"
-            frame = self._vision.latest(want) or self._vision.latest()
-            if frame is None:
-                return "I can't see a shared screen or camera right now."
-            content = [
-                {"type": "text", "text": f"{prompt} (looking at the {frame.describe()})"},
-                {"type": "image_url", "image_url": {"url": frame.data_url()}},
-            ]
-        return await self._vision_consult(content)
-
-    async def _vision_consult(self, content: list[dict]) -> str:
-        try:
-            from agent.auxiliary_client import async_call_llm
-
-            resp = await async_call_llm(
-                task="vision", messages=[{"role": "user", "content": content}], max_tokens=400
-            )
-            text = resp.choices[0].message.content if resp and resp.choices else ""
-            return (text or "").strip() or "I couldn't quite make that out."
-        except Exception:  # noqa: BLE001
-            self._vision_budget.refund()  # consult failed before the model — give it back
-            logger.error("[teams_voice] vision consult failed", exc_info=True)
-            return "I had trouble looking at that."
-
-    async def _show_to_caller(self, prompt: str, count: object = 1) -> str:
-        prompt = prompt.strip()
-        if not prompt:
-            return "What would you like me to show?"
-        try:
-            n = max(1, min(int(count), 3))
-        except (TypeError, ValueError):
-            n = 1
-        try:
-            from tools.image_generation_tool import image_generate_tool
-
-            paths: list[str] = []
-            for _ in range(n):
-                raw = await asyncio.to_thread(
-                    lambda: image_generate_tool(prompt=prompt, aspect_ratio="landscape")
-                )
-                data = json.loads(raw)
-                if data.get("success") and data.get("image"):
-                    paths.append(data["image"])
-            if not paths:
-                return "I couldn't create that image."
-            # Paced slideshow: 4.5s hold for non-final, 5s for the final image.
-            for idx, path in enumerate(paths):
-                final = idx == len(paths) - 1
-                img_bytes = Path(path).read_bytes()
-                mime = "image/png" if str(path).lower().endswith(".png") else "image/jpeg"
-                if self._session is not None:
-                    await self._session.send_display_image(
-                        base64.b64encode(img_bytes).decode("ascii"),
-                        mime,
-                        duration_ms=5000 if final else 4500,
-                        mode="overlay",
-                        caption=prompt[:80],
-                    )
-                if not final:
-                    await asyncio.sleep(4.0)
-            return "I'm showing it on screen now." if len(paths) == 1 else f"Showing you {len(paths)} images."
-        except Exception:  # noqa: BLE001
-            logger.error("[teams_voice] show_to_caller failed", exc_info=True)
-            return "I made the image but couldn't display it."
-
-    async def _call_me_back(self, message: str) -> str:
-        message = message.strip()
-        caller = self._caller
-        if self._bridge is None or caller is None or not caller.aad_id:
-            return "I can't call you back — I don't have a number to reach you."
-        tenant = caller.tenant_id or self._bridge.tenant_id
-        if not tenant:
-            return "I can't call you back — missing your tenant."
-        try:
-            result = await place_call(
-                user_object_id=caller.aad_id,
-                tenant_id=tenant,
-                shared_secret=self._bridge.shared_secret,
-                worker_base_url=self._bridge.worker_base_url,
-                allow_remote=self._bridge.allow_remote_worker,
-            )
-        except OutboundError as exc:
-            logger.warning("[teams_voice] call_me_back failed: %s", exc)
-            return "I couldn't place the call-back just now."
-        call_id = result.get("callId")
-        if call_id:
-            _pending_set(call_id, message or "Here's what you asked for.")
-        return "Okay — I'll call you right back with that."
-
-    async def _agent_task(self, query: str) -> str:
-        """Run a long job in the background; deliver the result via a call-back."""
-        query = query.strip()
-        caller = self._caller
-        if not query:
-            return "What would you like me to work on?"
-        if self._bridge is None or caller is None or not caller.aad_id:
-            # No way to call back — fall back to an inline consult.
-            return await self._consult.ask(query)
-        asyncio.create_task(self._run_background_task(query, caller))
-        return "Got it — I'll work on that in the background and call you back with the result."
-
-    async def _run_background_task(self, query: str, caller: protocol.CallerInfo) -> None:
-        try:
-            result = await self._consult.ask(query, timeout_s=300.0)
-        except Exception:  # noqa: BLE001
-            logger.error("[teams_voice] background task failed", exc_info=True)
-            result = "I couldn't complete that task."
-        if self._bridge is None or not caller.aad_id:
-            return
-        tenant = caller.tenant_id or self._bridge.tenant_id
-        if not tenant:
-            return
-        try:
-            res = await place_call(
-                user_object_id=caller.aad_id,
-                tenant_id=tenant,
-                shared_secret=self._bridge.shared_secret,
-                worker_base_url=self._bridge.worker_base_url,
-                allow_remote=self._bridge.allow_remote_worker,
-            )
-        except OutboundError as exc:
-            logger.warning("[teams_voice] background callback failed: %s", exc)
-            return
-        cid = res.get("callId")
-        if cid:
-            _pending_set(cid, result)
-
-    # ── helpers ──────────────────────────────────────────────────────────────
-
-    async def _safe_expression(self, emotion: str) -> None:
-        if self._session is None:
-            return
-        try:
-            await self._session.send_expression(emotion)
-        except Exception:  # noqa: BLE001 — cosmetic
-            pass
-
-
-class StreamingCallSessionHandler(CallSessionHandler):
+class StreamingCallSessionHandler(BaseTeamsCallHandler):
     """Streaming voice path: STT → agent → TTS (half-duplex, turn-based).
 
     Segments caller audio into utterances (VAD), transcribes them, applies the
@@ -599,40 +365,41 @@ class StreamingCallSessionHandler(CallSessionHandler):
     """
 
     def __init__(self, bridge_config: TeamsVoiceConfig | None = None) -> None:
+        super().__init__(bridge_config)  # shared session policy / state
         from .streaming_audio import UtteranceBuffer
 
-        self._bridge = bridge_config
-        self._require_recording = bridge_config.require_recording_status if bridge_config else True
         self._utterance_task: asyncio.Task | None = None
-        self._session: CallSession | None = None
-        self._caller: protocol.CallerInfo | None = None
         self._buf = UtteranceBuffer()
-        self._consult = AgentConsult()
-        wake = tuple(bridge_config.wake_phrases) if (bridge_config and bridge_config.wake_phrases) else ("assistant", "hermes")
-        self._gate_cfg = group_call_gate.GroupCallGateConfig(wake_phrases=wake)
-        self._last_addressed_ms: float | None = None
         self._out_seq = 0
         self._out_ts = 0
         self._processing = False  # half-duplex: one utterance at a time
-        self._meeting = MeetingTranscript()
-        self._thread_id = ""
 
     async def on_session_start(self, session: CallSession, msg: protocol.SessionStart) -> None:
-        await super().on_session_start(session, msg)
-        self._session = session
-        self._caller = msg.caller
-        self._thread_id = msg.thread_id
-        # Caller allowlist parity with the realtime path.
-        if (msg.direction or "").lower() != "outbound" and self._bridge and not caller_allowed(
-            self._bridge, msg.caller.aad_id, msg.caller.display_name
-        ):
-            logger.info("[teams_voice] caller not allowlisted; rejecting %s", session.call_id)
-            await session._ws.close()
+        if not await self._begin_session(session, msg):  # state + allowlist + scope
             return
-        scope = self._bridge.session_scope if self._bridge else "per-call"
-        key = msg.thread_id if scope == "per-thread" else (msg.caller.aad_id if scope == "per-aad" else msg.call_id)
-        self._consult = AgentConsult(session_id=f"teams:{key or msg.call_id}")
         await self._safe_expression(expression.NEUTRAL)
+
+    async def on_recording_status(self, session: CallSession, msg: protocol.RecordingStatus) -> None:
+        await super().on_recording_status(session, msg)
+        if not session.recording_active or self._greeted:
+            return
+        self._greeted = True
+        # Greet-on-answer: outbound speaks the pending result; inbound greets by name.
+        if self._outbound and self._pending_greeting:
+            text, self._pending_greeting = self._pending_greeting, None
+        elif not self._outbound:
+            name = self._first_name()
+            text = f"Hello{(' ' + name) if name else ''}, how can I help you?"
+        else:
+            return
+        self._processing = True  # half-duplex: hold the turn while we greet
+        self._utterance_task = asyncio.create_task(self._speak_turn(text))
+
+    async def _speak_turn(self, text: str) -> None:
+        try:
+            await self._speak(text)
+        finally:
+            self._processing = False
 
     async def on_session_end(self, session: CallSession, msg: protocol.SessionEnd) -> None:
         await super().on_session_end(session, msg)
@@ -661,22 +428,19 @@ class StreamingCallSessionHandler(CallSessionHandler):
                 return
             if verbal_interrupts.is_verbal_interrupt(transcript, self._gate_cfg.wake_phrases):
                 return  # nothing playing in half-duplex; just don't reply
-            is_group = (self._session.human_count if self._session else 0) >= 2
-            now = time.monotonic() * 1000.0
-            decision = group_call_gate.should_respond_to_group_turn(
-                transcript=transcript, is_group=is_group, config=self._gate_cfg,
-                last_addressed_at_ms=self._last_addressed_ms, now_ms=now,
-            )
-            if not decision.respond:
-                return
-            if decision.addressed:
-                self._last_addressed_ms = now
-            caller_name = (self._caller.display_name.split(" ")[0] if self._caller and self._caller.display_name else "Caller")
-            self._meeting.add(caller_name, transcript)
+            # Capture ALL caller speech for the minutes — including unaddressed
+            # meeting discussion — before the respond gate.
+            self._meeting.add(self._first_name() or "Caller", transcript)
             # On-demand "summarize the meeting" → post minutes instead of a normal reply.
             if meeting.is_summary_request(transcript):
                 await self._speak(await meeting.post_minutes(self._consult, self._meeting, self._thread_id))
                 return
+            now = time.monotonic() * 1000.0
+            _is_group, decision = self._group_decision(transcript, now)
+            if not decision.respond:
+                return
+            if decision.addressed:
+                self._last_addressed_ms = now
             await self._safe_expression(expression.THINKING)
             reply = await self._consult.ask(transcript)
             self._meeting.add("Assistant", reply)
@@ -758,11 +522,3 @@ class StreamingCallSessionHandler(CallSessionHandler):
                 Path(out).unlink(missing_ok=True)
             except OSError:
                 pass
-
-    async def _safe_expression(self, emotion: str) -> None:
-        if self._session is None:
-            return
-        try:
-            await self._session.send_expression(emotion)
-        except Exception:  # noqa: BLE001
-            pass

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -32,7 +32,7 @@ from .call_session_base import (
     _pending_pop,
     _pending_set,
 )
-from .call_tools import CallContext, CallToolRunner
+from .call_tools import CallToolRunner
 from .config import BYTES_PER_FRAME, FRAME_DURATION_MS, PCM_SAMPLE_RATE_HZ, TeamsVoiceConfig
 from .echo_guard import EchoGuard
 from .outbound import OutboundError, place_call
@@ -99,18 +99,10 @@ class RealtimeCallSessionHandler(BaseTeamsCallHandler):
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 
-    def _tool_context(self) -> CallContext:
-        """Typed per-call context for the tool runner (references stable post-begin)."""
-        return CallContext(
-            bridge=self._bridge, session=self._session, caller=self._caller,
-            consult=self._consult, vision=self._vision, vision_budget=self._vision_budget,
-            meeting=self._meeting, thread_id=self._thread_id,
-        )
-
     async def on_session_start(self, session: CallSession, msg: protocol.SessionStart) -> None:
         if not await self._begin_session(session, msg):  # state + allowlist + scope
             return
-        self._tools = CallToolRunner(self._tool_context())
+        self._tools = CallToolRunner(self)
 
         rt = RealtimeSession(replace(self._cfg, instructions=self._build_instructions()))
         rt.tools = realtime_tools.default_tools()

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -17,10 +17,11 @@ import asyncio
 import base64
 import json
 import logging
-import uuid
+import time
+from dataclasses import replace
 from pathlib import Path
 
-from . import audio, expression, protocol, realtime_tools, viseme_estimate
+from . import audio, expression, group_call_gate, protocol, realtime_tools, verbal_interrupts, viseme_estimate
 from .agent_consult import AgentConsult
 from .bridge_server import CallSession, CallSessionHandler
 from .config import BYTES_PER_FRAME, FRAME_DURATION_MS, PCM_SAMPLE_RATE_HZ, TeamsVoiceConfig
@@ -72,6 +73,7 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         self._session: CallSession | None = None
         self._caller: protocol.CallerInfo | None = None
         self._outbound = False
+        self._greeted = False
         self._pending_greeting: str | None = None
         # Outbound (model -> worker) framing state.
         self._out_seq = 0
@@ -84,6 +86,10 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         self._echo = EchoGuard()
         self._vision = VisionStore()
         self._consult = AgentConsult()
+        # Group-call gate state.
+        self._gate_cfg = group_call_gate.GroupCallGateConfig(wake_phrases=("assistant", "hermes"))
+        self._last_addressed_ms: float | None = None
+        self._drop_response = False  # deterministic egress drop for gated turns
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 
@@ -96,10 +102,11 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         if self._outbound:
             self._pending_greeting = _PENDING_OUTBOUND.pop(msg.call_id, None)
 
-        rt = RealtimeSession(self._cfg)
+        rt = RealtimeSession(replace(self._cfg, instructions=self._build_instructions()))
         rt.tools = realtime_tools.default_tools()
         rt.on_audio_delta = self._on_model_audio
         rt.on_transcript_delta = self._on_transcript
+        rt.on_input_transcript = self._on_input_transcript
         rt.on_speech_started = self._on_barge_in
         rt.on_response_done = self._on_response_done
         rt.on_function_call = self._on_function_call
@@ -109,19 +116,45 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         except Exception:  # noqa: BLE001 — keep socket; worker shows neutral avatar
             logger.error("[teams_voice] realtime connect failed for %s", session.call_id, exc_info=True)
             return
-        # Inbound greeting fires from the model; outbound waits for recording-active.
-        if not self._outbound:
-            await self._safe_expression(expression.NEUTRAL)
+        # Greeting fires on recording-active (greet-on-answer); show a neutral face now.
+        await self._safe_expression(expression.NEUTRAL)
+
+    def _first_name(self) -> str:
+        name = (self._caller.display_name if self._caller else "") or ""
+        return name.strip().split(" ")[0] if name.strip() else ""
+
+    def _build_instructions(self) -> str:
+        """Augment base instructions with roster name + group-gate etiquette."""
+        parts = [self._cfg.instructions]
+        name = self._first_name()
+        if name:
+            parts.append(f"The caller's first name is {name}; address them by name naturally.")
+        phrases = ", ".join(f'"{p}"' for p in self._gate_cfg.wake_phrases)
+        parts.append(
+            "If more than one person is on the call, stay silent unless someone "
+            f"addresses you by name ({phrases}); in a one-on-one call respond normally."
+        )
+        return " ".join(parts)
 
     async def on_recording_status(self, session: CallSession, msg: protocol.RecordingStatus) -> None:
         await super().on_recording_status(session, msg)
         # Outbound delivery: speak the result only once the callee has answered
         # (recording active), not while the phone is still ringing (greet-on-answer).
-        if self._outbound and session.recording_active and self._pending_greeting and self._rt:
+        if not session.recording_active or self._rt is None:
+            return
+        if self._outbound and self._pending_greeting:
             greeting, self._pending_greeting = self._pending_greeting, None
             await self._rt.request_say(
                 f"The caller just answered. Deliver this result clearly and concisely, "
                 f"then say goodbye: {greeting}"
+            )
+        elif not self._outbound and not self._greeted:
+            # Roster greeting by name, on answer (not while ringing).
+            self._greeted = True
+            name = self._first_name()
+            who = f" the caller, {name}," if name else " the caller"
+            await self._rt.request_say(
+                f"Greet{who} warmly and briefly, then ask how you can help."
             )
 
     async def on_audio_frame(self, session: CallSession, msg: protocol.AudioFrame) -> None:
@@ -159,6 +192,9 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         session = self._session
         if session is None:
             return
+        if self._drop_response:  # group gate dropped this (unaddressed) turn
+            self._out_residual = b""
+            return
         pcm16 = audio.resample_pcm16(pcm24, REALTIME_SAMPLE_RATE_HZ, PCM_SAMPLE_RATE_HZ)
         frames, self._out_residual = audio.frame_pcm16(self._out_residual + pcm16, BYTES_PER_FRAME)
         for frame in frames:
@@ -190,7 +226,8 @@ class RealtimeCallSessionHandler(CallSessionHandler):
             except Exception:  # noqa: BLE001
                 pass
 
-    async def _on_barge_in(self) -> None:
+    async def _cut_playback(self) -> None:
+        """Stop playback immediately: flush the worker queue and cancel the model."""
         self._turn_id += 1
         self._echo.collapse()
         self._echo.mark_caller_turn()
@@ -202,6 +239,36 @@ class RealtimeCallSessionHandler(CallSessionHandler):
                 pass
         if self._rt is not None:
             await self._rt.cancel_response()
+
+    async def _on_barge_in(self) -> None:
+        await self._cut_playback()
+
+    async def _on_input_transcript(self, text: str) -> None:
+        """Caller's finished turn — drive verbal interrupts and the group gate."""
+        self._echo.mark_caller_turn()
+        # 1) Deterministic verbal interrupt ("stop" / "توقف" / "⟨name⟩, stop").
+        if verbal_interrupts.is_verbal_interrupt(text, self._gate_cfg.wake_phrases):
+            self._drop_response = True  # suppress any reply to the interrupt itself
+            await self._cut_playback()
+            return
+        # 2) Group-call gate: stay silent unless addressed (2+ humans).
+        is_group = (self._session.human_count if self._session else 0) >= 2
+        now = time.monotonic() * 1000.0
+        decision = group_call_gate.should_respond_to_group_turn(
+            transcript=text,
+            is_group=is_group,
+            config=self._gate_cfg,
+            last_addressed_at_ms=self._last_addressed_ms,
+            now_ms=now,
+        )
+        if decision.respond:
+            if decision.addressed:
+                self._last_addressed_ms = now
+        else:
+            # Unaddressed meeting turn: drop the auto-created reply at the egress.
+            self._drop_response = True
+            if self._rt is not None:
+                await self._rt.cancel_response()
 
     async def _on_response_done(self) -> None:
         session = self._session
@@ -218,6 +285,7 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         self._out_residual = b""
         self._transcript = ""
         self._last_emotion = None
+        self._drop_response = False  # next turn starts fresh
 
     # ── tool dispatch ────────────────────────────────────────────────────────
 
@@ -226,6 +294,8 @@ class RealtimeCallSessionHandler(CallSessionHandler):
             args = json.loads(args_json or "{}")
         except (TypeError, ValueError):
             args = {}
+        # Show a "thinking" face while the tool runs; the reply re-cues the emotion.
+        await self._safe_expression(expression.THINKING)
         result = await self._run_tool(name, args if isinstance(args, dict) else {})
         if self._rt is not None:
             await self._rt.send_function_result(call_id, result or "Done.")

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -94,6 +94,7 @@ class RealtimeCallSessionHandler(BaseTeamsCallHandler):
         self._ambient_last_ts: dict[str, int] = {}
         self._vision_budget = VisionBudget(bridge_config.max_vision_per_minute if bridge_config else 30)
         self._last_speaker = ""  # from unmixed-audio speaker_name, for attribution
+        self._auto_on = True  # server-VAD auto-response (off until 1:1 is confirmed)
         self._tools = CallToolRunner(self)
 
     # ── lifecycle ────────────────────────────────────────────────────────────
@@ -116,6 +117,12 @@ class RealtimeCallSessionHandler(BaseTeamsCallHandler):
         except Exception:  # noqa: BLE001 — keep socket; worker shows neutral avatar
             logger.error("[teams_voice] realtime connect failed for %s", session.call_id, exc_info=True)
             return
+        # Start in MANUAL response mode (auto-response off): until participants is
+        # known, no auto-reply can leak in a meeting. We enable auto-response only
+        # once we learn it's a 1:1; group/unknown stays manual (we create_response
+        # ourselves for addressed turns). Race-free.
+        await rt.set_auto_response(False)
+        self._auto_on = False
         # Greeting fires on recording-active (greet-on-answer); show a neutral face now.
         await self._safe_expression(expression.NEUTRAL)
         self._ambient_task = asyncio.create_task(self._ambient_vision_loop())
@@ -161,11 +168,13 @@ class RealtimeCallSessionHandler(BaseTeamsCallHandler):
 
     async def on_participants(self, session: CallSession, msg: protocol.Participants) -> None:
         await super().on_participants(session, msg)  # sets session.human_count
-        # Race-free group gate: in a meeting (2+ humans) turn OFF server-VAD
-        # auto-response, so the model only speaks when we explicitly create a
-        # response for an addressed turn (no audio can leak before a cancel).
+        # Race-free group gate: enable server-VAD auto-response only for a confirmed
+        # 1:1; meetings (2+ humans) stay manual (we create a response only for an
+        # addressed turn), so no audio can leak before a cancel.
+        enable = session.human_count < 2
         if self._rt is not None:
-            await self._rt.set_auto_response(session.human_count < 2)
+            await self._rt.set_auto_response(enable)
+        self._auto_on = enable
 
     async def on_audio_frame(self, session: CallSession, msg: protocol.AudioFrame) -> None:
         if self._require_recording and not session.recording_active:
@@ -309,12 +318,13 @@ class RealtimeCallSessionHandler(BaseTeamsCallHandler):
             return
         # 2) Group-call gate: stay silent unless addressed (2+ humans).
         now = time.monotonic() * 1000.0
-        is_group, decision = self._group_decision(text, now)
+        _is_group, decision = self._group_decision(text, now)
         if decision.respond:
             if decision.addressed:
                 self._last_addressed_ms = now
-            # In group mode auto-response is OFF, so trigger the reply ourselves.
-            if is_group and self._rt is not None:
+            # In manual mode (group, or 1:1 before participants is known) auto-
+            # response is OFF, so trigger the reply ourselves.
+            if not self._auto_on and self._rt is not None:
                 await self._rt.create_response()
         else:
             # Unaddressed meeting turn: egress-drop backstop + cancel any response.

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -28,6 +28,7 @@ from .config import BYTES_PER_FRAME, FRAME_DURATION_MS, PCM_SAMPLE_RATE_HZ, Team
 from .echo_guard import EchoGuard
 from .outbound import OutboundError, place_call
 from .realtime.openai_client import REALTIME_SAMPLE_RATE_HZ, RealtimeConfig, RealtimeSession
+from .vision_budget import VisionBudget
 from .vision_store import StoredFrame, VisionStore
 
 logger = logging.getLogger(__name__)
@@ -87,12 +88,15 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         self._vision = VisionStore()
         self._consult = AgentConsult()
         # Group-call gate state.
-        self._gate_cfg = group_call_gate.GroupCallGateConfig(wake_phrases=("assistant", "hermes"))
+        wake = tuple(bridge_config.wake_phrases) if (bridge_config and bridge_config.wake_phrases) else ("assistant", "hermes")
+        self._gate_cfg = group_call_gate.GroupCallGateConfig(wake_phrases=wake)
         self._last_addressed_ms: float | None = None
         self._drop_response = False  # deterministic egress drop for gated turns
-        # Ambient continuous vision (push the latest changed frame every ~6s).
+        # Ambient continuous vision (push the latest changed frame per source ~6s).
         self._ambient_task: asyncio.Task | None = None
         self._ambient_interval_s = 6.0
+        self._ambient_last_ts: dict[str, int] = {}
+        self._vision_budget = VisionBudget(bridge_config.max_vision_per_minute if bridge_config else 30)
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 
@@ -104,6 +108,25 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         # If this is the delivery leg of a call-back, fetch the pending result.
         if self._outbound:
             self._pending_greeting = _PENDING_OUTBOUND.pop(msg.call_id, None)
+
+        # Caller allowlist (enforced only when configured): reject unmatched inbound.
+        if not self._outbound and self._bridge and self._bridge.allowlist:
+            ident = (msg.caller.aad_id or "").lower()
+            name = (msg.caller.display_name or "").lower()
+            if ident not in self._bridge.allowlist and name not in self._bridge.allowlist:
+                logger.info("[teams_voice] caller not allowlisted; rejecting %s", session.call_id)
+                await session._ws.close()
+                return
+
+        # Agent session continuity scope.
+        scope = self._bridge.session_scope if self._bridge else "per-call"
+        if scope == "per-thread":
+            skey = msg.thread_id or msg.call_id
+        elif scope == "per-aad":
+            skey = msg.caller.aad_id or msg.call_id
+        else:
+            skey = msg.call_id
+        self._consult = AgentConsult(session_id=f"teams:{skey}")
 
         rt = RealtimeSession(replace(self._cfg, instructions=self._build_instructions()))
         rt.tools = realtime_tools.default_tools()
@@ -208,21 +231,25 @@ class RealtimeCallSessionHandler(CallSessionHandler):
     async def _ambient_vision_loop(self) -> None:
         """Every ~6s, push the latest *changed* frame to the model (no forced
         response), so it stays visually aware between explicit look_at_screen calls."""
-        last_ts: int | None = None
         try:
             while True:
                 await asyncio.sleep(self._ambient_interval_s)
                 session = self._session
                 if self._rt is None or session is None or not session.recording_active:
                     continue
-                frame = self._vision.latest()
-                if frame is None or frame.ts == last_ts:
-                    continue  # nothing new since last push (dedup)
-                last_ts = frame.ts
-                try:
-                    await self._rt.send_image(frame.data_url())
-                except Exception:  # noqa: BLE001 — ambient, best-effort
-                    pass
+                # Push each source (screen + camera) that changed since last time.
+                # The worker only emits scene-change frames, so a new ts == a new scene.
+                for src in ("screenshare", "camera"):
+                    frame = self._vision.latest(src)
+                    if frame is None or frame.ts == self._ambient_last_ts.get(src):
+                        continue
+                    if not self._vision_budget.try_consume():
+                        break  # over the per-minute vision cap
+                    self._ambient_last_ts[src] = frame.ts
+                    try:
+                        await self._rt.send_image(frame.data_url())
+                    except Exception:  # noqa: BLE001 — ambient, best-effort
+                        pass
         except asyncio.CancelledError:
             raise
 
@@ -351,7 +378,7 @@ class RealtimeCallSessionHandler(CallSessionHandler):
                     str(args.get("question", "")), args.get("source"), str(args.get("scope") or "live")
                 )
             if name == "show_to_caller":
-                return await self._show_to_caller(str(args.get("prompt", "")))
+                return await self._show_to_caller(str(args.get("prompt", "")), args.get("count", 1))
             if name == "call_me_back":
                 return await self._call_me_back(str(args.get("message", "")))
         except Exception:  # noqa: BLE001 — a tool fault must not break the call
@@ -360,6 +387,8 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         return f"Unknown tool: {name}."
 
     async def _look_at_screen(self, question: str, source: str | None, scope: str = "live") -> str:
+        if not self._vision_budget.try_consume():
+            return "I've looked at a lot just now — give me a moment before the next one."
         prompt = question.strip() or "Describe what you see."
         if scope == "history":
             frames = self._vision.history(limit=6)
@@ -390,31 +419,47 @@ class RealtimeCallSessionHandler(CallSessionHandler):
             text = resp.choices[0].message.content if resp and resp.choices else ""
             return (text or "").strip() or "I couldn't quite make that out."
         except Exception:  # noqa: BLE001
+            self._vision_budget.refund()  # consult failed before the model — give it back
             logger.error("[teams_voice] vision consult failed", exc_info=True)
             return "I had trouble looking at that."
 
-    async def _show_to_caller(self, prompt: str) -> str:
+    async def _show_to_caller(self, prompt: str, count: object = 1) -> str:
         prompt = prompt.strip()
         if not prompt:
             return "What would you like me to show?"
         try:
+            n = max(1, min(int(count), 3))
+        except (TypeError, ValueError):
+            n = 1
+        try:
             from tools.image_generation_tool import image_generate_tool
 
-            raw = await asyncio.to_thread(lambda: image_generate_tool(prompt=prompt, aspect_ratio="landscape"))
-            data = json.loads(raw)
-            if not data.get("success") or not data.get("image"):
-                return "I couldn't create that image."
-            img_bytes = Path(data["image"]).read_bytes()
-            mime = "image/png" if str(data["image"]).lower().endswith(".png") else "image/jpeg"
-            if self._session is not None:
-                await self._session.send_display_image(
-                    base64.b64encode(img_bytes).decode("ascii"),
-                    mime,
-                    duration_ms=6000,
-                    mode="overlay",
-                    caption=prompt[:80],
+            paths: list[str] = []
+            for _ in range(n):
+                raw = await asyncio.to_thread(
+                    lambda: image_generate_tool(prompt=prompt, aspect_ratio="landscape")
                 )
-            return "I'm showing it on screen now."
+                data = json.loads(raw)
+                if data.get("success") and data.get("image"):
+                    paths.append(data["image"])
+            if not paths:
+                return "I couldn't create that image."
+            # Paced slideshow: 4.5s hold for non-final, 5s for the final image.
+            for idx, path in enumerate(paths):
+                final = idx == len(paths) - 1
+                img_bytes = Path(path).read_bytes()
+                mime = "image/png" if str(path).lower().endswith(".png") else "image/jpeg"
+                if self._session is not None:
+                    await self._session.send_display_image(
+                        base64.b64encode(img_bytes).decode("ascii"),
+                        mime,
+                        duration_ms=5000 if final else 4500,
+                        mode="overlay",
+                        caption=prompt[:80],
+                    )
+                if not final:
+                    await asyncio.sleep(4.0)
+            return "I'm showing it on screen now." if len(paths) == 1 else f"Showing you {len(paths)} images."
         except Exception:  # noqa: BLE001
             logger.error("[teams_voice] show_to_caller failed", exc_info=True)
             return "I made the image but couldn't display it."

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -32,7 +32,7 @@ from .call_session_base import (
     _pending_pop,
     _pending_set,
 )
-from .call_tools import CallToolRunner
+from .call_tools import CallContext, CallToolRunner
 from .config import BYTES_PER_FRAME, FRAME_DURATION_MS, PCM_SAMPLE_RATE_HZ, TeamsVoiceConfig
 from .echo_guard import EchoGuard
 from .outbound import OutboundError, place_call
@@ -95,13 +95,22 @@ class RealtimeCallSessionHandler(BaseTeamsCallHandler):
         self._vision_budget = VisionBudget(bridge_config.max_vision_per_minute if bridge_config else 30)
         self._last_speaker = ""  # from unmixed-audio speaker_name, for attribution
         self._auto_on = True  # server-VAD auto-response (off until 1:1 is confirmed)
-        self._tools = CallToolRunner(self)
+        self._tools: CallToolRunner | None = None  # built once the session is established
 
     # ── lifecycle ────────────────────────────────────────────────────────────
+
+    def _tool_context(self) -> CallContext:
+        """Typed per-call context for the tool runner (references stable post-begin)."""
+        return CallContext(
+            bridge=self._bridge, session=self._session, caller=self._caller,
+            consult=self._consult, vision=self._vision, vision_budget=self._vision_budget,
+            meeting=self._meeting, thread_id=self._thread_id,
+        )
 
     async def on_session_start(self, session: CallSession, msg: protocol.SessionStart) -> None:
         if not await self._begin_session(session, msg):  # state + allowlist + scope
             return
+        self._tools = CallToolRunner(self._tool_context())
 
         rt = RealtimeSession(replace(self._cfg, instructions=self._build_instructions()))
         rt.tools = realtime_tools.default_tools()
@@ -151,17 +160,17 @@ class RealtimeCallSessionHandler(BaseTeamsCallHandler):
         # (recording active), not while the phone is still ringing (greet-on-answer).
         if not session.recording_active or self._rt is None:
             return
-        if self._outbound and self._pending_greeting:
-            greeting, self._pending_greeting = self._pending_greeting, None
+        plan = self._greeting_plan()
+        if plan is None:
+            return
+        kind, payload = plan
+        if kind == "deliver":
             await self._rt.request_say(
                 f"The caller just answered. Deliver this result clearly and concisely, "
-                f"then say goodbye: {greeting}"
+                f"then say goodbye: {payload}"
             )
-        elif not self._outbound and not self._greeted:
-            # Roster greeting by name, on answer (not while ringing).
-            self._greeted = True
-            name = self._first_name()
-            who = f" the caller, {name}," if name else " the caller"
+        else:  # greet by name, on answer (not while ringing)
+            who = f" the caller, {payload}," if payload else " the caller"
             await self._rt.request_say(
                 f"Greet{who} warmly and briefly, then ask how you can help."
             )
@@ -360,6 +369,8 @@ class RealtimeCallSessionHandler(BaseTeamsCallHandler):
             args = {}
         # Show a "thinking" face while the tool runs; the reply re-cues the emotion.
         await self._safe_expression(expression.THINKING)
+        if self._tools is None:
+            return
         result = await self._tools.run_tool(name, args if isinstance(args, dict) else {})
         if self._rt is not None:
             await self._rt.send_function_result(call_id, result or "Done.")
@@ -396,17 +407,14 @@ class StreamingCallSessionHandler(BaseTeamsCallHandler):
 
     async def on_recording_status(self, session: CallSession, msg: protocol.RecordingStatus) -> None:
         await super().on_recording_status(session, msg)
-        if not session.recording_active or self._greeted:
+        if not session.recording_active:
             return
-        self._greeted = True
-        # Greet-on-answer: outbound speaks the pending result; inbound greets by name.
-        if self._outbound and self._pending_greeting:
-            text, self._pending_greeting = self._pending_greeting, None
-        elif not self._outbound:
-            name = self._first_name()
-            text = f"Hello{(' ' + name) if name else ''}, how can I help you?"
-        else:
+        plan = self._greeting_plan()
+        if plan is None:
             return
+        kind, payload = plan
+        # deliver → speak the result verbatim; greet → friendly inbound greeting.
+        text = payload if kind == "deliver" else f"Hello{(' ' + payload) if payload else ''}, how can I help you?"
         self._processing = True  # half-duplex: hold the turn while we greet
         self._utterance_task = asyncio.create_task(self._speak_turn(text))
 

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -90,6 +90,9 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         self._gate_cfg = group_call_gate.GroupCallGateConfig(wake_phrases=("assistant", "hermes"))
         self._last_addressed_ms: float | None = None
         self._drop_response = False  # deterministic egress drop for gated turns
+        # Ambient continuous vision (push the latest changed frame every ~6s).
+        self._ambient_task: asyncio.Task | None = None
+        self._ambient_interval_s = 6.0
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 
@@ -118,6 +121,7 @@ class RealtimeCallSessionHandler(CallSessionHandler):
             return
         # Greeting fires on recording-active (greet-on-answer); show a neutral face now.
         await self._safe_expression(expression.NEUTRAL)
+        self._ambient_task = asyncio.create_task(self._ambient_vision_loop())
 
     def _first_name(self) -> str:
         name = (self._caller.display_name if self._caller else "") or ""
@@ -179,12 +183,43 @@ class RealtimeCallSessionHandler(CallSessionHandler):
             )
         )
 
+    async def on_dtmf(self, session: CallSession, msg: protocol.Dtmf) -> None:
+        # Surface keypad input to the realtime model (recording-gated) so it can
+        # run "press 1 to…" flows.
+        if not session.recording_active or self._rt is None:
+            return
+        await self._rt.send_user_text(f"The caller pressed the {msg.digit} key on the keypad.")
+
     async def on_session_end(self, session: CallSession, msg: protocol.SessionEnd) -> None:
         await super().on_session_end(session, msg)
+        if self._ambient_task is not None:
+            self._ambient_task.cancel()
+            self._ambient_task = None
         self._vision.clear()
         if self._rt is not None:
             await self._rt.close()
             self._rt = None
+
+    async def _ambient_vision_loop(self) -> None:
+        """Every ~6s, push the latest *changed* frame to the model (no forced
+        response), so it stays visually aware between explicit look_at_screen calls."""
+        last_ts: int | None = None
+        try:
+            while True:
+                await asyncio.sleep(self._ambient_interval_s)
+                session = self._session
+                if self._rt is None or session is None or not session.recording_active:
+                    continue
+                frame = self._vision.latest()
+                if frame is None or frame.ts == last_ts:
+                    continue  # nothing new since last push (dedup)
+                last_ts = frame.ts
+                try:
+                    await self._rt.send_image(frame.data_url())
+                except Exception:  # noqa: BLE001 — ambient, best-effort
+                    pass
+        except asyncio.CancelledError:
+            raise
 
     # ── model -> worker callbacks ────────────────────────────────────────────
 
@@ -305,7 +340,9 @@ class RealtimeCallSessionHandler(CallSessionHandler):
             if name == "hermes_agent_consult":
                 return await self._consult.ask(str(args.get("query", "")))
             if name == "look_at_screen":
-                return await self._look_at_screen(str(args.get("question", "")), args.get("source"))
+                return await self._look_at_screen(
+                    str(args.get("question", "")), args.get("source"), str(args.get("scope") or "live")
+                )
             if name == "show_to_caller":
                 return await self._show_to_caller(str(args.get("prompt", "")))
             if name == "call_me_back":
@@ -315,29 +352,38 @@ class RealtimeCallSessionHandler(CallSessionHandler):
             return "Sorry, that didn't work."
         return f"Unknown tool: {name}."
 
-    async def _look_at_screen(self, question: str, source: str | None) -> str:
-        want = "camera" if str(source or "").lower() == "camera" else "screenshare"
-        frame = self._vision.latest(want) or self._vision.latest()
-        if frame is None:
-            return "I can't see a shared screen or camera right now."
+    async def _look_at_screen(self, question: str, source: str | None, scope: str = "live") -> str:
         prompt = question.strip() or "Describe what you see."
+        if scope == "history":
+            frames = self._vision.history(limit=6)
+            if not frames:
+                return "I don't have any earlier frames to look back on."
+            content: list[dict] = [{"type": "text", "text": prompt}]
+            for f in frames:  # timestamped, attributed keyframes
+                content.append({"type": "text", "text": f"(earlier, from {f.describe()})"})
+                content.append({"type": "image_url", "image_url": {"url": f.data_url()}})
+        else:
+            want = "camera" if str(source or "").lower() == "camera" else "screenshare"
+            frame = self._vision.latest(want) or self._vision.latest()
+            if frame is None:
+                return "I can't see a shared screen or camera right now."
+            content = [
+                {"type": "text", "text": f"{prompt} (looking at the {frame.describe()})"},
+                {"type": "image_url", "image_url": {"url": frame.data_url()}},
+            ]
+        return await self._vision_consult(content)
+
+    async def _vision_consult(self, content: list[dict]) -> str:
         try:
             from agent.auxiliary_client import async_call_llm
 
-            messages = [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": prompt},
-                        {"type": "image_url", "image_url": {"url": frame.data_url()}},
-                    ],
-                }
-            ]
-            resp = await async_call_llm(task="vision", messages=messages, max_tokens=400)
+            resp = await async_call_llm(
+                task="vision", messages=[{"role": "user", "content": content}], max_tokens=400
+            )
             text = resp.choices[0].message.content if resp and resp.choices else ""
             return (text or "").strip() or "I couldn't quite make that out."
         except Exception:  # noqa: BLE001
-            logger.error("[teams_voice] look_at_screen vision call failed", exc_info=True)
+            logger.error("[teams_voice] vision consult failed", exc_info=True)
             return "I had trouble looking at that."
 
     async def _show_to_caller(self, prompt: str) -> str:

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -487,16 +487,49 @@ class StreamingCallSessionHandler(BaseTeamsCallHandler):
         if not text or session is None:
             return
         await self._safe_expression(expression.infer_emotion(text))
-        from hermes_constants import get_hermes_home
+        synth = await self._synthesize(text)
+        if synth is None:
+            return
+        pcm16k, marks_payload = synth
+        if marks_payload:
+            try:
+                await session.send_speech_marks(marks_payload, ts=self._out_ts)
+            except Exception:  # noqa: BLE001
+                pass
+        frames, _ = audio.frame_pcm16(pcm16k, BYTES_PER_FRAME)
+        for frame in frames:
+            try:
+                await session.send_audio_frame(
+                    self._out_seq, self._out_ts, base64.b64encode(frame).decode("ascii")
+                )
+            except Exception:  # noqa: BLE001
+                return
+            self._out_seq += 1
+            self._out_ts += FRAME_DURATION_MS
 
-        from .streaming_audio import decode_to_pcm16k
+    async def _synthesize(self, text: str) -> tuple[bytes, list[dict]] | None:
+        """TTS → (PCM 16k, viseme marks). Prefers ElevenLabs ``/with-timestamps``
+        (real per-character timing); falls back to the configured TTS + estimator."""
+        from . import elevenlabs_tts
+        from .streaming_audio import decode_bytes_to_pcm16k, decode_to_pcm16k
+
+        el_cfg = elevenlabs_tts.resolve_config()
+        if el_cfg:
+            res = await elevenlabs_tts.synth_with_timestamps(text, el_cfg)
+            if res:
+                mp3, timing = res
+                pcm16k = await asyncio.to_thread(decode_bytes_to_pcm16k, mp3)
+                if pcm16k:
+                    marks = viseme_estimate.visemes_from_alignment(timing)  # real timing
+                    return pcm16k, viseme_estimate.marks_to_payload(marks)
+
+        from hermes_constants import get_hermes_home
+        from tools.tts_tool import text_to_speech_tool
 
         d = Path(get_hermes_home()) / "cache" / "teams_voice"
         d.mkdir(parents=True, exist_ok=True)
         out = d / f"tts_{uuid.uuid4().hex}.mp3"
         try:
-            from tools.tts_tool import text_to_speech_tool
-
             raw = await asyncio.to_thread(lambda: text_to_speech_tool(text, output_path=str(out)))
             path = str(out)
             try:
@@ -507,26 +540,10 @@ class StreamingCallSessionHandler(BaseTeamsCallHandler):
                 pass
             pcm16k = await asyncio.to_thread(decode_to_pcm16k, path)
             if not pcm16k:
-                return
-            # TODO(viseme): swap the estimator for real ElevenLabs /with-timestamps
-            # alignment when the TTS path exposes per-character timing.
+                return None
             dur_ms = (len(pcm16k) // 2) // PCM_SAMPLE_RATE_HZ_MS
             marks = viseme_estimate.estimate_visemes(text, dur_ms)
-            if marks:
-                try:
-                    await session.send_speech_marks(viseme_estimate.marks_to_payload(marks), ts=self._out_ts)
-                except Exception:  # noqa: BLE001
-                    pass
-            frames, _ = audio.frame_pcm16(pcm16k, BYTES_PER_FRAME)
-            for frame in frames:
-                try:
-                    await session.send_audio_frame(
-                        self._out_seq, self._out_ts, base64.b64encode(frame).decode("ascii")
-                    )
-                except Exception:  # noqa: BLE001
-                    return
-                self._out_seq += 1
-                self._out_ts += FRAME_DURATION_MS
+            return pcm16k, viseme_estimate.marks_to_payload(marks)
         finally:
             try:
                 Path(out).unlink(missing_ok=True)

--- a/plugins/teams_voice/handlers.py
+++ b/plugins/teams_voice/handlers.py
@@ -18,6 +18,7 @@ import base64
 import json
 import logging
 import time
+import uuid
 from dataclasses import replace
 from pathlib import Path
 
@@ -30,6 +31,8 @@ from .outbound import OutboundError, place_call
 from .realtime.openai_client import REALTIME_SAMPLE_RATE_HZ, RealtimeConfig, RealtimeSession
 from .vision_budget import VisionBudget
 from .vision_store import StoredFrame, VisionStore
+
+PCM_SAMPLE_RATE_HZ_MS = PCM_SAMPLE_RATE_HZ // 1000  # samples per ms (16) — duration math
 
 logger = logging.getLogger(__name__)
 
@@ -532,4 +535,153 @@ class RealtimeCallSessionHandler(CallSessionHandler):
         try:
             await self._session.send_expression(emotion)
         except Exception:  # noqa: BLE001 — cosmetic
+            pass
+
+
+class StreamingCallSessionHandler(CallSessionHandler):
+    """Streaming voice path: STT → agent → TTS (half-duplex, turn-based).
+
+    Segments caller audio into utterances (VAD), transcribes them, applies the
+    verbal-interrupt + group gate on the transcript, runs the Hermes agent, then
+    speaks the reply via TTS with expression + estimated visemes. Simpler than the
+    realtime path but works with any STT/TTS provider and no realtime model.
+    """
+
+    def __init__(self, bridge_config: TeamsVoiceConfig | None = None) -> None:
+        from .streaming_audio import UtteranceBuffer
+
+        self._bridge = bridge_config
+        self._session: CallSession | None = None
+        self._caller: protocol.CallerInfo | None = None
+        self._buf = UtteranceBuffer()
+        self._consult = AgentConsult()
+        wake = tuple(bridge_config.wake_phrases) if (bridge_config and bridge_config.wake_phrases) else ("assistant", "hermes")
+        self._gate_cfg = group_call_gate.GroupCallGateConfig(wake_phrases=wake)
+        self._last_addressed_ms: float | None = None
+        self._out_seq = 0
+        self._out_ts = 0
+        self._processing = False  # half-duplex: one utterance at a time
+
+    async def on_session_start(self, session: CallSession, msg: protocol.SessionStart) -> None:
+        await super().on_session_start(session, msg)
+        self._session = session
+        self._caller = msg.caller
+        scope = self._bridge.session_scope if self._bridge else "per-call"
+        key = msg.thread_id if scope == "per-thread" else (msg.caller.aad_id if scope == "per-aad" else msg.call_id)
+        self._consult = AgentConsult(session_id=f"teams:{key or msg.call_id}")
+        await self._safe_expression(expression.NEUTRAL)
+
+    async def on_audio_frame(self, session: CallSession, msg: protocol.AudioFrame) -> None:
+        if not session.recording_active or self._processing:
+            return
+        pcm = base64.b64decode(msg.payload_base64)
+        utterance = self._buf.push(pcm, audio.pcm16_rms(pcm))
+        if utterance is not None:
+            self._processing = True
+            asyncio.create_task(self._handle_utterance(utterance))
+
+    async def _handle_utterance(self, pcm: bytes) -> None:
+        try:
+            transcript = await self._transcribe(pcm)
+            if not transcript:
+                return
+            if verbal_interrupts.is_verbal_interrupt(transcript, self._gate_cfg.wake_phrases):
+                return  # nothing playing in half-duplex; just don't reply
+            is_group = (self._session.human_count if self._session else 0) >= 2
+            now = time.monotonic() * 1000.0
+            decision = group_call_gate.should_respond_to_group_turn(
+                transcript=transcript, is_group=is_group, config=self._gate_cfg,
+                last_addressed_at_ms=self._last_addressed_ms, now_ms=now,
+            )
+            if not decision.respond:
+                return
+            if decision.addressed:
+                self._last_addressed_ms = now
+            await self._safe_expression(expression.THINKING)
+            reply = await self._consult.ask(transcript)
+            await self._speak(reply)
+        except Exception:  # noqa: BLE001 — never let a turn crash the call
+            logger.error("[teams_voice] streaming turn failed", exc_info=True)
+        finally:
+            self._buf.reset()
+            self._processing = False
+
+    async def _transcribe(self, pcm: bytes) -> str:
+        from hermes_constants import get_hermes_home
+
+        from .streaming_audio import write_wav_pcm16
+
+        d = Path(get_hermes_home()) / "cache" / "teams_voice"
+        d.mkdir(parents=True, exist_ok=True)
+        wav = d / f"utt_{uuid.uuid4().hex}.wav"
+        try:
+            await asyncio.to_thread(write_wav_pcm16, pcm, str(wav), PCM_SAMPLE_RATE_HZ)
+            from tools.transcription_tools import transcribe_audio
+
+            res = await asyncio.to_thread(transcribe_audio, str(wav))
+            return (res.get("transcript") or "").strip() if res.get("success") else ""
+        finally:
+            try:
+                wav.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    async def _speak(self, text: str) -> None:
+        text = (text or "").strip()
+        session = self._session
+        if not text or session is None:
+            return
+        await self._safe_expression(expression.infer_emotion(text))
+        from hermes_constants import get_hermes_home
+
+        from .streaming_audio import decode_to_pcm16k
+
+        d = Path(get_hermes_home()) / "cache" / "teams_voice"
+        d.mkdir(parents=True, exist_ok=True)
+        out = d / f"tts_{uuid.uuid4().hex}.mp3"
+        try:
+            from tools.tts_tool import text_to_speech_tool
+
+            raw = await asyncio.to_thread(lambda: text_to_speech_tool(text, output_path=str(out)))
+            path = str(out)
+            try:
+                fp = json.loads(raw).get("file_path")
+                if fp:
+                    path = fp
+            except (TypeError, ValueError):
+                pass
+            pcm16k = await asyncio.to_thread(decode_to_pcm16k, path)
+            if not pcm16k:
+                return
+            # TODO(viseme): swap the estimator for real ElevenLabs /with-timestamps
+            # alignment when the TTS path exposes per-character timing.
+            dur_ms = (len(pcm16k) // 2) // PCM_SAMPLE_RATE_HZ_MS
+            marks = viseme_estimate.estimate_visemes(text, dur_ms)
+            if marks:
+                try:
+                    await session.send_speech_marks(viseme_estimate.marks_to_payload(marks), ts=self._out_ts)
+                except Exception:  # noqa: BLE001
+                    pass
+            frames, _ = audio.frame_pcm16(pcm16k, BYTES_PER_FRAME)
+            for frame in frames:
+                try:
+                    await session.send_audio_frame(
+                        self._out_seq, self._out_ts, base64.b64encode(frame).decode("ascii")
+                    )
+                except Exception:  # noqa: BLE001
+                    return
+                self._out_seq += 1
+                self._out_ts += FRAME_DURATION_MS
+        finally:
+            try:
+                Path(out).unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    async def _safe_expression(self, emotion: str) -> None:
+        if self._session is None:
+            return
+        try:
+            await self._session.send_expression(emotion)
+        except Exception:  # noqa: BLE001
             pass

--- a/plugins/teams_voice/hmac_auth.py
+++ b/plugins/teams_voice/hmac_auth.py
@@ -1,0 +1,104 @@
+"""HMAC-SHA256 handshake + single-use replay guard for the bridge upgrade.
+
+The .NET worker signs ``HMAC(sharedSecret, "{timestampMs}.{callId}")`` and sends
+it as two headers on the WebSocket upgrade (see ``config.HEADER_*``). This module
+verifies that signature constant-time, enforces a clock-skew/replay window, and
+records each accepted ``(callId, ts, signature)`` tuple as **single-use** —
+expiring at ``ts + window`` (not ``now + window``) so a future-dated handshake
+from worker clock skew cannot outlive its own validity window.
+
+Mirrors ``HmacSigner.cs`` (worker) and the handshake in ``msteams-media-stream.ts``
+(the original TypeScript driver).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+from dataclasses import dataclass, field
+
+
+def sign(secret: str, timestamp_ms: int, call_id: str) -> str:
+    """Return the lowercase-hex HMAC-SHA256 over ``"{timestamp_ms}.{call_id}"``."""
+    payload = f"{timestamp_ms}.{call_id}".encode("utf-8")
+    digest = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256)
+    return digest.hexdigest()
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+@dataclass
+class ReplayGuard:
+    """Tracks accepted handshake tuples so each is usable at most once.
+
+    Only *verified* tuples are recorded, so an attacker without the secret cannot
+    grow the map. Entries expire at the timestamp's own validity horizon.
+    """
+
+    window_ms: int = 60_000
+    _seen: dict[str, int] = field(default_factory=dict)  # key -> expiry epoch ms
+
+    def _prune(self, now_ms: int) -> None:
+        expired = [k for k, exp in self._seen.items() if exp <= now_ms]
+        for k in expired:
+            del self._seen[k]
+
+    def check_and_record(self, call_id: str, timestamp_ms: int, signature: str) -> bool:
+        """Return True if this tuple is fresh; record it. False if already used."""
+        now_ms = _now_ms()
+        self._prune(now_ms)
+        key = f"{call_id}.{timestamp_ms}.{signature}"
+        if key in self._seen:
+            return False
+        # Expire at the timestamp's OWN horizon (ts + window), not now + window,
+        # so a future-dated handshake from worker clock skew cannot outlive its
+        # validity window. A stale ts is rejected by the window check in
+        # verify_upgrade before it ever reaches here.
+        self._seen[key] = timestamp_ms + self.window_ms
+        return True
+
+
+def verify_upgrade(
+    *,
+    secret: str,
+    call_id: str,
+    timestamp_header: str | None,
+    signature_header: str | None,
+    window_ms: int = 60_000,
+    replay_guard: ReplayGuard | None = None,
+    now_ms: int | None = None,
+) -> tuple[bool, str]:
+    """Verify a WebSocket upgrade's HMAC headers.
+
+    Returns ``(ok, reason)``. ``reason`` is a short, non-sensitive string for
+    logging (never includes the secret or signature). Order of checks: presence,
+    timestamp parse + window, constant-time signature compare, then single-use
+    replay.
+    """
+    if not secret:
+        return False, "bridge not configured (no shared secret)"
+    if not timestamp_header or not signature_header:
+        return False, "missing auth headers"
+
+    try:
+        ts = int(str(timestamp_header).strip())
+    except (TypeError, ValueError):
+        return False, "unparseable timestamp"
+
+    current = now_ms if now_ms is not None else _now_ms()
+    if abs(current - ts) > window_ms:
+        return False, "timestamp outside window"
+
+    expected = sign(secret, ts, call_id)
+    if not hmac.compare_digest(expected, str(signature_header).strip().lower()):
+        return False, "bad signature"
+
+    if replay_guard is not None and not replay_guard.check_and_record(
+        call_id, ts, str(signature_header).strip().lower()
+    ):
+        return False, "replayed handshake"
+
+    return True, ""

--- a/plugins/teams_voice/meeting.py
+++ b/plugins/teams_voice/meeting.py
@@ -1,0 +1,92 @@
+"""Meeting transcript accumulation + minutes prompt building.
+
+The voice handlers append each caller/assistant turn to a :class:`MeetingTranscript`.
+At call end (opt-in ``meeting_recap``) or on the ``post_meeting_minutes`` tool, the
+handler asks the Hermes agent to summarize the transcript into minutes and post
+them to the Teams conversation via the agent's own ``send_message`` tool — so the
+cross-process delivery and DOCX creation are the agent's job, not the bridge's.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MeetingTranscript:
+    """Ordered (speaker, text) turns for end-of-call minutes."""
+
+    turns: list[tuple[str, str]] = field(default_factory=list)
+
+    def add(self, speaker: str, text: str) -> None:
+        text = (text or "").strip()
+        if text:
+            self.turns.append((speaker or "Caller", text))
+
+    def is_empty(self) -> bool:
+        return not self.turns
+
+    def render(self, max_chars: int = 12_000) -> str:
+        body = "\n".join(f"{sp}: {tx}" for sp, tx in self.turns)
+        # Keep the tail if very long (recent context matters most for minutes).
+        return body[-max_chars:] if len(body) > max_chars else body
+
+
+def is_summary_request(text: str) -> bool:
+    """True if the caller asked to summarize / send minutes of the meeting."""
+    t = (text or "").lower()
+    summary = any(w in t for w in ("summarize", "summarise", "minutes", "recap", "notes"))
+    subject = any(w in t for w in ("meeting", "call", "conversation", "discussion"))
+    return summary and subject
+
+
+def summarize_prompt(transcript: str) -> str:
+    """Prompt the agent to produce minutes text only (no posting)."""
+    return (
+        "Summarize the transcript of this Microsoft Teams meeting into concise "
+        "minutes with three sections — **Key Points**, **Decisions**, and **Action "
+        "Items** (name owners where stated). Output only the minutes, briefly and "
+        f"factually.\n\nTranscript:\n{transcript}"
+    )
+
+
+async def _deliver_to_teams(conversation_id: str, text: str) -> bool:
+    """Post text to a Teams conversation via the adapter's standalone REST sender
+    (works without the gateway running; reads bot creds from env)."""
+    try:
+        from plugins.platforms.teams.adapter import _standalone_send
+    except Exception:  # noqa: BLE001 — teams adapter unavailable
+        return False
+    pconfig = type("_PConfig", (), {"extra": {}})()
+    try:
+        result = await _standalone_send(pconfig, chat_id=conversation_id, message=text)
+        return bool(result.get("success"))
+    except Exception:  # noqa: BLE001
+        logger.error("[teams_voice] recap delivery failed", exc_info=True)
+        return False
+
+
+async def post_minutes(consult, transcript: "MeetingTranscript", conversation_id: str) -> str:
+    """Summarize the transcript via the agent, then post the minutes to Teams.
+
+    Returns a short spoken-result string. No-op on an empty transcript.
+    """
+    if transcript.is_empty() or not conversation_id:
+        return "There wasn't enough of a conversation to summarize."
+    try:
+        minutes = await consult.ask(summarize_prompt(transcript.render()), timeout_s=120.0)
+    except Exception:  # noqa: BLE001 — recap must never crash teardown
+        logger.error("[teams_voice] meeting summary failed", exc_info=True)
+        return "I couldn't summarize the meeting."
+    minutes = (minutes or "").strip()
+    if not minutes:
+        return "I couldn't summarize the meeting."
+    ok = await _deliver_to_teams(conversation_id, f"📝 **Meeting minutes**\n\n{minutes}")
+    return (
+        "I've posted the minutes to your Teams chat."
+        if ok
+        else "I summarized the meeting but couldn't post it to the chat."
+    )

--- a/plugins/teams_voice/meeting.py
+++ b/plugins/teams_voice/meeting.py
@@ -69,10 +69,14 @@ async def _deliver_to_teams(conversation_id: str, text: str) -> bool:
         return False
 
 
-async def post_minutes(consult, transcript: "MeetingTranscript", conversation_id: str) -> str:
+async def post_minutes(
+    consult, transcript: "MeetingTranscript", conversation_id: str, *, deliver=None
+) -> str:
     """Summarize the transcript via the agent, then post the minutes to Teams.
 
-    Returns a short spoken-result string. No-op on an empty transcript.
+    ``deliver`` is an injectable ``async (conversation_id, text) -> bool`` (defaults
+    to the Teams standalone sender) — decouples voice from the chat adapter and
+    keeps this unit-testable. Returns a short spoken-result string.
     """
     if transcript.is_empty() or not conversation_id:
         return "There wasn't enough of a conversation to summarize."
@@ -84,7 +88,8 @@ async def post_minutes(consult, transcript: "MeetingTranscript", conversation_id
     minutes = (minutes or "").strip()
     if not minutes:
         return "I couldn't summarize the meeting."
-    ok = await _deliver_to_teams(conversation_id, f"📝 **Meeting minutes**\n\n{minutes}")
+    deliver = deliver or _deliver_to_teams
+    ok = await deliver(conversation_id, f"📝 **Meeting minutes**\n\n{minutes}")
     return (
         "I've posted the minutes to your Teams chat."
         if ok

--- a/plugins/teams_voice/meeting.py
+++ b/plugins/teams_voice/meeting.py
@@ -63,6 +63,11 @@ async def _deliver_to_teams(conversation_id: str, text: str) -> bool:
     pconfig = type("_PConfig", (), {"extra": {}})()
     try:
         result = await _standalone_send(pconfig, chat_id=conversation_id, message=text)
+        if not result.get("success"):
+            logger.warning(
+                "[teams_voice] minutes delivery to %s failed: %s",
+                conversation_id, result.get("error"),
+            )
         return bool(result.get("success"))
     except Exception:  # noqa: BLE001
         logger.error("[teams_voice] recap delivery failed", exc_info=True)

--- a/plugins/teams_voice/meeting.py
+++ b/plugins/teams_voice/meeting.py
@@ -4,8 +4,8 @@ The voice handlers append each caller/assistant turn to a :class:`MeetingTranscr
 At call end (opt-in ``meeting_recap``) or on the ``post_meeting_minutes`` tool, the
 agent summarizes the transcript into minutes which are posted to the Teams chat via
 the adapter's standalone Bot Framework sender. A Word-openable ``.docx`` is also
-generated; when ``sharePointSiteId`` is configured it is uploaded to SharePoint and
-attached to the chat as a native file card, otherwise the minutes post as text.
+generated; when ``sharePointSiteId`` is configured it is uploaded to SharePoint
+(OneDrive) and attached to the chat as a native file card, otherwise it posts as text.
 """
 
 from __future__ import annotations

--- a/plugins/teams_voice/meeting.py
+++ b/plugins/teams_voice/meeting.py
@@ -2,9 +2,10 @@
 
 The voice handlers append each caller/assistant turn to a :class:`MeetingTranscript`.
 At call end (opt-in ``meeting_recap``) or on the ``post_meeting_minutes`` tool, the
-handler asks the Hermes agent to summarize the transcript into minutes and post
-them to the Teams conversation via the agent's own ``send_message`` tool — so the
-cross-process delivery and DOCX creation are the agent's job, not the bridge's.
+agent summarizes the transcript into minutes which are posted to the Teams chat via
+the adapter's standalone Bot Framework sender. A Word-openable ``.docx`` is also
+generated; when ``sharePointSiteId`` is configured it is uploaded to SharePoint and
+attached to the chat as a native file card, otherwise the minutes post as text.
 """
 
 from __future__ import annotations
@@ -77,10 +78,10 @@ async def _deliver_to_teams(conversation_id: str, text: str) -> bool:
 
 
 def _save_docx_artifact(minutes: str) -> str | None:
-    """Write a Word-openable minutes .docx under the Hermes workspace; log the path.
+    """Write a Word-openable minutes .docx under the Hermes workspace; return the path.
 
-    Best-effort: cross-process attachment to the Teams chat is text-only, so this
-    produces a retrievable artifact rather than an inline chat attachment."""
+    Best-effort: the file is uploaded + attached to the chat when SharePoint is
+    configured (see :func:`_deliver_file_to_teams`), and kept as a local artifact."""
     try:
         from hermes_constants import get_hermes_home
 
@@ -95,6 +96,32 @@ def _save_docx_artifact(minutes: str) -> str | None:
     except Exception:  # noqa: BLE001 — artifact is optional
         logger.warning("[teams_voice] minutes .docx generation failed", exc_info=True)
         return None
+
+
+async def _deliver_file_to_teams(conversation_id: str, file_path: str, display_name: str, *, caption: str = "") -> bool:
+    """Upload a file to SharePoint and post it to the Teams chat as a file card.
+
+    Returns False (caller degrades to text) when SharePoint isn't configured or the
+    upload fails. The Word document content type keeps Teams' Open-in-Word working."""
+    try:
+        from plugins.platforms.teams.adapter import _standalone_send_file
+    except Exception:  # noqa: BLE001 — teams adapter unavailable
+        return False
+    try:
+        content = Path(file_path).read_bytes()
+    except OSError:
+        return False
+    pconfig = type("_PConfig", (), {"extra": {}})()
+    docx_ct = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    try:
+        result = await _standalone_send_file(
+            pconfig, chat_id=conversation_id, content=content,
+            filename=display_name, content_type=docx_ct, caption=caption,
+        )
+        return bool(result.get("success"))
+    except Exception:  # noqa: BLE001
+        logger.error("[teams_voice] minutes file delivery failed", exc_info=True)
+        return False
 
 
 async def post_minutes(
@@ -116,9 +143,15 @@ async def post_minutes(
     minutes = (minutes or "").strip()
     if not minutes:
         return "I couldn't summarize the meeting."
-    _save_docx_artifact(minutes)  # best-effort Word-openable artifact
+    body = f"📝 **Meeting minutes**\n\n{minutes}"
+    docx_path = _save_docx_artifact(minutes)  # Word-openable artifact
+    # When SharePoint file-send is configured, attach the Word document to the chat;
+    # otherwise (or for an injected test deliver) post the minutes as text.
+    if docx_path and deliver is None:
+        if await _deliver_file_to_teams(conversation_id, docx_path, "Meeting minutes.docx", caption=body):
+            return "I've posted the minutes (with the Word document) to your Teams chat."
     deliver = deliver or _deliver_to_teams
-    ok = await deliver(conversation_id, f"📝 **Meeting minutes**\n\n{minutes}")
+    ok = await deliver(conversation_id, body)
     return (
         "I've posted the minutes to your Teams chat."
         if ok

--- a/plugins/teams_voice/meeting.py
+++ b/plugins/teams_voice/meeting.py
@@ -10,7 +10,9 @@ cross-process delivery and DOCX creation are the agent's job, not the bridge's.
 from __future__ import annotations
 
 import logging
+import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +76,27 @@ async def _deliver_to_teams(conversation_id: str, text: str) -> bool:
         return False
 
 
+def _save_docx_artifact(minutes: str) -> str | None:
+    """Write a Word-openable minutes .docx under the Hermes workspace; log the path.
+
+    Best-effort: cross-process attachment to the Teams chat is text-only, so this
+    produces a retrievable artifact rather than an inline chat attachment."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        from .meeting_docx import write_minutes_docx
+
+        d = Path(get_hermes_home()) / "workspace" / "teams_minutes"
+        d.mkdir(parents=True, exist_ok=True)
+        path = d / f"minutes_{uuid.uuid4().hex[:8]}.docx"
+        write_minutes_docx("Meeting minutes", minutes, str(path))
+        logger.info("[teams_voice] minutes document saved: %s", path)
+        return str(path)
+    except Exception:  # noqa: BLE001 — artifact is optional
+        logger.warning("[teams_voice] minutes .docx generation failed", exc_info=True)
+        return None
+
+
 async def post_minutes(
     consult, transcript: "MeetingTranscript", conversation_id: str, *, deliver=None
 ) -> str:
@@ -93,6 +116,7 @@ async def post_minutes(
     minutes = (minutes or "").strip()
     if not minutes:
         return "I couldn't summarize the meeting."
+    _save_docx_artifact(minutes)  # best-effort Word-openable artifact
     deliver = deliver or _deliver_to_teams
     ok = await deliver(conversation_id, f"📝 **Meeting minutes**\n\n{minutes}")
     return (

--- a/plugins/teams_voice/meeting.py
+++ b/plugins/teams_voice/meeting.py
@@ -111,7 +111,18 @@ async def _deliver_file_to_teams(conversation_id: str, file_path: str, display_n
         content = Path(file_path).read_bytes()
     except OSError:
         return False
-    pconfig = type("_PConfig", (), {"extra": {}})()
+    # Pass the resolved SharePoint site id (config.yaml or env) so the standalone
+    # sender can upload even though its own pconfig has no platform extra.
+    extra: dict = {}
+    try:
+        from .config import resolve_config
+
+        site_id = resolve_config().share_point_site_id
+        if site_id:
+            extra["share_point_site_id"] = site_id
+    except Exception:  # noqa: BLE001
+        pass
+    pconfig = type("_PConfig", (), {"extra": extra})()
     docx_ct = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     try:
         result = await _standalone_send_file(

--- a/plugins/teams_voice/meeting_docx.py
+++ b/plugins/teams_voice/meeting_docx.py
@@ -1,0 +1,54 @@
+"""Minimal, dependency-free .docx writer for meeting minutes.
+
+A .docx is just a ZIP of OOXML parts; we emit the three required parts so the file
+opens in Word/LibreOffice without needing python-docx. Used to produce a
+Word-openable minutes artifact alongside the text posted to the Teams chat (cross-
+process attachment to the chat itself remains text-only — see meeting.py).
+"""
+
+from __future__ import annotations
+
+import zipfile
+from xml.sax.saxutils import escape
+
+_CONTENT_TYPES = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+    '<Default Extension="xml" ContentType="application/xml"/>'
+    '<Override PartName="/word/document.xml" '
+    'ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>'
+    "</Types>"
+)
+_RELS = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    '<Relationship Id="rId1" '
+    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" '
+    'Target="word/document.xml"/></Relationships>'
+)
+
+
+def _para(text: str, *, bold: bool = False) -> str:
+    rpr = "<w:rPr><w:b/></w:rPr>" if bold else ""
+    return f'<w:p><w:r>{rpr}<w:t xml:space="preserve">{escape(text)}</w:t></w:r></w:p>'
+
+
+def write_minutes_docx(title: str, minutes_text: str, path: str) -> None:
+    """Write ``minutes_text`` (markdown-ish) to a Word-openable .docx at ``path``."""
+    paras = [_para(title, bold=True)]
+    for raw in minutes_text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        bold = line.startswith("**") and line.endswith("**")
+        paras.append(_para(line.strip("*").strip(), bold=bold))
+    document = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+        "<w:body>" + "".join(paras) + "<w:sectPr/></w:body></w:document>"
+    )
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("[Content_Types].xml", _CONTENT_TYPES)
+        z.writestr("_rels/.rels", _RELS)
+        z.writestr("word/document.xml", document)

--- a/plugins/teams_voice/outbound.py
+++ b/plugins/teams_voice/outbound.py
@@ -13,13 +13,17 @@ Contract (worker `OutboundCallController.cs`):
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
+from urllib.parse import urlparse
 
 from . import hmac_auth
 from .config import HEADER_SIGNATURE, HEADER_TIMESTAMP
 
 logger = logging.getLogger(__name__)
+
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 
 class OutboundError(RuntimeError):
@@ -33,11 +37,15 @@ async def place_call(
     shared_secret: str,
     worker_base_url: str = "http://127.0.0.1:9440",
     timeout_s: float = 15.0,
+    allow_remote: bool = False,
 ) -> dict:
     """Place an outbound Teams call to ``user_object_id`` in ``tenant_id``.
 
     Returns the worker's ``{"callId": ..., "scenarioId": ...}`` on success.
     Raises :class:`OutboundError` on validation/auth/transport failure.
+
+    SSRF guard: refuses a non-loopback ``worker_base_url`` unless ``allow_remote``
+    — otherwise a misconfigured host would receive the HMAC-signed request.
     """
     import aiohttp
 
@@ -45,6 +53,12 @@ async def place_call(
         raise OutboundError("user_object_id and tenant_id are required")
     if not shared_secret:
         raise OutboundError("shared secret not configured")
+    host = (urlparse(worker_base_url).hostname or "").lower()
+    if not allow_remote and host not in _LOOPBACK_HOSTS:
+        raise OutboundError(
+            f"refusing outbound place-call to non-loopback worker '{host}' "
+            "(set allow_remote_worker to override)"
+        )
 
     ts = int(time.time() * 1000)
     signature = hmac_auth.sign(shared_secret, ts, user_object_id)
@@ -67,5 +81,5 @@ async def place_call(
                     return await resp.json()
                 except (aiohttp.ContentTypeError, ValueError):
                     return {"raw": text}
-    except aiohttp.ClientError as exc:
+    except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
         raise OutboundError(f"transport error placing call: {exc}") from exc

--- a/plugins/teams_voice/outbound.py
+++ b/plugins/teams_voice/outbound.py
@@ -1,0 +1,71 @@
+"""Outbound "call me back" — place a Teams call via the worker's HTTP endpoint.
+
+The worker exposes a loopback HTTP endpoint (`POST {worker_base_url}/api/calls`,
+default port 9440) that places an outbound 1:1 Teams call. It is HMAC-authenticated
+exactly like the WS bridge, except the signed payload is ``"{ts}.{userObjectId}"``
+(the callee's AAD object id) rather than the callId.
+
+Contract (worker `OutboundCallController.cs`):
+  headers: X-OpenClawTeamsBridge-Timestamp, X-OpenClawTeamsBridge-Signature
+  body:    {"userObjectId": <aad id>, "tenantId": <tenant>}
+  200 ->   {"callId": ..., "scenarioId": ...}
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from . import hmac_auth
+from .config import HEADER_SIGNATURE, HEADER_TIMESTAMP
+
+logger = logging.getLogger(__name__)
+
+
+class OutboundError(RuntimeError):
+    """Raised when an outbound place-call request fails."""
+
+
+async def place_call(
+    *,
+    user_object_id: str,
+    tenant_id: str,
+    shared_secret: str,
+    worker_base_url: str = "http://127.0.0.1:9440",
+    timeout_s: float = 15.0,
+) -> dict:
+    """Place an outbound Teams call to ``user_object_id`` in ``tenant_id``.
+
+    Returns the worker's ``{"callId": ..., "scenarioId": ...}`` on success.
+    Raises :class:`OutboundError` on validation/auth/transport failure.
+    """
+    import aiohttp
+
+    if not user_object_id or not tenant_id:
+        raise OutboundError("user_object_id and tenant_id are required")
+    if not shared_secret:
+        raise OutboundError("shared secret not configured")
+
+    ts = int(time.time() * 1000)
+    signature = hmac_auth.sign(shared_secret, ts, user_object_id)
+    headers = {
+        HEADER_TIMESTAMP: str(ts),
+        HEADER_SIGNATURE: signature,
+        "Content-Type": "application/json",
+    }
+    body = {"userObjectId": user_object_id, "tenantId": tenant_id}
+    url = f"{worker_base_url.rstrip('/')}/api/calls"
+
+    try:
+        timeout = aiohttp.ClientTimeout(total=timeout_s)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(url, json=body, headers=headers) as resp:
+                text = await resp.text()
+                if resp.status != 200:
+                    raise OutboundError(f"worker returned {resp.status}: {text}")
+                try:
+                    return await resp.json()
+                except (aiohttp.ContentTypeError, ValueError):
+                    return {"raw": text}
+    except aiohttp.ClientError as exc:
+        raise OutboundError(f"transport error placing call: {exc}") from exc

--- a/plugins/teams_voice/outbound.py
+++ b/plugins/teams_voice/outbound.py
@@ -5,8 +5,8 @@ default port 9440) that places an outbound 1:1 Teams call. It is HMAC-authentica
 exactly like the WS bridge, except the signed payload is ``"{ts}.{userObjectId}"``
 (the callee's AAD object id) rather than the callId.
 
-Contract (worker `OutboundCallController.cs`):
-  headers: X-OpenClawTeamsBridge-Timestamp, X-OpenClawTeamsBridge-Signature
+Contract (worker outbound-call endpoint):
+  headers: X-OpenClawTeamsBridge-Timestamp, X-OpenClawTeamsBridge-Signature  (must match the worker)
   body:    {"userObjectId": <aad id>, "tenantId": <tenant>}
   200 ->   {"callId": ..., "scenarioId": ...}
 """

--- a/plugins/teams_voice/plugin.yaml
+++ b/plugins/teams_voice/plugin.yaml
@@ -25,3 +25,29 @@ optional_env:
     description: "Bind address for the bridge WebSocket server (default 127.0.0.1)."
   - name: TEAMS_VOICE_PORT
     description: "Port for the bridge WebSocket server (default 8443)."
+  - name: TEAMS_VOICE_ALLOWLIST
+    description: "Comma-separated caller AAD object ids allowed to call (empty = allow all)."
+  - name: TEAMS_VOICE_WAKE_PHRASES
+    description: "Comma-separated group-call wake phrases (default: assistant,hermes)."
+  - name: TEAMS_VOICE_MEETING_RECAP
+    description: "Post end-of-call meeting minutes to the Teams chat (true/false)."
+  - name: TEAMS_VOICE_MAX_VISION_PER_MINUTE
+    description: "Per-call vision spend cap across look_at_screen + ambient push (0 = unlimited)."
+  - name: TEAMS_VOICE_SESSION_SCOPE
+    description: "Agent session continuity: per-call | per-thread | per-aad."
+  - name: TEAMS_VOICE_WORKER_BASE_URL
+    description: "Worker loopback HTTP endpoint for outbound place-call (default http://127.0.0.1:9440)."
+  - name: TEAMS_VOICE_TENANT_ID
+    description: "Default Azure AD tenant for outbound calls (falls back to TEAMS_TENANT_ID)."
+  - name: TEAMS_VOICE_REALTIME_BACKEND
+    description: "Realtime speech provider: azure | openai."
+  - name: TEAMS_VOICE_AZURE_ENDPOINT
+    description: "Azure OpenAI resource endpoint for the realtime model."
+  - name: TEAMS_VOICE_AZURE_DEPLOYMENT
+    description: "Azure realtime deployment name (e.g. gpt-realtime)."
+  - name: TEAMS_VOICE_AZURE_API_VERSION
+    description: "Azure realtime API version (e.g. 2025-04-01-preview)."
+  - name: TEAMS_VOICE_REALTIME_VOICE
+    description: "Realtime voice name (e.g. cedar)."
+  - name: TEAMS_VOICE_BILINGUAL
+    description: "Pin the realtime model to bilingual Arabic/English (true/false)."

--- a/plugins/teams_voice/plugin.yaml
+++ b/plugins/teams_voice/plugin.yaml
@@ -56,3 +56,5 @@ optional_env:
     description: "Permit outbound place-call to a non-loopback worker URL (default false)."
   - name: TEAMS_VOICE_REQUIRE_RECORDING_STATUS
     description: "Gate media processing until Teams recording is active (default true)."
+  - name: TEAMS_SHAREPOINT_SITE_ID
+    description: "SharePoint (OneDrive) site id (host,siteGuid,webGuid) to attach the meeting-minutes .docx to the chat; needs the bot app's Graph Sites.ReadWrite.All."

--- a/plugins/teams_voice/plugin.yaml
+++ b/plugins/teams_voice/plugin.yaml
@@ -1,0 +1,27 @@
+name: teams_voice
+version: 0.1.0
+description: >-
+  Microsoft Teams real-time voice/video (CVI) bridge driver. Hosts an
+  HMAC-authenticated WebSocket the companion .NET media worker (OpenClawBridge /
+  AzureBot) dials into, then drives dialogue (realtime speech-to-speech or
+  streaming STT->agent->TTS), perception (camera/screen vision), and the avatar
+  rendering cues (expression / visemes / show-to-caller). The Windows-only media
+  worker renders; this plugin sends the drivers. Chat-plane integration
+  (messages, message actions, recap posting) is handled by the existing
+  ``platforms/teams`` adapter, not here.
+author: NousResearch
+kind: standalone
+# Pure-Python driver: runs anywhere Hermes runs (the *media worker* it pairs with
+# is Windows-only, but it is a separate process reached over the WebSocket).
+provides_tools:
+  - teams_voice_status
+hooks:
+  - on_session_end
+optional_env:
+  - name: TEAMS_VOICE_SHARED_SECRET
+    description: "HMAC secret shared with the .NET media worker (must equal the worker's OpenClawSharedSecret)."
+    password: true
+  - name: TEAMS_VOICE_HOST
+    description: "Bind address for the bridge WebSocket server (default 127.0.0.1)."
+  - name: TEAMS_VOICE_PORT
+    description: "Port for the bridge WebSocket server (default 8443)."

--- a/plugins/teams_voice/plugin.yaml
+++ b/plugins/teams_voice/plugin.yaml
@@ -2,8 +2,7 @@ name: teams_voice
 version: 0.1.0
 description: >-
   Microsoft Teams real-time voice/video (CVI) bridge driver. Hosts an
-  HMAC-authenticated WebSocket the companion .NET media worker (OpenClawBridge /
-  AzureBot) dials into, then drives dialogue (realtime speech-to-speech or
+  HMAC-authenticated WebSocket the companion .NET media worker dials into, then drives dialogue (realtime speech-to-speech or
   streaming STT->agent->TTS), perception (camera/screen vision), and the avatar
   rendering cues (expression / visemes / show-to-caller). The Windows-only media
   worker renders; this plugin sends the drivers. Chat-plane integration
@@ -19,7 +18,7 @@ hooks:
   - on_session_end
 optional_env:
   - name: TEAMS_VOICE_SHARED_SECRET
-    description: "HMAC secret shared with the .NET media worker (must equal the worker's OpenClawSharedSecret)."
+    description: "HMAC secret shared with the .NET media worker (must equal the worker's shared-secret setting)."
     password: true
   - name: TEAMS_VOICE_HOST
     description: "Bind address for the bridge WebSocket server (default 127.0.0.1)."

--- a/plugins/teams_voice/plugin.yaml
+++ b/plugins/teams_voice/plugin.yaml
@@ -51,3 +51,9 @@ optional_env:
     description: "Realtime voice name (e.g. cedar)."
   - name: TEAMS_VOICE_BILINGUAL
     description: "Pin the realtime model to bilingual Arabic/English (true/false)."
+  - name: TEAMS_VOICE_ALLOWLIST_ALLOW_NAMES
+    description: "Also match the allowlist against caller display names (weaker; default false)."
+  - name: TEAMS_VOICE_ALLOW_REMOTE_WORKER
+    description: "Permit outbound place-call to a non-loopback worker URL (default false)."
+  - name: TEAMS_VOICE_REQUIRE_RECORDING_STATUS
+    description: "Gate media processing until Teams recording is active (default true)."

--- a/plugins/teams_voice/protocol.py
+++ b/plugins/teams_voice/protocol.py
@@ -1,0 +1,288 @@
+"""Bridge wire protocol — Python mirror of the .NET worker's ``Protocol.cs``.
+
+The companion media worker (AzureBot / OpenClawBridge) and this driver exchange
+newline-free JSON text frames over one WebSocket per call, discriminated on a
+``type`` field, camelCase keys. This module models the **inbound** messages
+(worker -> gateway) as dataclasses with a single :func:`decode` entry point, and
+provides **outbound** builders (gateway -> worker).
+
+The contract is fixed by the existing worker; keep field names camelCase and
+additive — unknown fields are ignored and unknown message types degrade
+gracefully (older/newer peers interoperate). See ``Protocol.cs`` for the
+authoritative C# records.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# ── Message type discriminators ──────────────────────────────────────────────
+
+# Inbound: worker -> gateway
+TYPE_SESSION_START = "session.start"
+TYPE_SESSION_END = "session.end"
+TYPE_RECORDING_STATUS = "recording.status"
+TYPE_AUDIO_FRAME = "audio.frame"  # also outbound (TTS)
+TYPE_VIDEO_FRAME = "video.frame"
+TYPE_PARTICIPANTS = "participants"
+TYPE_DTMF = "dtmf"
+TYPE_PING = "ping"
+
+# Outbound: gateway -> worker
+TYPE_EXPRESSION = "expression"
+TYPE_SPEECH_MARKS = "speech.marks"
+TYPE_DISPLAY_IMAGE = "display.image"
+TYPE_ASSISTANT_CANCEL = "assistant.cancel"
+TYPE_PONG = "pong"
+
+
+class ProtocolError(ValueError):
+    """Raised when an inbound frame is malformed or fails schema validation."""
+
+
+# ── Inbound message models ───────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CallerInfo:
+    """Caller identity from ``session.start``. All fields best-effort/nullable.
+
+    Blank/whitespace strings are coerced to ``None`` so distinct anonymous
+    callers never collide on an empty AAD id (cross-caller memory bleed guard).
+    """
+
+    aad_id: Optional[str] = None
+    display_name: Optional[str] = None
+    tenant_id: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "CallerInfo":
+        payload = payload or {}
+        return cls(
+            aad_id=_clean(payload.get("aadId")),
+            display_name=_clean(payload.get("displayName")),
+            tenant_id=_clean(payload.get("tenantId")),
+        )
+
+
+@dataclass(frozen=True)
+class SessionStart:
+    type: str
+    call_id: str
+    thread_id: str
+    caller: CallerInfo
+    recording_status: Optional[str] = None  # "active" | "inactive" | "unknown"
+    direction: Optional[str] = None  # "inbound" | "outbound"
+
+
+@dataclass(frozen=True)
+class SessionEnd:
+    type: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class RecordingStatus:
+    type: str
+    status: str  # "active" | "inactive" | "unknown"
+
+
+@dataclass(frozen=True)
+class AudioFrame:
+    type: str
+    seq: int
+    timestamp_ms: int
+    payload_base64: str
+    speaker_name: Optional[str] = None  # unmixed-audio attribution (additive)
+
+
+@dataclass(frozen=True)
+class VideoFrame:
+    type: str
+    source: str  # "camera" | "screenshare"
+    ts: int
+    width: int
+    height: int
+    mime: str
+    data_base64: str
+    participant_id: Optional[str] = None
+    participant_name: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class Participants:
+    type: str
+    count: int  # human participants, excludes the bot
+
+
+@dataclass(frozen=True)
+class Dtmf:
+    type: str
+    digit: str  # "0"-"9", "*", "#"
+
+
+@dataclass(frozen=True)
+class Ping:
+    type: str
+    ts: int
+
+
+InboundMessage = (
+    SessionStart
+    | SessionEnd
+    | RecordingStatus
+    | AudioFrame
+    | VideoFrame
+    | Participants
+    | Dtmf
+    | Ping
+)
+
+
+def decode(raw: str | bytes) -> InboundMessage:
+    """Parse one inbound text frame into a typed message.
+
+    Raises :class:`ProtocolError` on malformed JSON, a missing/blank ``type``,
+    or a required field missing for a known type. An unknown ``type`` also raises
+    so the caller can log-and-skip without crashing the read loop.
+    """
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode("utf-8")
+    try:
+        obj = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ProtocolError(f"invalid JSON: {exc}") from exc
+    if not isinstance(obj, dict):
+        raise ProtocolError("frame is not a JSON object")
+
+    mtype = obj.get("type")
+    if not isinstance(mtype, str) or not mtype:
+        raise ProtocolError("missing 'type'")
+
+    try:
+        if mtype == TYPE_SESSION_START:
+            return SessionStart(
+                type=mtype,
+                call_id=_require_str(obj, "callId"),
+                thread_id=_require_str(obj, "threadId"),
+                caller=CallerInfo.from_dict(obj.get("caller")),
+                recording_status=_clean(obj.get("recordingStatus")),
+                direction=_clean(obj.get("direction")),
+            )
+        if mtype == TYPE_SESSION_END:
+            return SessionEnd(type=mtype, reason=str(obj.get("reason") or ""))
+        if mtype == TYPE_RECORDING_STATUS:
+            return RecordingStatus(type=mtype, status=_require_str(obj, "status"))
+        if mtype == TYPE_AUDIO_FRAME:
+            return AudioFrame(
+                type=mtype,
+                seq=int(obj.get("seq") or 0),
+                timestamp_ms=int(obj.get("timestampMs") or 0),
+                payload_base64=_require_str(obj, "payloadBase64"),
+                speaker_name=_clean(obj.get("speakerName")),
+            )
+        if mtype == TYPE_VIDEO_FRAME:
+            return VideoFrame(
+                type=mtype,
+                source=_require_str(obj, "source"),
+                ts=int(obj.get("ts") or 0),
+                width=int(obj.get("width") or 0),
+                height=int(obj.get("height") or 0),
+                mime=str(obj.get("mime") or "image/jpeg"),
+                data_base64=_require_str(obj, "dataBase64"),
+                participant_id=_clean(obj.get("participantId")),
+                participant_name=_clean(obj.get("participantName")),
+            )
+        if mtype == TYPE_PARTICIPANTS:
+            return Participants(type=mtype, count=int(obj.get("count") or 0))
+        if mtype == TYPE_DTMF:
+            return Dtmf(type=mtype, digit=_require_str(obj, "digit"))
+        if mtype == TYPE_PING:
+            return Ping(type=mtype, ts=int(obj.get("ts") or 0))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ProtocolError(f"bad {mtype!r} frame: {exc}") from exc
+
+    raise ProtocolError(f"unknown message type: {mtype!r}")
+
+
+# ── Outbound builders (gateway -> worker) ────────────────────────────────────
+
+
+def audio_frame(seq: int, timestamp_ms: int, payload_base64: str) -> dict[str, Any]:
+    """Outbound TTS / realtime audio chunk (PCM 16 kHz, base64, 20 ms)."""
+    return {
+        "type": TYPE_AUDIO_FRAME,
+        "seq": seq,
+        "timestampMs": timestamp_ms,
+        "payloadBase64": payload_base64,
+    }
+
+
+def expression(emotion: str) -> dict[str, Any]:
+    """Avatar emotion cue. Best-effort/cosmetic; older worker ignores it."""
+    return {"type": TYPE_EXPRESSION, "emotion": emotion}
+
+
+def speech_marks(marks: list[dict[str, int]], ts: int = 0) -> dict[str, Any]:
+    """Viseme timeline for lip-sync. ``marks`` = ``[{"tMs": int, "visemeId": int}]``."""
+    return {"type": TYPE_SPEECH_MARKS, "ts": ts, "marks": marks}
+
+
+def display_image(
+    data_base64: str,
+    mime: str,
+    *,
+    duration_ms: int | None = None,
+    mode: str | None = None,  # "fullscreen" (default) | "overlay" (PiP)
+    caption: str | None = None,
+    ts: int = 0,
+) -> dict[str, Any]:
+    """``show_to_caller`` — render an image on the bot's tile, then return to avatar."""
+    msg: dict[str, Any] = {
+        "type": TYPE_DISPLAY_IMAGE,
+        "dataBase64": data_base64,
+        "mime": mime,
+        "ts": ts,
+    }
+    if duration_ms is not None:
+        msg["durationMs"] = duration_ms
+    if mode is not None:
+        msg["mode"] = mode
+    if caption is not None:
+        msg["caption"] = caption
+    return msg
+
+
+def assistant_cancel(turn_id: int) -> dict[str, Any]:
+    """Barge-in — tell the worker to flush playback for ``turn_id``."""
+    return {"type": TYPE_ASSISTANT_CANCEL, "turnId": turn_id}
+
+
+def pong(ts: int) -> dict[str, Any]:
+    """Keepalive reply echoing the worker's ping timestamp."""
+    return {"type": TYPE_PONG, "ts": ts}
+
+
+def encode(msg: dict[str, Any]) -> str:
+    """Serialize an outbound message dict to a compact JSON text frame."""
+    return json.dumps(msg, separators=(",", ":"), ensure_ascii=False)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _clean(value: Any) -> Optional[str]:
+    """Normalize to a non-blank string or ``None`` (blank-as-null guard)."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _require_str(obj: dict[str, Any], key: str) -> str:
+    value = obj.get(key)
+    if value is None or str(value).strip() == "":
+        raise ProtocolError(f"missing required field {key!r}")
+    return str(value)

--- a/plugins/teams_voice/protocol.py
+++ b/plugins/teams_voice/protocol.py
@@ -1,6 +1,6 @@
 """Bridge wire protocol — Python mirror of the .NET worker's ``Protocol.cs``.
 
-The companion media worker (AzureBot / OpenClawBridge) and this driver exchange
+The companion .NET media worker and this driver exchange
 newline-free JSON text frames over one WebSocket per call, discriminated on a
 ``type`` field, camelCase keys. This module models the **inbound** messages
 (worker -> gateway) as dataclasses with a single :func:`decode` entry point, and

--- a/plugins/teams_voice/realtime/__init__.py
+++ b/plugins/teams_voice/realtime/__init__.py
@@ -1,0 +1,1 @@
+"""Realtime speech-to-speech client(s) for the teams_voice bridge."""

--- a/plugins/teams_voice/realtime/openai_client.py
+++ b/plugins/teams_voice/realtime/openai_client.py
@@ -181,6 +181,7 @@ class RealtimeSession:
         self._session: Any = None
         self._recv_task: Optional[asyncio.Task] = None
         self._closed = False
+        self._response_active = False  # True between response.created and response.done
 
         # Function tools exposed to the model (realtime shape: flat
         # {type:"function", name, description, parameters}). Set before connect().
@@ -265,8 +266,13 @@ class RealtimeSession:
         )
 
     async def cancel_response(self) -> None:
-        """Cancel the in-flight model response (barge-in)."""
-        if not self._closed:
+        """Cancel the in-flight model response (barge-in), if one is active.
+
+        Guarded on ``_response_active`` so we don't spam ``response.cancel`` when
+        nothing is playing (server-VAD fires speech_started on every utterance).
+        """
+        if not self._closed and self._response_active:
+            self._response_active = False
             await self._send({"type": "response.cancel"})
 
     async def request_say(self, instruction: str) -> None:
@@ -345,6 +351,8 @@ class RealtimeSession:
             text = evt.get("delta") or ""
             if text:
                 await self._safe(self.on_transcript_delta, text)
+        elif etype == "response.created":
+            self._response_active = True
         elif etype == "input_audio_buffer.speech_started":
             await self._safe(self.on_speech_started)
         elif etype == "conversation.item.input_audio_transcription.completed":
@@ -352,6 +360,7 @@ class RealtimeSession:
             if text:
                 await self._safe(self.on_input_transcript, text)
         elif etype == "response.done":
+            self._response_active = False
             # A response may carry function calls (no audio) and/or spoken output.
             resp = evt.get("response") or {}
             for item in resp.get("output") or []:

--- a/plugins/teams_voice/realtime/openai_client.py
+++ b/plugins/teams_voice/realtime/openai_client.py
@@ -58,6 +58,9 @@ class RealtimeConfig:
     # Caller-audio transcription (for wake words / verbal interrupts). Empty
     # string disables it (some deployments don't support the field).
     input_transcribe_model: str = "whisper-1"
+    # Bilingual Arabic/English mode (opt-in): pin the model to detect/mirror the
+    # caller's language and translate on request.
+    bilingual: bool = False
 
     @property
     def configured(self) -> bool:
@@ -122,6 +125,7 @@ def realtime_config_from_env(block: "dict[str, Any] | None" = None) -> RealtimeC
     transcribe_model = _pick(block, "input_transcribe_model", "TEAMS_VOICE_INPUT_TRANSCRIBE_MODEL", "whisper-1")
     if transcribe_model.lower() in ("none", "off", "disabled"):
         transcribe_model = ""
+    bilingual = _pick(block, "bilingual", "TEAMS_VOICE_BILINGUAL", "").lower() in ("1", "true", "yes", "on")
     is_azure = backend == "azure" or bool(azure_endpoint) or "azure.com" in explicit_url
 
     if is_azure:
@@ -150,6 +154,7 @@ def realtime_config_from_env(block: "dict[str, Any] | None" = None) -> RealtimeC
             prefix_padding_ms=prefix_padding_ms,
             silence_duration_ms=silence_duration_ms,
             input_transcribe_model=transcribe_model,
+            bilingual=bilingual,
         )
 
     return RealtimeConfig(
@@ -164,6 +169,7 @@ def realtime_config_from_env(block: "dict[str, Any] | None" = None) -> RealtimeC
         prefix_padding_ms=prefix_padding_ms,
         silence_duration_ms=silence_duration_ms,
         input_transcribe_model=transcribe_model,
+        bilingual=bilingual,
     )
 
 

--- a/plugins/teams_voice/realtime/openai_client.py
+++ b/plugins/teams_voice/realtime/openai_client.py
@@ -1,0 +1,357 @@
+"""Realtime speech-to-speech client (OpenAI / Azure Realtime API).
+
+A thin async wrapper over the Realtime WebSocket. It is provider-pure: it deals
+only in the model's native PCM 24 kHz audio and fires callbacks; resampling to
+the bridge's 16 kHz, frame chunking, expression/viseme emission, and barge-in
+handling all live in the dialogue handler (``handlers.py``).
+
+Mirrors the role of openclaw ``msteams-realtime.ts``. Uses aiohttp's WS client
+(already a bridge dependency) rather than adding the ``websockets`` package.
+
+Azure note: pass ``base_url`` like
+``wss://<resource>.openai.azure.com/openai/realtime?api-version=...&deployment=...``
+and ``api_key_header="api-key"``; the default is OpenAI's bearer auth.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "wss://api.openai.com/v1/realtime"
+DEFAULT_MODEL = "gpt-realtime"
+DEFAULT_VOICE = "alloy"
+DEFAULT_AZURE_API_VERSION = "2024-10-01-preview"
+DEFAULT_INSTRUCTIONS = (
+    "You are a helpful voice assistant on a Microsoft Teams call. Keep replies "
+    "brief and conversational. For anything requiring real work (lookups, "
+    "actions, files), delegate to the agent rather than guessing."
+)
+
+# The model emits/consumes PCM 16-bit mono at this rate over the Realtime API.
+REALTIME_SAMPLE_RATE_HZ = 24_000
+
+AsyncCb = Callable[..., Awaitable[None]]
+
+
+@dataclass
+class RealtimeConfig:
+    """Resolved realtime-provider settings (OpenAI or Azure OpenAI)."""
+
+    api_key: str
+    model: str = DEFAULT_MODEL
+    voice: str = DEFAULT_VOICE
+    instructions: str = DEFAULT_INSTRUCTIONS
+    base_url: str = DEFAULT_BASE_URL
+    api_key_header: str = "Authorization"  # "api-key" for Azure
+    # Server-VAD tuning (mirrors the openclaw realtime provider config).
+    vad_threshold: float = 0.5
+    prefix_padding_ms: int = 300
+    silence_duration_ms: int = 500
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.api_key)
+
+
+def _to_ws(url: str) -> str:
+    """Normalize an http(s) endpoint to a ws(s) one; pass ws(s) through."""
+    if url.startswith("https://"):
+        return "wss://" + url[len("https://") :]
+    if url.startswith("http://"):
+        return "ws://" + url[len("http://") :]
+    return url
+
+
+def _pick(block: "dict[str, Any]", key: str, env: str, default: str = "") -> str:
+    """Resolve one value: config.yaml block first, then env, then default."""
+    val = block.get(key)
+    if val is not None and str(val).strip() != "":
+        return str(val).strip()
+    return os.getenv(env, "").strip() or default
+
+
+def realtime_config_from_env(block: "dict[str, Any] | None" = None) -> RealtimeConfig:
+    """Build a :class:`RealtimeConfig` from config.yaml + environment.
+
+    Both sources are supported per the Hermes docs: the per-plugin config.yaml
+    block (``plugins.entries.teams_voice.config.realtime``) takes precedence,
+    with environment variables as the fallback. ``block`` is read from config.yaml
+    when omitted (pass ``{}`` to force env-only, e.g. in tests).
+
+    Azure is selected when ``backend: azure`` / ``TEAMS_VOICE_REALTIME_BACKEND=azure``,
+    an Azure endpoint is set, or an explicit ``*.azure.com`` URL is given;
+    otherwise OpenAI (bearer auth). The Azure key falls back to
+    ``AZURE_OPENAI_API_KEY`` / ``AZURE_FOUNDRY_API_KEY`` so the gateway key is reused.
+    """
+    if block is None:
+        try:
+            from ..config import plugin_config_block
+
+            block = plugin_config_block().get("realtime", {}) or {}
+        except Exception:  # noqa: BLE001
+            block = {}
+
+    backend = _pick(block, "backend", "TEAMS_VOICE_REALTIME_BACKEND").lower()
+    explicit_url = _pick(block, "url", "TEAMS_VOICE_REALTIME_URL")
+    azure_endpoint = _pick(block, "azure_endpoint", "TEAMS_VOICE_AZURE_ENDPOINT")
+    voice = _pick(block, "voice", "TEAMS_VOICE_REALTIME_VOICE", DEFAULT_VOICE)
+    instructions = _pick(block, "instructions", "TEAMS_VOICE_REALTIME_INSTRUCTIONS", DEFAULT_INSTRUCTIONS)
+
+    def _vad() -> "tuple[float, int, int]":
+        try:
+            thr = float(_pick(block, "vad_threshold", "TEAMS_VOICE_VAD_THRESHOLD", "0.5"))
+            prefix = int(_pick(block, "prefix_padding_ms", "TEAMS_VOICE_PREFIX_PADDING_MS", "300"))
+            silence = int(_pick(block, "silence_duration_ms", "TEAMS_VOICE_SILENCE_DURATION_MS", "500"))
+        except ValueError:
+            return 0.5, 300, 500
+        return thr, prefix, silence
+
+    vad_threshold, prefix_padding_ms, silence_duration_ms = _vad()
+    is_azure = backend == "azure" or bool(azure_endpoint) or "azure.com" in explicit_url
+
+    if is_azure:
+        deployment = _pick(block, "azure_deployment", "TEAMS_VOICE_AZURE_DEPLOYMENT")
+        api_version = _pick(
+            block, "azure_api_version", "TEAMS_VOICE_AZURE_API_VERSION", DEFAULT_AZURE_API_VERSION
+        )
+        if explicit_url:
+            base_url = _to_ws(explicit_url)
+        else:
+            base = _to_ws(azure_endpoint.rstrip("/"))
+            base_url = f"{base}/openai/realtime?api-version={api_version}&deployment={deployment}"
+        api_key = (
+            _pick(block, "api_key", "TEAMS_VOICE_REALTIME_API_KEY")
+            or os.getenv("AZURE_OPENAI_API_KEY", "").strip()
+            or os.getenv("AZURE_FOUNDRY_API_KEY", "").strip()
+        )
+        return RealtimeConfig(
+            api_key=api_key,
+            model=deployment or DEFAULT_MODEL,
+            voice=voice,
+            instructions=instructions,
+            base_url=base_url,
+            api_key_header="api-key",
+            vad_threshold=vad_threshold,
+            prefix_padding_ms=prefix_padding_ms,
+            silence_duration_ms=silence_duration_ms,
+        )
+
+    return RealtimeConfig(
+        api_key=_pick(block, "api_key", "TEAMS_VOICE_REALTIME_API_KEY")
+        or os.getenv("OPENAI_API_KEY", "").strip(),
+        model=_pick(block, "model", "TEAMS_VOICE_REALTIME_MODEL", DEFAULT_MODEL),
+        voice=voice,
+        instructions=instructions,
+        base_url=explicit_url or DEFAULT_BASE_URL,
+        api_key_header="Authorization",
+        vad_threshold=vad_threshold,
+        prefix_padding_ms=prefix_padding_ms,
+        silence_duration_ms=silence_duration_ms,
+    )
+
+
+class RealtimeSession:
+    """One realtime model connection for a single call.
+
+    Set the ``on_*`` callbacks before :meth:`connect`. All callbacks are async
+    and best-effort — an exception in a callback is logged, never propagated into
+    the receive loop.
+    """
+
+    def __init__(self, config: RealtimeConfig) -> None:
+        self._cfg = config
+        self._ws: Any = None
+        self._session: Any = None
+        self._recv_task: Optional[asyncio.Task] = None
+        self._closed = False
+
+        # Function tools exposed to the model (realtime shape: flat
+        # {type:"function", name, description, parameters}). Set before connect().
+        self.tools: list[dict] = []
+
+        # Callbacks (wired by the handler).
+        self.on_audio_delta: Optional[AsyncCb] = None  # (pcm24k: bytes)
+        self.on_transcript_delta: Optional[AsyncCb] = None  # (text: str)
+        self.on_speech_started: Optional[AsyncCb] = None  # () -> barge-in
+        self.on_response_done: Optional[AsyncCb] = None  # ()
+        self.on_function_call: Optional[AsyncCb] = None  # (name, call_id, args_json)
+        self.on_error: Optional[AsyncCb] = None  # (error: Any)
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Open the WS, configure the session, and start the receive loop."""
+        import aiohttp
+
+        if self._cfg.api_key_header.lower() == "authorization":
+            headers = {
+                "Authorization": f"Bearer {self._cfg.api_key}",
+                "OpenAI-Beta": "realtime=v1",
+            }
+        else:  # Azure-style
+            headers = {self._cfg.api_key_header: self._cfg.api_key}
+
+        url = self._cfg.base_url
+        if "model=" not in url and "deployment=" not in url:
+            sep = "&" if "?" in url else "?"
+            url = f"{url}{sep}model={self._cfg.model}"
+
+        self._session = aiohttp.ClientSession()
+        self._ws = await self._session.ws_connect(url, headers=headers, max_msg_size=0)
+
+        session: dict[str, Any] = {
+            "modalities": ["audio", "text"],
+            "instructions": self._cfg.instructions,
+            "voice": self._cfg.voice,
+            "input_audio_format": "pcm16",
+            "output_audio_format": "pcm16",
+            "turn_detection": {
+                "type": "server_vad",
+                "threshold": self._cfg.vad_threshold,
+                "prefix_padding_ms": self._cfg.prefix_padding_ms,
+                "silence_duration_ms": self._cfg.silence_duration_ms,
+                "create_response": True,
+            },
+        }
+        if self.tools:
+            session["tools"] = self.tools
+            session["tool_choice"] = "auto"
+        await self._send({"type": "session.update", "session": session})
+        self._recv_task = asyncio.create_task(self._recv_loop())
+        logger.info("[teams_voice] realtime connected model=%s", self._cfg.model)
+
+    async def close(self) -> None:
+        self._closed = True
+        if self._recv_task:
+            self._recv_task.cancel()
+        try:
+            if self._ws is not None and not self._ws.closed:
+                await self._ws.close()
+        finally:
+            if self._session is not None and not self._session.closed:
+                await self._session.close()
+
+    # ── send paths ───────────────────────────────────────────────────────────
+
+    async def push_audio(self, pcm24k: bytes) -> None:
+        """Append a chunk of caller audio (PCM 24 kHz) to the input buffer."""
+        if self._closed or not pcm24k:
+            return
+        await self._send(
+            {"type": "input_audio_buffer.append", "audio": base64.b64encode(pcm24k).decode("ascii")}
+        )
+
+    async def cancel_response(self) -> None:
+        """Cancel the in-flight model response (barge-in)."""
+        if not self._closed:
+            await self._send({"type": "response.cancel"})
+
+    async def request_say(self, instruction: str) -> None:
+        """Inject an instruction and trigger a spoken response.
+
+        Used for outbound delivery ("deliver this result, then say goodbye: …")
+        where there is no caller turn to respond to.
+        """
+        if self._closed or not instruction:
+            return
+        await self._send(
+            {
+                "type": "conversation.item.create",
+                "item": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": instruction}],
+                },
+            }
+        )
+        await self._send({"type": "response.create"})
+
+    async def send_function_result(self, call_id: str, output: str) -> None:
+        """Return a tool result to the model and ask it to continue speaking.
+
+        ``output`` is a plain string (the tool's spoken-result text). The model
+        then generates a new audio response incorporating it.
+        """
+        if self._closed:
+            return
+        await self._send(
+            {
+                "type": "conversation.item.create",
+                "item": {"type": "function_call_output", "call_id": call_id, "output": output},
+            }
+        )
+        await self._send({"type": "response.create"})
+
+    async def _send(self, obj: dict) -> None:
+        if self._ws is None or self._ws.closed:
+            return
+        await self._ws.send_str(json.dumps(obj))
+
+    # ── receive loop ─────────────────────────────────────────────────────────
+
+    async def _recv_loop(self) -> None:
+        import aiohttp
+
+        try:
+            async for msg in self._ws:
+                if msg.type is not aiohttp.WSMsgType.TEXT:
+                    if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.ERROR):
+                        break
+                    continue
+                try:
+                    evt = json.loads(msg.data)
+                except json.JSONDecodeError:
+                    continue
+                await self._dispatch(evt)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — keep the call alive on transport hiccups
+            logger.error("[teams_voice] realtime recv loop error", exc_info=True)
+
+    async def _dispatch(self, evt: dict) -> None:
+        etype = evt.get("type", "")
+        # Audio output (handle both the beta and GA event names).
+        if etype in ("response.audio.delta", "response.output_audio.delta"):
+            b64 = evt.get("delta")
+            if b64:
+                await self._safe(self.on_audio_delta, base64.b64decode(b64))
+        elif etype in (
+            "response.audio_transcript.delta",
+            "response.output_audio_transcript.delta",
+        ):
+            text = evt.get("delta") or ""
+            if text:
+                await self._safe(self.on_transcript_delta, text)
+        elif etype == "input_audio_buffer.speech_started":
+            await self._safe(self.on_speech_started)
+        elif etype == "response.done":
+            # A response may carry function calls (no audio) and/or spoken output.
+            resp = evt.get("response") or {}
+            for item in resp.get("output") or []:
+                if isinstance(item, dict) and item.get("type") == "function_call":
+                    await self._safe(
+                        self.on_function_call,
+                        item.get("name", ""),
+                        item.get("call_id", ""),
+                        item.get("arguments", "") or "{}",
+                    )
+            await self._safe(self.on_response_done)
+        elif etype == "error":
+            logger.warning("[teams_voice] realtime error: %s", evt.get("error"))
+            await self._safe(self.on_error, evt.get("error"))
+
+    async def _safe(self, cb: Optional[AsyncCb], *args: Any) -> None:
+        if cb is None:
+            return
+        try:
+            await cb(*args)
+        except Exception:  # noqa: BLE001 — a callback fault must not kill the loop
+            logger.error("[teams_voice] realtime callback error", exc_info=True)

--- a/plugins/teams_voice/realtime/openai_client.py
+++ b/plugins/teams_voice/realtime/openai_client.py
@@ -188,6 +188,7 @@ class RealtimeSession:
         self._recv_task: Optional[asyncio.Task] = None
         self._closed = False
         self._response_active = False  # True between response.created and response.done
+        self._auto_response = True  # turn_detection.create_response (off in group mode)
 
         # Function tools exposed to the model (realtime shape: flat
         # {type:"function", name, description, parameters}). Set before connect().
@@ -271,6 +272,33 @@ class RealtimeSession:
             {"type": "input_audio_buffer.append", "audio": base64.b64encode(pcm24k).decode("ascii")}
         )
 
+    async def set_auto_response(self, enabled: bool) -> None:
+        """Toggle server-VAD auto-response (off in group mode for a race-free gate)."""
+        if self._closed or enabled == self._auto_response:
+            return
+        self._auto_response = enabled
+        await self._send(
+            {
+                "type": "session.update",
+                "session": {
+                    "turn_detection": {
+                        "type": "server_vad",
+                        "threshold": self._cfg.vad_threshold,
+                        "prefix_padding_ms": self._cfg.prefix_padding_ms,
+                        "silence_duration_ms": self._cfg.silence_duration_ms,
+                        "create_response": enabled,
+                    }
+                },
+            }
+        )
+
+    async def create_response(self) -> None:
+        """Manually request a response (used when auto-response is off in groups)."""
+        if self._closed or self._response_active:
+            return
+        self._response_active = True
+        await self._send({"type": "response.create"})
+
     async def cancel_response(self) -> None:
         """Cancel the in-flight model response (barge-in), if one is active.
 
@@ -341,7 +369,9 @@ class RealtimeSession:
                 "item": {"type": "function_call_output", "call_id": call_id, "output": output},
             }
         )
-        await self._send({"type": "response.create"})
+        if not self._response_active:  # guard like send_user_text (no double-create)
+            self._response_active = True
+            await self._send({"type": "response.create"})
 
     async def _send(self, obj: dict) -> None:
         if self._ws is None or self._ws.closed:

--- a/plugins/teams_voice/realtime/openai_client.py
+++ b/plugins/teams_voice/realtime/openai_client.py
@@ -5,8 +5,8 @@ only in the model's native PCM 24 kHz audio and fires callbacks; resampling to
 the bridge's 16 kHz, frame chunking, expression/viseme emission, and barge-in
 handling all live in the dialogue handler (``handlers.py``).
 
-Mirrors the role of openclaw ``msteams-realtime.ts``. Uses aiohttp's WS client
-(already a bridge dependency) rather than adding the ``websockets`` package.
+Uses aiohttp's WS client (already a bridge dependency) rather than adding the
+``websockets`` package.
 
 Azure note: pass ``base_url`` like
 ``wss://<resource>.openai.azure.com/openai/realtime?api-version=...&deployment=...``
@@ -51,7 +51,7 @@ class RealtimeConfig:
     instructions: str = DEFAULT_INSTRUCTIONS
     base_url: str = DEFAULT_BASE_URL
     api_key_header: str = "Authorization"  # "api-key" for Azure
-    # Server-VAD tuning (mirrors the openclaw realtime provider config).
+    # Server-VAD tuning.
     vad_threshold: float = 0.5
     prefix_padding_ms: int = 300
     silence_duration_ms: int = 500
@@ -339,8 +339,7 @@ class RealtimeSession:
     async def send_image(self, image_url: str) -> None:
         """Push an ambient image into the conversation with NO forced response.
 
-        Keeps the realtime model continuously visually aware (the openclaw
-        ``sendImage`` equivalent). Best-effort.
+        Keeps the realtime model continuously visually aware. Best-effort.
         """
         if self._closed or not image_url:
             return

--- a/plugins/teams_voice/realtime/openai_client.py
+++ b/plugins/teams_voice/realtime/openai_client.py
@@ -55,6 +55,9 @@ class RealtimeConfig:
     vad_threshold: float = 0.5
     prefix_padding_ms: int = 300
     silence_duration_ms: int = 500
+    # Caller-audio transcription (for wake words / verbal interrupts). Empty
+    # string disables it (some deployments don't support the field).
+    input_transcribe_model: str = "whisper-1"
 
     @property
     def configured(self) -> bool:
@@ -115,6 +118,10 @@ def realtime_config_from_env(block: "dict[str, Any] | None" = None) -> RealtimeC
         return thr, prefix, silence
 
     vad_threshold, prefix_padding_ms, silence_duration_ms = _vad()
+    # "" / "none" / "off" disables caller transcription.
+    transcribe_model = _pick(block, "input_transcribe_model", "TEAMS_VOICE_INPUT_TRANSCRIBE_MODEL", "whisper-1")
+    if transcribe_model.lower() in ("none", "off", "disabled"):
+        transcribe_model = ""
     is_azure = backend == "azure" or bool(azure_endpoint) or "azure.com" in explicit_url
 
     if is_azure:
@@ -142,6 +149,7 @@ def realtime_config_from_env(block: "dict[str, Any] | None" = None) -> RealtimeC
             vad_threshold=vad_threshold,
             prefix_padding_ms=prefix_padding_ms,
             silence_duration_ms=silence_duration_ms,
+            input_transcribe_model=transcribe_model,
         )
 
     return RealtimeConfig(
@@ -155,6 +163,7 @@ def realtime_config_from_env(block: "dict[str, Any] | None" = None) -> RealtimeC
         vad_threshold=vad_threshold,
         prefix_padding_ms=prefix_padding_ms,
         silence_duration_ms=silence_duration_ms,
+        input_transcribe_model=transcribe_model,
     )
 
 
@@ -179,7 +188,8 @@ class RealtimeSession:
 
         # Callbacks (wired by the handler).
         self.on_audio_delta: Optional[AsyncCb] = None  # (pcm24k: bytes)
-        self.on_transcript_delta: Optional[AsyncCb] = None  # (text: str)
+        self.on_transcript_delta: Optional[AsyncCb] = None  # (text: str) — bot reply
+        self.on_input_transcript: Optional[AsyncCb] = None  # (text: str) — caller turn
         self.on_speech_started: Optional[AsyncCb] = None  # () -> barge-in
         self.on_response_done: Optional[AsyncCb] = None  # ()
         self.on_function_call: Optional[AsyncCb] = None  # (name, call_id, args_json)
@@ -221,6 +231,11 @@ class RealtimeSession:
                 "create_response": True,
             },
         }
+        # Transcribe the caller's audio so the handler can detect wake words and
+        # verbal interrupts. Configurable/optional: if unsupported, set the model
+        # to "" and the gate/interrupts degrade gracefully (VAD barge-in still works).
+        if self._cfg.input_transcribe_model:
+            session["input_audio_transcription"] = {"model": self._cfg.input_transcribe_model}
         if self.tools:
             session["tools"] = self.tools
             session["tool_choice"] = "auto"
@@ -332,6 +347,10 @@ class RealtimeSession:
                 await self._safe(self.on_transcript_delta, text)
         elif etype == "input_audio_buffer.speech_started":
             await self._safe(self.on_speech_started)
+        elif etype == "conversation.item.input_audio_transcription.completed":
+            text = evt.get("transcript") or ""
+            if text:
+                await self._safe(self.on_input_transcript, text)
         elif etype == "response.done":
             # A response may carry function calls (no audio) and/or spoken output.
             resp = evt.get("response") or {}

--- a/plugins/teams_voice/realtime/openai_client.py
+++ b/plugins/teams_voice/realtime/openai_client.py
@@ -275,13 +275,13 @@ class RealtimeSession:
             self._response_active = False
             await self._send({"type": "response.cancel"})
 
-    async def request_say(self, instruction: str) -> None:
-        """Inject an instruction and trigger a spoken response.
+    async def send_user_text(self, text: str, *, respond: bool = True) -> None:
+        """Inject a user-role text item; optionally trigger a spoken response.
 
-        Used for outbound delivery ("deliver this result, then say goodbye: …")
-        where there is no caller turn to respond to.
+        ``respond`` is guarded on ``_response_active`` so we never hit
+        'conversation already has an active response'.
         """
-        if self._closed or not instruction:
+        if self._closed or not text:
             return
         await self._send(
             {
@@ -289,11 +289,37 @@ class RealtimeSession:
                 "item": {
                     "type": "message",
                     "role": "user",
-                    "content": [{"type": "input_text", "text": instruction}],
+                    "content": [{"type": "input_text", "text": text}],
                 },
             }
         )
-        await self._send({"type": "response.create"})
+        if respond and not self._response_active:
+            self._response_active = True
+            await self._send({"type": "response.create"})
+
+    async def request_say(self, instruction: str) -> None:
+        """Inject an instruction and trigger a spoken response (outbound delivery
+        / greeting, where there is no caller turn to respond to)."""
+        await self.send_user_text(instruction, respond=True)
+
+    async def send_image(self, image_url: str) -> None:
+        """Push an ambient image into the conversation with NO forced response.
+
+        Keeps the realtime model continuously visually aware (the openclaw
+        ``sendImage`` equivalent). Best-effort.
+        """
+        if self._closed or not image_url:
+            return
+        await self._send(
+            {
+                "type": "conversation.item.create",
+                "item": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_image", "image_url": image_url}],
+                },
+            }
+        )
 
     async def send_function_result(self, call_id: str, output: str) -> None:
         """Return a tool result to the model and ask it to continue speaking.

--- a/plugins/teams_voice/realtime_tools.py
+++ b/plugins/teams_voice/realtime_tools.py
@@ -1,0 +1,91 @@
+"""Realtime function-tool schemas exposed to the speech-to-speech model.
+
+Realtime tools use a flat shape: ``{type, name, description, parameters}`` (not
+the chat-completions ``{type:"function", function:{...}}`` nesting). The handler
+dispatches calls to these by ``name``.
+"""
+
+from __future__ import annotations
+
+HERMES_AGENT_CONSULT = {
+    "type": "function",
+    "name": "hermes_agent_consult",
+    "description": (
+        "Delegate to the Hermes agent to answer a question or perform an action — "
+        "lookups, calculations, files, web, or running tools. Use this for anything "
+        "beyond small talk. Returns a short result to speak to the caller."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "What to look into or do, phrased as a task.",
+            }
+        },
+        "required": ["query"],
+    },
+}
+
+LOOK_AT_SCREEN = {
+    "type": "function",
+    "name": "look_at_screen",
+    "description": (
+        "Look at what the caller is currently showing — their shared screen or "
+        "camera — and answer a question about it."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "question": {"type": "string", "description": "What to determine from the image."},
+            "source": {
+                "type": "string",
+                "enum": ["screen", "camera"],
+                "description": "Which feed to look at; defaults to the shared screen.",
+            },
+        },
+        "required": ["question"],
+    },
+}
+
+SHOW_TO_CALLER = {
+    "type": "function",
+    "name": "show_to_caller",
+    "description": (
+        "Generate an image from a text prompt and display it on the bot's own video "
+        "tile so the caller can see it."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {"type": "string", "description": "What image to create and show."}
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+CALL_ME_BACK = {
+    "type": "function",
+    "name": "call_me_back",
+    "description": (
+        "Place an outbound Teams call back to the current caller to deliver a "
+        "result. Use when work will take a while and the caller asked to be called "
+        "back, or when ending the call but a result is still pending. The result is "
+        "spoken once they answer."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "message": {
+                "type": "string",
+                "description": "The result/message to speak when they answer.",
+            }
+        },
+        "required": ["message"],
+    },
+}
+
+
+def default_tools() -> list[dict]:
+    return [HERMES_AGENT_CONSULT, LOOK_AT_SCREEN, SHOW_TO_CALLER, CALL_ME_BACK]

--- a/plugins/teams_voice/realtime_tools.py
+++ b/plugins/teams_voice/realtime_tools.py
@@ -95,5 +95,30 @@ CALL_ME_BACK = {
 }
 
 
+HERMES_AGENT_TASK = {
+    "type": "function",
+    "name": "hermes_agent_task",
+    "description": (
+        "Run a long-running job in the background (multi-step work or research that "
+        "takes more than a few seconds). Acknowledge to the caller that you're on it; "
+        "the result is delivered by calling them back when it's done. Use this instead "
+        "of hermes_agent_consult when the work won't finish within the conversation."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "The task to run in the background."}
+        },
+        "required": ["query"],
+    },
+}
+
+
 def default_tools() -> list[dict]:
-    return [HERMES_AGENT_CONSULT, LOOK_AT_SCREEN, SHOW_TO_CALLER, CALL_ME_BACK]
+    return [
+        HERMES_AGENT_CONSULT,
+        HERMES_AGENT_TASK,
+        LOOK_AT_SCREEN,
+        SHOW_TO_CALLER,
+        CALL_ME_BACK,
+    ]

--- a/plugins/teams_voice/realtime_tools.py
+++ b/plugins/teams_voice/realtime_tools.py
@@ -118,6 +118,18 @@ HERMES_AGENT_TASK = {
 }
 
 
+POST_MEETING_MINUTES = {
+    "type": "function",
+    "name": "post_meeting_minutes",
+    "description": (
+        "Summarize the meeting so far and post the minutes (key points, decisions, "
+        "action items) to the Teams chat. Use when the caller asks to 'summarize the "
+        "meeting' or send notes."
+    ),
+    "parameters": {"type": "object", "properties": {}},
+}
+
+
 def default_tools() -> list[dict]:
     return [
         HERMES_AGENT_CONSULT,
@@ -125,4 +137,5 @@ def default_tools() -> list[dict]:
         LOOK_AT_SCREEN,
         SHOW_TO_CALLER,
         CALL_ME_BACK,
+        POST_MEETING_MINUTES,
     ]

--- a/plugins/teams_voice/realtime_tools.py
+++ b/plugins/teams_voice/realtime_tools.py
@@ -66,7 +66,11 @@ SHOW_TO_CALLER = {
     "parameters": {
         "type": "object",
         "properties": {
-            "prompt": {"type": "string", "description": "What image to create and show."}
+            "prompt": {"type": "string", "description": "What image to create and show."},
+            "count": {
+                "type": "integer",
+                "description": "How many images to show as a paced slideshow (1-3). Default 1.",
+            },
         },
         "required": ["prompt"],
     },

--- a/plugins/teams_voice/realtime_tools.py
+++ b/plugins/teams_voice/realtime_tools.py
@@ -43,6 +43,14 @@ LOOK_AT_SCREEN = {
                 "enum": ["screen", "camera"],
                 "description": "Which feed to look at; defaults to the shared screen.",
             },
+            "scope": {
+                "type": "string",
+                "enum": ["live", "history"],
+                "description": (
+                    "'live' = the current frame (default); 'history' = recent "
+                    "keyframes, to answer about something shown earlier."
+                ),
+            },
         },
         "required": ["question"],
     },

--- a/plugins/teams_voice/streaming_audio.py
+++ b/plugins/teams_voice/streaming_audio.py
@@ -91,3 +91,19 @@ def decode_to_pcm16k(path: str) -> bytes:
     except (FileNotFoundError, OSError):
         return b""
     return proc.stdout if proc.returncode == 0 else b""
+
+
+def decode_bytes_to_pcm16k(data: bytes) -> bytes:
+    """Decode in-memory audio bytes (mp3/…) to PCM 16 kHz mono via ffmpeg stdin."""
+    if not data:
+        return b""
+    try:
+        proc = subprocess.run(
+            ["ffmpeg", "-i", "pipe:0", "-ar", "16000", "-ac", "1", "-f", "s16le", "-loglevel", "quiet", "pipe:1"],
+            input=data,
+            capture_output=True,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return b""
+    return proc.stdout if proc.returncode == 0 else b""

--- a/plugins/teams_voice/streaming_audio.py
+++ b/plugins/teams_voice/streaming_audio.py
@@ -1,0 +1,93 @@
+"""Streaming-mode audio helpers: utterance VAD segmentation + format decode.
+
+The streaming voice path is STT→agent→TTS (vs realtime speech-to-speech). It needs
+to slice the continuous caller PCM into *utterances* (energy VAD with trailing-
+silence detection), and to turn TTS output (mp3/wav/…) back into PCM 16 kHz frames.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import wave
+
+
+class UtteranceBuffer:
+    """Accumulate caller audio and emit a complete utterance after trailing silence.
+
+    Frame-based (each pushed frame is ~``frame_ms``). Pre-speech silence is dropped;
+    an utterance ends after ``silence_ms`` of trailing silence once at least
+    ``min_speech_ms`` of speech has been seen, or at ``max_utterance_ms``.
+    """
+
+    def __init__(
+        self,
+        *,
+        silence_ms: int = 700,
+        min_speech_ms: int = 300,
+        speech_rms: float = 0.02,
+        frame_ms: int = 20,
+        max_utterance_ms: int = 20_000,
+    ) -> None:
+        self.speech_rms = speech_rms
+        self._silence_frames = max(1, silence_ms // frame_ms)
+        self._min_speech_frames = max(1, min_speech_ms // frame_ms)
+        self._max_frames = max(1, max_utterance_ms // frame_ms)
+        self.reset()
+
+    def reset(self) -> None:
+        self._buf = bytearray()
+        self._frames = 0
+        self._speech_frames = 0
+        self._trailing_silence = 0
+        self._in_speech = False
+
+    def push(self, frame: bytes, rms: float) -> bytes | None:
+        """Add one frame; return the utterance PCM when it completes, else None."""
+        is_speech = rms >= self.speech_rms
+        if not self._in_speech:
+            if not is_speech:
+                return None  # drop pre-speech silence
+            self._in_speech = True
+        self._buf += frame
+        self._frames += 1
+        if is_speech:
+            self._speech_frames += 1
+            self._trailing_silence = 0
+        else:
+            self._trailing_silence += 1
+        ended = (
+            self._trailing_silence >= self._silence_frames
+            and self._speech_frames >= self._min_speech_frames
+        )
+        if ended or self._frames >= self._max_frames:
+            return self._emit()
+        return None
+
+    def _emit(self) -> bytes:
+        pcm = bytes(self._buf)
+        self.reset()
+        return pcm
+
+
+def write_wav_pcm16(pcm: bytes, path: str, sample_rate: int = 16_000) -> None:
+    """Write mono 16-bit PCM to a WAV file for the STT engine."""
+    with wave.open(path, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(pcm)
+
+
+def decode_to_pcm16k(path: str) -> bytes:
+    """Decode any audio file (mp3/wav/ogg…) to raw PCM 16 kHz mono via ffmpeg.
+
+    Returns ``b""`` if ffmpeg is unavailable or the decode fails (caller degrades)."""
+    try:
+        proc = subprocess.run(
+            ["ffmpeg", "-i", path, "-ar", "16000", "-ac", "1", "-f", "s16le", "-loglevel", "quiet", "-"],
+            capture_output=True,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return b""
+    return proc.stdout if proc.returncode == 0 else b""

--- a/plugins/teams_voice/tests/test_audio.py
+++ b/plugins/teams_voice/tests/test_audio.py
@@ -1,0 +1,54 @@
+"""Tests for the PCM16 audio helpers (resample / frame / rms)."""
+
+from __future__ import annotations
+
+import struct
+
+from plugins.teams_voice import audio
+
+
+def _pcm(*samples: int) -> bytes:
+    return struct.pack("<" + "h" * len(samples), *samples)
+
+
+def test_resample_identity_when_rates_equal():
+    data = _pcm(1, 2, 3, 4)
+    assert audio.resample_pcm16(data, 16000, 16000) == data
+
+
+def test_resample_empty_and_odd_length():
+    assert audio.resample_pcm16(b"", 16000, 24000) == b""
+    # odd trailing byte is dropped, single sample survives
+    out = audio.resample_pcm16(_pcm(1000) + b"\x01", 16000, 24000)
+    assert len(out) % 2 == 0
+
+
+def test_resample_16k_to_24k_length_ratio():
+    # 160 samples (10 ms @16k) -> ~240 samples (10 ms @24k)
+    data = _pcm(*([0] * 160))
+    out = audio.resample_pcm16(data, 16000, 24000)
+    out_samples = len(out) // 2
+    assert 236 <= out_samples <= 244  # ~1.5x within rounding
+
+
+def test_resample_roundtrip_preserves_length_class():
+    data = _pcm(*range(-100, 100))
+    up = audio.resample_pcm16(data, 16000, 24000)
+    down = audio.resample_pcm16(up, 24000, 16000)
+    # back to ~original sample count
+    assert abs(len(down) // 2 - len(data) // 2) <= 2
+
+
+def test_frame_pcm16_splits_and_keeps_residual():
+    data = b"\x00" * (640 + 640 + 100)
+    frames, residual = audio.frame_pcm16(data, 640)
+    assert len(frames) == 2
+    assert all(len(f) == 640 for f in frames)
+    assert len(residual) == 100
+
+
+def test_pcm16_rms_silence_and_signal():
+    assert audio.pcm16_rms(b"") == 0.0
+    assert audio.pcm16_rms(_pcm(0, 0, 0, 0)) == 0.0
+    loud = audio.pcm16_rms(_pcm(32767, -32768, 32767, -32768))
+    assert 0.9 <= loud <= 1.01

--- a/plugins/teams_voice/tests/test_call_tools.py
+++ b/plugins/teams_voice/tests/test_call_tools.py
@@ -1,0 +1,60 @@
+"""Tests for the extracted CallToolRunner (now unit-testable in isolation)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from plugins.teams_voice.call_tools import CallToolRunner
+from plugins.teams_voice.meeting import MeetingTranscript
+from plugins.teams_voice.vision_budget import VisionBudget
+from plugins.teams_voice.vision_store import VisionStore
+
+
+class _FakeConsult:
+    async def ask(self, query, *, timeout_s=45.0):
+        return f"CONSULT:{query}"
+
+
+class _FakeHandler:
+    """Minimal call context the runner needs."""
+
+    def __init__(self):
+        self._consult = _FakeConsult()
+        self._meeting = MeetingTranscript()
+        self._thread_id = ""
+        self._vision = VisionStore()
+        self._vision_budget = VisionBudget(0)  # unlimited
+        self._session = None
+        self._caller = None
+        self._bridge = None
+
+
+def test_run_tool_consult_delegates():
+    r = CallToolRunner(_FakeHandler())
+    assert asyncio.run(r.run_tool("hermes_agent_consult", {"query": "hi"})) == "CONSULT:hi"
+
+
+def test_run_tool_unknown():
+    r = CallToolRunner(_FakeHandler())
+    assert "Unknown tool" in asyncio.run(r.run_tool("nope", {}))
+
+
+def test_look_at_screen_no_frame():
+    r = CallToolRunner(_FakeHandler())  # empty vision store
+    out = asyncio.run(r.run_tool("look_at_screen", {"question": "what's there"}))
+    assert "can't see" in out.lower()
+
+
+def test_look_at_screen_budget_exhausted():
+    h = _FakeHandler()
+    h._vision_budget = VisionBudget(max_per_minute=1)
+    h._vision_budget.try_consume()  # use up the single slot
+    r = CallToolRunner(h)
+    out = asyncio.run(r.run_tool("look_at_screen", {"question": "x"}))
+    assert "moment" in out.lower()  # budget message
+
+
+def test_call_me_back_without_caller():
+    r = CallToolRunner(_FakeHandler())  # no bridge/caller
+    out = asyncio.run(r.run_tool("call_me_back", {"message": "the result"}))
+    assert "can't call you back" in out.lower()

--- a/plugins/teams_voice/tests/test_call_tools.py
+++ b/plugins/teams_voice/tests/test_call_tools.py
@@ -58,3 +58,22 @@ def test_call_me_back_without_caller():
     r = CallToolRunner(_FakeHandler())  # no bridge/caller
     out = asyncio.run(r.run_tool("call_me_back", {"message": "the result"}))
     assert "can't call you back" in out.lower()
+
+
+def test_agent_task_delivers_result_to_chat(monkeypatch):
+    import plugins.teams_voice.meeting as meeting
+
+    delivered = {}
+
+    async def fake_deliver(conv, text):
+        delivered["conv"] = conv
+        delivered["text"] = text
+        return True
+
+    monkeypatch.setattr(meeting, "_deliver_to_teams", fake_deliver)
+    h = _FakeHandler()
+    h._thread_id = "19:abc@thread.v2"
+    r = CallToolRunner(h)
+    asyncio.run(r._run_background_task("do X", None))  # no caller, but a postable thread
+    assert delivered["conv"] == "19:abc@thread.v2"
+    assert "CONSULT:do X" in delivered["text"]  # result delivered to chat, no call-back

--- a/plugins/teams_voice/tests/test_call_tools.py
+++ b/plugins/teams_voice/tests/test_call_tools.py
@@ -1,10 +1,10 @@
-"""Tests for the extracted CallToolRunner (now unit-testable in isolation)."""
+"""Tests for CallToolRunner (unit-testable against a fake handler)."""
 
 from __future__ import annotations
 
 import asyncio
 
-from plugins.teams_voice.call_tools import CallContext, CallToolRunner
+from plugins.teams_voice.call_tools import CallToolRunner
 from plugins.teams_voice.meeting import MeetingTranscript
 from plugins.teams_voice.vision_budget import VisionBudget
 from plugins.teams_voice.vision_store import VisionStore
@@ -15,31 +15,32 @@ class _FakeConsult:
         return f"CONSULT:{query}"
 
 
-def _ctx(*, thread_id="", vision_budget=None, vision=None):
-    return CallContext(
-        bridge=None,
-        session=None,
-        caller=None,
-        consult=_FakeConsult(),
-        vision=vision or VisionStore(),
-        vision_budget=vision_budget or VisionBudget(0),  # 0 = unlimited
-        meeting=MeetingTranscript(),
-        thread_id=thread_id,
-    )
+class _FakeHandler:
+    """Minimal handler exposing the attrs CallToolRunner reads."""
+
+    def __init__(self, *, thread_id="", vision_budget=None, vision=None):
+        self._bridge = None
+        self._session = None
+        self._caller = None
+        self._consult = _FakeConsult()
+        self._vision = vision or VisionStore()
+        self._vision_budget = vision_budget or VisionBudget(0)  # 0 = unlimited
+        self._meeting = MeetingTranscript()
+        self._thread_id = thread_id
 
 
 def test_run_tool_consult_delegates():
-    r = CallToolRunner(_ctx())
+    r = CallToolRunner(_FakeHandler())
     assert asyncio.run(r.run_tool("hermes_agent_consult", {"query": "hi"})) == "CONSULT:hi"
 
 
 def test_run_tool_unknown():
-    r = CallToolRunner(_ctx())
+    r = CallToolRunner(_FakeHandler())
     assert "Unknown tool" in asyncio.run(r.run_tool("nope", {}))
 
 
 def test_look_at_screen_no_frame():
-    r = CallToolRunner(_ctx())  # empty vision store
+    r = CallToolRunner(_FakeHandler())  # empty vision store
     out = asyncio.run(r.run_tool("look_at_screen", {"question": "what's there"}))
     assert "can't see" in out.lower()
 
@@ -47,13 +48,13 @@ def test_look_at_screen_no_frame():
 def test_look_at_screen_budget_exhausted():
     budget = VisionBudget(max_per_minute=1)
     budget.try_consume()  # use up the single slot
-    r = CallToolRunner(_ctx(vision_budget=budget))
+    r = CallToolRunner(_FakeHandler(vision_budget=budget))
     out = asyncio.run(r.run_tool("look_at_screen", {"question": "x"}))
-    assert "moment" in out.lower()  # budget message
+    assert "moment" in out.lower()
 
 
 def test_call_me_back_without_caller():
-    r = CallToolRunner(_ctx())  # no bridge/caller
+    r = CallToolRunner(_FakeHandler())  # no bridge/caller
     out = asyncio.run(r.run_tool("call_me_back", {"message": "the result"}))
     assert "can't call you back" in out.lower()
 
@@ -69,7 +70,7 @@ def test_agent_task_delivers_result_to_chat(monkeypatch):
         return True
 
     monkeypatch.setattr(meeting, "_deliver_to_teams", fake_deliver)
-    r = CallToolRunner(_ctx(thread_id="19:abc@thread.v2"))
+    r = CallToolRunner(_FakeHandler(thread_id="19:abc@thread.v2"))
     asyncio.run(r._run_background_task("do X", None))  # no caller, but a postable thread
     assert delivered["conv"] == "19:abc@thread.v2"
-    assert "CONSULT:do X" in delivered["text"]  # result delivered to chat, no call-back
+    assert "CONSULT:do X" in delivered["text"]

--- a/plugins/teams_voice/tests/test_call_tools.py
+++ b/plugins/teams_voice/tests/test_call_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-from plugins.teams_voice.call_tools import CallToolRunner
+from plugins.teams_voice.call_tools import CallContext, CallToolRunner
 from plugins.teams_voice.meeting import MeetingTranscript
 from plugins.teams_voice.vision_budget import VisionBudget
 from plugins.teams_voice.vision_store import VisionStore
@@ -15,47 +15,45 @@ class _FakeConsult:
         return f"CONSULT:{query}"
 
 
-class _FakeHandler:
-    """Minimal call context the runner needs."""
-
-    def __init__(self):
-        self._consult = _FakeConsult()
-        self._meeting = MeetingTranscript()
-        self._thread_id = ""
-        self._vision = VisionStore()
-        self._vision_budget = VisionBudget(0)  # unlimited
-        self._session = None
-        self._caller = None
-        self._bridge = None
+def _ctx(*, thread_id="", vision_budget=None, vision=None):
+    return CallContext(
+        bridge=None,
+        session=None,
+        caller=None,
+        consult=_FakeConsult(),
+        vision=vision or VisionStore(),
+        vision_budget=vision_budget or VisionBudget(0),  # 0 = unlimited
+        meeting=MeetingTranscript(),
+        thread_id=thread_id,
+    )
 
 
 def test_run_tool_consult_delegates():
-    r = CallToolRunner(_FakeHandler())
+    r = CallToolRunner(_ctx())
     assert asyncio.run(r.run_tool("hermes_agent_consult", {"query": "hi"})) == "CONSULT:hi"
 
 
 def test_run_tool_unknown():
-    r = CallToolRunner(_FakeHandler())
+    r = CallToolRunner(_ctx())
     assert "Unknown tool" in asyncio.run(r.run_tool("nope", {}))
 
 
 def test_look_at_screen_no_frame():
-    r = CallToolRunner(_FakeHandler())  # empty vision store
+    r = CallToolRunner(_ctx())  # empty vision store
     out = asyncio.run(r.run_tool("look_at_screen", {"question": "what's there"}))
     assert "can't see" in out.lower()
 
 
 def test_look_at_screen_budget_exhausted():
-    h = _FakeHandler()
-    h._vision_budget = VisionBudget(max_per_minute=1)
-    h._vision_budget.try_consume()  # use up the single slot
-    r = CallToolRunner(h)
+    budget = VisionBudget(max_per_minute=1)
+    budget.try_consume()  # use up the single slot
+    r = CallToolRunner(_ctx(vision_budget=budget))
     out = asyncio.run(r.run_tool("look_at_screen", {"question": "x"}))
     assert "moment" in out.lower()  # budget message
 
 
 def test_call_me_back_without_caller():
-    r = CallToolRunner(_FakeHandler())  # no bridge/caller
+    r = CallToolRunner(_ctx())  # no bridge/caller
     out = asyncio.run(r.run_tool("call_me_back", {"message": "the result"}))
     assert "can't call you back" in out.lower()
 
@@ -71,9 +69,7 @@ def test_agent_task_delivers_result_to_chat(monkeypatch):
         return True
 
     monkeypatch.setattr(meeting, "_deliver_to_teams", fake_deliver)
-    h = _FakeHandler()
-    h._thread_id = "19:abc@thread.v2"
-    r = CallToolRunner(h)
+    r = CallToolRunner(_ctx(thread_id="19:abc@thread.v2"))
     asyncio.run(r._run_background_task("do X", None))  # no caller, but a postable thread
     assert delivered["conv"] == "19:abc@thread.v2"
     assert "CONSULT:do X" in delivered["text"]  # result delivered to chat, no call-back

--- a/plugins/teams_voice/tests/test_caps_allowlist.py
+++ b/plugins/teams_voice/tests/test_caps_allowlist.py
@@ -1,0 +1,49 @@
+"""Tests for vision budget, allowlist/scope/wake config, and slideshow schema."""
+
+from __future__ import annotations
+
+from plugins.teams_voice import realtime_tools
+from plugins.teams_voice.config import resolve_config
+from plugins.teams_voice.vision_budget import VisionBudget
+
+
+def test_vision_budget_caps_per_minute():
+    b = VisionBudget(max_per_minute=2)
+    assert b.try_consume(now=0.0) is True
+    assert b.try_consume(now=1.0) is True
+    assert b.try_consume(now=2.0) is False  # cap hit within the window
+
+
+def test_vision_budget_window_slides():
+    b = VisionBudget(max_per_minute=1)
+    assert b.try_consume(now=0.0) is True
+    assert b.try_consume(now=30.0) is False  # still in window
+    assert b.try_consume(now=61.0) is True  # first hit aged out
+
+
+def test_vision_budget_refund_and_unlimited():
+    b = VisionBudget(max_per_minute=1)
+    assert b.try_consume(now=0.0) is True
+    b.refund()
+    assert b.try_consume(now=1.0) is True  # refunded slot reusable
+    assert VisionBudget(max_per_minute=0).try_consume() is True  # 0 = unlimited
+
+
+def test_config_resolves_caps_and_allowlist():
+    extra = {
+        "shared_secret": "s",
+        "allowlist": ["AAD-123", "Alice"],
+        "max_vision_per_minute": 10,
+        "session_scope": "per-thread",
+        "wake_phrases": ["Aria", "Bot"],
+    }
+    c = resolve_config(extra=extra)
+    assert c.allowlist == ("aad-123", "alice")  # lowercased
+    assert c.max_vision_per_minute == 10
+    assert c.session_scope == "per-thread"
+    assert c.wake_phrases == ("aria", "bot")
+
+
+def test_show_to_caller_has_count():
+    props = realtime_tools.SHOW_TO_CALLER["parameters"]["properties"]
+    assert props["count"]["type"] == "integer"

--- a/plugins/teams_voice/tests/test_config_sources.py
+++ b/plugins/teams_voice/tests/test_config_sources.py
@@ -1,0 +1,43 @@
+"""Both config sources work: config.yaml block precedence + env fallback."""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.teams_voice import config as cfgmod
+from plugins.teams_voice.realtime import openai_client as rc
+
+
+def test_resolve_config_prefers_block_then_env(monkeypatch):
+    monkeypatch.setenv("TEAMS_VOICE_SHARED_SECRET", "from-env")
+    monkeypatch.setenv("TEAMS_VOICE_PORT", "9999")
+    # config.yaml block wins for the keys it sets...
+    block = {"shared_secret": "from-config", "host": "0.0.0.0"}
+    cfg = cfgmod.resolve_config(extra=block)
+    assert cfg.shared_secret == "from-config"  # block beats env
+    assert cfg.host == "0.0.0.0"
+    assert cfg.port == 9999  # ...and env fills the rest
+
+
+def test_resolve_config_env_only_when_block_empty(monkeypatch):
+    monkeypatch.setenv("TEAMS_VOICE_SHARED_SECRET", "env-secret")
+    cfg = cfgmod.resolve_config(extra={})
+    assert cfg.shared_secret == "env-secret"
+
+
+def test_realtime_block_overrides_env(monkeypatch):
+    monkeypatch.setenv("TEAMS_VOICE_REALTIME_VOICE", "cedar")  # env
+    monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "envkey")
+    block = {
+        "backend": "azure",
+        "azure_endpoint": "https://res.cognitiveservices.azure.com",
+        "azure_deployment": "gpt-realtime",
+        "azure_api_version": "2025-04-01-preview",
+        "voice": "verse",  # config.yaml beats the env voice
+        "api_key": "blockkey",
+    }
+    cfg = rc.realtime_config_from_env(block=block)
+    assert cfg.voice == "verse"
+    assert cfg.api_key == "blockkey"
+    assert cfg.api_key_header == "api-key"
+    assert cfg.base_url.endswith("deployment=gpt-realtime")

--- a/plugins/teams_voice/tests/test_contract.py
+++ b/plugins/teams_voice/tests/test_contract.py
@@ -1,7 +1,7 @@
 """Golden wire-contract test — the JSON the .NET worker (Protocol.cs) exchanges.
 
 Locks the exact camelCase field names + type discriminators on both directions so
-the Hermes driver and OpenClawBridge can't silently drift.
+the Hermes driver and the .NET media worker can't silently drift.
 """
 
 from __future__ import annotations

--- a/plugins/teams_voice/tests/test_contract.py
+++ b/plugins/teams_voice/tests/test_contract.py
@@ -1,0 +1,79 @@
+"""Golden wire-contract test — the JSON the .NET worker (Protocol.cs) exchanges.
+
+Locks the exact camelCase field names + type discriminators on both directions so
+the Hermes driver and OpenClawBridge can't silently drift.
+"""
+
+from __future__ import annotations
+
+import json
+
+from plugins.teams_voice import protocol as p
+from plugins.teams_voice import viseme_estimate as viz
+
+
+def test_decode_inbound_session_start():
+    m = p.decode(json.dumps({
+        "type": "session.start", "callId": "c1", "threadId": "t1",
+        "caller": {"aadId": "a", "displayName": "Dee", "tenantId": "tn"},
+        "recordingStatus": "active", "direction": "inbound",
+    }))
+    assert isinstance(m, p.SessionStart)
+    assert (m.call_id, m.thread_id, m.recording_status, m.direction) == ("c1", "t1", "active", "inbound")
+    assert (m.caller.aad_id, m.caller.display_name, m.caller.tenant_id) == ("a", "Dee", "tn")
+
+
+def test_decode_inbound_media_and_control():
+    af = p.decode(json.dumps({"type": "audio.frame", "seq": 1, "timestampMs": 20, "payloadBase64": "AA", "speakerName": "Sara"}))
+    assert (af.seq, af.timestamp_ms, af.payload_base64, af.speaker_name) == (1, 20, "AA", "Sara")
+    vf = p.decode(json.dumps({"type": "video.frame", "source": "screenshare", "ts": 5, "width": 1,
+                              "height": 2, "mime": "image/jpeg", "dataBase64": "ZZ",
+                              "participantId": "pid", "participantName": "Bob"}))
+    assert (vf.source, vf.data_base64, vf.participant_name) == ("screenshare", "ZZ", "Bob")
+    assert p.decode(json.dumps({"type": "recording.status", "status": "active"})).status == "active"
+    assert p.decode(json.dumps({"type": "participants", "count": 3})).count == 3
+    assert p.decode(json.dumps({"type": "dtmf", "digit": "5"})).digit == "5"
+    assert p.decode(json.dumps({"type": "ping", "ts": 99})).ts == 99
+    assert p.decode(json.dumps({"type": "session.end", "reason": "call-ended"})).reason == "call-ended"
+
+
+def test_encode_outbound_exact_keys():
+    assert json.loads(p.encode(p.audio_frame(1, 20, "AA"))) == {
+        "type": "audio.frame", "seq": 1, "timestampMs": 20, "payloadBase64": "AA"}
+    assert json.loads(p.encode(p.expression("happy"))) == {"type": "expression", "emotion": "happy"}
+    sm = json.loads(p.encode(p.speech_marks([{"tMs": 0, "visemeId": 2}], ts=0)))
+    assert sm["type"] == "speech.marks" and sm["marks"][0] == {"tMs": 0, "visemeId": 2}
+    di = json.loads(p.encode(p.display_image("ZZ", "image/png", duration_ms=5000, mode="overlay", caption="c")))
+    assert di["type"] == "display.image"
+    assert (di["dataBase64"], di["mime"], di["durationMs"], di["mode"], di["caption"]) == ("ZZ", "image/png", 5000, "overlay", "c")
+    assert json.loads(p.encode(p.assistant_cancel(7))) == {"type": "assistant.cancel", "turnId": 7}
+    assert json.loads(p.encode(p.pong(99))) == {"type": "pong", "ts": 99}
+
+
+def test_blank_caller_fields_coerced_to_none():
+    m = p.decode(json.dumps({"type": "session.start", "callId": "c", "threadId": "t", "caller": {"aadId": "  "}}))
+    assert m.caller.aad_id is None  # blank-as-null guard (cross-caller bleed)
+
+
+def test_minutes_docx_is_valid_openable(tmp_path):
+    from plugins.teams_voice.meeting_docx import write_minutes_docx
+
+    out = tmp_path / "m.docx"
+    write_minutes_docx("Meeting minutes", "**Key Points**\n- shipped it\n**Decisions**\n- go", str(out))
+    import zipfile
+
+    assert zipfile.is_zipfile(out)
+    with zipfile.ZipFile(out) as z:
+        names = set(z.namelist())
+        assert {"[Content_Types].xml", "_rels/.rels", "word/document.xml"} <= names
+        body = z.read("word/document.xml").decode("utf-8")
+        assert "Key Points" in body and "shipped it" in body  # content present + escaped
+
+
+def test_arabic_visemes_are_shaped_not_neutral():
+    # Arabic graphemes now map to real mouth shapes (not the neutral default).
+    assert viz.viseme_for_char("و") == viz.VISEME_OO  # waw → round
+    assert viz.viseme_for_char("ب") == viz.VISEME_MBP  # ba → closed
+    assert viz.viseme_for_char("ف") == viz.VISEME_FV  # fa → lip-teeth
+    marks = viz.estimate_visemes("توقف", 200)  # "stop" — should change shape, not flat
+    assert len({m.viseme_id for m in marks}) >= 2

--- a/plugins/teams_voice/tests/test_cvi_extras.py
+++ b/plugins/teams_voice/tests/test_cvi_extras.py
@@ -1,0 +1,54 @@
+"""Tests for CVI extras: attribution, look_at_screen scope, ambient/DTMF client paths."""
+
+from __future__ import annotations
+
+import asyncio
+
+from plugins.teams_voice import realtime_tools
+from plugins.teams_voice.realtime.openai_client import RealtimeConfig, RealtimeSession
+from plugins.teams_voice.vision_store import StoredFrame
+
+
+def _session_capturing() -> tuple[RealtimeSession, list[dict]]:
+    sent: list[dict] = []
+    s = RealtimeSession(RealtimeConfig(api_key="x"))
+    s._closed = False
+
+    async def fake_send(obj):
+        sent.append(obj)
+
+    s._send = fake_send  # type: ignore[assignment]
+    return s, sent
+
+
+def test_frame_describe_attribution():
+    assert StoredFrame("screenshare", "x", "image/jpeg", 1, "Alice").describe() == "Alice's shared screen"
+    assert StoredFrame("camera", "x", "image/jpeg", 1).describe() == "camera"
+
+
+def test_look_at_screen_schema_has_scope():
+    props = realtime_tools.LOOK_AT_SCREEN["parameters"]["properties"]
+    assert props["scope"]["enum"] == ["live", "history"]
+
+
+def test_send_user_text_guards_double_response():
+    s, sent = _session_capturing()
+    s._response_active = True  # a response is already in progress
+    asyncio.run(s.send_user_text("the caller pressed 1", respond=True))
+    types = [m["type"] for m in sent]
+    assert "conversation.item.create" in types
+    assert "response.create" not in types  # guarded — no 'already active' error
+
+
+def test_send_user_text_creates_when_idle():
+    s, sent = _session_capturing()
+    s._response_active = False
+    asyncio.run(s.send_user_text("hello", respond=True))
+    assert [m["type"] for m in sent] == ["conversation.item.create", "response.create"]
+
+
+def test_send_image_is_ambient_no_response():
+    s, sent = _session_capturing()
+    asyncio.run(s.send_image("data:image/jpeg;base64,AAA"))
+    assert sent[0]["item"]["content"][0]["type"] == "input_image"
+    assert all(m["type"] != "response.create" for m in sent)

--- a/plugins/teams_voice/tests/test_dialogue_depth.py
+++ b/plugins/teams_voice/tests/test_dialogue_depth.py
@@ -95,7 +95,13 @@ def test_outbound_signature_matches_userobjectid_payload():
 
 def test_default_tools_present_and_well_formed():
     names = {t["name"] for t in realtime_tools.default_tools()}
-    assert names == {"hermes_agent_consult", "look_at_screen", "show_to_caller", "call_me_back"}
+    assert names == {
+        "hermes_agent_consult",
+        "hermes_agent_task",
+        "look_at_screen",
+        "show_to_caller",
+        "call_me_back",
+    }
     for tool in realtime_tools.default_tools():
         assert tool["type"] == "function"
         assert "parameters" in tool and tool["parameters"]["type"] == "object"

--- a/plugins/teams_voice/tests/test_dialogue_depth.py
+++ b/plugins/teams_voice/tests/test_dialogue_depth.py
@@ -1,0 +1,101 @@
+"""Tests for the dialogue-depth pieces: echo guard, vision store, outbound."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from plugins.teams_voice import hmac_auth, realtime_tools
+from plugins.teams_voice.echo_guard import EchoGuard
+from plugins.teams_voice.vision_store import StoredFrame, VisionStore
+
+
+# ── echo guard ───────────────────────────────────────────────────────────────
+
+
+def test_echo_guard_passes_when_silent():
+    g = EchoGuard()
+    # nothing played out yet → not speaking → always allow
+    assert g.allow_input(0.001, now=1000.0) is True
+
+
+def test_echo_guard_suppresses_own_playback_before_first_turn():
+    g = EchoGuard(tail_window_ms=600, barge_in_rms=0.04)
+    g.note_output(1000.0, now=0.0)  # queued 1s of audio at t=0 → playout_end=1000
+    # at t=500 we're "speaking"; before the first caller turn, even loud is dropped
+    assert g.allow_input(0.9, now=500.0) is False
+
+
+def test_echo_guard_allows_loud_barge_in_after_first_turn():
+    g = EchoGuard(tail_window_ms=600, barge_in_rms=0.04)
+    g.mark_caller_turn()
+    g.note_output(1000.0, now=0.0)
+    assert g.allow_input(0.9, now=500.0) is True  # loud → barge-in
+    assert g.allow_input(0.01, now=500.0) is False  # quiet echo → dropped
+
+
+def test_echo_guard_collapse_stops_guarding():
+    g = EchoGuard()
+    g.mark_caller_turn()
+    g.note_output(1000.0, now=0.0)
+    g.collapse(now=500.0)  # barge-in accepted; playback cut
+    assert g.allow_input(0.01, now=510.0) is True
+
+
+def test_echo_guard_disabled_passes_everything():
+    g = EchoGuard(enabled=False)
+    g.note_output(1000.0, now=0.0)
+    assert g.allow_input(0.0, now=100.0) is True
+
+
+# ── vision store ─────────────────────────────────────────────────────────────
+
+
+def _frame(source, ts):
+    return StoredFrame(source=source, data_base64="AAA", mime="image/jpeg", ts=ts)
+
+
+def test_vision_store_latest_prefers_screenshare():
+    s = VisionStore()
+    s.store(_frame("camera", 1))
+    s.store(_frame("screenshare", 2))
+    assert s.latest().source == "screenshare"
+    assert s.latest("camera").source == "camera"
+
+
+def test_vision_store_history_ring_bounded():
+    s = VisionStore(history=3)
+    for i in range(5):
+        s.store(_frame("screenshare", i))
+    hist = s.history(limit=10)
+    assert len(hist) == 3  # ring capped
+    assert [f.ts for f in hist] == [2, 3, 4]  # oldest-first, newest retained
+
+
+def test_vision_store_data_url():
+    f = _frame("camera", 1)
+    assert f.data_url() == "data:image/jpeg;base64,AAA"
+
+
+# ── outbound signing ─────────────────────────────────────────────────────────
+
+
+def test_outbound_signature_matches_userobjectid_payload():
+    # The outbound endpoint signs "{ts}.{userObjectId}" (not callId) — same helper.
+    secret, uid, ts = "s3cret", "user-123", 1700000000000
+    sig = hmac_auth.sign(secret, ts, uid)
+    expected = hmac.new(
+        secret.encode(), f"{ts}.{uid}".encode(), hashlib.sha256
+    ).hexdigest()
+    assert sig == expected == sig.lower()
+
+
+# ── tool surface ─────────────────────────────────────────────────────────────
+
+
+def test_default_tools_present_and_well_formed():
+    names = {t["name"] for t in realtime_tools.default_tools()}
+    assert names == {"hermes_agent_consult", "look_at_screen", "show_to_caller", "call_me_back"}
+    for tool in realtime_tools.default_tools():
+        assert tool["type"] == "function"
+        assert "parameters" in tool and tool["parameters"]["type"] == "object"

--- a/plugins/teams_voice/tests/test_dialogue_depth.py
+++ b/plugins/teams_voice/tests/test_dialogue_depth.py
@@ -101,6 +101,7 @@ def test_default_tools_present_and_well_formed():
         "look_at_screen",
         "show_to_caller",
         "call_me_back",
+        "post_meeting_minutes",
     }
     for tool in realtime_tools.default_tools():
         assert tool["type"] == "function"

--- a/plugins/teams_voice/tests/test_expression_viseme.py
+++ b/plugins/teams_voice/tests/test_expression_viseme.py
@@ -1,0 +1,36 @@
+"""Tests for the expression heuristic and viseme estimator ports."""
+
+from __future__ import annotations
+
+from plugins.teams_voice import expression as expr
+from plugins.teams_voice import viseme_estimate as viz
+
+
+def test_expression_priority_and_defaults():
+    assert expr.infer_emotion("") == expr.NEUTRAL
+    assert expr.infer_emotion("just a plain sentence") == expr.NEUTRAL
+    assert expr.infer_emotion("That's perfect!!") == expr.SURPRISED  # !! beats happy word
+    assert expr.infer_emotion("That is great and wonderful") == expr.HAPPY
+    assert expr.infer_emotion("Unfortunately the deal failed") == expr.SAD
+    assert expr.infer_emotion("wow that is something") == expr.SURPRISED
+
+
+def test_estimate_visemes_even_spread_and_collapse():
+    marks = viz.estimate_visemes("aa", 100)
+    # two 'a' chars collapse to a single mark (same viseme id)
+    assert len(marks) == 1
+    assert marks[0].viseme_id == viz.VISEME_AA
+    assert marks[0].t_ms == 0
+
+
+def test_estimate_visemes_empty_inputs():
+    assert viz.estimate_visemes("", 100) == []
+    assert viz.estimate_visemes("hello", 0) == []
+
+
+def test_visemes_from_alignment_sorted_payload():
+    marks = viz.visemes_from_alignment([("m", 30), ("a", 0), ("p", 60)])
+    payload = viz.marks_to_payload(marks)
+    # sorted by time; first is the 'a'->open at t=0
+    assert payload[0]["tMs"] == 0
+    assert all("tMs" in m and "visemeId" in m for m in payload)

--- a/plugins/teams_voice/tests/test_group_call_gate.py
+++ b/plugins/teams_voice/tests/test_group_call_gate.py
@@ -1,0 +1,73 @@
+"""Tests for the group-call "speak only when addressed" gate."""
+
+from __future__ import annotations
+
+from plugins.teams_voice.group_call_gate import (
+    GroupCallGateConfig,
+    is_addressed,
+    resolve_group_call_gate_config,
+    should_respond_to_group_turn,
+)
+
+
+def test_is_addressed_word_boundary():
+    phrases = ("assistant", "aria")
+    assert is_addressed("Hey assistant, what's up?", phrases)
+    assert is_addressed("ARIA can you help", phrases)
+    # boundary: "assistantship" must NOT match "assistant"
+    assert not is_addressed("the assistantship program", phrases)
+    assert not is_addressed("no wake word here", phrases)
+
+
+def test_is_addressed_unicode_arabic():
+    # Unicode-aware boundaries: Arabic wake phrase matches.
+    assert is_addressed("مرحبا مساعد كيف حالك", ("مساعد",))
+
+
+def test_one_to_one_always_responds():
+    cfg = GroupCallGateConfig()
+    d = should_respond_to_group_turn(
+        transcript="anything", is_group=False, config=cfg,
+        last_addressed_at_ms=None, now_ms=1000,
+    )
+    assert d.respond and not d.gated
+
+
+def test_group_gate_suppresses_unaddressed():
+    cfg = GroupCallGateConfig(wake_phrases=("assistant",))
+    d = should_respond_to_group_turn(
+        transcript="just chatting with colleagues", is_group=True, config=cfg,
+        last_addressed_at_ms=None, now_ms=1000,
+    )
+    assert not d.respond and d.gated
+
+
+def test_group_follow_up_window():
+    cfg = GroupCallGateConfig(wake_phrases=("assistant",), follow_up_window_ms=12_000)
+    # addressed at t=0
+    addressed = should_respond_to_group_turn(
+        transcript="assistant, hello", is_group=True, config=cfg,
+        last_addressed_at_ms=None, now_ms=0,
+    )
+    assert addressed.respond and addressed.addressed
+    # follow-up 5s later without the name still responds
+    follow = should_respond_to_group_turn(
+        transcript="and what about tomorrow", is_group=True, config=cfg,
+        last_addressed_at_ms=0, now_ms=5_000,
+    )
+    assert follow.respond and not follow.addressed
+    # 20s later (past window) goes quiet
+    late = should_respond_to_group_turn(
+        transcript="and what about tomorrow", is_group=True, config=cfg,
+        last_addressed_at_ms=0, now_ms=20_000,
+    )
+    assert not late.respond
+
+
+def test_resolve_config_merges_camelcase():
+    cfg = resolve_group_call_gate_config(
+        {"requireAddress": True, "wakePhrases": ["Assistant", "Hermes"], "followUpWindowMs": 8000}
+    )
+    assert cfg.require_address is True
+    assert cfg.wake_phrases == ("assistant", "hermes")
+    assert cfg.follow_up_window_ms == 8000

--- a/plugins/teams_voice/tests/test_integration.py
+++ b/plugins/teams_voice/tests/test_integration.py
@@ -1,0 +1,141 @@
+"""Integration-ish tests: handler wiring with fake sessions/realtime."""
+
+from __future__ import annotations
+
+import asyncio
+
+from plugins.teams_voice import handlers, meeting, protocol
+from plugins.teams_voice.config import resolve_config
+from plugins.teams_voice.realtime.openai_client import RealtimeConfig
+
+
+class FakeWS:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeSession:
+    def __init__(self, human_count=1):
+        self._ws = FakeWS()
+        self.recording_active = True
+        self.human_count = human_count
+        self.call_id = "call-1"
+        self.cancels: list[int] = []
+
+    async def send_expression(self, e):
+        ...
+
+    async def send_audio_frame(self, *a):
+        ...
+
+    async def send_speech_marks(self, *a, **k):
+        ...
+
+    async def send_assistant_cancel(self, t):
+        self.cancels.append(t)
+
+
+class FakeRealtime:
+    def __init__(self):
+        self.auto: list[bool] = []
+        self.created = 0
+        self.cancelled = 0
+
+    async def set_auto_response(self, enabled):
+        self.auto.append(enabled)
+
+    async def create_response(self):
+        self.created += 1
+
+    async def cancel_response(self):
+        self.cancelled += 1
+
+
+def _start(aad="aad-x", direction="inbound"):
+    return protocol.SessionStart(
+        type="session.start", call_id="call-1", thread_id="thread-1",
+        caller=protocol.CallerInfo(aad_id=aad, display_name="X"),
+        recording_status="inactive", direction=direction,
+    )
+
+
+def test_realtime_allowlist_rejects_and_closes_ws():
+    cfg = resolve_config(extra={"shared_secret": "s", "allowlist": ["aad-allowed"]})
+    h = handlers.RealtimeCallSessionHandler(RealtimeConfig(api_key="x"), bridge_config=cfg)
+    sess = FakeSession()
+    asyncio.run(h.on_session_start(sess, _start(aad="aad-OTHER")))
+    assert sess._ws.closed is True
+    assert h._rt is None  # rejected before connecting
+
+
+def test_streaming_allowlist_rejects_and_closes_ws():
+    cfg = resolve_config(extra={"shared_secret": "s", "allowlist": ["aad-allowed"]})
+    h = handlers.StreamingCallSessionHandler(bridge_config=cfg)
+    sess = FakeSession()
+    asyncio.run(h.on_session_start(sess, _start(aad="nope")))
+    assert sess._ws.closed is True
+
+
+def test_realtime_group_gate_manual_response_no_leak():
+    cfg = resolve_config(extra={"shared_secret": "s", "wake_phrases": ["aria"]})
+    h = handlers.RealtimeCallSessionHandler(RealtimeConfig(api_key="x"), bridge_config=cfg)
+    h._rt = FakeRealtime()
+    sess = FakeSession(human_count=2)
+    h._session = sess
+
+    # 2 humans → auto-response turned OFF (race-free gate)
+    asyncio.run(h.on_participants(sess, protocol.Participants(type="participants", count=2)))
+    assert h._rt.auto[-1] is False
+
+    # unaddressed turn → drop + cancel, NO response created
+    asyncio.run(h._on_input_transcript("just chatting with my colleague"))
+    assert h._drop_response is True and h._rt.cancelled >= 1 and h._rt.created == 0
+
+    # addressed turn → we explicitly create the response
+    asyncio.run(h._on_input_transcript("aria, what do you think?"))
+    assert h._rt.created == 1
+
+
+def test_streaming_session_end_cancels_inflight_task():
+    h = handlers.StreamingCallSessionHandler(bridge_config=resolve_config(extra={"shared_secret": "s"}))
+    h._session = FakeSession()
+
+    async def run():
+        async def _slow():
+            await asyncio.sleep(5)
+
+        task = asyncio.create_task(_slow())
+        h._utterance_task = task
+        await asyncio.sleep(0)
+        await h.on_session_end(h._session, protocol.SessionEnd(type="session.end", reason="x"))
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        return task
+
+    task = asyncio.run(run())
+    assert task.cancelled()
+
+
+def test_meeting_post_minutes_injected_deliver():
+    class FakeConsult:
+        async def ask(self, q, *, timeout_s=120.0):
+            return "Key Points: discussed X. Decisions: ship it."
+
+    delivered = {}
+
+    async def fake_deliver(conv, text):
+        delivered["conv"] = conv
+        delivered["text"] = text
+        return True
+
+    t = meeting.MeetingTranscript()
+    t.add("Sara", "let's ship")
+    out = asyncio.run(meeting.post_minutes(FakeConsult(), t, "19:abc@thread.v2", deliver=fake_deliver))
+    assert "posted the minutes" in out.lower()
+    assert delivered["conv"] == "19:abc@thread.v2"
+    assert "Key Points" in delivered["text"]

--- a/plugins/teams_voice/tests/test_integration.py
+++ b/plugins/teams_voice/tests/test_integration.py
@@ -121,6 +121,35 @@ def test_streaming_session_end_cancels_inflight_task():
     assert task.cancelled()
 
 
+def test_streaming_vision_auto_attach(monkeypatch):
+    import agent.auxiliary_client as ac
+
+    h = handlers.StreamingCallSessionHandler(bridge_config=resolve_config(extra={"shared_secret": "s"}))
+    sess = FakeSession()
+    h._session = sess
+    asyncio.run(h.on_video_frame(sess, protocol.VideoFrame(
+        type="video.frame", source="screenshare", ts=7, width=1, height=1,
+        mime="image/jpeg", data_base64="ZZ", participant_id="p", participant_name="Bob")))
+    assert h._vision.latest() is not None  # ingested
+
+    class _Msg:
+        content = "a budget spreadsheet"
+
+    class _Choice:
+        message = _Msg()
+
+    class _Resp:
+        choices = [_Choice()]
+
+    async def fake_llm(**kw):
+        return _Resp()
+
+    monkeypatch.setattr(ac, "async_call_llm", fake_llm)
+    ctx = asyncio.run(h._vision_context())
+    assert "budget spreadsheet" in ctx and "sharing" in ctx.lower()
+    assert asyncio.run(h._vision_context()) == ""  # no new frame → no re-attach
+
+
 def test_meeting_post_minutes_injected_deliver():
     class FakeConsult:
         async def ask(self, q, *, timeout_s=120.0):

--- a/plugins/teams_voice/tests/test_integration.py
+++ b/plugins/teams_voice/tests/test_integration.py
@@ -168,3 +168,28 @@ def test_meeting_post_minutes_injected_deliver():
     assert "posted the minutes" in out.lower()
     assert delivered["conv"] == "19:abc@thread.v2"
     assert "Key Points" in delivered["text"]
+
+
+def _streaming():
+    return handlers.StreamingCallSessionHandler(bridge_config=resolve_config(extra={"shared_secret": "s"}))
+
+
+def test_greeting_plan_inbound_greets_once():
+    h = _streaming()
+    h._caller = protocol.CallerInfo(aad_id="a", display_name="Dee Smith")
+    assert h._greeting_plan() == ("greet", "Dee")
+    assert h._greeting_plan() is None  # fires once
+
+
+def test_greeting_plan_outbound_delivers_pending():
+    h = _streaming()
+    h._outbound = True
+    h._pending_greeting = "the result"
+    assert h._greeting_plan() == ("deliver", "the result")
+    assert h._greeting_plan() is None  # pending consumed, fires once
+
+
+def test_greeting_plan_outbound_without_pending_is_silent():
+    h = _streaming()
+    h._outbound = True
+    assert h._greeting_plan() is None

--- a/plugins/teams_voice/tests/test_meeting.py
+++ b/plugins/teams_voice/tests/test_meeting.py
@@ -1,0 +1,52 @@
+"""Tests for meeting transcript accumulation + summary-request detection."""
+
+from __future__ import annotations
+
+import asyncio
+
+from plugins.teams_voice import meeting, realtime_tools
+from plugins.teams_voice.meeting import MeetingTranscript, post_minutes
+
+
+def test_transcript_add_and_render():
+    t = MeetingTranscript()
+    assert t.is_empty()
+    t.add("Alice", "  hello there  ")
+    t.add("Assistant", "hi")
+    t.add("Bob", "")  # blank ignored
+    assert not t.is_empty()
+    assert t.render() == "Alice: hello there\nAssistant: hi"
+
+
+def test_transcript_render_caps_length():
+    t = MeetingTranscript()
+    for i in range(1000):
+        t.add("X", f"line {i}")
+    out = t.render(max_chars=200)
+    assert len(out) <= 200
+
+
+def test_is_summary_request():
+    assert meeting.is_summary_request("can you summarize the meeting")
+    assert meeting.is_summary_request("send me the call minutes")
+    assert meeting.is_summary_request("recap of our discussion please")
+    assert not meeting.is_summary_request("what's the weather in Dubai")
+    assert not meeting.is_summary_request("summarize this PDF")  # no meeting subject
+
+
+def test_post_minutes_empty_is_noop():
+    t = MeetingTranscript()
+    out = asyncio.run(post_minutes(consult=None, transcript=t, conversation_id="19:x@thread.v2"))
+    assert "wasn't enough" in out.lower()
+
+
+def test_post_minutes_requires_conversation():
+    t = MeetingTranscript()
+    t.add("A", "hi")
+    out = asyncio.run(post_minutes(consult=None, transcript=t, conversation_id=""))
+    assert "wasn't enough" in out.lower()
+
+
+def test_post_meeting_minutes_tool_registered():
+    names = {t["name"] for t in realtime_tools.default_tools()}
+    assert "post_meeting_minutes" in names

--- a/plugins/teams_voice/tests/test_protocol_hmac.py
+++ b/plugins/teams_voice/tests/test_protocol_hmac.py
@@ -1,0 +1,95 @@
+"""Tests for the bridge protocol decode/encode and HMAC handshake."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from plugins.teams_voice import hmac_auth, protocol
+
+
+def test_decode_session_start_blank_aad_is_none():
+    raw = json.dumps(
+        {
+            "type": "session.start",
+            "callId": "abc",
+            "threadId": "t1",
+            "caller": {"aadId": "   ", "displayName": "Alaa"},
+            "direction": "inbound",
+            "recordingStatus": "inactive",
+        }
+    )
+    msg = protocol.decode(raw)
+    assert isinstance(msg, protocol.SessionStart)
+    assert msg.call_id == "abc"
+    assert msg.caller.aad_id is None  # blank coerced to None
+    assert msg.caller.display_name == "Alaa"
+
+
+def test_decode_audio_frame_and_missing_field():
+    msg = protocol.decode(
+        json.dumps({"type": "audio.frame", "seq": 3, "timestampMs": 60, "payloadBase64": "AAAA"})
+    )
+    assert isinstance(msg, protocol.AudioFrame)
+    assert msg.seq == 3 and msg.payload_base64 == "AAAA"
+
+    with pytest.raises(protocol.ProtocolError):
+        protocol.decode(json.dumps({"type": "audio.frame", "seq": 1}))
+
+
+def test_decode_rejects_unknown_and_malformed():
+    with pytest.raises(protocol.ProtocolError):
+        protocol.decode("{not json")
+    with pytest.raises(protocol.ProtocolError):
+        protocol.decode(json.dumps({"type": "bogus.message"}))
+
+
+def test_outbound_builders_camelcase():
+    assert protocol.expression("happy") == {"type": "expression", "emotion": "happy"}
+    marks = protocol.speech_marks([{"tMs": 0, "visemeId": 2}], ts=0)
+    assert marks["marks"][0]["visemeId"] == 2
+    img = protocol.display_image("ZZ", "image/png", mode="overlay", caption="hi")
+    assert img["mode"] == "overlay" and img["caption"] == "hi"
+    assert protocol.assistant_cancel(7) == {"type": "assistant.cancel", "turnId": 7}
+
+
+def test_hmac_sign_matches_dotnet_payload_shape():
+    # payload is "{timestampMs}.{callId}", HMAC-SHA256, lowercase hex
+    sig = hmac_auth.sign("secret", 1700000000000, "call-1")
+    assert sig == sig.lower() and len(sig) == 64
+
+
+def test_hmac_verify_window_and_signature():
+    secret, call_id, now = "s3cr3t", "c1", 1_000_000
+    ts = now
+    sig = hmac_auth.sign(secret, ts, call_id)
+
+    ok, reason = hmac_auth.verify_upgrade(
+        secret=secret, call_id=call_id, timestamp_header=str(ts),
+        signature_header=sig, window_ms=60_000, now_ms=now,
+    )
+    assert ok, reason
+
+    # bad signature
+    ok, reason = hmac_auth.verify_upgrade(
+        secret=secret, call_id=call_id, timestamp_header=str(ts),
+        signature_header="deadbeef", window_ms=60_000, now_ms=now,
+    )
+    assert not ok and reason == "bad signature"
+
+    # outside window
+    ok, reason = hmac_auth.verify_upgrade(
+        secret=secret, call_id=call_id, timestamp_header=str(ts - 120_000),
+        signature_header=hmac_auth.sign(secret, ts - 120_000, call_id),
+        window_ms=60_000, now_ms=now,
+    )
+    assert not ok and reason == "timestamp outside window"
+
+
+def test_hmac_replay_guard_single_use():
+    guard = hmac_auth.ReplayGuard(window_ms=60_000)
+    ts = hmac_auth._now_ms()  # realistic timestamp so the entry isn't pruned
+    assert guard.check_and_record("c1", ts, "sigA") is True
+    assert guard.check_and_record("c1", ts, "sigA") is False  # replay rejected
+    assert guard.check_and_record("c1", ts + 1, "sigB") is True  # fresh ts ok

--- a/plugins/teams_voice/tests/test_realtime_config.py
+++ b/plugins/teams_voice/tests/test_realtime_config.py
@@ -1,0 +1,67 @@
+"""Tests for realtime backend config resolution (OpenAI vs Azure)."""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.teams_voice.realtime import openai_client as rc
+
+_ENV_KEYS = [
+    "TEAMS_VOICE_REALTIME_BACKEND",
+    "TEAMS_VOICE_REALTIME_URL",
+    "TEAMS_VOICE_AZURE_ENDPOINT",
+    "TEAMS_VOICE_AZURE_DEPLOYMENT",
+    "TEAMS_VOICE_AZURE_API_VERSION",
+    "TEAMS_VOICE_REALTIME_VOICE",
+    "TEAMS_VOICE_REALTIME_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_FOUNDRY_API_KEY",
+    "OPENAI_API_KEY",
+    "TEAMS_VOICE_REALTIME_MODEL",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for k in _ENV_KEYS:
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_azure_builds_proven_url(monkeypatch):
+    monkeypatch.setenv("TEAMS_VOICE_REALTIME_BACKEND", "azure")
+    monkeypatch.setenv("TEAMS_VOICE_AZURE_ENDPOINT", "https://pcfcaoai2.cognitiveservices.azure.com")
+    monkeypatch.setenv("TEAMS_VOICE_AZURE_DEPLOYMENT", "gpt-realtime")
+    monkeypatch.setenv("TEAMS_VOICE_AZURE_API_VERSION", "2025-04-01-preview")
+    monkeypatch.setenv("TEAMS_VOICE_REALTIME_VOICE", "cedar")
+    monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "k123")
+
+    cfg = rc.realtime_config_from_env(block={})
+    assert cfg.configured
+    assert cfg.api_key_header == "api-key"
+    assert cfg.voice == "cedar"
+    assert cfg.api_key == "k123"  # reused from AZURE_FOUNDRY_API_KEY
+    assert cfg.base_url == (
+        "wss://pcfcaoai2.cognitiveservices.azure.com/openai/realtime"
+        "?api-version=2025-04-01-preview&deployment=gpt-realtime"
+    )
+
+
+def test_azure_explicit_url_passthrough(monkeypatch):
+    monkeypatch.setenv("TEAMS_VOICE_REALTIME_URL", "wss://x.openai.azure.com/openai/realtime?foo=1")
+    monkeypatch.setenv("TEAMS_VOICE_REALTIME_API_KEY", "k")
+    cfg = rc.realtime_config_from_env(block={})
+    assert cfg.api_key_header == "api-key"  # azure.com detected
+    assert cfg.base_url == "wss://x.openai.azure.com/openai/realtime?foo=1"
+
+
+def test_openai_default_backend(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg = rc.realtime_config_from_env(block={})
+    assert cfg.api_key_header == "Authorization"
+    assert cfg.base_url == rc.DEFAULT_BASE_URL
+    assert cfg.api_key == "sk-test"
+
+
+def test_unconfigured_when_no_key(monkeypatch):
+    cfg = rc.realtime_config_from_env(block={})
+    assert not cfg.configured

--- a/plugins/teams_voice/tests/test_review_fixes.py
+++ b/plugins/teams_voice/tests/test_review_fixes.py
@@ -1,0 +1,109 @@
+"""Tests for the code-review fixes: allowlist, pending TTL, SSRF, group gate."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from plugins.teams_voice import handlers
+from plugins.teams_voice.config import caller_allowed, resolve_config
+from plugins.teams_voice.outbound import OutboundError, place_call
+from plugins.teams_voice.realtime.openai_client import RealtimeConfig, RealtimeSession
+
+
+# ── allowlist (AAD-only by default) ──────────────────────────────────────────
+
+
+def test_allowlist_empty_allows_all():
+    cfg = resolve_config(extra={"shared_secret": "s"})
+    assert caller_allowed(cfg, "anyone", "Anyone")
+
+
+def test_allowlist_matches_aad_not_name_by_default():
+    cfg = resolve_config(extra={"shared_secret": "s", "allowlist": ["aad-1", "Bob"]})
+    assert caller_allowed(cfg, "AAD-1", "Whoever")  # aad match (case-insensitive)
+    assert not caller_allowed(cfg, "other", "Bob")  # name match OFF by default
+
+
+def test_allowlist_name_match_opt_in():
+    cfg = resolve_config(extra={"shared_secret": "s", "allowlist": ["bob"], "allowlist_allow_names": True})
+    assert caller_allowed(cfg, "other", "Bob")
+
+
+# ── pending-outbound TTL ─────────────────────────────────────────────────────
+
+
+def test_pending_set_pop_roundtrip():
+    handlers._PENDING_OUTBOUND.clear()
+    handlers._pending_set("call-1", "the result")
+    assert handlers._pending_pop("call-1") == "the result"
+    assert handlers._pending_pop("call-1") is None  # single-use
+
+
+def test_pending_entry_expires():
+    handlers._PENDING_OUTBOUND.clear()
+    handlers._PENDING_OUTBOUND["old"] = ("stale", time.monotonic() - 1.0)  # already expired
+    assert handlers._pending_pop("old") is None
+    assert "old" not in handlers._PENDING_OUTBOUND  # pruned
+
+
+# ── outbound SSRF guard ──────────────────────────────────────────────────────
+
+
+def test_place_call_refuses_non_loopback_worker():
+    with pytest.raises(OutboundError, match="non-loopback"):
+        asyncio.run(
+            place_call(
+                user_object_id="u", tenant_id="t", shared_secret="s",
+                worker_base_url="http://evil.example.com:9440",
+            )
+        )
+
+
+def test_place_call_allows_loopback():
+    # Loopback passes the guard (then fails on connection, not on the guard).
+    with pytest.raises(OutboundError) as ei:
+        asyncio.run(
+            place_call(
+                user_object_id="u", tenant_id="t", shared_secret="s",
+                worker_base_url="http://127.0.0.1:9", timeout_s=0.2,
+            )
+        )
+    assert "non-loopback" not in str(ei.value)  # got past the SSRF guard
+
+
+# ── realtime group-gate auto-response control ────────────────────────────────
+
+
+def _session():
+    sent: list[dict] = []
+    s = RealtimeSession(RealtimeConfig(api_key="x"))
+    s._closed = False
+
+    async def fake_send(obj):
+        sent.append(obj)
+
+    s._send = fake_send  # type: ignore[assignment]
+    return s, sent
+
+
+def test_set_auto_response_toggles_and_is_idempotent():
+    s, sent = _session()
+    s._auto_response = True
+    asyncio.run(s.set_auto_response(False))
+    assert sent[-1]["session"]["turn_detection"]["create_response"] is False
+    sent.clear()
+    asyncio.run(s.set_auto_response(False))  # no-op when unchanged
+    assert sent == []
+
+
+def test_create_response_guarded_on_active():
+    s, sent = _session()
+    s._response_active = True
+    asyncio.run(s.create_response())
+    assert sent == []  # nothing created while a response is active
+    s._response_active = False
+    asyncio.run(s.create_response())
+    assert sent[-1]["type"] == "response.create"

--- a/plugins/teams_voice/tests/test_review_fixes.py
+++ b/plugins/teams_voice/tests/test_review_fixes.py
@@ -107,3 +107,19 @@ def test_create_response_guarded_on_active():
     s._response_active = False
     asyncio.run(s.create_response())
     assert sent[-1]["type"] == "response.create"
+
+
+def test_send_function_result_guarded_on_active():
+    s, sent = _session()
+    s._response_active = True  # a response is already in progress
+    asyncio.run(s.send_function_result("call-1", "the tool result"))
+    types = [m["type"] for m in sent]
+    assert "conversation.item.create" in types  # tool output item is still added
+    assert "response.create" not in types  # but no second response (guarded)
+
+
+def test_allowlist_inherits_chat_allowed_users(monkeypatch):
+    monkeypatch.delenv("TEAMS_VOICE_ALLOWLIST", raising=False)
+    monkeypatch.setenv("TEAMS_ALLOWED_USERS", "aad-shared, Other")
+    cfg = resolve_config(extra={"shared_secret": "s"})
+    assert cfg.allowlist == ("aad-shared", "other")  # voice inherits the chat allowlist

--- a/plugins/teams_voice/tests/test_streaming_audio.py
+++ b/plugins/teams_voice/tests/test_streaming_audio.py
@@ -1,0 +1,51 @@
+"""Tests for the streaming-mode VAD utterance segmenter."""
+
+from __future__ import annotations
+
+from plugins.teams_voice.streaming_audio import UtteranceBuffer
+
+FRAME = b"\x00\x00" * 320  # 640 bytes = one 20 ms frame
+LOUD = 0.5
+QUIET = 0.0
+
+
+def _buf():
+    # 100 ms speech minimum, 200 ms trailing silence, 20 ms frames
+    return UtteranceBuffer(silence_ms=200, min_speech_ms=100, speech_rms=0.02, frame_ms=20)
+
+
+def test_drops_pre_speech_silence():
+    b = _buf()
+    assert b.push(FRAME, QUIET) is None
+    assert b.push(FRAME, QUIET) is None  # still nothing buffered
+
+
+def test_emits_after_trailing_silence():
+    b = _buf()
+    # 6 speech frames (120 ms ≥ 100 ms min)
+    for _ in range(6):
+        assert b.push(FRAME, LOUD) is None
+    # trailing silence: 200 ms / 20 ms = 10 frames to trigger
+    out = None
+    for _ in range(10):
+        out = b.push(FRAME, QUIET)
+    assert out is not None
+    assert len(out) == 16 * 640  # 6 speech + 10 silence frames buffered
+
+
+def test_resets_after_emit():
+    b = _buf()
+    for _ in range(6):
+        b.push(FRAME, LOUD)
+    for _ in range(10):
+        b.push(FRAME, QUIET)
+    # next push starts fresh — a lone quiet frame is pre-speech silence again
+    assert b.push(FRAME, QUIET) is None
+
+
+def test_max_utterance_caps():
+    b = UtteranceBuffer(silence_ms=10_000, min_speech_ms=20, frame_ms=20, max_utterance_ms=100)
+    out = None
+    for _ in range(10):  # 10 frames * 20 ms = 200 ms > 100 ms cap
+        out = b.push(FRAME, 0.5) or out
+    assert out is not None  # capped even without trailing silence

--- a/plugins/teams_voice/tests/test_voice_ux.py
+++ b/plugins/teams_voice/tests/test_voice_ux.py
@@ -1,0 +1,45 @@
+"""Tests for Voice UX completion: verbal interrupts + expression states."""
+
+from __future__ import annotations
+
+from plugins.teams_voice import expression, verbal_interrupts
+from plugins.teams_voice.verbal_interrupts import is_verbal_interrupt
+
+WAKE = ("assistant", "hermes", "aria")
+
+
+def test_bare_interrupts():
+    assert is_verbal_interrupt("stop")
+    assert is_verbal_interrupt("STOP!")
+    assert is_verbal_interrupt("hold on")
+    assert is_verbal_interrupt("never mind")
+    assert is_verbal_interrupt("cancel that")
+
+
+def test_filler_and_wake_phrase_stripping():
+    assert is_verbal_interrupt("please stop")
+    assert is_verbal_interrupt("um, stop")
+    assert is_verbal_interrupt("assistant, stop", WAKE)  # leading wake phrase
+    assert is_verbal_interrupt("stop aria", WAKE)  # trailing wake phrase
+    assert is_verbal_interrupt("hey hermes, hold on", WAKE)
+
+
+def test_not_an_interrupt_substring():
+    assert not is_verbal_interrupt("stop by the store")
+    assert not is_verbal_interrupt("what time is it in tokyo")
+    assert not is_verbal_interrupt("can you wait for the report")  # 'wait' mid-sentence
+    assert not is_verbal_interrupt("")
+
+
+def test_arabic_interrupts_and_tashkeel():
+    assert is_verbal_interrupt("توقف")
+    assert is_verbal_interrupt("خلاص")
+    assert is_verbal_interrupt("خَلَاص")  # with tashkeel diacritics
+    assert is_verbal_interrupt("يا مساعد، توقف", ("مساعد",))  # Arabic wake-phrase strip
+    assert not is_verbal_interrupt("ما هو الطقس اليوم")  # normal Arabic sentence
+
+
+def test_thinking_expression_constant():
+    assert expression.THINKING == "thinking"
+    # the heuristic never infers 'thinking' from text (it's a state cue)
+    assert expression.infer_emotion("I am thinking about it") != expression.THINKING

--- a/plugins/teams_voice/tools.py
+++ b/plugins/teams_voice/tools.py
@@ -1,0 +1,47 @@
+"""Agent-facing tools for the teams_voice bridge.
+
+For the scaffold this is just a read-only status tool. The realtime call tools
+(``look_at_screen``, ``show_to_caller``, ``post_meeting_minutes``) are surfaced
+to the *realtime model* per-call by the dialogue handler, not registered here as
+global agent tools — they only make sense inside an active call.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from .config import resolve_config
+
+TEAMS_VOICE_STATUS_SCHEMA: Dict[str, Any] = {
+    "name": "teams_voice_status",
+    "description": (
+        "Report the Microsoft Teams voice/video (CVI) bridge configuration and "
+        "readiness: bind host/port, whether a shared secret is configured, and "
+        "whether the aiohttp dependency is available. Does not reveal the secret."
+    ),
+    "parameters": {"type": "object", "properties": {}},
+}
+
+
+def check_requirements() -> bool:
+    """The bridge needs aiohttp (already a Hermes gateway dependency)."""
+    try:
+        import aiohttp  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def handle_teams_voice_status(**_kwargs: Any) -> str:
+    cfg = resolve_config()
+    return json.dumps(
+        {
+            "ok": True,
+            "configured": cfg.configured,  # bool — never the secret itself
+            "host": cfg.host,
+            "port": cfg.port,
+            "path": cfg.path,
+            "deps_available": check_requirements(),
+        }
+    )

--- a/plugins/teams_voice/verbal_interrupts.py
+++ b/plugins/teams_voice/verbal_interrupts.py
@@ -1,0 +1,106 @@
+"""Deterministic verbal interrupts — "stop" / "hold on" / Arabic equivalents.
+
+Ported from openclaw #92081. A spoken interrupt cuts playback in code (not by
+trusting the model), so it works even when the model wouldn't have stopped. The
+match is **whole-utterance** with filler and configured wake-phrase stripping:
+
+* ``"stop"`` / ``"⟨name⟩, stop"`` / ``"please stop"`` → interrupt
+* ``"stop by the store"`` → NOT an interrupt (substring never triggers)
+
+Unicode-aware (``\\p{L}``-style via Python's default ``\\w``) with tashkeel-safe
+Arabic normalization, so Arabic interrupts ("توقف", "خلاص", …) match identically.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+# Whole-utterance interrupt phrases (normalized). English + Arabic.
+_INTERRUPT_PHRASES: frozenset[str] = frozenset(
+    {
+        # English
+        "stop",
+        "stop stop",
+        "wait",
+        "wait wait",
+        "hold on",
+        "hold up",
+        "never mind",
+        "nevermind",
+        "quiet",
+        "be quiet",
+        "shut up",
+        "enough",
+        "cancel",
+        "cancel that",
+        # Arabic
+        "توقف",
+        "قف",
+        "خلاص",
+        "كفى",
+        "اسكت",
+        "بس",
+        "كفاية",
+    }
+)
+
+# Leading/trailing filler stripped before matching.
+_FILLER: frozenset[str] = frozenset(
+    {"um", "uh", "er", "ok", "okay", "please", "hey", "yeah", "no", "من", "فضلك", "يا"}
+)
+
+# Arabic diacritics (tashkeel) + tatweel to strip for robust matching.
+_TASHKEEL = re.compile(r"[ؐ-ًؚ-ٰٟۖ-ۭـ]")
+_NON_WORD = re.compile(r"[^\w]+", re.UNICODE)
+
+
+def _normalize(text: str) -> str:
+    text = unicodedata.normalize("NFKC", text or "")
+    text = _TASHKEEL.sub("", text)
+    text = text.lower()
+    text = _NON_WORD.sub(" ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _strip_edges(tokens: list[str], wake_lists: list[list[str]]) -> list[str]:
+    """Iteratively peel leading/trailing filler and wake phrases until stable."""
+
+    def peel_leading(toks: list[str]) -> bool:
+        changed = False
+        while toks and toks[0] in _FILLER:
+            toks.pop(0)
+            changed = True
+        for wl in wake_lists:
+            if wl and toks[: len(wl)] == wl:
+                del toks[: len(wl)]
+                return True
+        return changed
+
+    def peel_trailing(toks: list[str]) -> bool:
+        changed = False
+        while toks and toks[-1] in _FILLER:
+            toks.pop()
+            changed = True
+        for wl in wake_lists:
+            if wl and len(toks) >= len(wl) and toks[len(toks) - len(wl) :] == wl:
+                del toks[len(toks) - len(wl) :]
+                return True
+        return changed
+
+    while tokens and peel_leading(tokens):
+        pass
+    while tokens and peel_trailing(tokens):
+        pass
+    return tokens
+
+
+def is_verbal_interrupt(transcript: str, wake_phrases: tuple[str, ...] = ()) -> bool:
+    """True if ``transcript`` is (just) a verbal interrupt, after stripping
+    leading/trailing wake phrases and filler words."""
+    norm = _normalize(transcript)
+    if not norm:
+        return False
+    wake_lists = [_normalize(p).split(" ") for p in wake_phrases if _normalize(p)]
+    tokens = _strip_edges([t for t in norm.split(" ") if t], wake_lists)
+    return " ".join(tokens) in _INTERRUPT_PHRASES

--- a/plugins/teams_voice/verbal_interrupts.py
+++ b/plugins/teams_voice/verbal_interrupts.py
@@ -1,6 +1,6 @@
 """Deterministic verbal interrupts — "stop" / "hold on" / Arabic equivalents.
 
-Ported from openclaw #92081. A spoken interrupt cuts playback in code (not by
+A spoken interrupt cuts playback in code (not by
 trusting the model), so it works even when the model wouldn't have stopped. The
 match is **whole-utterance** with filler and configured wake-phrase stripping:
 

--- a/plugins/teams_voice/viseme_estimate.py
+++ b/plugins/teams_voice/viseme_estimate.py
@@ -1,0 +1,121 @@
+"""Viseme lip-shape estimation — Python port of openclaw ``viseme-estimate.ts``.
+
+Produces a timeline of ``{tMs, visemeId}`` marks for the avatar mouth, using the
+Microsoft/Azure SSML viseme id set (0-21). Two timing sources:
+
+* :func:`visemes_from_alignment` — real per-character timing (e.g. ElevenLabs
+  ``/with-timestamps``); preferred when available.
+* :func:`estimate_visemes` — an even-spread estimate from text + audio duration;
+  the always-available fallback.
+
+The worker blends these coarse shapes over its RMS-driven mouth openness, so a
+missing/empty timeline simply degrades to RMS-only lip-sync. Covers Latin; Arabic
+graphemes map to a neutral-open shape (full parity is a follow-up — see TODO).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# A representative subset of Azure viseme ids. The worker's ``ShapeForViseme``
+# maps the full 0-21 range; here we emit the ids the estimator can resolve from
+# text. 0 = silence.
+VISEME_SILENCE = 0
+VISEME_AA = 2  # open vowel (a)
+VISEME_EE = 4  # wide (e/i)
+VISEME_OH = 8  # round (o)
+VISEME_OO = 7  # tight round (u/w)
+VISEME_FV = 18  # lip-teeth (f/v)
+VISEME_L = 14  # dental-ish (l/d/t/n)
+VISEME_MBP = 21  # closed (m/b/p)
+VISEME_SS = 15  # wide fricative (s/z)
+VISEME_NEUTRAL = 1  # mid-open default
+
+# Grapheme -> viseme id. Lowercase Latin only; everything else -> neutral/open.
+_CHAR_VISEME: dict[str, int] = {
+    "a": VISEME_AA,
+    "e": VISEME_EE,
+    "i": VISEME_EE,
+    "o": VISEME_OH,
+    "u": VISEME_OO,
+    "w": VISEME_OO,
+    "f": VISEME_FV,
+    "v": VISEME_FV,
+    "m": VISEME_MBP,
+    "b": VISEME_MBP,
+    "p": VISEME_MBP,
+    "s": VISEME_SS,
+    "z": VISEME_SS,
+    "l": VISEME_L,
+    "d": VISEME_L,
+    "t": VISEME_L,
+    "n": VISEME_L,
+    "r": VISEME_OO,
+}
+
+
+@dataclass(frozen=True)
+class VisemeMark:
+    """One mouth-shape change at ``t_ms`` (relative to utterance start)."""
+
+    t_ms: int
+    viseme_id: int
+
+    def to_dict(self) -> dict[str, int]:
+        return {"tMs": self.t_ms, "visemeId": self.viseme_id}
+
+
+def viseme_for_char(ch: str) -> int:
+    """Map a single character to a viseme id (whitespace/punct -> silence)."""
+    if not ch or ch.isspace():
+        return VISEME_SILENCE
+    lowered = ch.lower()
+    if lowered in _CHAR_VISEME:
+        return _CHAR_VISEME[lowered]
+    if lowered.isalpha():
+        # TODO(arabic): map Arabic graphemes to their nearest shapes for true
+        # lip-sync instead of neutral-open (parity with viseme-estimate.ts).
+        return VISEME_NEUTRAL
+    return VISEME_SILENCE
+
+
+def _collapse(marks: list[VisemeMark]) -> list[VisemeMark]:
+    """Drop consecutive marks with the same viseme id (only emit changes)."""
+    out: list[VisemeMark] = []
+    last_id: int | None = None
+    for m in marks:
+        if m.viseme_id != last_id:
+            out.append(m)
+            last_id = m.viseme_id
+    return out
+
+
+def estimate_visemes(text: str, duration_ms: int) -> list[VisemeMark]:
+    """Even-spread viseme timeline across ``duration_ms`` from ``text`` shape.
+
+    Used when the TTS provider returns no per-character timing. Returns an empty
+    list for empty text or non-positive duration (worker falls back to RMS-only).
+    """
+    if not text or duration_ms <= 0:
+        return []
+    chars = list(text)
+    n = len(chars)
+    step = duration_ms / n
+    marks = [VisemeMark(int(i * step), viseme_for_char(chars[i])) for i in range(n)]
+    return _collapse(marks)
+
+
+def visemes_from_alignment(chars: list[tuple[str, int]]) -> list[VisemeMark]:
+    """Build a timeline from real per-character timing.
+
+    ``chars`` is ``[(character, start_ms), ...]`` as surfaced by a TTS provider's
+    alignment endpoint. Preferred over :func:`estimate_visemes` when present.
+    """
+    marks = [VisemeMark(int(start_ms), viseme_for_char(ch)) for ch, start_ms in chars]
+    marks.sort(key=lambda m: m.t_ms)
+    return _collapse(marks)
+
+
+def marks_to_payload(marks: list[VisemeMark]) -> list[dict[str, int]]:
+    """Convert marks to the wire shape consumed by ``protocol.speech_marks``."""
+    return [m.to_dict() for m in marks]

--- a/plugins/teams_voice/viseme_estimate.py
+++ b/plugins/teams_voice/viseme_estimate.py
@@ -16,6 +16,7 @@ graphemes map to a neutral-open shape (full parity is a follow-up — see TODO).
 from __future__ import annotations
 
 from dataclasses import dataclass
+from itertools import groupby
 
 # A representative subset of Azure viseme ids. The worker's ``ShapeForViseme``
 # maps the full 0-21 range; here we emit the ids the estimator can resolve from
@@ -97,13 +98,7 @@ def viseme_for_char(ch: str) -> int:
 
 def _collapse(marks: list[VisemeMark]) -> list[VisemeMark]:
     """Drop consecutive marks with the same viseme id (only emit changes)."""
-    out: list[VisemeMark] = []
-    last_id: int | None = None
-    for m in marks:
-        if m.viseme_id != last_id:
-            out.append(m)
-            last_id = m.viseme_id
-    return out
+    return [next(g) for _, g in groupby(marks, key=lambda m: m.viseme_id)]
 
 
 def estimate_visemes(text: str, duration_ms: int) -> list[VisemeMark]:

--- a/plugins/teams_voice/viseme_estimate.py
+++ b/plugins/teams_voice/viseme_estimate.py
@@ -1,4 +1,4 @@
-"""Viseme lip-shape estimation — Python port of openclaw ``viseme-estimate.ts``.
+"""Viseme lip-shape estimation for the avatar mouth.
 
 Produces a timeline of ``{tMs, visemeId}`` marks for the avatar mouth, using the
 Microsoft/Azure SSML viseme id set (0-21). Two timing sources:

--- a/plugins/teams_voice/viseme_estimate.py
+++ b/plugins/teams_voice/viseme_estimate.py
@@ -53,6 +53,22 @@ _CHAR_VISEME: dict[str, int] = {
     "r": VISEME_OO,
 }
 
+# Arabic grapheme -> viseme id (so Arabic lip-sync isn't neutral-only). Maps the
+# common letters to their nearest mouth shape; diacritics/short vowels are handled
+# by the surrounding consonants.
+_ARABIC_VISEME: dict[str, int] = {
+    "ا": VISEME_AA, "أ": VISEME_AA, "إ": VISEME_AA, "آ": VISEME_AA, "ء": VISEME_AA,  # alif/hamza (open)
+    "و": VISEME_OO, "ؤ": VISEME_OO,  # waw (round)
+    "ي": VISEME_EE, "ى": VISEME_EE, "ئ": VISEME_EE,  # ya (wide)
+    "ب": VISEME_MBP, "م": VISEME_MBP,  # bilabial (closed)
+    "ف": VISEME_FV,  # fa (lip-teeth)
+    "س": VISEME_SS, "ص": VISEME_SS, "ز": VISEME_SS, "ش": VISEME_SS,  # sibilants (wide)
+    "ت": VISEME_L, "ث": VISEME_L, "د": VISEME_L, "ذ": VISEME_L, "ط": VISEME_L,
+    "ظ": VISEME_L, "ل": VISEME_L, "ن": VISEME_L, "ر": VISEME_L, "ة": VISEME_L,  # dental/alveolar
+    "ج": VISEME_AA, "ك": VISEME_AA, "ق": VISEME_AA, "غ": VISEME_AA, "خ": VISEME_AA,
+    "ح": VISEME_AA, "ع": VISEME_AA, "ه": VISEME_AA,  # velar/guttural (mouth open)
+}
+
 
 @dataclass(frozen=True)
 class VisemeMark:
@@ -72,10 +88,10 @@ def viseme_for_char(ch: str) -> int:
     lowered = ch.lower()
     if lowered in _CHAR_VISEME:
         return _CHAR_VISEME[lowered]
+    if ch in _ARABIC_VISEME:
+        return _ARABIC_VISEME[ch]
     if lowered.isalpha():
-        # TODO(arabic): map Arabic graphemes to their nearest shapes for true
-        # lip-sync instead of neutral-open (parity with viseme-estimate.ts).
-        return VISEME_NEUTRAL
+        return VISEME_NEUTRAL  # other scripts: mid-open default
     return VISEME_SILENCE
 
 

--- a/plugins/teams_voice/vision_budget.py
+++ b/plugins/teams_voice/vision_budget.py
@@ -1,7 +1,7 @@
 """Per-call vision spend cap — a sliding 60-second window.
 
 Bounds vision-model cost across all consumers (look_at_screen, ambient push).
-``max_per_minute <= 0`` means unlimited. Port of the openclaw vision budget.
+``max_per_minute <= 0`` means unlimited.
 """
 
 from __future__ import annotations

--- a/plugins/teams_voice/vision_budget.py
+++ b/plugins/teams_voice/vision_budget.py
@@ -1,0 +1,32 @@
+"""Per-call vision spend cap — a sliding 60-second window.
+
+Bounds vision-model cost across all consumers (look_at_screen, ambient push).
+``max_per_minute <= 0`` means unlimited. Port of the openclaw vision budget.
+"""
+
+from __future__ import annotations
+
+import time
+
+
+class VisionBudget:
+    def __init__(self, max_per_minute: int = 30) -> None:
+        self.max_per_minute = max_per_minute
+        self._hits: list[float] = []
+
+    def try_consume(self, now: float | None = None) -> bool:
+        """Record a vision use if under the per-minute limit; return success."""
+        if self.max_per_minute <= 0:
+            return True
+        now = time.monotonic() if now is None else now
+        cutoff = now - 60.0
+        self._hits = [t for t in self._hits if t > cutoff]
+        if len(self._hits) >= self.max_per_minute:
+            return False
+        self._hits.append(now)
+        return True
+
+    def refund(self) -> None:
+        """Give back the most recent hit (e.g. a consult failed before the model)."""
+        if self._hits:
+            self._hits.pop()

--- a/plugins/teams_voice/vision_store.py
+++ b/plugins/teams_voice/vision_store.py
@@ -1,0 +1,53 @@
+"""Per-call vision store — latest frame per source + a keyframe history ring.
+
+The worker forwards sampled ``video.frame`` messages (camera / screenshare). This
+keeps the most recent frame per source for an on-demand ``look_at_screen``, plus a
+bounded ring of recent keyframes for retroactive questions ("what did the earlier
+slide say?"). Port of the openclaw ``msteams-vision-store``.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StoredFrame:
+    source: str  # "camera" | "screenshare"
+    data_base64: str
+    mime: str
+    ts: int
+    participant_name: str | None = None
+
+    def data_url(self) -> str:
+        return f"data:{self.mime};base64,{self.data_base64}"
+
+
+class VisionStore:
+    def __init__(self, history: int = 16) -> None:
+        self._latest: dict[str, StoredFrame] = {}
+        self._history: deque[StoredFrame] = deque(maxlen=history)
+
+    def store(self, frame: StoredFrame) -> None:
+        self._latest[frame.source] = frame
+        self._history.append(frame)
+
+    def latest(self, source: str | None = None) -> StoredFrame | None:
+        """Latest frame for ``source``; if unspecified, prefer screenshare."""
+        if source:
+            return self._latest.get(source)
+        return (
+            self._latest.get("screenshare")
+            or self._latest.get("camera")
+            or next(iter(self._latest.values()), None)
+        )
+
+    def history(self, limit: int = 6) -> list[StoredFrame]:
+        """Up to ``limit`` most-recent keyframes, oldest first."""
+        items = list(self._history)
+        return items[-limit:] if limit > 0 else items
+
+    def clear(self) -> None:
+        self._latest.clear()
+        self._history.clear()

--- a/plugins/teams_voice/vision_store.py
+++ b/plugins/teams_voice/vision_store.py
@@ -23,6 +23,13 @@ class StoredFrame:
     def data_url(self) -> str:
         return f"data:{self.mime};base64,{self.data_base64}"
 
+    def describe(self) -> str:
+        """Attribution label, e.g. "Alice's shared screen" / "the camera"."""
+        surface = "shared screen" if self.source == "screenshare" else "camera"
+        if self.participant_name:
+            return f"{self.participant_name}'s {surface}"
+        return surface
+
 
 class VisionStore:
     def __init__(self, history: int = 16) -> None:

--- a/plugins/teams_voice/vision_store.py
+++ b/plugins/teams_voice/vision_store.py
@@ -3,7 +3,7 @@
 The worker forwards sampled ``video.frame`` messages (camera / screenshare). This
 keeps the most recent frame per source for an on-demand ``look_at_screen``, plus a
 bounded ring of recent keyframes for retroactive questions ("what did the earlier
-slide say?"). Port of the openclaw ``msteams-vision-store``.
+slide say?").
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Adds **Microsoft Teams as a first-class voice, video, and chat channel** for Hermes, with a full **Conversational Video Interface (CVI)**. The agent answers and places Teams calls, **sees** the caller's camera and screen-share, **converses** in real time, **appears** as a lip-synced animated avatar tile, participates in **group meetings** (speaking only when addressed), and handles **Teams chat** — all over recording-gated, allowlisted, HMAC-authenticated transport.

This adds a cross-platform Python driver (`plugins/teams_voice/`) plus chat-plane additions to `plugins/platforms/teams`; a separate companion Windows/.NET media worker owns the Graph/Skype.Bots.Media socket and renders the avatar tile, paired over the HMAC WebSocket bridge.

> **Also available as a standalone plugin on PyPI.** For anyone who wants this before (or without) the merge, the same code is published as a pip-installable Hermes extension that loads via the `hermes_agent.plugins` entry-point — no fork needed: `pip install hermes-plugin-teams-voice` → https://pypi.org/project/hermes-plugin-teams-voice/

| Pillar | Meaning | In this PR |
| --- | --- | --- |
| **Perception** | the agent *sees* | inbound `video.frame` vision — `look_at_screen` (live + retroactive history), realtime continuous/ambient push, camera + screen-share, per-participant attribution |
| **Dialogue** | the agent *converses* | realtime speech-to-speech **and** streaming STT→agent→TTS, barge-in, deterministic verbal interrupts, group "speak only when addressed" gate, recording-gated |
| **Rendering** | the agent *is seen* | a lip-synced avatar tile driven by **expression cues**, **viseme `speech.marks`**, and **`show_to_caller`/`display.image`** senders |

## What's included

**Voice**
- `msteams` on both voice-call modes — **streaming** (STT → agent → TTS) and **realtime** (speech-to-speech), with barge-in.
- Caller **allowlist** (AAD-id, closed when configured); recording-status gate before any media-derived data is processed.
- **Realtime delegation** — the realtime model handles small talk and delegates real work to the Hermes agent: `hermes_agent_consult` for inline answers (a "working on it" filler covers longer runs) and `hermes_agent_task` for background jobs delivered via call-back.
- **Deterministic verbal interrupts** — "stop" / "wait" / "hold on" / "never mind" handled in code, with wake-phrase-form and filler stripping, whole-utterance matching, and Unicode-aware Arabic support.
- **DTMF / IVR** — in-band keypad tones surfaced to the realtime model for "press 1 to…" flows (recording-gated).
- **Bilingual Arabic/English** (opt-in) — detect, mirror, switch-with-caller, translate on request; the deterministic layers (interrupts, visemes) understand Arabic regardless.
- **Roster greeting** — greets the caller by first name and addresses participants by speaker label.

**Inbound video vision**
- `video.frame` ingestion (per source); `look_at_screen` tool + per-turn frame attachment; the agent sees the caller's **camera** and **screen-share**.
- **Realtime continuous vision** — pushes the latest changed frame as an ambient image every ~6 s, no forced response, budget-capped and recording-gated.
- **Scene-change ambient vision** (camera + screen simultaneously, per-source) and **retroactive vision** — a ring of 16 keyframes; `look_at_screen scope:"history"` attaches up to 6 timestamped, attributed keyframes to one budgeted consult.
- Per-call **vision spend cap** (`maxVisionPerMinute`, default 30, `0` = unlimited).

**CVI rendering drivers**
- **Expression cues** — a dependency-free lexical heuristic infers neutral/happy/sad/surprised from reply text; a "thinking" expression holds while a tool runs.
- **Viseme lip-sync** — `speech.marks` carry a per-sound timeline so the avatar mouth changes shape (estimator today; audio never depends on timing).
- **Visual sharing** — `show_to_caller` produces a trusted-local image and renders it via `display.image`, fullscreen or as a **picture-in-picture overlay**, with captions and paced multi-image slideshows.

**Group / meeting calls**
- **Per-participant attribution** — frames carry `participantId` / `participantName`; `look_at_screen` names the participant.
- **Speak only when addressed** — in a group call (2+ humans) the assistant stays silent until addressed by name (`wakePhrases`) with a short follow-up window; 1:1 always responds. Race-free on realtime (auto-response is disabled in meetings; the bot speaks only when an addressed turn creates a response).

**Outbound (call me back)**
- `call_me_back` places a Teams call via the worker's authenticated, SSRF-guarded endpoint; the agent speaks the **result**, then hangs up.
- **Greet-on-answer** — the call-back speaks only once the callee answers (recording-active), not while ringing.

**Chat & governance**
- **"Ask Hermes about this" message action** — a Teams message-context command quotes the selected message into a prompt and dispatches it through the normal message path.
- **Voice-message transcription** (opt-in) — inbound Teams audio clips are transcribed and folded into the agent's turn.
- **Audit-log channel** (opt-in) — agent replies are mirrored to a named Teams conversation at the delivery choke point; a loop guard keeps the audit channel's own traffic out.
- **DLP outbound redaction** (opt-in) — built-in categories plus custom patterns redacted on text, adaptive cards, and captions.
- **SharePoint (OneDrive) file sending** — with `sharePointSiteId` configured, the bot uploads a file to the site drive (app-only Graph), creates an organization sharing link, and posts it to the chat as a **native Teams file card** (markdown-link fallback). Requires the bot app's Graph `Sites.ReadWrite.All` permission.

**Meeting productivity**
- **End-of-meeting recap** (opt-in) — key points / decisions / action items posted to the Teams chat at call end.
- **On-demand minutes** — `post_meeting_minutes` / "summarize the meeting" mid-call posts the running minutes; **per-person attribution** from unmixed meeting audio.
- **Word document** — minutes are also written as a dependency-free, Word-openable `.docx` and **attached to the chat** when SharePoint (OneDrive) file-sending is configured (text-only otherwise).

**Sessions**
- `session_scope` per-call / per-thread / per-aad for agent continuity.

## Validation (live, production tenant)

**Avatar live on the bot's Teams video tile during a production-tenant validation call**

<img width="600" alt="avatar live on the bot's Teams video tile during a production-tenant validation call" src="https://github.com/user-attachments/assets/06af3f1f-b943-4a40-88c9-cd4eb95fc7ba" />

## Reliability & security

- **Echo self-answer fix** — echo guard on a playout clock; no barge-in until the caller's first real turn.
- **HMAC handshake** with single-use `(callId, timestamp, signature)` replay tuples expiring at `ts+window`; loopback bind by default; per-IP / total / pre-start connection caps; strict typed message validation.
- **Compliance** — `require_recording_status` gates audio/video/DTMF until recording is active.
- **Secrets** via `.env` / `${VAR}`, never logged; **SSRF-guarded** outbound (refuses a non-loopback worker URL unless explicitly allowed).

## Config

config.yaml (`plugins.entries.teams_voice.config` + `platforms.teams.extra`), secrets via `${VAR}` in `.env`. Realtime supports OpenAI or Azure. DLP, audit, transcription, bilingual, meeting-recap, and the allowlist are opt-in.

File sending uses `TEAMS_SHAREPOINT_SITE_ID` (env) / `share_point_site_id` (config.yaml `teams_voice.config`, accepts `${TEAMS_SHAREPOINT_SITE_ID}`) — the SharePoint (OneDrive) site id in `host,siteGuid,webGuid` form; empty = text-only minutes. Resolution is config-or-env with an unexpanded-`${VAR}` guard. New env keys are surfaced in both `plugin.yaml` manifests for the config UI.

## Setup — Microsoft Graph permissions

The bot's Azure AD app needs these **application** permissions (admin-consented) for calls, chat, and file sending:

| Permission | Enables |
| --- | --- |
| `Calls.JoinGroupCall.All` | The media worker answers / joins Teams calls and meetings |
| `Calls.AccessMedia.All` | Access the call's real-time audio/video media (`Skype.Bots.Media`) |
| `Chat.Read.All` | Resolve chat / thread ids and read message context |
| `ChatMessage.Read.Chat` | Read messages in chats the bot is installed in (resource-specific consent) |
| `Sites.ReadWrite.All` | Upload files / meeting minutes to SharePoint (OneDrive) for chat attachments |

Outbound "call me back" additionally needs `Calls.InitiateGroupCall.All` (omit if outbound calls aren't used). The call media itself is carried by the companion Windows/.NET media worker; this driver handles signalling-side authorization via the same app registration.

## Tests

120 unit + integration tests — protocol, HMAC/replay + golden wire-contract, audio resampling, VAD utterance segmentation, expression, visemes (Latin + Arabic), group gate, verbal interrupts (EN/AR), config precedence, vision budget, allowlist (+ inheritance), pending-outbound TTL, outbound SSRF, realtime response guards, streaming vision auto-attach, DLP engine + adapter integration, message-action extraction, meeting transcript/summary + `.docx`, SharePoint file-card builder, CallToolRunner / CallContext, and handler integration (allowlist-rejects, race-free group gate, streaming task-cancel). Cross-platform (Windows-footgun lint clean). Validated end-to-end on a live Teams call (realtime, Azure OpenAI).

Worker-owned (inherited from the companion .NET media worker, not this driver): outbound voicemail fallback, auto-hangup / no-answer timeout, active-speaker camera follow, and the roster `displayName` (resolved worker-side; the driver already reads `caller.displayName`).
