### PR TITLE
fix(acp): read file:// resources on native Windows instead of /mnt paths

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -151,8 +151,11 @@ def _path_from_file_uri(uri: str) -> Path | None:
     """Convert local file URIs/paths from ACP clients into a readable Path.
 
     Zed may send POSIX file URIs from Linux/WSL workspaces or Windows-ish paths
-    when launched through wsl.exe. Translate the common Windows drive form to
-    /mnt/<drive>/... so Hermes running in WSL can read it.
+    when launched through wsl.exe. When Hermes itself runs inside WSL, translate
+    the common Windows drive form to /mnt/<drive>/... so it can read the file.
+    On native Windows the drive path is already usable and must be kept as-is —
+    rewriting it to /mnt/<drive> there points at a non-existent path and the
+    read fails with FileNotFoundError (#48986).
     """
     raw = (uri or "").strip()
     if not raw:
@@ -170,14 +173,21 @@ def _path_from_file_uri(uri: str) -> Path | None:
         path_text = unquote(raw)
 
     # file:///C:/Users/... or C:\Users\...
+    drive: str | None = None
+    rest = ""
     if len(path_text) >= 3 and path_text[0] == "/" and path_text[2] == ":" and path_text[1].isalpha():
-        drive = path_text[1].lower()
+        drive = path_text[1]
         rest = path_text[3:].lstrip("/\\").replace("\\", "/")
-        return Path("/mnt") / drive / rest
-    if len(path_text) >= 2 and path_text[1] == ":" and path_text[0].isalpha():
-        drive = path_text[0].lower()
+    elif len(path_text) >= 2 and path_text[1] == ":" and path_text[0].isalpha():
+        drive = path_text[0]
         rest = path_text[2:].lstrip("/\\").replace("\\", "/")
-        return Path("/mnt") / drive / rest
+
+    if drive is not None:
+        from hermes_constants import is_wsl
+
+        if is_wsl():
+            return Path("/mnt") / drive.lower() / rest
+        return Path(f"{drive.upper()}:/{rest}")
 
     return Path(path_text)
 

--- a/tests/acp_adapter/test_acp_images.py
+++ b/tests/acp_adapter/test_acp_images.py
@@ -38,7 +38,10 @@ def test_text_only_acp_blocks_stay_string_for_legacy_prompt_path():
 
 def test_acp_resource_link_file_is_inlined_as_text(tmp_path):
     attached = tmp_path / "notes.md"
-    attached.write_text("# Notes\n\nAttached file body", encoding="utf-8")
+    # newline="" disables the platform newline translation so the fixture keeps
+    # LF on Windows too; otherwise write_text emits CRLF and the inlined body
+    # no longer matches the LF-based expectation below.
+    attached.write_text("# Notes\n\nAttached file body", encoding="utf-8", newline="")
 
     content = _content_blocks_to_openai_user_content([
         TextContentBlock(type="text", text="Please read this file"),


### PR DESCRIPTION
## What

ACP file:// resource links now resolve to the real Windows drive path on native Windows, instead of a non-existent `/mnt/<drive>` WSL path.

## Why

`_path_from_file_uri` in `acp_adapter/server.py` unconditionally rewrote `file:///C:/Users/...` to `/mnt/c/Users/...`. That WSL mount form only exists under WSL; on native Windows the read failed with `FileNotFoundError [WinError 3]` and the attached file was silently dropped from the prompt.

## Change

- Gate the `/mnt/<drive>` rewrite behind `is_wsl()` (the same guard `acp_adapter/session.py` already uses for cwd translation). On native Windows the real drive path is kept.
- Fix the text fixture in `test_acp_images.py` to write with `newline=""` so its body stays LF on Windows and matches the LF-based assertion.

## Tests

`tests/acp_adapter/` — was 3 failing on native Windows (the `file://` resource-link cases), now 19/19 pass. No change in behavior on Linux/WSL.

Part of #48986.