### PR TITLE
fix(guardrail): add skills_list and skill_view to IDEMPOTENT_TOOL_NAMES

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -35,6 +35,8 @@ IDEMPOTENT_TOOL_NAMES = frozenset(
         "mcp_filesystem_directory_tree",
         "mcp_filesystem_get_file_info",
         "mcp_filesystem_search_files",
+        "skills_list",
+        "skill_view",
     }
 )
 


### PR DESCRIPTION
## Problem

`agent/tool_guardrails.py`'s `ToolCallGuardrailController` protects against unproductive tool-call loops via two independent tracking paths:

1. **Failure-based** (`exact_failure`, `same_tool_failure`) — counts repeated calls that return an error/failure result.
2. **Idempotent no-progress** (`idempotent_no_progress`) — counts repeated calls that return the same successful result, for tools listed in the hardcoded `IDEMPOTENT_TOOL_NAMES` frozenset.

`IDEMPOTENT_TOOL_NAMES` includes `read_file`, `search_files`, `web_search`, `web_extract`, `session_search`, browser tools, and `mcp_filesystem_*` read tools — but **not** `skills_list` or `skill_view` (`tools/skills_tool.py`).

Both are read-only, deterministic-for-a-given-input tools in the same functional class as `read_file`/`search_files`. Their absence means an agent that repeatedly calls `skill_view` on a skill it has already loaded is invisible to the loop guardrail. Each call returns a normal success payload (the skill content), so `classify_tool_failure()` never flags it, and `_is_idempotent("skill_view")` returns `False` because the tool isn't in `IDEMPOTENT_TOOL_NAMES`.

## Fix

Add `skills_list` and `skill_view` to `IDEMPOTENT_TOOL_NAMES` in `agent/tool_guardrails.py`. Single-line addition to an existing frozenset literal — no behavior change for any tool already on the list.

## Tests

All 13 existing tests in `tests/agent/test_tool_guardrails.py` pass unchanged.

Fixes #49075
