### PR TITLE
fix(desktop): resolve curated priority and docs when backend provider label differs from PROVIDER_GROUPS name

### DIFF
--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -23,7 +23,7 @@ import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
 import { isKeyVar, ProviderKeyRows } from './credential-key-ui'
 import { SettingsCategoryHeading, useEnvCredentials } from './env-credentials'
-import { providerGroup, providerMeta, providerPriority } from './helpers'
+import { providerGroup, providerMeta } from './helpers'
 import { LoadingState, SettingsContent } from './primitives'
 
 // The embedded terminal (and thus the "run disconnect command" path) only
@@ -85,10 +85,13 @@ function buildProviderKeyGroups(vars: Record<string, EnvVarInfo>): ProviderKeyGr
       continue
     }
 
-    // Presentation overlay (priority, blurb, docs) is keyed by the prefix-based
-    // group name; when the backend introduced this provider it may have no
-    // overlay entry, so fall back to the backend/env metadata for display.
-    const meta = providerMeta(name)
+    // The backend label (used as the bucket name) may differ from the curated
+    // PROVIDER_GROUPS name (e.g. "Google AI Studio" vs "Gemini"), so try both
+    // when resolving the presentation overlay (priority, blurb, docs).
+    const curatedName = providerGroup(primary[0])
+    const meta =
+      providerMeta(name) ??
+      (curatedName !== name && curatedName !== 'Other' ? providerMeta(curatedName) : undefined)
 
     groups.push({
       // Advanced = the provider's non-key knobs (base URL, region, deployment).
@@ -103,7 +106,7 @@ function buildProviderKeyGroups(vars: Record<string, EnvVarInfo>): ProviderKeyGr
       hasAnySet: entries.some(([, i]) => i.is_set),
       name,
       primary,
-      priority: providerPriority(name)
+      priority: meta?.priority ?? 99
     })
   }
 


### PR DESCRIPTION
## Summary

- `buildProviderKeyGroups` uses the backend `provider_label` as the bucket name, but `providerMeta`/`providerPriority` look up the curated overlay by matching against `PROVIDER_GROUPS[].name`
- When the two diverge (e.g. `"Google AI Studio"` vs `"Gemini"`, `"Qwen Cloud"` vs `"DashScope (Qwen)"`, `"HuggingFace"` vs `"Hugging Face"`), the lookup misses and the provider drops to priority 99, losing its curated description and docs URL
- Affected providers: Gemini, DashScope/Qwen, GLM/Z.AI, Kimi/Moonshot, Hugging Face, NovitaAI (7 of 11 checked popular providers)
- Fix: fall back to a prefix-based `providerGroup()` lookup on the primary env key so the curated overlay is found regardless of label wording

## Test plan

- [ ] Open Settings → Providers → API Keys
- [ ] Verify Gemini (`GOOGLE_API_KEY`) appears near the top (priority 4), not at priority 99
- [ ] Verify DashScope/Qwen, GLM, Kimi, Hugging Face retain their curated descriptions and docs links
- [ ] Verify providers that match directly (Anthropic, xAI, DeepSeek) are unaffected
- [ ] Verify new backend-only providers with no curated entry still render at priority 99
- [ ] `npm --workspace apps/desktop run typecheck` passes