### PR TITLE
fix(cli): read QQBot home channel from canonical QQBOT_HOME_CHANNEL in status

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -437,7 +437,7 @@ def show_status(args):
         "WeCom Callback": ("WECOM_CALLBACK_CORP_ID", None),
         "Weixin": ("WEIXIN_ACCOUNT_ID", "WEIXIN_HOME_CHANNEL"),
         "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
-        "QQBot": ("QQ_APP_ID", "QQ_HOME_CHANNEL"),
+        "QQBot": ("QQ_APP_ID", "QQBOT_HOME_CHANNEL"),
         "Yuanbao": ("YUANBAO_APP_ID", "YUANBAO_HOME_CHANNEL"),
     }
 

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -14,6 +14,32 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     assert "tvly...cdef" in output
 
 
+def test_show_status_qqbot_home_uses_canonical_env(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("QQ_APP_ID", "app-123")
+    monkeypatch.setenv("QQBOT_HOME_CHANNEL", "group-openid-home")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "QQBot" in output
+    assert "home: group-openid-home" in output
+
+
+def test_show_status_qqbot_home_falls_back_to_legacy_env(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("QQ_APP_ID", "app-123")
+    # Only the deprecated variable is set; status should still surface it.
+    monkeypatch.delenv("QQBOT_HOME_CHANNEL", raising=False)
+    monkeypatch.setenv("QQ_HOME_CHANNEL", "legacy-openid-home")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "QQBot" in output
+    assert "home: legacy-openid-home" in output
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## What changed and why

`hermes status` read the QQBot home channel from the **deprecated** `QQ_HOME_CHANNEL` env var as the *primary* source. Everywhere else in the codebase the canonical variable is `QQBOT_HOME_CHANNEL`, with `QQ_HOME_CHANNEL` kept only as a legacy fallback:

- `gateway/config.py:1966` — reads `QQBOT_HOME_CHANNEL` first, warns that `QQ_HOME_CHANNEL` is deprecated
- `hermes_cli/setup.py:2212` — `get_env_value("QQBOT_HOME_CHANNEL") or get_env_value("QQ_HOME_CHANNEL")`
- `hermes_cli/gateway.py:5861/5869` — saves to `QQBOT_HOME_CHANNEL`

As a result, a user who configured QQBot with the current `QQBOT_HOME_CHANNEL` saw **no home channel** in `hermes status`. The existing back-compat branch in `status.py` was also dead code:

```python
if not home_channel and home_var == "QQBOT_HOME_CHANNEL":   # home_var was "QQ_HOME_CHANNEL" → never true
    home_channel = os.getenv("QQ_HOME_CHANNEL", "")
```

The fix swaps the primary var to `QQBOT_HOME_CHANNEL`, which also makes the existing fallback to legacy `QQ_HOME_CHANNEL` reachable and correct — so both the current and legacy variables now display properly.

## How to test

```bash
QQ_APP_ID=app-123 QQBOT_HOME_CHANNEL=group-openid-home hermes status
# QQBot row now shows "(home: group-openid-home)"; previously showed no home

QQ_APP_ID=app-123 QQ_HOME_CHANNEL=legacy-home hermes status
# Legacy var still works via the back-compat fallback
```

Or run the added tests:

```bash
pytest tests/hermes_cli/test_status.py -q
```

Both new tests fail on the unpatched code (the canonical-var test) / exercise the documented fallback, and pass after the fix. Full `tests/hermes_cli/test_status.py` (19 tests) passes; `ruff check` clean.

## Platforms tested

macOS (Darwin). Change is pure stdlib env-var logic with no platform-specific behavior.