### PR TITLE
fix(tools): use POSIX separators for container paths on Windows

### DIFF
--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -1,7 +1,7 @@
 """Tests for credential file passthrough and skills directory mounting."""
 
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from unittest.mock import patch
 
 import pytest
@@ -202,6 +202,34 @@ class TestIterSkillsFiles:
 
         with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
             assert iter_skills_files() == []
+
+    def test_nested_container_path_uses_posix_separators_on_windows(
+        self, tmp_path, monkeypatch,
+    ):
+        """Skills container paths must use '/' even on a Windows host.
+
+        See the matching iter_cache_files test — container paths are POSIX
+        regardless of host OS, but Windows ``relative_to`` yields backslash
+        parts that must be normalized via ``as_posix()``.
+        """
+        hermes_home = tmp_path / ".hermes"
+        skills_dir = hermes_home / "skills"
+        (skills_dir / "cat" / "myskill" / "scripts").mkdir(parents=True)
+        (skills_dir / "cat" / "myskill" / "scripts" / "run.sh").write_text("#!/bin/bash")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        real_relative_to = Path.relative_to
+
+        def _windows_relative_to(self, *other):
+            rel = real_relative_to(self, *other)
+            return PureWindowsPath(*rel.parts)
+
+        monkeypatch.setattr(Path, "relative_to", _windows_relative_to)
+
+        files = iter_skills_files()
+        paths = {f["container_path"] for f in files}
+        assert all("\\" not in p for p in paths), paths
+        assert "/root/.hermes/skills/cat/myskill/scripts/run.sh" in paths
 
 class TestPathTraversalSecurity:
     """Path traversal and absolute path rejection.
@@ -520,3 +548,38 @@ class TestIterCacheFiles:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         assert iter_cache_files() == []
+
+    def test_nested_container_path_uses_posix_separators_on_windows(
+        self, tmp_path, monkeypatch,
+    ):
+        """Container paths must use '/' even when the host is Windows.
+
+        Container/remote paths are POSIX regardless of the host OS. On a
+        Windows host ``Path.relative_to`` yields backslash-separated parts;
+        formatting that straight into the container path produced e.g.
+        ``/root/.hermes/cache/screenshots/session_abc\\screen1.png``, which
+        is a broken mount path. Simulate Windows by making the relative path
+        a ``PureWindowsPath`` and assert the separators are normalized.
+        """
+        hermes_home = tmp_path / ".hermes"
+        ss_dir = hermes_home / "cache" / "screenshots"
+        sub = ss_dir / "session_abc"
+        sub.mkdir(parents=True)
+        (sub / "screen1.png").write_bytes(b"PNG")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        # Force a Windows-style relative path the way relative_to() would
+        # return one on a Windows host.
+        real_relative_to = Path.relative_to
+
+        def _windows_relative_to(self, *other):
+            rel = real_relative_to(self, *other)
+            return PureWindowsPath(*rel.parts)
+
+        monkeypatch.setattr(Path, "relative_to", _windows_relative_to)
+
+        entries = iter_cache_files()
+        assert len(entries) == 1
+        container_path = entries[0]["container_path"]
+        assert "\\" not in container_path
+        assert container_path == "/root/.hermes/cache/screenshots/session_abc/screen1.png"

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -313,7 +313,7 @@ def iter_skills_files(
             rel = item.relative_to(skills_dir)
             result.append({
                 "host_path": str(item),
-                "container_path": f"{container_root}/{rel}",
+                "container_path": f"{container_root}/{rel.as_posix()}",
             })
 
     # Include external skill dirs
@@ -329,7 +329,7 @@ def iter_skills_files(
                 rel = item.relative_to(ext_dir)
                 result.append({
                     "host_path": str(item),
-                    "container_path": f"{container_root}/{rel}",
+                    "container_path": f"{container_root}/{rel.as_posix()}",
                 })
     except ImportError:
         pass
@@ -443,7 +443,7 @@ def iter_cache_files(
             rel = item.relative_to(host_dir)
             result.append({
                 "host_path": str(item),
-                "container_path": f"{container_root}/{rel}",
+                "container_path": f"{container_root}/{rel.as_posix()}",
             })
     return result
 


### PR DESCRIPTION
## What changed and why

`iter_skills_files` and `iter_cache_files` in `tools/credential_files.py` build container/remote mount paths by formatting a `Path` object straight into an f-string:

```python
rel = item.relative_to(skills_dir)   # a Path
"container_path": f"{container_root}/{rel}"
```

On a **Windows host**, `rel` stringifies with backslashes, so the container path comes out as:

```
/root/.hermes/skills/cat\myskill\scripts\run.sh
```

These `container_path`s are consumed by remote backends (Docker, Modal) where paths are **always POSIX**, so the mount target is malformed and the credential/skill file isn't found inside the sandbox.

The sibling helper `map_cache_path_to_container` in the same module already handles this correctly and documents the rule:

> Always joins with `posixpath` because container/remote paths are POSIX regardless of the host OS.

…using `rel.as_posix()`. The three enumeration sites (`iter_skills_files` bundled + external-skills loops, and `iter_cache_files`) simply forgot it. This fix applies the same `.as_posix()` normalization at all three.

```diff
-                "container_path": f"{container_root}/{rel}",
+                "container_path": f"{container_root}/{rel.as_posix()}",
```

## How to test

```bash
pytest tests/tools/test_credential_files.py -q
```

Added two regression tests (`TestIterCacheFiles` and `TestIterSkillsFiles`) that monkeypatch `Path.relative_to` to return a `PureWindowsPath` — simulating a Windows host on any CI OS. They fail on the unpatched code (producing `...session_abc\screen1.png`) and pass after the fix. Full file (35 tests) passes; `ruff check` clean.

## Platforms tested

Verified on macOS (Darwin). The bug is Windows-specific; the regression tests reproduce it deterministically on POSIX CI by simulating Windows path semantics, so the fix is covered regardless of the runner OS.