### PR TITLE
fix(agent): enable thinking for Kimi /coding endpoint via Anthropic Messages

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2438,8 +2438,7 @@ def build_anthropic_kwargs(
     # silently hides reasoning text that Hermes surfaces in its CLI. We
     # request "summarized" so the reasoning blocks stay populated — matching
     # 4.6 behavior and preserving the activity-feed UX during long tool runs.
-    _is_kimi_coding = _is_kimi_family_endpoint(base_url, model)
-    if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
+    if reasoning_config and isinstance(reasoning_config, dict):
         if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
             effort = str(reasoning_config.get("effort", "medium")).lower()
             budget = THINKING_BUDGET.get(effort, 8000)


### PR DESCRIPTION
The `kimi-coding` provider routes `sk-kimi-*` keys to `https://api.kimi.com/coding` and correctly uses `anthropic_messages` API mode. However, `build_anthropic_kwargs()` previously skipped the `thinking` parameter for all Kimi-family endpoints due to concerns that Kimi required `reasoning_content` on every replayed tool-call message in thinking mode.

I tested directly against the live `https://api.kimi.com/coding/v1/messages` endpoint:

- Single-turn requests with `thinking: {"type": "enabled"}` return `type: "thinking"` blocks
- Multi-turn replay with signed thinking blocks → 200 OK
- Multi-turn replay with unsigned thinking blocks → 200 OK
- Multi-turn replay without any thinking block → 200 OK
- Tool-call conversations (thinking + tool_use + tool_result + follow-up) → 200 OK

Kimi no longer enforces the reasoning_content requirement that motivated the original exclusion. The existing `_needs_thinking_reasoning_pad()` and `_manage_thinking_signatures()` machinery already handles the echo-back for Kimi, so no additional changes are needed for multi-turn continuity.

**Testing**: I applied this fix locally and confirmed that Kimi K2.6 now displays reasoning/thinking output in Hermes agent.