### PR TITLE
fix(approval): strip zero-width Unicode from commands before detection

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -570,6 +570,20 @@ def _normalize_command_for_detection(command: str) -> str:
     command = command.replace('\x00', '')
     # Normalize Unicode (fullwidth Latin, halfwidth Katakana, etc.)
     command = unicodedata.normalize('NFKC', command)
+    # Strip zero-width and invisible Unicode format characters that cannot
+    # be normalised away by NFKC (U+200B ZERO WIDTH SPACE, U+200C ZWNJ,
+    # U+200D ZWJ, bidi marks, word joiners, soft hyphens, variation
+    # selectors, etc.).  Without this step an AI agent can insert a
+    # U+200B between "rm" and " -rf" to evade pattern matching while the
+    # resulting string is still executed as "rm -rf" by the shell (the
+    # shell strips zero-width characters during word-splitting).
+    command = ''.join(
+        ch for ch in command
+        if unicodedata.category(ch) != 'Cf'
+    )
+    # Variation Selectors (VS1–VS256, U+FE00–U+FE0F and U+E0100–U+E01EF)
+    # also survive NFKC and can break regex word-boundary matching.
+    command = re.sub(r'[\ufe00-\ufe0f\U000e0100-\U000e01ef]', '', command)
     # Strip shell backslash-escapes: r\m → rm. Prevents \-injection bypass.
     command = re.sub(r'\\([^\n])', r'\1', command)
     # Strip empty-string literals that split tokens: r''m → rm, r"\"m → rm.


### PR DESCRIPTION
## Summary

Fixes a security bypass in the dangerous-command detection pipeline
(`tools/approval.py::_normalize_command_for_detection`) where Unicode
zero-width and invisible format characters survive NFKC normalization
and allow an attacker to evade pattern-based command blocking.

## Problem

The `_normalize_command_for_detection` function applies six layers of
defense before matching commands against dangerous-pattern regexes:

1. Strip ANSI escape sequences
2. Strip null bytes
3. NFKC Unicode normalization (fullwidth to ASCII)
4. Strip shell backslash-escapes (r\m to rm)
5. Strip empty-string literals (r''m to rm)
6. Fold resolved home/hermes paths

However, NFKC normalization does not remove zero-width and invisible
Unicode characters. Characters in Unicode category "Cf" (Format) and
Variation Selectors survive all six layers because none of them target
this class of characters.

### Proof of Concept

An AI agent (the very thing Hermes IS) can construct a command with an
invisible character between tokens to evade detection:

Normal command - detected as dangerous
rm -rf /

Same command with U+200B (ZERO WIDTH SPACE) between "rm" and " -rf"
The shell ignores ZWS during word-splitting, so execution is identical
rm -rf / <- NOT detected!

Python verification:

```python
import unicodedata

zws = '\u200b'  # U+200B ZERO WIDTH SPACE

normal = 'rm -rf /'
bypass = 'rm' + zws + ' -rf /'

# These look identical to human eyes
print(normal == bypass)  # False - Python sees the invisible character

# NFKC normalization does NOT remove it
norm = unicodedata.normalize('NFKC', bypass)
print(zws in norm)  # True - ZWS survives NFKC
```

## Fix

Add two steps to `_normalize_command_for_detection` after NFKC
normalization:

```python
# Strip zero-width and invisible Unicode format characters
# (category "Cf") that cannot be normalised away by NFKC.
command = ''.join(
    ch for ch in command
    if unicodedata.category(ch) != 'Cf'
)

# Strip Variation Selectors (U+FE00-U+FE0F, U+E0100-U+E01EF)
# that break regex word-boundary matching.
command = re.sub(r'[\ufe00-\ufe0f\U000e0100-\U000e01ef]', '', command)
```

## Verification

All 11 bypass vectors are now blocked:

| Input | Description | Before | After |
|---|---|---|---|
| rm -rf / | Normal (baseline) | BLOCKED | BLOCKED |
| rm[U+200B] -rf / | ZERO WIDTH SPACE | PASSED | BLOCKED |
| rm[U+200C] -rf / | ZERO WIDTH NON-JOINER | PASSED | BLOCKED |
| rm[U+200D] -rf / | ZERO WIDTH JOINER | PASSED | BLOCKED |
| rm[U+200E] -rf / | LTR MARK | PASSED | BLOCKED |
| rm[U+200F] -rf / | RTL MARK | PASSED | BLOCKED |
| rm[U+2060] -rf / | WORD JOINER | PASSED | BLOCKED |
| rm[U+FEFF] -rf / | BOM | PASSED | BLOCKED |
| rm[U+00AD] -rf / | SOFT HYPHEN | PASSED | BLOCKED |
| rm[U+FE00] -rf / | VS1 | PASSED | BLOCKED |
| echo hello | Safe command | ALLOWED | ALLOWED |

Safe commands (no zero-width injection) are unaffected.

## Related

- CWE-838: Inappropriate Encoding for Output Context
- https://trojansource.codes/ (CVE-2021-42574)