### PR TITLE
fix(dashboard): sort chat session switcher by most-recent activity

### DIFF
--- a/web/src/components/ChatSessionList.tsx
+++ b/web/src/components/ChatSessionList.tsx
@@ -85,7 +85,7 @@ export function ChatSessionList({
     setLoading(true);
     setError(null);
     api
-      .getSessions(SESSION_LIMIT, 0, scopeKey)
+      .getSessions(SESSION_LIMIT, 0, scopeKey, "recent")
       .then((res) => {
         if (reqRef.current !== myReq) return;
         setSessions(res.sessions);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -344,9 +344,17 @@ export const api = {
       window.location.assign("/login");
       return r;
     }),
-  getSessions: (limit = 20, offset = 0, profile = getManagementProfile()) =>
+  getSessions: (
+    limit = 20,
+    offset = 0,
+    profile = getManagementProfile(),
+    order: "created" | "recent" = "created",
+  ) =>
     fetchJSON<PaginatedSessions>(
-      appendProfileParam(`/api/sessions?limit=${limit}&offset=${offset}`, profile),
+      appendProfileParam(
+        `/api/sessions?limit=${limit}&offset=${offset}&order=${order}`,
+        profile,
+      ),
     ),
   getSessionMessages: (id: string, profile = getManagementProfile()) =>
     fetchJSON<SessionMessagesResponse>(


### PR DESCRIPTION
## Summary
The dashboard Chat-tab session switcher now sorts by most-recent activity instead of original creation time, so the list matches the `last_active` timestamp each row displays.

Root cause: `ChatSessionList` called `api.getSessions()`, which hit `/api/sessions` with the endpoint's default `order="created"`. Rows render `timeAgo(s.last_active)`, so a just-messaged session could sit below an older one and the list looked unsorted against its own timestamps.

## Changes
- `web/src/lib/api.ts`: `getSessions` gains an optional `order: "created" | "recent"` arg (default `"created"`, so all existing callers are unchanged) and forwards it as `&order=`.
- `web/src/components/ChatSessionList.tsx`: pass `order="recent"`.

The backend already supports `order="recent"` (sorts by latest activity across the compression chain, keeping a long conversation on the first page after it auto-compresses into a new continuation id). The paginated Sessions page intentionally stays on `created` for stable pagination.

## Validation
| | Before | After |
|---|---|---|
| Switcher ordering | original start time | latest activity (matches displayed timestamp) |
| Sessions page | created | created (unchanged) |
| Desktop / CLI consumers | n/a | unaffected (default preserved) |

## Infographic

![session-switcher-recent-order](https://v3b.fal.media/files/b/0a9eeed9/Hrxx_mEPzi9W6d6ZBGyuW_dXbhXcFR.png)
