### PR TITLE
fix(cli): preserve named provider aggregator models (#49126)

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -164,14 +164,15 @@ def build_models_payload(
     )
 
     # --- Deduplicate: remove models from aggregators that overlap with
-    # user-defined providers.  When a local proxy (e.g. litellm-proxy)
+    # local custom proxy providers.  When a local proxy (custom:<name>)
     # serves a model whose name also appears in an aggregator's curated
     # catalog, the picker would show the model under both providers.
     # Selecting it from the aggregator row sets model.provider to the
     # aggregator (e.g. openrouter) instead of the user's proxy — silently
     # breaking the call.  Filtering at the payload level keeps the
-    # aggregator rows honest: they only show models the user can't get
-    # from a more-specific provider.  (#45954)
+    # aggregator rows honest for local proxies while preserving independent
+    # named third-party providers configured under providers:.  (#45954,
+    # #49126)
     try:
         from hermes_cli.providers import is_aggregator as _is_aggregator
     except Exception:
@@ -180,7 +181,8 @@ def build_models_payload(
     if _is_aggregator is not None:
         user_models: set[str] = set()
         for row in rows:
-            if row.get("is_user_defined"):
+            slug = row.get("slug", "")
+            if row.get("is_user_defined") and slug.startswith("custom:"):
                 user_models.update(m.lower() for m in (row.get("models") or []))
         if user_models:
             for row in rows:

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -511,18 +511,18 @@ def _aggregator_row(slug: str, models: list[str]) -> dict:
     }
 
 
-def test_aggregator_dedup_removes_overlapping_models():
-    """Models served by a user-defined provider are removed from
+def test_aggregator_dedup_removes_overlapping_custom_proxy_models():
+    """Models served by a local ``custom:*`` proxy are removed from
     aggregator rows so the picker doesn't show them under the wrong
     provider.  (#45954)"""
     rows = [
-        _user_provider_row("litellm-proxy", [
+        _user_provider_row("custom:litellm-proxy", [
             "nvidia/nim/minimax-m3",
             "nvidia/nim/kimi-k2.6",
         ]),
         _aggregator_row("openrouter", [
             "minimax/minimax-m3",
-            "nvidia/nim/minimax-m3",  # overlaps with litellm-proxy
+            "nvidia/nim/minimax-m3",  # overlaps with custom proxy
             "anthropic/claude-sonnet-4.6",
         ]),
     ]
@@ -531,7 +531,9 @@ def test_aggregator_dedup_removes_overlapping_models():
         payload = build_models_payload(ctx)
 
     or_row = next(r for r in payload["providers"] if r["slug"] == "openrouter")
-    proxy_row = next(r for r in payload["providers"] if r["slug"] == "litellm-proxy")
+    proxy_row = next(
+        r for r in payload["providers"] if r["slug"] == "custom:litellm-proxy"
+    )
 
     # User-defined provider keeps all its models
     assert proxy_row["models"] == ["nvidia/nim/minimax-m3", "nvidia/nim/kimi-k2.6"]
@@ -543,10 +545,41 @@ def test_aggregator_dedup_removes_overlapping_models():
     assert or_row["total_models"] == 2
 
 
-def test_aggregator_dedup_case_insensitive():
-    """Dedup uses case-insensitive matching.  (#45954)"""
+def test_named_user_provider_does_not_dedup_independent_aggregator():
+    """Named third-party providers configured under ``providers:`` can be
+    marked ``is_user_defined=True``, but they are not local proxies.  Their
+    overlapping models must not be stripped from independent aggregators.
+    (#49126)"""
     rows = [
-        _user_provider_row("my-proxy", ["NVIDIA/NIM/MiniMax-M3"]),
+        _user_provider_row("volcengine-agent-plan", [
+            "deepseek-v4-pro",
+            "deepseek-v4-flash",
+        ]),
+        _aggregator_row("opencode-go", [
+            "deepseek-v4-pro",
+            "deepseek-v4-flash",
+            "anthropic/claude-sonnet-4.6",
+        ]),
+    ]
+    ctx = _empty_ctx()
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx)
+
+    opencode_row = next(
+        r for r in payload["providers"] if r["slug"] == "opencode-go"
+    )
+    assert opencode_row["models"] == [
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "anthropic/claude-sonnet-4.6",
+    ]
+    assert opencode_row["total_models"] == 3
+
+
+def test_aggregator_dedup_case_insensitive_for_custom_proxy():
+    """Dedup uses case-insensitive matching for local custom proxies.  (#45954)"""
+    rows = [
+        _user_provider_row("custom:my-proxy", ["NVIDIA/NIM/MiniMax-M3"]),
         _aggregator_row("openrouter", ["nvidia/nim/minimax-m3", "other/model"]),
     ]
     ctx = _empty_ctx()
@@ -590,12 +623,12 @@ def test_aggregator_dedup_no_user_providers_unchanged():
     assert len(or_row["models"]) == 2
 
 
-def test_aggregator_dedup_multiple_user_providers():
-    """Models from all user-defined providers are excluded from aggregators.
+def test_aggregator_dedup_multiple_custom_proxy_providers():
+    """Models from all local custom proxy providers are excluded from aggregators.
     (#45954)"""
     rows = [
-        _user_provider_row("proxy-a", ["model-x"]),
-        _user_provider_row("proxy-b", ["model-y"]),
+        _user_provider_row("custom:proxy-a", ["model-x"]),
+        _user_provider_row("custom:proxy-b", ["model-y"]),
         _aggregator_row("openrouter", ["model-x", "model-y", "model-z"]),
     ]
     ctx = _empty_ctx()


### PR DESCRIPTION
## Summary

- Preserve overlapping models in aggregator catalogs when the overlap comes from an independent named provider configured under `providers:`.
- Continue deduplicating aggregator models against genuine local/custom proxy providers identified by `custom:` slugs.
- Keep aggregator `models` and `total_models` consistent, with case-insensitive matching preserved for custom proxy dedup.

## Why

Issue #49126 reports that named third-party providers such as `volcengine-agent-plan` can be marked `is_user_defined=True`, causing their model IDs to be globally collected and stripped from unrelated aggregators like `opencode-go`. That makes models such as `deepseek-v4-pro` and `deepseek-v4-flash` silently disappear from the picker.

The root cause is that `build_models_payload()` treated every user-defined provider as a local proxy. This patch narrows the dedup source set to `custom:*` providers only, which preserves the intended #45954 local-proxy protection without removing legitimate third-party aggregator entries.

## Verification

- RED proof on upstream/main: `test_named_user_provider_does_not_dedup_independent_aggregator` failed because `opencode-go` was reduced to only `anthropic/claude-sonnet-4.6`.
- GREEN after fix:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/hermes_cli/test_inventory.py -v -o addopts= --tb=short`
  - Result: 34 passed in 5.30s
- Branch state verified after rebase: `git rev-list --left-right --count upstream/main...HEAD` → `0 1`.

## Duplicate / competitor check

- Same-author issue search for open Tranquil-Flow PRs referencing `49126`: none.
- Same-author branch search for `fix/49126*`: none before publication.
- Open PR search for `49126 in:title,body`: none.
- Topic search for `aggregator dedup named provider volcengine opencode-go`: none.

Auto-published by Moonsong via Path B automated pipeline.
