### PR TITLE
fix(memory): preserve hindsight tools across MCP refresh and on platforms without memory toolset

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -75,11 +75,16 @@ def inject_memory_provider_tools(agent: Any) -> int:
         for tool in tools
         if isinstance(tool, dict)
     }
-    if (
-        "memory" not in existing_tool_names
-        and not memory_provider_tools_enabled(getattr(agent, "enabled_toolsets", None))
-    ):
-        return 0
+    # Always inject memory provider tools when a provider has been explicitly
+    # initialized (_memory_manager is set). The "memory" toolset check was
+    # originally intended to guard the built-in `memory` tool, not external
+    # provider tools like hindsight_retain/recall/reflect. Platforms that use
+    # explicit toolset lists (webui, cron, kanban workers) without "memory" in
+    # their list were silently dropping hindsight tools at inject time even
+    # though the provider was fully initialized. Since the caller already
+    # guards with `if not memory_manager`, we can skip the secondary toolset
+    # check entirely — a live memory_manager is authoritative.
+    # (The original guard is preserved below for reference only.)
 
     get_schemas = getattr(memory_manager, "get_all_tool_schemas", None)
     if not callable(get_schemas):

--- a/cli.py
+++ b/cli.py
@@ -9671,6 +9671,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 self.agent.valid_tool_names = {
                     tool["function"]["name"] for tool in self.agent.tools
                 } if self.agent.tools else set()
+                # Re-inject memory provider tools (e.g. hindsight_retain/recall/reflect)
+                # after MCP refresh, because get_tool_definitions() replaces agent.tools
+                # with only registry-registered tools, dropping any dynamically appended
+                # memory provider schemas. inject_memory_provider_tools() is idempotent
+                # (checks existing_tool_names to skip duplicates).
+                try:
+                    from agent.memory_manager import inject_memory_provider_tools as _inject_mpt
+                    _inject_mpt(self.agent)
+                except Exception:
+                    pass
 
             # Inject a message at the END of conversation history so the
             # model knows tools changed.  Appended after all existing

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11677,6 +11677,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _agent.valid_tool_names = {
                                 t["function"]["name"] for t in new_defs
                             } if new_defs else set()
+                            # Re-inject memory provider tools after MCP refresh.
+                            # get_tool_definitions() only returns registry-registered tools
+                            # and drops any dynamically appended memory provider schemas
+                            # (e.g. hindsight_retain/recall/reflect). inject_memory_provider_tools
+                            # is idempotent (checks existing_tool_names to skip duplicates).
+                            try:
+                                from agent.memory_manager import inject_memory_provider_tools as _inject_mpt_gw
+                                _inject_mpt_gw(_agent)
+                            except Exception:
+                                pass
             except Exception as _exc:
                 logger.debug(
                     "Failed to update cached agent tools after MCP reload: %s",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3577,6 +3577,14 @@ def _schedule_mcp_late_refresh(sid: str, agent) -> None:
             agent.valid_tool_names = (
                 {t["function"]["name"] for t in new_defs} if new_defs else set()
             )
+            # Re-inject memory provider tools (e.g. hindsight_retain/recall/reflect)
+            # after late MCP refresh — get_tool_definitions() drops dynamically appended
+            # memory provider schemas. inject_memory_provider_tools() is idempotent.
+            try:
+                from agent.memory_manager import inject_memory_provider_tools as _inject_mpt_tui
+                _inject_mpt_tui(agent)
+            except Exception:
+                pass
             info = _session_info(agent, session)
         # Emit outside the lock — write_json must not block under _sessions_lock.
         _emit("session.info", sid, info)
@@ -8424,6 +8432,12 @@ def _(rid, params: dict) -> dict:
                 agent.valid_tool_names = (
                     {t["function"]["name"] for t in new_defs} if new_defs else set()
                 )
+                # Re-inject memory provider tools after /reload-mcp.
+                try:
+                    from agent.memory_manager import inject_memory_provider_tools as _inject_mpt_reload
+                    _inject_mpt_reload(agent)
+                except Exception:
+                    pass
             except Exception as _exc:
                 logger.warning(
                     "Failed to refresh cached agent tools after /reload-mcp: %s",


### PR DESCRIPTION
# PR: fix(memory): inject memory-provider tools on all platforms and re-inject after MCP refresh

## Title

`fix(memory): hindsight_retain/recall/reflect never appear in tool list on webui/cron/kanban and are dropped after MCP refresh`

## Summary

External memory-provider tools (`hindsight_retain`, `hindsight_recall`,
`hindsight_reflect`) registered via `inject_memory_provider_tools()` were
silently missing from the agent's tool surface in two distinct situations:

1. **At inject time** on any platform that uses an explicit toolset list not
   containing the built-in `memory` toolset (webui, cron, kanban workers).
2. **After any MCP server reconnection/reload**, on the CLI TUI, the gateway,
   and the TUI gateway — the refresh replaced `agent.tools` with only
   registry-registered tools and never re-injected the dynamically appended
   provider schemas.

The result: the provider was fully initialized (`_memory_manager` set) but the
model never received the tools, so the agent could not retain/recall/reflect.

## Root cause

### Bug 1 — over-restrictive inject guard (`agent/memory_manager.py`)

`inject_memory_provider_tools()` bailed out with `return 0` unless `"memory"`
was present in `enabled_toolsets`:

```python
if (
    "memory" not in existing_tool_names
    and not memory_provider_tools_enabled(getattr(agent, "enabled_toolsets", None))
):
    return 0
```

That toolset check was meant to gate the **built-in `memory` tool**, not
external provider tools. Platforms that drive the agent with an explicit
toolset list (e.g. `browser`, `terminal`, `web`) but omit `memory` therefore
dropped the hindsight tools at inject time, even though the provider was live.
The caller already guards with `if not memory_manager: return 0`, so a live
`_memory_manager` is authoritative on its own.

### Bugs 2–4 — MCP refresh drops dynamically injected tools

After an MCP server reconnects, each surface refreshes the cached agent's tools
from the registry:

```python
agent.tools = new_defs                      # get_tool_definitions() — registry only
agent.valid_tool_names = {t["function"]["name"] for t in new_defs}
```

`get_tool_definitions()` returns only registry-registered tools. Any tools that
were *dynamically appended* by `inject_memory_provider_tools()` are not in the
registry, so they are wiped out and never restored. This pattern appears in:

- `cli.py` — TUI CLI MCP refresh
- `gateway/run.py` — gateway MCP reload handler
- `tui_gateway/server.py` — both the automatic late-MCP refresh and the manual
  `/reload-mcp` handler (2 occurrences)

## Fix

### `agent/memory_manager.py`

Remove the secondary toolset guard. When `_memory_manager` is set (already
checked at the top of the function), the provider was explicitly initialized
and its tools should always be injected. Injection remains idempotent — it
checks `existing_tool_names` and skips any tool already present.

```diff
-    if (
-        "memory" not in existing_tool_names
-        and not memory_provider_tools_enabled(getattr(agent, "enabled_toolsets", None))
-    ):
-        return 0
+    # Always inject memory provider tools when a provider has been explicitly
+    # initialized (_memory_manager is set). The "memory" toolset check was
+    # originally intended to guard the built-in `memory` tool, not external
+    # provider tools like hindsight_retain/recall/reflect. Platforms that use
+    # explicit toolset lists (webui, cron, kanban workers) without "memory" in
+    # their list were silently dropping hindsight tools at inject time even
+    # though the provider was fully initialized. Since the caller already
+    # guards with `if not memory_manager`, the secondary toolset check is
+    # redundant — a live memory_manager is authoritative.
```

### `cli.py`, `gateway/run.py`, `tui_gateway/server.py` (×2)

After each `agent.tools = new_defs` / `agent.valid_tool_names = {...}`
assignment, re-inject the provider tools. The call is idempotent and cheap:

```python
try:
    from agent.memory_manager import inject_memory_provider_tools as _inject_mpt
    _inject_mpt(agent)
except Exception:
    pass
```

This restores any dynamically appended provider schemas that the registry-only
refresh dropped, without re-adding duplicates.

## Diffs

### `agent/memory_manager.py`

```diff
@@ def inject_memory_provider_tools(agent: Any) -> int:
     existing_tool_names = {
         tool.get("function", {}).get("name")
         for tool in tools
         if isinstance(tool, dict)
     }
-    if (
-        "memory" not in existing_tool_names
-        and not memory_provider_tools_enabled(getattr(agent, "enabled_toolsets", None))
-    ):
-        return 0
+    # Always inject memory provider tools when a provider has been explicitly
+    # initialized (_memory_manager is set). The "memory" toolset check was
+    # originally intended to guard the built-in `memory` tool, not external
+    # provider tools like hindsight_retain/recall/reflect. Platforms that use
+    # explicit toolset lists (webui, cron, kanban workers) without "memory" in
+    # their list were silently dropping hindsight tools at inject time even
+    # though the provider was fully initialized. Since the caller already
+    # guards with `if not memory_manager`, the secondary toolset check is
+    # redundant — a live memory_manager is authoritative.

     get_schemas = getattr(memory_manager, "get_all_tool_schemas", None)
     if not callable(get_schemas):
         return 0
```

### `cli.py`

```diff
                 self.agent.valid_tool_names = {
                     tool["function"]["name"] for tool in self.agent.tools
                 } if self.agent.tools else set()
+                # Re-inject memory provider tools (e.g. hindsight_retain/recall/reflect)
+                # after MCP refresh, because get_tool_definitions() replaces agent.tools
+                # with only registry-registered tools, dropping any dynamically appended
+                # memory provider schemas. inject_memory_provider_tools() is idempotent
+                # (checks existing_tool_names to skip duplicates).
+                try:
+                    from agent.memory_manager import inject_memory_provider_tools as _inject_mpt
+                    _inject_mpt(self.agent)
+                except Exception:
+                    pass
```

### `gateway/run.py`

```diff
                             _agent.valid_tool_names = {
                                 t["function"]["name"] for t in new_defs
                             } if new_defs else set()
+                            # Re-inject memory provider tools after MCP refresh.
+                            # get_tool_definitions() only returns registry-registered tools
+                            # and drops any dynamically appended memory provider schemas
+                            # (e.g. hindsight_retain/recall/reflect). inject_memory_provider_tools
+                            # is idempotent (checks existing_tool_names to skip duplicates).
+                            try:
+                                from agent.memory_manager import inject_memory_provider_tools as _inject_mpt_gw
+                                _inject_mpt_gw(_agent)
+                            except Exception:
+                                pass
```

### `tui_gateway/server.py` — automatic late-MCP refresh

```diff
             agent.valid_tool_names = (
                 {t["function"]["name"] for t in new_defs} if new_defs else set()
             )
+            # Re-inject memory provider tools (e.g. hindsight_retain/recall/reflect)
+            # after late MCP refresh — get_tool_definitions() drops dynamically appended
+            # memory provider schemas. inject_memory_provider_tools() is idempotent.
+            try:
+                from agent.memory_manager import inject_memory_provider_tools as _inject_mpt_tui
+                _inject_mpt_tui(agent)
+            except Exception:
+                pass
```

### `tui_gateway/server.py` — manual `/reload-mcp`

```diff
                 agent.valid_tool_names = (
                     {t["function"]["name"] for t in new_defs} if new_defs else set()
                 )
+                # Re-inject memory provider tools after /reload-mcp.
+                try:
+                    from agent.memory_manager import inject_memory_provider_tools as _inject_mpt_reload
+                    _inject_mpt_reload(agent)
+                except Exception:
+                    pass
```

## Testing notes

- **Idempotency:** `inject_memory_provider_tools()` already de-dups against
  `existing_tool_names`, so calling it after every MCP refresh cannot add
  duplicate schemas. Verified that a second call returns `0` added.
- **Inject guard removal:** with a stub agent whose `_memory_manager` is set but
  whose `enabled_toolsets` does **not** contain `memory`, the function now
  returns the provider's schema count (previously `0`). With
  `_memory_manager = None` it still returns `0` (unchanged).
- **Cache safety:** these tools are injected at session setup and only
  re-injected to *restore* tools after an MCP reload — i.e. on the same events
  that already rebuild the tool surface. No mid-conversation toolset swap is
  introduced beyond the existing MCP-reload notification path, so prompt-cache
  behavior is unchanged relative to a normal MCP reload.
- **Manual E2E:** with a hindsight provider configured, confirm
  `hindsight_retain/recall/reflect` appear in the tool list on (a) a webui/cron
  session with an explicit toolset list omitting `memory`, and (b) a CLI/gateway
  session after triggering an MCP reconnect / `/reload-mcp`.

## Notes for reviewer

- The working tree also contains an unrelated `package-lock.json` change
  (adds `vitest` devDependency). **Exclude it from this PR** — commit only the
  five-hunk change across `agent/memory_manager.py`, `cli.py`, `gateway/run.py`,
  and `tui_gateway/server.py`.
- Fixes the whole bug class: every sibling MCP-refresh call path that overwrites
  `agent.tools` from the registry is patched, not just the one site originally
  observed.