### PR TITLE
fix(plugins): remove unsupported tool_choice from codex image gen (#49008)

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -163,11 +163,6 @@ def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[st
             "background": "opaque",
             "partial_images": 1,
         }],
-        "tool_choice": {
-            "type": "allowed_tools",
-            "mode": "required",
-            "tools": [{"type": "image_generation"}],
-        },
         "stream": True,
     }
 


### PR DESCRIPTION
Fixes #49008. The Codex backend at chatgpt.com/backend-api/codex/responses does not support the image_generation tool type. The tool_choice parameter referencing image_generation causes an HTTP 400 error. Removing tool_choice lets the Codex backend invoke the image_generation tool from the tools list without explicit forcing.