### PR TITLE
fix(desktop): keep message/reasoning text visible after alt-tab during enter animation

### DIFF
--- a/apps/desktop/src/lib/use-enter-animation.test.ts
+++ b/apps/desktop/src/lib/use-enter-animation.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useEnterAnimation } from './use-enter-animation'
+
+// The hook is a callback ref; we don't need React to exercise it — invoking
+// the returned ref with a fake element is exactly what React does on mount.
+// We render via a tiny manual harness to satisfy the rules-of-hooks (the hook
+// calls useRef/useCallback). renderHook from @testing-library keeps it honest.
+import { renderHook } from '@testing-library/react'
+
+type FakeAnimation = {
+  finish: ReturnType<typeof vi.fn>
+  finished: Promise<void>
+  _resolve: () => void
+}
+
+function makeFakeElement() {
+  const animations: Array<{ keyframes: unknown; options: unknown; anim: FakeAnimation }> = []
+
+  const el = {
+    isConnected: true,
+    animate(keyframes: unknown, options: unknown) {
+      let resolve!: () => void
+      const finished = new Promise<void>(r => {
+        resolve = r
+      })
+      const anim: FakeAnimation = {
+        finish: vi.fn(() => resolve()),
+        finished,
+        _resolve: resolve
+      }
+      animations.push({ keyframes, options, anim })
+
+      return anim as unknown as Animation
+    }
+  } as unknown as HTMLElement & { animate: HTMLElement['animate'] }
+
+  return { el, animations }
+}
+
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => (hidden ? 'hidden' : 'visible')
+  })
+}
+
+describe('useEnterAnimation', () => {
+  beforeEach(() => {
+    setHidden(false)
+    // Default: motion allowed.
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as unknown as typeof window.matchMedia
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('plays the enter animation when the document is visible', () => {
+    const { result } = renderHook(() => useEnterAnimation(true))
+    const { el, animations } = makeFakeElement()
+
+    result.current(el)
+
+    expect(animations).toHaveLength(1)
+    // End keyframe must be fully opaque.
+    expect((animations[0].keyframes as Array<{ opacity: number }>).at(-1)?.opacity).toBe(1)
+  })
+
+  it('does NOT create an opacity:0-pinned animation while the document is hidden', () => {
+    setHidden(true)
+    const { result } = renderHook(() => useEnterAnimation(true))
+    const { el, animations } = makeFakeElement()
+
+    result.current(el)
+
+    // No animation at all → element keeps its natural (visible) styles, so it
+    // can never be stranded transparent behind a paused timeline.
+    expect(animations).toHaveLength(0)
+  })
+
+  it('force-finishes a mid-flight animation when the document becomes hidden', () => {
+    const { result } = renderHook(() => useEnterAnimation(true))
+    const { el, animations } = makeFakeElement()
+
+    result.current(el)
+    expect(animations).toHaveLength(1)
+
+    // Simulate alt-tab mid-animation: window hides, visibilitychange fires.
+    setHidden(true)
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    // finish() jumps to the end keyframe (opacity:1) synchronously even though
+    // the timeline is paused — the message can't be left invisible.
+    expect(animations[0].anim.finish).toHaveBeenCalledTimes(1)
+  })
+
+  it('respects prefers-reduced-motion (no animation)', () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia
+    const { result } = renderHook(() => useEnterAnimation(true))
+    const { el, animations } = makeFakeElement()
+
+    result.current(el)
+
+    expect(animations).toHaveLength(0)
+  })
+
+  it('detaches the visibilitychange listener once the animation settles', async () => {
+    const addSpy = vi.spyOn(document, 'addEventListener')
+    const removeSpy = vi.spyOn(document, 'removeEventListener')
+
+    const { result } = renderHook(() => useEnterAnimation(true))
+    const { el, animations } = makeFakeElement()
+
+    result.current(el)
+    expect(addSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+
+    // Natural completion resolves `finished` → cleanup runs.
+    animations[0].anim._resolve()
+    await animations[0].anim.finished
+
+    expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+  })
+})

--- a/apps/desktop/src/lib/use-enter-animation.ts
+++ b/apps/desktop/src/lib/use-enter-animation.ts
@@ -79,13 +79,52 @@ export function useEnterAnimation(enabled: boolean, animationKey?: string): (el:
       return
     }
 
-    el.animate(
+    // The Web Animations document timeline PAUSES while the tab/window is
+    // hidden (alt-tab, app switch, OS occlusion). An enter animation with
+    // `fill: 'both'` created — or frozen mid-flight — while hidden pins the
+    // element at its opening keyframe (`opacity: 0`) while it still occupies
+    // full layout height, so on return the user sees a blank gap where the
+    // message/reasoning text should be. Guard BOTH ends: skip entirely when
+    // already hidden, and force-finish (jump to the fully-visible end frame)
+    // the instant the document goes hidden mid-play. `finish()` sets
+    // currentTime to the end synchronously regardless of timeline state, so
+    // the computed style resolves to the end keyframe (opacity: 1) even while
+    // paused — the element can never be stranded transparent.
+    if (typeof document !== 'undefined' && document.hidden) {
+      if (key) {
+        rememberPlayedAnimation(key)
+      }
+
+      return
+    }
+
+    const animation = el.animate(
       [
         { opacity: 0, transform: 'translateY(0.375rem)' },
         { opacity: 1, transform: 'translateY(0)' }
       ],
       { duration: 180, easing: 'cubic-bezier(0.16, 1, 0.3, 1)', fill: 'both' }
     )
+
+    if (typeof document !== 'undefined' && typeof animation.finished?.then === 'function') {
+      const finishIfHidden = () => {
+        if (document.hidden) {
+          try {
+            animation.finish()
+          } catch {
+            // Already finished/cancelled — nothing to settle.
+          }
+        }
+      }
+
+      document.addEventListener('visibilitychange', finishIfHidden)
+
+      const cleanup = () => document.removeEventListener('visibilitychange', finishIfHidden)
+
+      // Resolves on natural completion (180ms) OR an early finish()/cancel —
+      // detaches the listener so we never accumulate one per message.
+      animation.finished.then(cleanup, cleanup)
+    }
 
     if (key) {
       // In React StrictMode the first mount can be immediately torn down.


### PR DESCRIPTION
fix(desktop): keep message/reasoning text visible after alt-tab during enter animation

Symptom: switching apps/IDEs or swapping sessions left a large blank gap
in the transcript where an assistant message (or its "Thinking" reasoning
block) should be — full layout height reserved, but the text painted
invisible. Reported as "text disappearing" tied specifically to alt-tab /
window-swap, not to scrolling.

Root cause: useEnterAnimation plays a 180ms fade-in via
`el.animate([{opacity:0,...},{opacity:1,...}], { fill: 'both' })` on every
assistant-message root and every ThinkingDisclosure as it mounts. The Web
Animations document timeline PAUSES while the window is hidden
(alt-tab / app switch / OS occlusion). With `fill: 'both'`, an animation
created — or frozen mid-flight — while the timeline isn't advancing pins the
element at its opening keyframe (`opacity: 0`) while it still occupies full
layout height. On return the message is stranded transparent: blank gap, no
text. There was zero visibility handling anywhere in the renderer.

Fix (the one shared hook → all four callers — assistant message, thinking
disclosure, tool fallback, agents panel):
- If the document is already hidden when an element mounts, skip the
  animation entirely. The element keeps its natural visible styles and can
  never be stranded transparent behind a paused timeline.
- If the document becomes hidden mid-play, force-finish the animation on
  `visibilitychange`. `animation.finish()` jumps currentTime to the end
  keyframe (opacity: 1) synchronously regardless of timeline state, so the
  computed style resolves visible even while paused.
- The visibilitychange listener self-detaches when the animation settles
  (natural completion or early finish/cancel via `animation.finished`), so
  we never accumulate one listener per message.

Test: src/lib/use-enter-animation.test.ts — plays when visible, does NOT
create an opacity:0-pinned animation while hidden, force-finishes on
visibilitychange-to-hidden, respects prefers-reduced-motion, and detaches
the listener once the animation settles.
