### PR TITLE
fix(tui): remove Apple_Terminal from light-mode defaults

### DIFF
--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -89,10 +89,13 @@ describe('detectLightMode', () => {
     expect(detectLightMode({})).toBe(false)
   })
 
-  it('defaults Apple Terminal to light when no stronger signal is present', async () => {
+  it('does not default Apple Terminal to light when no stronger signal is present (#49082)', async () => {
     const { detectLightMode } = await importThemeWithCleanEnv()
 
-    expect(detectLightMode({ TERM_PROGRAM: 'Apple_Terminal' })).toBe(true)
+    // Apple Terminal can have a dark profile — hardcoding it as light was
+    // a wrong premise. Without an explicit signal, we stay dark (matching
+    // the Python TUI's behaviour).
+    expect(detectLightMode({ TERM_PROGRAM: 'Apple_Terminal' })).toBe(false)
   })
 
   it('honors HERMES_TUI_LIGHT on/off', async () => {
@@ -261,7 +264,7 @@ describe('fromSkin', () => {
   })
 
   it('normalizes non-banner foregrounds on light Apple Terminal', async () => {
-    const { fromSkin } = await importThemeWithEnv({ TERM_PROGRAM: 'Apple_Terminal' })
+    const { fromSkin } = await importThemeWithEnv({ TERM_PROGRAM: 'Apple_Terminal', HERMES_TUI_LIGHT: '1' })
 
     const theme = fromSkin({
       banner_accent: '#FFBF00',
@@ -281,14 +284,14 @@ describe('fromSkin', () => {
   })
 
   it('does not normalize light Apple Terminal when truecolor is advertised', async () => {
-    const { fromSkin } = await importThemeWithEnv({ COLORTERM: 'truecolor', TERM_PROGRAM: 'Apple_Terminal' })
+    const { fromSkin } = await importThemeWithEnv({ COLORTERM: 'truecolor', TERM_PROGRAM: 'Apple_Terminal', HERMES_TUI_LIGHT: '1' })
     const theme = fromSkin({ banner_text: '#FFF8DC' }, {})
 
     expect(theme.color.text).toBe('#FFF8DC')
   })
 
   it('normalizes Apple Terminal names before matching', async () => {
-    const { fromSkin } = await importThemeWithEnv({ TERM_PROGRAM: ' Apple_Terminal ' })
+    const { fromSkin } = await importThemeWithEnv({ TERM_PROGRAM: ' Apple_Terminal ', HERMES_TUI_LIGHT: '1' })
     const theme = fromSkin({ banner_text: '#FFF8DC' }, {})
 
     expect(theme.color.text).toBe('ansi256(136)')

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -353,10 +353,12 @@ const TRUE_RE = /^(?:1|true|yes|on)$/
 const FALSE_RE = /^(?:0|false|no|off)$/
 
 // TERM_PROGRAM fallback allow-list for terminals whose default profile is
-// light and which may not expose COLORFGBG. This currently includes Apple
-// Terminal. Explicit HERMES_TUI_THEME / COLORFGBG signals above still win,
-// so dark Apple Terminal profiles that advertise a dark background stay dark.
-const LIGHT_DEFAULT_TERM_PROGRAMS = new Set<string>(['Apple_Terminal'])
+// light and which may not expose COLORFGBG. Kept empty to match the Python
+// TUI's behaviour — Apple Terminal can be configured with a dark profile,
+// so hardcoding it as light-mode is a wrong premise (#49082). Explicit
+// HERMES_TUI_LIGHT / HERMES_TUI_THEME / COLORFGBG signals above still
+// detect light mode correctly for users who need it.
+const LIGHT_DEFAULT_TERM_PROGRAMS = new Set<string>([])
 
 // Best-effort RGB → luminance check.  Currently only accepts a 3- or
 // 6-digit hex value (with or without a leading `#`); the env var name


### PR DESCRIPTION
## Summary

`detectLightMode()` in `ui-tui/src/theme.ts` hardcoded `TERM_PROGRAM=Apple_Terminal` as a definitive light-mode signal via `LIGHT_DEFAULT_TERM_PROGRAMS`. This forced a light completion menu (`#F5F5F5` background) even when Terminal.app was configured with a dark profile — making the slash-command popup nearly unreadable.

The Python TUI (`cli.py` → `_detect_light_mode` / `_query_osc11_background`) correctly probes the actual background via OSC-11 and does **not** hardcode Apple_Terminal. This PR brings the TUI in line with the Python side.

## Fix

Remove `Apple_Terminal` from `LIGHT_DEFAULT_TERM_PROGRAMS` (now an empty set, matching the Python TUI). Without an explicit signal (`HERMES_TUI_LIGHT`, `HERMES_TUI_THEME`, `COLORFGBG`, `HERMES_TUI_BACKGROUND`), the default stays dark.

## What is NOT affected

- **ANSI normalization** (`shouldNormalizeAnsiLightTheme`) — checks both `termProgram === "Apple_Terminal"` **AND** `isLight`. Since `isLight` is now `false` by default for Apple_Terminal, normalization only fires when the user explicitly opts into light mode. This is correct: ANSI downgrade is only needed for light Apple Terminal.
- **Explicit light-mode signals** — `HERMES_TUI_LIGHT=1`, `HERMES_TUI_THEME=light`, `COLORFGBG=0;15`, etc. all still work exactly as before.

## Test

Updated 4 tests in `theme.test.ts`:
- `detectLightMode({ TERM_PROGRAM: 'Apple_Terminal' })` → now expects `false` (was `true`)
- 3 `fromSkin` ANSI-normalization tests now pass `HERMES_TUI_LIGHT=1` to explicitly trigger light mode (since it no longer auto-detects from TERM_PROGRAM alone)

```
✓ src/__tests__/theme.test.ts (29 tests) 87ms
Test Files  1 passed (1)
Tests  29 passed (29)
```

Closes #49082