### PR TITLE
fix(desktop): pre-fetch Electron dist after clean install on update (#47917)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5461,6 +5461,25 @@ def cmd_gui(args: argparse.Namespace):
                     print("  ⚠ Dependency install failed with a missing Electron dist; "
                           "continuing to the build so electron-builder can attempt "
                           "the Electron fetch itself.")
+            elif not source_mode and _electron_pkg_staged_missing_dist(PROJECT_ROOT):
+                # `npm ci` succeeded but left ``node_modules/electron/dist`` empty.
+                # This is the steady-state cost of ``hermes update`` reinstalling
+                # repo-root deps with ``--workspaces=false`` (it does NOT reinstall
+                # the desktop workspace, so electron's postinstall — which fetches
+                # dist/ — never runs on update; #47917). electron-builder would
+                # then fall through to a fresh ``@electron/get`` download on every
+                # single update ("no local electron dist; …will fetch"), turning a
+                # near-no-op rebuild into a slow network round-trip — or a hard
+                # failure where GitHub's release host is blocked. Repopulate dist/
+                # proactively (canonical host, then mirror) so the first pack reuses
+                # the local binary instead of racing the network.
+                if _try_redownload_electron_dist(PROJECT_ROOT, env):
+                    print("  ⚠ Electron dist was missing after install (update reinstalls "
+                          "repo-root deps only); repopulated it before building.")
+                else:
+                    print("  ⚠ Electron dist missing after install and could not be "
+                          "pre-fetched; continuing so electron-builder can attempt "
+                          "the Electron fetch itself.")
 
             build_label = "source build" if source_mode else "packaged app"
             print(f"→ Building desktop {build_label}...")

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -246,6 +246,83 @@ def test_gui_source_mode_uses_renderer_build_and_electron(tmp_path, monkeypatch)
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 
 
+def test_gui_prefetches_electron_dist_after_clean_install_before_pack(tmp_path, monkeypatch):
+    """`npm ci` succeeds but leaves dist/ empty -> repopulate BEFORE the first pack.
+
+    This is the #47917 residual: `hermes update` reinstalls repo-root deps with
+    ``--workspaces=false``, so electron's dist-fetching postinstall never runs on
+    update and ``node_modules/electron/dist`` is empty even though the install
+    succeeded. Without a proactive repair, electron-builder silently falls
+    through to a fresh ``@electron/get`` download on every update. The first pack
+    must only run after dist/ has been repopulated.
+    """
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+    pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    call_order: list[str] = []
+
+    def _record_prefetch(*_a, **_kw):
+        call_order.append("prefetch")
+        return True
+
+    def _record_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["/usr/bin/npm", "run", "pack"]:
+            call_order.append("pack")
+            return pack_ok
+        return launch_ok
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._electron_pkg_staged_missing_dist", return_value=True), \
+         patch("hermes_cli.main._try_redownload_electron_dist", side_effect=_record_prefetch) as mock_prefetch, \
+         patch("hermes_cli.main._stop_desktop_processes_locking_build", return_value=[]), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=_record_run), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    mock_prefetch.assert_called_once()
+    # The repair must happen BEFORE the first pack, not as after-failure recovery.
+    assert call_order[:2] == ["prefetch", "pack"]
+
+
+def test_gui_skips_electron_prefetch_when_dist_present(tmp_path, monkeypatch):
+    """Healthy dist/ after install -> no redundant pre-fetch, straight to pack."""
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+    pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._electron_pkg_staged_missing_dist", return_value=False), \
+         patch("hermes_cli.main._try_redownload_electron_dist") as mock_prefetch, \
+         patch("hermes_cli.main._stop_desktop_processes_locking_build", return_value=[]), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    mock_prefetch.assert_not_called()
+    assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
+
+
 @pytest.mark.parametrize(
     "argv",
     [


### PR DESCRIPTION
## Summary

Fixes the **residual** behind the #47917 "it resurfaced" reports that continue *after* the dynamic-`electronDist` fix (#48091) — the `The specified electronDist does not exist` / "no local electron dist; will fetch" build failures and delays on every `hermes update`.

## Root cause

This is **not** the path-resolution class that #48091 fixed (that's resolved). It's the *download* class, driven by the update model:

- `hermes update` deliberately installs **repo-root** deps with `--workspaces=false` (see `cmd_update` in `hermes_cli/main.py` and the rebuild note in `apps/bootstrap-installer/src-tauri/src/update.rs`). It does **not** reinstall the `apps/desktop` workspace.
- So electron's dist-fetching **postinstall never runs on update**, and `node_modules/electron/dist` stays **empty** even though the install "succeeded".
- On the next `hermes desktop --build-only` rebuild, `run-electron-builder.cjs` correctly finds no local dist and **falls through to a fresh `@electron/get` download every single time** — a slow network round-trip, or a hard failure where GitHub's release host is throttled/blocked (the version churn `40.9.3` / `40.10.2` / `42.3.3` users see in their electron cache).

`cmd_gui` already self-heals **after a pack fails** (`_purge_electron_build_cache` + `_redownload_electron_dist` + mirror retry), and repairs on the `npm ci` **failure** branch. But on the common case — `npm ci` **succeeds** but leaves `dist/` empty — it goes straight to pack with no proactive check, so every update pays the download tax.

## The fix

One proactive pre-build check on the install-**success** path: when `npm ci` succeeds but electron is staged with an empty `dist/` (`_electron_pkg_staged_missing_dist`), repopulate it via the existing `_try_redownload_electron_dist` (canonical host → mirror) **before** the first pack. Then the build reuses the local binary instead of racing the network.

Reuses the helpers introduced in #48091 — no new download machinery, just closes the timing gap.

```python
elif not source_mode and _electron_pkg_staged_missing_dist(PROJECT_ROOT):
    if _try_redownload_electron_dist(PROJECT_ROOT, env):
        print("  ⚠ Electron dist was missing after install …; repopulated it before building.")
    else:
        print("  ⚠ Electron dist missing after install and could not be pre-fetched; continuing …")
```

## Tests

`tests/hermes_cli/test_gui_command.py`:

- `test_gui_prefetches_electron_dist_after_clean_install_before_pack` — asserts the repair runs **before** the first pack (ordering, not just "called"), failing without this change since the old code never pre-fetched on success.
- `test_gui_skips_electron_prefetch_when_dist_present` — no redundant fetch when `dist/` is healthy; straight to pack.

```
$ python3 -m pytest tests/hermes_cli/test_gui_command.py -k prefetch -v
tests/hermes_cli/test_gui_command.py::test_gui_prefetches_electron_dist_after_clean_install_before_pack PASSED
tests/hermes_cli/test_gui_command.py::test_gui_skips_electron_prefetch_when_dist_present PASSED
```

(38/38 non-`pathspec` tests in the file pass; the 5 `content_hash`/`build_stamp_round_trip` failures are a pre-existing missing-`pathspec` dep on the test env, unaffected by this change and failing identically on clean `upstream/main`.)

## How to test manually

1. Build the desktop once (`hermes desktop --build-only`) so it works.
2. Empty the dist: `rm -rf node_modules/electron/dist` (simulates the post-update state).
3. Re-run `hermes desktop --build-only`. Before: log shows `no local electron dist; …will fetch` and a slow/blocked download. After: dist is repopulated before the pack and the build reuses it.

Fixes #47917
