### PR TITLE
fix(agent): preserve vision provider for base_url fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4807,9 +4807,12 @@ def _resolve_task_provider_model(
       3. "auto" (full auto-detection chain)
 
     Returns (provider, model, base_url, api_key, api_mode) where model may
-    be None (use provider default). When base_url is set, provider is forced
-    to "custom" and the task uses that direct endpoint. api_mode is one of
-    "chat_completions", "codex_responses", or None (auto-detect).
+    be None (use provider default). When base_url is set without a provider,
+    provider is forced to "custom" and the task uses that direct endpoint.
+    When base_url is paired with a non-auto provider, preserve the provider
+    so its normal credential resolver can still use provider-specific env vars.
+    api_mode is one of "chat_completions", "codex_responses", or None
+    (auto-detect).
     """
     cfg_provider = None
     cfg_model = None
@@ -4847,6 +4850,8 @@ def _resolve_task_provider_model(
     if cfg_provider:
         cfg_provider, cfg_base_url = _expand_direct_api_alias(cfg_provider, cfg_base_url)
 
+    if base_url and provider and provider != "auto":
+        return provider, resolved_model, base_url, api_key, resolved_api_mode
     if base_url:
         return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:

--- a/tests/agent/test_vision_resolved_args.py
+++ b/tests/agent/test_vision_resolved_args.py
@@ -3,6 +3,13 @@
 from unittest.mock import patch, MagicMock
 
 
+def _write_hermes_config(tmp_path, monkeypatch, text):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text(text)
+
+
 def test_vision_call_uses_resolved_provider_args():
     """Resolved provider/model/key/url from config must reach resolve_vision_provider_client."""
     from agent.auxiliary_client import call_llm
@@ -35,6 +42,48 @@ def test_vision_call_uses_resolved_provider_args():
     assert call_args.kwargs["model"] == "my-resolved-model"
     assert call_args.kwargs["base_url"] == "http://resolved"
     assert call_args.kwargs["api_key"] == "resolved-key"
+
+
+def test_vision_call_preserves_provider_for_base_url_env_fallback(tmp_path, monkeypatch):
+    """Config provider+base_url without api_key must keep provider env fallback."""
+    _write_hermes_config(
+        tmp_path,
+        monkeypatch,
+        """
+model:
+  default: deepseek-chat
+  provider: deepseek
+auxiliary:
+  vision:
+    provider: gemini
+    model: gemini-3.1-flash-lite
+    base_url: https://generativelanguage.googleapis.com/v1beta
+""",
+    )
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-env-key")
+
+    from agent.auxiliary_client import call_llm
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="description"))],
+        usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+    )
+
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        return_value=(fake_client, "gemini-3.1-flash-lite"),
+    ) as mock_resolve:
+        call_llm(
+            "vision",
+            messages=[{"role": "user", "content": "describe this"}],
+        )
+
+    assert mock_resolve.call_args.args[0] == "gemini"
+    assert mock_resolve.call_args.kwargs["explicit_base_url"] == (
+        "https://generativelanguage.googleapis.com/v1beta"
+    )
+    assert mock_resolve.call_args.kwargs["explicit_api_key"] is None
 
 
 def test_vision_base_url_override_keeps_explicit_provider():


### PR DESCRIPTION
Fixes #49119.

This is a narrow alternative to #49039 focused only on the vision provider/base_url credential fallback path.

When `call_llm(task="vision")` resolves `auxiliary.vision.provider=gemini` plus `auxiliary.vision.base_url`, it calls `resolve_vision_provider_client()` with the already-resolved provider and base URL. The second resolver pass treated any explicit `base_url` as a custom provider override, so the provider collapsed from `gemini` to `custom` and provider-specific env fallback (`GOOGLE_API_KEY` / `GEMINI_API_KEY`) was skipped.

This preserves a non-auto provider when it is paired with `base_url`, while retaining the existing `custom` behavior for base_url-only configuration.

Tests:
- `scripts/run_tests.sh tests/agent/test_vision_resolved_args.py tests/agent/test_auxiliary_named_custom_providers.py` (32 passed)