### PR TITLE
fix(context_compressor): thread custom_providers to get_model_context_length

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1542,6 +1542,7 @@ def init_agent(
             provider=agent.provider,
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
+            custom_providers=_custom_providers,
         )
     agent.compression_enabled = compression_enabled
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -683,6 +683,7 @@ class ContextCompressor(ContextEngine):
         provider: str = "",
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
+        custom_providers: list | None = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -704,6 +705,7 @@ class ContextCompressor(ContextEngine):
             model, base_url=base_url, api_key=api_key,
             config_context_length=config_context_length,
             provider=provider,
+            custom_providers=custom_providers,
         )
         # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even if
         # the percentage would suggest a lower value.  This prevents premature

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -190,6 +190,73 @@ class TestCompressorSessionReset:
         assert c._previous_summary is None
 
 
+class TestCompressorCustomProvidersOverride:
+    """Verify ContextCompressor respects per-model custom_providers context_length overrides.
+
+    Regression: before #47784, ContextCompressor.__init__ called
+    get_model_context_length() without the custom_providers parameter, so
+    per-model overrides in config.yaml's ``providers.<key>.models.<model>.
+    context_length`` were silently ignored — the compressor fell through to
+    the M3 hardcoded 1M bump (and similar provider-specific overrides)
+    instead of using the user-set value.
+    """
+
+    def test_custom_providers_per_model_override_reaches_compressor(self):
+        """Per-model context_length in custom_providers is honored."""
+        custom_providers = [
+            {
+                "name": "opencode-go",
+                "base_url": "https://opencode.ai/zen/go/v1",
+                "models": {
+                    "minimax-m3": {"context_length": 524288},
+                },
+            },
+        ]
+        c = ContextCompressor(
+            model="minimax-m3",
+            base_url="https://opencode.ai/zen/go/v1",
+            provider="opencode-go",
+            quiet_mode=True,
+            custom_providers=custom_providers,
+        )
+        # Without the fix, this would be 1,000,000 (M3 hardcoded bump).
+        assert c.context_length == 524288
+
+    def test_custom_providers_none_falls_back_to_legacy_path(self):
+        """custom_providers=None is a valid no-op (backward compatible)."""
+        c = ContextCompressor(
+            model="minimax-m3",
+            base_url="https://opencode.ai/zen/go/v1",
+            provider="opencode-go",
+            quiet_mode=True,
+            config_context_length=524288,
+            custom_providers=None,
+        )
+        # config_context_length still works on its own (step 0 of the chain).
+        assert c.context_length == 524288
+
+    def test_custom_providers_does_not_override_explicit_config(self):
+        """config_context_length (step 0) wins over custom_providers (step 0b)."""
+        custom_providers = [
+            {
+                "name": "opencode-go",
+                "base_url": "https://opencode.ai/zen/go/v1",
+                "models": {
+                    "minimax-m3": {"context_length": 524288},
+                },
+            },
+        ]
+        c = ContextCompressor(
+            model="minimax-m3",
+            base_url="https://opencode.ai/zen/go/v1",
+            provider="opencode-go",
+            quiet_mode=True,
+            config_context_length=200000,  # user-set, should win
+            custom_providers=custom_providers,
+        )
+        assert c.context_length == 200000
+
+
 # ---------------------------------------------------------------------------
 # Plugin slot (PluginManager integration)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Closes the second half of the bug family tracked in #47782. Where #47783 fixed the bare-vs-prefixed divergence in `get_model_context_length`, this PR fixes a wiring bug that prevented the resolution chain's per-model `custom_providers` override from reaching the context compressor at agent startup.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issue

Companion to #47783, addresses the implementation gap identified while reproducing #47782. Without this fix, per-model `context_length` overrides in `config.yaml`'s `providers.<key>.models.<model>.context_length` are silently ignored at agent startup — the compressor falls through to the M3 hardcoded 1M bump (and similar provider-specific overrides) instead of using the user-set value.

## Bug Description

**Repro (config.yaml):**
```yaml
providers:
  opencode-go:
    models:
      minimax-m3:
        context_length: 524288
```

**Expected:** `compressor.context_length == 524288`
**Actual:** `compressor.context_length == 1_000_000`

## Root Cause

`agent/context_compressor.py:703-707` called `get_model_context_length(...)` without the `custom_providers` parameter:

```python
self.context_length = get_model_context_length(
    model, base_url=base_url, api_key=api_key,
    config_context_length=config_context_length,
    provider=provider,
    # ← custom_providers missing
)
```

Without `custom_providers`, step 0b of the resolution chain (`hermes_cli.config.get_custom_provider_context_length`) returns `None`, and execution falls through to step 5 — the M3 hardcoded 1M bump at `model_metadata.py:1920`.

`/model` switch and `/info` display go through different code paths that *do* thread `custom_providers` correctly (per `_format_session_info` and `model_switch.resolve_display_context_length`), which is why the override appears to work in some surfaces but not others.

## Changes Made

### 1. `agent/context_compressor.py` (+2 lines)

Added `custom_providers: list | None = None` parameter to `__init__`, threaded through to `get_model_context_length`.

### 2. `agent/agent_init.py` (+1 line)

Passes the already-resolved `_custom_providers` list to `ContextCompressor()`.

### 3. `tests/agent/test_context_engine.py` (+67 lines)

New `TestCompressorCustomProvidersOverride` class with three tests:
- `test_custom_providers_per_model_override_reaches_compressor` — the regression test
- `test_custom_providers_none_falls_back_to_legacy_path` — backward compat
- `test_custom_providers_does_not_override_explicit_config` — precedence (step 0 > step 0b)

No other files touched.

## How to Test

```bash
git checkout fix/context-compressor-thread-custom-providers
pytest tests/agent/test_context_engine.py::TestCompressorCustomProvidersOverride -v
```

End-to-end:
1. Add a per-model override to `~/.hermes/config.yaml`:
   ```yaml
   providers:
     opencode-go:
       models:
         minimax-m3:
           context_length: 524288
   ```
2. Launch `hermes` (no `/resume`).
3. Send a prompt to M3.
4. Inspect the TUI status bar — it should now show `.../524K` instead of `.../1M`.
5. Inspect `~/.hermes/state.db` session row — `context_length` should be `524288`.

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — `fix(context_compressor): thread custom_providers to get_model_context_length`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and confirmed this is not a duplicate
- [x] My code follows the project's style guidelines (existing parameter pattern in `__init__`)

### Code

- [x] My change requires no changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings

### Documentation & Housekeeping

- [x] I have run `hermes curator` and addressed any flagged issues
- [x] I have run `hermes format` and verified the output matches the project's formatting style
- [x] I have updated any relevant documentation in `website/docs/`

*Small, focused PR per CONTRIBUTING.md "Keep PRs focused" guidance. Companion to #47783, same bug family as #47782.*