### PR TITLE
fix(cron): fall back to default scripts dir when profile context misses script

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -38,7 +38,7 @@ from typing import List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hermes_constants import get_hermes_home
+from hermes_constants import _get_platform_default_hermes_home, get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
@@ -990,8 +990,23 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             f"({scripts_dir_resolved}): {script_path!r}"
         )
 
+    # Fallback: when running inside a non-default profile, also check the
+    # default ~/.hermes/scripts/ directory.  Users who place scripts in the
+    # global scripts dir expect them to work regardless of which profile
+    # the cron scheduler is running under.
     if not path.exists():
-        return False, f"Script not found: {path}"
+        default_home = _get_platform_default_hermes_home()
+        default_scripts = default_home / "scripts"
+        if default_scripts.resolve() != scripts_dir_resolved:
+            default_candidate = (default_scripts / raw).resolve() if not raw.is_absolute() else path
+            try:
+                default_candidate.relative_to(default_scripts.resolve())
+                if default_candidate.exists() and default_candidate.is_file():
+                    path = default_candidate
+            except ValueError:
+                pass
+        if not path.exists():
+            return False, f"Script not found: {path}"
     if not path.is_file():
         return False, f"Script path is not a file: {path}"
 

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -540,3 +540,109 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+
+
+class TestScriptProfileFallback:
+    """Test that scripts resolve to the default ~/.hermes/scripts/ when not
+    found in the profile-specific scripts directory."""
+
+    def test_script_in_default_dir_found_from_profile_context(self, tmp_path, monkeypatch):
+        """When HERMES_HOME points to a profile dir, scripts in the default
+        ~/.hermes/scripts/ should still be found."""
+        from cron.scheduler import _run_job_script
+
+        # Simulate a profile context: HERMES_HOME = ~/.hermes/profiles/personal/
+        default_home = tmp_path / ".hermes"
+        profile_home = default_home / "profiles" / "personal"
+        profile_home.mkdir(parents=True)
+        (profile_home / "scripts").mkdir()
+
+        # Script exists in default scripts dir, NOT in profile scripts dir
+        default_scripts = default_home / "scripts"
+        default_scripts.mkdir(parents=True)
+        script = default_scripts / "watchdog.sh"
+        script.write_text('#!/bin/bash\necho "default fallback"')
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        import cron.scheduler as sched_mod
+        monkeypatch.setattr(sched_mod, "_hermes_home", profile_home)
+        monkeypatch.setattr(
+            "cron.scheduler._get_platform_default_hermes_home",
+            lambda: default_home,
+        )
+
+        success, output = _run_job_script("watchdog.sh")
+        assert success is True
+        assert "default fallback" in output
+
+    def test_profile_script_takes_precedence_over_default(self, tmp_path, monkeypatch):
+        """When a script exists in both profile and default dirs, the profile
+        version should take precedence."""
+        from cron.scheduler import _run_job_script
+
+        default_home = tmp_path / ".hermes"
+        profile_home = default_home / "profiles" / "personal"
+        (profile_home / "scripts").mkdir(parents=True)
+        (default_home / "scripts").mkdir(parents=True)
+
+        # Same script name in both locations with different content
+        (profile_home / "scripts" / "check.py").write_text('print("profile")')
+        (default_home / "scripts" / "check.py").write_text('print("default")')
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        import cron.scheduler as sched_mod
+        monkeypatch.setattr(sched_mod, "_hermes_home", profile_home)
+        monkeypatch.setattr(
+            "cron.scheduler._get_platform_default_hermes_home",
+            lambda: default_home,
+        )
+
+        success, output = _run_job_script("check.py")
+        assert success is True
+        assert output == "profile"
+
+    def test_fallback_not_triggered_in_default_context(self, tmp_path, monkeypatch):
+        """When HERMES_HOME IS the default dir, no fallback should occur
+        (the dirs are the same)."""
+        from cron.scheduler import _run_job_script
+
+        default_home = tmp_path / ".hermes"
+        (default_home / "scripts").mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+        import cron.scheduler as sched_mod
+        monkeypatch.setattr(sched_mod, "_hermes_home", default_home)
+        monkeypatch.setattr(
+            "cron.scheduler._get_platform_default_hermes_home",
+            lambda: default_home,
+        )
+
+        # Script doesn't exist — should fail without fallback attempt
+        success, output = _run_job_script("nonexistent.py")
+        assert success is False
+        assert "not found" in output.lower()
+
+    def test_fallback_path_traversal_still_blocked(self, tmp_path, monkeypatch):
+        """Path traversal must be blocked even in the fallback path."""
+        from cron.scheduler import _run_job_script
+
+        default_home = tmp_path / ".hermes"
+        profile_home = default_home / "profiles" / "personal"
+        (profile_home / "scripts").mkdir(parents=True)
+        (default_home / "scripts").mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        import cron.scheduler as sched_mod
+        monkeypatch.setattr(sched_mod, "_hermes_home", profile_home)
+        monkeypatch.setattr(
+            "cron.scheduler._get_platform_default_hermes_home",
+            lambda: default_home,
+        )
+
+        # Traversal attempt — should be blocked by the initial check
+        success, output = _run_job_script("../../etc/passwd")
+        assert success is False


### PR DESCRIPTION
## What does this PR do?

Fixes cron script resolution when the scheduler runs inside a non-default profile. Scripts placed in the global `~/.hermes/scripts/` directory are now found even when `HERMES_HOME` points to a profile-specific directory like `~/.hermes/profiles/personal/`.

## Related Issue

Fixes #49158

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: Added fallback in `_run_job_script()` to check the platform-default `~/.hermes/scripts/` directory when a script is not found in the profile-specific scripts directory. Profile scripts still take precedence when both exist.
- `tests/cron/test_cron_script.py`: Added `TestScriptProfileFallback` class with 4 tests covering fallback resolution, precedence, default-context no-op, and path traversal blocking.

## How to Test

1. Create a profile: `hermes profile create test-profile`
2. Place a script in `~/.hermes/scripts/watchdog.sh` (global scripts dir)
3. Run `hermes --profile test-profile cron tick` — the script should be found via fallback
4. Place a different `watchdog.sh` in `~/.hermes/profiles/test-profile/scripts/` — the profile version should take precedence
5. Run `pytest tests/cron/test_cron_script.py -q` — all 40 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `cron/scheduler.py::_run_job_script`, `hermes_constants.py::_get_platform_default_hermes_home`
- Blast radius: LOW — single function, fallback-only path
- Related patterns: `_get_hermes_home()` profile resolution, `Path.relative_to()` containment guard
