### PR TITLE
feat(cron): add configurable progress heartbeats

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -847,6 +847,35 @@ def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Opti
     )
 
 
+def _normalize_progress(progress: Any) -> Optional[Dict[str, Any]]:
+    """Normalize optional per-job cron progress overrides.
+
+    Stored shape mirrors ``cron.progress`` config but only keeps known fields:
+    ``enabled``, ``initial_delay_seconds``, ``interval_seconds``,
+    ``edit_in_place``, and ``state_path``. ``None`` / empty dict clears the
+    override. A bare bool or string is shorthand for ``{"enabled": value}``.
+    """
+    if progress is None:
+        return None
+    if isinstance(progress, bool):
+        return {"enabled": progress}
+    if isinstance(progress, str):
+        text = progress.strip()
+        return {"enabled": text} if text else None
+    if not isinstance(progress, dict):
+        raise ValueError("Cron progress override must be a bool, string, or object")
+
+    allowed = {
+        "enabled",
+        "initial_delay_seconds",
+        "interval_seconds",
+        "edit_in_place",
+        "state_path",
+    }
+    normalized = {k: v for k, v in progress.items() if k in allowed and v is not None}
+    return normalized or None
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -865,6 +894,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    progress: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -909,6 +939,9 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        progress: Optional per-job progress override. Mirrors ``cron.progress``
+                config; bool/string is shorthand for the ``enabled`` field.
+                None means inherit global config.
 
     Returns:
         The created job dict
@@ -941,6 +974,7 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_progress = _normalize_progress(progress)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1016,6 +1050,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "progress": normalized_progress,
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
@@ -1113,6 +1148,8 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = _normalize_workdir(_wd)
 
             previous_inference_axes = _normalized_inference_axes(job)
+            if "progress" in updates:
+                updates["progress"] = _normalize_progress(updates["progress"])
             updated = _apply_skill_fields({**job, **updates})
             schedule_changed = "schedule" in updates
             inference_fields_changed = bool(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -20,6 +20,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -1815,6 +1816,406 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     return None
 
 
+_DEFAULT_CRON_PROGRESS_INITIAL_DELAY = 90.0
+_DEFAULT_CRON_PROGRESS_INTERVAL = 120.0
+_CRON_PROGRESS_AUTO_SKILL_MARKERS = frozenset({
+    "github-pr-workflow",
+    "github-ci-repair",
+    "github-code-review",
+    "requesting-code-review",
+    "systematic-debugging",
+    "test-driven-development",
+    "webapp-playwright-testing",
+})
+_CRON_PROGRESS_AUTO_TEXT_MARKERS = frozenset({
+    "cron-ready",
+    "implement",
+    "implementation",
+    "long-running",
+    "code change",
+    "pull request",
+    "github pr",
+    "focused checks",
+    "pytest",
+    "git diff",
+    "git status",
+})
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    """Coerce common config/env bool spellings without raising."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if not text:
+        return default
+    if text in {"1", "true", "yes", "y", "on", "enabled"}:
+        return True
+    if text in {"0", "false", "no", "n", "off", "disabled"}:
+        return False
+    return default
+
+
+def _positive_float(value: Any, default: float, *, minimum: float = 0.0) -> float:
+    """Parse a positive-ish float for timing config; fall back safely."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if parsed < minimum:
+        return default
+    return parsed
+
+
+def _env_float(name: str, default: float, *, minimum: float = 0.0) -> float:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    return _positive_float(raw, default, minimum=minimum)
+
+
+def _job_progress_override(job: dict) -> dict:
+    raw = job.get("progress")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _cron_progress_auto_enabled(job: dict) -> bool:
+    """Best-effort auto policy for cron progress heartbeats.
+
+    ``cron.progress.enabled: auto`` keeps fresh installs quiet for ordinary
+    reports/watchdogs, while still surfacing progress for jobs that look likely
+    to run for a long time: repo-scoped jobs, implementation/review skills, or
+    prompts containing long-running work markers. Operators can bypass this
+    classifier entirely with ``cron.progress.enabled: true`` or per-job
+    ``progress.enabled: true``.
+    """
+    if job.get("no_agent"):
+        return False
+
+    if (job.get("workdir") or "").strip():
+        return True
+
+    skills = {str(s).strip().lower() for s in (job.get("skills") or [])}
+    legacy_skill = str(job.get("skill") or "").strip().lower()
+    if legacy_skill:
+        skills.add(legacy_skill)
+    if skills & _CRON_PROGRESS_AUTO_SKILL_MARKERS:
+        return True
+
+    haystack = "\n".join(
+        str(part or "").lower()
+        for part in (
+            job.get("name"),
+            job.get("prompt"),
+            " ".join(str(s) for s in (job.get("skills") or [])),
+        )
+    )
+    return any(marker in haystack for marker in _CRON_PROGRESS_AUTO_TEXT_MARKERS)
+
+
+def _resolve_cron_progress_enabled(value: Any, job: dict, *, default: str = "auto") -> bool:
+    """Resolve cron progress enabled mode.
+
+    Accepted values:
+      - true/on/yes/all/always: every cron run, including no_agent scripts
+      - false/off/no/never: disabled
+      - auto: conservative classifier via _cron_progress_auto_enabled()
+    """
+    if value is None:
+        value = default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if not text:
+        text = default
+    if text in {"1", "true", "yes", "y", "on", "enabled", "all", "always"}:
+        return True
+    if text in {"0", "false", "no", "n", "off", "disabled", "never"}:
+        return False
+    if text == "auto":
+        return _cron_progress_auto_enabled(job)
+    return _cron_progress_auto_enabled(job) if default == "auto" else _coerce_bool(text, False)
+
+
+def _extract_cron_progress_state_path(job: dict, workdir: Optional[str] = None) -> str:
+    """Find a useful state/plan path to show in progress heartbeats."""
+    override = _job_progress_override(job).get("state_path")
+    if override:
+        return str(override)
+
+    prompt = str(job.get("prompt") or "")
+    # Common dev-cron plans use `.hermes/plans/.../state.json`; keep the
+    # pattern intentionally narrow so arbitrary prose does not become noise.
+    match = re.search(r"(?P<path>(?:[\w./~:-]+)?(?:state|progress|handoff)\.json)", prompt)
+    if match:
+        return match.group("path")
+    match = re.search(r"(?P<path>(?:[\w./~:-]+)?\.hermes/plans/[\w./~:-]+\.md)", prompt)
+    if match:
+        return match.group("path")
+    return str(workdir or job.get("workdir") or "")
+
+
+def _resolve_cron_progress_config(job: dict, cfg: Any) -> dict:
+    """Resolve generic cron progress heartbeat settings for one job."""
+    job_progress = _job_progress_override(job)
+    cron_cfg = (cfg or {}).get("cron", {}) if isinstance(cfg, dict) else {}
+    raw_cfg = {}
+    if isinstance(cron_cfg, dict):
+        raw_cfg = cron_cfg.get("progress", {})
+    if isinstance(raw_cfg, bool):
+        progress_cfg: dict = {"enabled": raw_cfg}
+    elif isinstance(raw_cfg, dict):
+        progress_cfg = dict(raw_cfg)
+    else:
+        progress_cfg = {}
+
+    enabled_value = progress_cfg.get("enabled", "auto")
+    if "enabled" in job_progress:
+        enabled_value = job_progress.get("enabled")
+    explicit_bool = job.get("progress")
+    if isinstance(explicit_bool, bool):
+        enabled_value = explicit_bool
+    env_enabled = os.getenv("HERMES_CRON_PROGRESS_ENABLED", "").strip()
+    if env_enabled:
+        enabled_value = env_enabled
+    enabled = _resolve_cron_progress_enabled(enabled_value, job, default="auto")
+
+    initial_delay = _positive_float(
+        job_progress.get("initial_delay_seconds", progress_cfg.get("initial_delay_seconds")),
+        _DEFAULT_CRON_PROGRESS_INITIAL_DELAY,
+        minimum=0.0,
+    )
+    interval = _positive_float(
+        job_progress.get("interval_seconds", progress_cfg.get("interval_seconds")),
+        _DEFAULT_CRON_PROGRESS_INTERVAL,
+        minimum=1.0,
+    )
+    initial_delay = _env_float(
+        "HERMES_CRON_PROGRESS_INITIAL_DELAY",
+        initial_delay,
+        minimum=0.0,
+    )
+    interval = _env_float("HERMES_CRON_PROGRESS_INTERVAL", interval, minimum=1.0)
+    edit_in_place = _coerce_bool(
+        job_progress.get("edit_in_place", progress_cfg.get("edit_in_place")),
+        True,
+    )
+
+    return {
+        "enabled": enabled,
+        "initial_delay_seconds": initial_delay,
+        "interval_seconds": interval,
+        "edit_in_place": edit_in_place,
+        "state_path": str(job_progress.get("state_path") or ""),
+    }
+
+
+def _format_cron_progress_message(
+    job: dict,
+    activity: dict,
+    *,
+    elapsed_seconds: float,
+    state_path: str = "",
+) -> str:
+    """Render a compact, human-readable heartbeat for a cron run."""
+    job_name = str(job.get("name") or job.get("id") or "cron job")
+    job_id = str(job.get("id") or "")
+    elapsed_mins = max(0, int(elapsed_seconds // 60))
+    api_call_count = activity.get("api_call_count", 0)
+    max_iterations = activity.get("max_iterations", 0)
+    action = activity.get("current_tool") or activity.get("last_activity_desc") or "working"
+    idle = activity.get("seconds_since_activity")
+
+    lines = [f"⏳ Cron job: {job_name}"]
+    if job_id:
+        lines[0] += f" ({job_id})"
+    detail = f"{elapsed_mins} min elapsed"
+    if max_iterations:
+        detail += f" — iteration {api_call_count}/{max_iterations}"
+    lines.append(detail)
+    if action:
+        action_text = str(action)
+        if idle is not None:
+            action_text += f" ({float(idle):.0f}s since last activity)"
+        lines.append(f"Activity: {action_text}")
+    if state_path:
+        lines.append(f"State: {state_path}")
+    return "\n".join(lines)
+
+
+def _target_progress_key(target: dict) -> str:
+    return f"{target.get('platform', '').lower()}:{target.get('chat_id')}:{target.get('thread_id') or ''}"
+
+
+def _deliver_cron_progress_update(
+    job: dict,
+    content: str,
+    progress_state: dict,
+    *,
+    adapters=None,
+    loop=None,
+    edit_in_place: bool = True,
+) -> Optional[str]:
+    """Best-effort progress delivery for a running cron job."""
+    targets = _resolve_delivery_targets(job)
+    if not targets:
+        return None
+
+    try:
+        from gateway.config import Platform, load_gateway_config
+        from tools.send_message_tool import _send_to_platform
+        config = load_gateway_config()
+    except Exception as exc:
+        msg = f"failed to load delivery config for cron progress: {exc}"
+        logger.debug("Job '%s': %s", job.get("id", "?"), msg)
+        return msg
+
+    message_ids = progress_state.setdefault("message_ids", {})
+    delivery_errors: list[str] = []
+
+    for target in targets:
+        platform_name = str(target["platform"]).lower()
+        chat_id = target["chat_id"]
+        thread_id = target.get("thread_id")
+        key = _target_progress_key(target)
+
+        try:
+            platform = Platform(platform_name)
+        except (ValueError, KeyError):
+            delivery_errors.append(f"unknown platform '{platform_name}'")
+            continue
+
+        pconfig = config.platforms.get(platform)
+        if not pconfig or not pconfig.enabled:
+            delivery_errors.append(f"platform '{platform_name}' not configured/enabled")
+            continue
+
+        runtime_adapter = (adapters or {}).get(platform)
+        send_metadata = {"thread_id": thread_id} if thread_id else None
+        delivered = False
+
+        if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
+            try:
+                from agent.async_utils import safe_schedule_threadsafe
+
+                message_id = message_ids.get(key)
+                if edit_in_place and message_id and hasattr(runtime_adapter, "edit_message"):
+                    edit_future = safe_schedule_threadsafe(
+                        runtime_adapter.edit_message(chat_id, message_id, content),
+                        loop,
+                    )
+                    if edit_future is not None:
+                        try:
+                            edit_result = edit_future.result(timeout=15)
+                            if edit_result and getattr(edit_result, "success", False):
+                                delivered = True
+                        except TimeoutError:
+                            edit_future.cancel()
+                            logger.debug("Job '%s': cron progress edit timed out", job.get("id", "?"))
+
+                if not delivered:
+                    send_future = safe_schedule_threadsafe(
+                        runtime_adapter.send(chat_id, content, metadata=send_metadata),
+                        loop,
+                    )
+                    if send_future is not None:
+                        send_result = send_future.result(timeout=15)
+                        if send_result and getattr(send_result, "success", True):
+                            delivered = True
+                            new_message_id = getattr(send_result, "message_id", None)
+                            if new_message_id:
+                                message_ids[key] = str(new_message_id)
+            except Exception as exc:
+                logger.debug(
+                    "Job '%s': live cron progress delivery to %s:%s failed: %s",
+                    job.get("id", "?"),
+                    platform_name,
+                    chat_id,
+                    exc,
+                )
+
+        if delivered:
+            continue
+
+        # Standalone fallback: cannot edit in place, but still gives visibility
+        # when the scheduler is not running inside a live gateway process.
+        try:
+            coro = _send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id)
+            try:
+                result = asyncio.run(coro)
+            except RuntimeError:
+                coro.close()
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                    future = pool.submit(
+                        asyncio.run,
+                        _send_to_platform(platform, pconfig, chat_id, content, thread_id=thread_id),
+                    )
+                    result = future.result(timeout=15)
+            if result and result.get("error"):
+                delivery_errors.append(f"progress delivery error: {result['error']}")
+            elif result and result.get("message_id"):
+                message_ids[key] = str(result["message_id"])
+        except Exception as exc:
+            delivery_errors.append(f"progress delivery to {platform_name}:{chat_id} failed: {exc}")
+
+    if delivery_errors:
+        return "; ".join(delivery_errors)
+    return None
+
+
+def _maybe_send_cron_progress(
+    job: dict,
+    agent: Any,
+    progress_cfg: dict,
+    progress_state: dict,
+    *,
+    adapters=None,
+    loop=None,
+    workdir: Optional[str] = None,
+    activity_override: Optional[dict] = None,
+) -> None:
+    """Rate-limited progress heartbeat for long-running cron jobs."""
+    if not progress_cfg.get("enabled"):
+        return
+    now = time.time()
+    started_at = float(progress_state.setdefault("started_at", now))
+    last_sent_at = float(progress_state.get("last_sent_at") or 0.0)
+    elapsed = now - started_at
+    if elapsed < float(progress_cfg.get("initial_delay_seconds", _DEFAULT_CRON_PROGRESS_INITIAL_DELAY)):
+        return
+    if last_sent_at and now - last_sent_at < float(progress_cfg.get("interval_seconds", _DEFAULT_CRON_PROGRESS_INTERVAL)):
+        return
+
+    activity = activity_override or {}
+    if not activity and hasattr(agent, "get_activity_summary"):
+        try:
+            activity = agent.get_activity_summary() or {}
+        except Exception:
+            activity = {}
+    state_path = str(progress_cfg.get("state_path") or "") or _extract_cron_progress_state_path(job, workdir)
+    message = _format_cron_progress_message(
+        job,
+        activity,
+        elapsed_seconds=elapsed,
+        state_path=state_path,
+    )
+    # Update the throttle even when delivery fails so a bad platform config does
+    # not add a delivery attempt every 5s while the underlying cron continues.
+    progress_state["last_sent_at"] = now
+    error = _deliver_cron_progress_update(
+        job,
+        message,
+        progress_state,
+        adapters=adapters,
+        loop=loop,
+        edit_in_place=bool(progress_cfg.get("edit_in_place", True)),
+    )
+    if error:
+        logger.debug("Job '%s': cron progress delivery issue: %s", job.get("id", "?"), error)
+
+
 _DEFAULT_SCRIPT_TIMEOUT = 3600  # seconds (1 hour)
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
@@ -1975,6 +2376,46 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         return False, f"Script timed out after {script_timeout}s: {path}"
     except Exception as exc:
         return False, f"Script execution failed: {exc}"
+
+
+
+def _run_job_script_with_progress(
+    job: dict,
+    script_path: str,
+    progress_cfg: dict,
+    progress_state: dict,
+    *,
+    adapters=None,
+    loop=None,
+    workdir: Optional[str] = None,
+) -> tuple[bool, str]:
+    """Run a cron script while optionally sending generic progress heartbeats."""
+    if not progress_cfg.get("enabled"):
+        return _run_job_script(script_path)
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = pool.submit(_run_job_script, script_path)
+    try:
+        while True:
+            done, _ = concurrent.futures.wait({future}, timeout=5.0)
+            if done:
+                return future.result()
+            _maybe_send_cron_progress(
+                job,
+                None,
+                progress_cfg,
+                progress_state,
+                adapters=adapters,
+                loop=loop,
+                workdir=workdir,
+                activity_override={
+                    "last_activity_desc": f"running script: {script_path}",
+                    "current_tool": "script",
+                    "seconds_since_activity": 0.0,
+                },
+            )
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
 
 
 def _parse_wake_gate(script_output: str) -> bool:
@@ -2322,7 +2763,7 @@ def _guard_job_credential_exfil(job: dict) -> None:
         raise RuntimeError(f"Cron job '{job_id}' blocked for safety: {err}")
 
 
-def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
+def run_job(job: dict, adapters=None, loop=None) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
     
@@ -2370,7 +2811,25 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _prior_cwd = None
 
         try:
-            ok, output = _run_job_script(script_path)
+            try:
+                _script_progress_cfg_source = load_config() or {}
+            except Exception:
+                _script_progress_cfg_source = {}
+            _script_progress_cfg = _resolve_cron_progress_config(job, _script_progress_cfg_source)
+            _script_progress_state = {
+                "started_at": time.time(),
+                "last_sent_at": 0.0,
+                "message_ids": {},
+            }
+            ok, output = _run_job_script_with_progress(
+                job,
+                script_path,
+                _script_progress_cfg,
+                _script_progress_state,
+                adapters=adapters,
+                loop=loop,
+                workdir=_job_workdir,
+            )
         finally:
             if _prior_cwd is not None:
                 try:
@@ -2459,7 +2918,24 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script(script_path)
+        try:
+            _script_progress_cfg_source = load_config() or {}
+        except Exception:
+            _script_progress_cfg_source = {}
+        _script_progress_cfg = _resolve_cron_progress_config(job, _script_progress_cfg_source)
+        _script_progress_state = {
+            "started_at": time.time(),
+            "last_sent_at": 0.0,
+            "message_ids": {},
+        }
+        prerun_script = _run_job_script_with_progress(
+            job,
+            script_path,
+            _script_progress_cfg,
+            _script_progress_state,
+            adapters=adapters,
+            loop=loop,
+        )
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
@@ -2925,6 +3401,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         else:
             _cron_timeout = 600.0
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
+        _progress_cfg = _resolve_cron_progress_config(job, _cfg)
+        _progress_state = {
+            "started_at": time.time(),
+            "last_sent_at": 0.0,
+            "message_ids": {},
+        }
         _POLL_INTERVAL = 5.0
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         # Preserve scheduler-scoped ContextVar state (for example skill-declared
@@ -2934,29 +3416,36 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
         try:
-            if _cron_inactivity_limit is None:
-                # Unlimited — just wait for the result.
-                result = _cron_future.result()
-            else:
-                result = None
-                while True:
-                    done, _ = concurrent.futures.wait(
-                        {_cron_future}, timeout=_POLL_INTERVAL,
-                    )
-                    if done:
-                        result = _cron_future.result()
-                        break
-                    # Agent still running — check inactivity.
-                    _idle_secs = 0.0
-                    if hasattr(agent, "get_activity_summary"):
-                        try:
-                            _act = agent.get_activity_summary()
-                            _idle_secs = _act.get("seconds_since_activity", 0.0)
-                        except Exception:
-                            pass
-                    if _idle_secs >= _cron_inactivity_limit:
-                        _inactivity_timeout = True
-                        break
+            result = None
+            while True:
+                done, _ = concurrent.futures.wait(
+                    {_cron_future}, timeout=_POLL_INTERVAL,
+                )
+                if done:
+                    result = _cron_future.result()
+                    break
+                _maybe_send_cron_progress(
+                    job,
+                    agent,
+                    _progress_cfg,
+                    _progress_state,
+                    adapters=adapters,
+                    loop=loop,
+                    workdir=_job_workdir,
+                )
+                if _cron_inactivity_limit is None:
+                    continue
+                # Agent still running — check inactivity.
+                _idle_secs = 0.0
+                if hasattr(agent, "get_activity_summary"):
+                    try:
+                        _act = agent.get_activity_summary()
+                        _idle_secs = _act.get("seconds_since_activity", 0.0)
+                    except Exception:
+                        pass
+                if _idle_secs >= _cron_inactivity_limit:
+                    _inactivity_timeout = True
+                    break
         except Exception:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
             raise
@@ -3203,7 +3692,12 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             build_profile_secret_scope(_get_hermes_home())
         )
         try:
-            success, output, final_response, error = run_job(job)
+            if adapters is None and loop is None:
+                # Preserve the historical run_job(job) call shape for tests
+                # and third-party monkeypatches that wrap the scheduler.
+                success, output, final_response, error = run_job(job)
+            else:
+                success, output, final_response, error = run_job(job, adapters=adapters, loop=loop)
         finally:
             reset_secret_scope(_scope_token)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2568,6 +2568,17 @@ DEFAULT_CONFIG = {
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.
         "output_retention": 50,
+        # Human-readable progress heartbeats for long-running cron jobs.
+        # enabled: false/off disables; auto enables conservative likely-long jobs;
+        # true/all enables every cron run, including no_agent scripts.
+        # Env overrides: HERMES_CRON_PROGRESS_ENABLED,
+        # HERMES_CRON_PROGRESS_INITIAL_DELAY, HERMES_CRON_PROGRESS_INTERVAL.
+        "progress": {
+            "enabled": "auto",
+            "initial_delay_seconds": 90,
+            "interval_seconds": 120,
+            "edit_in_place": True,
+        },
     },
 
     # Kanban multi-agent coordination — controls the dispatcher loop that

--- a/tests/cron/test_cron_progress.py
+++ b/tests/cron/test_cron_progress.py
@@ -1,0 +1,350 @@
+"""Tests for generic cron progress heartbeats."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+# Ensure project root is importable when this file is run directly.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME for tests that create real cron jobs."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "scripts").mkdir()
+    (home / "cron").mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+    import hermes_constants
+
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+    import tools.cronjob_tools
+    importlib.reload(tools.cronjob_tools)
+    return home
+
+
+class FakeProgressAgent:
+    def get_activity_summary(self):
+        return {
+            "last_activity_desc": "terminal running focused tests",
+            "seconds_since_activity": 3.0,
+            "current_tool": "terminal",
+            "api_call_count": 4,
+            "max_iterations": 90,
+        }
+
+
+def test_auto_progress_policy_skips_no_agent_watchdogs():
+    from cron.scheduler import _cron_progress_auto_enabled
+
+    assert not _cron_progress_auto_enabled(
+        {
+            "name": "memory watchdog implement alert",
+            "prompt": "implement a check",
+            "script": "memory.sh",
+            "no_agent": True,
+        }
+    )
+
+
+def test_auto_progress_policy_uses_workdir_and_skill_markers():
+    from cron.scheduler import _cron_progress_auto_enabled
+
+    assert _cron_progress_auto_enabled({"name": "repo worker", "workdir": "/repo", "no_agent": False})
+    assert _cron_progress_auto_enabled(
+        {
+            "name": "continuable worker",
+            "skills": ["github-pr-workflow"],
+            "no_agent": False,
+        }
+    )
+    assert not _cron_progress_auto_enabled(
+        {"name": "daily learning drip", "prompt": "teach one lesson", "no_agent": False}
+    )
+
+
+def test_progress_config_defaults_to_auto_mode(monkeypatch):
+    from cron.scheduler import _resolve_cron_progress_config
+
+    monkeypatch.delenv("HERMES_CRON_PROGRESS_ENABLED", raising=False)
+    likely_long_cfg = _resolve_cron_progress_config({"workdir": "/repo", "no_agent": False}, {})
+    report_cfg = _resolve_cron_progress_config({"name": "daily report", "no_agent": False}, {})
+    no_agent_cfg = _resolve_cron_progress_config(
+        {"name": "watchdog", "no_agent": True, "script": "watchdog.sh"}, {}
+    )
+
+    assert likely_long_cfg["enabled"] is True
+    assert report_cfg["enabled"] is False
+    assert no_agent_cfg["enabled"] is False
+    assert likely_long_cfg["initial_delay_seconds"] == 90.0
+    assert likely_long_cfg["interval_seconds"] == 120.0
+
+
+def test_progress_config_true_enables_all_cron_jobs_including_no_agent(monkeypatch):
+    from cron.scheduler import _resolve_cron_progress_config
+
+    monkeypatch.delenv("HERMES_CRON_PROGRESS_ENABLED", raising=False)
+    cfg = {"cron": {"progress": {"enabled": True, "interval_seconds": 30}}}
+
+    report_cfg = _resolve_cron_progress_config({"name": "daily report", "no_agent": False}, cfg)
+    no_agent_cfg = _resolve_cron_progress_config(
+        {"name": "watchdog", "no_agent": True, "script": "watchdog.sh"}, cfg
+    )
+
+    assert report_cfg["enabled"] is True
+    assert no_agent_cfg["enabled"] is True
+    assert report_cfg["interval_seconds"] == 30.0
+
+
+def test_progress_config_honours_job_and_env_overrides(monkeypatch):
+    from cron.scheduler import _resolve_cron_progress_config
+
+    job = {
+        "workdir": "/repo",
+        "no_agent": False,
+        "progress": {"enabled": False, "initial_delay_seconds": 5, "interval_seconds": 7},
+    }
+    cfg = {"cron": {"progress": {"enabled": True, "interval_seconds": 30}}}
+    disabled = _resolve_cron_progress_config(job, cfg)
+    assert disabled["enabled"] is False
+    assert disabled["initial_delay_seconds"] == 5.0
+    assert disabled["interval_seconds"] == 7.0
+
+    monkeypatch.setenv("HERMES_CRON_PROGRESS_ENABLED", "all")
+    monkeypatch.setenv("HERMES_CRON_PROGRESS_INTERVAL", "11")
+    enabled = _resolve_cron_progress_config(job, cfg)
+    assert enabled["enabled"] is True
+    assert enabled["interval_seconds"] == 11.0
+
+
+
+def test_create_job_stores_progress_override(hermes_env):
+    from cron.jobs import create_job
+
+    job = create_job(
+        prompt="run a long report",
+        schedule="every 5m",
+        deliver="local",
+        progress={
+            "enabled": "all",
+            "interval_seconds": 10,
+            "state_path": "state.json",
+            "ignored": "drop me",
+        },
+    )
+
+    assert job["progress"] == {
+        "enabled": "all",
+        "interval_seconds": 10,
+        "state_path": "state.json",
+    }
+
+
+def test_cronjob_tool_create_update_and_clear_progress(hermes_env):
+    import json
+
+    from tools.cronjob_tools import cronjob
+
+    created = json.loads(
+        cronjob(
+            action="create",
+            schedule="every 5m",
+            prompt="run a long report",
+            deliver="local",
+            progress={"enabled": True, "initial_delay_seconds": 1},
+        )
+    )
+    assert created["success"] is True
+    assert created["job"]["progress"] == {"enabled": True, "initial_delay_seconds": 1}
+
+    job_id = created["job_id"]
+    updated = json.loads(cronjob(action="update", job_id=job_id, progress="off"))
+    assert updated["success"] is True
+    assert updated["job"]["progress"] == {"enabled": "off"}
+
+    cleared = json.loads(cronjob(action="update", job_id=job_id, progress={}))
+    assert cleared["success"] is True
+    assert "progress" not in cleared["job"]
+
+
+def test_progress_message_is_human_readable_and_includes_state_path():
+    from cron.scheduler import _format_cron_progress_message
+
+    message = _format_cron_progress_message(
+        {"id": "abc123", "name": "repo-worker"},
+        {
+            "current_tool": "terminal",
+            "last_activity_desc": "api call",
+            "seconds_since_activity": 12.2,
+            "api_call_count": 6,
+            "max_iterations": 90,
+        },
+        elapsed_seconds=367,
+        state_path=".hermes/plans/router/state.json",
+    )
+
+    assert "⏳ Cron job: repo-worker (abc123)" in message
+    assert "6 min elapsed — iteration 6/90" in message
+    assert "Activity: terminal (12s since last activity)" in message
+    assert "State: .hermes/plans/router/state.json" in message
+
+
+def test_maybe_send_progress_is_rate_limited(monkeypatch):
+    import cron.scheduler as scheduler
+
+    sent = []
+
+    def fake_deliver(job, content, progress_state, **kwargs):
+        sent.append(content)
+        progress_state.setdefault("message_ids", {})["telegram:1:"] = "msg-1"
+        return None
+
+    monkeypatch.setattr(scheduler, "_deliver_cron_progress_update", fake_deliver)
+    monkeypatch.setattr(scheduler.time, "time", lambda: 125.0)
+
+    job = {
+        "id": "job1",
+        "name": "repo worker",
+        "prompt": "Use .hermes/plans/dev/state.json as durable state",
+        "workdir": "/repo",
+        "no_agent": False,
+    }
+    cfg = {"enabled": True, "initial_delay_seconds": 10.0, "interval_seconds": 60.0}
+    state = {"started_at": 100.0, "last_sent_at": 0.0, "message_ids": {}}
+
+    scheduler._maybe_send_cron_progress(job, FakeProgressAgent(), cfg, state, workdir="/repo")
+    scheduler._maybe_send_cron_progress(job, FakeProgressAgent(), cfg, state, workdir="/repo")
+
+    assert len(sent) == 1
+    assert state["last_sent_at"] == 125.0
+    assert "State: .hermes/plans/dev/state.json" in sent[0]
+
+
+def test_maybe_send_progress_waits_for_initial_delay(monkeypatch):
+    import cron.scheduler as scheduler
+
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_cron_progress_update",
+        lambda job, content, progress_state, **kwargs: sent.append(content),
+    )
+    monkeypatch.setattr(scheduler.time, "time", lambda: 105.0)
+
+    scheduler._maybe_send_cron_progress(
+        {"id": "job1", "name": "repo worker", "workdir": "/repo"},
+        FakeProgressAgent(),
+        {"enabled": True, "initial_delay_seconds": 10.0, "interval_seconds": 60.0},
+        {"started_at": 100.0, "last_sent_at": 0.0, "message_ids": {}},
+        workdir="/repo",
+    )
+
+    assert sent == []
+
+
+def test_maybe_send_progress_accepts_script_activity_override(monkeypatch):
+    import cron.scheduler as scheduler
+
+    sent = []
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_cron_progress_update",
+        lambda job, content, progress_state, **kwargs: sent.append(content),
+    )
+    monkeypatch.setattr(scheduler.time, "time", lambda: 125.0)
+
+    scheduler._maybe_send_cron_progress(
+        {"id": "job1", "name": "script worker", "no_agent": True},
+        None,
+        {"enabled": True, "initial_delay_seconds": 10.0, "interval_seconds": 60.0},
+        {"started_at": 100.0, "last_sent_at": 0.0, "message_ids": {}},
+        activity_override={
+            "current_tool": "script",
+            "last_activity_desc": "running script: watchdog.sh",
+            "seconds_since_activity": 0.0,
+        },
+    )
+
+    assert len(sent) == 1
+    assert "Activity: script (0s since last activity)" in sent[0]
+
+
+def test_progress_delivery_sends_then_edits_live_adapter(monkeypatch):
+    import asyncio
+
+    import agent.async_utils as async_utils
+    import cron.scheduler as scheduler
+    import gateway.config as gateway_config
+
+    platform = gateway_config.Platform("telegram")
+
+    class FakeLoop:
+        def is_running(self):
+            return True
+
+    class FakeAdapter:
+        def __init__(self):
+            self.sent = []
+            self.edited = []
+
+        async def send(self, chat_id, text, metadata=None):
+            self.sent.append((chat_id, text, metadata))
+            return SimpleNamespace(success=True, message_id="msg-1")
+
+        async def edit_message(self, chat_id, message_id, text):
+            self.edited.append((chat_id, message_id, text))
+            return SimpleNamespace(success=True)
+
+    def fake_safe_schedule(coro, loop):
+        result = asyncio.run(coro)
+        return SimpleNamespace(result=lambda timeout=None: result)
+
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_delivery_targets",
+        lambda job: [{"platform": "telegram", "chat_id": "123", "thread_id": None}],
+    )
+    monkeypatch.setattr(
+        gateway_config,
+        "load_gateway_config",
+        lambda: SimpleNamespace(platforms={platform: SimpleNamespace(enabled=True)}),
+    )
+    monkeypatch.setattr(async_utils, "safe_schedule_threadsafe", fake_safe_schedule)
+
+    adapter = FakeAdapter()
+    state = {"message_ids": {}}
+    job = {"id": "job1", "name": "repo worker"}
+
+    assert scheduler._deliver_cron_progress_update(
+        job,
+        "first heartbeat",
+        state,
+        adapters={platform: adapter},
+        loop=FakeLoop(),
+        edit_in_place=True,
+    ) is None
+    assert adapter.sent == [("123", "first heartbeat", None)]
+    assert state["message_ids"]["telegram:123:"] == "msg-1"
+
+    assert scheduler._deliver_cron_progress_update(
+        job,
+        "second heartbeat",
+        state,
+        adapters={platform: adapter},
+        loop=FakeLoop(),
+        edit_in_place=True,
+    ) is None
+    assert adapter.edited == [("123", "msg-1", "second heartbeat")]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -598,6 +598,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("progress"):
+        result["progress"] = job["progress"]
     return result
 
 
@@ -667,6 +669,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    progress: Optional[Union[bool, str, Dict[str, Any]]] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -740,6 +743,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                progress=progress,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -913,6 +917,8 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if progress is not None:
+                updates["progress"] = progress
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -1075,6 +1081,23 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "progress": {
+                "description": "Optional progress heartbeat override for this job. Mirrors cron.progress config: bool/string shorthand controls enabled; object may include enabled, initial_delay_seconds, interval_seconds, edit_in_place, and state_path. Omit to inherit global cron.progress. On update, pass false/off to disable for this job or an object to override timing/state path.",
+                "anyOf": [
+                    {"type": "boolean"},
+                    {"type": "string"},
+                    {
+                        "type": "object",
+                        "properties": {
+                            "enabled": {"type": ["boolean", "string"]},
+                            "initial_delay_seconds": {"type": "number"},
+                            "interval_seconds": {"type": "number"},
+                            "edit_in_place": {"type": "boolean"},
+                            "state_path": {"type": "string"},
+                        },
+                    },
+                ],
+            },
         },
         "required": ["action"]
     }
@@ -1130,6 +1153,8 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
+        progress=args.get("progress"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## Summary
- Adds configurable human-readable progress heartbeats for long-running cron jobs.
- Supports global config under `cron.progress` and per-job `progress` overrides via the `cronjob` tool.
- Keeps default behavior conservative with `enabled: auto`, so ordinary reports/watchdogs stay quiet while repo/workdir/dev-style jobs can surface progress.

## Why
Long-running development/review cron jobs can appear silent for several minutes even when they are healthy and actively working. Operators need lightweight visibility without turning every cron tick into chat noise.

## What changed
- `cron.jobs`: stores and normalizes optional per-job `progress` overrides.
- `cron.scheduler`: resolves progress config, formats compact heartbeat messages, rate-limits updates, and delivers them through scheduler/runtime delivery rather than the agent messaging tool.
- `tools.cronjob_tools`: exposes `progress` for create/update/list formatting.
- `hermes_cli.config`: adds default `cron.progress` config.
- `tests/cron/test_cron_progress.py`: covers auto policy, config/env/job overrides, create/update/clear, message formatting, rate limiting, script activity overrides, and live-adapter send/edit behavior.

## Rebase note
This branch was rebased onto current `origin/main` and the old cron conflicts were resolved while preserving recent `main` behavior, including `attach_to_session`, provider/model drift snapshots, script timeout/output retention, prompt-injection scanning, secret-scope execution, provider/base_url safety guard, and at-most-once dispatch claiming.

## Configuration
```yaml
cron:
  progress:
    enabled: auto          # false/off, auto, true/all
    initial_delay_seconds: 90
    interval_seconds: 120
    edit_in_place: true
```

Environment overrides for live debugging:
- `HERMES_CRON_PROGRESS_ENABLED`
- `HERMES_CRON_PROGRESS_INITIAL_DELAY`
- `HERMES_CRON_PROGRESS_INTERVAL`

Per-job override example:
```json
{
  "progress": {
    "enabled": true,
    "interval_seconds": 60,
    "state_path": ".hermes/plans/dev/state.json"
  }
}
```

## How to test
1. Create a cron job with a `workdir` or a per-job `progress` override.
2. Let it run longer than `initial_delay_seconds` while it is still active.
3. Verify a compact heartbeat is delivered to the same cron delivery target.
4. If the live adapter supports editing, verify later heartbeats edit the previous heartbeat; otherwise they fall back to standalone sends.
5. Update the job with `progress: "off"` or `{}` and verify override behavior/clearing.

## Tests run
- `python -m py_compile cron/jobs.py cron/scheduler.py hermes_cli/config.py tools/cronjob_tools.py tests/cron/test_cron_progress.py` ✅
- `python -m pytest tests/cron/test_cron_progress.py -q -o 'addopts='` ✅ `12 passed`
- `python -m pytest tests/cron/test_cron_progress.py tests/cron/test_cron_script.py -q -o 'addopts='` ✅ `49 passed`
- `scripts/run_tests.sh tests/cron/test_cron_progress.py tests/cron/test_cron_script.py` ✅ `49 passed`
- `git diff --check origin/main..HEAD` ✅

## Manual smoke
Temp `HERMES_HOME` direct-path smoke, outside pytest:

```text
SMOKE_PR49165_OK job_id=2cfeaea9d150 progress={'enabled': 'off'}
```

The smoke created a local-only cron job with `progress`, updated the override to `off`, resolved `auto` config for a workdir job, and rendered a heartbeat containing the expected state path.

## Platforms tested
- Linux `ablott-S42E` / Ubuntu 24.04 kernel `6.17.0-35-generic` / x86_64
- Python `3.11.14`
- Rebased onto `origin/main` `7203898ce`

## Security / data notes
- No new dependencies.
- Progress delivery is best-effort scheduler/runtime plumbing, not a model-callable messaging action.
- Delivery failures are logged/debugged and do not abort the cron job.
- No secrets are added to config or output; the heartbeat only includes job name/id, elapsed time, activity summary, iteration count, and optional state/workdir path.

## Related issues / prior art
- No directly linked issue in the PR body.
- Prior-art search checked `cron progress heartbeats` and related cron visibility terms before updating this PR.
