### PR TITLE
fix(desktop): normalize artifact timestamps

### DIFF
--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -59,4 +59,67 @@ describe('collectArtifactsForSession', () => {
       value: 'https://example.com/changelog/latest'
     })
   })
+
+  it('normalizes epoch-second message timestamps for sorting and display', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Reference: https://example.com/report.pdf',
+        role: 'assistant',
+        timestamp: 1_781_774_001.5943704
+      }
+    ])
+
+    expect(artifacts[0]?.timestamp).toBe(1_781_774_001_594.3704)
+  })
+
+  it('leaves millisecond message timestamps unchanged', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Reference: https://example.com/report.pdf',
+        role: 'assistant',
+        timestamp: 1_781_774_001_594
+      }
+    ])
+
+    expect(artifacts[0]?.timestamp).toBe(1_781_774_001_594)
+  })
+
+  it('does not promote browser page image assets to artifacts', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({
+          snapshot:
+            'link "ad" https://example.com/workspace-advertising/banner.gif and text https://example.com/article'
+        }),
+        role: 'tool',
+        timestamp: 4000,
+        tool_name: 'browser_snapshot'
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({
+      href: 'https://example.com/article',
+      kind: 'link',
+      value: 'https://example.com/article'
+    })
+  })
+
+  it('keeps generated remote images as artifacts', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: JSON.stringify({ image: 'https://cdn.example.com/generated/cat.png', success: true }),
+        role: 'tool',
+        timestamp: 5000,
+        tool_name: 'image_generate'
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({
+      href: 'https://cdn.example.com/generated/cat.png',
+      kind: 'image',
+      value: 'https://cdn.example.com/generated/cat.png'
+    })
+  })
 })

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -57,6 +57,7 @@ const PATH_RE = /(^|[\s("'`])((?:\/|~\/|\.\.?\/)[^\s"'`<>]+(?:\.[a-z0-9]{1,8})?)
 const IMAGE_EXT_RE = /\.(?:png|jpe?g|gif|webp|svg|bmp)(?:\?.*)?$/i
 const FILE_EXT_RE = /\.(?:png|jpe?g|gif|webp|svg|bmp|pdf|txt|json|md|csv|zip|tar|gz|mp3|wav|mp4|mov)(?:\?.*)?$/i
 const KEY_HINT_RE = /(path|file|url|image|artifact|output|download|result|target)/i
+const EPOCH_SECONDS_CUTOFF = 1_000_000_000_000
 
 const ARTIFACT_TIME_FMT = new Intl.DateTimeFormat(undefined, {
   day: 'numeric',
@@ -67,6 +68,22 @@ const ARTIFACT_TIME_FMT = new Intl.DateTimeFormat(undefined, {
 
 function normalizeValue(value: string): string {
   return value.trim().replace(/[),.;]+$/, '')
+}
+
+function artifactTimestampMs(timestamp: number): number {
+  return timestamp > 0 && timestamp < EPOCH_SECONDS_CUTOFF ? timestamp * 1000 : timestamp
+}
+
+function messageToolName(message: SessionMessage): string {
+  return message.tool_name || message.name || ''
+}
+
+function isBrowserToolMessage(message: SessionMessage): boolean {
+  return message.role === 'tool' && messageToolName(message).startsWith('browser_')
+}
+
+function isRemoteImageArtifact(value: string): boolean {
+  return value.startsWith('data:image/') || (/^https?:\/\//i.test(value) && IMAGE_EXT_RE.test(value))
 }
 
 function parseMaybeJson(value: string): unknown {
@@ -276,10 +293,16 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
       continue
     }
 
+    const browserToolMessage = isBrowserToolMessage(message)
+
     collectArtifactsFromMessage(message, candidate => {
       const value = normalizeValue(candidate)
 
       if (!value || !looksLikeArtifact(value)) {
+        return
+      }
+
+      if (browserToolMessage && isRemoteImageArtifact(value)) {
         return
       }
 
@@ -297,7 +320,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         label: artifactLabel(value),
         sessionId: session.id,
         sessionTitle: title,
-        timestamp: message.timestamp || session.last_active || session.started_at || Date.now()
+        timestamp: artifactTimestampMs(message.timestamp || session.last_active || session.started_at || Date.now())
       })
     })
   }
@@ -306,7 +329,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
 }
 
 function formatArtifactTime(timestamp: number): string {
-  return ARTIFACT_TIME_FMT.format(new Date(timestamp))
+  return ARTIFACT_TIME_FMT.format(new Date(artifactTimestampMs(timestamp)))
 }
 
 function pageRangeLabel(total: number, page: number, pageSize: number, a: Translations['artifacts']): string {


### PR DESCRIPTION
## Summary
- normalize Desktop Artifacts timestamps from epoch seconds to JavaScript milliseconds before sorting/formatting
- keep millisecond timestamps unchanged for compatibility
- suppress remote page image assets emitted by browser_* tool output while preserving generated image artifacts

Fixes #48350

## Tests
- npm --workspace apps/desktop run test:ui -- src/app/artifacts/index.test.ts
- npm --workspace apps/desktop run typecheck
- npm --workspace apps/desktop exec eslint src/app/artifacts/index.tsx src/app/artifacts/index.test.ts
- git diff --check

## Review
- Subagent review: no blocking or high-confidence non-blocking issues found