### PR TITLE
test(agent): honor Windows expanduser home in HOME-dependent tests

### DIFF
--- a/tests/agent/lsp/test_workspace.py
+++ b/tests/agent/lsp/test_workspace.py
@@ -134,6 +134,12 @@ def test_resolve_workspace_falls_back_to_file_location(tmp_path: Path, monkeypat
 
 
 def test_normalize_path_expands_tilde(monkeypatch):
+    # os.path.expanduser resolves ~ from USERPROFILE (then HOMEDRIVE+HOMEPATH)
+    # on Windows and from HOME on POSIX. Set all of them so the test pins the
+    # same home on every platform instead of leaking the real Windows profile.
     monkeypatch.setenv("HOME", "/home/user")
+    monkeypatch.setenv("USERPROFILE", "/home/user")
+    monkeypatch.delenv("HOMEDRIVE", raising=False)
+    monkeypatch.delenv("HOMEPATH", raising=False)
     p = normalize_path("~/x.py")
     assert p == os.path.abspath("/home/user/x.py")

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -331,7 +331,14 @@ def test_defaults_allowed_root_to_cwd(tmp_path: Path):
 async def test_blocks_sensitive_home_and_hermes_paths(tmp_path: Path, monkeypatch):
     from agent.context_references import preprocess_context_references_async
 
+    # The sensitive-path guard derives the home dir from os.path.expanduser,
+    # which reads USERPROFILE (then HOMEDRIVE+HOMEPATH) on Windows and HOME on
+    # POSIX. Pin all of them to tmp_path so the ~/.ssh block is actually tested
+    # on Windows instead of falling back to the real user profile.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("HOMEDRIVE", raising=False)
+    monkeypatch.delenv("HOMEPATH", raising=False)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
 
     hermes_env = tmp_path / ".hermes" / ".env"


### PR DESCRIPTION
## What

Two HOME-dependent tests now resolve `~` to the test's tmp dir on native Windows, instead of leaking the real user profile.

## Why

`os.path.expanduser` reads `USERPROFILE` (then `HOMEDRIVE`+`HOMEPATH`) on Windows and `HOME` on POSIX. The tests set only `HOME`, so on native Windows `~` expanded to the real profile:

- `test_normalize_path_expands_tilde` asserted against the wrong home and failed.
- `test_blocks_sensitive_home_and_hermes_paths` compared the `~/.ssh/id_rsa` guard against the real profile, so the SSH-key block was never actually exercised on Windows — the security assertion silently passed over.

## Change

Pin `USERPROFILE` alongside `HOME` and clear `HOMEDRIVE`/`HOMEPATH` so `~` resolves to the same home on every platform. Test-only; no production code change, POSIX behavior unaffected.

## Tests

Both pass on native Windows after the change; unchanged on POSIX.

Part of #48986.