### PR TITLE
fix(cli): clear viewport on width-change resize so the status bar can't duplicate

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3680,6 +3680,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # terminal reflow settles, so the status bar returns during idle
         # without waiting for the next submitted input.
         self._status_bar_unsuppress_timer = None
+        # Last terminal width seen by the resize handler. Used to distinguish a
+        # width change (column reflow → possible ghost chrome, needs a viewport
+        # clear) from a rows-only change (no reflow). None until the first
+        # resize fires.
+        self._last_resize_width = None
 
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
@@ -3836,6 +3841,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         drawing a fresh full-width bar immediately makes the old and new
         versions look duplicated (#19280, #22976).
 
+        Suppression alone is not enough on a WIDTH change.  prompt_toolkit's
+        ``renderer.erase()`` does ``cursor_up(_cursor_pos.y)`` + ``erase_down()``
+        using the ``_cursor_pos.y`` cached from the LAST render at the OLD
+        width (renderer.py).  When the column count shrinks, the terminal
+        reflows each already-painted full-width chrome row into 2+ physical
+        rows, so the cached ``y`` undershoots: ``cursor_up`` does not climb
+        past the reflowed rows and ``erase_down`` leaves the stale bar stranded
+        ABOVE the live origin.  The next paint then stacks a fresh bar below it
+        — the duplicated-status-bar report (two bars, two elapsed readings).
+        Suppression hides the *new* bar but never erases the already-reflowed
+        *old* one, so the ghost survives the whole suppression window.
+
+        Fix: on a width change, wipe the visible viewport with ``erase_screen``
+        (CSI 2J) BEFORE delegating to prompt_toolkit's resize, then let its
+        repaint redraw from a clean origin.  This is banner-safe: 2J clears
+        only the visible screen, NOT scrollback history (that is CSI 3J, which
+        we do not send here — ``rebuild_scrollback=False``), so the startup
+        banner that scrolled into history is preserved and
+        ``_replay_output_history`` is not needed.  Row-count-only changes skip
+        the clear (no reflow, so no ghost) to avoid an unnecessary repaint.
+
         The suppression is transient: a short follow-up timer clears it and
         repaints once the reflow has settled, so the bar returns on its own
         during idle.  Previously the flag was only cleared on the next
@@ -3846,6 +3872,31 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         at the input loop remains as a fast path.
         """
         self._status_bar_suppressed_after_resize = True
+        # On a WIDTH change the terminal has already reflowed the old full-width
+        # chrome into extra physical rows that prompt_toolkit's stale-cursor
+        # erase (cursor_up(_cursor_pos.y) cached at the OLD width) will not
+        # reach, leaving a duplicated status bar stranded above the live origin.
+        # Ctrl+L / /redraw clears it cleanly, so route the resize path through
+        # the SAME recovery: wipe the visible viewport (banner-safe — CSI 2J
+        # only, never CSI 3J) and replay the transcript so nothing is lost.
+        # Row-count-only changes skip this (no reflow → no ghost) to avoid an
+        # unnecessary full repaint.
+        try:
+            new_width = self._get_tui_terminal_width()
+        except Exception:
+            new_width = None
+        prev_width = getattr(self, "_last_resize_width", None)
+        # First resize of the session has no prior width to compare against;
+        # treat it as a change so an initial maximize/restore is covered too.
+        width_changed = new_width is not None and new_width != prev_width
+        if width_changed:
+            try:
+                self._clear_prompt_toolkit_screen(app, rebuild_scrollback=False)
+                _replay_output_history()
+            except Exception:
+                pass
+        if new_width is not None:
+            self._last_resize_width = new_width
         original_on_resize()
         self._schedule_status_bar_unsuppress(app)
 

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -71,14 +71,14 @@ class TestForceFullRedraw:
             "invalidate",
         ]
 
-    def test_resize_recovery_uses_prompt_toolkit_original_resize_before_reset(self, bare_cli, monkeypatch):
-        """Resize recovery must preserve prompt_toolkit's tracked cursor state.
+    def test_resize_recovery_skips_clear_when_width_unchanged(self, bare_cli, monkeypatch):
+        """A rows-only resize (same width) must NOT clear the screen.
 
         prompt_toolkit's built-in Application._on_resize() starts with
         renderer.erase(leave_alternate_screen=False), which uses the renderer's
         cached cursor position to move back to the live prompt origin before
-        erase_down(). If Hermes resets the renderer first, that cursor position
-        is lost and stale prompt glyphs can remain after a narrow resize.
+        erase_down(). With no column reflow there is no ghost chrome to wipe,
+        so we delegate straight to prompt_toolkit and avoid an extra repaint.
         """
         app = MagicMock()
         events = []
@@ -86,8 +86,13 @@ class TestForceFullRedraw:
         app.invalidate.side_effect = lambda: events.append("invalidate")
         original_on_resize = lambda: events.append("original_resize")
 
-        # bare_cli skips __init__, so seed the attribute the way __init__ would.
+        # bare_cli skips __init__, so seed attributes the way __init__ would.
         bare_cli._status_bar_suppressed_after_resize = False
+        bare_cli._last_resize_width = 120
+        # Same width on this resize → rows-only change.
+        monkeypatch.setattr(bare_cli, "_get_tui_terminal_width", lambda: 120)
+        monkeypatch.setattr(bare_cli, "_schedule_status_bar_unsuppress", lambda *_: None)
+
         bare_cli._recover_after_resize(app, original_on_resize)
 
         assert events == ["original_resize"]
@@ -98,6 +103,39 @@ class TestForceFullRedraw:
         app.renderer.output.write_raw.assert_not_called()
         app.renderer.output.cursor_goto.assert_not_called()
         # Status bar / input rules must be suppressed until the next prompt.
+        assert bare_cli._status_bar_suppressed_after_resize is True
+
+    def test_resize_recovery_clears_viewport_on_width_change(self, bare_cli, monkeypatch):
+        """A WIDTH change must wipe the visible viewport (CSI 2J) and replay.
+
+        On column shrink the terminal reflows the old full-width chrome into
+        extra rows that prompt_toolkit's stale-cursor erase cannot reach,
+        leaving a duplicated status bar (#19280/#5474 class). We route through
+        the same recovery as Ctrl+L: erase_screen (2J) + replay transcript.
+        It must be banner-safe — CSI 3J (write_raw) must NOT fire.
+        """
+        app = MagicMock()
+        events = []
+        app.renderer.output.erase_screen.side_effect = lambda: events.append("erase")
+        app.renderer.output.write_raw.side_effect = lambda *_: events.append("scrollback_wipe")
+        original_on_resize = lambda: events.append("original_resize")
+
+        bare_cli._status_bar_suppressed_after_resize = False
+        bare_cli._last_resize_width = 200
+        monkeypatch.setattr(bare_cli, "_get_tui_terminal_width", lambda: 90)
+        monkeypatch.setattr(bare_cli, "_schedule_status_bar_unsuppress", lambda *_: None)
+        monkeypatch.setattr(cli_mod, "_replay_output_history", lambda: events.append("replay"))
+
+        bare_cli._recover_after_resize(app, original_on_resize)
+
+        # Viewport cleared and transcript replayed BEFORE prompt_toolkit's resize.
+        assert "erase" in events
+        assert "replay" in events
+        assert events.index("erase") < events.index("original_resize")
+        # Banner-safe: scrollback (CSI 3J) must never be wiped on a resize.
+        assert "scrollback_wipe" not in events
+        # New width recorded for the next comparison.
+        assert bare_cli._last_resize_width == 90
         assert bare_cli._status_bar_suppressed_after_resize is True
 
     def test_force_redraw_uses_full_screen_clear_without_scrollback_clear(self, bare_cli):


### PR DESCRIPTION
## Symptom

After a **horizontal** terminal resize the classic CLI status bar appears **twice** — two bars at two different widths, with two different elapsed readings (e.g. `45s / ✓22s` above, `22s / ✓0s` below). Reported live; `Ctrl+L` / `/redraw` clears it, which is the tell.

## Root cause

prompt_toolkit's `Application._on_resize()` calls `renderer.erase()`:

```python
# prompt_toolkit/renderer.py:745
output.cursor_backward(self._cursor_pos.x)
output.cursor_up(self._cursor_pos.y)   # _cursor_pos.y cached at the OLD width
output.erase_down()
```

On a **column shrink** the terminal reflows the already-painted full-width chrome into 2+ physical rows. `_cursor_pos.y` was measured at the old (wider) width, so `cursor_up` undershoots — it doesn't climb past the reflowed rows, and `erase_down` starts below them. The old bar is left stranded **above** the live origin; the next paint stacks a fresh bar below it.

The existing post-resize suppression (`_status_bar_suppressed_after_resize`, #49105 / #19280) hides the **new** bar for ~0.35s but never erases the already-reflowed **old** one, so the ghost survives the whole suppression window. The design deliberately avoided `erase_screen` to protect the startup banner — but the banner lives in **scrollback history**, which `CSI 2J` does not touch (only `CSI 3J` wipes scrollback).

## Fix

On a **width change**, `_recover_after_resize` now routes through the same recovery `Ctrl+L` uses:

- `_clear_prompt_toolkit_screen(rebuild_scrollback=False)` → `CSI 2J` (visible viewport only) + cursor home + `renderer.reset()`
- `_replay_output_history()` → repaint the transcript

…**before** delegating to prompt_toolkit's resize. Banner-safe: never sends `CSI 3J`, so scrollback history (the startup banner) is preserved. Rows-only resizes skip the clear (no reflow → no ghost) to avoid an unnecessary repaint. `_last_resize_width` tracks width across resizes to distinguish the two cases.

## Tests

- Replaced the now-obsolete `test_resize_recovery_uses_prompt_toolkit_original_resize_before_reset` (which asserted `erase_screen` is *never* called on resize — the very assumption that caused the bug) with `test_resize_recovery_skips_clear_when_width_unchanged` (rows-only delegates without clearing).
- Added `test_resize_recovery_clears_viewport_on_width_change` — width change wipes the viewport + replays before prompt_toolkit's resize, and **never** wipes scrollback (`write_raw` / CSI 3J not called).
- `tests/cli/test_cli_force_redraw.py`: **10 passed**. `tests/cli/test_cli_status_bar.py`: **47 passed**. `ruff check` clean.

Fixes the duplicated-status-bar class (#5474 / #19280 / #19216 / #25418) for the classic-CLI horizontal-resize path.

## Infographic

![resize-ghost-fix](https://v3b.fal.media/files/b/0a9eefd1/WcwV_Jw373TXXimjL9Wgo_wykNDCMS.png)
