### PR TITLE
fix(delegation): use target_model for bedrock api_mode routing (#49095)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1742,7 +1742,7 @@ def resolve_runtime_provider(
         # Dual-path routing: Claude models use AnthropicBedrock SDK for full
         # feature parity (prompt caching, thinking budgets, adaptive thinking).
         # Non-Claude models use the Converse API for multi-model support.
-        _current_model = str(model_cfg.get("default") or "").strip()
+        _current_model = str(target_model or model_cfg.get("default") or "").strip()
         if is_anthropic_bedrock_model(_current_model):
             # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path
             runtime = {


### PR DESCRIPTION
Fixes #49095. When delegation.provider=bedrock is configured, resolve_runtime_provider() used the main model config to decide between anthropic_messages and bedrock_converse api_mode, ignoring the delegation target model. This caused non-Claude bedrock models (Nova, DeepSeek, Llama) to incorrectly use the AnthropicBedrock SDK path, which then failed silently and fell back to openrouter/free. The fix passes target_model through to the bedrock api_mode decision so delegation targets are routed to the correct transport.