### PR TITLE
fix(guardrails): add skills_list/skill_view to IDEMPOTENT_TOOL_NAMES

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -27,6 +27,8 @@ IDEMPOTENT_TOOL_NAMES = frozenset(
         "browser_snapshot",
         "browser_console",
         "browser_get_images",
+        "skills_list",
+        "skill_view",
         "mcp_filesystem_read_file",
         "mcp_filesystem_read_text_file",
         "mcp_filesystem_read_multiple_files",

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -228,6 +228,31 @@ def test_hard_stop_enabled_blocks_idempotent_no_progress_future_repeat():
     assert blocked.code == "idempotent_no_progress_block"
 
 
+def test_skill_tools_are_idempotent_for_loop_guardrail():
+    """skills_list and skill_view are read-only tools that should be
+    covered by the idempotent no-progress guardrail (issue #49075)."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=2,
+        )
+    )
+    args = {"name": "some-skill"}
+    result = '{"success": true, "content": "skill body"}'
+
+    assert controller.before_call("skill_view", args).action == "allow"
+    assert controller.after_call("skill_view", args, result, failed=False).action == "allow"
+    assert controller.before_call("skill_view", args).action == "allow"
+    warn = controller.after_call("skill_view", args, result, failed=False)
+    assert warn.action == "warn"
+    assert warn.code == "idempotent_no_progress_warning"
+
+    blocked = controller.before_call("skill_view", args)
+    assert blocked.action == "block"
+    assert blocked.code == "idempotent_no_progress_block"
+
+
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)


### PR DESCRIPTION
## Summary

`skills_list` and `skill_view` are read-only, deterministic-for-a-given-input tools in the same functional category as `read_file`, `search_files`, and `session_search` — but they were missing from the `IDEMPOTENT_TOOL_NAMES` frozenset in `agent/tool_guardrails.py`.

This meant an agent that repeatedly calls `skill_view` on an already-loaded skill (a successful call every time, never an "error") was invisible to the `idempotent_no_progress` loop guardrail entirely. The threshold never fired, regardless of `hard_stop_enabled` or threshold configuration, because the no-progress check only runs if `tool_name in self.config.idempotent_tools`.

## Fix

Add `skills_list` and `skill_view` to `IDEMPOTENT_TOOL_NAMES`. Single-line addition to an existing frozenset — no behavior change for any tool already on the list.

## Test

Added `test_skill_tools_are_idempotent_for_loop_guardrail` which verifies that repeated identical `skill_view` calls trigger the `idempotent_no_progress` warning and block path, mirroring the existing `read_file` test pattern.

```
tests/agent/test_tool_guardrails.py::test_skill_tools_are_idempotent_for_loop_guardrail PASSED
```

All 14 tests in `test_tool_guardrails.py` pass.

Closes #49075