### PR TITLE
test(process): document stderr warnings do not terminate background jobs

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -388,6 +389,42 @@ class TestStdinHelpers:
             pytest.fail("process did not exit after stdin was closed")
         finally:
             registry.kill_process(session.id)
+
+
+# =========================================================================
+# Stderr is output, not a liveness signal
+# =========================================================================
+
+def test_background_stderr_warning_does_not_terminate_process(registry, tmp_path):
+    ready = tmp_path / "stderr-ready"
+    script = (
+        "import pathlib, sys, time; "
+        "print('stdin is not a TTY', file=sys.stderr, flush=True); "
+        f"pathlib.Path({str(ready)!r}).write_text('ready'); "
+        "time.sleep(0.75); "
+        "print('done')"
+    )
+
+    session = registry.spawn_local(
+        f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}",
+        cwd=str(tmp_path),
+    )
+
+    try:
+        assert _wait_until(ready.exists, timeout=3.0), (
+            "child never reached the post-stderr ready marker"
+        )
+
+        poll = registry.poll(session.id)
+        assert poll["status"] == "running", poll
+        assert session.exit_code is None
+
+        result = registry.wait(session.id, timeout=5)
+        assert result["status"] == "exited", result
+        assert result["exit_code"] == 0
+        assert "stdin is not a TTY" in result["output"]
+    finally:
+        registry.kill_process(session.id)
 
 
 # =========================================================================


### PR DESCRIPTION
Related to #48968. Current `main` did not reproduce the reported kill-on-stderr behavior, so this PR is a regression guard rather than a full Windows/Node-path fix.

It pins the current process-registry contract: a tracked local background process that writes `stdin is not a TTY` to stderr remains `running`, exits naturally with code 0, and preserves the warning in captured output.

If maintainers prefer to keep #48968 focused only on the original Windows/Node report, this PR can be closed as a no-op regression guard.

Tests:
- `scripts/run_tests.sh tests/tools/test_process_registry.py` (72 passed)