### PR TITLE
fix(gateway): persist inline-keyboard model-picker selections by default, matching /model (#49066)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1152,7 +1152,7 @@ class GatewaySlashCommandsMixin:
                             current_model=_cur_model,
                             current_base_url=_cur_base_url,
                             current_api_key=_cur_api_key,
-                            is_global=False,
+                            is_global=persist_global,
                             explicit_provider=provider_slug,
                             user_providers=user_provs,
                             custom_providers=custom_provs,
@@ -1216,6 +1216,34 @@ class GatewaySlashCommandsMixin:
                         # stale cache signature to trigger a rebuild.
                         _self._evict_cached_agent(_session_key)
 
+                        # Persist to config (default) unless --session opted out,
+                        # mirroring the text /model command path above so a picked
+                        # model survives across sessions like a typed one (#49066).
+                        if persist_global:
+                            try:
+                                if config_path.exists():
+                                    with open(config_path, encoding="utf-8") as f:
+                                        _persist_cfg = yaml.safe_load(f) or {}
+                                else:
+                                    _persist_cfg = {}
+                                _raw_model = _persist_cfg.get("model")
+                                if isinstance(_raw_model, dict):
+                                    _persist_model_cfg = _raw_model
+                                elif isinstance(_raw_model, str) and _raw_model.strip():
+                                    _persist_model_cfg = {"default": _raw_model.strip()}
+                                    _persist_cfg["model"] = _persist_model_cfg
+                                else:
+                                    _persist_model_cfg = {}
+                                    _persist_cfg["model"] = _persist_model_cfg
+                                _persist_model_cfg["default"] = result.new_model
+                                _persist_model_cfg["provider"] = result.target_provider
+                                if result.base_url:
+                                    _persist_model_cfg["base_url"] = result.base_url
+                                from hermes_cli.config import save_config
+                                save_config(_persist_cfg)
+                            except Exception as e:
+                                logger.warning("Failed to persist model switch: %s", e)
+
                         # Build confirmation text
                         plabel = result.provider_label or result.target_provider
                         lines = [t("gateway.model.switched", model=result.new_model)]
@@ -1249,7 +1277,10 @@ class GatewaySlashCommandsMixin:
                             if mi.has_cost_data():
                                 lines.append(t("gateway.model.cost_label", cost=mi.format_cost()))
                             lines.append(t("gateway.model.capabilities_label", capabilities=mi.format_capabilities()))
-                        lines.append(t("gateway.model.session_only_hint"))
+                        if persist_global:
+                            lines.append(t("gateway.model.saved_global"))
+                        else:
+                            lines.append(t("gateway.model.session_only_hint"))
                         return "\n".join(lines)
 
                     metadata = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))


### PR DESCRIPTION
#49066 made the `/model <name>` text command **and** the CLI prompt_toolkit picker persist the selected model to `config.yaml` by default. But the gateway (Telegram / Discord / Matrix) inline-keyboard picker callback (`_on_model_selected` in `gateway/slash_commands.py`) was left session-only: it hard-codes `is_global=False`, never writes `config.yaml`, and always shows the `session_only_hint`.

The result is a behavioral contradiction the same PR introduced: typing `/model qwen…` persists across launches, but **tapping** the same model in the picker — the natural bot UX — silently reverts on the next launch.

This mirrors the in-file text `/model` path:
- pass the already-resolved `persist_global` (defaults to `True`, still honors `--session`/`--global` when given with a bare `/model`) instead of hard-coded `False`;
- persist `model.default`/`provider`/`base_url` to `config.yaml` via the same read-modify-write block (with the same scalar-`model:` coercion guard);
- show `saved_global` vs `session_only_hint` based on whether it persisted.

No new dependencies; the persist block is the text path's existing logic. Follow-up to merged #49066.