### PR TITLE
fix(lsp): map aliased server_id to recipe key in `lsp which`

### DIFF
--- a/agent/lsp/cli.py
+++ b/agent/lsp/cli.py
@@ -249,8 +249,9 @@ def _cmd_restart() -> int:
 def _cmd_which(server_id: str) -> int:
     from agent.lsp.install import INSTALL_RECIPES, _existing_binary
 
-    recipe = INSTALL_RECIPES.get(server_id)
-    bin_name = (recipe or {}).get("bin", server_id)
+    pkg = _recipe_pkg_for(server_id)
+    recipe = INSTALL_RECIPES.get(pkg)
+    bin_name = (recipe or {}).get("bin", pkg)
     resolved = _existing_binary(bin_name)
     if resolved:
         sys.stdout.write(resolved + "\n")

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -111,6 +111,37 @@ def test_existing_binary_finds_windows_wrapper_in_staging(tmp_path, monkeypatch)
     assert install_mod.detect_status("pyright") == "installed"
 
 
+def test_cmd_which_resolves_aliased_server_id(tmp_path, monkeypatch):
+    """``hermes lsp which`` must map aliased server_ids to their recipe.
+
+    Registry server_ids like ``typescript`` and ``dockerfile-ls`` are not
+    keys in ``INSTALL_RECIPES`` — they alias to ``typescript-language-server``
+    / ``dockerfile-language-server-nodejs`` via ``_recipe_pkg_for``.  Without
+    that mapping, ``_cmd_which`` probed for a binary literally named
+    ``typescript`` (which never exists) and reported "not installed" even
+    when the server was present.
+    """
+    from agent.lsp import cli as lsp_cli
+
+    probed: list[str] = []
+
+    def fake_existing_binary(name: str):
+        probed.append(name)
+        # The real binary for the typescript server is
+        # ``typescript-language-server``; pretend it's installed.
+        return "/opt/lsp/typescript-language-server" if name == "typescript-language-server" else None
+
+    monkeypatch.setattr("agent.lsp.install._existing_binary", fake_existing_binary)
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = lsp_cli._cmd_which("typescript")
+
+    assert rc == 0
+    assert probed == ["typescript-language-server"]
+    assert "typescript-language-server" in out.getvalue()
+
+
 def test_install_pip_finds_windows_scripts_launcher(tmp_path, monkeypatch):
     """pip console scripts can land in Scripts/ on native Windows."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## What changed and why

`hermes lsp which <server>` looked up `INSTALL_RECIPES.get(server_id)` **directly**, unlike every other command in `agent/lsp/cli.py` (`_cmd_status`, `_cmd_list`, `_cmd_install`, `_cmd_install_all`), which first map the registry `server_id` to its recipe key via `_recipe_pkg_for()`.

Several registry `server_id`s differ from their `INSTALL_RECIPES` key:

| `server_id` (registry) | recipe key |
|---|---|
| `typescript` | `typescript-language-server` |
| `dockerfile-ls` | `dockerfile-language-server-nodejs` |
| `astro-language-server` | `@astrojs/language-server` |
| `vue-language-server` | `@vue/language-server` |

For those, `INSTALL_RECIPES.get(server_id)` returned `None`, so `bin_name` fell back to the raw `server_id` and `_existing_binary` probed for a binary literally named `typescript` / `dockerfile-ls`, which never exists. As a result `hermes lsp which typescript` reported **"not installed"** even when the server was present and `hermes lsp install typescript` / `hermes lsp status` correctly saw it.

The fix routes `server_id` through `_recipe_pkg_for()` before the recipe lookup, exactly as the sibling commands do.

```python
 def _cmd_which(server_id: str) -> int:
     from agent.lsp.install import INSTALL_RECIPES, _existing_binary

-    recipe = INSTALL_RECIPES.get(server_id)
-    bin_name = (recipe or {}).get("bin", server_id)
+    pkg = _recipe_pkg_for(server_id)
+    recipe = INSTALL_RECIPES.get(pkg)
+    bin_name = (recipe or {}).get("bin", pkg)
```

## How to test

```bash
# with typescript-language-server installed via `hermes lsp install typescript`:
hermes lsp which typescript        # now prints the resolved path (was: "typescript: not installed")
hermes lsp which dockerfile-ls     # same fix
```

Or run the added regression test:

```bash
pytest tests/agent/lsp/test_install_and_lint_fixes.py -q
```

The new test (`test_cmd_which_resolves_aliased_server_id`) fails on the unpatched code (`rc == 1`, "not installed") and passes after the fix. Full file (15 tests) passes; `ruff check` clean.

## Platforms tested

macOS (Darwin). Pure lookup-mapping change, no platform-specific behavior.