### PR TITLE
feat(file): enforce configured workspace root

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -321,6 +321,7 @@ terminal:
 # Docs: https://github.com/sheeki03/tirith
 #
 # security:
+#   workspace_root: "/absolute/path/to/workspace"  # Optional: constrain local file tools to this host directory
 #   tirith_enabled: true        # Enable/disable tirith scanning
 #   tirith_path: "tirith"       # Path to tirith binary (supports ~ expansion)
 #   tirith_timeout: 5           # Scan timeout in seconds

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2220,6 +2220,7 @@ DEFAULT_CONFIG = {
     "security": {
         "allow_private_urls": False,  # Allow requests to private/internal IPs (for OpenWrt, proxies, VPNs)
         "redact_secrets": True,
+        "workspace_root": "",  # Optional absolute host path that local file tools cannot escape
         "tirith_enabled": True,
         "tirith_path": "tirith",
         "tirith_timeout": 5,

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -77,7 +78,10 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            str(Path("/tmp/out.txt").resolve()),
+            "hello world!\n",
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -155,7 +159,12 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            str(Path("/tmp/f.py").resolve()),
+            "foo",
+            "bar",
+            False,
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -168,7 +177,12 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         patch_tool(mode="replace", path="/tmp/f.py",
                    old_string="x", new_string="y", replace_all=True)
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
+        mock_ops.patch_replace.assert_called_once_with(
+            str(Path("/tmp/f.py").resolve()),
+            "x",
+            "y",
+            True,
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):
@@ -463,6 +477,179 @@ class TestSensitivePathCheck:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/other.txt", "hello"))
         assert result["status"] == "ok"
+
+
+class TestWorkspaceRootEnforcement:
+    """security.workspace_root constrains local file-tool paths."""
+
+    def _set_workspace_root(self, monkeypatch, root):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setattr("tools.file_tools._SENSITIVE_PATH_PREFIXES", ())
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"security": {"workspace_root": str(root)}},
+        )
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_inside_workspace_root_allowed(self, mock_get, tmp_path, monkeypatch):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        self._set_workspace_root(monkeypatch, workspace)
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "path": "inside.txt"}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import write_file_tool
+
+        result = json.loads(write_file_tool("inside.txt", "ok"))
+
+        assert result["status"] == "ok"
+        mock_ops.write_file.assert_called_once_with(
+            str((workspace / "inside.txt").resolve()),
+            "ok",
+        )
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_read_outside_workspace_root_blocked_before_file_ops(self, mock_get, tmp_path, monkeypatch):
+        workspace = tmp_path / "workspace"
+        outside = tmp_path / "outside"
+        workspace.mkdir()
+        outside.mkdir()
+        target = outside / "secret.txt"
+        target.write_text("nope")
+        self._set_workspace_root(monkeypatch, workspace)
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+        from tools.file_tools import read_file_tool
+
+        result = json.loads(read_file_tool(str(target)))
+
+        assert "error" in result
+        assert "security.workspace_root" in result["error"]
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_relative_escape_blocked(self, mock_get, tmp_path, monkeypatch):
+        workspace = tmp_path / "workspace"
+        outside = tmp_path / "outside"
+        workspace.mkdir()
+        outside.mkdir()
+        self._set_workspace_root(monkeypatch, workspace)
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+        from tools.file_tools import write_file_tool
+
+        result = json.loads(write_file_tool("../outside/blocked.txt", "nope"))
+
+        assert "error" in result
+        assert "security.workspace_root" in result["error"]
+        assert not (outside / "blocked.txt").exists()
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_replace_outside_workspace_root_blocked(self, mock_get, tmp_path, monkeypatch):
+        workspace = tmp_path / "workspace"
+        outside = tmp_path / "outside"
+        workspace.mkdir()
+        outside.mkdir()
+        target = outside / "target.py"
+        target.write_text("old\n")
+        self._set_workspace_root(monkeypatch, workspace)
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+        from tools.file_tools import patch_tool
+
+        result = json.loads(patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string="old",
+            new_string="new",
+        ))
+
+        assert "error" in result
+        assert "security.workspace_root" in result["error"]
+        assert target.read_text() == "old\n"
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_v4a_patch_outside_workspace_root_blocked(self, mock_get, tmp_path, monkeypatch):
+        workspace = tmp_path / "workspace"
+        outside = tmp_path / "outside"
+        workspace.mkdir()
+        outside.mkdir()
+        target = outside / "target.py"
+        self._set_workspace_root(monkeypatch, workspace)
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+        from tools.file_tools import patch_tool
+
+        result = json.loads(patch_tool(
+            mode="patch",
+            patch=(
+                "*** Begin Patch\n"
+                f"*** Add File: {target}\n"
+                "+print('nope')\n"
+                "*** End Patch\n"
+            ),
+        ))
+
+        assert "error" in result
+        assert "security.workspace_root" in result["error"]
+        assert not target.exists()
+        mock_get.return_value.patch_v4a.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_outside_workspace_root_blocked(self, mock_get, tmp_path, monkeypatch):
+        workspace = tmp_path / "workspace"
+        outside = tmp_path / "outside"
+        workspace.mkdir()
+        outside.mkdir()
+        self._set_workspace_root(monkeypatch, workspace)
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+        from tools.file_tools import search_tool
+
+        result = json.loads(search_tool(pattern="needle", path=str(outside)))
+
+        assert "error" in result
+        assert "security.workspace_root" in result["error"]
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_non_local_backend_keeps_backend_path_semantics(self, mock_get, tmp_path, monkeypatch):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"security": {"workspace_root": str(workspace)}},
+        )
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"matches": []}
+        mock_ops.search.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import search_tool
+
+        result = json.loads(search_tool(pattern="needle", path="/root/project"))
+
+        assert result["matches"] == []
+        mock_ops.search.assert_called_once_with(
+            pattern="needle",
+            path="/root/project",
+            target="content",
+            file_glob=None,
+            limit=50,
+            offset=0,
+            output_mode="content",
+            context=0,
+        )
 
 
 class TestPatchSchemaShape:

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -36,6 +36,12 @@ def _isolated_cwd(tmp_path, monkeypatch):
     # Process cwd = decoy, analogous to "main repo" while the terminal is in
     # the worktree.
     monkeypatch.chdir(decoy)
+    # These tests run in pytest temp dirs, which are under /private/var on
+    # macOS. Disable the unrelated system-path write guard for this cwd suite.
+    monkeypatch.setattr(ft, "_SENSITIVE_PATH_PREFIXES", ())
+    # Keep shell-backed patch tests focused on cwd resolution; on some macOS
+    # shells an inherited C.UTF-8 locale warning is emitted into redirected IO.
+    monkeypatch.setenv("LC_ALL", "C")
     # No live-terminal-cwd tracking recorded yet (fresh-session condition).
     monkeypatch.setattr(ft, "_get_live_tracking_cwd", lambda task_id="default": None)
     return workspace, decoy

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -36,12 +36,6 @@ def _isolated_cwd(tmp_path, monkeypatch):
     # Process cwd = decoy, analogous to "main repo" while the terminal is in
     # the worktree.
     monkeypatch.chdir(decoy)
-    # These tests run in pytest temp dirs, which are under /private/var on
-    # macOS. Disable the unrelated system-path write guard for this cwd suite.
-    monkeypatch.setattr(ft, "_SENSITIVE_PATH_PREFIXES", ())
-    # Keep shell-backed patch tests focused on cwd resolution; on some macOS
-    # shells an inherited C.UTF-8 locale warning is emitted into redirected IO.
-    monkeypatch.setenv("LC_ALL", "C")
     # No live-terminal-cwd tracking recorded yet (fresh-session condition).
     monkeypatch.setattr(ft, "_get_live_tracking_cwd", lambda task_id="default": None)
     return workspace, decoy
@@ -305,6 +299,7 @@ def test_patch_reports_resolved_absolute_path(_isolated_cwd, monkeypatch):
     """patch_tool (replace mode) must put the absolute on-disk path in files_modified."""
     workspace, decoy = _isolated_cwd
     monkeypatch.setattr(ft, "_get_live_tracking_cwd", lambda task_id="default": str(workspace))
+    monkeypatch.setenv("LC_ALL", "C")
 
     import json
     out = json.loads(ft.patch_tool(

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -245,6 +245,86 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path:
     return (_resolve_base_dir(task_id) / p).resolve()
 
 
+def _workspace_root_applies_to_task(task_id: str = "default") -> bool:
+    """Return True when file tools are operating on the local host FS."""
+    try:
+        from tools.terminal_tool import _active_environments, _env_lock, _resolve_container_task_id
+
+        container_key = _resolve_container_task_id(task_id)
+        with _env_lock:
+            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+        if env is not None:
+            return env.__class__.__name__ == "LocalEnvironment"
+    except Exception:
+        pass
+
+    try:
+        from tools.terminal_tool import _get_env_config
+
+        return str(_get_env_config().get("env_type") or "local").lower() == "local"
+    except Exception:
+        return True
+
+
+def _configured_workspace_root_path() -> tuple[Path | None, str | None]:
+    """Return configured workspace root, or an error for invalid config."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()
+    except Exception:
+        return None, None
+
+    security = cfg.get("security", {}) if isinstance(cfg, dict) else {}
+    raw_root = security.get("workspace_root") if isinstance(security, dict) else None
+    if raw_root is None or str(raw_root).strip() == "":
+        return None, None
+
+    root = Path(str(raw_root)).expanduser()
+    if not root.is_absolute():
+        return None, (
+            "Invalid security.workspace_root: expected an absolute local path, "
+            f"got {raw_root!r}."
+        )
+
+    try:
+        resolved = root.resolve()
+    except (OSError, RuntimeError, ValueError) as exc:
+        return None, f"Invalid security.workspace_root {str(root)!r}: {exc}"
+
+    if not resolved.exists():
+        return None, f"Invalid security.workspace_root {str(resolved)!r}: path does not exist."
+    if not resolved.is_dir():
+        return None, f"Invalid security.workspace_root {str(resolved)!r}: path is not a directory."
+    return resolved, None
+
+
+def _check_workspace_root_path(filepath: str, task_id: str = "default") -> str | None:
+    """Return an error when a local file-tool path escapes workspace_root."""
+    if not _workspace_root_applies_to_task(task_id):
+        return None
+
+    root, root_error = _configured_workspace_root_path()
+    if root_error:
+        return root_error
+    if root is None:
+        return None
+
+    try:
+        resolved = _resolve_path_for_task(filepath, task_id)
+    except (OSError, RuntimeError, ValueError) as exc:
+        return f"Cannot resolve path {filepath!r} under security.workspace_root: {exc}"
+
+    try:
+        resolved.relative_to(root)
+        return None
+    except ValueError:
+        return (
+            f"Path {filepath!r} resolves outside security.workspace_root "
+            f"({str(root)!r}): {str(resolved)!r}"
+        )
+
+
 def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:
     """Warn when a relative path resolved OUTSIDE the task's workspace root.
 
@@ -797,6 +877,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 ),
             })
 
+        workspace_err = _check_workspace_root_path(path, task_id)
+        if workspace_err:
+            return json.dumps({"error": workspace_err}, ensure_ascii=False)
+
         _resolved = _resolve_path_for_task(path, task_id)
 
         # ── Structured-document extraction ────────────────────────────
@@ -1191,6 +1275,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     sensitive_err = _check_sensitive_path(path, task_id)
     if sensitive_err:
         return tool_error(sensitive_err)
+    workspace_err = _check_workspace_root_path(path, task_id)
+    if workspace_err:
+        return tool_error(workspace_err)
     if not cross_profile:
         cross_warning = _check_cross_profile_path(path, task_id)
         if cross_warning:
@@ -1293,6 +1380,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         sensitive_err = _check_sensitive_path(_p, task_id)
         if sensitive_err:
             return tool_error(sensitive_err)
+        workspace_err = _check_workspace_root_path(_p, task_id)
+        if workspace_err:
+            return tool_error(workspace_err)
         if not cross_profile:
             cross_warning = _check_cross_profile_path(_p, task_id)
             if cross_warning:
@@ -1434,6 +1524,10 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
     """Search for content or files."""
     try:
         offset, limit = normalize_search_pagination(offset, limit)
+
+        workspace_err = _check_workspace_root_path(path, task_id)
+        if workspace_err:
+            return tool_error(workspace_err)
 
         # Track searches to detect *consecutive* repeated search loops.
         # Include pagination args so users can page through truncated


### PR DESCRIPTION
Fixes #8940.

This is the atomic file-tool slice split out from the broader, stale #9098 workspace-root work.

What changed:
- adds optional `security.workspace_root` config default/documentation
- constrains local file-tool paths (`read_file`, `write_file`, `patch`, `search_files`) to that configured host directory
- rejects absolute paths, relative `..` escapes, and V4A patch headers that resolve outside the root
- keeps non-local terminal backends (docker/modal/ssh/etc.) on their existing backend path semantics

Behavior is unchanged when `security.workspace_root` is unset.

Tests:
- `scripts/run_tests.sh tests/tools/test_file_tools.py tests/tools/test_file_tools_cwd_resolution.py tests/hermes_cli/test_config.py` (167 passed)

Notes:
- This intentionally does not constrain terminal command execution, gateway/CLI `@file` context expansion, clone routing, or scheduler/multi-agent policy. Those belong in separate slices.