### PR TITLE
fix(config): silence unknown-key warnings for non-HTTP provider blocks

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4015,7 +4015,10 @@ def _normalize_custom_provider_entry(
             )
             entry[snake] = entry[camel]
     unknown = set(entry.keys()) - _KNOWN_KEYS - set(_CAMEL_ALIASES.keys())
-    if unknown:
+    # Non-HTTP blocks (e.g. providers.acp launcher settings) may omit base_url;
+    # they are consumed outside custom-provider normalization — do not warn.
+    has_url_candidate = any(entry.get(k) for k in ("base_url", "url", "api"))
+    if unknown and has_url_candidate:
         logger.warning(
             "providers.%s: unknown config keys ignored: %s",
             provider_key or "?", ", ".join(sorted(unknown)),

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -139,6 +139,19 @@ class TestNormalizeCustomProviderEntry:
         result = _normalize_custom_provider_entry(entry, provider_key="test")
         assert result is None
 
+    def test_non_http_acp_launcher_keys_not_flagged_unknown(self, caplog):
+        """ACP launcher blocks under providers.acp omit base_url; keys are not HTTP provider fields."""
+        entry = {
+            "args": "acp",
+            "command": "/usr/local/bin/cursor-agent",
+            "env": '{"CURSOR_MODEL": "auto"}',
+            "stale_timeout_seconds": 900,
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="acp")
+        assert result is None
+        assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
+
     def test_no_name_returns_none(self):
         """Entry with no name and no provider_key should return None."""
         entry = {


### PR DESCRIPTION
When a provider block under `providers.*` is not an HTTP-style custom provider (e.g. `providers.acp` launcher settings), it may legitimately omit `base_url`. The current `_normalize_custom_provider_entry` warns about every unknown key in such blocks, which produces noisy log warnings on every Hermes startup for users using the ACP launcher.

This change:

- Skips the unknown-key warning when the entry has no URL-shaped keys (`base_url` / `url` / `api`). Those entries are not HTTP providers — they're consumed outside custom-provider normalization (ACP launcher config is one example; other plugin-style provider blocks may follow the same pattern).
- Adds a test case verifying ACP launcher keys (`args`, `command`, `env`, `stale_timeout_seconds`) don't trip the warning.

Mirrors the live config blocks that the user's `providers.acp` setup writes — see their environment for context.

**Reproduction:** add a `providers.acp` block to your config.yaml without `base_url`. Hermes emits `providers.acp: unknown config keys ignored: args, command, env` on every startup. After this fix, the warning is silent.

Originally authored in noidsoup/hermes-agent @ ec8a92664.