### PR TITLE
fix(telegram): redact proxy credentials in the proxy-detected log line

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2066,7 +2066,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
                 )
             elif proxy_url:
-                logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
+                _safe_proxy = re.sub(r"//[^@/]+@", "//<redacted>@", proxy_url)
+                logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, _safe_proxy)
                 request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
                 get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
             else:


### PR DESCRIPTION
## Problem

When an explicit proxy is configured, `TelegramAdapter` logs the proxy URL at INFO on every (re)connect:

    logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)

`proxy_url` carries the proxy credentials in its userinfo (`user:pass@host`), so they are written to the gateway log in plaintext.

## Fix

Redact the userinfo before logging. The real `proxy_url` is still passed unchanged to `HTTPXRequest(proxy=proxy_url)`, so there is no behavioral change. No new dependencies (`re` is already imported).

Before: `... HTTPXRequest: https://user:pass@127.0.0.1:14322`
After:  `... HTTPXRequest: https://<redacted>@127.0.0.1:14322`

🤖 Generated with [Claude Code](https://claude.com/claude-code)