### PR TITLE
fix(copilot): validate token scope at seed time, skip dead credential pool entries

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1778,11 +1778,23 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # Copilot tokens are resolved dynamically via `gh auth token` or
         # env vars (COPILOT_GITHUB_TOKEN / GH_TOKEN).  They don't live in
         # the auth store or credential pool, so we resolve them here.
+        #
+        # We validate the token at seed time by performing the Copilot token
+        # exchange (GET /copilot_internal/v2/token).  If the exchange fails
+        # (e.g. the gh auth token lacks Copilot scope), we skip seeding rather
+        # than surfacing a dead picker entry that silently falls back to the
+        # default provider on use.  Fixes #49002.
         try:
-            from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
+            from hermes_cli.copilot_auth import resolve_copilot_token, exchange_copilot_token
             token, source = resolve_copilot_token()
             if token:
-                api_token = get_copilot_api_token(token)
+                try:
+                    api_token, _ = exchange_copilot_token(token)
+                except Exception:
+                    logger.debug(
+                        "Copilot token exchange failed for %s — skipping auto-seed", source
+                    )
+                    raise  # re-raise to outer except, skip seeding
                 source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
                 if not _is_suppressed(provider, source_name):
                     active_sources.add(source_name)

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2236,6 +2236,10 @@ def test_load_pool_seeds_copilot_via_gh_auth_token(tmp_path, monkeypatch):
         "hermes_cli.copilot_auth.resolve_copilot_token",
         lambda: ("gho_fake_token_abc123", "gh auth token"),
     )
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.exchange_copilot_token",
+        lambda token: ("gho_exchanged_token_xyz", time.time() + 3600),
+    )
 
     from agent.credential_pool import load_pool
     pool = load_pool("copilot")
@@ -2244,7 +2248,7 @@ def test_load_pool_seeds_copilot_via_gh_auth_token(tmp_path, monkeypatch):
     entries = pool.entries()
     assert len(entries) == 1
     assert entries[0].source == "gh_cli"
-    assert entries[0].access_token == "gho_fake_token_abc123"
+    assert entries[0].access_token == "gho_exchanged_token_xyz"
     assert entries[0].base_url == "https://api.githubcopilot.com"
 
 
@@ -2256,6 +2260,27 @@ def test_load_pool_does_not_seed_copilot_when_no_token(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.copilot_auth.resolve_copilot_token",
         lambda: ("", ""),
+    )
+
+    from agent.credential_pool import load_pool
+    pool = load_pool("copilot")
+
+    assert not pool.has_credentials()
+    assert pool.entries() == []
+
+
+def test_load_pool_does_not_seed_copilot_when_exchange_fails(tmp_path, monkeypatch):
+    """Copilot should NOT be seeded when token exchange fails (no Copilot scope)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "credential_pool": {}})
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("gho_no_copilot_scope", "gh auth token"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.exchange_copilot_token",
+        lambda token: (_ for _ in ()).throw(ValueError("403 no Copilot scope")),
     )
 
     from agent.credential_pool import load_pool

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1901,10 +1901,13 @@ def test_auth_remove_copilot_suppresses_all_variants(tmp_path, monkeypatch):
 
     with patch(
         "hermes_cli.copilot_auth.resolve_copilot_token",
-        return_value=("ghp_fake", "gh"),
+        return_value=("gho_fake", "gh"),
     ), patch(
         "hermes_cli.copilot_auth.get_copilot_api_token",
         return_value="ghu_fake_api",
+    ), patch(
+        "hermes_cli.copilot_auth.exchange_copilot_token",
+        return_value=("ghu_fake_api", time.time() + 3600),
     ):
         auth_remove_command(SimpleNamespace(provider="copilot", target="1"))
 


### PR DESCRIPTION
## Problem

On a fresh Hermes install, any active `gh auth login` session causes the credential pool seeder to populate a "GitHub Copilot" section with ~15 models — even when the user never configured Copilot and the token does not have Copilot scope.

Selecting any of those models fails silently. The request falls back to the default provider with no visual error, and the user gets answers from the wrong model without realizing it.

**Root cause:** `_seed_from_singletons` in `agent/credential_pool.py` used `get_copilot_api_token()` which silently falls back to returning the raw token when the Copilot token exchange fails (e.g. `gh auth token` lacks Copilot scope → HTTP 403). The credential pool entry got created with a token that would never work against the Copilot API.

## Fix

In `_seed_from_singletons`, use `exchange_copilot_token()` directly instead of `get_copilot_api_token()`. If the exchange fails (token has no Copilot scope), the exception propagates to the outer handler and the pool entry is skipped entirely. Only tokens that successfully exchange get seeded into the pool.

Users with valid Copilot subscriptions are unaffected — their tokens exchange normally and the pool entry is created as before. Users without Copilot scope no longer see dead picker entries.

## Tests

- Updated `test_load_pool_seeds_copilot_via_gh_auth_token` to mock `exchange_copilot_token` (the new dependency) and assert on the exchanged token.
- Added `test_load_pool_does_not_seed_copilot_when_exchange_fails` to verify that a failed exchange (simulating no Copilot scope) correctly skips seeding.

All 79 tests in `tests/agent/test_credential_pool.py` pass, plus 12 copilot token exchange tests.

Fixes #49002
