### PR TITLE
chore(deps): npm audit fix — clear transitive undici advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8764,9 +8764,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -12207,9 +12207,9 @@
       }
     },
     "node_modules/jsdom/node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17467,9 +17467,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -18692,7 +18692,8 @@
         "three": "^0.180.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.56.1",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.5"
       }
     },
     "web/node_modules/@nous-research/ui": {


### PR DESCRIPTION
## Summary
Clears the 2 npm audit advisories (1 high, 1 moderate), both from transitive `undici`.

## Changes
- `package-lock.json` — `npm audit fix`, lockfile-only (no `package.json` edits):
  - `undici` 6.26.0 → 6.27.0 — **high** (TLS validation bypass / Set-Cookie header injection / keep-alive response-queue poisoning class). Pulled via `node-gyp` (→ `@electron/rebuild`) and `ui-tui`.
  - `jsdom`'s nested `undici` 7.27.2 → 7.28.0 — **moderate**. Pulled via `jsdom` (vitest / `apps/desktop` test dep).
  - Incidental in-range reconciliations during the install: `dompurify` 3.4.10 → 3.4.11 (patch), and the `web` workspace's already-declared `vitest ^4.1.5` devDep synced into the lockfile.

Both undici bumps are in-range (no `--force`). All advisory paths are dev/build-time transitive deps — neither undici ships in the runtime agent.

## Validation
| package dir | before | after |
|---|---|---|
| root | 2 (1 high, 1 moderate) | **0** |
| ui-tui | 1 high | **0** |
| apps/desktop | 2 (1 high, 1 moderate) | **0** |

All three resolve through the root workspace `node_modules`; only the root `package-lock.json` changed.

## Infographic

![npm-audit-undici-cleared](https://v3b.fal.media/files/b/0a9eef90/TOm7xz0Ah2a6Z7NlIhOk0_VrrdFXw7.png)
