### PR TITLE
fix(telegram): handle channel senders and fix guest reply ordering

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -6894,6 +6894,13 @@ class TelegramAdapter(BasePlatformAdapter):
         # All send() / send_draft() / send_or_update_status() calls during processing
         # were silently buffered; we fire a single answerGuestQuery here with the
         # complete response so the user sees the full answer, not a status fragment.
+        #
+        # Private-chat routing note: in groups the reply appears in the group chat as
+        # expected.  In P2P private chats between two regular users, Telegram cannot
+        # post a bot message into the conversation, so it surfaces the reply in the
+        # bot's own DM thread with the mentioning user instead.  This is Telegram API
+        # behaviour — our call is identical in both cases; the difference is how
+        # Telegram routes the answerGuestQuery result on its end.
         _gc_id = str(getattr(event.source, "chat_id", None) or "")
         if _gc_id:
             _guest_qid = self._pending_guest_queries.pop(_gc_id, None)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -476,6 +476,12 @@ class TelegramAdapter(BasePlatformAdapter):
         self._forum_command_registered: set[int] = set()
         # Lock per la registrazione sicura dei comandi nei forum supergroup
         self._forum_lock = asyncio.Lock()
+        # chat_id → guest_query_id for Bot API 10.0 guest replies
+        self._pending_guest_queries: Dict[str, str] = {}
+        # chat IDs that are guest-mode only (bot not a member)
+        self._guest_only_chats: set = set()
+        # accumulated send() content for guest chats; flushed via answerGuestQuery in on_processing_complete
+        self._guest_reply_buffer: Dict[str, str] = {}
         # DM Topics config from extra.dm_topics
         self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
         # Precomputed chat_ids that have DM topics configured (for O(1) root-DM ignore check)
@@ -1591,7 +1597,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             try:
                 await self._app.updater.start_polling(
-                    allowed_updates=Update.ALL_TYPES,
+                    allowed_updates=[*Update.ALL_TYPES, "guest_message"],
                     drop_pending_updates=False,
                     error_callback=self._polling_error_callback_ref,
                 )
@@ -2098,6 +2104,15 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            # Handle guest_message updates (Bot API 10.0 — not yet in PTB typed layer;
+            # the raw payload arrives in update.api_kwargs["guest_message"]).
+            try:
+                from telegram.ext import TypeHandler as _TypeHandler
+                self._app.add_handler(
+                    _TypeHandler(Update, self._handle_guest_message_update), group=1
+                )
+            except Exception as _th_err:
+                logger.warning("[%s] Could not register guest_message TypeHandler: %s", self.name, _th_err)
             
             # Start polling — retry initialize() for transient TLS resets
             try:
@@ -2160,7 +2175,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     url_path=webhook_path,
                     webhook_url=webhook_url,
                     secret_token=webhook_secret,
-                    allowed_updates=Update.ALL_TYPES,
+                    allowed_updates=[*Update.ALL_TYPES, "guest_message"],
                     drop_pending_updates=True,
                 )
                 self._webhook_mode = True
@@ -2193,7 +2208,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._polling_error_callback_ref = _polling_error_callback
 
                 await self._app.updater.start_polling(
-                    allowed_updates=Update.ALL_TYPES,
+                    allowed_updates=[*Update.ALL_TYPES, "guest_message"],
                     drop_pending_updates=True,
                     error_callback=_polling_error_callback,
                 )
@@ -2368,6 +2383,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     for chunk in chunks
                 ]
             
+            # Bot API 10.0 guest reply: keep only the last send() content (the final answer).
+            # Earlier send() calls carry thinking/tool-progress text; the stream consumer
+            # always issues one final send() with the complete response, which overwrites them.
+            if self._pending_guest_queries.get(chat_id) is not None or chat_id in self._guest_only_chats:
+                self._guest_reply_buffer[chat_id] = content
+                return SendResult(success=True, message_id=None)
+
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
@@ -2628,6 +2650,10 @@ class TelegramAdapter(BasePlatformAdapter):
         message in place. If the edit fails (message deleted, too old, etc.)
         we drop the cached id and send fresh.
         """
+        # Guest chats have no existing message to edit and status messages would
+        # consume the one-shot query_id before the real answer is ready.
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=True, message_id=None)
         key = (str(chat_id), str(status_key))
         cached_id = self._status_message_ids.get(key)
         if cached_id is not None:
@@ -3062,6 +3088,10 @@ class TelegramAdapter(BasePlatformAdapter):
         final ``sendMessage``/``sendRichMessage`` is what the user receives in
         their history).
         """
+        # Guest chats: draft streaming requires an existing message to animate;
+        # the bot is not a member, so suppress silently.
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=True, message_id=None)
         if not self._bot:
             return SendResult(success=False, error="not_connected")
 
@@ -5897,6 +5927,56 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    async def _handle_guest_message_update(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle guest_message updates (Bot API 10.0 guest bot feature).
+
+        Telegram delivers @mentions from chats the bot hasn't joined via the
+        ``guest_message`` update field.  PTB doesn't know this field yet so it
+        lands in ``update.api_kwargs``.  We parse the raw payload, store the
+        ``guest_query_id`` so ``send()`` can call ``answerGuestQuery``, then
+        route the message through the normal text-processing pipeline.
+        """
+        if not self._telegram_guest_mode():
+            return
+        raw_gm = update.api_kwargs.get("guest_message") if update.api_kwargs else None
+        if not raw_gm or not isinstance(raw_gm, dict):
+            return
+        logger.info("[%s] guest_message update received (update_id=%s)", self.name, update.update_id)
+
+        guest_query_id = raw_gm.get("guest_query_id")
+        if not guest_query_id:
+            logger.warning("[%s] guest_message missing guest_query_id, skipping", self.name)
+            return
+
+        try:
+            msg = Message.de_json(raw_gm, self._bot)
+        except Exception as exc:
+            logger.warning("[%s] Failed to parse guest_message payload: %s", self.name, exc)
+            return
+        if not msg:
+            return
+
+        text = msg.text or getattr(msg, "caption", None) or ""
+        if not text.strip():
+            return
+
+        chat_id_str = str(msg.chat.id) if msg.chat else ""
+        if not chat_id_str:
+            return
+
+        # Store guest_query_id so send() uses answerGuestQuery for the reply.
+        self._pending_guest_queries[chat_id_str] = guest_query_id
+        self._guest_only_chats.add(chat_id_str)
+
+        if not self._should_process_message(msg):
+            self._pending_guest_queries.pop(chat_id_str, None)
+            return
+
+        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+        event.text = self._clean_bot_trigger_text(event.text)
+        event = self._apply_telegram_group_observe_attribution(event)
+        self._enqueue_text_event(event)
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -6809,6 +6889,36 @@ class TelegramAdapter(BasePlatformAdapter):
         another agent run to swap it to 👍/👎 — which never happens if the
         cancellation was the last activity in the chat.
         """
+        # Flush buffered guest reply via answerGuestQuery (Bot API 10.0).
+        # All send() / send_draft() / send_or_update_status() calls during processing
+        # were silently buffered; we fire a single answerGuestQuery here with the
+        # complete response so the user sees the full answer, not a status fragment.
+        _gc_id = str(getattr(event.source, "chat_id", None) or "")
+        if _gc_id:
+            _guest_qid = self._pending_guest_queries.pop(_gc_id, None)
+            _buffered = self._guest_reply_buffer.pop(_gc_id, "")
+            self._guest_only_chats.discard(_gc_id)
+            if _guest_qid and self._bot:
+                _plain = _strip_mdv2(self.format_message(_buffered)).strip() if _buffered else ""
+                _plain = _plain[:4096] or "​"  # zero-width space if somehow empty
+                _gq_result = {
+                    "type": "article",
+                    "id": "reply",
+                    "title": "Reply",
+                    "input_message_content": {"message_text": _plain},
+                }
+                try:
+                    await self._bot.do_api_request(
+                        "answerGuestQuery",
+                        api_kwargs={"guest_query_id": _guest_qid, "result": _gq_result},
+                    )
+                    logger.info("[%s] answerGuestQuery flushed (chat=%s)", self.name, _gc_id)
+                except Exception as _flush_err:
+                    logger.warning(
+                        "[%s] answerGuestQuery flush failed (chat=%s): %s",
+                        self.name, _gc_id, _flush_err,
+                    )
+
         if not self._reactions_enabled():
             return
         chat_id = getattr(event.source, "chat_id", None)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5970,6 +5970,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         if not self._should_process_message(msg):
             self._pending_guest_queries.pop(chat_id_str, None)
+            self._guest_only_chats.discard(chat_id_str)
             return
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2693,6 +2693,11 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        # "__no_edit__" is a stream_consumer sentinel meaning "no preview message
+        # was created"; treating it as a real message_id would crash int() below.
+        if message_id == "__no_edit__":
+            return SendResult(success=True, message_id=message_id)
+
         # Rich finalize (Bot API 10.1): when the completed content has
         # constructs the legacy MarkdownV2 edit degrades (tables → bullet
         # lists, task lists, <details>, block math) and rich is available,
@@ -4380,6 +4385,29 @@ class TelegramAdapter(BasePlatformAdapter):
             )
         return error
 
+    def _resolve_workspace_path(self, path: str) -> str:
+        """Translate /workspace/ Docker container paths to host equivalents.
+
+        When the terminal backend is Docker, tool-generated media lives at
+        /workspace/<file> inside the container. The gateway runs on the host
+        where that path does not exist. This looks up the active Docker env's
+        workspace host directory and rewrites the path so os.path.exists() works.
+        """
+        if not path.startswith("/workspace"):
+            return path
+        try:
+            from tools.terminal_tool import _active_environments  # type: ignore[import]
+            for env in list(_active_environments.values()):
+                wd = getattr(env, "_workspace_dir", None)
+                if wd:
+                    if path == "/workspace":
+                        return wd
+                    if path.startswith("/workspace/"):
+                        return wd + path[len("/workspace"):]
+        except Exception:
+            pass
+        return path
+
     def _telegram_media_too_large_note(self, label: str, file_size: Any, max_bytes: int) -> str:
         limit_mb = max(1, max_bytes // (1024 * 1024))
         try:
@@ -4419,7 +4447,11 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send audio as a native Telegram voice message or audio file."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
-        
+
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=True, message_id=None)
+
+        audio_path = self._resolve_workspace_path(audio_path)
         try:
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Audio", audio_path))
@@ -4646,6 +4678,10 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=True, message_id=None)
+
+        image_path = self._resolve_workspace_path(image_path)
         try:
             if not os.path.exists(image_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Image", image_path))
@@ -4740,6 +4776,10 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=True, message_id=None)
+
+        file_path = self._resolve_workspace_path(file_path)
         try:
             if not os.path.exists(file_path):
                 return SendResult(success=False, error=self._missing_media_path_error("File", file_path))
@@ -4790,6 +4830,10 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
+            return SendResult(success=True, message_id=None)
+
+        video_path = self._resolve_workspace_path(video_path)
         try:
             if not os.path.exists(video_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Video", video_path))

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2353,6 +2353,13 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=None)
         
         try:
+            # Bot API 10.0 guest reply: buffer content and return immediately.
+            # Must run before the rich/legacy send paths — both use sendMessage
+            # which Telegram rejects with Forbidden when the bot is not a member.
+            if self._pending_guest_queries.get(chat_id) is not None or chat_id in self._guest_only_chats:
+                self._guest_reply_buffer[chat_id] = content
+                return SendResult(success=True, message_id=None)
+
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls
             # through to the legacy MarkdownV2 path on permanent/capability
@@ -2383,13 +2390,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     for chunk in chunks
                 ]
             
-            # Bot API 10.0 guest reply: keep only the last send() content (the final answer).
-            # Earlier send() calls carry thinking/tool-progress text; the stream consumer
-            # always issues one final send() with the complete response, which overwrites them.
-            if self._pending_guest_queries.get(chat_id) is not None or chat_id in self._guest_only_chats:
-                self._guest_reply_buffer[chat_id] = content
-                return SendResult(success=True, message_id=None)
-
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
@@ -6788,6 +6788,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     break
 
         # Build source
+        # When a user posts "as a channel" in a group, from_user is None but
+        # sender_chat carries the channel identity. Use sender_chat.id so the
+        # auth check can match it and the session key is stable across messages.
+        sender_chat = getattr(message, "sender_chat", None)
         source = self.build_source(
             chat_id=str(chat.id),
             chat_name=chat.title or (chat.full_name if hasattr(chat, "full_name") else None),
@@ -6795,15 +6799,23 @@ class TelegramAdapter(BasePlatformAdapter):
             user_id=(
                 str(user.id)
                 if user
-                else (str(chat.id) if chat_type in {"dm", "channel"} else None)
+                else (
+                    str(sender_chat.id)
+                    if sender_chat
+                    else (str(chat.id) if chat_type in {"dm", "channel"} else None)
+                )
             ),
             user_name=(
                 user.full_name
                 if user
                 else (
-                    chat.full_name
-                    if hasattr(chat, "full_name") and chat_type == "dm"
-                    else (chat.title if chat_type == "channel" else None)
+                    getattr(sender_chat, "title", None) or getattr(sender_chat, "username", None)
+                    if sender_chat
+                    else (
+                        chat.full_name
+                        if hasattr(chat, "full_name") and chat_type == "dm"
+                        else (chat.title if chat_type == "channel" else None)
+                    )
                 )
             ),
             thread_id=thread_id_str,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4449,7 +4449,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
-            return SendResult(success=True, message_id=None)
+            return SendResult(success=False, error="guest_chat_no_media: bot is not a member of this group so Telegram blocks file uploads. Send the file to the user's private DMs and tell them in the group that the file is in their DMs.")
 
         audio_path = self._resolve_workspace_path(audio_path)
         try:
@@ -4679,7 +4679,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
-            return SendResult(success=True, message_id=None)
+            return SendResult(success=False, error="guest_chat_no_media: bot is not a member of this group so Telegram blocks file uploads. Send the file to the user's private DMs and tell them in the group that the file is in their DMs.")
 
         image_path = self._resolve_workspace_path(image_path)
         try:
@@ -4777,7 +4777,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
-            return SendResult(success=True, message_id=None)
+            return SendResult(success=False, error="guest_chat_no_media: bot is not a member of this group so Telegram blocks file uploads. Send the file to the user's private DMs and tell them in the group that the file is in their DMs.")
 
         file_path = self._resolve_workspace_path(file_path)
         try:
@@ -4831,7 +4831,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         if self._pending_guest_queries.get(str(chat_id)) is not None or str(chat_id) in self._guest_only_chats:
-            return SendResult(success=True, message_id=None)
+            return SendResult(success=False, error="guest_chat_no_media: bot is not a member of this group so Telegram blocks file uploads. Send the file to the user's private DMs and tell them in the group that the file is in their DMs.")
 
         video_path = self._resolve_workspace_path(video_path)
         try:

--- a/tests/gateway/test_telegram_guest_mode.py
+++ b/tests/gateway/test_telegram_guest_mode.py
@@ -1,0 +1,330 @@
+"""Tests for Telegram Bot API 10.0 guest mode support.
+
+Covers:
+- _handle_guest_message_update: payload parsing, state setup, routing
+- send() / send_or_update_status() / send_draft(): suppression for guest chats
+- on_processing_complete(): answerGuestQuery flush and state cleanup
+- Denial path: both _pending_guest_queries and _guest_only_chats cleared on reject
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome, SendResult
+from gateway.session import SessionSource
+
+
+# ── fake telegram package ─────────────────────────────────────────────────────
+
+
+def _install_fake_telegram(monkeypatch):
+    """Stub python-telegram-bot so TelegramAdapter can be imported without it."""
+    fake_telegram = types.ModuleType("telegram")
+    fake_update = MagicMock()
+    fake_update.ALL_TYPES = ()
+    fake_telegram.Update = fake_update
+    fake_telegram.Bot = object
+    fake_telegram.Message = MagicMock()
+    fake_telegram.InlineKeyboardButton = object
+    fake_telegram.InlineKeyboardMarkup = object
+
+    fake_error = types.ModuleType("telegram.error")
+    fake_error.NetworkError = type("NetworkError", (Exception,), {})
+    fake_error.BadRequest = type("BadRequest", (Exception,), {})
+    fake_error.TimedOut = type("TimedOut", (Exception,), {})
+    fake_telegram.error = fake_error
+
+    fake_constants = types.ModuleType("telegram.constants")
+    fake_constants.ParseMode = SimpleNamespace(MARKDOWN_V2="MarkdownV2")
+    fake_constants.ChatType = SimpleNamespace(
+        GROUP="group", SUPERGROUP="supergroup",
+        CHANNEL="channel", PRIVATE="private",
+    )
+    fake_telegram.constants = fake_constants
+
+    fake_ext = types.ModuleType("telegram.ext")
+    fake_ext.Application = object
+    fake_ext.CommandHandler = object
+    fake_ext.CallbackQueryHandler = object
+    fake_ext.MessageHandler = object
+    fake_ext.TypeHandler = object
+    fake_ext.ContextTypes = SimpleNamespace(DEFAULT_TYPE=object)
+    fake_ext.filters = object
+
+    fake_request = types.ModuleType("telegram.request")
+    fake_request.HTTPXRequest = object
+
+    monkeypatch.setitem(sys.modules, "telegram", fake_telegram)
+    monkeypatch.setitem(sys.modules, "telegram.error", fake_error)
+    monkeypatch.setitem(sys.modules, "telegram.constants", fake_constants)
+    monkeypatch.setitem(sys.modules, "telegram.ext", fake_ext)
+    monkeypatch.setitem(sys.modules, "telegram.request", fake_request)
+
+
+# ── shared fixtures ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    _install_fake_telegram(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_GUEST_MODE", "true")
+    from gateway.platforms.telegram import TelegramAdapter
+
+    a = object.__new__(TelegramAdapter)
+    a.platform = Platform.TELEGRAM
+    a.config = PlatformConfig(enabled=True, token="fake-token")
+    a._bot = MagicMock()
+    a._bot.do_api_request = AsyncMock()
+    a._pending_guest_queries: dict = {}
+    a._guest_only_chats: set = set()
+    a._guest_reply_buffer: dict = {}
+    a._status_message_ids: dict = {}
+    return a
+
+
+def _make_event(chat_id: str = "999") -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=chat_id,
+            chat_type="group",
+            user_id="42",
+            user_name="Tester",
+        ),
+        message_id="1",
+    )
+
+
+# ── _handle_guest_message_update ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_guest_message_stores_query_id(monkeypatch, adapter):
+    """guest_query_id must be stored so on_processing_complete can flush."""
+    _install_fake_telegram(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_GUEST_MODE", "true")
+
+    raw_gm = {
+        "message_id": 1,
+        "date": 0,
+        "chat": {"id": -100123, "type": "supergroup"},
+        "from": {"id": 42, "is_bot": False, "first_name": "Tester"},
+        "text": "@bot hello",
+        "guest_query_id": "gqid-abc",
+    }
+    fake_update = SimpleNamespace(
+        update_id=1,
+        api_kwargs={"guest_message": raw_gm},
+    )
+
+    fake_msg = SimpleNamespace(
+        text="@bot hello",
+        caption=None,
+        chat=SimpleNamespace(id=-100123),
+    )
+
+    with (
+        patch.object(type(adapter), "_telegram_guest_mode", return_value=True),
+        patch("gateway.platforms.telegram.Message") as MockMsg,
+        patch.object(adapter, "_should_process_message", return_value=True),
+        patch.object(adapter, "_build_message_event", return_value=_make_event("-100123")),
+        patch.object(adapter, "_clean_bot_trigger_text", side_effect=lambda t: t),
+        patch.object(adapter, "_apply_telegram_group_observe_attribution", side_effect=lambda e: e),
+        patch.object(adapter, "_enqueue_text_event"),
+    ):
+        MockMsg.de_json.return_value = fake_msg
+        await adapter._handle_guest_message_update(fake_update, None)
+
+    assert adapter._pending_guest_queries.get("-100123") == "gqid-abc"
+    assert "-100123" in adapter._guest_only_chats
+
+
+@pytest.mark.asyncio
+async def test_handle_guest_message_skips_when_guest_mode_off(monkeypatch, adapter):
+    """Nothing should happen when guest_mode is disabled."""
+    monkeypatch.setenv("TELEGRAM_GUEST_MODE", "false")
+
+    fake_update = SimpleNamespace(update_id=1, api_kwargs={"guest_message": {"guest_query_id": "x"}})
+
+    with patch.object(type(adapter), "_telegram_guest_mode", return_value=False):
+        await adapter._handle_guest_message_update(fake_update, None)
+
+    assert adapter._pending_guest_queries == {}
+    assert adapter._guest_only_chats == set()
+
+
+@pytest.mark.asyncio
+async def test_handle_guest_message_denial_clears_both_state_dicts(monkeypatch, adapter):
+    """When _should_process_message returns False, both state dicts must be cleared.
+
+    Without discarding from _guest_only_chats, future send() calls to the same
+    chat would be silently suppressed even after the bot joins the group.
+    """
+    raw_gm = {
+        "message_id": 2,
+        "date": 0,
+        "chat": {"id": -100456, "type": "supergroup"},
+        "text": "@bot hi",
+        "guest_query_id": "gqid-denied",
+    }
+    fake_update = SimpleNamespace(update_id=2, api_kwargs={"guest_message": raw_gm})
+    fake_msg = SimpleNamespace(text="@bot hi", caption=None, chat=SimpleNamespace(id=-100456))
+
+    with (
+        patch.object(type(adapter), "_telegram_guest_mode", return_value=True),
+        patch("gateway.platforms.telegram.Message") as MockMsg,
+        patch.object(adapter, "_should_process_message", return_value=False),
+        patch.object(adapter, "_enqueue_text_event") as mock_enqueue,
+    ):
+        MockMsg.de_json.return_value = fake_msg
+        await adapter._handle_guest_message_update(fake_update, None)
+
+    assert "-100456" not in adapter._pending_guest_queries
+    assert "-100456" not in adapter._guest_only_chats
+    mock_enqueue.assert_not_called()
+
+
+# ── send() buffering ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_buffers_content_for_guest_chat(adapter):
+    """send() must buffer content rather than calling sendMessage for guest chats."""
+    adapter._pending_guest_queries["chat-1"] = "gqid-xyz"
+
+    result = await adapter.send("chat-1", "The answer is 42.")
+
+    assert result.success is True
+    assert result.message_id is None
+    assert adapter._guest_reply_buffer["chat-1"] == "The answer is 42."
+    adapter._bot.send_message = MagicMock()  # verify it was never called
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_last_write_wins_for_guest_chat(adapter):
+    """Each send() overwrites the buffer so only the final answer is kept."""
+    adapter._pending_guest_queries["chat-1"] = "gqid-xyz"
+
+    await adapter.send("chat-1", "Thinking about it...")
+    await adapter.send("chat-1", "Here is your answer.")
+
+    assert adapter._guest_reply_buffer["chat-1"] == "Here is your answer."
+
+
+@pytest.mark.asyncio
+async def test_send_buffers_for_guest_only_chat_without_query_id(adapter):
+    """_guest_only_chats membership alone should also trigger buffering."""
+    adapter._guest_only_chats.add("chat-2")
+
+    result = await adapter.send("chat-2", "Extra chunk.")
+
+    assert result.success is True
+    assert adapter._guest_reply_buffer.get("chat-2") == "Extra chunk."
+
+
+# ── send_or_update_status() suppression ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_or_update_status_suppressed_for_guest_chat(adapter):
+    """Status messages must be fully suppressed for guest chats."""
+    adapter._pending_guest_queries["chat-1"] = "gqid-xyz"
+
+    with patch.object(adapter, "send", new_callable=AsyncMock) as mock_send:
+        result = await adapter.send_or_update_status("chat-1", "thinking", "Searching...")
+
+    assert result.success is True
+    mock_send.assert_not_awaited()
+    assert adapter._guest_reply_buffer == {}
+
+
+@pytest.mark.asyncio
+async def test_send_or_update_status_suppressed_for_guest_only_chat(adapter):
+    """_guest_only_chats membership also suppresses send_or_update_status."""
+    adapter._guest_only_chats.add("chat-3")
+
+    with patch.object(adapter, "send", new_callable=AsyncMock) as mock_send:
+        result = await adapter.send_or_update_status("chat-3", "lifecycle", "Done.")
+
+    assert result.success is True
+    mock_send.assert_not_awaited()
+
+
+# ── on_processing_complete() flush ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_processing_complete_flushes_via_answer_guest_query(monkeypatch, adapter):
+    """on_processing_complete must call answerGuestQuery with the buffered reply."""
+    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+
+    adapter._pending_guest_queries["-100999"] = "gqid-flush"
+    adapter._guest_only_chats.add("-100999")
+    adapter._guest_reply_buffer["-100999"] = "The final answer."
+
+    with patch.object(type(adapter), "_reactions_enabled", return_value=False):
+        await adapter.on_processing_complete(_make_event("-100999"), ProcessingOutcome.SUCCESS)
+
+    adapter._bot.do_api_request.assert_awaited_once()
+    call_kwargs = adapter._bot.do_api_request.call_args
+    assert call_kwargs[0][0] == "answerGuestQuery"
+    api_kw = call_kwargs[1]["api_kwargs"]
+    assert api_kw["guest_query_id"] == "gqid-flush"
+    result = api_kw["result"]
+    assert result["type"] == "article"
+    assert "The final answer" in result["input_message_content"]["message_text"]
+
+
+@pytest.mark.asyncio
+async def test_on_processing_complete_cleans_up_all_state(monkeypatch, adapter):
+    """All three guest state dicts must be cleared after flushing."""
+    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+
+    adapter._pending_guest_queries["-100999"] = "gqid-flush"
+    adapter._guest_only_chats.add("-100999")
+    adapter._guest_reply_buffer["-100999"] = "Answer."
+
+    with patch.object(type(adapter), "_reactions_enabled", return_value=False):
+        await adapter.on_processing_complete(_make_event("-100999"), ProcessingOutcome.SUCCESS)
+
+    assert "-100999" not in adapter._pending_guest_queries
+    assert "-100999" not in adapter._guest_only_chats
+    assert "-100999" not in adapter._guest_reply_buffer
+
+
+@pytest.mark.asyncio
+async def test_on_processing_complete_no_op_for_non_guest_chat(monkeypatch, adapter):
+    """answerGuestQuery must NOT be called for regular (non-guest) chats."""
+    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+
+    with patch.object(type(adapter), "_reactions_enabled", return_value=False):
+        await adapter.on_processing_complete(_make_event("777"), ProcessingOutcome.SUCCESS)
+
+    adapter._bot.do_api_request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_processing_complete_flush_error_does_not_raise(monkeypatch, adapter):
+    """A failed answerGuestQuery call must be logged but not propagate."""
+    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+
+    adapter._pending_guest_queries["-100999"] = "gqid-bad"
+    adapter._guest_reply_buffer["-100999"] = "Answer."
+    adapter._bot.do_api_request.side_effect = RuntimeError("QUERY_ID_INVALID")
+
+    with patch.object(type(adapter), "_reactions_enabled", return_value=False):
+        await adapter.on_processing_complete(_make_event("-100999"), ProcessingOutcome.SUCCESS)
+
+    # State is still cleaned up even when the API call fails.
+    assert "-100999" not in adapter._pending_guest_queries
+    assert "-100999" not in adapter._guest_only_chats


### PR DESCRIPTION
## Summary

Follow-up to #43049 — two fixes for group chat message handling discovered during testing of the guest mode feature:

- **Channel sender identity**: when a user posts "as a channel" in a group, `from_user` is `None` and `sender_chat` carries the channel's `id`/`title`/`username`. Previously this set `user_id=None`, silently failing the auth check with no error surfaced to the user. Now `sender_chat.id` is used as the `user_id` fallback, so allow-lists can authorize the channel and the session key is stable across messages from the same channel.

- **Guest reply ordering**: the Bot API 10.0 guest buffer check in `send()` was placed *after* the `sendRichMessage` fast-path (added in #43049 for the legacy MarkdownV2 path). This caused `send()` to attempt `sendMessage` — which Telegram rejects with `Forbidden: bot is not a member` for non-member bots — before falling back to `answerGuestQuery`. Moving the guest check to the top of `send()` short-circuits before any network call is made, eliminating the spurious delivery-failure notification.

## Test plan

- [ ] Personal user @mention in group the bot is not a member of → bot responds via `answerGuestQuery`
- [ ] Channel @mention (posting "as a channel") in the same group → `sender_chat.id` is used as `user_id`, auth passes if channel ID is in the allowlist, bot responds
- [ ] No "Message delivery failed" error on guest replies when `rich_messages` is enabled
- [ ] DM and member-group messages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)