### PR TITLE
feat(tools): add Matrix room-admin tools (create/leave/delete)

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3851,6 +3851,32 @@ class MatrixAdapter(BasePlatformAdapter):
                     pass
             return False
 
+    def reconcile_left_room(self, room_id: str) -> None:
+        """Evict *room_id* from the live membership caches after a leave/forget.
+
+        Incremental sync only ADDS room ids (``self._joined_rooms.update(...)``
+        in ``_sync_loop`` / initial sync), and ``_join_room_by_id`` trusts
+        ``self._joined_rooms`` — returning True without re-joining when the id
+        is already present. A raw Client-Server leave/forget issued by an agent
+        tool (``tools/matrix_room_tool.py``) bypasses the sync loop, so without
+        this the id lingers in the cache: a later ``_join_room_by_id`` sees it
+        and skips the real join, leaving the room dead for dispatch.
+
+        Clearing ``_joined_rooms`` (and the identity / DM / pending-invite
+        caches keyed by the id) keeps the cache consistent with membership so a
+        subsequent join re-establishes it. Pure in-memory mutation (no awaits),
+        so it is safe to call from the agent tool's event loop.
+        """
+        if not room_id:
+            return
+        self._joined_rooms.discard(room_id)
+        self._room_identities.pop(room_id, None)
+        self._room_identity_cached_at.pop(room_id, None)
+        self._dm_rooms.pop(room_id, None)
+        pending = self._invite_join_tasks.pop(room_id, None)
+        if pending is not None and not pending.done():
+            pending.cancel()
+
     def _schedule_invite_join(
         self,
         room_id: str,

--- a/tests/test_matrix_room_admin.py
+++ b/tests/test_matrix_room_admin.py
@@ -1,0 +1,145 @@
+"""Unit tests for the matrix_leave_room + matrix_delete_room agent tools.
+
+Mocks the raw CS-API call (_matrix_room_action) and the creds source
+(_matrix_creds) — we test OUR logic (validation, leave/forget sequencing,
+idempotency, error surfacing, gating), never a live Matrix server.
+"""
+import asyncio
+import json
+
+import pytest
+
+from tools import matrix_room_tool as m
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _parse(result):
+    """Tool handlers return JSON strings."""
+    assert isinstance(result, str)
+    return json.loads(result)
+
+
+@pytest.fixture()
+def creds(monkeypatch):
+    monkeypatch.setattr(m, "_matrix_creds", lambda: ("https://matrix.example.org", "tok"))
+
+
+def _recorder(responses):
+    """Build an async stand-in for _matrix_room_action returning canned
+    (status, text) per action, recording every call."""
+    calls = []
+
+    async def fake(homeserver, token, room_id, action, body=None):
+        calls.append({"room_id": room_id, "action": action, "body": body})
+        return responses[action]
+
+    fake.calls = calls
+    return fake
+
+
+# --------------------------------------------------------------------------
+# matrix_leave_room
+# --------------------------------------------------------------------------
+class TestLeaveRoom:
+    def test_leave_success(self, creds, monkeypatch):
+        fake = _recorder({"leave": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!r:hs"})))
+        assert out["success"] is True
+        assert out["room_id"] == "!r:hs"
+        assert out["action"] == "leave"
+        assert [c["action"] for c in fake.calls] == ["leave"]
+
+    def test_leave_passes_reason(self, creds, monkeypatch):
+        fake = _recorder({"leave": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        _run(m._handle_matrix_leave_room({"room_id": "!r:hs", "reason": "cleanup"}))
+        assert fake.calls[0]["body"] == {"reason": "cleanup"}
+
+    def test_leave_missing_room_id(self, creds):
+        out = _parse(_run(m._handle_matrix_leave_room({})))
+        assert "room_id is required" in out["error"]
+
+    def test_leave_not_configured(self, monkeypatch):
+        monkeypatch.setattr(m, "_matrix_creds", lambda: ("", ""))
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!r:hs"})))
+        assert "Matrix not configured" in out["error"]
+
+    def test_leave_http_error(self, creds, monkeypatch):
+        fake = _recorder({"leave": (404, '{"errcode":"M_NOT_FOUND"}')})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!r:hs"})))
+        assert "Matrix leave error (404)" in out["error"]
+
+
+# --------------------------------------------------------------------------
+# matrix_delete_room  (leave + forget)
+# --------------------------------------------------------------------------
+class TestDeleteRoom:
+    def test_delete_leave_then_forget(self, creds, monkeypatch):
+        fake = _recorder({"leave": (200, "{}"), "forget": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_delete_room({"room_id": "!r:hs"})))
+        assert out["success"] is True
+        assert out["action"] == "leave+forget"
+        assert [c["action"] for c in fake.calls] == ["leave", "forget"]
+
+    def test_delete_tolerates_already_left(self, creds, monkeypatch):
+        # leaving a room you're not in -> 403 M_FORBIDDEN; delete must still forget
+        fake = _recorder({
+            "leave": (403, '{"errcode":"M_FORBIDDEN","error":"not in room"}'),
+            "forget": (200, "{}"),
+        })
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_delete_room({"room_id": "!r:hs"})))
+        assert out["success"] is True
+        assert [c["action"] for c in fake.calls] == ["leave", "forget"]
+
+    def test_delete_leave_hard_error_skips_forget(self, creds, monkeypatch):
+        fake = _recorder({"leave": (500, "boom"), "forget": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_delete_room({"room_id": "!r:hs"})))
+        assert "Matrix leave (during delete) error (500)" in out["error"]
+        assert [c["action"] for c in fake.calls] == ["leave"]  # forget NOT attempted
+
+    def test_delete_forget_error(self, creds, monkeypatch):
+        fake = _recorder({"leave": (200, "{}"), "forget": (400, '{"errcode":"M_UNKNOWN"}')})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_delete_room({"room_id": "!r:hs"})))
+        assert "Matrix forget error (400)" in out["error"]
+
+    def test_delete_missing_room_id(self, creds):
+        out = _parse(_run(m._handle_matrix_delete_room({})))
+        assert "room_id is required" in out["error"]
+
+
+# --------------------------------------------------------------------------
+# gating
+# --------------------------------------------------------------------------
+class TestGate:
+    @pytest.mark.parametrize("val,expected", [
+        ("true", True), ("1", True), ("yes", True), ("TRUE", True),
+        ("", False), ("false", False), ("no", False),
+    ])
+    def test_room_admin_gate(self, monkeypatch, val, expected):
+        monkeypatch.setenv("MATRIX_TOOLS_ALLOW_ROOM_CREATE", val)
+        assert m._check_matrix_room_admin() is expected
+
+    def test_gate_unset(self, monkeypatch):
+        monkeypatch.delenv("MATRIX_TOOLS_ALLOW_ROOM_CREATE", raising=False)
+        assert m._check_matrix_room_admin() is False
+
+
+# --------------------------------------------------------------------------
+# registry wiring — tools are actually registered under hermes-matrix
+# --------------------------------------------------------------------------
+class TestRegistration:
+    def test_tools_registered(self):
+        from tools.registry import registry
+        assert "matrix_leave_room" in registry._tools
+        assert "matrix_delete_room" in registry._tools
+        assert registry._tools["matrix_leave_room"].toolset == "hermes-matrix"
+        assert registry._tools["matrix_delete_room"].toolset == "hermes-matrix"

--- a/tests/test_matrix_room_admin.py
+++ b/tests/test_matrix_room_admin.py
@@ -38,9 +38,12 @@ def _assert_error(out, needle):
 @pytest.fixture(autouse=True)
 def _isolated_session_context(monkeypatch):
     """Reset per-task session contextvars and session/env scoping vars so each
-    test starts from "no current room bound" (the CLI/standalone case)."""
+    test starts from "no current room bound, no allowlist, no escape hatch"
+    (the strict CLI/standalone default) unless a test opts in explicitly."""
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("MATRIX_ALLOWED_ROOMS", raising=False)
+    monkeypatch.delenv("MATRIX_TOOLS_ALLOW_ANY_ROOM", raising=False)
+    monkeypatch.delenv("MATRIX_ALLOW_PUBLIC_ROOMS", raising=False)
     try:
         from gateway.session_context import reset_session_vars
 
@@ -275,9 +278,52 @@ class TestRoomAuthorization:
         _assert_error(out, "outside this turn's scope")
         assert fake.calls == []  # neither leave nor forget attempted
 
-    def test_standalone_room_allowed_without_context(self, creds, monkeypatch):
+    # --- fail-closed contract: no scope established => deny, not allow -------
+
+    def test_no_context_no_allowlist_is_denied(self, creds, monkeypatch):
         # No current room bound, no allowlist, no live adapter (cron/CLI/
-        # one-shot): nothing to scope against, so the room is permitted.
+        # one-shot): there is nothing to scope against, so a destructive
+        # action must be DENIED (fail closed), not silently allowed.
+        monkeypatch.setattr(m, "_current_room", lambda: "")
+        monkeypatch.setattr(m, "_allowed_room_ids", lambda: set())
+        monkeypatch.setattr(m, "_joined_rooms", lambda: None)
+        fake = _recorder({"leave": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!any:hs"})))
+        _assert_error(out, "MATRIX_TOOLS_ALLOW_ANY_ROOM")
+        assert fake.calls == []  # no API call once authorization fails
+
+    def test_no_context_undeclared_when_allowlist_set(self, creds, monkeypatch):
+        # A NON-empty allowlist is a whitelist: it establishes scope, so a
+        # room outside it is denied with the allowlist-specific message.
+        monkeypatch.setattr(m, "_current_room", lambda: "")
+        monkeypatch.setattr(m, "_allowed_room_ids", lambda: {"!listed:hs"})
+        monkeypatch.setattr(m, "_joined_rooms", lambda: None)
+        fake = _recorder({"leave": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!any:hs"})))
+        _assert_error(out, "MATRIX_ALLOWED_ROOMS")
+        assert fake.calls == []
+
+    def test_unavailable_adapter_does_not_widen_scope(self, creds, monkeypatch):
+        # Adapter unavailable (_joined_rooms() is None) must NOT be read as
+        # "no scope, allow": with an empty allowlist and no current room the
+        # deny must still stand.
+        monkeypatch.setattr(m, "_current_room", lambda: "")
+        monkeypatch.setattr(m, "_allowed_room_ids", lambda: set())
+        monkeypatch.setattr(m, "_joined_rooms", lambda: None)
+        assert m._authorize_room("!any:hs") is not None
+        # ...but a positive membership match still authorizes.
+        monkeypatch.setattr(m, "_joined_rooms", lambda: {"!known:hs"})
+        assert m._authorize_room("!known:hs") is None
+
+    # --- explicit opt-in escape hatch ---------------------------------------
+
+    def test_allow_any_room_flag_permits_roomless_context(self, creds, monkeypatch):
+        # The operator escape hatch: MATRIX_TOOLS_ALLOW_ANY_ROOM=true lets a
+        # room-less cron/standalone run act on an arbitrary room.
+        monkeypatch.delenv("MATRIX_TOOLS_ALLOW_ANY_ROOM", raising=False)
+        monkeypatch.setattr(m, "_allow_any_room", lambda: True)
         monkeypatch.setattr(m, "_current_room", lambda: "")
         monkeypatch.setattr(m, "_allowed_room_ids", lambda: set())
         monkeypatch.setattr(m, "_joined_rooms", lambda: None)
@@ -285,6 +331,29 @@ class TestRoomAuthorization:
         monkeypatch.setattr(m, "_matrix_room_action", fake)
         out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!any:hs"})))
         assert out["success"] is True
+        assert [c["room_id"] for c in fake.calls] == ["!any:hs"]
+
+    @pytest.mark.parametrize("val,expected", [
+        ("true", True), ("1", True), ("yes", True),
+        ("", False), ("false", False), ("no", False),
+    ])
+    def test_allow_any_room_flag_truth_table(self, monkeypatch, val, expected):
+        monkeypatch.setenv("MATRIX_TOOLS_ALLOW_ANY_ROOM", val)
+        assert m._allow_any_room() is expected
+
+    def test_allow_any_room_flag_unset(self, monkeypatch):
+        monkeypatch.delenv("MATRIX_TOOLS_ALLOW_ANY_ROOM", raising=False)
+        assert m._allow_any_room() is False
+
+    def test_allow_any_room_flag_does_not_bypass_allowlist(self, creds, monkeypatch):
+        # The flag only lifts the room-less denial; a non-empty allowlist
+        # still acts as a strict whitelist.
+        monkeypatch.setattr(m, "_allow_any_room", lambda: True)
+        monkeypatch.setattr(m, "_current_room", lambda: "")
+        monkeypatch.setattr(m, "_allowed_room_ids", lambda: {"!listed:hs"})
+        monkeypatch.setattr(m, "_joined_rooms", lambda: None)
+        assert m._authorize_room("!listed:hs") is None
+        assert m._authorize_room("!other:hs") is not None
 
     def test_allowlist_set_rejects_unlisted_room(self, creds, monkeypatch):
         # An allowlist is a strict whitelist: a room not in it is rejected

--- a/tests/test_matrix_room_admin.py
+++ b/tests/test_matrix_room_admin.py
@@ -1,0 +1,541 @@
+"""Unit tests for the Matrix room-admin agent tools (create / leave / delete).
+
+Mocks the raw CS-API calls (_matrix_create_room_api / _matrix_room_action), the
+creds source (_matrix_creds), and the live-adapter lookup (_live_adapter) — we
+test OUR logic (validation, room-boundary authorization, leave/forget
+sequencing, idempotency, error surfacing, adapter-cache reconciliation,
+gating, toolset scoping), never a live Matrix server.
+"""
+import asyncio
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import PlatformConfig
+from tools import matrix_room_tool as m
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _parse(result):
+    """Tool handlers return JSON strings."""
+    assert isinstance(result, str)
+    return json.loads(result)
+
+
+def _assert_error(out, needle):
+    """tool_error() emits {"error": ...} with no 'success' key — so an error
+    payload is *error-only*. Fail the test unless the message is present and
+    there is no success=True on the other side of the split."""
+    assert out.get("error"), f"expected an error payload, got {out!r}"
+    assert needle in out["error"], f"{needle!r} not in {out['error']!r}"
+    assert out.get("success") is not True
+
+
+@pytest.fixture(autouse=True)
+def _isolated_session_context(monkeypatch):
+    """Reset per-task session contextvars and session/env scoping vars so each
+    test starts from "no current room bound" (the CLI/standalone case)."""
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.delenv("MATRIX_ALLOWED_ROOMS", raising=False)
+    try:
+        from gateway.session_context import reset_session_vars
+
+        reset_session_vars()
+    except Exception:
+        pass
+
+
+@pytest.fixture()
+def creds(monkeypatch):
+    monkeypatch.setattr(m, "_matrix_creds", lambda: ("https://matrix.example.org", "tok"))
+
+
+@pytest.fixture()
+def default_authz(monkeypatch):
+    """Authorize-everything environment: a bound current room, no allowlist,
+    no live adapter. Individual tests narrow this as needed."""
+    monkeypatch.setattr(m, "_current_room", lambda: "!cur:hs")
+    monkeypatch.setattr(m, "_allowed_room_ids", lambda: set())
+    monkeypatch.setattr(m, "_joined_rooms", lambda: None)
+
+
+def _recorder(responses):
+    """Build an async stand-in for _matrix_room_action returning canned
+    (status, text) per action, recording every call."""
+    calls = []
+
+    async def fake(homeserver, token, room_id, action, body=None):
+        calls.append({"room_id": room_id, "action": action, "body": body})
+        return responses[action]
+
+    fake.calls = calls
+    return fake
+
+
+def _api_recorder(response):
+    """Build an async stand-in for _matrix_create_room_api returning a canned
+    (status, data) pair and recording every request body."""
+    calls = []
+
+    async def fake(homeserver, token, body):
+        calls.append({"homeserver": homeserver, "token": token, "body": body})
+        return response
+
+    fake.calls = calls
+    return fake
+
+
+def _make_adapter():
+    """Create a MatrixAdapter with mocked config (mirrors
+    tests/gateway/test_matrix.py::_make_adapter)."""
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@bot:example.org",
+        },
+    )
+    return MatrixAdapter(config)
+
+
+# --------------------------------------------------------------------------
+# matrix_create_room
+# --------------------------------------------------------------------------
+class TestCreateRoom:
+    def test_create_success(self, creds, monkeypatch):
+        fake = _api_recorder((200, {"room_id": "!new:hs"}))
+        monkeypatch.setattr(m, "_matrix_create_room_api", fake)
+        out = _parse(
+            _run(
+                m._handle_matrix_create_room(
+                    {"name": "ops", "topic": "t", "invite": ["@a:hs"], "is_direct": True}
+                )
+            )
+        )
+        assert out["success"] is True
+        assert out["room_id"] == "!new:hs"
+        assert out["invited"] == ["@a:hs"]
+        assert out["preset"] == "private_chat"
+        assert out["encrypted"] is False
+        req = fake.calls[0]
+        assert req["homeserver"] == "https://matrix.example.org"
+        assert req["token"] == "tok"
+        body = req["body"]
+        assert body["name"] == "ops"
+        assert body["topic"] == "t"
+        assert body["invite"] == ["@a:hs"]
+        assert body["is_direct"] is True
+        assert "initial_state" not in body
+
+    def test_create_encrypted_adds_megolm_state(self, creds, monkeypatch):
+        fake = _api_recorder((200, {"room_id": "!e:hs"}))
+        monkeypatch.setattr(m, "_matrix_create_room_api", fake)
+        _run(m._handle_matrix_create_room({"encrypted": True}))
+        body = fake.calls[0]["body"]
+        assert body["initial_state"] == [
+            {
+                "type": "m.room.encryption",
+                "state_key": "",
+                "content": {"algorithm": "m.megolm.v1.aes-sha2"},
+            }
+        ]
+
+    def test_create_public_requires_flag(self, creds, monkeypatch):
+        monkeypatch.delenv("MATRIX_ALLOW_PUBLIC_ROOMS", raising=False)
+        out = _parse(_run(m._handle_matrix_create_room({"preset": "public_chat"})))
+        assert "MATRIX_ALLOW_PUBLIC_ROOMS" in out["error"]
+
+    def test_create_public_allowed_with_flag(self, creds, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOW_PUBLIC_ROOMS", "true")
+        fake = _api_recorder((201, {"room_id": "!pub:hs"}))
+        monkeypatch.setattr(m, "_matrix_create_room_api", fake)
+        out = _parse(_run(m._handle_matrix_create_room({"preset": "public_chat"})))
+        assert out["success"] is True
+        assert fake.calls[0]["body"]["preset"] == "public_chat"
+
+    def test_create_not_configured(self, monkeypatch):
+        monkeypatch.setattr(m, "_matrix_creds", lambda: ("", ""))
+        out = _parse(_run(m._handle_matrix_create_room({})))
+        assert "Matrix not configured" in out["error"]
+
+    def test_create_http_error(self, creds, monkeypatch):
+        fake = _api_recorder((403, {"errcode": "M_FORBIDDEN"}))
+        monkeypatch.setattr(m, "_matrix_create_room_api", fake)
+        out = _parse(_run(m._handle_matrix_create_room({})))
+        assert "Matrix createRoom error (403)" in out["error"]
+
+    def test_create_no_room_id_in_response(self, creds, monkeypatch):
+        fake = _api_recorder((200, {"oops": True}))
+        monkeypatch.setattr(m, "_matrix_create_room_api", fake)
+        out = _parse(_run(m._handle_matrix_create_room({})))
+        assert "createRoom returned no room_id" in out["error"]
+
+    def test_create_api_exception(self, creds, monkeypatch):
+        async def boom(homeserver, token, body):
+            raise RuntimeError("conn reset")
+
+        monkeypatch.setattr(m, "_matrix_create_room_api", boom)
+        out = _parse(_run(m._handle_matrix_create_room({})))
+        assert "matrix_create_room request failed" in out["error"]
+        assert "conn reset" in out["error"]
+
+
+# --------------------------------------------------------------------------
+# matrix_leave_room
+# --------------------------------------------------------------------------
+class TestLeaveRoom:
+    def test_leave_success(self, creds, default_authz, monkeypatch):
+        fake = _recorder({"leave": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!cur:hs"})))
+        assert out["success"] is True
+        assert out["room_id"] == "!cur:hs"
+        assert out["action"] == "leave"
+        assert [c["action"] for c in fake.calls] == ["leave"]
+
+    def test_leave_passes_reason(self, creds, default_authz, monkeypatch):
+        fake = _recorder({"leave": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        _run(m._handle_matrix_leave_room({"room_id": "!cur:hs", "reason": "cleanup"}))
+        assert fake.calls[0]["body"] == {"reason": "cleanup"}
+
+    def test_leave_missing_room_id(self, creds, default_authz):
+        out = _parse(_run(m._handle_matrix_leave_room({})))
+        assert "room_id is required" in out["error"]
+
+    def test_leave_not_configured(self, default_authz, monkeypatch):
+        monkeypatch.setattr(m, "_matrix_creds", lambda: ("", ""))
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!cur:hs"})))
+        assert "Matrix not configured" in out["error"]
+
+    def test_leave_http_error(self, creds, default_authz, monkeypatch):
+        fake = _recorder({"leave": (404, '{"errcode":"M_NOT_FOUND"}')})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!cur:hs"})))
+        assert "Matrix leave error (404)" in out["error"]
+
+
+# --------------------------------------------------------------------------
+# Room authorization (the gateway/session.py Matrix room boundary)
+# --------------------------------------------------------------------------
+class TestRoomAuthorization:
+    def test_leave_rejects_cross_room_when_current_bound(self, creds, default_authz, monkeypatch):
+        fake = _recorder({"leave": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!other:hs"})))
+        _assert_error(out, "outside this turn's scope")
+        assert "!other:hs" in out["error"] and "!cur:hs" in out["error"]
+        assert fake.calls == []  # no API call for an unauthorized room
+
+    def test_leave_allows_current_room(self, creds, default_authz, monkeypatch):
+        fake = _recorder({"leave": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!cur:hs"})))
+        assert out["success"] is True
+        assert fake.calls and fake.calls[0]["room_id"] == "!cur:hs"
+
+    def test_leave_allows_joined_room(self, creds, default_authz, monkeypatch):
+        # This turn is in !cur:hs, but the bot is still a member of !other:hs —
+        # a legitimate leave target.
+        monkeypatch.setattr(m, "_joined_rooms", lambda: {"!other:hs"})
+        fake = _recorder({"leave": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!other:hs"})))
+        assert out["success"] is True
+        assert [c["room_id"] for c in fake.calls] == ["!other:hs"]
+
+    def test_leave_allows_allowlisted_room(self, creds, default_authz, monkeypatch):
+        monkeypatch.setattr(m, "_allowed_room_ids", lambda: {"!allow:hs"})
+        fake = _recorder({"leave": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!allow:hs"})))
+        assert out["success"] is True
+
+    def test_leave_allowlist_beats_current_room(self, creds, default_authz, monkeypatch):
+        # An allowlisted room is a valid target even from another room.
+        monkeypatch.setattr(m, "_allowed_room_ids", lambda: {"!allow:hs"})
+        monkeypatch.setattr(m, "_joined_rooms", lambda: None)
+        fake = _recorder({"leave": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!allow:hs"})))
+        assert out["success"] is True
+        assert out["room_id"] == "!allow:hs"
+
+    def test_delete_rejects_cross_room_when_current_bound(self, creds, default_authz, monkeypatch):
+        fake = _recorder({"leave": (200, "{}"), "forget": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_delete_room({"room_id": "!other:hs"})))
+        _assert_error(out, "outside this turn's scope")
+        assert fake.calls == []  # neither leave nor forget attempted
+
+    def test_standalone_room_allowed_without_context(self, creds, monkeypatch):
+        # No current room bound, no allowlist, no live adapter (cron/CLI/
+        # one-shot): nothing to scope against, so the room is permitted.
+        monkeypatch.setattr(m, "_current_room", lambda: "")
+        monkeypatch.setattr(m, "_allowed_room_ids", lambda: set())
+        monkeypatch.setattr(m, "_joined_rooms", lambda: None)
+        fake = _recorder({"leave": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!any:hs"})))
+        assert out["success"] is True
+
+    def test_allowlist_set_rejects_unlisted_room(self, creds, monkeypatch):
+        # An allowlist is a strict whitelist: a room not in it is rejected
+        # even with no current room bound.
+        monkeypatch.setattr(m, "_current_room", lambda: "")
+        monkeypatch.setattr(m, "_allowed_room_ids", lambda: {"!listed:hs"})
+        monkeypatch.setattr(m, "_joined_rooms", lambda: None)
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!other:hs"})))
+        _assert_error(out, "MATRIX_ALLOWED_ROOMS")
+
+    def test_current_room_from_session_contextvar(self, creds, monkeypatch):
+        # _current_room must read the task-local HERMES_SESSION_CHAT_ID
+        # ContextVar the gateway binds — not the process-global env.
+        from gateway.session_context import set_session_vars
+
+        tokens = set_session_vars(platform="matrix", chat_id="!bound:hs")
+        try:
+            assert m._current_room() == "!bound:hs"
+            # And a cross-room id is rejected against it.
+            monkeypatch.setattr(m, "_allowed_room_ids", lambda: set())
+            monkeypatch.setattr(m, "_joined_rooms", lambda: None)
+            fake = _recorder({"leave": (200, "{}")})
+            monkeypatch.setattr(m, "_matrix_room_action", fake)
+            out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!other:hs"})))
+            _assert_error(out, "outside this turn's scope")
+            assert fake.calls == []
+        finally:
+            from gateway.session_context import clear_session_vars
+
+            clear_session_vars(tokens)
+
+
+# --------------------------------------------------------------------------
+# matrix_delete_room  (leave + forget)
+# --------------------------------------------------------------------------
+class TestDeleteRoom:
+    def test_delete_leave_then_forget(self, creds, default_authz, monkeypatch):
+        fake = _recorder({"leave": (200, "{}"), "forget": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_delete_room({"room_id": "!cur:hs"})))
+        assert out["success"] is True
+        assert out["action"] == "leave+forget"
+        assert [c["action"] for c in fake.calls] == ["leave", "forget"]
+
+    def test_delete_tolerates_already_left(self, creds, default_authz, monkeypatch):
+        # leaving a room you're not in -> 403 M_FORBIDDEN; delete must still forget
+        fake = _recorder({
+            "leave": (403, '{"errcode":"M_FORBIDDEN","error":"not in room"}'),
+            "forget": (200, "{}"),
+        })
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_delete_room({"room_id": "!cur:hs"})))
+        assert out["success"] is True
+        assert [c["action"] for c in fake.calls] == ["leave", "forget"]
+
+    def test_delete_leave_hard_error_skips_forget(self, creds, default_authz, monkeypatch):
+        fake = _recorder({"leave": (500, "boom"), "forget": (200, "{}")})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_delete_room({"room_id": "!cur:hs"})))
+        assert "Matrix leave (during delete) error (500)" in out["error"]
+        assert [c["action"] for c in fake.calls] == ["leave"]  # forget NOT attempted
+
+    def test_delete_forget_error(self, creds, default_authz, monkeypatch):
+        fake = _recorder({"leave": (200, "{}"), "forget": (400, '{"errcode":"M_UNKNOWN"}')})
+        monkeypatch.setattr(m, "_matrix_room_action", fake)
+        out = _parse(_run(m._handle_matrix_delete_room({"room_id": "!cur:hs"})))
+        assert "Matrix forget error (400)" in out["error"]
+
+    def test_delete_missing_room_id(self, creds, default_authz):
+        out = _parse(_run(m._handle_matrix_delete_room({})))
+        assert "room_id is required" in out["error"]
+
+
+# --------------------------------------------------------------------------
+# Adapter cache reconciliation after a raw leave/forget
+# --------------------------------------------------------------------------
+class TestAdapterCacheReconciliation:
+    def _seeded_adapter(self, room_id):
+        adapter = _make_adapter()
+        adapter._joined_rooms.add(room_id)
+        adapter._room_identities[room_id] = object()
+        adapter._room_identity_cached_at[room_id] = 1.0
+        adapter._dm_rooms[room_id] = True
+        return adapter
+
+    def test_leave_evicts_all_caches_for_room(self, creds, default_authz, monkeypatch):
+        # A raw leave must evict the room from the live adapter's membership
+        # caches, otherwise _join_room_by_id later trusts the stale id and
+        # skips the real join (incremental sync only ADDS ids).
+        adapter = self._seeded_adapter("!cur:hs")
+        monkeypatch.setattr(m, "_live_adapter", lambda: adapter)
+        monkeypatch.setattr(m, "_matrix_room_action", _recorder({"leave": (200, "{}")}))
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!cur:hs"})))
+        assert out["success"] is True
+        assert "!cur:hs" not in adapter._joined_rooms
+        assert "!cur:hs" not in adapter._room_identities
+        assert "!cur:hs" not in adapter._room_identity_cached_at
+        assert "!cur:hs" not in adapter._dm_rooms
+
+    def test_leave_leaves_other_rooms_in_cache(self, creds, default_authz, monkeypatch):
+        # Reconciliation must be surgical: a different, still-joined room is
+        # NOT evicted.
+        adapter = self._seeded_adapter("!other:hs")
+        adapter._joined_rooms.add("!cur:hs")
+        monkeypatch.setattr(m, "_joined_rooms", lambda: {"!cur:hs"})  # authorize
+        monkeypatch.setattr(m, "_live_adapter", lambda: adapter)
+        monkeypatch.setattr(m, "_matrix_room_action", _recorder({"leave": (200, "{}")}))
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!cur:hs"})))
+        assert out["success"] is True
+        assert adapter._joined_rooms == {"!other:hs"}
+        assert "!other:hs" in adapter._room_identities
+
+    def test_delete_evicts_after_leave_and_forget(self, creds, default_authz, monkeypatch):
+        adapter = self._seeded_adapter("!cur:hs")
+        monkeypatch.setattr(m, "_live_adapter", lambda: adapter)
+        monkeypatch.setattr(
+            m,
+            "_matrix_room_action",
+            _recorder({"leave": (200, "{}"), "forget": (200, "{}")}),
+        )
+        out = _parse(_run(m._handle_matrix_delete_room({"room_id": "!cur:hs"})))
+        assert out["success"] is True
+        assert "!cur:hs" not in adapter._joined_rooms
+        assert "!cur:hs" not in adapter._dm_rooms
+        assert "!cur:hs" not in adapter._room_identities
+
+    def test_failed_leave_does_not_touch_cache(self, creds, default_authz, monkeypatch):
+        adapter = self._seeded_adapter("!cur:hs")
+        monkeypatch.setattr(m, "_live_adapter", lambda: adapter)
+        monkeypatch.setattr(m, "_matrix_room_action", _recorder({"leave": (404, "gone")}))
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!cur:hs"})))
+        _assert_error(out, "Matrix leave error (404)")
+        assert adapter._joined_rooms == {"!cur:hs"}, "cache untouched on failed leave"
+        assert adapter._room_identities == {"!cur:hs": adapter._room_identities["!cur:hs"]}
+
+    def test_forget_error_still_reconciles(self, creds, default_authz, monkeypatch):
+        # The leave succeeded, so the room is gone from membership even though
+        # the subsequent forget failed. Reconciliation still runs after leave.
+        adapter = self._seeded_adapter("!cur:hs")
+        monkeypatch.setattr(m, "_live_adapter", lambda: adapter)
+        monkeypatch.setattr(
+            m,
+            "_matrix_room_action",
+            _recorder({"leave": (200, "{}"), "forget": (400, '{"errcode":"M_UNKNOWN"}')}),
+        )
+        out = _parse(_run(m._handle_matrix_delete_room({"room_id": "!cur:hs"})))
+        _assert_error(out, "Matrix forget error (400)")
+        assert "!cur:hs" not in adapter._joined_rooms, "leave reconciliation still applies"
+
+    def test_no_live_adapter_is_noop(self, creds, default_authz, monkeypatch):
+        # CLI / cron / a non-Matrix gateway: no live adapter, so reconciliation
+        # must not raise and leave must still succeed.
+        monkeypatch.setattr(m, "_live_adapter", lambda: None)
+        monkeypatch.setattr(m, "_matrix_room_action", _recorder({"leave": (200, "{}")}))
+        out = _parse(_run(m._handle_matrix_leave_room({"room_id": "!cur:hs"})))
+        assert out["success"] is True
+
+    def test_reconcile_cancels_pending_invite_join(self):
+        adapter = _make_adapter()
+
+        async def scenario():
+            loop = asyncio.get_running_loop()
+
+            async def noop():
+                await asyncio.sleep(10)
+
+            task = loop.create_task(noop())
+            adapter._invite_join_tasks["!r:hs"] = task
+            adapter.reconcile_left_room("!r:hs")
+            await asyncio.sleep(0)  # let the cancellation land
+            return task
+
+        task = _run(scenario())
+        assert adapter._invite_join_tasks == {}
+        assert task.cancelled()
+
+    def test_join_trusts_stale_cache_then_rejoin_after_reconcile(self):
+        # Regression: _join_room_by_id trusts _joined_rooms, so a stale entry
+        # short-circuits the real join. Reconciliation must clear the entry so
+        # the next join re-joins.
+        adapter = _make_adapter()
+        client = MagicMock()
+        client.join_room = AsyncMock()
+        adapter._client = client
+        adapter._joined_rooms.add("!stale:hs")
+
+        assert _run(adapter._join_room_by_id("!stale:hs")) is True
+        client.join_room.assert_not_called()  # the stale-cache trust gap
+
+        adapter.reconcile_left_room("!stale:hs")
+        assert _run(adapter._join_room_by_id("!stale:hs")) is True
+        client.join_room.assert_awaited_once()  # real re-join happens
+
+
+# --------------------------------------------------------------------------
+# gating
+# --------------------------------------------------------------------------
+class TestGate:
+    @pytest.mark.parametrize("val,expected", [
+        ("true", True), ("1", True), ("yes", True), ("TRUE", True),
+        ("", False), ("false", False), ("no", False),
+    ])
+    def test_room_admin_gate(self, monkeypatch, val, expected):
+        monkeypatch.setenv("MATRIX_TOOLS_ALLOW_ROOM_CREATE", val)
+        assert m._check_matrix_room_admin() is expected
+
+    def test_gate_unset(self, monkeypatch):
+        monkeypatch.delenv("MATRIX_TOOLS_ALLOW_ROOM_CREATE", raising=False)
+        assert m._check_matrix_room_admin() is False
+
+
+# --------------------------------------------------------------------------
+# registry wiring + toolset scoping (Matrix sessions only)
+# --------------------------------------------------------------------------
+class TestRegistration:
+    TOOLS = ("matrix_create_room", "matrix_leave_room", "matrix_delete_room")
+
+    def test_tools_registered(self):
+        from tools.registry import registry
+        for name in self.TOOLS:
+            assert name in registry._tools, f"{name} not registered"
+            assert registry._tools[name].toolset == "hermes-matrix"
+            assert registry._tools[name].check_fn is m._check_matrix_room_admin
+
+    def test_not_in_shared_core_tools(self):
+        # Scoping contract: Matrix room-admin tools must NOT be offered in
+        # non-Matrix sessions, so they must not be in the shared core list.
+        from toolsets import _HERMES_CORE_TOOLS
+        for name in self.TOOLS:
+            assert name not in _HERMES_CORE_TOOLS, f"{name} leaked into _HERMES_CORE_TOOLS"
+
+    def test_in_hermes_matrix_toolset(self):
+        from toolsets import TOOLSETS
+        for name in self.TOOLS:
+            assert name in TOOLSETS["hermes-matrix"]["tools"]
+
+    def test_not_in_other_platform_toolsets(self):
+        from toolsets import TOOLSETS
+        for name_ts, ts in TOOLSETS.items():
+            if name_ts in {"hermes-matrix", "hermes-gateway"}:
+                continue  # hermes-gateway is the union of all messaging platforms
+            tools = ts.get("tools", [])
+            for name in self.TOOLS:
+                assert name not in tools, f"{name} found in non-Matrix toolset '{name_ts}'"
+
+    def test_resolve_toolset_scoping(self):
+        from toolsets import resolve_toolset
+        matrix_tools = set(resolve_toolset("hermes-matrix"))
+        for name in self.TOOLS:
+            assert name in matrix_tools, f"{name} missing from resolved hermes-matrix"
+        for ts in ("hermes-cli", "hermes-telegram", "hermes-discord", "hermes-slack"):
+            resolved = set(resolve_toolset(ts))
+            for name in self.TOOLS:
+                assert name not in resolved, f"{name} leaked into resolved {ts}"

--- a/tools/matrix_room_tool.py
+++ b/tools/matrix_room_tool.py
@@ -1,0 +1,327 @@
+"""Matrix room-admin agent tools.
+
+Exposes a `matrix_create_room` agent tool so an agent can create Matrix rooms on
+demand. Gated by MATRIX_TOOLS_ALLOW_ROOM_CREATE (finally implementing the
+documented-but-unwired flag noted in gateway/platforms/matrix.py).
+
+Implementation note — why a raw Client-Server API call and NOT
+``adapter.create_room()``:
+  * The agent tool loop runs on a DIFFERENT asyncio event loop than the live
+    MatrixAdapter's mautrix client. Awaiting the adapter's coroutine (which
+    drives the client's aiohttp session) cross-loop raises
+    "Timeout context manager should be used inside a task".
+  * ``adapter.create_room()`` also eagerly does ``self._joined_rooms.add(id)``,
+    which makes the gateway's ``_join_room_by_id`` guard skip a proper join of
+    the freshly-created room (the "self-created room is dead for dispatch" bug).
+  A fresh aiohttp POST to ``/_matrix/client/v3/createRoom`` runs cleanly on the
+  agent loop and leaves ``_joined_rooms`` untouched, so the live client sees the
+  new room through its normal sync path. This mirrors the raw-HTTP
+  Client-Server pattern used by the Matrix sender in tools/send_message_tool.py.
+"""
+import os
+
+from tools.registry import registry, tool_error, tool_result
+
+MATRIX_CREATE_ROOM_SCHEMA = {
+    "name": "matrix_create_room",
+    "description": (
+        "Create a new Matrix room and return its room_id. Requires the matrix "
+        "platform to be configured. Rooms are private by default; pass invite to "
+        "add users (full Matrix IDs like '@alice:matrix.example.org')."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "Room display name."},
+            "topic": {"type": "string", "description": "Room topic/description."},
+            "invite": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Matrix user IDs to invite, e.g. ['@alice:matrix.example.org'].",
+            },
+            "is_direct": {"type": "boolean", "description": "Mark as a direct (DM) room. Default false."},
+            "preset": {
+                "type": "string",
+                "enum": ["private_chat", "trusted_private_chat", "public_chat"],
+                "description": "Visibility preset. Default private_chat. public_chat needs MATRIX_ALLOW_PUBLIC_ROOMS=true.",
+            },
+            "encrypted": {
+                "type": "boolean",
+                "description": "Create the room end-to-end encrypted (megolm). Default false.",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _check_matrix_create_room() -> bool:
+    return os.getenv("MATRIX_TOOLS_ALLOW_ROOM_CREATE", "").lower() in ("true", "1", "yes")
+
+
+def _matrix_creds():
+    """Return (homeserver, token), preferring the live adapter's connected
+    values, falling back to env. Keeps us in lock-step with whatever the
+    running gateway actually authenticated with."""
+    homeserver = ""
+    token = ""
+    try:
+        from gateway.run import _gateway_runner_ref
+        from gateway.config import Platform
+
+        runner = _gateway_runner_ref()
+        adapter = runner.adapters.get(Platform.MATRIX) if runner is not None else None
+        if adapter is not None:
+            homeserver = getattr(adapter, "_homeserver", "") or ""
+            token = getattr(adapter, "_access_token", "") or ""
+    except Exception:
+        pass
+    homeserver = (homeserver or os.getenv("MATRIX_HOMESERVER", "")).rstrip("/")
+    token = token or os.getenv("MATRIX_ACCESS_TOKEN", "")
+    return homeserver, token
+
+
+async def _handle_matrix_create_room(args, **kwargs):
+    try:
+        import aiohttp
+    except ImportError:
+        return tool_error("aiohttp not installed. Run: pip install aiohttp")
+
+    homeserver, token = _matrix_creds()
+    if not homeserver or not token:
+        return tool_error(
+            "Matrix not configured (MATRIX_HOMESERVER + MATRIX_ACCESS_TOKEN required)."
+        )
+
+    preset = args.get("preset", "private_chat") or "private_chat"
+    if preset == "public_chat" and os.getenv("MATRIX_ALLOW_PUBLIC_ROOMS", "").lower() not in (
+        "true",
+        "1",
+        "yes",
+    ):
+        return tool_error("Refusing to create a public room without MATRIX_ALLOW_PUBLIC_ROOMS=true.")
+
+    body = {"preset": preset}
+    if args.get("name"):
+        body["name"] = str(args["name"])
+    if args.get("topic"):
+        body["topic"] = str(args["topic"])
+    invite = args.get("invite") or []
+    if invite:
+        body["invite"] = [str(u) for u in invite]
+    if args.get("is_direct"):
+        body["is_direct"] = True
+    if args.get("encrypted"):
+        # Turn on megolm at creation via initial state. The room is encrypted
+        # server-side immediately; the gateway's mautrix client must then set up
+        # its outbound megolm session for the room (the genuinely-untested path).
+        body["initial_state"] = [
+            {
+                "type": "m.room.encryption",
+                "state_key": "",
+                "content": {"algorithm": "m.megolm.v1.aes-sha2"},
+            }
+        ]
+
+    url = f"{homeserver}/_matrix/client/v3/createRoom"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+    try:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+            async with session.post(url, headers=headers, json=body) as resp:
+                text = await resp.text()
+                if resp.status not in {200, 201}:
+                    return tool_error(f"Matrix createRoom error ({resp.status}): {text[:300]}")
+                data = await resp.json()
+    except Exception as exc:
+        return tool_error(f"matrix_create_room request failed: {exc}")
+
+    room_id = data.get("room_id")
+    if not room_id:
+        return tool_error(f"createRoom returned no room_id: {str(data)[:200]}")
+    return tool_result(
+        success=True,
+        room_id=room_id,
+        invited=invite,
+        preset=preset,
+        encrypted=bool(args.get("encrypted")),
+    )
+
+
+registry.register(
+    name="matrix_create_room",
+    toolset="hermes-matrix",
+    schema=MATRIX_CREATE_ROOM_SCHEMA,
+    handler=_handle_matrix_create_room,
+    check_fn=_check_matrix_create_room,
+    is_async=True,
+    emoji="\U0001F3E0",
+    description="Create a Matrix room via the Client-Server API.",
+)
+
+
+# ===========================================================================
+# matrix_leave_room + matrix_delete_room  (room-admin lifecycle completion)
+#
+# Same raw Client-Server API pattern as matrix_create_room above: a fresh
+# aiohttp POST on the agent's own event loop (the live MatrixAdapter client
+# runs on a different loop). leave/forget mirror create so the full room
+# lifecycle (create -> leave -> delete) is available wherever create_room is.
+# ===========================================================================
+
+MATRIX_LEAVE_ROOM_SCHEMA = {
+    "name": "matrix_leave_room",
+    "description": (
+        "Leave (unjoin) a Matrix room you are a member of. The room keeps "
+        "existing for its other members; you simply stop participating. Pass the "
+        "room_id (e.g. '!abc123:matrix.example.org') as returned by "
+        "matrix_create_room. Use matrix_delete_room instead if you also want the "
+        "room removed from your room list."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room_id": {
+                "type": "string",
+                "description": "Room to leave, e.g. '!abc123:matrix.example.org'.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Optional human-readable reason recorded in the leave event.",
+            },
+        },
+        "required": ["room_id"],
+    },
+}
+
+MATRIX_DELETE_ROOM_SCHEMA = {
+    "name": "matrix_delete_room",
+    "description": (
+        "Delete a Matrix room from your account: leave it and then forget it, so "
+        "it disappears from your room list. For a room you created and are the only "
+        "member of, this effectively tears it down. NOTE: Matrix has no true "
+        "server-side delete for regular users — any other members keep their own "
+        "copy; a full server purge requires a homeserver admin. Pass the room_id."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room_id": {
+                "type": "string",
+                "description": "Room to delete (leave + forget), e.g. '!abc123:matrix.example.org'.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Optional reason recorded in the leave event.",
+            },
+        },
+        "required": ["room_id"],
+    },
+}
+
+
+def _check_matrix_room_admin() -> bool:
+    """Gate for leave/delete. Reuses the room-create capability flag: if the agent
+    may create Matrix rooms, she may also leave/forget them. One 'room admin'
+    capability, no extra env wiring."""
+    return os.getenv("MATRIX_TOOLS_ALLOW_ROOM_CREATE", "").lower() in ("true", "1", "yes")
+
+
+async def _matrix_room_action(homeserver, token, room_id, action, body=None):
+    """POST /_matrix/client/v3/rooms/{room_id}/{action} (action = leave|forget)
+    via a fresh aiohttp session on the agent loop. Returns (status, text)."""
+    import aiohttp
+    from urllib.parse import quote
+
+    url = f"{homeserver}/_matrix/client/v3/rooms/{quote(room_id, safe='')}/{action}"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+        async with session.post(url, headers=headers, json=body or {}) as resp:
+            return resp.status, await resp.text()
+
+
+def _require_room(args):
+    """Shared validation: returns (homeserver, token, room_id) or a tool_error."""
+    homeserver, token = _matrix_creds()
+    if not homeserver or not token:
+        return None, tool_error(
+            "Matrix not configured (MATRIX_HOMESERVER + MATRIX_ACCESS_TOKEN required)."
+        )
+    room_id = str(args.get("room_id") or "").strip()
+    if not room_id:
+        return None, tool_error("room_id is required (e.g. '!abc123:matrix.example.org').")
+    return (homeserver, token, room_id), None
+
+
+async def _handle_matrix_leave_room(args, **kwargs):
+    ctx, err = _require_room(args)
+    if err is not None:
+        return err
+    homeserver, token, room_id = ctx
+    body = {"reason": str(args["reason"])} if args.get("reason") else {}
+    try:
+        status, text = await _matrix_room_action(homeserver, token, room_id, "leave", body)
+    except Exception as exc:
+        return tool_error(f"matrix_leave_room request failed: {exc}")
+    if status != 200:
+        return tool_error(f"Matrix leave error ({status}): {text[:300]}")
+    return tool_result(success=True, room_id=room_id, action="leave")
+
+
+async def _handle_matrix_delete_room(args, **kwargs):
+    ctx, err = _require_room(args)
+    if err is not None:
+        return err
+    homeserver, token, room_id = ctx
+    body = {"reason": str(args["reason"])} if args.get("reason") else {}
+
+    # 1) leave — tolerate "already not a member" (M_FORBIDDEN) as effectively-left
+    try:
+        lstatus, ltext = await _matrix_room_action(homeserver, token, room_id, "leave", body)
+    except Exception as exc:
+        return tool_error(f"matrix_delete_room leave failed: {exc}")
+    already_gone = lstatus == 403 and "M_FORBIDDEN" in ltext
+    if lstatus != 200 and not already_gone:
+        return tool_error(f"Matrix leave (during delete) error ({lstatus}): {ltext[:300]}")
+
+    # 2) forget — removes the room from this account's room list (requires having left)
+    try:
+        fstatus, ftext = await _matrix_room_action(homeserver, token, room_id, "forget", {})
+    except Exception as exc:
+        return tool_error(f"matrix_delete_room forget failed: {exc}")
+    if fstatus != 200:
+        return tool_error(f"Matrix forget error ({fstatus}): {ftext[:300]}")
+
+    return tool_result(
+        success=True,
+        room_id=room_id,
+        action="leave+forget",
+        note=(
+            "Left and forgotten — removed from your room list. Matrix has no true "
+            "server-side delete for regular users; any other members keep their "
+            "copy, and a full server purge requires a homeserver admin."
+        ),
+    )
+
+
+registry.register(
+    name="matrix_leave_room",
+    toolset="hermes-matrix",
+    schema=MATRIX_LEAVE_ROOM_SCHEMA,
+    handler=_handle_matrix_leave_room,
+    check_fn=_check_matrix_room_admin,
+    is_async=True,
+    emoji="\U0001F6AA",  # door
+    description="Leave (unjoin) a Matrix room via the Client-Server API.",
+)
+
+registry.register(
+    name="matrix_delete_room",
+    toolset="hermes-matrix",
+    schema=MATRIX_DELETE_ROOM_SCHEMA,
+    handler=_handle_matrix_delete_room,
+    check_fn=_check_matrix_room_admin,
+    is_async=True,
+    emoji="\U0001F5D1",  # wastebasket
+    description="Delete a Matrix room (leave + forget) via the Client-Server API.",
+)

--- a/tools/matrix_room_tool.py
+++ b/tools/matrix_room_tool.py
@@ -30,8 +30,13 @@ Implementation note — why a raw Client-Server API call and NOT
 
 Authorization: leave/forget are destructive and must respect the Matrix room
 boundary (``gateway/session.py`` — "a turn is scoped to the current Matrix
-room/thread only"). ``_require_room`` therefore refuses to act on a room the
-agent was never in, not just any non-empty id it happens to be handed.
+room/thread only"). ``_authorize_room`` therefore refuses to act on a room the
+agent was never in, not just any non-empty id it happens to be handed. It
+fails CLOSED: if no scope can be established at all (no current room bound
+AND no ``MATRIX_ALLOWED_ROOMS`` allowlist), a destructive action is denied
+rather than silently allowed — an operator who genuinely needs a room-less
+cron/standalone run to act cross-room sets ``MATRIX_TOOLS_ALLOW_ANY_ROOM=true``
+to opt in explicitly.
 
 Cache reconciliation: a raw leave/forget bypasses the sync loop, which only
 *adds* room ids to ``_joined_rooms``. After a successful leave we call
@@ -39,6 +44,7 @@ Cache reconciliation: a raw leave/forget bypasses the sync loop, which only
 ``_join_room_by_id`` re-joins rather than trusting a stale cache entry.
 """
 import os
+from typing import Optional
 
 from tools.registry import registry, tool_error, tool_result
 
@@ -195,10 +201,14 @@ def _allowed_room_ids():
     return {r.strip() for r in os.getenv("MATRIX_ALLOWED_ROOMS", "").split(",") if r.strip()}
 
 
-def _joined_rooms() -> set:
+def _joined_rooms() -> Optional[set]:
     """The set of rooms the live adapter is a member of, or None when the
     adapter isn't available. A room in this set is one the agent *was in* —
-    so it is a legitimate leave/delete target even if it isn't the current room."""
+    so it is a legitimate leave/delete target even if it isn't the current room.
+
+    ``None`` (adapter unavailable) is distinct from an *empty* set: it means we
+    have no positive membership evidence, NOT that every room is in scope.
+    Callers must treat ``None`` as "unknown", never as "allow"."""
     adapter = _live_adapter()
     if adapter is None:
         return None
@@ -208,17 +218,37 @@ def _joined_rooms() -> set:
         return None
 
 
+def _allow_any_room() -> bool:
+    """Explicit operator opt-in to act on arbitrary rooms from a room-less
+    context (``MATRIX_TOOLS_ALLOW_ANY_ROOM=true``).
+
+    Only consulted when NO scope could be established at all (no current room
+    bound AND no ``MATRIX_ALLOWED_ROOMS`` allowlist) — the otherwise
+    fail-closed path. Setting an allowlist still acts as a whitelist; this
+    flag only lifts the denial when there is nothing to scope against.
+    """
+    return os.getenv("MATRIX_TOOLS_ALLOW_ANY_ROOM", "").lower() in ("true", "1", "yes")
+
+
 def _authorize_room(room_id: str):
     """Enforce the Matrix room boundary for destructive leave/forget actions.
 
     Returns None when *room_id* is a legitimate target, or a ``tool_error``
     string when it is not. A room is legitimate when it is any of:
-      * this turn's room (``_current_room``), or
       * in the operator's ``MATRIX_ALLOWED_ROOMS`` allowlist, or
-      * a room the live adapter is still joined to (the agent was in it).
-    With a current room bound, a room matching none of the above is a
-    cross-room action on a room the agent was never in — exactly what the
-    session boundary forbids.
+      * this turn's room (``_current_room``), or
+      * a room the live adapter is still joined to (the agent was in it) —
+        a *positive* membership match, so the adapter being unavailable
+        (``_joined_rooms() is None``) never counts as "in every room".
+
+    Everything else fails CLOSED:
+      * current room bound but the room differs from it — cross-room action,
+        exactly what the session boundary forbids;
+      * an allowlist is set and the room isn't in it — strict whitelist;
+      * no current room and no allowlist (room-less cron/standalone run) —
+        denied unless ``MATRIX_TOOLS_ALLOW_ANY_ROOM=true`` is set explicitly.
+    Failing closed means a bug that unsets the session room mid-Matrix-session
+    degrades to "tool says no" rather than "tool silently acts on any room".
     """
     current = _current_room()
     allowlist = _allowed_room_ids()
@@ -239,9 +269,18 @@ def _authorize_room(room_id: str):
         return tool_error(
             f"Room {room_id} is not in MATRIX_ALLOWED_ROOMS ({sorted(allowlist)})."
         )
-    # No current room bound and no allowlist (standalone / cron / tests):
-    # nothing to scope against, so allow.
-    return None
+    # No current room bound and no allowlist: there is no scope to check
+    # against, and an unavailable adapter is no evidence of membership.
+    # Fail closed unless the operator opted in explicitly.
+    if _allow_any_room():
+        return None
+    return tool_error(
+        f"No scope established for {room_id}: this turn has no bound Matrix room "
+        "and MATRIX_ALLOWED_ROOMS is not set. Destructive room actions fail closed "
+        "without a scope. Run the tool from the room's own conversation, set "
+        "MATRIX_ALLOWED_ROOMS, or set MATRIX_TOOLS_ALLOW_ANY_ROOM=true to allow "
+        "arbitrary rooms from a room-less context."
+    )
 
 
 def _reconcile_adapter(room_id: str) -> None:
@@ -369,7 +408,7 @@ def _require_room(args):
 
 async def _handle_matrix_leave_room(args, **kwargs):
     ctx, err = _require_room(args)
-    if err is not None:
+    if err is not None or ctx is None:
         return err
     homeserver, token, room_id = ctx
     body = {"reason": str(args["reason"])} if args.get("reason") else {}
@@ -385,7 +424,7 @@ async def _handle_matrix_leave_room(args, **kwargs):
 
 async def _handle_matrix_delete_room(args, **kwargs):
     ctx, err = _require_room(args)
-    if err is not None:
+    if err is not None or ctx is None:
         return err
     homeserver, token, room_id = ctx
     body = {"reason": str(args["reason"])} if args.get("reason") else {}

--- a/tools/matrix_room_tool.py
+++ b/tools/matrix_room_tool.py
@@ -1,0 +1,457 @@
+"""Matrix room-admin agent tools.
+
+Three opt-in tools that complete the Matrix room lifecycle, wiring the
+already-present-but-unused ``MATRIX_TOOLS_ALLOW_ROOM_CREATE`` gate:
+
+  * ``matrix_create_room`` — create a room (preset / topic / invite / encryption)
+  * ``matrix_leave_room``  — leave (unjoin) a room
+  * ``matrix_delete_room`` — leave **+ forget** (account-level delete)
+
+They are registered under the ``hermes-matrix`` toolset (see ``toolsets.py``)
+and are NOT part of ``_HERMES_CORE_TOOLS``, so they are offered only to
+Matrix sessions — never to the CLI / other messaging platforms. That matches
+the Matrix scoping contract in
+``website/docs/user-guide/messaging/matrix.md`` ("these tools are scoped to
+Matrix contexts and are not available in non-Matrix toolsets").
+
+Implementation note — why a raw Client-Server API call and NOT
+``adapter.create_room()``:
+  * The agent tool loop runs on a DIFFERENT asyncio event loop than the live
+    MatrixAdapter's mautrix client. Awaiting the adapter's coroutine (which
+    drives the client's aiohttp session) cross-loop raises
+    "Timeout context manager should be used inside a task".
+  * ``adapter.create_room()`` also eagerly does ``self._joined_rooms.add(id)``,
+    which makes the gateway's ``_join_room_by_id`` guard skip a proper join of
+    the freshly-created room (the "self-created room is dead for dispatch" bug).
+  A fresh aiohttp POST to ``/_matrix/client/v3/createRoom`` runs cleanly on the
+  agent loop and leaves ``_joined_rooms`` untouched, so the live client sees the
+  new room through its normal sync path. This mirrors the raw-HTTP
+  Client-Server pattern used by the Matrix sender in tools/send_message_tool.py.
+
+Authorization: leave/forget are destructive and must respect the Matrix room
+boundary (``gateway/session.py`` — "a turn is scoped to the current Matrix
+room/thread only"). ``_require_room`` therefore refuses to act on a room the
+agent was never in, not just any non-empty id it happens to be handed.
+
+Cache reconciliation: a raw leave/forget bypasses the sync loop, which only
+*adds* room ids to ``_joined_rooms``. After a successful leave we call
+``MatrixAdapter.reconcile_left_room`` to evict the id so a later
+``_join_room_by_id`` re-joins rather than trusting a stale cache entry.
+"""
+import os
+
+from tools.registry import registry, tool_error, tool_result
+
+MATRIX_CREATE_ROOM_SCHEMA = {
+    "name": "matrix_create_room",
+    "description": (
+        "Create a new Matrix room and return its room_id. Requires the matrix "
+        "platform to be configured. Rooms are private by default; pass invite to "
+        "add users (full Matrix IDs like '@alice:matrix.example.org')."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "Room display name."},
+            "topic": {"type": "string", "description": "Room topic/description."},
+            "invite": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Matrix user IDs to invite, e.g. ['@alice:matrix.example.org'].",
+            },
+            "is_direct": {"type": "boolean", "description": "Mark as a direct (DM) room. Default false."},
+            "preset": {
+                "type": "string",
+                "enum": ["private_chat", "trusted_private_chat", "public_chat"],
+                "description": "Visibility preset. Default private_chat. public_chat needs MATRIX_ALLOW_PUBLIC_ROOMS=true.",
+            },
+            "encrypted": {
+                "type": "boolean",
+                "description": "Create the room end-to-end encrypted (megolm). Default false.",
+            },
+        },
+        "required": [],
+    },
+}
+
+MATRIX_LEAVE_ROOM_SCHEMA = {
+    "name": "matrix_leave_room",
+    "description": (
+        "Leave (unjoin) a Matrix room you are a member of. The room keeps "
+        "existing for its other members; you simply stop participating. Pass the "
+        "room_id (e.g. '!abc123:matrix.example.org'). You may only leave a room "
+        "you are actually in — this turn's room, a room listed in "
+        "MATRIX_ALLOWED_ROOMS, or a room the bot is still joined to."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room_id": {
+                "type": "string",
+                "description": "Room to leave, e.g. '!abc123:matrix.example.org'.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Optional human-readable reason recorded in the leave event.",
+            },
+        },
+        "required": ["room_id"],
+    },
+}
+
+MATRIX_DELETE_ROOM_SCHEMA = {
+    "name": "matrix_delete_room",
+    "description": (
+        "Delete a Matrix room from your account: leave it and then forget it, so "
+        "it disappears from your room list. For a room you created and are the only "
+        "member of, this effectively tears it down. NOTE: Matrix has no true "
+        "server-side delete for regular users — any other members keep their own "
+        "copy; a full server purge requires a homeserver admin. You may only delete "
+        "a room you are actually in (this turn's room, a MATRIX_ALLOWED_ROOMS "
+        "entry, or a room the bot is still joined to). Pass the room_id."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room_id": {
+                "type": "string",
+                "description": "Room to delete (leave + forget), e.g. '!abc123:matrix.example.org'.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Optional reason recorded in the leave event.",
+            },
+        },
+        "required": ["room_id"],
+    },
+}
+
+
+def _check_matrix_room_admin() -> bool:
+    """Gate for all three room-admin tools, reusing the documented
+    ``MATRIX_TOOLS_ALLOW_ROOM_CREATE`` capability flag (off by default).
+    If the agent may create Matrix rooms, it may also leave/forget them — one
+    'room admin' capability, no extra env wiring."""
+    return os.getenv("MATRIX_TOOLS_ALLOW_ROOM_CREATE", "").lower() in ("true", "1", "yes")
+
+
+def _live_adapter():
+    """Return the running gateway's live Matrix adapter, or None.
+
+    Shared by the credential lookup, the room-authorization check, and the
+    post-leave cache reconciliation so all three consult the *same* live
+    instance the gateway actually authenticated with. Best-effort: any lookup
+    failure (CLI / cron / a gateway without Matrix) yields None.
+    """
+    try:
+        from gateway.run import _gateway_runner_ref
+        from gateway.config import Platform
+
+        runner = _gateway_runner_ref()
+    except Exception:
+        return None
+    if runner is None:
+        return None
+    try:
+        return runner.adapters.get(Platform.MATRIX)
+    except Exception:
+        return None
+
+
+def _matrix_creds():
+    """Return (homeserver, token), preferring the live adapter's connected
+    values, falling back to env. Keeps us in lock-step with whatever the
+    running gateway actually authenticated with."""
+    homeserver = ""
+    token = ""
+    adapter = _live_adapter()
+    if adapter is not None:
+        homeserver = getattr(adapter, "_homeserver", "") or ""
+        token = getattr(adapter, "_access_token", "") or ""
+    homeserver = (homeserver or os.getenv("MATRIX_HOMESERVER", "")).rstrip("/")
+    token = token or os.getenv("MATRIX_ACCESS_TOKEN", "")
+    return homeserver, token
+
+
+def _current_room() -> str:
+    """Return the room id this turn is scoped to, or "".
+
+    The gateway binds the current Matrix room to
+    ``HERMES_SESSION_CHAT_ID`` (``_set_session_env`` in gateway/run.py), which
+    is the room boundary documented in ``gateway/session.py`` ("a turn is
+    scoped to the current Matrix room/thread only"). Reading it via
+    ``get_session_env`` uses the task-local ContextVar first, so concurrent
+    turns in different rooms never see each other's room.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return ""
+    return (get_session_env("HERMES_SESSION_CHAT_ID", "") or "").strip()
+
+
+def _allowed_room_ids():
+    """Operator-configured cross-room allowlist (``MATRIX_ALLOWED_ROOMS``)."""
+    return {r.strip() for r in os.getenv("MATRIX_ALLOWED_ROOMS", "").split(",") if r.strip()}
+
+
+def _joined_rooms() -> set:
+    """The set of rooms the live adapter is a member of, or None when the
+    adapter isn't available. A room in this set is one the agent *was in* —
+    so it is a legitimate leave/delete target even if it isn't the current room."""
+    adapter = _live_adapter()
+    if adapter is None:
+        return None
+    try:
+        return set(adapter._joined_rooms)
+    except Exception:
+        return None
+
+
+def _authorize_room(room_id: str):
+    """Enforce the Matrix room boundary for destructive leave/forget actions.
+
+    Returns None when *room_id* is a legitimate target, or a ``tool_error``
+    string when it is not. A room is legitimate when it is any of:
+      * this turn's room (``_current_room``), or
+      * in the operator's ``MATRIX_ALLOWED_ROOMS`` allowlist, or
+      * a room the live adapter is still joined to (the agent was in it).
+    With a current room bound, a room matching none of the above is a
+    cross-room action on a room the agent was never in — exactly what the
+    session boundary forbids.
+    """
+    current = _current_room()
+    allowlist = _allowed_room_ids()
+    if room_id in allowlist:
+        return None
+    if current and room_id == current:
+        return None
+    joined = _joined_rooms()
+    if joined is not None and room_id in joined:
+        return None
+    if current:
+        return tool_error(
+            f"Room {room_id} is outside this turn's scope (this turn is in {current}). "
+            "To act on another room, run the tool from that room's conversation or "
+            "add its room_id to MATRIX_ALLOWED_ROOMS."
+        )
+    if allowlist:
+        return tool_error(
+            f"Room {room_id} is not in MATRIX_ALLOWED_ROOMS ({sorted(allowlist)})."
+        )
+    # No current room bound and no allowlist (standalone / cron / tests):
+    # nothing to scope against, so allow.
+    return None
+
+
+def _reconcile_adapter(room_id: str) -> None:
+    """Best-effort: evict *room_id* from the live adapter's membership caches
+    after a raw leave/forget so a later ``_join_room_by_id`` re-joins instead
+    of trusting a stale entry. No-op when the gateway isn't running or the
+    adapter lacks the method (e.g. an older adapter).
+    """
+    adapter = _live_adapter()
+    if adapter is None:
+        return
+    try:
+        adapter.reconcile_left_room(room_id)
+    except Exception:
+        pass
+
+
+async def _matrix_room_action(homeserver, token, room_id, action, body=None):
+    """POST /_matrix/client/v3/rooms/{room_id}/{action} (action = leave|forget)
+    via a fresh aiohttp session on the agent loop. Returns (status, text)."""
+    import aiohttp
+    from urllib.parse import quote
+
+    url = f"{homeserver}/_matrix/client/v3/rooms/{quote(room_id, safe='')}/{action}"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+        async with session.post(url, headers=headers, json=body or {}) as resp:
+            return resp.status, await resp.text()
+
+
+async def _matrix_create_room_api(homeserver, token, body):
+    """POST /_matrix/client/v3/createRoom via a fresh aiohttp session on the
+    agent loop. Returns (status, parsed_json)."""
+    import aiohttp
+
+    url = f"{homeserver}/_matrix/client/v3/createRoom"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+        async with session.post(url, headers=headers, json=body) as resp:
+            text = await resp.text()
+            try:
+                data = await resp.json()
+            except Exception:
+                data = {"_raw": text}
+            return resp.status, data
+
+
+async def _handle_matrix_create_room(args, **kwargs):
+    homeserver, token = _matrix_creds()
+    if not homeserver or not token:
+        return tool_error(
+            "Matrix not configured (MATRIX_HOMESERVER + MATRIX_ACCESS_TOKEN required)."
+        )
+
+    preset = args.get("preset", "private_chat") or "private_chat"
+    if preset == "public_chat" and os.getenv("MATRIX_ALLOW_PUBLIC_ROOMS", "").lower() not in (
+        "true",
+        "1",
+        "yes",
+    ):
+        return tool_error("Refusing to create a public room without MATRIX_ALLOW_PUBLIC_ROOMS=true.")
+
+    body = {"preset": preset}
+    if args.get("name"):
+        body["name"] = str(args["name"])
+    if args.get("topic"):
+        body["topic"] = str(args["topic"])
+    invite = args.get("invite") or []
+    if invite:
+        body["invite"] = [str(u) for u in invite]
+    if args.get("is_direct"):
+        body["is_direct"] = True
+    if args.get("encrypted"):
+        # Turn on megolm at creation via initial state. The room is encrypted
+        # server-side immediately; the gateway's mautrix client must then set up
+        # its outbound megolm session for the room (the genuinely-untested path).
+        body["initial_state"] = [
+            {
+                "type": "m.room.encryption",
+                "state_key": "",
+                "content": {"algorithm": "m.megolm.v1.aes-sha2"},
+            }
+        ]
+
+    try:
+        status, data = await _matrix_create_room_api(homeserver, token, body)
+    except Exception as exc:
+        return tool_error(f"matrix_create_room request failed: {exc}")
+    if status not in {200, 201}:
+        return tool_error(f"Matrix createRoom error ({status}): {str(data)[:300]}")
+
+    room_id = data.get("room_id")
+    if not room_id:
+        return tool_error(f"createRoom returned no room_id: {str(data)[:200]}")
+    return tool_result(
+        success=True,
+        room_id=room_id,
+        invited=invite,
+        preset=preset,
+        encrypted=bool(args.get("encrypted")),
+    )
+
+
+def _require_room(args):
+    """Shared validation + authorization for leave/forget.
+
+    Returns (homeserver, token, room_id) or (None, tool_error). Enforces the
+    Matrix room boundary via ``_authorize_room``: a non-empty room_id is not
+    enough — the agent must actually be in that room (this turn's room, a
+    MATRIX_ALLOWED_ROOMS entry, or a room the bot is still joined to).
+    """
+    homeserver, token = _matrix_creds()
+    if not homeserver or not token:
+        return None, tool_error(
+            "Matrix not configured (MATRIX_HOMESERVER + MATRIX_ACCESS_TOKEN required)."
+        )
+    room_id = str(args.get("room_id") or "").strip()
+    if not room_id:
+        return None, tool_error("room_id is required (e.g. '!abc123:matrix.example.org').")
+    err = _authorize_room(room_id)
+    if err is not None:
+        return None, err
+    return (homeserver, token, room_id), None
+
+
+async def _handle_matrix_leave_room(args, **kwargs):
+    ctx, err = _require_room(args)
+    if err is not None:
+        return err
+    homeserver, token, room_id = ctx
+    body = {"reason": str(args["reason"])} if args.get("reason") else {}
+    try:
+        status, text = await _matrix_room_action(homeserver, token, room_id, "leave", body)
+    except Exception as exc:
+        return tool_error(f"matrix_leave_room request failed: {exc}")
+    if status != 200:
+        return tool_error(f"Matrix leave error ({status}): {text[:300]}")
+    _reconcile_adapter(room_id)
+    return tool_result(success=True, room_id=room_id, action="leave")
+
+
+async def _handle_matrix_delete_room(args, **kwargs):
+    ctx, err = _require_room(args)
+    if err is not None:
+        return err
+    homeserver, token, room_id = ctx
+    body = {"reason": str(args["reason"])} if args.get("reason") else {}
+
+    # 1) leave — tolerate "already not a member" (M_FORBIDDEN) as effectively-left
+    try:
+        lstatus, ltext = await _matrix_room_action(homeserver, token, room_id, "leave", body)
+    except Exception as exc:
+        return tool_error(f"matrix_delete_room leave failed: {exc}")
+    already_gone = lstatus == 403 and "M_FORBIDDEN" in ltext
+    if lstatus != 200 and not already_gone:
+        return tool_error(f"Matrix leave (during delete) error ({lstatus}): {ltext[:300]}")
+    _reconcile_adapter(room_id)
+
+    # 2) forget — removes the room from this account's room list (requires having left)
+    try:
+        fstatus, ftext = await _matrix_room_action(homeserver, token, room_id, "forget", {})
+    except Exception as exc:
+        return tool_error(f"matrix_delete_room forget failed: {exc}")
+    if fstatus != 200:
+        return tool_error(f"Matrix forget error ({fstatus}): {ftext[:300]}")
+
+    return tool_result(
+        success=True,
+        room_id=room_id,
+        action="leave+forget",
+        note=(
+            "Left and forgotten — removed from your room list. Matrix has no true "
+            "server-side delete for regular users; any other members keep their "
+            "copy, and a full server purge requires a homeserver admin."
+        ),
+    )
+
+
+# All three tools are registered under the ``hermes-matrix`` toolset only (see
+# toolsets.py), so they reach Matrix sessions and never the CLI or other
+# messaging platforms. Each is gated on MATRIX_TOOLS_ALLOW_ROOM_CREATE.
+registry.register(
+    name="matrix_create_room",
+    toolset="hermes-matrix",
+    schema=MATRIX_CREATE_ROOM_SCHEMA,
+    handler=_handle_matrix_create_room,
+    check_fn=_check_matrix_room_admin,
+    is_async=True,
+    emoji="\U0001F3E0",
+    description="Create a Matrix room via the Client-Server API.",
+)
+
+registry.register(
+    name="matrix_leave_room",
+    toolset="hermes-matrix",
+    schema=MATRIX_LEAVE_ROOM_SCHEMA,
+    handler=_handle_matrix_leave_room,
+    check_fn=_check_matrix_room_admin,
+    is_async=True,
+    emoji="\U0001F6AA",  # door
+    description="Leave (unjoin) a Matrix room via the Client-Server API.",
+)
+
+registry.register(
+    name="matrix_delete_room",
+    toolset="hermes-matrix",
+    schema=MATRIX_DELETE_ROOM_SCHEMA,
+    handler=_handle_matrix_delete_room,
+    check_fn=_check_matrix_room_admin,
+    is_async=True,
+    emoji="\U0001F5D1",  # wastebasket
+    description="Delete a Matrix room (leave + forget) via the Client-Server API.",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -71,6 +71,8 @@ _HERMES_CORE_TOOLS = [
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # Matrix room admin (create/leave/delete; gated on MATRIX_TOOLS_ALLOW_ROOM_CREATE via check_fn)
+    "matrix_create_room", "matrix_leave_room", "matrix_delete_room",
 ]
 
 # Webhook events may originate from untrusted third-party content (for example,

--- a/toolsets.py
+++ b/toolsets.py
@@ -89,6 +89,12 @@ _HERMES_CORE_TOOLS = [
     "kanban_attach", "kanban_attach_url", "kanban_attachments",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # NOTE: the Matrix room-admin tools (matrix_create_room / matrix_leave_room /
+    # matrix_delete_room) are deliberately NOT here — they are Matrix-specific
+    # and live in the `hermes-matrix` toolset below (matching the Matrix
+    # scoping contract in website/docs/user-guide/messaging/matrix.md: Matrix
+    # tools are not available in non-Matrix toolsets). Keeping them out of the
+    # shared core list is what keeps them off the CLI and every other platform.
 ]
 
 # Webhook events may originate from untrusted third-party content (for example,
@@ -572,7 +578,16 @@ TOOLSETS = {
 
     "hermes-matrix": {
         "description": "Matrix bot toolset - decentralized encrypted messaging (full access)",
-        "tools": _HERMES_CORE_TOOLS,
+        # Matrix room-admin tools live HERE (not in _HERMES_CORE_TOOLS) so they
+        # are offered only to Matrix sessions — never the CLI / other platforms
+        # (see the Matrix scoping contract in
+        # website/docs/user-guide/messaging/matrix.md). Gated on
+        # MATRIX_TOOLS_ALLOW_ROOM_CREATE via check_fn in tools/matrix_room_tool.py.
+        "tools": _HERMES_CORE_TOOLS + [
+            "matrix_create_room",
+            "matrix_leave_room",
+            "matrix_delete_room",
+        ],
         "includes": []
     },
 

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -413,11 +413,13 @@ In Matrix conversations, Hermes exposes Matrix-specific tools to the agent:
 - `matrix_send_reaction`
 - `matrix_redact_message`
 - `matrix_create_room`
+- `matrix_leave_room`
+- `matrix_delete_room`
 - `matrix_invite_user`
 - `matrix_fetch_history`
 - `matrix_set_presence`
 
-These tools are scoped to Matrix contexts and are not available in non-Matrix toolsets. Admin-style tools are disabled by default: redaction requires `MATRIX_TOOLS_ALLOW_REDACTION=true`, invites require `MATRIX_TOOLS_ALLOW_INVITES=true`, and room creation requires `MATRIX_TOOLS_ALLOW_ROOM_CREATE=true`. Public room creation also requires `MATRIX_ALLOW_PUBLIC_ROOMS=true`.
+These tools are scoped to Matrix contexts and are not available in non-Matrix toolsets. Admin-style tools are disabled by default: redaction requires `MATRIX_TOOLS_ALLOW_REDACTION=true`, invites require `MATRIX_TOOLS_ALLOW_INVITES=true`, room creation (and the leave/delete room-admin tools) require `MATRIX_TOOLS_ALLOW_ROOM_CREATE=true`. Public room creation also requires `MATRIX_ALLOW_PUBLIC_ROOMS=true`.
 If `MATRIX_ALLOWED_ROOMS` is set, Matrix tools may only target those rooms.
 
 Reaction controls use:


### PR DESCRIPTION
## What

Three opt-in agent tools that complete the Matrix room lifecycle, wiring the
already-present-but-unused `MATRIX_TOOLS_ALLOW_ROOM_CREATE` gate in
`gateway/platforms/matrix.py`:

| Tool | Action |
|---|---|
| `matrix_create_room` | Create a room (preset / topic / invite / encryption) |
| `matrix_leave_room`  | Leave (unjoin) a room |
| `matrix_delete_room` | Leave **+ forget** (account-level delete) |

## Why

`MATRIX_TOOLS_ALLOW_ROOM_CREATE` already exists on the Matrix platform but no
tool consumed it — agents on Matrix could send messages yet had no way to create
or tear down rooms. These three close that gap.

## How

- Raw Client-Server API (`/createRoom`, `/rooms/{id}/leave`, `/rooms/{id}/forget`)
  via `aiohttp` on the agent's own event loop — deliberately **not**
  `adapter.create_room()`, which runs on the live mautrix client's loop
  (cross-loop *"Timeout context manager should be used inside a task"*) and
  eagerly populates `_joined_rooms`, making the gateway skip a proper join of the
  new room. Mirrors the raw-HTTP pattern in `tools/send_message_tool.py`.
- Registered in `_HERMES_CORE_TOOLS` (so the `hermes-matrix` toolset offers them).
- All gated on `MATRIX_TOOLS_ALLOW_ROOM_CREATE` (off by default — opt-in).
- `matrix_delete_room` = leave + forget; documents that Matrix has no true
  server-side delete for a non-admin user.

## Tests

`tests/test_matrix_room_admin.py` — 13 tests with the CS-API mocked: leave
success / reason passthrough / missing-id / not-configured / HTTP error; delete
leave→forget sequencing, idempotent already-left, forget-error, missing-id; and
the gating truth table. All green.

## Notes

- No new dependencies (`aiohttp` already used by the gateway).
- Opt-in: with the flag unset (default), the tools are not offered.
