### PR TITLE
fix(agent): include runtime model in aux client cache key

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2204,9 +2204,22 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     those as-is so auxiliary clients inherit the same authentication
     surface as the main agent. The OpenAI SDK accepts ``Callable[[], str]``
     for ``api_key`` and calls it before every request.
+
+    When main_runtime is None, fall back to the process-local globals
+    (_RUNTIME_MAIN_*) so the cache key reflects the live runtime model.
+    This ensures that switching models via /model invalidates the aux
+    client cache, forcing a rebuild with the new model.
     """
     if not isinstance(main_runtime, dict):
-        return {}
+        # Fall back to process-local globals when no runtime dict provided.
+        return {
+            "provider": (_RUNTIME_MAIN_PROVIDER or "").strip().lower(),
+            "model": (_RUNTIME_MAIN_MODEL or "").strip(),
+            "base_url": (_RUNTIME_MAIN_BASE_URL or "").strip(),
+            "api_key": (_RUNTIME_MAIN_API_KEY or "").strip(),
+            "api_mode": (_RUNTIME_MAIN_API_MODE or "").strip(),
+            "auth_mode": "",
+        }
     normalized: Dict[str, Any] = {}
     for field in _MAIN_RUNTIME_FIELDS:
         value = main_runtime.get(field)


### PR DESCRIPTION
### What this PR does

Fixes the auxiliary client cache not invalidating when switching models via `/model`.

### Problem

When switching the active model mid-session via `/model <new-model>`, auxiliary tasks (smart approval, compression, web extract, vision) continue using the **old** model cached from the previous session.

This causes constant GPU weight churn in llama-swap proxy environments where only one model can be loaded at a time.

### Root Cause

`_normalize_main_runtime()` in `agent/auxiliary_client.py` returned `{}` when `main_runtime` was `None`. The cache key for `_get_cached_client()` was built from this normalized dict, so the runtime model override (`_RUNTIME_MAIN_MODEL`) set by `/model` was never reflected in the cache key. The old cached client was reused regardless of model switches.

### Fix

When `main_runtime` is `None`, `_normalize_main_runtime()` now falls back to the process-local globals (`_RUNTIME_MAIN_*`), which contain the live runtime provider/model from `/model`. This ensures the cache key includes the current model, so switching models produces a different cache key and the old client is evicted.

### Files changed

- `agent/auxiliary_client.py` — `_normalize_main_runtime()` function (lines 2199-2210)

### How to test

1. Start Hermes with main model `qwen35b-code`
2. Trigger a smart approval (run a terminal command that needs approval)
3. Switch to `qwen27b-code` via `/model qwen27b-code`
4. Trigger another smart approval
5. Verify the approval LLM call uses `qwen27b-code`, not the old `qwen35b-code`

Fixes NousResearch/hermes-agent#49151
