### PR TITLE
fix(dashboard): fully close sidebar on X and expand main content

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,8 +36,6 @@ import {
   Menu,
   MessageSquare,
   Package,
-  PanelLeftClose,
-  PanelLeftOpen,
   Plug,
   Puzzle,
   Radio,
@@ -344,34 +342,49 @@ function buildRoutes(
   return routes;
 }
 
-const SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
+const SIDEBAR_OPEN_KEY = "hermes-sidebar-open";
+/** @deprecated Replaced by SIDEBAR_OPEN_KEY — read once for migration. */
+const LEGACY_SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
+
+function readSidebarOpenFromStorage(): boolean {
+  try {
+    const storedOpen = localStorage.getItem(SIDEBAR_OPEN_KEY);
+    if (storedOpen !== null) return storedOpen !== "false";
+
+    const legacyCollapsed = localStorage.getItem(LEGACY_SIDEBAR_COLLAPSED_KEY);
+    if (legacyCollapsed !== null) {
+      // Old "collapsed" was a narrow icon rail; the new model is open (w-64)
+      // or fully closed — never a rail. Treat legacy collapsed=true as closed.
+      const open = legacyCollapsed !== "true";
+      localStorage.setItem(SIDEBAR_OPEN_KEY, open ? "true" : "false");
+      localStorage.removeItem(LEGACY_SIDEBAR_COLLAPSED_KEY);
+      return open;
+    }
+  } catch {
+    /* localStorage may be unavailable in private browsing */
+  }
+  return true;
+}
 
 export default function App() {
   const { t } = useI18n();
   const { pathname } = useLocation();
   const { manifests, loading: pluginsLoading } = usePlugins();
   const { theme } = useTheme();
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const closeMobile = useCallback(() => setMobileOpen(false), []);
-
-  const [collapsed, setCollapsed] = useState(() => {
+  const [sidebarOpen, setSidebarOpen] = useState(readSidebarOpenFromStorage);
+  const closeSidebar = useCallback(() => {
+    setSidebarOpen(false);
     try {
-      return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "true";
-    } catch {
-      return false;
-    }
-  });
-  const toggleCollapsed = useCallback(() => {
-    setCollapsed((prev) => {
-      const next = !prev;
-      try {
-        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
-      } catch { /* localStorage may be unavailable in private browsing */ }
-      return next;
-    });
+      localStorage.setItem(SIDEBAR_OPEN_KEY, "false");
+    } catch { /* localStorage may be unavailable in private browsing */ }
+  }, []);
+  const openSidebar = useCallback(() => {
+    setSidebarOpen(true);
+    try {
+      localStorage.setItem(SIDEBAR_OPEN_KEY, "true");
+    } catch { /* localStorage may be unavailable in private browsing */ }
   }, []);
   const isMobile = useBelowBreakpoint(1024);
-  const isDesktopCollapsed = collapsed && !isMobile;
   const tooltipWarmRef = useRef(0);
   const sidebarStatus = useSidebarStatus();
   const isDocsRoute = pathname === "/docs" || pathname === "/docs/";
@@ -457,9 +470,9 @@ export default function App() {
   const layoutVariant = theme.layoutVariant ?? "standard";
 
   useEffect(() => {
-    if (!mobileOpen) return;
+    if (!sidebarOpen || !isMobile) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setMobileOpen(false);
+      if (e.key === "Escape") closeSidebar();
     };
     document.addEventListener("keydown", onKey);
     const prevOverflow = document.body.style.overflow;
@@ -468,16 +481,7 @@ export default function App() {
       document.removeEventListener("keydown", onKey);
       document.body.style.overflow = prevOverflow;
     };
-  }, [mobileOpen]);
-
-  useEffect(() => {
-    const mql = window.matchMedia("(min-width: 1024px)");
-    const onChange = (e: MediaQueryListEvent) => {
-      if (e.matches) setMobileOpen(false);
-    };
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
+  }, [closeSidebar, isMobile, sidebarOpen]);
 
   return (
     <ProfileProvider>
@@ -510,9 +514,9 @@ export default function App() {
         <Button
           ghost
           size="icon"
-          onClick={() => setMobileOpen(true)}
+          onClick={openSidebar}
           aria-label={t.app.openNavigation}
-          aria-expanded={mobileOpen}
+          aria-expanded={sidebarOpen}
           aria-controls="app-sidebar"
           className="text-text-secondary hover:text-midground"
         >
@@ -524,11 +528,11 @@ export default function App() {
         </Typography>
       </header>
 
-      {mobileOpen && (
+      {sidebarOpen && isMobile && (
         <Button
           ghost
           aria-label={t.app.closeNavigation}
-          onClick={closeMobile}
+          onClick={closeSidebar}
           className={cn(
             "lg:hidden fixed inset-0 z-40 p-0 block",
             "bg-black/70",
@@ -541,18 +545,22 @@ export default function App() {
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-14 lg:pt-0">
         <div className="flex min-h-0 min-w-0 flex-1">
+          {(isMobile || sidebarOpen) && (
           <aside
             id="app-sidebar"
             aria-label={t.app.navigation}
+            aria-hidden={!sidebarOpen}
             className={cn(
-              "fixed top-0 left-0 z-50 flex h-dvh max-h-dvh w-64 min-h-0 flex-col font-sans",
+              "flex h-dvh max-h-dvh min-h-0 flex-col font-sans",
               "border-r border-current/20",
               "bg-background-base",
-              "transition-[transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]",
-              mobileOpen ? "translate-x-0" : "-translate-x-full",
-              "lg:sticky lg:top-0 lg:translate-x-0 lg:shrink-0 lg:overflow-hidden",
-              "lg:transition-[width] lg:duration-300 lg:ease-[cubic-bezier(0.23,1,0.32,1)]",
-              collapsed && "lg:w-14",
+              isMobile
+                ? cn(
+                    "fixed top-0 left-0 z-50 w-64",
+                    "transition-[transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]",
+                    sidebarOpen ? "translate-x-0" : "-translate-x-full",
+                  )
+                : "sticky top-0 z-50 w-64 min-w-64 max-w-64 shrink-0 overflow-hidden",
             )}
             style={{
               background: "var(--component-sidebar-background)",
@@ -564,15 +572,10 @@ export default function App() {
               className={cn(
                 "flex h-14 shrink-0 items-center gap-2",
                 "border-b border-current/20",
-                collapsed ? "lg:justify-center lg:px-0" : "px-4 justify-between",
+                "px-4 justify-between",
               )}
             >
-              <div
-                className={cn(
-                  "flex items-center gap-2",
-                  collapsed && "lg:hidden",
-                )}
-              >
+              <div className="flex items-center gap-2">
                 <PluginSlot name="header-left" />
 
                 <Typography className="font-bold text-[1.125rem] leading-[0.95] tracking-[0.0525rem] text-midground uppercase">
@@ -585,31 +588,15 @@ export default function App() {
               <Button
                 ghost
                 size="icon"
-                onClick={closeMobile}
+                onClick={closeSidebar}
                 aria-label={t.app.closeNavigation}
-                className="lg:hidden text-text-secondary hover:text-midground"
+                className="text-text-secondary hover:text-midground"
               >
                 <X />
               </Button>
-
-              <Button
-                ghost
-                size="icon"
-                onClick={toggleCollapsed}
-                aria-label={
-                  collapsed ? t.common.expand : t.common.collapse
-                }
-                className="hidden lg:flex text-text-secondary hover:text-midground"
-              >
-                {collapsed ? (
-                  <PanelLeftOpen className="h-4 w-4" />
-                ) : (
-                  <PanelLeftClose className="h-4 w-4" />
-                )}
-              </Button>
             </div>
 
-            <ProfileSwitcher collapsed={isDesktopCollapsed} />
+            <ProfileSwitcher collapsed={false} />
 
             <nav
               className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden border-t border-current/10 py-2"
@@ -618,8 +605,8 @@ export default function App() {
               <ul className="flex flex-col">
                 {sidebarNav.coreItems.map((item) => (
                   <SidebarNavLink
-                    closeMobile={closeMobile}
-                    collapsed={isDesktopCollapsed}
+                    closeMobile={isMobile ? closeSidebar : undefined}
+                    collapsed={false}
                     item={item}
                     key={item.path}
                     t={t}
@@ -638,7 +625,6 @@ export default function App() {
                     className={cn(
                       "px-5 pt-2.5 pb-1",
                       "font-sans text-display text-xs tracking-[0.12em] text-text-tertiary",
-                      isDesktopCollapsed && "lg:hidden",
                     )}
                     id="hermes-sidebar-plugin-nav-heading"
                   >
@@ -648,8 +634,8 @@ export default function App() {
                   <ul className="flex flex-col">
                     {sidebarNav.pluginItems.map((item) => (
                       <SidebarNavLink
-                        closeMobile={closeMobile}
-                        collapsed={isDesktopCollapsed}
+                        closeMobile={isMobile ? closeSidebar : undefined}
+                        collapsed={false}
                         item={item}
                         key={item.path}
                         t={t}
@@ -662,8 +648,8 @@ export default function App() {
             </nav>
 
             <SidebarSystemActions
-              collapsed={isDesktopCollapsed}
-              onNavigate={closeMobile}
+              collapsed={false}
+              onNavigate={isMobile ? closeSidebar : undefined}
               status={sidebarStatus}
               tooltipWarmRef={tooltipWarmRef}
             />
@@ -673,47 +659,57 @@ export default function App() {
                 "flex shrink-0 items-center gap-2",
                 "px-3 py-2",
                 "border-t border-current/20",
-                isDesktopCollapsed
-                  ? "lg:flex-col lg:items-start lg:gap-3 lg:py-3"
-                  : "justify-between",
+                "justify-between",
               )}
             >
-              <div
-                className={cn(
-                  "flex min-w-0 items-center gap-2",
-                  isDesktopCollapsed && "lg:flex-col lg:items-start",
-                )}
-              >
+              <div className="flex min-w-0 items-center gap-2">
                 <PluginSlot name="header-right" />
 
                 <SidebarIconWithTooltip
-                  collapsed={isDesktopCollapsed}
+                  collapsed={false}
                   label={t.theme?.switchTheme ?? "Switch theme"}
                   tooltipWarmRef={tooltipWarmRef}
                 >
-                  <ThemeSwitcher collapsed={isDesktopCollapsed} dropUp />
+                  <ThemeSwitcher collapsed={false} dropUp />
                 </SidebarIconWithTooltip>
 
                 <SidebarIconWithTooltip
-                  collapsed={isDesktopCollapsed}
+                  collapsed={false}
                   label={t.language.switchTo}
                   tooltipWarmRef={tooltipWarmRef}
                 >
-                  <LanguageSwitcher collapsed={isDesktopCollapsed} dropUp />
+                  <LanguageSwitcher collapsed={false} dropUp />
                 </SidebarIconWithTooltip>
               </div>
             </div>
 
-            <div
-              className={cn(
-                "flex shrink-0 flex-col",
-                isDesktopCollapsed && "lg:hidden",
-              )}
-            >
+            <div className="flex shrink-0 flex-col">
               <AuthWidget />
               <SidebarFooter status={sidebarStatus} />
             </div>
           </aside>
+          )}
+
+          {!isMobile && !sidebarOpen ? (
+            <div
+              className={cn(
+                "shrink-0 border-b border-current/20",
+                "bg-background-base px-3 py-2 sm:px-6",
+              )}
+              style={{ backgroundColor: "var(--background-base)" }}
+            >
+              <Button
+                ghost
+                size="icon"
+                onClick={openSidebar}
+                aria-label={t.app.openNavigation}
+                aria-controls="app-sidebar"
+                className="text-text-secondary hover:text-midground"
+              >
+                <Menu />
+              </Button>
+            </div>
+          ) : null}
 
           <PageHeaderProvider pluginTabs={pluginTabMeta}>
             <div
@@ -836,7 +832,7 @@ function SidebarNavLink({
       <NavLink
         to={path}
         end={path === "/sessions"}
-        onClick={closeMobile}
+        onClick={() => closeMobile?.()}
         aria-label={collapsed ? navLabel : undefined}
         onFocus={collapsed ? showTooltip : undefined}
         onBlur={collapsed ? hideTooltip : undefined}
@@ -975,21 +971,21 @@ function SidebarSystemActions({
     }
     void runAction(action);
     navigate("/sessions");
-    onNavigate();
+    onNavigate?.();
   };
 
   const confirmRestart = () => {
     setRestartConfirmOpen(false);
     void runAction("restart");
     navigate("/sessions");
-    onNavigate();
+    onNavigate?.();
   };
 
   const confirmUpdate = () => {
     setUpdateConfirmOpen(false);
     void runAction("update");
     navigate("/sessions");
-    onNavigate();
+    onNavigate?.();
   };
 
   return (
@@ -1317,7 +1313,7 @@ interface SidebarIconWithTooltipProps {
 }
 
 interface SidebarNavLinkProps {
-  closeMobile: () => void;
+  closeMobile?: () => void;
   collapsed: boolean;
   item: NavItem;
   t: Translations;
@@ -1326,7 +1322,7 @@ interface SidebarNavLinkProps {
 
 interface SidebarSystemActionsProps {
   collapsed: boolean;
-  onNavigate: () => void;
+  onNavigate?: () => void;
   status: StatusResponse | null;
   tooltipWarmRef: TooltipWarmRef;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -97,6 +97,10 @@ import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
 import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
+import {
+  readDesktopSidebarOpenFromStorage,
+  writeDesktopSidebarOpenToStorage,
+} from "@/lib/sidebar-preference";
 import { api } from "@/lib/api";
 import type { StatusResponse, UpdateCheckResponse } from "@/lib/api";
 
@@ -342,47 +346,24 @@ function buildRoutes(
   return routes;
 }
 
-const SIDEBAR_OPEN_KEY = "hermes-sidebar-open";
-/** @deprecated Replaced by SIDEBAR_OPEN_KEY — read once for migration. */
-const LEGACY_SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
-
-function readSidebarOpenFromStorage(): boolean {
-  try {
-    const storedOpen = localStorage.getItem(SIDEBAR_OPEN_KEY);
-    if (storedOpen !== null) return storedOpen !== "false";
-
-    const legacyCollapsed = localStorage.getItem(LEGACY_SIDEBAR_COLLAPSED_KEY);
-    if (legacyCollapsed !== null) {
-      // Old "collapsed" was a narrow icon rail; the new model is open (w-64)
-      // or fully closed — never a rail. Treat legacy collapsed=true as closed.
-      const open = legacyCollapsed !== "true";
-      localStorage.setItem(SIDEBAR_OPEN_KEY, open ? "true" : "false");
-      localStorage.removeItem(LEGACY_SIDEBAR_COLLAPSED_KEY);
-      return open;
-    }
-  } catch {
-    /* localStorage may be unavailable in private browsing */
-  }
-  return true;
-}
-
 export default function App() {
   const { t } = useI18n();
   const { pathname } = useLocation();
   const { manifests, loading: pluginsLoading } = usePlugins();
   const { theme } = useTheme();
-  const [sidebarOpen, setSidebarOpen] = useState(readSidebarOpenFromStorage);
-  const closeSidebar = useCallback(() => {
-    setSidebarOpen(false);
-    try {
-      localStorage.setItem(SIDEBAR_OPEN_KEY, "false");
-    } catch { /* localStorage may be unavailable in private browsing */ }
+  const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
+  const [desktopSidebarOpen, setDesktopSidebarOpen] = useState(
+    readDesktopSidebarOpenFromStorage,
+  );
+  const closeMobileDrawer = useCallback(() => setMobileDrawerOpen(false), []);
+  const openMobileDrawer = useCallback(() => setMobileDrawerOpen(true), []);
+  const closeDesktopSidebar = useCallback(() => {
+    setDesktopSidebarOpen(false);
+    writeDesktopSidebarOpenToStorage(false);
   }, []);
-  const openSidebar = useCallback(() => {
-    setSidebarOpen(true);
-    try {
-      localStorage.setItem(SIDEBAR_OPEN_KEY, "true");
-    } catch { /* localStorage may be unavailable in private browsing */ }
+  const openDesktopSidebar = useCallback(() => {
+    setDesktopSidebarOpen(true);
+    writeDesktopSidebarOpenToStorage(true);
   }, []);
   const isMobile = useBelowBreakpoint(1024);
   const tooltipWarmRef = useRef(0);
@@ -470,9 +451,9 @@ export default function App() {
   const layoutVariant = theme.layoutVariant ?? "standard";
 
   useEffect(() => {
-    if (!sidebarOpen || !isMobile) return;
+    if (!mobileDrawerOpen || !isMobile) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeSidebar();
+      if (e.key === "Escape") closeMobileDrawer();
     };
     document.addEventListener("keydown", onKey);
     const prevOverflow = document.body.style.overflow;
@@ -481,7 +462,16 @@ export default function App() {
       document.removeEventListener("keydown", onKey);
       document.body.style.overflow = prevOverflow;
     };
-  }, [closeSidebar, isMobile, sidebarOpen]);
+  }, [closeMobileDrawer, isMobile, mobileDrawerOpen]);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(min-width: 1024px)");
+    const onChange = (e: MediaQueryListEvent) => {
+      if (e.matches) setMobileDrawerOpen(false);
+    };
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
 
   return (
     <ProfileProvider>
@@ -514,9 +504,9 @@ export default function App() {
         <Button
           ghost
           size="icon"
-          onClick={openSidebar}
+          onClick={openMobileDrawer}
           aria-label={t.app.openNavigation}
-          aria-expanded={sidebarOpen}
+          aria-expanded={mobileDrawerOpen}
           aria-controls="app-sidebar"
           className="text-text-secondary hover:text-midground"
         >
@@ -528,11 +518,11 @@ export default function App() {
         </Typography>
       </header>
 
-      {sidebarOpen && isMobile && (
+      {mobileDrawerOpen && isMobile && (
         <Button
           ghost
           aria-label={t.app.closeNavigation}
-          onClick={closeSidebar}
+          onClick={closeMobileDrawer}
           className={cn(
             "lg:hidden fixed inset-0 z-40 p-0 block",
             "bg-black/70",
@@ -545,11 +535,11 @@ export default function App() {
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-14 lg:pt-0">
         <div className="flex min-h-0 min-w-0 flex-1">
-          {(isMobile || sidebarOpen) && (
+          {(isMobile || desktopSidebarOpen) && (
           <aside
             id="app-sidebar"
             aria-label={t.app.navigation}
-            aria-hidden={!sidebarOpen}
+            aria-hidden={isMobile ? !mobileDrawerOpen : false}
             className={cn(
               "flex h-dvh max-h-dvh min-h-0 flex-col font-sans",
               "border-r border-current/20",
@@ -558,7 +548,7 @@ export default function App() {
                 ? cn(
                     "fixed top-0 left-0 z-50 w-64",
                     "transition-[transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]",
-                    sidebarOpen ? "translate-x-0" : "-translate-x-full",
+                    mobileDrawerOpen ? "translate-x-0" : "-translate-x-full",
                   )
                 : "sticky top-0 z-50 w-64 min-w-64 max-w-64 shrink-0 overflow-hidden",
             )}
@@ -588,7 +578,7 @@ export default function App() {
               <Button
                 ghost
                 size="icon"
-                onClick={closeSidebar}
+                onClick={isMobile ? closeMobileDrawer : closeDesktopSidebar}
                 aria-label={t.app.closeNavigation}
                 className="text-text-secondary hover:text-midground"
               >
@@ -605,7 +595,7 @@ export default function App() {
               <ul className="flex flex-col">
                 {sidebarNav.coreItems.map((item) => (
                   <SidebarNavLink
-                    closeMobile={isMobile ? closeSidebar : undefined}
+                    closeMobile={isMobile ? closeMobileDrawer : undefined}
                     collapsed={false}
                     item={item}
                     key={item.path}
@@ -634,7 +624,7 @@ export default function App() {
                   <ul className="flex flex-col">
                     {sidebarNav.pluginItems.map((item) => (
                       <SidebarNavLink
-                        closeMobile={isMobile ? closeSidebar : undefined}
+                        closeMobile={isMobile ? closeMobileDrawer : undefined}
                         collapsed={false}
                         item={item}
                         key={item.path}
@@ -649,7 +639,7 @@ export default function App() {
 
             <SidebarSystemActions
               collapsed={false}
-              onNavigate={isMobile ? closeSidebar : undefined}
+              onNavigate={isMobile ? closeMobileDrawer : undefined}
               status={sidebarStatus}
               tooltipWarmRef={tooltipWarmRef}
             />
@@ -690,7 +680,7 @@ export default function App() {
           </aside>
           )}
 
-          {!isMobile && !sidebarOpen ? (
+          {!isMobile && !desktopSidebarOpen ? (
             <div
               className={cn(
                 "shrink-0 border-b border-current/20",
@@ -701,7 +691,7 @@ export default function App() {
               <Button
                 ghost
                 size="icon"
-                onClick={openSidebar}
+                onClick={openDesktopSidebar}
                 aria-label={t.app.openNavigation}
                 aria-controls="app-sidebar"
                 className="text-text-secondary hover:text-midground"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -103,6 +103,10 @@ import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
 import { latchChatActivation } from "@/lib/chat-activation";
+import {
+  readDesktopSidebarOpenFromStorage,
+  writeDesktopSidebarOpenToStorage,
+} from "@/lib/sidebar-preference";
 import { api } from "@/lib/api";
 import type { StatusResponse, UpdateCheckResponse } from "@/lib/api";
 
@@ -365,47 +369,24 @@ function buildRoutes(
   return routes;
 }
 
-const SIDEBAR_OPEN_KEY = "hermes-sidebar-open";
-/** @deprecated Replaced by SIDEBAR_OPEN_KEY — read once for migration. */
-const LEGACY_SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
-
-function readSidebarOpenFromStorage(): boolean {
-  try {
-    const storedOpen = localStorage.getItem(SIDEBAR_OPEN_KEY);
-    if (storedOpen !== null) return storedOpen !== "false";
-
-    const legacyCollapsed = localStorage.getItem(LEGACY_SIDEBAR_COLLAPSED_KEY);
-    if (legacyCollapsed !== null) {
-      // Old "collapsed" was a narrow icon rail; the new model is open (w-64)
-      // or fully closed — never a rail. Treat legacy collapsed=true as closed.
-      const open = legacyCollapsed !== "true";
-      localStorage.setItem(SIDEBAR_OPEN_KEY, open ? "true" : "false");
-      localStorage.removeItem(LEGACY_SIDEBAR_COLLAPSED_KEY);
-      return open;
-    }
-  } catch {
-    /* localStorage may be unavailable in private browsing */
-  }
-  return true;
-}
-
 export default function App() {
   const { t } = useI18n();
   const { pathname } = useLocation();
   const { manifests, loading: pluginsLoading } = usePlugins();
   const { theme } = useTheme();
-  const [sidebarOpen, setSidebarOpen] = useState(readSidebarOpenFromStorage);
-  const closeSidebar = useCallback(() => {
-    setSidebarOpen(false);
-    try {
-      localStorage.setItem(SIDEBAR_OPEN_KEY, "false");
-    } catch { /* localStorage may be unavailable in private browsing */ }
+  const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
+  const [desktopSidebarOpen, setDesktopSidebarOpen] = useState(
+    readDesktopSidebarOpenFromStorage,
+  );
+  const closeMobileDrawer = useCallback(() => setMobileDrawerOpen(false), []);
+  const openMobileDrawer = useCallback(() => setMobileDrawerOpen(true), []);
+  const closeDesktopSidebar = useCallback(() => {
+    setDesktopSidebarOpen(false);
+    writeDesktopSidebarOpenToStorage(false);
   }, []);
-  const openSidebar = useCallback(() => {
-    setSidebarOpen(true);
-    try {
-      localStorage.setItem(SIDEBAR_OPEN_KEY, "true");
-    } catch { /* localStorage may be unavailable in private browsing */ }
+  const openDesktopSidebar = useCallback(() => {
+    setDesktopSidebarOpen(true);
+    writeDesktopSidebarOpenToStorage(true);
   }, []);
   const isMobile = useBelowBreakpoint(1024);
   const tooltipWarmRef = useRef(0);
@@ -500,9 +481,9 @@ export default function App() {
   const layoutVariant = theme.layoutVariant ?? "standard";
 
   useEffect(() => {
-    if (!sidebarOpen || !isMobile) return;
+    if (!mobileDrawerOpen || !isMobile) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeSidebar();
+      if (e.key === "Escape") closeMobileDrawer();
     };
     document.addEventListener("keydown", onKey);
     const prevOverflow = document.body.style.overflow;
@@ -511,7 +492,16 @@ export default function App() {
       document.removeEventListener("keydown", onKey);
       document.body.style.overflow = prevOverflow;
     };
-  }, [closeSidebar, isMobile, sidebarOpen]);
+  }, [closeMobileDrawer, isMobile, mobileDrawerOpen]);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(min-width: 1024px)");
+    const onChange = (e: MediaQueryListEvent) => {
+      if (e.matches) setMobileDrawerOpen(false);
+    };
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
 
   return (
     <ProfileProvider>
@@ -544,9 +534,9 @@ export default function App() {
         <Button
           ghost
           size="icon"
-          onClick={openSidebar}
+          onClick={openMobileDrawer}
           aria-label={t.app.openNavigation}
-          aria-expanded={sidebarOpen}
+          aria-expanded={mobileDrawerOpen}
           aria-controls="app-sidebar"
           className="text-text-secondary hover:text-midground"
         >
@@ -558,11 +548,11 @@ export default function App() {
         </Typography>
       </header>
 
-      {sidebarOpen && isMobile && (
+      {mobileDrawerOpen && isMobile && (
         <Button
           ghost
           aria-label={t.app.closeNavigation}
-          onClick={closeSidebar}
+          onClick={closeMobileDrawer}
           className={cn(
             "lg:hidden fixed inset-0 z-40 p-0 block",
             "bg-black/70",
@@ -581,11 +571,11 @@ export default function App() {
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         <div className="flex min-h-0 min-w-0 flex-1">
-          {(isMobile || sidebarOpen) && (
+          {(isMobile || desktopSidebarOpen) && (
           <aside
             id="app-sidebar"
             aria-label={t.app.navigation}
-            aria-hidden={!sidebarOpen}
+            aria-hidden={isMobile ? !mobileDrawerOpen : false}
             className={cn(
               "flex h-dvh max-h-dvh min-h-0 flex-col font-sans",
               "border-r border-current/20",
@@ -594,7 +584,7 @@ export default function App() {
                 ? cn(
                     "fixed top-0 left-0 z-50 w-64",
                     "transition-[transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]",
-                    sidebarOpen ? "translate-x-0" : "-translate-x-full",
+                    mobileDrawerOpen ? "translate-x-0" : "-translate-x-full",
                   )
                 : "sticky top-0 z-50 w-64 min-w-64 max-w-64 shrink-0 overflow-hidden",
             )}
@@ -624,7 +614,7 @@ export default function App() {
               <Button
                 ghost
                 size="icon"
-                onClick={closeSidebar}
+                onClick={isMobile ? closeMobileDrawer : closeDesktopSidebar}
                 aria-label={t.app.closeNavigation}
                 className="text-text-secondary hover:text-midground"
               >
@@ -641,7 +631,7 @@ export default function App() {
               <ul className="flex flex-col">
                 {sidebarNav.coreItems.map((item) => (
                   <SidebarNavLink
-                    closeMobile={isMobile ? closeSidebar : undefined}
+                    closeMobile={isMobile ? closeMobileDrawer : undefined}
                     collapsed={false}
                     item={item}
                     key={item.path}
@@ -670,7 +660,7 @@ export default function App() {
                   <ul className="flex flex-col">
                     {sidebarNav.pluginItems.map((item) => (
                       <SidebarNavLink
-                        closeMobile={isMobile ? closeSidebar : undefined}
+                        closeMobile={isMobile ? closeMobileDrawer : undefined}
                         collapsed={false}
                         item={item}
                         key={item.path}
@@ -685,7 +675,7 @@ export default function App() {
 
             <SidebarSystemActions
               collapsed={false}
-              onNavigate={isMobile ? closeSidebar : undefined}
+              onNavigate={isMobile ? closeMobileDrawer : undefined}
               status={sidebarStatus}
               tooltipWarmRef={tooltipWarmRef}
             />
@@ -726,7 +716,7 @@ export default function App() {
           </aside>
           )}
 
-          {!isMobile && !sidebarOpen ? (
+          {!isMobile && !desktopSidebarOpen ? (
             <div
               className={cn(
                 "shrink-0 border-b border-current/20",
@@ -737,7 +727,7 @@ export default function App() {
               <Button
                 ghost
                 size="icon"
-                onClick={openSidebar}
+                onClick={openDesktopSidebar}
                 aria-label={t.app.openNavigation}
                 aria-controls="app-sidebar"
                 className="text-text-secondary hover:text-midground"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,8 +38,6 @@ import {
   Menu,
   MessageSquare,
   Package,
-  PanelLeftClose,
-  PanelLeftOpen,
   Plug,
   Puzzle,
   Radio,
@@ -367,34 +365,49 @@ function buildRoutes(
   return routes;
 }
 
-const SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
+const SIDEBAR_OPEN_KEY = "hermes-sidebar-open";
+/** @deprecated Replaced by SIDEBAR_OPEN_KEY — read once for migration. */
+const LEGACY_SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
+
+function readSidebarOpenFromStorage(): boolean {
+  try {
+    const storedOpen = localStorage.getItem(SIDEBAR_OPEN_KEY);
+    if (storedOpen !== null) return storedOpen !== "false";
+
+    const legacyCollapsed = localStorage.getItem(LEGACY_SIDEBAR_COLLAPSED_KEY);
+    if (legacyCollapsed !== null) {
+      // Old "collapsed" was a narrow icon rail; the new model is open (w-64)
+      // or fully closed — never a rail. Treat legacy collapsed=true as closed.
+      const open = legacyCollapsed !== "true";
+      localStorage.setItem(SIDEBAR_OPEN_KEY, open ? "true" : "false");
+      localStorage.removeItem(LEGACY_SIDEBAR_COLLAPSED_KEY);
+      return open;
+    }
+  } catch {
+    /* localStorage may be unavailable in private browsing */
+  }
+  return true;
+}
 
 export default function App() {
   const { t } = useI18n();
   const { pathname } = useLocation();
   const { manifests, loading: pluginsLoading } = usePlugins();
   const { theme } = useTheme();
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const closeMobile = useCallback(() => setMobileOpen(false), []);
-
-  const [collapsed, setCollapsed] = useState(() => {
+  const [sidebarOpen, setSidebarOpen] = useState(readSidebarOpenFromStorage);
+  const closeSidebar = useCallback(() => {
+    setSidebarOpen(false);
     try {
-      return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "true";
-    } catch {
-      return false;
-    }
-  });
-  const toggleCollapsed = useCallback(() => {
-    setCollapsed((prev) => {
-      const next = !prev;
-      try {
-        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
-      } catch { /* localStorage may be unavailable in private browsing */ }
-      return next;
-    });
+      localStorage.setItem(SIDEBAR_OPEN_KEY, "false");
+    } catch { /* localStorage may be unavailable in private browsing */ }
+  }, []);
+  const openSidebar = useCallback(() => {
+    setSidebarOpen(true);
+    try {
+      localStorage.setItem(SIDEBAR_OPEN_KEY, "true");
+    } catch { /* localStorage may be unavailable in private browsing */ }
   }, []);
   const isMobile = useBelowBreakpoint(1024);
-  const isDesktopCollapsed = collapsed && !isMobile;
   const tooltipWarmRef = useRef(0);
   const sidebarStatus = useSidebarStatus();
   const isDocsRoute = pathname === "/docs" || pathname === "/docs/";
@@ -487,9 +500,9 @@ export default function App() {
   const layoutVariant = theme.layoutVariant ?? "standard";
 
   useEffect(() => {
-    if (!mobileOpen) return;
+    if (!sidebarOpen || !isMobile) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setMobileOpen(false);
+      if (e.key === "Escape") closeSidebar();
     };
     document.addEventListener("keydown", onKey);
     const prevOverflow = document.body.style.overflow;
@@ -498,16 +511,7 @@ export default function App() {
       document.removeEventListener("keydown", onKey);
       document.body.style.overflow = prevOverflow;
     };
-  }, [mobileOpen]);
-
-  useEffect(() => {
-    const mql = window.matchMedia("(min-width: 1024px)");
-    const onChange = (e: MediaQueryListEvent) => {
-      if (e.matches) setMobileOpen(false);
-    };
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
+  }, [closeSidebar, isMobile, sidebarOpen]);
 
   return (
     <ProfileProvider>
@@ -540,9 +544,9 @@ export default function App() {
         <Button
           ghost
           size="icon"
-          onClick={() => setMobileOpen(true)}
+          onClick={openSidebar}
           aria-label={t.app.openNavigation}
-          aria-expanded={mobileOpen}
+          aria-expanded={sidebarOpen}
           aria-controls="app-sidebar"
           className="text-text-secondary hover:text-midground"
         >
@@ -554,11 +558,11 @@ export default function App() {
         </Typography>
       </header>
 
-      {mobileOpen && (
+      {sidebarOpen && isMobile && (
         <Button
           ghost
           aria-label={t.app.closeNavigation}
-          onClick={closeMobile}
+          onClick={closeSidebar}
           className={cn(
             "lg:hidden fixed inset-0 z-40 p-0 block",
             "bg-black/70",
@@ -577,18 +581,22 @@ export default function App() {
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         <div className="flex min-h-0 min-w-0 flex-1">
+          {(isMobile || sidebarOpen) && (
           <aside
             id="app-sidebar"
             aria-label={t.app.navigation}
+            aria-hidden={!sidebarOpen}
             className={cn(
-              "fixed top-0 left-0 z-50 flex h-dvh max-h-dvh w-64 min-h-0 flex-col font-sans",
+              "flex h-dvh max-h-dvh min-h-0 flex-col font-sans",
               "border-r border-current/20",
               "bg-background-base",
-              "transition-[transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]",
-              mobileOpen ? "translate-x-0" : "-translate-x-full",
-              "lg:sticky lg:top-0 lg:translate-x-0 lg:shrink-0 lg:overflow-hidden",
-              "lg:transition-[width] lg:duration-300 lg:ease-[cubic-bezier(0.23,1,0.32,1)]",
-              collapsed && "lg:w-14",
+              isMobile
+                ? cn(
+                    "fixed top-0 left-0 z-50 w-64",
+                    "transition-[transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]",
+                    sidebarOpen ? "translate-x-0" : "-translate-x-full",
+                  )
+                : "sticky top-0 z-50 w-64 min-w-64 max-w-64 shrink-0 overflow-hidden",
             )}
             style={{
               background: "var(--component-sidebar-background)",
@@ -600,15 +608,10 @@ export default function App() {
               className={cn(
                 "flex h-14 shrink-0 items-center gap-2",
                 "border-b border-current/20",
-                collapsed ? "lg:justify-center lg:px-0" : "px-4 justify-between",
+                "px-4 justify-between",
               )}
             >
-              <div
-                className={cn(
-                  "flex items-center gap-2",
-                  collapsed && "lg:hidden",
-                )}
-              >
+              <div className="flex items-center gap-2">
                 <PluginSlot name="header-left" />
 
                 <Typography className="font-bold text-[1.125rem] leading-[0.95] tracking-[0.0525rem] text-midground uppercase">
@@ -621,31 +624,15 @@ export default function App() {
               <Button
                 ghost
                 size="icon"
-                onClick={closeMobile}
+                onClick={closeSidebar}
                 aria-label={t.app.closeNavigation}
-                className="lg:hidden text-text-secondary hover:text-midground"
+                className="text-text-secondary hover:text-midground"
               >
                 <X />
               </Button>
-
-              <Button
-                ghost
-                size="icon"
-                onClick={toggleCollapsed}
-                aria-label={
-                  collapsed ? t.common.expand : t.common.collapse
-                }
-                className="hidden lg:flex text-text-secondary hover:text-midground"
-              >
-                {collapsed ? (
-                  <PanelLeftOpen className="h-4 w-4" />
-                ) : (
-                  <PanelLeftClose className="h-4 w-4" />
-                )}
-              </Button>
             </div>
 
-            <ProfileSwitcher collapsed={isDesktopCollapsed} />
+            <ProfileSwitcher collapsed={false} />
 
             <nav
               className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden border-t border-current/10 py-2"
@@ -654,8 +641,8 @@ export default function App() {
               <ul className="flex flex-col">
                 {sidebarNav.coreItems.map((item) => (
                   <SidebarNavLink
-                    closeMobile={closeMobile}
-                    collapsed={isDesktopCollapsed}
+                    closeMobile={isMobile ? closeSidebar : undefined}
+                    collapsed={false}
                     item={item}
                     key={item.path}
                     t={t}
@@ -674,7 +661,6 @@ export default function App() {
                     className={cn(
                       "px-5 pt-2.5 pb-1",
                       "font-sans text-display text-xs tracking-[0.12em] text-text-tertiary",
-                      isDesktopCollapsed && "lg:hidden",
                     )}
                     id="hermes-sidebar-plugin-nav-heading"
                   >
@@ -684,8 +670,8 @@ export default function App() {
                   <ul className="flex flex-col">
                     {sidebarNav.pluginItems.map((item) => (
                       <SidebarNavLink
-                        closeMobile={closeMobile}
-                        collapsed={isDesktopCollapsed}
+                        closeMobile={isMobile ? closeSidebar : undefined}
+                        collapsed={false}
                         item={item}
                         key={item.path}
                         t={t}
@@ -698,8 +684,8 @@ export default function App() {
             </nav>
 
             <SidebarSystemActions
-              collapsed={isDesktopCollapsed}
-              onNavigate={closeMobile}
+              collapsed={false}
+              onNavigate={isMobile ? closeSidebar : undefined}
               status={sidebarStatus}
               tooltipWarmRef={tooltipWarmRef}
             />
@@ -709,47 +695,57 @@ export default function App() {
                 "flex shrink-0 items-center gap-2",
                 "px-3 py-2",
                 "border-t border-current/20",
-                isDesktopCollapsed
-                  ? "lg:flex-col lg:items-start lg:gap-3 lg:py-3"
-                  : "justify-between",
+                "justify-between",
               )}
             >
-              <div
-                className={cn(
-                  "flex min-w-0 items-center gap-2",
-                  isDesktopCollapsed && "lg:flex-col lg:items-start",
-                )}
-              >
+              <div className="flex min-w-0 items-center gap-2">
                 <PluginSlot name="header-right" />
 
                 <SidebarIconWithTooltip
-                  collapsed={isDesktopCollapsed}
+                  collapsed={false}
                   label={t.theme?.switchTheme ?? "Switch theme"}
                   tooltipWarmRef={tooltipWarmRef}
                 >
-                  <ThemeSwitcher collapsed={isDesktopCollapsed} dropUp />
+                  <ThemeSwitcher collapsed={false} dropUp />
                 </SidebarIconWithTooltip>
 
                 <SidebarIconWithTooltip
-                  collapsed={isDesktopCollapsed}
+                  collapsed={false}
                   label={t.language.switchTo}
                   tooltipWarmRef={tooltipWarmRef}
                 >
-                  <LanguageSwitcher collapsed={isDesktopCollapsed} dropUp />
+                  <LanguageSwitcher collapsed={false} dropUp />
                 </SidebarIconWithTooltip>
               </div>
             </div>
 
-            <div
-              className={cn(
-                "flex shrink-0 flex-col",
-                isDesktopCollapsed && "lg:hidden",
-              )}
-            >
+            <div className="flex shrink-0 flex-col">
               <AuthWidget />
               <SidebarFooter status={sidebarStatus} />
             </div>
           </aside>
+          )}
+
+          {!isMobile && !sidebarOpen ? (
+            <div
+              className={cn(
+                "shrink-0 border-b border-current/20",
+                "bg-background-base px-3 py-2 sm:px-6",
+              )}
+              style={{ backgroundColor: "var(--background-base)" }}
+            >
+              <Button
+                ghost
+                size="icon"
+                onClick={openSidebar}
+                aria-label={t.app.openNavigation}
+                aria-controls="app-sidebar"
+                className="text-text-secondary hover:text-midground"
+              >
+                <Menu />
+              </Button>
+            </div>
+          ) : null}
 
           <PageHeaderProvider pluginTabs={pluginTabMeta}>
             <div
@@ -875,7 +871,7 @@ function SidebarNavLink({
       <NavLink
         to={path}
         end={path === "/sessions"}
-        onClick={closeMobile}
+        onClick={() => closeMobile?.()}
         aria-label={collapsed ? navLabel : undefined}
         onFocus={collapsed ? showTooltip : undefined}
         onBlur={collapsed ? hideTooltip : undefined}
@@ -1014,21 +1010,21 @@ function SidebarSystemActions({
     }
     void runAction(action);
     navigate("/sessions");
-    onNavigate();
+    onNavigate?.();
   };
 
   const confirmRestart = () => {
     setRestartConfirmOpen(false);
     void runAction("restart");
     navigate("/sessions");
-    onNavigate();
+    onNavigate?.();
   };
 
   const confirmUpdate = () => {
     setUpdateConfirmOpen(false);
     void runAction("update");
     navigate("/sessions");
-    onNavigate();
+    onNavigate?.();
   };
 
   return (
@@ -1356,7 +1352,7 @@ interface SidebarIconWithTooltipProps {
 }
 
 interface SidebarNavLinkProps {
-  closeMobile: () => void;
+  closeMobile?: () => void;
   collapsed: boolean;
   item: NavItem;
   t: Translations;
@@ -1365,7 +1361,7 @@ interface SidebarNavLinkProps {
 
 interface SidebarSystemActionsProps {
   collapsed: boolean;
-  onNavigate: () => void;
+  onNavigate?: () => void;
   status: StatusResponse | null;
   tooltipWarmRef: TooltipWarmRef;
 }

--- a/web/src/lib/sidebar-preference.test.ts
+++ b/web/src/lib/sidebar-preference.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  LEGACY_SIDEBAR_COLLAPSED_KEY,
+  readDesktopSidebarOpenFromStorage,
+  SIDEBAR_OPEN_KEY,
+  writeDesktopSidebarOpenToStorage,
+} from "./sidebar-preference";
+
+function mockStorage(initial: Record<string, string> = {}) {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => (data.has(key) ? data.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    snapshot: () => Object.fromEntries(data),
+  };
+}
+
+describe("readDesktopSidebarOpenFromStorage", () => {
+  it("defaults to open when no preference is stored (fresh load)", () => {
+    expect(readDesktopSidebarOpenFromStorage(mockStorage())).toBe(true);
+  });
+
+  it("returns false when desktop preference is explicitly closed", () => {
+    const storage = mockStorage({ [SIDEBAR_OPEN_KEY]: "false" });
+    expect(readDesktopSidebarOpenFromStorage(storage)).toBe(false);
+  });
+
+  it("returns true when desktop preference is explicitly open", () => {
+    const storage = mockStorage({ [SIDEBAR_OPEN_KEY]: "true" });
+    expect(readDesktopSidebarOpenFromStorage(storage)).toBe(true);
+  });
+
+  it("migrates legacy collapsed rail to fully closed and removes legacy key", () => {
+    const storage = mockStorage({ [LEGACY_SIDEBAR_COLLAPSED_KEY]: "true" });
+    expect(readDesktopSidebarOpenFromStorage(storage)).toBe(false);
+    expect(storage.snapshot()).toEqual({ [SIDEBAR_OPEN_KEY]: "false" });
+  });
+
+  it("migrates legacy expanded rail to open sidebar", () => {
+    const storage = mockStorage({ [LEGACY_SIDEBAR_COLLAPSED_KEY]: "false" });
+    expect(readDesktopSidebarOpenFromStorage(storage)).toBe(true);
+    expect(storage.snapshot()).toEqual({ [SIDEBAR_OPEN_KEY]: "true" });
+  });
+});
+
+describe("writeDesktopSidebarOpenToStorage", () => {
+  it("persists desktop open preference", () => {
+    const storage = mockStorage();
+    writeDesktopSidebarOpenToStorage(true, storage);
+    expect(storage.snapshot()).toEqual({ [SIDEBAR_OPEN_KEY]: "true" });
+  });
+
+  it("persists desktop closed preference", () => {
+    const storage = mockStorage();
+    writeDesktopSidebarOpenToStorage(false, storage);
+    expect(storage.snapshot()).toEqual({ [SIDEBAR_OPEN_KEY]: "false" });
+  });
+});

--- a/web/src/lib/sidebar-preference.ts
+++ b/web/src/lib/sidebar-preference.ts
@@ -1,0 +1,44 @@
+export const SIDEBAR_OPEN_KEY = "hermes-sidebar-open";
+/** @deprecated Replaced by SIDEBAR_OPEN_KEY — read once for migration. */
+export const LEGACY_SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+/**
+ * Read the persisted desktop sidebar preference from storage.
+ * Defaults to open when no preference is stored (desktop-first layout).
+ */
+export function readDesktopSidebarOpenFromStorage(
+  storage: StorageLike | null | undefined = localStorage,
+): boolean {
+  if (!storage) return true;
+  try {
+    const storedOpen = storage.getItem(SIDEBAR_OPEN_KEY);
+    if (storedOpen !== null) return storedOpen !== "false";
+
+    const legacyCollapsed = storage.getItem(LEGACY_SIDEBAR_COLLAPSED_KEY);
+    if (legacyCollapsed !== null) {
+      // Old "collapsed" was a narrow icon rail; the new model is open (w-64)
+      // or fully closed — never a rail. Treat legacy collapsed=true as closed.
+      const open = legacyCollapsed !== "true";
+      storage.setItem(SIDEBAR_OPEN_KEY, open ? "true" : "false");
+      storage.removeItem(LEGACY_SIDEBAR_COLLAPSED_KEY);
+      return open;
+    }
+  } catch {
+    /* storage may be unavailable in private browsing */
+  }
+  return true;
+}
+
+export function writeDesktopSidebarOpenToStorage(
+  open: boolean,
+  storage: StorageLike | null | undefined = localStorage,
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(SIDEBAR_OPEN_KEY, open ? "true" : "false");
+  } catch {
+    /* storage may be unavailable in private browsing */
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the Hermes dashboard sidebar so the **X button actually closes the sidebar** and the **main content expands to use the full width**. Previously the toggle felt broken (especially on Safari/WebKit) and on desktop “close” only collapsed the nav to a narrow icon rail (`w-14`) instead of hiding it.

## Stacking note (#49581)

#49581 (page header + plugin CSS) is **rebased onto this branch**. Safe to merge alone; #49581 can follow with a single header commit or merge independently (it includes these sidebar commits until this PR lands on `main`).


## Problem

- **Close / toggle appeared dead** — users could not reliably open or close the sidebar from the header controls.
- **Wrong close semantics on desktop** — the control collapsed the sidebar to an icon rail rather than fully hiding it; main content did not reflow.
- **Partial refactor** — `sidebarOpen` state was introduced alongside legacy `collapsed` / `mobileOpen` paths, leaving inconsistent behavior.

## Root cause

1. **Z-index stacking** — the `Backdrop` inversion layer sits at `z-200`, while the sidebar shell was at `z-50` and the mobile header at `z-40`. On WebKit, clicks often do not pass through `pointer-events: none` overlays to lower layers, so sidebar buttons received no events.
2. **Collapse vs. close** — desktop used a persisted “collapsed” rail mode (`PanelLeftClose` / `PanelLeftOpen`) instead of removing the sidebar from layout.
3. **Divergent mobile/desktop state** — separate code paths made behavior hard to reason about and easy to break during refactors.

## What changed

### `web/src/App.tsx`
- Replaced collapse rail (`SIDEBAR_COLLAPSED_KEY`, `collapsed`, `toggleCollapsed`) with a single **open/closed** model (`SIDEBAR_OPEN_KEY`, `sidebarOpen`, `closeSidebar`, `openSidebar`).
- **X always fully closes** the sidebar (mobile drawer off-screen + desktop aside removed from flex layout).
- When closed on desktop, the `<aside>` is **not rendered in the flex row**, so `<main className="flex-1">` expands to full width.
- Raised shell stacking: `SHELL_Z = z-[210]`, mobile backdrop `z-[205]` (above backdrop inversion at `z-200`).
- Mobile backdrop uses a native `<button>` for a reliable full-screen hit target.
- Nav links call `closeSidebar` only on mobile (desktop keeps the sidebar open after navigation).

### Supporting components
- `Backdrop.tsx` — comment documenting that interactive shell UI must sit above `z-200`.
- `ThemeSwitcher.tsx` / `LanguageSwitcher.tsx` — dropdown menus raised to `z-[220]` so they stay above the shell.
- `ProfileScopeBanner.tsx` — comment aligned with shell z-index.

## Desktop reopen

When the sidebar is fully closed on desktop, a compact **menu** bar appears above the main column so users can call `openSidebar()` without refreshing.

## localStorage migration

Reads legacy `hermes-sidebar-collapsed` once and migrates to `hermes-sidebar-open` (collapsed rail → fully closed).

## Test plan

- [ ] `npm run build -w web` succeeds
- [ ] `hermes dashboard` — hard refresh (Cmd+Shift+R) to load new `web_dist`
- [ ] **Desktop**: sidebar open → click **X** → sidebar disappears, chat/main area uses full width
- [ ] **Desktop**: refresh page → closed state persists (`localStorage` `hermes-sidebar-open`)
- [ ] **Mobile / narrow viewport**: hamburger opens drawer; backdrop tap and **X** close; nav link closes drawer
- [ ] **Safari/WebKit**: header **X** and mobile menu button respond on first click
- [ ] Theme / language dropdowns still open above the shell

## Screenshots

Before: sidebar “close” left a `w-14` icon rail; toggle could appear unresponsive under the backdrop layer.

After: **X** fully hides the sidebar; main content expands edge-to-edge.
