### PR TITLE
fix(wecom): block unsafe media redirects

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -42,7 +42,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import unquote, urlparse
+from urllib.parse import unquote, urljoin, urlparse
 
 try:
     import aiohttp
@@ -73,6 +73,7 @@ from utils import env_float
 logger = logging.getLogger(__name__)
 
 DEFAULT_WS_URL = "wss://openws.work.weixin.qq.com"
+REMOTE_MEDIA_MAX_REDIRECTS = 10
 
 APP_CMD_SUBSCRIBE = "aibot_subscribe"
 APP_CMD_CALLBACK = "aibot_msg_callback"
@@ -104,6 +105,23 @@ ABSOLUTE_MAX_BYTES = FILE_MAX_BYTES
 UPLOAD_CHUNK_SIZE = 512 * 1024
 MAX_UPLOAD_CHUNKS = 100
 VOICE_SUPPORTED_MIMES = {"audio/amr"}
+
+
+def _redirect_target_from_response(response: Any) -> Optional[str]:
+    """Return the redirect target visible from an httpx response."""
+    if not getattr(response, "is_redirect", False):
+        return None
+
+    headers = getattr(response, "headers", {}) or {}
+    location = headers.get("location")
+    if location:
+        return urljoin(str(getattr(response, "url", "")), str(location))
+
+    next_request = getattr(response, "next_request", None)
+    if next_request:
+        return str(next_request.url)
+
+    return None
 
 
 def check_wecom_requirements() -> bool:
@@ -1071,9 +1089,7 @@ class WeComAdapter(BasePlatformAdapter):
         url: str,
         max_bytes: int,
     ) -> Tuple[bytes, Dict[str, str]]:
-        from tools.url_safety import is_safe_url
-        if not is_safe_url(url):
-            raise ValueError(f"Blocked unsafe URL (SSRF protection): {url[:80]}")
+        from tools.url_safety import async_is_safe_url
 
         if not HTTPX_AVAILABLE:
             raise RuntimeError("httpx is required for WeCom media download")
@@ -1081,31 +1097,52 @@ class WeComAdapter(BasePlatformAdapter):
         client = self._http_client or httpx.AsyncClient(timeout=30.0, follow_redirects=True)
         created_client = client is not self._http_client
         try:
-            async with client.stream(
-                "GET",
-                url,
-                headers={
-                    "User-Agent": "HermesAgent/1.0",
-                    "Accept": "*/*",
-                },
-            ) as response:
-                response.raise_for_status()
-                headers = {key.lower(): value for key, value in response.headers.items()}
-                content_length = headers.get("content-length")
-                if content_length and content_length.isdigit() and int(content_length) > max_bytes:
-                    raise ValueError(
-                        f"Remote media exceeds WeCom limit: {int(content_length)} bytes > {max_bytes} bytes"
-                    )
+            current_url = url
+            for _redirect_count in range(REMOTE_MEDIA_MAX_REDIRECTS + 1):
+                if not await async_is_safe_url(current_url):
+                    raise ValueError(f"Blocked unsafe URL (SSRF protection): {current_url[:80]}")
 
-                data = bytearray()
-                async for chunk in response.aiter_bytes():
-                    data.extend(chunk)
-                    if len(data) > max_bytes:
+                async with client.stream(
+                    "GET",
+                    current_url,
+                    headers={
+                        "User-Agent": "HermesAgent/1.0",
+                        "Accept": "*/*",
+                    },
+                    follow_redirects=False,
+                ) as response:
+                    if getattr(response, "is_redirect", False):
+                        redirect_url = _redirect_target_from_response(response)
+                        if not redirect_url:
+                            raise ValueError("Remote media redirect did not include a target")
+                        if not await async_is_safe_url(redirect_url):
+                            raise ValueError("Blocked unsafe redirect URL (SSRF protection)")
+                        current_url = redirect_url
+                        continue
+
+                    final_url = str(getattr(response, "url", current_url))
+                    if final_url and not await async_is_safe_url(final_url):
+                        raise ValueError("Blocked unsafe final URL (SSRF protection)")
+
+                    response.raise_for_status()
+                    headers = {key.lower(): value for key, value in response.headers.items()}
+                    content_length = headers.get("content-length")
+                    if content_length and content_length.isdigit() and int(content_length) > max_bytes:
                         raise ValueError(
-                            f"Remote media exceeds WeCom limit while downloading: {len(data)} bytes > {max_bytes} bytes"
+                            f"Remote media exceeds WeCom limit: {int(content_length)} bytes > {max_bytes} bytes"
                         )
 
-                return bytes(data), headers
+                    data = bytearray()
+                    async for chunk in response.aiter_bytes():
+                        data.extend(chunk)
+                        if len(data) > max_bytes:
+                            raise ValueError(
+                                f"Remote media exceeds WeCom limit while downloading: {len(data)} bytes > {max_bytes} bytes"
+                            )
+
+                    return bytes(data), headers
+
+            raise ValueError("Remote media exceeded redirect limit")
         finally:
             if created_client:
                 await client.aclose()

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -437,7 +437,7 @@ class TestMediaUpload:
         assert calls[3][1]["chunk_index"] == 2
 
     @pytest.mark.asyncio
-    @patch("tools.url_safety.is_safe_url", return_value=True)
+    @patch("tools.url_safety.async_is_safe_url", return_value=True)
     async def test_download_remote_bytes_rejects_large_content_length(self, _mock_safe):
         from plugins.platforms.wecom.adapter import WeComAdapter
 
@@ -457,7 +457,7 @@ class TestMediaUpload:
                 yield b"abc"
 
         class FakeClient:
-            def stream(self, method, url, headers=None):
+            def stream(self, method, url, headers=None, **kwargs):
                 return FakeResponse()
 
         adapter = WeComAdapter(PlatformConfig(enabled=True))
@@ -465,6 +465,85 @@ class TestMediaUpload:
 
         with pytest.raises(ValueError, match="exceeds WeCom limit"):
             await adapter._download_remote_bytes("https://example.com/file.bin", max_bytes=4)
+
+    @pytest.mark.asyncio
+    @patch(
+        "tools.url_safety.async_is_safe_url",
+        side_effect=lambda url: not str(url).startswith("http://169.254.169.254"),
+    )
+    async def test_download_remote_bytes_blocks_unsafe_redirect_target(self, _mock_safe):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        consumed = False
+
+        class FakeResponse:
+            is_redirect = True
+            url = "https://example.com/file.bin"
+            headers = {"location": "http://169.254.169.254/latest/meta-data/"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def aiter_bytes(self):
+                nonlocal consumed
+                consumed = True
+                yield b"metadata"
+
+        class FakeClient:
+            def stream(self, method, url, headers=None, **kwargs):
+                return FakeResponse()
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = FakeClient()
+
+        with pytest.raises(ValueError, match="unsafe redirect URL"):
+            await adapter._download_remote_bytes("https://example.com/file.bin", max_bytes=1024)
+
+        assert consumed is False
+
+    @pytest.mark.asyncio
+    @patch(
+        "tools.url_safety.async_is_safe_url",
+        side_effect=lambda url: not str(url).startswith("http://169.254.169.254"),
+    )
+    async def test_download_remote_bytes_blocks_unsafe_final_response_url_before_body_read(self, _mock_safe):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        consumed = False
+
+        class FakeResponse:
+            is_redirect = False
+            url = "http://169.254.169.254/latest/meta-data/"
+            headers = {"content-length": "8"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_bytes(self):
+                nonlocal consumed
+                consumed = True
+                yield b"metadata"
+
+        class FakeClient:
+            def stream(self, method, url, headers=None, **kwargs):
+                return FakeResponse()
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = FakeClient()
+
+        with pytest.raises(ValueError, match="unsafe final URL"):
+            await adapter._download_remote_bytes("https://example.com/file.bin", max_bytes=1024)
+
+        assert consumed is False
 
     @pytest.mark.asyncio
     async def test_cache_media_decrypts_url_payload_before_writing(self):
@@ -548,6 +627,44 @@ class TestSend:
 
         assert result.success is True
         adapter.send.assert_awaited_once_with(chat_id="chat-123", content="demo\nhttps://example.com/demo.png", reply_to=None)
+
+    @pytest.mark.asyncio
+    @patch(
+        "tools.url_safety.async_is_safe_url",
+        side_effect=lambda url: not str(url).startswith("http://169.254.169.254"),
+    )
+    async def test_send_image_blocks_unsafe_remote_redirect_before_upload(self, _mock_safe):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        class FakeResponse:
+            is_redirect = True
+            url = "https://example.com/demo.png"
+            headers = {"location": "http://169.254.169.254/latest/meta-data/"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+        class FakeClient:
+            def stream(self, method, url, headers=None, **kwargs):
+                return FakeResponse()
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = FakeClient()
+        adapter._upload_media_bytes = AsyncMock()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-1"))
+
+        result = await adapter.send_image("chat-123", "https://example.com/demo.png", caption="demo")
+
+        assert result.success is True
+        adapter._upload_media_bytes.assert_not_awaited()
+        adapter.send.assert_awaited_once_with(
+            chat_id="chat-123",
+            content="demo\nhttps://example.com/demo.png",
+            reply_to=None,
+        )
 
     @pytest.mark.asyncio
     async def test_send_voice_sends_caption_and_downgrade_note(self):


### PR DESCRIPTION
## Summary
- validate every WeCom remote-media redirect target before following it
- re-check the final response URL before reading body bytes
- use async URL safety checks so media downloads do not block the event loop during DNS checks

## Duplicate check
- Not a duplicate of #40255: that PR switches other platform adapters to async URL safety checks, but does not touch WeCom or redirect-target validation.

## Tests
- `C:\Users\downl\Documents\New project\hermes-agent\.venv\Scripts\python.exe -m pytest tests\gateway\test_wecom.py -q`