### PR TITLE
fix(delegation): force bedrock_converse api_mode for bedrock delegation provider

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1045,6 +1045,27 @@ class TestDelegationCredentialResolution(unittest.TestCase):
 
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_bedrock_provider_forces_bedrock_converse_api_mode(self, mock_resolve):
+        """When delegation.provider is bedrock, api_mode must be bedrock_converse.
+
+        resolve_runtime_provider('bedrock') returns api_mode='anthropic_messages',
+        but agent_init.py needs 'bedrock_converse' to trigger the boto3 path.
+        Without this override, the child silently falls back to openrouter/free.
+        Fixes #49095.
+        """
+        mock_resolve.return_value = {
+            "provider": "bedrock",
+            "base_url": "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "api_key": "bedrock-session-token",
+            "api_mode": "anthropic_messages",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "global.anthropic.claude-sonnet-4-6", "provider": "bedrock"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_mode"], "bedrock_converse")
+        self.assertEqual(creds["provider"], "bedrock")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolution_failure_raises_valueerror(self, mock_resolve):
         """When provider resolution fails, ValueError is raised with helpful message."""
         mock_resolve.side_effect = RuntimeError("OPENROUTER_API_KEY not set")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2756,7 +2756,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "provider": configured_provider if runtime.get("provider") == _RUNTIME_PROVIDER_CUSTOM else runtime.get("provider"),
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
-        "api_mode": runtime.get("api_mode"),
+        "api_mode": "bedrock_converse" if (configured_provider or "").lower() == "bedrock" else runtime.get("api_mode"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
     }


### PR DESCRIPTION
## Problem

When `delegation.provider = bedrock` is configured in `config.yaml`, subagents silently route to `openrouter/free` instead of using AWS Bedrock.

**Root cause:** `_resolve_delegation_credentials()` in `tools/delegate_tool.py` calls `resolve_runtime_provider("bedrock")` which returns `api_mode: "anthropic_messages"`. This gets passed to the child agent via `override_api_mode`. In `agent_init.py`, line 316 matches `"anthropic_messages"` from the known set and sets `agent.api_mode = "anthropic_messages"`. The bedrock-specific `elif agent.provider == "bedrock"` branch at line 339 never fires because it was already consumed. The child then tries the Anthropic adapter with bedrock credentials (which don't work as raw API keys), falls through to `resolve_provider_client("bedrock")` → no pool credentials → silently routes to openrouter/free.

## Fix

One-line change in `_resolve_delegation_credentials()`:

```python
# Before:
"api_mode": runtime.get("api_mode"),

# After:
"api_mode": "bedrock_converse" if (configured_provider or "").lower() == "bedrock" else runtime.get("api_mode"),
```

This ensures the child agent gets `api_mode="bedrock_converse"`, which `agent_init.py` line 316 recognizes and triggers the boto3 init path (line 702) instead of the broken Anthropic adapter fallback.

## Tests

Added `test_bedrock_provider_forces_bedrock_converse_api_mode` — mocks `resolve_runtime_provider` to return `api_mode="anthropic_messages"` (the current broken behavior) and asserts the delegation resolver now overrides it to `"bedrock_converse"`.

All 141 tests in `tests/tools/test_delegate.py` pass.

Fixes #49095
