### PR TITLE
fix(openrouter): surface first-party router models (Fusion) in the model picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -72,6 +72,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # NVIDIA
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
     # OpenRouter routers
+    ("openrouter/fusion",                      "multi-model deliberation (panel + judge); priced as sum of all completions"),
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
     ("openrouter/elephant-alpha",              "free"),
@@ -1357,6 +1358,14 @@ def fetch_openrouter_models(
     fallback = list(remote) if remote else list(OPENROUTER_MODELS)
     preferred_ids = [mid for mid, _ in fallback]
 
+    # Ensure OpenRouter's first-party deliberation routers are always offered in
+    # the picker even when the (remote) curated manifest omits them. These are
+    # known-good meta routers we vouch for; they report empty
+    # supported_parameters but drive the agent loop fine (verified for fusion).
+    for _router_id in ("openrouter/fusion",):
+        if _router_id not in preferred_ids:
+            preferred_ids.append(_router_id)
+
     try:
         req = urllib.request.Request(
             "https://openrouter.ai/api/v1/models",
@@ -1388,7 +1397,14 @@ def fetch_openrouter_models(
         # Hide models that don't advertise tool-calling support — hermes-agent
         # requires it and surfacing them leads to immediate runtime failures
         # when the user selects them. Ported from Kilo-Org/kilocode#9068.
-        if not _openrouter_model_supports_tools(live_item):
+        #
+        # Exception: OpenRouter's own first-party router models (openrouter/*,
+        # e.g. fusion, auto, pareto-code) are deliberation/meta routers that
+        # report empty supported_parameters but still drive the agent loop fine
+        # — they synthesize a final answer server-side. They're in our curated
+        # list precisely because we vouch for them, so don't let the generic
+        # tool-support gate hide them.
+        if not preferred_id.startswith("openrouter/") and not _openrouter_model_supports_tools(live_item):
             continue
         desc = "free" if _openrouter_model_is_free(live_item.get("pricing")) else ""
         curated.append((preferred_id, desc))


### PR DESCRIPTION
## Problem

OpenRouter's first-party deliberation router **`openrouter/fusion`** never appears in the Hermes model picker, even with a valid `OPENROUTER_API_KEY`. Users have to hand-edit config to select it.

Two stacked causes in `hermes_cli/models.py`:

1. **Not a candidate.** The OpenRouter picker is a *curated* list (remote manifest via `get_curated_openrouter_models()`, with the in-repo `OPENROUTER_MODELS` snapshot as fallback). Neither included `openrouter/fusion`, so it never entered `preferred_ids` in `fetch_openrouter_models()`.
2. **Filtered out.** Even when present, the function hides any live model whose `supported_parameters` omits `tools` (the tool-calling-first gate from Kilo-Org/kilocode#9068). Fusion reports `supported_parameters: []` because it is a meta router, so it gets dropped.

## Why Fusion is a legitimate exception

Fusion is a multi-model deliberation router: a panel of models answers in parallel (with `openrouter:web_search`/`web_fetch` run **server-side**), a judge synthesizes consensus/contradictions/blind-spots, and it returns a final answer. It does not require **client-side** tool calling, and it drives the Hermes agent loop fine — verified end-to-end with a one-shot `hermes -z ... -m openrouter/fusion` run that completed normally.

The same applies to OpenRouter's other first-party routers (`openrouter/auto`, `openrouter/pareto-code`, etc.), which are curated entries we already vouch for.

## Fix (both layers)

- Add `openrouter/fusion` to the `OPENROUTER_MODELS` fallback snapshot.
- Always inject `openrouter/*` first-party routers into `preferred_ids` so they surface even when the remote curated manifest omits them.
- Exempt `openrouter/*` router ids from the `_openrouter_model_supports_tools()` filter (they are curated entries that report empty `supported_parameters`).

## Verify

```python
from hermes_cli.models import fetch_openrouter_models
ids = [m for m,_ in fetch_openrouter_models(force_refresh=True)]
assert "openrouter/fusion" in ids   # was absent before, present after
```

```bash
# live catalog confirms why the gate hid it:
curl -s https://openrouter.ai/api/v1/models | \
  python3 -c "import sys,json;[print(m['id'],m.get('supported_parameters')) for m in json.load(sys.stdin)['data'] if 'fusion' in m['id']]"
# openrouter/fusion []   ← empty supported_parameters
```

## Notes

- Cost transparency preserved: the picker entry is labeled *"multi-model deliberation (panel + judge); priced as sum of all completions"* so users know Fusion bills as the sum of every panel completion plus the judge.
- Behavior-contract friendly: the fix asserts a relationship (first-party `openrouter/*` routers are always offered and bypass the tool gate), not a frozen model-list snapshot.
