### PR TITLE
fix(deepseek): keep retired aliases out of the picker via models.dev merge filter

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -363,8 +363,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "deepseek": [
         "deepseek-v4-pro",
         "deepseek-v4-flash",
-        "deepseek-chat",
-        "deepseek-reasoner",
     ],
     "xiaomi": [
         "mimo-v2.5-pro",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3810,6 +3810,9 @@ def _merge_with_models_dev(provider: str, curated: list[str]) -> list[str]:
     Returns models.dev entries first (in models.dev order), then any
     curated-only entries appended. Preserves case for curated fallbacks
     (e.g. ``MiniMax-M2.7``) while trusting models.dev for newer variants.
+    Retired aliases (``_PROVIDER_RETIRED_ALIASES``, e.g. DeepSeek's
+    ``deepseek-chat`` / ``deepseek-reasoner``) are dropped from BOTH sources
+    so they can never resurface through the merge.
 
     If models.dev is unreachable or returns nothing, the curated list is
     returned unchanged — this is the offline/CI fallback path.
@@ -3823,18 +3826,21 @@ def _merge_with_models_dev(provider: str, curated: list[str]) -> list[str]:
     if not mdev:
         return list(curated)
 
+    # Retired aliases must never resurface via models.dev merges.
+    retired = {str(m).lower() for m in _PROVIDER_RETIRED_ALIASES.get(provider, ())}
+
     # Case-insensitive dedup while preserving order and curated casing.
     seen_lower: set[str] = set()
     merged: list[str] = []
     for mid in mdev:
         key = str(mid).lower()
-        if key in seen_lower:
+        if key in seen_lower or key in retired:
             continue
         seen_lower.add(key)
         merged.append(mid)
     for mid in curated:
         key = str(mid).lower()
-        if key in seen_lower:
+        if key in seen_lower or key in retired:
             continue
         seen_lower.add(key)
         merged.append(mid)

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -89,12 +89,9 @@ deepseek = DeepSeekProfile(
     display_name="DeepSeek",
     description="DeepSeek — native DeepSeek API",
     signup_url="https://platform.deepseek.com/",
-    fallback_models=(
-        "deepseek-chat",
-        "deepseek-reasoner",
-    ),
+    fallback_models=(),
     base_url="https://api.deepseek.com/v1",
-    default_aux_model="deepseek-chat",
+    default_aux_model="deepseek-v4-flash",
 )
 
 register_provider(deepseek)

--- a/tests/hermes_cli/test_models_dev_preferred_merge.py
+++ b/tests/hermes_cli/test_models_dev_preferred_merge.py
@@ -45,6 +45,27 @@ class TestMergeHelper:
         # models.dev casing wins since it came first
         assert out == ["MiniMax-M2.7", "minimax-m2.5"]
 
+    def test_merge_filters_retired_aliases_from_models_dev(self):
+        """DeepSeek's retired aliases must not resurface via the models.dev merge.
+
+        models.dev still lists ``deepseek-chat`` / ``deepseek-reasoner``
+        (tool_call=true); the merge must drop them from the mdev stream so
+        the picker shows exactly the two first-class models.
+        """
+        mdev = ["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-chat", "deepseek-reasoner"]
+        curated = ["deepseek-v4-pro", "deepseek-v4-flash"]
+        with patch("agent.models_dev.list_agentic_models", return_value=mdev):
+            out = _merge_with_models_dev("deepseek", curated)
+        assert out == ["deepseek-v4-flash", "deepseek-v4-pro"]
+
+    def test_merge_filters_retired_aliases_from_curated(self):
+        """Curated entries that are retired aliases are dropped as well."""
+        mdev = ["deepseek-v4-flash"]
+        curated = ["deepseek-v4-pro", "deepseek-chat", "deepseek-reasoner"]
+        with patch("agent.models_dev.list_agentic_models", return_value=mdev):
+            out = _merge_with_models_dev("deepseek", curated)
+        assert out == ["deepseek-v4-flash", "deepseek-v4-pro"]
+
 
 class TestProviderModelIdsPreferred:
 


### PR DESCRIPTION
## Status: remaining gap from the original fix

The original static-list trim — `_PROVIDER_MODELS["deepseek"]` reduced to the two first-class models, explicit `fallback_models`, `default_aux_model` → `deepseek-v4-flash` — is **already in `main`**. This PR closes the one path where the retired aliases still leak into the picker.

## Problem

DeepSeek's API only accepts `deepseek-v4-pro` and `deepseek-v4-flash`. The retired names `deepseek-chat` / `deepseek-reasoner` now return **HTTP 400** (no longer silently aliased).

models.dev still lists all four with `tool_call=true`, and because `deepseek` is in `_MODELS_DEV_PREFERRED`, `_merge_with_models_dev()` merged those dead IDs back on top of the trimmed static list — so `/model` showed 4 DeepSeek entries, and selecting either legacy alias produced an unusable session.

## Fix

`_merge_with_models_dev()` now drops entries matching `_PROVIDER_RETIRED_ALIASES` (already defined and used for auto-detection) from **both** the models.dev stream and the curated fallback, before the case-insensitive dedup:

```python
retired = {str(m).lower() for m in _PROVIDER_RETIRED_ALIASES.get(provider, ())}
```

After this, `provider_model_ids("deepseek")` returns exactly `["deepseek-v4-pro", "deepseek-v4-flash"]`.

## Tests

- `tests/hermes_cli/test_models_dev_preferred_merge.py`:
  - `test_merge_filters_retired_aliases_from_models_dev` — models.dev stream still carrying the aliases is filtered.
  - `test_merge_filters_retired_aliases_from_curated` — curated entries that are retired aliases are dropped too.
- Related suites green: **103 passed** (gemini / ollama / opencode-go / xai / xiaomi / deepseek-profile + this file).

## Verification

```bash
$ python -m pytest tests/hermes_cli/test_models_dev_preferred_merge.py -v
# 7 passed
```

## Out of scope

`models_dev_cache.json` (the on-disk mirror of <https://models.dev/api.json>) still lists the aliases until its next refresh — that's an upstream data-source issue in models.dev. This fix guarantees the aliases can never resurface in the picker regardless of the data source.
