### PR TITLE
fix(cron): honor configured service tier

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -210,7 +210,7 @@ def init_agent(
     event_callback: Optional[Callable[[str, dict], None]] = None,
     max_tokens: int = None,
     reasoning_config: Dict[str, Any] = None,
-    service_tier: str = None,
+    service_tier: Optional[str] = None,
     request_overrides: Dict[str, Any] = None,
     prefill_messages: List[Dict[str, Any]] = None,
     platform: str = None,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2297,14 +2297,40 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
         # Reasoning config from config.yaml
         from hermes_constants import parse_reasoning_effort
-        effort = str(_cfg.get("agent", {}).get("reasoning_effort", "")).strip()
+        _agent_raw = _cfg.get("agent", {}) if isinstance(_cfg, dict) else {}
+        agent_cfg = _agent_raw if isinstance(_agent_raw, dict) else {}
+        effort = str(agent_cfg.get("reasoning_effort", "")).strip()
         reasoning_config = parse_reasoning_effort(effort)
+
+        # Priority/fast mode from config.yaml.  Gateway and CLI sessions already
+        # honor agent.service_tier; cron constructs its own AIAgent here, so it
+        # must pass the parsed tier explicitly instead of silently dropping it.
+        service_tier: Optional[str] = None
+        raw_service_tier_value = agent_cfg.get("service_tier", "")
+        if isinstance(raw_service_tier_value, bool):
+            # PyYAML's YAML 1.1 resolver parses unquoted `on`/`off` as bools.
+            raw_service_tier = "on" if raw_service_tier_value else "off"
+        else:
+            raw_service_tier = str(raw_service_tier_value or "").strip()
+        service_tier_value = raw_service_tier.lower()
+        if service_tier_value in {"fast", "priority", "on"}:
+            service_tier = "priority"
+        elif service_tier_value and service_tier_value not in {"normal", "default", "standard", "off", "none"}:
+            logger.warning("Job '%s': unknown agent.service_tier '%s', ignoring", job_id, raw_service_tier)
+
+        request_overrides = {}
+        if service_tier:
+            try:
+                from hermes_cli.models import resolve_fast_mode_overrides
+                request_overrides = resolve_fast_mode_overrides(model) or {}
+            except Exception as e:
+                logger.warning("Job '%s': failed to resolve fast-mode overrides: %s", job_id, e)
+                request_overrides = {}
 
         # Prefill messages from env or config.yaml. The top-level
         # prefill_messages_file key is canonical; agent.prefill_messages_file is
         # retained as a legacy fallback for older CLI/godmode configs.
         prefill_messages = None
-        agent_cfg = _cfg.get("agent", {}) if isinstance(_cfg.get("agent", {}), dict) else {}
         prefill_file = (
             os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
             or _cfg.get("prefill_messages_file", "")
@@ -2476,6 +2502,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             acp_args=runtime.get("args"),
             max_iterations=max_iterations,
             reasoning_config=reasoning_config,
+            service_tier=service_tier,
+            request_overrides=request_overrides,
             prefill_messages=prefill_messages,
             fallback_model=fallback_model,
             credential_pool=credential_pool,

--- a/run_agent.py
+++ b/run_agent.py
@@ -401,7 +401,7 @@ class AIAgent:
         event_callback: Optional[Callable[[str, dict], None]] = None,
         max_tokens: int = None,
         reasoning_config: Dict[str, Any] = None,
-        service_tier: str = None,
+        service_tier: Optional[str] = None,
         request_overrides: Dict[str, Any] = None,
         prefill_messages: List[Dict[str, Any]] = None,
         platform: str = None,

--- a/tests/cron/test_scheduler_service_tier.py
+++ b/tests/cron/test_scheduler_service_tier.py
@@ -1,0 +1,115 @@
+"""Regression tests for cron honoring configured priority service tier."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure project root is importable when this file is run directly.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+@pytest.fixture
+def cron_env(tmp_path, monkeypatch):
+    """Isolated cron environment with temp HERMES_HOME."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "cron").mkdir()
+    (hermes_home / "cron" / "output").mkdir()
+    (hermes_home / "scripts").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import cron.jobs as jobs_mod
+    from cron import scheduler
+
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", hermes_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
+    monkeypatch.setattr(scheduler, "_hermes_home", hermes_home)
+
+    return hermes_home
+
+
+def _run_job_and_capture_agent_kwargs(cron_env: Path, service_tier_value: str):
+    """Run a cron job with a fake agent and return its constructor kwargs."""
+    (cron_env / "config.yaml").write_text(
+        "model:\n"
+        "  default: gpt-5.5\n"
+        "agent:\n"
+        f"  service_tier: {service_tier_value}\n",
+        encoding="utf-8",
+    )
+
+    captured: dict = {}
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def run_conversation(self, prompt):
+            assert "cron service tier regression" in prompt
+            return {"completed": True, "final_response": "ok"}
+
+        def close(self):
+            return None
+
+    class FakeSessionDB:
+        def set_session_title(self, *args, **kwargs):
+            return None
+
+        def end_session(self, *args, **kwargs):
+            return None
+
+        def close(self):
+            return None
+
+    job = {
+        "id": "service-tier-regression",
+        "name": "service-tier-regression",
+        "prompt": "cron service tier regression",
+        "schedule_display": "manual",
+    }
+
+    with (
+        patch("run_agent.AIAgent", FakeAIAgent),
+        patch("hermes_state.SessionDB", FakeSessionDB),
+        patch("tools.mcp_tool.discover_mcp_tools", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "openai-codex",
+                "api_key": None,
+                "base_url": None,
+                "api_mode": None,
+                "command": None,
+                "args": None,
+            },
+        ),
+    ):
+        from cron.scheduler import run_job
+
+        success, _output, final_response, error = run_job(job)
+
+    assert success is True, error
+    assert final_response == "ok"
+    return captured
+
+
+@pytest.mark.parametrize("configured", ["fast", "priority", "on"])
+def test_cron_agent_receives_priority_service_tier(cron_env, configured):
+    kwargs = _run_job_and_capture_agent_kwargs(cron_env, configured)
+
+    assert kwargs["service_tier"] == "priority"
+    assert kwargs["request_overrides"] == {"service_tier": "priority"}
+
+
+@pytest.mark.parametrize("configured", ["normal", "default", "standard", "off", "none", ""])
+def test_cron_agent_leaves_normal_service_tier_unset(cron_env, configured):
+    kwargs = _run_job_and_capture_agent_kwargs(cron_env, configured)
+
+    assert kwargs["service_tier"] is None
+    assert kwargs["request_overrides"] == {}


### PR DESCRIPTION
## Summary
- Make cron-spawned agents honor `agent.service_tier` from `config.yaml`.
- Normalize `fast` / `priority` / `on` to Priority Processing, including PyYAML's boolean parsing of unquoted `on` / `off`.
- Resolve model-specific fast-mode `request_overrides` and pass them into `AIAgent` so the transport actually includes the priority request setting.
- Add regression coverage for priority and normal service-tier values.

## Test plan
- `python -m pytest tests/cron/test_scheduler_service_tier.py tests/cron/test_scheduler_mcp_init.py tests/cron/test_cron_script.py::TestRunJobEnvVarCleanup -q -o 'addopts='` -> 11 passed
- `python -m pytest tests/run_agent/test_provider_parity.py -q -o 'addopts='` -> 93 passed
- `python -m pytest tests/cron -q -o 'addopts='` -> 484 passed
- `git diff --check` -> passed
- Independent code review subagent: passed, no security concerns or logic errors
