### PR TITLE
fix(gateway): rename the Telegram topic from /title, not only auto-titles

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2794,6 +2794,22 @@ class GatewaySlashCommandsMixin:
             # Set the title
             try:
                 if self._session_db.set_session_title(session_id, sanitized):
+                    # Propagate the user-chosen title to the visible Telegram
+                    # forum topic name too. Auto-generated titles already rename
+                    # the topic; without this, /title only updated the DB title
+                    # and the topic kept its auto-assigned name. No-ops off
+                    # Telegram topic lanes and when auto-rename is disabled.
+                    schedule_rename = getattr(
+                        self, "_schedule_telegram_topic_title_rename", None
+                    )
+                    if callable(schedule_rename):
+                        try:
+                            schedule_rename(source, session_id, sanitized)
+                        except Exception:
+                            logger.debug(
+                                "Failed to rename Telegram topic from /title",
+                                exc_info=True,
+                            )
                     return t("gateway.title.set_to", title=sanitized)
                 else:
                     return t("gateway.title.not_found")

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -166,6 +166,42 @@ class TestHandleTitleCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_set_title_propagates_to_telegram_topic_rename(self, tmp_path):
+        """/title <name> also renames the visible Telegram topic, not just the DB."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        runner._schedule_telegram_topic_title_rename = MagicMock()
+
+        event = _make_event(text="/title My Topic Name")
+        result = await runner._handle_title_command(event)
+
+        assert "My Topic Name" in result
+        runner._schedule_telegram_topic_title_rename.assert_called_once_with(
+            event.source, "test_session_123", "My Topic Name"
+        )
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_show_title_does_not_rename_topic(self, tmp_path):
+        """Showing the title (no arg) must not trigger a topic rename."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+        db.set_session_title("test_session_123", "Existing Title")
+
+        runner = _make_runner(session_db=db)
+        runner._schedule_telegram_topic_title_rename = MagicMock()
+
+        event = _make_event(text="/title")
+        await runner._handle_title_command(event)
+
+        runner._schedule_telegram_topic_title_rename.assert_not_called()
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_works_across_platforms(self, tmp_path):
         """The /title command works for Discord, Slack, and WhatsApp too."""
         from hermes_state import SessionDB


### PR DESCRIPTION
## What

`/title <name>` now also renames the visible Telegram forum topic, not just the session title in the database.

## Why

Auto-generated session titles already rename the Telegram topic (via the auto-title `title_callback`). But `_handle_title_command` only called `set_session_title`. On a Telegram topic lane, a user who ran `/title` to override the auto-assigned topic name saw the database title change while the topic name stayed the same — there was no way to rename the topic after Hermes auto-named it.

## Change

On a successful `/title` set, call the existing `_schedule_telegram_topic_title_rename` helper with the sanitized title. It already no-ops off Telegram topic lanes and when `disable_topic_auto_rename` is set, so other platforms and the show-title path are unaffected.

## Tests

`tests/gateway/test_title_command.py` — `/title <name>` schedules the topic rename with the sanitized title; the show-title path does not.