### PR TITLE
fix: resolve terminal.config bridge ordering on profile switch

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11187,11 +11187,30 @@ def _resolve_chat_argv(
 
     argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
     env = os.environ.copy()
+    
+    # Set HERMES_HOME in env BEFORE applying terminal config bridge.
+    # This ensures the subprocess gets the correct terminal.cwd from the
+    # target profile's config, not the dashboard's current profile.
+    original_hermes_home = os.environ.get("HERMES_HOME")
+    if profile_dir is not None:
+        env["HERMES_HOME"] = str(profile_dir)
+        # Temporarily set os.environ HERMES_HOME so apply_terminal_config_to_env
+        # reads the profile's config.yaml (read_raw_config uses os.environ)
+        os.environ["HERMES_HOME"] = str(profile_dir)
+    
     try:
         from hermes_cli.config import apply_terminal_config_to_env
         apply_terminal_config_to_env(env=env)
     except Exception:
         _log.debug("Failed to apply terminal config bridge for dashboard chat", exc_info=True)
+    finally:
+        # Restore original HERMES_HOME in os.environ
+        if profile_dir is not None:
+            if original_hermes_home is not None:
+                os.environ["HERMES_HOME"] = original_hermes_home
+            else:
+                os.environ.pop("HERMES_HOME", None)
+    
     env.setdefault("NODE_ENV", "production")
     # Browser-embedded chat should prefer stable wheel-based scrollback over
     # native terminal mouse tracking. When mouse tracking is enabled, wheel
@@ -11202,9 +11221,6 @@ def _resolve_chat_argv(
     env.setdefault("HERMES_TUI_DISABLE_MOUSE", "1")
     env.setdefault("HERMES_TUI_INLINE", "1")
     env["HERMES_TUI_DASHBOARD"] = "1"
-
-    if profile_dir is not None:
-        env["HERMES_HOME"] = str(profile_dir)
 
     if resume:
         latest_resume, _latest_path = _session_latest_descendant(resume)


### PR DESCRIPTION
## Problem

When the Desktop Dashboard switches to a profile-scoped chat (e.g., clicking on a different profile), the terminal config bridge `apply_terminal_config_to_env()` was called BEFORE `HERMES_HOME` was updated to point at the target profile directory.

This caused `read_raw_config()` (inside `apply_terminal_config_to_env()`) to read the dashboard's (source) profile config.yaml instead of the target profile's config.yaml. As a result, `TERMINAL_CWD` inherited the wrong value — the terminal stayed in the previous profile's working directory instead of switching to the new profile's configured `terminal.cwd`.

## Solution

Reorder the operations in `_resolve_chat_argv()`:

1. Set `env["HERMES_HOME"]` to the target profile directory FIRST
2. Temporarily swap `os.environ["HERMES_HOME"]` to the profile dir
3. Call `apply_terminal_config_to_env(env=env)` so it reads the correct profile's config
4. Restore the original `os.environ["HERMES_HOME"]` in a `finally` block to keep the dashboard process's HERMES_HOME intact

This ensures that when a user clicks a profile in the Dashboard, the spawned chat subprocess picks up the correct `terminal.cwd` from that profile's config.yaml.

## Testing

- Verified that switching to a profile with `terminal.cwd` set correctly changes the working directory
- Profiles without `terminal.cwd` configured continue to work as before (fallback behavior preserved)
- The dashboard process's own `HERMES_HOME` is restored after the config bridge runs, so it doesn't affect other operations

## Related

This fix resolves the issue where users had to manually `cd` into the correct directory after switching profiles in the Desktop GUI.