### PR TITLE
fix(auth): openai-codex multi-profile rotation write-through (#48415)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -824,6 +824,11 @@ class CredentialPool:
                     _store_provider_state(auth_store, "nous", state, set_active=False)
 
                 elif self.provider == "openai-codex":
+                    # Check BEFORE _store_provider_state modifies auth_store —
+                    # once we write the codex block into the profile store, the
+                    # profile looks like it has its own block and the check
+                    # would always return True.
+                    write_through_to_root = not auth_mod._profile_has_own_codex_state(auth_store)
                     state = _load_provider_state(auth_store, "openai-codex")
                     if not isinstance(state, dict):
                         return
@@ -836,8 +841,17 @@ class CredentialPool:
                     if entry.last_refresh:
                         state["last_refresh"] = entry.last_refresh
                     _store_provider_state(auth_store, "openai-codex", state, set_active=False)
+                    # Multi-profile write-through (#48415): when this profile
+                    # lacks its own openai-codex block, it resolved the grant
+                    # from the root fallback. The rotated refresh token must
+                    # also land in root, or sibling profiles reading root's
+                    # stale grant die with refresh_token_reused.
+                    if write_through_to_root:
+                        auth_mod._write_through_codex_to_global_root(state)
 
                 elif self.provider == "xai-oauth":
+                    # Same pre-save check as openai-codex above.
+                    write_through_to_root = not auth_mod._profile_has_own_xai_oauth_state(auth_store)
                     state = _load_provider_state(auth_store, "xai-oauth")
                     if not isinstance(state, dict):
                         return
@@ -850,6 +864,11 @@ class CredentialPool:
                     if entry.last_refresh:
                         state["last_refresh"] = entry.last_refresh
                     _store_provider_state(auth_store, "xai-oauth", state, set_active=False)
+                    # Multi-profile write-through (#43589): mirror the same
+                    # pattern for xAI — a profile reading root's grant via
+                    # fallback must push rotated tokens back to root.
+                    if write_through_to_root:
+                        auth_mod._write_through_xai_oauth_to_global_root(state)
 
                 else:
                     return

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3513,6 +3513,13 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     with _auth_store_lock():
         auth_store = _load_auth_store()
+        # A profile that lacks its own openai-codex block is reading the root
+        # grant through _load_provider_state's fallback. When such a profile
+        # refreshes the (rotating) grant, we must write the rotated chain back
+        # to root too, or root is left holding a revoked refresh token (#48415).
+        # Check BEFORE modifying auth_store — _save_provider_state would add
+        # the openai-codex block and make the check always return True.
+        write_through_to_root = not _profile_has_own_codex_state(auth_store)
         state = _load_provider_state(auth_store, "openai-codex") or {}
         # Capture the previous singleton tokens BEFORE overwriting them.  The
         # pool-sync step uses this to distinguish legacy singleton-aliases
@@ -3533,6 +3540,8 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
             previous_singleton_tokens=previous_singleton_tokens,
         )
         _save_auth_store(auth_store)
+        if write_through_to_root:
+            _write_through_codex_to_global_root(state)
 
 
 def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
@@ -4098,6 +4107,18 @@ def _profile_has_own_xai_oauth_state(auth_store: Dict[str, Any]) -> bool:
     return isinstance(providers, dict) and isinstance(providers.get("xai-oauth"), dict)
 
 
+def _profile_has_own_codex_state(auth_store: Dict[str, Any]) -> bool:
+    """True when this store has its OWN ``providers.openai-codex`` block.
+
+    Mirrors ``_profile_has_own_xai_oauth_state`` for the Codex provider.
+    A profile that genuinely shadows root (has its own block) must NOT
+    clobber the root grant; a profile that only reads root via fallback
+    must write rotated tokens back to root (#48415).
+    """
+    providers = auth_store.get("providers")
+    return isinstance(providers, dict) and isinstance(providers.get("openai-codex"), dict)
+
+
 def _write_through_xai_oauth_to_global_root(state: Dict[str, Any]) -> None:
     """Persist a rotated xAI OAuth ``state`` into the global-root auth.json.
 
@@ -4141,6 +4162,51 @@ def _write_through_xai_oauth_to_global_root(state: Dict[str, Any]) -> None:
         _save_auth_store(global_store, global_path)
     except Exception as exc:  # pragma: no cover - best effort
         logger.debug("xAI OAuth: write-through to global root failed: %s", exc)
+
+
+def _write_through_codex_to_global_root(state: Dict[str, Any]) -> None:
+    """Persist a rotated Codex OAuth ``state`` into the global-root auth.json.
+
+    Best-effort write-through for the multi-profile rotation hazard (#48415):
+    openai-codex rotates the refresh_token on every refresh, so when a profile
+    session refreshes a grant it resolved from the root fallback, the rotated
+    chain must land back in root. Otherwise root keeps a now-revoked refresh
+    token and every other profile reading the stale root grant dies with
+    ``refresh_token_reused`` once its access token expires.
+
+    Only updates ``providers.openai-codex`` in the root store; never touches
+    the profile store (the caller already saved that). Swallows all errors —
+    a failed write-through degrades to the pre-existing behavior (root stale),
+    it must never break the profile's own successful save.
+
+    Mirrors ``_write_through_xai_oauth_to_global_root`` for the Codex provider.
+    """
+    global_path = _global_auth_file_path()
+    if global_path is None:
+        # Classic mode (profile == root); the profile save already hit root.
+        return
+    # Seat belt: under pytest, refuse to write the real user's
+    # ~/.hermes/auth.json even when HERMES_HOME points at a profile path.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        real_home_env = os.environ.get("HOME", "")
+        if real_home_env:
+            real_root = Path(real_home_env) / ".hermes" / "auth.json"
+            try:
+                if global_path.resolve(strict=False) == real_root.resolve(strict=False):
+                    return
+            except Exception:
+                return
+    try:
+        if global_path.exists():
+            global_store = _load_auth_store(global_path)
+        else:
+            global_store = {}
+        if not isinstance(global_store, dict):
+            return
+        _store_provider_state(global_store, "openai-codex", dict(state), set_active=False)
+        _save_auth_store(global_store, global_path)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.debug("Codex: write-through to global root failed: %s", exc)
 
 
 def _save_xai_oauth_tokens(

--- a/tests/hermes_cli/test_codex_oauth_writethrough.py
+++ b/tests/hermes_cli/test_codex_oauth_writethrough.py
@@ -1,0 +1,204 @@
+"""Regression tests for Codex OAuth refresh write-through to the global root.
+
+Companion to ``test_xai_oauth_writethrough.py``.  That file covers xAI OAuth
+(#43589); these cover the Codex analog (#48415).  The same multi-profile
+rotation hazard exists for openai-codex: when a profile that has no own
+``providers.openai-codex`` block refreshes the (rotating) grant it resolved
+from the root fallback, the rotated tokens must be written back to the global
+root too.  Otherwise root holds a revoked refresh token and sibling profiles
+die with ``refresh_token_reused``.
+
+The tests drive the real ``_save_codex_tokens`` against real on-disk auth
+stores (profile + root under ``tmp_path``) rather than mocking the save
+boundary, so they exercise the actual atomic write path.
+"""
+
+import json
+
+import pytest
+
+from hermes_cli import auth
+
+
+def _write_store(path, store):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(store), encoding="utf-8")
+
+
+def _read_store(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def profile_and_root(tmp_path, monkeypatch):
+    """Wire a profile auth store + a distinct global-root auth store on disk.
+
+    Returns (profile_path, root_path).  The pytest seat belt in
+    ``_write_through_codex_to_global_root`` only refuses the *real* user's
+    ``$HOME/.hermes/auth.json``; a tmp_path root is allowed, so we point HOME
+    away from the tmp root to keep the guard from tripping on these fixtures.
+    """
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    root_path = tmp_path / "root" / "auth.json"
+
+    monkeypatch.setattr(auth, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_path)
+    # Keep the pytest write seat belt from matching our tmp root.
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    return profile_path, root_path
+
+
+def test_refresh_writes_through_to_root_when_profile_has_no_own_state(profile_and_root):
+    """Profile reading root's grant must push rotated tokens back to root."""
+    profile_path, root_path = profile_and_root
+    # Profile has NO own openai-codex block (reads root via fallback).
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                    }
+                }
+            },
+        },
+    )
+
+    # Simulate a token refresh — the rotated tokens replace the old ones.
+    rotated = {
+        "access_token": "new-access",
+        "refresh_token": "new-refresh",
+    }
+    auth._save_codex_tokens(rotated)
+
+    # Profile got the rotated chain (existing behaviour).
+    profile = _read_store(profile_path)
+    assert profile["providers"]["openai-codex"]["tokens"]["access_token"] == "new-access"
+    assert profile["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-refresh"
+
+    # AND the global root no longer holds the revoked refresh token (#48415).
+    root = _read_store(root_path)
+    assert root["providers"]["openai-codex"]["tokens"]["access_token"] == "new-access"
+    assert root["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-refresh"
+
+
+def test_refresh_does_not_touch_root_when_profile_has_own_state(profile_and_root):
+    """A profile that genuinely shadows root must NOT clobber the root grant."""
+    profile_path, root_path = profile_and_root
+    # Profile has its OWN openai-codex block: it shadows root legitimately.
+    _write_store(
+        profile_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "profile-old-access",
+                        "refresh_token": "profile-old-refresh",
+                    }
+                }
+            },
+        },
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "root-access",
+                        "refresh_token": "root-refresh",
+                    }
+                }
+            },
+        },
+    )
+
+    auth._save_codex_tokens(
+        {"access_token": "profile-new-access", "refresh_token": "profile-new-refresh"}
+    )
+
+    profile = _read_store(profile_path)
+    assert profile["providers"]["openai-codex"]["tokens"]["refresh_token"] == "profile-new-refresh"
+
+    # Root is a separate grant chain — must be left exactly as-is.
+    root = _read_store(root_path)
+    assert root["providers"]["openai-codex"]["tokens"]["access_token"] == "root-access"
+    assert root["providers"]["openai-codex"]["tokens"]["refresh_token"] == "root-refresh"
+
+
+def test_write_through_is_noop_in_classic_mode(tmp_path, monkeypatch):
+    """Classic mode (profile == root) already saves to root; no double write."""
+    profile_path = tmp_path / "auth.json"
+    monkeypatch.setattr(auth, "_auth_file_path", lambda: profile_path)
+    # Classic mode: _global_auth_file_path returns None.
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: None)
+    _write_store(profile_path, {"version": 1, "providers": {}})
+
+    # Should not raise and should persist to the single store.
+    auth._save_codex_tokens({"access_token": "a", "refresh_token": "r"})
+    store = _read_store(profile_path)
+    assert store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "r"
+
+
+def test_write_through_failure_does_not_break_profile_save(profile_and_root, monkeypatch):
+    """A failed root write-through must not break the profile's own save."""
+    profile_path, root_path = profile_and_root
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    _write_store(root_path, {"version": 1, "providers": {}})
+
+    # Make the root write blow up; the profile save must still succeed.
+    real_save = auth._save_auth_store
+
+    def _exploding_save(store, target_path=None):
+        if target_path is not None and target_path == root_path:
+            raise OSError("simulated root write failure")
+        return real_save(store, target_path)
+
+    monkeypatch.setattr(auth, "_save_auth_store", _exploding_save)
+
+    auth._save_codex_tokens({"access_token": "a", "refresh_token": "r"})
+
+    profile = _read_store(profile_path)
+    assert profile["providers"]["openai-codex"]["tokens"]["refresh_token"] == "r"
+
+
+def test_write_through_does_not_set_active_provider(profile_and_root):
+    """The write-through must NOT flip active_provider in root (#48415)."""
+    profile_path, root_path = profile_and_root
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "active_provider": "xai-oauth",
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                    }
+                },
+                "xai-oauth": {
+                    "tokens": {
+                        "access_token": "xai-access",
+                        "refresh_token": "xai-refresh",
+                    }
+                },
+            },
+        },
+    )
+
+    auth._save_codex_tokens(
+        {"access_token": "new-access", "refresh_token": "new-refresh"}
+    )
+
+    root = _read_store(root_path)
+    # active_provider must stay xai-oauth, not flip to openai-codex.
+    assert root.get("active_provider") == "xai-oauth"
+    assert root["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-refresh"


### PR DESCRIPTION
When a profile session reads the openai-codex grant from root, refreshes it, and saves the rotated tokens only to its own profile store, the global root retains the now-revoked refresh token. Any other profile that later reads from root gets a dead grant.

This mirrors the fix from #43589 (xAI OAuth) for the Codex provider:

- Add `_profile_has_own_codex_state()` to hermes_cli/auth.py
- Add `_write_through_codex_to_global_root()` to hermes_cli/auth.py
- Wire write-through into `_save_codex_tokens()`
- Add openai-codex + xAI-oauth write-through paths in `agent/credential_pool.py:_sync_device_code_entry_to_auth_store()`
- Add regression tests in `test_codex_oauth_writethrough.py`

This is a clean re-submission of #49032 (previous PR included unrelated kanban commits in the branch history). This branch contains only the auth write-through changes.

Fixes: #48415