### PR TITLE
fix(desktop): limit slash trigger to input start

### DIFF
--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -11,6 +11,12 @@ describe('detectTrigger', () => {
     expect(detectTrigger('/skill')).toEqual({ kind: '/', query: 'skill', tokenLength: 6 })
   })
 
+  it('does not detect slash triggers after whitespace or text', () => {
+    expect(detectTrigger(' /skill')).toBeNull()
+    expect(detectTrigger('不附加文件 /文件夾')).toBeNull()
+    expect(detectTrigger('Run an A/B test')).toBeNull()
+  })
+
   it('detects a bare at-mention trigger with an empty query', () => {
     expect(detectTrigger('@')).toEqual({ kind: '@', query: '', tokenLength: 1 })
   })

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -7,12 +7,13 @@ export interface TriggerState {
 }
 
 // `@` triggers stop at the first whitespace — `@file:path` and `@diff` are
-// single tokens. `/` triggers keep going so the popover stays live while the
-// user types args (`/personality alic` → arg completer suggests `alice`).
+// single tokens. `/` triggers only at the start of the composer and keep going
+// so the popover stays live while the user types args (`/personality alic` →
+// arg completer suggests `alice`).
 // Restricting the slash command name to `[a-zA-Z][\w-]*` avoids matching file
 // paths like `src/foo/bar`.
 const AT_TRIGGER_RE = /(?:^|[\s])(@)([^\s@/]*)$/
-const SLASH_TRIGGER_RE = /(?:^|[\s])(\/)((?:[a-zA-Z][\w-]*(?:\s+\S*)*)?)$/
+const SLASH_TRIGGER_RE = /^(\/)((?:[a-zA-Z][\w-]*(?:\s+\S*)*)?)$/
 
 /** Stable key for paste dedupe — `items` and `files` often mirror the same image as different objects. */
 export function blobDedupeKey(blob: Blob): string {


### PR DESCRIPTION
## Summary
- only open the Desktop composer slash popover when the slash character is the first character of the input
- keep slash command argument completions live for start-of-input commands
- add regression coverage for whitespace and natural-text slash cases

Fixes #48913

## Tests
- npm --workspace apps/desktop run test:ui -- src/app/chat/composer/text-utils.test.ts
- npm --workspace apps/desktop run typecheck
- npm --workspace apps/desktop exec eslint src/app/chat/composer/text-utils.ts src/app/chat/composer/text-utils.test.ts
- git diff --check

## Review
- Subagent review: no blocking issues found