### PR TITLE
fix(cli): guard missing ui-tui workspace before TUI launch

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1650,6 +1650,22 @@ def _find_bundled_tui(hermes_cli_dir: Path | None = None) -> Path | None:
     return bundled if bundled.is_file() else None
 
 
+def _exit_missing_tui_workspace(tui_dir: Path) -> "NoReturn":
+    """Abort TUI launch with a recovery hint when the workspace checkout is missing."""
+    print(
+        "Error: the TUI workspace is missing from this Hermes checkout.\n"
+        f"Expected directory: {tui_dir}\n"
+        "This usually means `hermes update` left tracked ui-tui files deleted.\n"
+        "Recovery:\n"
+        "  1. From the Hermes checkout, run `git restore -- ui-tui`\n"
+        "  2. Run `npm install --silent --no-fund --no-audit --progress=false`\n"
+        "  3. Retry `hermes --tui`\n"
+        "If the checkout is still inconsistent, run `hermes update --force`.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
 def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     """TUI: --dev → tsx src; else node dist (HERMES_TUI_DIR prebuilt or esbuild)."""
     _ensure_tui_node()
@@ -1682,6 +1698,9 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             file=sys.stderr,
         )
         sys.exit(1)
+
+    if not ext_dir and not tui_dir.is_dir():
+        _exit_missing_tui_workspace(tui_dir)
 
     # 1. Prebuilt bundle (nix / packaged release): just run it.
     if not tui_dev:

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -327,6 +327,27 @@ def test_make_tui_argv_decodes_dev_prebuild_with_utf8_replace(
     _assert_utf8_replace_capture(calls[0][1])
 
 
+def test_make_tui_argv_exits_with_recovery_hint_when_workspace_missing(
+    tmp_path: Path, main_mod, monkeypatch, capsys
+) -> None:
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+
+    def fail_which(_name: str) -> str:
+        raise AssertionError("node/npm lookup must not run when ui-tui is missing")
+
+    monkeypatch.setattr(main_mod.shutil, "which", fail_which)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._make_tui_argv(tmp_path / "ui-tui", tui_dev=False)
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "TUI workspace is missing" in err
+    assert "git restore -- ui-tui" in err
+    assert "hermes update --force" in err
+
+
 # ── _workspace_root helper ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Prevents `hermes --tui` from crashing with `NotADirectoryError: [WinError 267]` when an update leaves the tracked `ui-tui/` workspace missing. `_make_tui_argv()` now detects that broken checkout state before any `npm` or `node` subprocess launch and exits with a concrete recovery path (`git restore -- ui-tui`, `npm install`, then `hermes --tui`, with `hermes update --force` as the fallback).

## Related Issue

Fixes #49145

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: add a missing-workspace preflight and print a recovery message instead of falling through to `subprocess.run(..., cwd=<missing ui-tui>)`.
- `tests/hermes_cli/test_tui_npm_install.py`: add a regression test that asserts the launcher exits cleanly and never looks up `node`/`npm` when `ui-tui/` is missing.

## How to Test

1. In a checkout without `HERMES_TUI_DIR` set, temporarily remove or rename the `ui-tui/` directory.
2. Run `hermes --tui`.
3. Confirm Hermes exits with the recovery instructions instead of crashing with `WinError 267` / `NotADirectoryError`.
4. Run `pytest tests/hermes_cli/test_tui_npm_install.py -q`.
5. Run `pytest tests/hermes_cli/test_tui_resume_flow.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS on darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## What platforms tested on

- macOS on darwin-arm64 (local)
- Windows not run locally; this fix targets the Windows broken-checkout path and is covered with a launcher-level regression test

## Screenshots / Logs

- Local broad-suite command `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` stopped during unrelated collection in `tests/hermes_cli/test_cron_fire_dashboard.py` because optional dashboard deps are unavailable in this environment: `SystemExit: Web UI requires fastapi and uvicorn.`
- Covering tests run locally: `pytest tests/hermes_cli/test_tui_npm_install.py -q` and `pytest tests/hermes_cli/test_tui_resume_flow.py -q`.

<!-- autocontrib:worker-id=issue-new-8a845c84 kind=pr-open -->