### PR TITLE
docs: add Hermes source-of-truth runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,54 @@ source .venv/bin/activate   # or: source venv/bin/activate
 `$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
 main checkout).
 
+## Operating Workflow
+
+- Track Hermes-specific work in the Linear `Hermes` team using `HERMES-*`
+  issues. Update the active Linear issue as work starts, meaningful findings
+  appear, code changes, tests run, blockers surface, and work finishes.
+- Add useful Linear labels while working. Always include `Hermes`; add domain
+  labels such as `Telegram`, `Fantastical`, `MCP`, `Models`, `YouTube`,
+  `Spotify`, `Apple Music`, `Vapi`, `Dashboard`, `UI`, `Bug`, `Feature`,
+  or `Improvement` when they describe the work.
+- Link every Hermes code PR to its Linear issue. Branch names, commit messages,
+  PR titles, and PR bodies should include the relevant `HERMES-*` identifier
+  when practical, and the Linear issue must get a short comment with the PR URL,
+  commit SHA, files changed, tests run, and remaining risks.
+- Prefer Linear's GitHub integration or native PR attachments when available,
+  but keep the human-readable Linear handoff comment even when auto-linking
+  works.
+- For Linear work, use the connector for simple reads, creates, comments, and
+  status changes. For precise or structural operations such as attachments,
+  saved views, bulk cleanup, or anything the connector does not expose, go
+  straight to the authenticated Linear CLI/raw GraphQL path before calling it
+  blocked. Use browser/UI only when auth, visual setup, or unavailable API
+  surface requires it.
+- When user action is needed, lead the update with an `Action Items For You`
+  list. Keep it short, concrete, and separate from agent-owned next steps; if
+  there are no user actions, say `Action Items For You: None`. Keep the
+  durable action item in Linear when it is a real task; use
+  `docs/operator/ACTION_ITEMS.md` as a short side-panel index that links to the
+  Linear issue. Label user-owned asks with `User Action` so they appear in the
+  shared Linear view `Hermes - Action Items For Jesse`.
+- Keep a canonical Hermes runbook at `docs/operator/HERMES_RUNTIME.md` and
+  update it whenever the runtime state, integrations, blockers, or next steps
+  change in a meaningful way. New Codex threads should treat that runbook as
+  the first handoff source before relying on chat history.
+- Use this operator checklist for Hermes work:
+  1. Identify the active `HERMES-*` issue before changing state.
+  2. Update Linear with current state, blocker, next step, and relevant links.
+  3. Refresh `docs/operator/HERMES_RUNTIME.md` when runtime behavior,
+     integrations, model routing, blockers, or next steps change.
+  4. Keep `docs/operator/ACTION_ITEMS.md` current for user-owned asks that need
+     side-panel visibility.
+  5. If a change only adds a comment, note, or follow-up without changing
+     runtime state, update Linear only unless the runbook would otherwise become
+     stale.
+- Do not design a new subsystem until you have reported the reuse scan. Before
+  implementing new behavior, search existing Hermes mechanisms, nearby tests,
+  and docs; then state what is reused, what new code/config is necessary, and
+  why it does not duplicate existing behavior.
+
 ## Project Structure
 
 File counts shift constantly — don't treat the tree below as exhaustive.

--- a/docs/operator/ACTION_ITEMS.md
+++ b/docs/operator/ACTION_ITEMS.md
@@ -1,0 +1,23 @@
+# Action Items For You
+
+Current status: none.
+
+Use Linear as the durable source of truth for operator action items. This file is
+the quick side-panel index: keep it short, current, and link to the Linear issue
+for any real task.
+
+Linear view: [Hermes - Action Items For Jesse](https://linear.app/agents-n-such/view/cc470bfc-fead-4608-95ea-53215413bfd0)
+Canonical runbook: [Hermes Runtime Handoff](./HERMES_RUNTIME.md)
+
+## Open
+
+- None.
+
+## Recently Cleared
+
+- 2026-06-11: Canonical Hermes runtime handoff created in `docs/operator/HERMES_RUNTIME.md`; use it as the first source of truth for current state.
+- 2026-06-10: Confirmed the Vapi pretzel-shop smoke call reached the phone; HERMES-9 remains open for call quality and confirmation-safe workflow implementation.
+- 2026-06-10: GitHub CLI authenticated as `jessemcnew`; `jessemcnew/hermes-agent` fork created; local `fork` remote repointed; active draft PRs moved from `heavyMGS` to `jessemcnew`.
+- 2026-06-10: Apple Music MusicKit setup completed; Telegram playlist create/add verified through `musickit_api`.
+- 2026-06-10: Created the `User Action` label and the Linear action-items view.
+- 2026-06-10: Added the workflow rule for surfacing user action items.

--- a/docs/operator/HERMES_RUNTIME.md
+++ b/docs/operator/HERMES_RUNTIME.md
@@ -1,0 +1,62 @@
+# Hermes Runtime Handoff
+
+Canonical current-state handoff for Hermes on Studio. Update this file whenever
+runtime shape, active integrations, blockers, or next steps change in a
+meaningful way. New Codex threads should start here before relying on chat
+history.
+
+## Current Runtime Shape
+
+- Primary local model: `omlx` `qwen3-30b-a3b-instruct-2507-4bit`
+- Telegram/gateway primary: OpenRouter `deepseek/deepseek-v4-flash`
+- Telegram/gateway fallback: OpenRouter `deepseek/deepseek-v4-pro`
+- Gateway local failover: enabled with 25s no-first-chunk and stale-chunk cutoffs
+- Global CLI/default model: local `qwen3-30b-a3b-instruct-2507-4bit`
+- Telegram tool exposure: `computer_use` removed; core messaging, memory, web, music, and media tools remain
+- Memory: Studio family/karate operational memory migrated and verified
+
+## Active Integrations
+
+- Telegram gateway is the main daily chat surface
+- Fantastical MCP is configured but still under reliability scrutiny for calendar reads
+- Raindrop integration is configured in Hermes MCP, but auth still needs a valid accepted token flow before it is usable
+- Apple Music and Spotify integrations are active in the current Studio setup
+- Vapi outbound calling is active, but call quality and confirmation-safe handling still need work
+
+## Blockers
+
+- Raindrop MCP auth is not yet accepted by the service; config reaches the endpoint, but the current token flow returns `401 Unauthorized`
+- Fantastical remains a reliability follow-up for live schedule reads in agent-driven turns
+- Telegram tool surfaces still need further hardening for cost and context size
+
+## Done
+
+- Telegram MVP backhaul is working
+- `computer_use` is no longer exposed to Telegram
+- Family/karate memory migrated into Studio Hermes
+- Apple Music Telegram playlist create/add works
+- Hermes runtime docs and action-item workflow are now anchored in the repo
+
+## Next
+
+1. Finish Raindrop auth so bookmark search/add/tag flows work from Hermes
+2. Continue Telegram hardening on tool exposure and prompt/context size
+3. Resolve Fantastical reliability so schedule lookups are trustworthy again
+4. Keep Linear as the issue tracker and update issue comments whenever runtime state changes
+
+## Active Hermes Links
+
+- [HERMES-9](https://linear.app/agents-n-such/issue/HERMES-9/implement-confirmation-safe-vapi-outbound-calling-for-hermes-telegram)
+- [HERMES-10](https://linear.app/agents-n-such/issue/HERMES-10/track-studio-hermes-spotify-and-apple-music-integrations)
+- [HERMES-19](https://linear.app/agents-n-such/issue/HERMES-19/evaluate-and-enable-hermes-web-uicontrol-surfaces)
+- [HERMES-31](https://linear.app/agents-n-such/issue/HERMES-31/telegram-e2e-harness-final-reply-detection-after-tool-progress)
+
+## Handoff Format
+
+Use this shape in Linear comments, repo notes, and thread summaries:
+
+- Current state
+- Blockers
+- Next action
+- Action items for you
+- Links


### PR DESCRIPTION
## Summary
- add a canonical Hermes runtime handoff under docs/operator
- add an operator action-items index that links to the runbook
- codify the Hermes update checklist in AGENTS.md

## Tests
- docs-only change; not run

## Notes
- split from codex/studio-runtime-cleanup so this PR contains only the source-of-truth workflow docs