### PR TITLE
feat(agent): add project-local foundation state

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -223,6 +223,7 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    project_local_state: Any = None,
 ):
     """
     Initialize the AI Agent.
@@ -304,6 +305,7 @@ def init_agent(
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
     agent.pass_session_id = pass_session_id
+    agent.project_local_state = project_local_state
     agent._credential_pool = credential_pool
     agent.log_prefix_chars = log_prefix_chars
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -423,6 +423,14 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
         if stored_mcp_hash != current_mcp_hash:
             return False
 
+    current_rejected_reason = str(
+        project_signature.get("project.rejected_reason") or ""
+    ).strip()
+    stored_rejected_reason = line_value("Project rejected reason")
+    if current_rejected_reason or stored_rejected_reason:
+        if stored_rejected_reason != current_rejected_reason:
+            return False
+
     return True
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -415,6 +415,14 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
         if stored_skills_hash != current_skills_hash:
             return False
 
+    current_mcp_hash = str(
+        project_signature.get("project.mcp_manifest_hash") or ""
+    ).strip()
+    stored_mcp_hash = line_value("Project MCP manifest")
+    if current_mcp_hash or stored_mcp_hash:
+        if stored_mcp_hash != current_mcp_hash:
+            return False
+
     return True
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -396,6 +396,25 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     if stored_provider and current_provider and stored_provider != current_provider:
         return False
 
+    project_local = getattr(agent, "project_local_state", None)
+    try:
+        project_signature = project_local.cache_signature() if project_local else {}
+    except Exception:
+        project_signature = {}
+    current_project = str(project_signature.get("project.canonical_id") or "").strip()
+    stored_project = line_value("Project ID")
+    if current_project or stored_project:
+        if stored_project != current_project:
+            return False
+
+    current_skills_hash = str(
+        project_signature.get("project.skills_manifest_hash") or ""
+    ).strip()
+    stored_skills_hash = line_value("Project skills manifest")
+    if current_skills_hash or stored_skills_hash:
+        if stored_skills_hash != current_skills_hash:
+            return False
+
     return True
 
 

--- a/agent/project_local.py
+++ b/agent/project_local.py
@@ -86,6 +86,8 @@ class ProjectLocalState:
             signature["project.skills_manifest_hash"] = self.skills_manifest_hash
         if self.mcp_manifest_hash:
             signature["project.mcp_manifest_hash"] = self.mcp_manifest_hash
+        if self.rejected_reason:
+            signature["project.rejected_reason"] = self.rejected_reason
         return signature
 
 

--- a/agent/project_local.py
+++ b/agent/project_local.py
@@ -69,6 +69,7 @@ class ProjectLocalState:
     skills_manifest_hash: str = ""
     consent_decision: str = ""
     mcp_manifest: tuple[tuple[str, str], ...] = ()
+    mcp_manifest_hash: str = ""
     rejected_reason: str = ""
 
     @property
@@ -78,10 +79,14 @@ class ProjectLocalState:
     def cache_signature(self) -> dict[str, str]:
         if not (self.recognized or self.rejected_reason):
             return {}
-        return {
+        signature = {
             "project.canonical_id": self.canonical_id,
-            "project.skills_manifest_hash": self.skills_manifest_hash,
         }
+        if self.skills_manifest_hash:
+            signature["project.skills_manifest_hash"] = self.skills_manifest_hash
+        if self.mcp_manifest_hash:
+            signature["project.mcp_manifest_hash"] = self.mcp_manifest_hash
+        return signature
 
 
 def clear_project_local_cache() -> None:
@@ -375,6 +380,13 @@ def _mcp_manifest(identity: ProjectIdentity) -> tuple[tuple[str, str], ...]:
         return ()
 
 
+def _mcp_manifest_hash(entries: tuple[tuple[str, str], ...]) -> str:
+    if not entries:
+        return ""
+    encoded = json.dumps(entries, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
 def _consent_decision(canonical_id: str, manifest_hash: str) -> str:
     if not canonical_id or not manifest_hash:
         return ""
@@ -415,6 +427,7 @@ def resolve_project_local_state(
     skill_roots, skills = _project_skills(identity)
     manifest_hash = _manifest_hash(skills)
     mcp = _mcp_manifest(identity)
+    mcp_hash = _mcp_manifest_hash(mcp)
     return ProjectLocalState(
         canonical_id=identity.canonical_id,
         worktree_root=identity.worktree_root,
@@ -424,6 +437,7 @@ def resolve_project_local_state(
         skills_manifest_hash=manifest_hash,
         consent_decision=_consent_decision(identity.canonical_id, manifest_hash),
         mcp_manifest=mcp,
+        mcp_manifest_hash=mcp_hash,
         rejected_reason=rejected_reason,
     )
 

--- a/agent/project_local.py
+++ b/agent/project_local.py
@@ -1,0 +1,446 @@
+"""Project-local identity, candidate detection, and trust state.
+
+This module is intentionally state-only. It discovers recognized project-local
+surfaces, builds immutable runtime state, and persists operator consent in a
+profile-aware sidecar. It does not load project-local skill instructions into a
+prompt; later project-local feature phases consume the state explicitly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import logging
+import os
+import subprocess
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+try:  # POSIX only; Windows falls back to the in-process lock.
+    import fcntl  # type: ignore
+except Exception:  # pragma: no cover
+    fcntl = None  # type: ignore
+
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
+
+logger = logging.getLogger("agent.project_local")
+
+PROJECT_TRUST_FILENAME = "project-trust.json"
+PROJECT_TRUST_VERSION = 1
+
+_GIT_TIMEOUT = 2.5
+_candidate_cache_lock = threading.Lock()
+_CandidateCacheStamp = tuple[tuple[str, int, int, bool], ...]
+_candidate_cache: dict[str, tuple[_CandidateCacheStamp, bool, str]] = {}
+_trust_write_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class ProjectIdentity:
+    """Canonical git-backed project identity."""
+
+    canonical_id: str
+    worktree_root: str
+    git_common_dir: str
+
+
+@dataclass(frozen=True)
+class ProjectSkillManifestEntry:
+    """One recognized project-local skill file."""
+
+    name: str
+    path: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class ProjectLocalState:
+    """Immutable project-local runtime state captured at agent construction."""
+
+    canonical_id: str = ""
+    worktree_root: str = ""
+    git_common_dir: str = ""
+    skill_roots: tuple[str, ...] = ()
+    skills_manifest: tuple[ProjectSkillManifestEntry, ...] = ()
+    skills_manifest_hash: str = ""
+    consent_decision: str = ""
+    mcp_manifest: tuple[tuple[str, str], ...] = ()
+    rejected_reason: str = ""
+
+    @property
+    def recognized(self) -> bool:
+        return bool(self.skills_manifest or self.mcp_manifest)
+
+    def cache_signature(self) -> dict[str, str]:
+        if not (self.recognized or self.rejected_reason):
+            return {}
+        return {
+            "project.canonical_id": self.canonical_id,
+            "project.skills_manifest_hash": self.skills_manifest_hash,
+        }
+
+
+def clear_project_local_cache() -> None:
+    with _candidate_cache_lock:
+        _candidate_cache.clear()
+
+
+def project_trust_path() -> Path:
+    return get_hermes_home() / PROJECT_TRUST_FILENAME
+
+
+def _empty_trust() -> dict[str, Any]:
+    return {"version": PROJECT_TRUST_VERSION, "projects": {}}
+
+
+def load_project_trust() -> dict[str, Any]:
+    try:
+        raw = json.loads(project_trust_path().read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return _empty_trust()
+    if not isinstance(raw, dict):
+        return _empty_trust()
+    if raw.get("version") != PROJECT_TRUST_VERSION:
+        return _empty_trust()
+    projects = raw.get("projects")
+    if not isinstance(projects, dict):
+        raw["projects"] = {}
+    return raw
+
+
+def save_project_trust(data: dict[str, Any]) -> None:
+    payload = dict(data if isinstance(data, dict) else {})
+    payload["version"] = PROJECT_TRUST_VERSION
+    if not isinstance(payload.get("projects"), dict):
+        payload["projects"] = {}
+    atomic_json_write(
+        project_trust_path(),
+        payload,
+        indent=2,
+        mode=0o600,
+        sort_keys=True,
+    )
+
+
+@contextlib.contextmanager
+def locked_project_trust() -> Iterator[dict[str, Any]]:
+    path = project_trust_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+
+    if fcntl is None:  # pragma: no cover
+        with _trust_write_lock:
+            data = load_project_trust()
+            yield data
+            save_project_trust(data)
+        return
+
+    with open(lock_path, "a+", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            data = load_project_trust()
+            yield data
+            save_project_trust(data)
+        finally:
+            with contextlib.suppress(OSError, IOError):
+                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+
+def record_project_skill_consent(
+    canonical_id: str,
+    *,
+    skills_manifest_hash: str,
+    decision: str,
+) -> None:
+    if not canonical_id:
+        return
+    with locked_project_trust() as trust:
+        projects = trust.setdefault("projects", {})
+        project = projects.setdefault(canonical_id, {})
+        project["skills"] = {
+            "manifest_hash": skills_manifest_hash,
+            "decision": str(decision or ""),
+        }
+        project.setdefault("mcp", {})
+
+
+def _git(
+    start: Path,
+    *args: str,
+) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(start), *args],
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError((result.stderr or result.stdout or "").strip())
+    return result.stdout.strip()
+
+
+def canonical_project_identity(start: str | Path | None = None) -> Optional[ProjectIdentity]:
+    try:
+        start_path = Path(start or os.getcwd()).expanduser()
+        if start_path.is_file():
+            start_path = start_path.parent
+        start_path = start_path.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+    try:
+        root = Path(_git(start_path, "rev-parse", "--show-toplevel")).expanduser()
+        if not root.is_absolute():
+            root = start_path / root
+        root = root.resolve()
+        common = Path(_git(root, "rev-parse", "--git-common-dir")).expanduser()
+        if not common.is_absolute():
+            common = root / common
+        common = common.resolve()
+    except Exception:
+        return None
+
+    digest = hashlib.sha256(str(common).encode("utf-8")).hexdigest()[:24]
+    return ProjectIdentity(
+        canonical_id=f"git:{digest}",
+        worktree_root=str(root),
+        git_common_dir=str(common),
+    )
+
+
+def _safe_lstat(path: Path) -> tuple[int, int, bool]:
+    try:
+        stat_result = path.lstat()
+    except OSError:
+        return -1, -1, False
+    return stat_result.st_mtime_ns, stat_result.st_size, path.is_symlink()
+
+
+def _candidate_cache_stamp(hermes_dir: Path) -> _CandidateCacheStamp:
+    entries: list[tuple[str, int, int, bool]] = []
+
+    def add(label: str, path: Path) -> None:
+        mtime, size, is_symlink = _safe_lstat(path)
+        entries.append((label, mtime, size, is_symlink))
+
+    add(".", hermes_dir)
+    add("config.yaml", hermes_dir / "config.yaml")
+
+    skills_dir = hermes_dir / "skills"
+    add("skills", skills_dir)
+    if skills_dir.exists() and not skills_dir.is_symlink():
+        try:
+            dirs = sorted(
+                (
+                    path
+                    for path in skills_dir.rglob("*")
+                    if path.is_dir() or path.is_symlink()
+                ),
+                key=lambda path: str(path.relative_to(hermes_dir)),
+            )
+        except OSError:
+            dirs = []
+        for path in dirs:
+            try:
+                label = str(path.relative_to(hermes_dir))
+            except ValueError:
+                label = str(path)
+            add(label, path)
+
+    return tuple(entries)
+
+
+def _has_mcp_config(hermes_dir: Path) -> bool:
+    config = hermes_dir / "config.yaml"
+    if not config.exists():
+        return False
+    if config.is_symlink():
+        return False
+    try:
+        import yaml
+
+        data = yaml.safe_load(config.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return False
+    return isinstance(data, dict) and "mcp_servers" in data
+
+
+def project_has_recognized_files(identity: ProjectIdentity) -> tuple[bool, str]:
+    hermes_dir = Path(identity.worktree_root) / ".hermes"
+    cache_stamp = _candidate_cache_stamp(hermes_dir)
+    with _candidate_cache_lock:
+        cached = _candidate_cache.get(identity.canonical_id)
+        if cached is not None and cached[0] == cache_stamp:
+            return cached[1], cached[2]
+
+    recognized = False
+    rejected_reason = ""
+    if hermes_dir.exists():
+        if hermes_dir.is_symlink():
+            rejected_reason = "symlinked .hermes directory is not trusted"
+        elif (
+            (hermes_dir / "skills").exists()
+            and not (hermes_dir / "skills").is_symlink()
+            and any(
+                path.name == "SKILL.md" and not path.is_symlink()
+                for path in (hermes_dir / "skills").rglob("SKILL.md")
+            )
+        ):
+            recognized = True
+        elif _has_mcp_config(hermes_dir):
+            recognized = True
+
+    with _candidate_cache_lock:
+        _candidate_cache[identity.canonical_id] = (
+            cache_stamp,
+            recognized,
+            rejected_reason,
+        )
+    return recognized, rejected_reason
+
+
+def _skill_name(skill_md: Path) -> str:
+    try:
+        content = skill_md.read_text(encoding="utf-8")
+        if content.startswith("---"):
+            end = content.find("\n---", 3)
+            if end != -1:
+                for line in content[3:end].splitlines():
+                    key, _, value = line.partition(":")
+                    if key.strip() == "name" and value.strip():
+                        return value.strip().strip("'\"")[:64]
+    except Exception:
+        pass
+    return skill_md.parent.name
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _project_skills(identity: ProjectIdentity) -> tuple[tuple[str, ...], tuple[ProjectSkillManifestEntry, ...]]:
+    skills_root = Path(identity.worktree_root) / ".hermes" / "skills"
+    if not skills_root.exists() or skills_root.is_symlink():
+        return (), ()
+
+    entries: list[ProjectSkillManifestEntry] = []
+    roots: set[str] = set()
+    for skill_md in sorted(skills_root.rglob("SKILL.md"), key=lambda p: str(p)):
+        if skill_md.is_symlink():
+            continue
+        try:
+            resolved_skill = skill_md.resolve()
+            resolved_root = skill_md.parent.resolve()
+            roots.add(str(resolved_root))
+            entries.append(
+                ProjectSkillManifestEntry(
+                    name=_skill_name(skill_md),
+                    path=str(resolved_skill),
+                    sha256=_sha256_file(skill_md),
+                )
+            )
+        except OSError:
+            continue
+    return tuple(sorted(roots)), tuple(entries)
+
+
+def _manifest_hash(entries: tuple[ProjectSkillManifestEntry, ...]) -> str:
+    if not entries:
+        return ""
+    payload = [
+        {"name": entry.name, "path": entry.path, "sha256": entry.sha256}
+        for entry in entries
+    ]
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _mcp_manifest(identity: ProjectIdentity) -> tuple[tuple[str, str], ...]:
+    hermes_dir = Path(identity.worktree_root) / ".hermes"
+    if not _has_mcp_config(hermes_dir):
+        return ()
+    config = hermes_dir / "config.yaml"
+    try:
+        return (("config_sha256", _sha256_file(config)),)
+    except OSError:
+        return ()
+
+
+def _consent_decision(canonical_id: str, manifest_hash: str) -> str:
+    if not canonical_id or not manifest_hash:
+        return ""
+    project = load_project_trust().get("projects", {}).get(canonical_id, {})
+    if not isinstance(project, dict):
+        return ""
+    skills = project.get("skills")
+    if not isinstance(skills, dict):
+        return ""
+    if skills.get("manifest_hash") != manifest_hash:
+        return ""
+    return str(skills.get("decision") or "")
+
+
+def resolve_project_local_state(
+    cwd: str | Path | None = None,
+) -> ProjectLocalState:
+    if cwd is None:
+        try:
+            from agent.runtime_cwd import resolve_agent_cwd
+
+            cwd = resolve_agent_cwd()
+        except Exception:
+            cwd = None
+    identity = canonical_project_identity(cwd)
+    if identity is None:
+        return ProjectLocalState()
+
+    recognized, rejected_reason = project_has_recognized_files(identity)
+    if not recognized:
+        return ProjectLocalState(
+            canonical_id=identity.canonical_id,
+            worktree_root=identity.worktree_root,
+            git_common_dir=identity.git_common_dir,
+            rejected_reason=rejected_reason,
+        )
+
+    skill_roots, skills = _project_skills(identity)
+    manifest_hash = _manifest_hash(skills)
+    mcp = _mcp_manifest(identity)
+    return ProjectLocalState(
+        canonical_id=identity.canonical_id,
+        worktree_root=identity.worktree_root,
+        git_common_dir=identity.git_common_dir,
+        skill_roots=skill_roots,
+        skills_manifest=skills,
+        skills_manifest_hash=manifest_hash,
+        consent_decision=_consent_decision(identity.canonical_id, manifest_hash),
+        mcp_manifest=mcp,
+        rejected_reason=rejected_reason,
+    )
+
+
+__all__ = [
+    "PROJECT_TRUST_FILENAME",
+    "PROJECT_TRUST_VERSION",
+    "ProjectIdentity",
+    "ProjectLocalState",
+    "ProjectSkillManifestEntry",
+    "canonical_project_identity",
+    "clear_project_local_cache",
+    "load_project_trust",
+    "locked_project_trust",
+    "project_has_recognized_files",
+    "project_trust_path",
+    "record_project_skill_consent",
+    "resolve_project_local_state",
+    "save_project_trust",
+]

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -417,6 +417,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         ).strip()
         if mcp_hash:
             project_lines.append(f"Project MCP manifest: {mcp_hash}")
+        rejected_reason = str(
+            project_signature.get("project.rejected_reason") or ""
+        ).strip()
+        if rejected_reason:
+            project_lines.append(f"Project rejected reason: {rejected_reason}")
         stable_parts.append("\n".join(project_lines))
 
     # ── Context tier (cwd-dependent, may change between sessions) ─

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -399,6 +399,21 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if _effective_hint:
         stable_parts.append(_effective_hint)
 
+    project_local = getattr(agent, "project_local_state", None)
+    try:
+        project_signature = project_local.cache_signature() if project_local else {}
+    except Exception:
+        project_signature = {}
+    project_id = str(project_signature.get("project.canonical_id") or "").strip()
+    if project_id:
+        project_lines = [f"Project ID: {project_id}"]
+        skills_hash = str(
+            project_signature.get("project.skills_manifest_hash") or ""
+        ).strip()
+        if skills_hash:
+            project_lines.append(f"Project skills manifest: {skills_hash}")
+        stable_parts.append("\n".join(project_lines))
+
     # ── Context tier (cwd-dependent, may change between sessions) ─
     context_parts: List[str] = []
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -412,6 +412,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         ).strip()
         if skills_hash:
             project_lines.append(f"Project skills manifest: {skills_hash}")
+        mcp_hash = str(
+            project_signature.get("project.mcp_manifest_hash") or ""
+        ).strip()
+        if mcp_hash:
+            project_lines.append(f"Project MCP manifest: {mcp_hash}")
         stable_parts.append("\n".join(project_lines))
 
     # ── Context tier (cwd-dependent, may change between sessions) ─

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11038,6 +11038,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         logger.warning("Background task vision enrichment failed: %s", e)
 
             def run_sync():
+                try:
+                    from agent.project_local import resolve_project_local_state
+
+                    project_local_state = resolve_project_local_state()
+                except Exception:
+                    project_local_state = None
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],
@@ -11066,6 +11072,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     thread_id=source.thread_id,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    project_local_state=project_local_state,
                 )
                 try:
                     return agent.run_conversation(
@@ -12542,6 +12549,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
+            cwd=os.environ.get("TERMINAL_CWD", ""),
         )
 
     def _clear_session_env(self, tokens: list) -> None:
@@ -15203,12 +15211,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
             # schemas for prompt cache hits.
+            try:
+                from agent.project_local import resolve_project_local_state
+
+                project_local_state = resolve_project_local_state()
+            except Exception:
+                project_local_state = None
+            try:
+                _cache_keys = dict(self._extract_cache_busting_config(user_config) or {})
+            except Exception:
+                _cache_keys = {}
+            if project_local_state is not None:
+                _cache_keys.update(project_local_state.cache_signature())
             _sig = self._agent_config_signature(
                 turn_route["model"],
                 turn_route["runtime"],
                 enabled_toolsets,
                 combined_ephemeral,
-                cache_keys=self._extract_cache_busting_config(user_config),
+                cache_keys=_cache_keys,
                 user_id=getattr(source, "user_id", None),
                 user_id_alt=getattr(source, "user_id_alt", None),
             )
@@ -15303,6 +15323,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     gateway_session_key=session_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    project_local_state=project_local_state,
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -190,6 +190,14 @@ class CLIAgentSetupMixin:
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
         }
+        try:
+            from agent.project_local import resolve_project_local_state
+
+            project_signature = tuple(
+                sorted(resolve_project_local_state().cache_signature().items())
+            )
+        except Exception:
+            project_signature = ()
         route = {
             "model": self.model,
             "runtime": runtime,
@@ -200,6 +208,7 @@ class CLIAgentSetupMixin:
                 runtime["api_mode"],
                 runtime["command"],
                 tuple(runtime["args"]),
+                project_signature,
             ),
         }
 
@@ -340,6 +349,9 @@ class CLIAgentSetupMixin:
                 "credential_pool": getattr(self, "_credential_pool", None),
             }
             effective_model = model_override or self.model
+            from agent.project_local import resolve_project_local_state
+
+            project_local_state = resolve_project_local_state()
             self.agent = AIAgent(
                 model=effective_model,
                 api_key=runtime.get("api_key"),
@@ -383,6 +395,7 @@ class CLIAgentSetupMixin:
                 pass_session_id=self.pass_session_id,
                 skip_context_files=self.ignore_rules,
                 skip_memory=self.ignore_rules,
+                project_local_state=project_local_state,
                 tool_progress_callback=self._on_tool_progress,
                 tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
@@ -414,6 +427,7 @@ class CLIAgentSetupMixin:
                 runtime.get("api_mode"),
                 runtime.get("command"),
                 tuple(runtime.get("args") or ()),
+                tuple(sorted(project_local_state.cache_signature().items())),
             )
 
             # Force-create DB row on /title intent, then apply title.

--- a/run_agent.py
+++ b/run_agent.py
@@ -412,6 +412,7 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        project_local_state: Any = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
@@ -487,6 +488,7 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            project_local_state=project_local_state,
         )
 
     def _get_session_db_for_recall(self):

--- a/tests/agent/test_project_local.py
+++ b/tests/agent/test_project_local.py
@@ -169,6 +169,10 @@ def test_symlinked_hermes_directory_is_rejected(tmp_path: Path):
 
     assert state.recognized is False
     assert "symlinked .hermes" in state.rejected_reason
+    assert state.cache_signature() == {
+        "project.canonical_id": state.canonical_id,
+        "project.rejected_reason": state.rejected_reason,
+    }
 
 
 def test_project_local_state_is_immutable_and_hashes_skills(tmp_path: Path):

--- a/tests/agent/test_project_local.py
+++ b/tests/agent/test_project_local.py
@@ -122,6 +122,15 @@ def test_recognized_files_detect_mcp_config(tmp_path: Path):
     assert rejected == ""
     assert state.recognized is True
     assert state.mcp_manifest
+    assert state.mcp_manifest_hash
+    assert state.cache_signature() == {
+        "project.canonical_id": state.canonical_id,
+        "project.mcp_manifest_hash": state.mcp_manifest_hash,
+    }
+
+    before = state.mcp_manifest_hash
+    config.write_text("mcp_servers:\n  local:\n    command: changed\n", encoding="utf-8")
+    assert resolve_project_local_state(repo).mcp_manifest_hash != before
 
 
 def test_recognized_file_cache_tracks_new_skill_under_existing_dir(tmp_path: Path):

--- a/tests/agent/test_project_local.py
+++ b/tests/agent/test_project_local.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import dataclasses
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent.project_local import (
+    canonical_project_identity,
+    clear_project_local_cache,
+    load_project_trust,
+    project_has_recognized_files,
+    project_trust_path,
+    record_project_skill_consent,
+    resolve_project_local_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_project_cache():
+    clear_project_local_cache()
+    yield
+    clear_project_local_cache()
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "README.md").write_text("repo\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(
+        repo,
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=Test User",
+        "commit",
+        "-m",
+        "init",
+    )
+    return repo
+
+
+def _write_project_skill(repo: Path, name: str, body: str = "Do useful work.") -> Path:
+    skill = repo / ".hermes" / "skills" / name / "SKILL.md"
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text(
+        f"---\nname: {name}\ndescription: test\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+    return skill
+
+
+def test_canonical_identity_collapses_subdirs_and_git_worktrees(tmp_path: Path):
+    repo = _git_repo(tmp_path)
+    subdir = repo / "src" / "pkg"
+    subdir.mkdir(parents=True)
+    worktree = tmp_path / "linked-worktree"
+    _git(repo, "worktree", "add", str(worktree), "-b", "test-worktree")
+
+    root_id = canonical_project_identity(repo)
+    subdir_id = canonical_project_identity(subdir)
+    worktree_id = canonical_project_identity(worktree)
+
+    assert root_id is not None
+    assert subdir_id is not None
+    assert worktree_id is not None
+    assert root_id.canonical_id == subdir_id.canonical_id
+    assert root_id.canonical_id == worktree_id.canonical_id
+    assert Path(root_id.git_common_dir).resolve() == Path(worktree_id.git_common_dir).resolve()
+
+
+def test_recognized_files_ignore_bare_hermes_directory(tmp_path: Path):
+    repo = _git_repo(tmp_path)
+    (repo / ".hermes" / "plans").mkdir(parents=True)
+    identity = canonical_project_identity(repo)
+    assert identity is not None
+
+    recognized, rejected = project_has_recognized_files(identity)
+
+    assert recognized is False
+    assert rejected == ""
+
+
+def test_recognized_files_detect_project_skill(tmp_path: Path):
+    repo = _git_repo(tmp_path)
+    _write_project_skill(repo, "local-skill")
+    identity = canonical_project_identity(repo)
+    assert identity is not None
+
+    recognized, rejected = project_has_recognized_files(identity)
+
+    assert recognized is True
+    assert rejected == ""
+
+
+def test_recognized_files_detect_mcp_config(tmp_path: Path):
+    repo = _git_repo(tmp_path)
+    config = repo / ".hermes" / "config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("mcp_servers:\n  local: {}\n", encoding="utf-8")
+    identity = canonical_project_identity(repo)
+    assert identity is not None
+
+    recognized, rejected = project_has_recognized_files(identity)
+    state = resolve_project_local_state(repo)
+
+    assert recognized is True
+    assert rejected == ""
+    assert state.recognized is True
+    assert state.mcp_manifest
+
+
+def test_recognized_file_cache_tracks_new_skill_under_existing_dir(tmp_path: Path):
+    repo = _git_repo(tmp_path)
+    skill_dir = repo / ".hermes" / "skills" / "late"
+    skill_dir.mkdir(parents=True)
+    identity = canonical_project_identity(repo)
+    assert identity is not None
+
+    recognized, rejected = project_has_recognized_files(identity)
+    assert recognized is False
+    assert rejected == ""
+
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: late\ndescription: test\n---\n\nNow visible.\n",
+        encoding="utf-8",
+    )
+
+    recognized, rejected = project_has_recognized_files(identity)
+    assert recognized is True
+    assert rejected == ""
+
+
+def test_symlinked_hermes_directory_is_rejected(tmp_path: Path):
+    repo = _git_repo(tmp_path)
+    target = tmp_path / "elsewhere"
+    target.mkdir()
+    try:
+        (repo / ".hermes").symlink_to(target, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+    identity = canonical_project_identity(repo)
+    assert identity is not None
+
+    state = resolve_project_local_state(repo)
+
+    assert state.recognized is False
+    assert "symlinked .hermes" in state.rejected_reason
+
+
+def test_project_local_state_is_immutable_and_hashes_skills(tmp_path: Path):
+    repo = _git_repo(tmp_path)
+    _write_project_skill(repo, "alpha")
+
+    state = resolve_project_local_state(repo)
+
+    assert state.recognized is True
+    assert state.skill_roots
+    assert state.skills_manifest_hash
+    assert state.cache_signature() == {
+        "project.canonical_id": state.canonical_id,
+        "project.skills_manifest_hash": state.skills_manifest_hash,
+    }
+    assert state.skills_manifest[0].name == "alpha"
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        state.canonical_id = "changed"  # type: ignore[misc]
+
+
+def test_unrecognized_repo_keeps_identity_but_has_no_cache_signature(tmp_path: Path):
+    repo = _git_repo(tmp_path)
+    (repo / ".hermes" / "plans").mkdir(parents=True)
+
+    state = resolve_project_local_state(repo)
+
+    assert state.canonical_id
+    assert state.recognized is False
+    assert state.cache_signature() == {}
+
+
+def test_default_resolution_uses_runtime_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repo = _git_repo(tmp_path)
+    _write_project_skill(repo, "alpha")
+    other = tmp_path / "other"
+    other.mkdir()
+    monkeypatch.chdir(other)
+    monkeypatch.setenv("TERMINAL_CWD", str(repo))
+
+    state = resolve_project_local_state()
+
+    assert state.recognized is True
+    assert state.worktree_root == str(repo.resolve())
+
+
+def test_trust_sidecar_round_trips_atomically_and_freezes_matching_consent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    repo = _git_repo(tmp_path)
+    _write_project_skill(repo, "alpha")
+    state = resolve_project_local_state(repo)
+    assert state.skills_manifest_hash
+
+    record_project_skill_consent(
+        state.canonical_id,
+        skills_manifest_hash=state.skills_manifest_hash,
+        decision="allow",
+    )
+
+    trust = load_project_trust()
+    assert trust["projects"][state.canonical_id]["skills"]["decision"] == "allow"
+    mode = stat.S_IMODE(project_trust_path().stat().st_mode)
+    assert mode == 0o600
+    assert resolve_project_local_state(repo).consent_decision == "allow"
+
+    _write_project_skill(repo, "alpha", body="Changed bytes.")
+    assert resolve_project_local_state(repo).consent_decision == ""

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -195,6 +195,44 @@ class TestStoredPromptReuse:
         )
         assert any("stale runtime identity" in r.getMessage() for r in caplog.records)
 
+    def test_present_row_with_stale_project_rejected_reason_rebuilds(self, caplog):
+        """A changed rejected project-local surface must not reuse old prompt bytes."""
+        stored = (
+            "Project ID: git:abc123\n"
+            "Project rejected reason: old rejection\n\n"
+            "Conversation started: Tuesday, June 16, 2026\n"
+            "Session ID: test-session-id\n"
+            "Model: test-model\n"
+            "Provider: openrouter"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(
+            session_db=db,
+            prebuilt_prompt=(
+                "Project ID: git:abc123\n"
+                "Project rejected reason: symlinked .hermes directory is not trusted\n\n"
+                "Conversation started: Tuesday, June 16, 2026\n"
+                "Session ID: test-session-id\n"
+                "Model: test-model\n"
+                "Provider: openrouter"
+            ),
+        )
+        agent.project_local_state = ProjectLocalState(
+            canonical_id="git:abc123",
+            rejected_reason="symlinked .hermes directory is not trusted",
+        )
+
+        with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert "Project rejected reason: symlinked .hermes" in agent._cached_system_prompt
+        agent._build_system_prompt.assert_called_once_with(None)
+        db.update_system_prompt.assert_called_once_with(
+            agent.session_id, agent._cached_system_prompt
+        )
+        assert any("stale runtime identity" in r.getMessage() for r in caplog.records)
+
 
 # ---------------------------------------------------------------------------
 # Legitimate fresh-build paths (no history, no DB)

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from agent.conversation_loop import _restore_or_build_system_prompt
+from agent.project_local import ProjectLocalState, ProjectSkillManifestEntry
 
 
 def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
@@ -31,6 +32,7 @@ def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
     agent.model = "test-model"
     agent.provider = "openrouter"
     agent.platform = "cli"
+    agent.project_local_state = None
     agent._session_db = session_db
     agent._build_system_prompt = MagicMock(return_value=prebuilt_prompt)
     return agent
@@ -103,6 +105,51 @@ class TestStoredPromptReuse:
         assert agent._cached_system_prompt.endswith(
             "Model: openai/gpt-5.5\nProvider: openrouter"
         )
+        agent._build_system_prompt.assert_called_once_with(None)
+        db.update_system_prompt.assert_called_once_with(
+            agent.session_id, agent._cached_system_prompt
+        )
+        assert any("stale runtime identity" in r.getMessage() for r in caplog.records)
+
+    def test_present_row_with_stale_project_skill_manifest_rebuilds(self, caplog):
+        """A changed project-local skill manifest must not reuse old prompt bytes."""
+        stored = (
+            "Project ID: git:abc123\n"
+            "Project skills manifest: old-hash\n\n"
+            "Conversation started: Tuesday, June 16, 2026\n"
+            "Session ID: test-session-id\n"
+            "Model: test-model\n"
+            "Provider: openrouter"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(
+            session_db=db,
+            prebuilt_prompt=(
+                "Project ID: git:abc123\n"
+                "Project skills manifest: new-hash\n\n"
+                "Conversation started: Tuesday, June 16, 2026\n"
+                "Session ID: test-session-id\n"
+                "Model: test-model\n"
+                "Provider: openrouter"
+            ),
+        )
+        agent.project_local_state = ProjectLocalState(
+            canonical_id="git:abc123",
+            skills_manifest=(
+                ProjectSkillManifestEntry(
+                    name="local",
+                    path="/repo/.hermes/skills/local/SKILL.md",
+                    sha256="sha256",
+                ),
+            ),
+            skills_manifest_hash="new-hash",
+        )
+
+        with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert "Project skills manifest: new-hash" in agent._cached_system_prompt
         agent._build_system_prompt.assert_called_once_with(None)
         db.update_system_prompt.assert_called_once_with(
             agent.session_id, agent._cached_system_prompt

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -156,6 +156,45 @@ class TestStoredPromptReuse:
         )
         assert any("stale runtime identity" in r.getMessage() for r in caplog.records)
 
+    def test_present_row_with_stale_project_mcp_manifest_rebuilds(self, caplog):
+        """A changed project-local MCP manifest must not reuse old prompt bytes."""
+        stored = (
+            "Project ID: git:abc123\n"
+            "Project MCP manifest: old-hash\n\n"
+            "Conversation started: Tuesday, June 16, 2026\n"
+            "Session ID: test-session-id\n"
+            "Model: test-model\n"
+            "Provider: openrouter"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(
+            session_db=db,
+            prebuilt_prompt=(
+                "Project ID: git:abc123\n"
+                "Project MCP manifest: new-hash\n\n"
+                "Conversation started: Tuesday, June 16, 2026\n"
+                "Session ID: test-session-id\n"
+                "Model: test-model\n"
+                "Provider: openrouter"
+            ),
+        )
+        agent.project_local_state = ProjectLocalState(
+            canonical_id="git:abc123",
+            mcp_manifest=(("config_sha256", "sha256"),),
+            mcp_manifest_hash="new-hash",
+        )
+
+        with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert "Project MCP manifest: new-hash" in agent._cached_system_prompt
+        agent._build_system_prompt.assert_called_once_with(None)
+        db.update_system_prompt.assert_called_once_with(
+            agent.session_id, agent._cached_system_prompt
+        )
+        assert any("stale runtime identity" in r.getMessage() for r in caplog.records)
+
 
 # ---------------------------------------------------------------------------
 # Legitimate fresh-build paths (no history, no DB)

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -254,6 +254,33 @@ class TestAgentConfigSignature:
 
         assert sig_before != sig_after
 
+    def test_project_local_rejected_reason_change_busts_cache(self):
+        """Rejected project-local surface changes must rebuild cached agents."""
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig_before = GatewayRunner._agent_config_signature(
+            "m",
+            runtime,
+            ["telegram"],
+            "",
+            cache_keys={
+                "project.canonical_id": "git:abc123",
+                "project.rejected_reason": "symlinked .hermes directory is not trusted",
+            },
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m",
+            runtime,
+            ["telegram"],
+            "",
+            cache_keys={
+                "project.canonical_id": "git:abc123",
+            },
+        )
+
+        assert sig_before != sig_after
+
 
 class TestExtractCacheBustingConfig:
     """Verify _extract_cache_busting_config pulls the documented subset of

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -198,6 +198,34 @@ class TestAgentConfigSignature:
 
         assert sig_before != sig_after
 
+    def test_project_local_skill_manifest_change_busts_cache(self):
+        """Project-local skill changes must rebuild cached gateway agents."""
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig_before = GatewayRunner._agent_config_signature(
+            "m",
+            runtime,
+            ["telegram"],
+            "",
+            cache_keys={
+                "project.canonical_id": "git:abc123",
+                "project.skills_manifest_hash": "old-hash",
+            },
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m",
+            runtime,
+            ["telegram"],
+            "",
+            cache_keys={
+                "project.canonical_id": "git:abc123",
+                "project.skills_manifest_hash": "new-hash",
+            },
+        )
+
+        assert sig_before != sig_after
+
 
 class TestExtractCacheBustingConfig:
     """Verify _extract_cache_busting_config pulls the documented subset of

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -226,6 +226,34 @@ class TestAgentConfigSignature:
 
         assert sig_before != sig_after
 
+    def test_project_local_mcp_manifest_change_busts_cache(self):
+        """Project-local MCP config changes must rebuild cached gateway agents."""
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig_before = GatewayRunner._agent_config_signature(
+            "m",
+            runtime,
+            ["telegram"],
+            "",
+            cache_keys={
+                "project.canonical_id": "git:abc123",
+                "project.mcp_manifest_hash": "old-hash",
+            },
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m",
+            runtime,
+            ["telegram"],
+            "",
+            cache_keys={
+                "project.canonical_id": "git:abc123",
+                "project.mcp_manifest_hash": "new-hash",
+            },
+        )
+
+        assert sig_before != sig_after
+
 
 class TestExtractCacheBustingConfig:
     """Verify _extract_cache_busting_config pulls the documented subset of

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -927,7 +927,7 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
-    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_set_session_context", lambda target, cwd=None: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(
         server,
@@ -990,7 +990,7 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
 
     monkeypatch.setattr(server, "_get_db", lambda: db)
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
-    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_set_session_context", lambda target, cwd=None: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
     monkeypatch.setattr(
@@ -1039,7 +1039,7 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
-    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_set_session_context", lambda target, cwd=None: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
     monkeypatch.setattr(server, "_session_info", lambda agent, *a: {"model": agent.model, "provider": agent.provider})
@@ -1119,7 +1119,7 @@ def test_session_resume_profile_uses_profile_db_cwd(monkeypatch, tmp_path):
     monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: profile_db)
     monkeypatch.setattr(server, "_get_db", lambda: launch_db)
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
-    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_set_session_context", lambda target, cwd=None: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
     monkeypatch.setattr(server, "_SlashWorker", FakeWorker)
@@ -7825,7 +7825,7 @@ def test_start_agent_build_passes_session_model_override(monkeypatch):
         captured.update(kwargs)
         return types.SimpleNamespace(model="claude-sonnet-4.6")
 
-    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_set_session_context", lambda target, cwd=None: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
     monkeypatch.setattr(server, "_SlashWorker", FakeWorker)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -935,7 +935,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
         home_token = None
         profile_home = current.get("profile_home")
         try:
-            tokens = _set_session_context(key)
+            tokens = _set_session_context_with_cwd(key, _session_cwd(current))
             # Build against the session's profile (global-remote): bind its
             # HERMES_HOME so config/skills/model resolve to it, and hand the
             # agent that profile's db so turns persist to the right state.db.
@@ -1419,6 +1419,15 @@ def _set_session_context(session_key: str, cwd: str | None = None) -> list:
         return set_session_vars(session_key=session_key, cwd=resolved)
     except Exception:
         return []
+
+
+def _set_session_context_with_cwd(session_key: str, cwd: str | None) -> list:
+    try:
+        return _set_session_context(session_key, cwd=cwd)
+    except TypeError as exc:
+        if "unexpected keyword argument 'cwd'" not in str(exc):
+            raise
+        return _set_session_context(session_key)
 
 
 def _clear_session_context(tokens: list) -> None:
@@ -3344,6 +3353,7 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "platform": "tui",
         "session_db": _get_db(),
         "fallback_model": _agent_fallback_model(agent),
+        "project_local_state": getattr(agent, "project_local_state", None),
     }
 
 
@@ -3693,6 +3703,12 @@ def _make_agent(
             target_model=model or None,
         )
     _pr = _load_provider_routing()
+    try:
+        from agent.project_local import resolve_project_local_state
+
+        project_local_state = resolve_project_local_state()
+    except Exception:
+        project_local_state = None
     return AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 90),
@@ -3738,6 +3754,7 @@ def _make_agent(
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         fallback_model=_load_fallback_model(),
+        project_local_state=project_local_state,
         **_agent_cbs(sid),
     )
 
@@ -4616,7 +4633,7 @@ def _(rid, params: dict) -> dict:
             : max(0, len(display_history) - len(history))
         ]
         messages = _history_to_messages(display_history)
-        tokens = _set_session_context(target)
+        tokens = _set_session_context_with_cwd(target, profile_resume_cwd)
         try:
             # Pass the profile's db so the agent persists turns to the right
             # state.db; home override is active here so config/skills/model
@@ -7391,7 +7408,7 @@ def _(rid, params: dict) -> dict:
     task_id = f"bg_{uuid.uuid4().hex[:6]}"
 
     def run():
-        session_tokens = _set_session_context(task_id, cwd=_session_cwd(session))
+        session_tokens = _set_session_context_with_cwd(task_id, _session_cwd(session))
         try:
             from run_agent import AIAgent
 
@@ -7488,7 +7505,10 @@ def _(rid, params: dict) -> dict:
     def run():
         # Pin the validated preview cwd, else the parent workspace — never an
         # invalid client path, which would silently fall back to the launch dir.
-        session_tokens = _set_session_context(task_id, cwd=(preview_cwd or _session_cwd(session)))
+        session_tokens = _set_session_context_with_cwd(
+            task_id,
+            preview_cwd or _session_cwd(session),
+        )
         try:
             from run_agent import AIAgent
             from tools.terminal_tool import register_task_env_overrides

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -935,7 +935,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
         home_token = None
         profile_home = current.get("profile_home")
         try:
-            tokens = _set_session_context_with_cwd(key, _session_cwd(current))
+            tokens = _set_session_context(key, cwd=_session_cwd(current))
             # Build against the session's profile (global-remote): bind its
             # HERMES_HOME so config/skills/model resolve to it, and hand the
             # agent that profile's db so turns persist to the right state.db.
@@ -1419,15 +1419,6 @@ def _set_session_context(session_key: str, cwd: str | None = None) -> list:
         return set_session_vars(session_key=session_key, cwd=resolved)
     except Exception:
         return []
-
-
-def _set_session_context_with_cwd(session_key: str, cwd: str | None) -> list:
-    try:
-        return _set_session_context(session_key, cwd=cwd)
-    except TypeError as exc:
-        if "unexpected keyword argument 'cwd'" not in str(exc):
-            raise
-        return _set_session_context(session_key)
 
 
 def _clear_session_context(tokens: list) -> None:
@@ -4633,7 +4624,7 @@ def _(rid, params: dict) -> dict:
             : max(0, len(display_history) - len(history))
         ]
         messages = _history_to_messages(display_history)
-        tokens = _set_session_context_with_cwd(target, profile_resume_cwd)
+        tokens = _set_session_context(target, cwd=profile_resume_cwd)
         try:
             # Pass the profile's db so the agent persists turns to the right
             # state.db; home override is active here so config/skills/model
@@ -7408,7 +7399,7 @@ def _(rid, params: dict) -> dict:
     task_id = f"bg_{uuid.uuid4().hex[:6]}"
 
     def run():
-        session_tokens = _set_session_context_with_cwd(task_id, _session_cwd(session))
+        session_tokens = _set_session_context(task_id, cwd=_session_cwd(session))
         try:
             from run_agent import AIAgent
 
@@ -7505,9 +7496,9 @@ def _(rid, params: dict) -> dict:
     def run():
         # Pin the validated preview cwd, else the parent workspace — never an
         # invalid client path, which would silently fall back to the launch dir.
-        session_tokens = _set_session_context_with_cwd(
+        session_tokens = _set_session_context(
             task_id,
-            preview_cwd or _session_cwd(session),
+            cwd=preview_cwd or _session_cwd(session),
         )
         try:
             from run_agent import AIAgent


### PR DESCRIPTION
## Summary
- add `agent.project_local` for canonical git-backed project identity, immutable `ProjectLocalState`, recognized project-local skill/MCP candidates, and profile-aware trust sidecar storage
- wire the frozen project-local state into CLI, gateway, TUI, background agents, system prompt metadata, stored-prompt reuse checks, and gateway agent-cache signatures
- include project skill manifest, project MCP manifest, and rejected project-local state in cache signatures so changed project-local surfaces do not reuse stale prompts/agents
- cover worktrees/subdirs, bare `.hermes` non-candidates, symlink rejection, MCP config candidates, consent hash invalidation, prompt rebuilds, and gateway cache busting

## Tests
- `scripts/run_tests.sh tests/agent/test_project_local.py tests/agent/test_system_prompt_restore.py tests/gateway/test_agent_cache.py tests/agent/test_system_prompt.py tests/agent/test_runtime_cwd.py tests/gateway/test_session_env.py tests/gateway/test_compression_failure_session_sync.py tests/cli/test_fast_command.py tests/cli/test_cli_provider_resolution.py tests/hermes_cli/test_mcp_startup.py tests/agent/test_credential_pool_routing.py tests/gateway/test_fast_command.py` (202 passed)
- `git diff --check`
- `python -m py_compile agent/project_local.py agent/conversation_loop.py agent/system_prompt.py tests/agent/test_project_local.py tests/agent/test_system_prompt_restore.py tests/gateway/test_agent_cache.py`

Fixes #48971