### PR TITLE
feat(gateway): add secure message redaction lane

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -100,6 +100,45 @@ def _image_error_max_dimension(error: Exception) -> Optional[int]:
     return None
 
 
+def _secure_marker_bounds() -> tuple[str, str]:
+    """Return configured secure marker bounds, falling back to defaults."""
+    start = "[[secure]]"
+    end = "[[/secure]]"
+    try:
+        from hermes_cli.config import load_config as _load_config
+        cfg = _load_config()
+        display = cfg.get("display", {}) if isinstance(cfg, dict) else {}
+        secure = display.get("secure_messages", {}) if isinstance(display, dict) else {}
+        if isinstance(secure, dict):
+            start = str(secure.get("marker_start") or start)
+            end = str(secure.get("marker_end") or end)
+    except Exception:
+        pass
+    return start, end
+
+
+def _redact_secure_markers(text: Any) -> Any:
+    """Remove secure-marker payloads from durable agent records."""
+    if not isinstance(text, str):
+        return text
+    start, end = _secure_marker_bounds()
+    if start not in text:
+        return text
+    return re.sub(
+        rf"{re.escape(start)}.*?(?:{re.escape(end)}|$)",
+        "[redacted — secure message omitted from transcript]",
+        text,
+        flags=re.DOTALL,
+    )
+
+
+def _redact_secure_markers_in_messages(messages: list) -> None:
+    """In-place redaction for assistant transcript messages before persistence."""
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            msg["content"] = _redact_secure_markers(msg.get("content"))
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -48,7 +48,7 @@ def finalize_turn(
     Lifted verbatim from ``run_conversation`` (the region after the main agent
     loop). See module docstring.
     """
-    from agent.conversation_loop import logger
+    from agent.conversation_loop import logger, _redact_secure_markers, _redact_secure_markers_in_messages
 
     if final_response is None and (
         api_call_count >= agent.max_iterations
@@ -128,6 +128,12 @@ def finalize_turn(
         and not failed
     )
 
+    # Redact before every durable save path (trajectory samples, JSONL logs,
+    # SQLite, and external-memory sync). The visible gateway reply is produced
+    # from ``final_response`` elsewhere; this mutation affects only persisted
+    # agent records.
+    _redact_secure_markers_in_messages(messages)
+
     # Save trajectory if enabled.  ``user_message`` may be a multimodal
     # list of parts; the trajectory format wants a plain string.
     agent._save_trajectory(messages, _summarize_user_message_for_log(user_message), completed)
@@ -140,6 +146,7 @@ def finalize_turn(
     # can replay assistant("(empty)") / recovery nudges and fall into the
     # same empty-response loop again.
     agent._drop_trailing_empty_response_scaffolding(messages)
+    _redact_secure_markers_in_messages(messages)
     agent._persist_session(messages, conversation_history)
 
     # ── Turn-exit diagnostic log ─────────────────────────────────────
@@ -297,7 +304,7 @@ def finalize_turn(
                 task_id=effective_task_id,
                 turn_id=turn_id,
                 user_message=original_user_message,
-                assistant_response=final_response,
+                assistant_response=_redact_secure_markers(final_response),
                 conversation_history=list(messages),
                 model=agent.model,
                 platform=getattr(agent, "platform", None) or "",
@@ -383,7 +390,7 @@ def finalize_turn(
     # External memory provider: sync the completed turn + queue next prefetch.
     agent._sync_external_memory_for_turn(
         original_user_message=original_user_message,
-        final_response=final_response,
+        final_response=_redact_secure_markers(final_response),
         interrupted=interrupted,
         messages=messages,
     )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1611,6 +1611,43 @@ class EphemeralReply(str):
         return str.__str__(self)
 
 
+class SecureReply(str):
+    """Sensitive reply that should expire/redact after a TTL.
+
+    This is the content-bearing counterpart to :class:`EphemeralReply`:
+    the message remains visible only long enough for the user to copy it,
+    then the adapter prefers editing the bot-owned message to a redacted
+    audit marker, falling back to delete where edit is unavailable.  Platforms
+    with no edit/delete support still get transcript metadata and visible
+    text that says expiry is best-effort rather than pretending magic exists.
+    """
+
+    ttl_seconds: Optional[int]
+    redacted_text: str
+    protect_content: bool
+    spoiler: bool
+
+    def __new__(
+        cls,
+        text: str,
+        ttl_seconds: Optional[int] = None,
+        *,
+        redacted_text: Optional[str] = None,
+        protect_content: bool = True,
+        spoiler: bool = True,
+    ):
+        instance = super().__new__(cls, text)
+        instance.ttl_seconds = ttl_seconds
+        instance.redacted_text = redacted_text or "[redacted — secure message expired]"
+        instance.protect_content = bool(protect_content)
+        instance.spoiler = bool(spoiler)
+        return instance
+
+    @property
+    def text(self) -> str:
+        return str.__str__(self)
+
+
 def merge_pending_message_event(
     pending_messages: Dict[str, MessageEvent],
     session_key: str,
@@ -1696,7 +1733,7 @@ _RETRYABLE_ERROR_PATTERNS = (
 # Type for message handlers.  Handlers may return a plain string (normal
 # reply), an ``EphemeralReply`` to opt the reply into auto-deletion, or
 # ``None`` when the response was already delivered (e.g. via streaming).
-MessageHandler = Callable[[MessageEvent], Awaitable[Optional[Union[str, "EphemeralReply"]]]]
+MessageHandler = Callable[[MessageEvent], Awaitable[Optional[Union[str, "EphemeralReply", "SecureReply"]]]]
 
 
 def resolve_channel_prompt(
@@ -2439,6 +2476,146 @@ class BasePlatformAdapter(ABC):
             return int(raw)
         except (TypeError, ValueError):
             return 0
+
+    def _get_secure_message_config(self) -> dict:
+        """Return merged global/per-platform secure-message config.
+
+        Config lives under ``display.secure_messages`` with optional per-platform
+        overrides under ``display.platforms.<platform>.secure_messages``.  The
+        feature is opt-in; marker-based ``SecureReply`` still works even when
+        global auto-detection is disabled.
+        """
+        base = {
+            "enabled": False,
+            "ttl_seconds": 300,
+            "spoiler": True,
+            "protect_content": True,
+            "redacted_text": "[redacted — secure message expired]",
+            "marker_start": "[[secure]]",
+            "marker_end": "[[/secure]]",
+        }
+        try:
+            from hermes_cli.config import load_config as _load_config
+            cfg = _load_config()
+        except Exception:
+            return base
+        display = cfg.get("display", {}) if isinstance(cfg, dict) else {}
+        if not isinstance(display, dict):
+            return base
+        global_cfg = display.get("secure_messages")
+        if isinstance(global_cfg, dict):
+            base.update(global_cfg)
+        platforms = display.get("platforms", {})
+        platform_name = _platform_name(getattr(self, "platform", None) or getattr(self, "name", None))
+        if isinstance(platforms, dict):
+            per_platform = platforms.get(platform_name)
+            if isinstance(per_platform, dict):
+                platform_cfg = per_platform.get("secure_messages")
+                if isinstance(platform_cfg, dict):
+                    base.update(platform_cfg)
+        return base
+
+    def _supports_secure_edit(self) -> bool:
+        """Whether this adapter has a real edit-message implementation."""
+        return type(self).edit_message is not BasePlatformAdapter.edit_message
+
+    def _supports_secure_delete(self) -> bool:
+        """Whether this adapter has a real delete-message implementation."""
+        return type(self).delete_message is not BasePlatformAdapter.delete_message
+
+    def _render_secure_content(self, text: str, *, spoiler: bool = True) -> str:
+        """Apply best-effort platform hiding without claiming secrecy.
+
+        Telegram and Discord understand ``||spoiler||``. Other platforms leave
+        the content as-is and rely on expiry/redaction where available.
+        """
+        if not spoiler:
+            return text
+        platform_name = _platform_name(getattr(self, "platform", None) or getattr(self, "name", None))
+        if platform_name in {"telegram", "discord"}:
+            safe = str(text).replace("||", "|\u200b|")
+            return f"||{safe}||"
+        return text
+
+    def _extract_secure_marker(self, text: str) -> tuple[str, bool]:
+        """Strip ``[[secure]]...[[/secure]]`` marker if present."""
+        cfg = self._get_secure_message_config()
+        start = str(cfg.get("marker_start") or "[[secure]]")
+        end = str(cfg.get("marker_end") or "[[/secure]]")
+        if not text or start not in text:
+            return text, False
+        stripped = text.replace(start, "", 1)
+        if end in stripped:
+            stripped = stripped.replace(end, "", 1)
+        return stripped.strip(), True
+
+    def _unwrap_secure(self, response: Any) -> tuple[Optional[str], Optional[dict]]:
+        """Unwrap SecureReply/marker text into content + secure metadata."""
+        cfg = self._get_secure_message_config()
+        if isinstance(response, SecureReply):
+            ttl = response.ttl_seconds
+            if ttl is None:
+                ttl = int(cfg.get("ttl_seconds") or 300)
+            return response.text, {
+                "ttl_seconds": int(ttl or 0),
+                "redacted_text": response.redacted_text,
+                "protect_content": bool(response.protect_content),
+                "spoiler": bool(response.spoiler),
+            }
+        if isinstance(response, str):
+            stripped, marked = self._extract_secure_marker(response)
+            if marked:
+                return stripped, {
+                    "ttl_seconds": int(cfg.get("ttl_seconds") or 300),
+                    "redacted_text": str(cfg.get("redacted_text") or "[redacted — secure message expired]"),
+                    "protect_content": bool(cfg.get("protect_content", True)),
+                    "spoiler": bool(cfg.get("spoiler", True)),
+                }
+        return response, None
+
+    def _schedule_secure_redaction(
+        self,
+        chat_id: str,
+        message_id: str,
+        ttl_seconds: int,
+        redacted_text: str,
+        *,
+        metadata: Optional[dict] = None,
+    ) -> None:
+        """After TTL, replace a sensitive message with a redacted marker.
+
+        Prefer edit to preserve conversational context.  If edit is not
+        available but delete is, delete.  If neither exists, the message stays
+        visible; the caller can inspect capabilities and warn if needed.
+        """
+
+        async def _run_redact() -> None:
+            try:
+                await asyncio.sleep(max(1, int(ttl_seconds)))
+                if self._supports_secure_edit():
+                    result = await self.edit_message(
+                        chat_id=chat_id,
+                        message_id=message_id,
+                        content=redacted_text,
+                        finalize=True,
+                    )
+                    if getattr(result, "success", False):
+                        return
+                if self._supports_secure_delete():
+                    await self.delete_message(chat_id=chat_id, message_id=message_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.debug(
+                    "[%s] Secure redaction failed for %s/%s: %s",
+                    self.name, chat_id, message_id, e,
+                )
+
+        coro = _run_redact()
+        try:
+            asyncio.create_task(coro)
+        except RuntimeError:
+            coro.close()
 
     def _schedule_ephemeral_delete(
         self,
@@ -4194,11 +4371,11 @@ class BasePlatformAdapter(ABC):
             # Slash-command handlers may return an EphemeralReply sentinel to
             # request that their reply message auto-delete after a TTL (used
             # for system notices like "✨ New session started!" that the user
-            # doesn't need to keep in the thread).  Unwrap here so all the
-            # downstream extract_media / text-processing logic sees a plain
-            # string, and remember the TTL + platform capability so the
-            # post-send block can schedule the deletion.
+            # doesn't need to keep in the thread).  SecureReply and the
+            # [[secure]]...[[/secure]] marker request best-effort platform
+            # hiding plus post-TTL redaction/deletion.
             response, _ephemeral_ttl = self._unwrap_ephemeral(response)
+            response, _secure_meta = self._unwrap_secure(response)
 
             # Send response if any.  A None/empty response is normal when
             # streaming already delivered the text (already_sent=True) or
@@ -4232,22 +4409,35 @@ class BasePlatformAdapter(ABC):
                 # Pre-extract snapshot for the #29346 recovery/invariant below.
                 _response_pre_extract = response
 
-                # Extract MEDIA:<path> tags (from TTS tool) before other processing
-                media_files, response = self.extract_media(response)
-                media_files = self.filter_media_delivery_paths(media_files)
+                # Extract MEDIA:<path> tags (from TTS tool) before other processing.
+                # Secure replies are intentionally text-only for now: native
+                # attachments cannot be edited on every platform after TTL, so
+                # extracting MEDIA/image/local-file payloads would leave a
+                # supposedly secure artifact permanently visible.
+                if _secure_meta:
+                    media_files = []
+                else:
+                    media_files, response = self.extract_media(response)
+                    media_files = self.filter_media_delivery_paths(media_files)
 
                 # Extract image URLs and send them as native platform attachments
-                images, text_content = self.extract_images(response)
+                if _secure_meta:
+                    images = []
+                    text_content = response
+                else:
+                    images, text_content = self.extract_images(response)
                 # Strip any remaining internal directives from message body (fixes #1561).
                 # _strip_media_directives shares MEDIA_TAG_CLEANUP_RE, so a MEDIA: tag
                 # with an unknown extension is intentionally left in the body for
                 # extract_local_files below to pick up rather than silently dropped (#34517).
                 text_content = _strip_media_directives(text_content).strip()
+                if _secure_meta and not text_content:
+                    text_content = "[secure attachment omitted — native secure media expiry is not supported]"
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
 
                 local_files = []
-                if not is_ephemeral_response:
+                if not (is_ephemeral_response or _secure_meta):
                     # Auto-detect bare local file paths for native media delivery
                     # (helps small models that don't use MEDIA: syntax). Skip
                     # system/command notices so config paths stay visible text
@@ -4333,8 +4523,15 @@ class BasePlatformAdapter(ABC):
 
                 # Send the text portion
                 if text_content and not _tts_caption_delivered:
+                    if _secure_meta:
+                        text_content = self._render_secure_content(
+                            text_content,
+                            spoiler=bool(_secure_meta.get("spoiler", True)),
+                        )
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
                     _reply_anchor = _reply_anchor_for_event(event)
+                    if _secure_meta:
+                        _final_thread_metadata["secure_message"] = dict(_secure_meta)  # type: ignore[index]
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,
                         content=text_content,
@@ -4356,6 +4553,19 @@ class BasePlatformAdapter(ABC):
                             chat_id=event.source.chat_id,
                             message_id=result.message_id,
                             ttl_seconds=_ephemeral_ttl,
+                        )
+                    if (
+                        _secure_meta
+                        and int(_secure_meta.get("ttl_seconds") or 0) > 0
+                        and result.success
+                        and result.message_id
+                    ):
+                        self._schedule_secure_redaction(
+                            chat_id=event.source.chat_id,
+                            message_id=result.message_id,
+                            ttl_seconds=int(_secure_meta.get("ttl_seconds") or 0),
+                            redacted_text=str(_secure_meta.get("redacted_text") or "[redacted — secure message expired]"),
+                            metadata=_thread_metadata,
                         )
 
                 # Human-like pacing delay between text and media

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -529,6 +529,17 @@ class TelegramAdapter(BasePlatformAdapter):
             return {}
         return {"disable_notification": True}
 
+    def _telegram_secure_kwargs(self, metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Return Telegram-specific secure-delivery kwargs.
+
+        ``protect_content`` prevents Telegram clients from forwarding/saving the
+        bot-owned message. It is not secrecy; it is a useful seatbelt.
+        """
+        secure = metadata.get("secure_message") if isinstance(metadata, dict) else None
+        if isinstance(secure, dict) and secure.get("protect_content"):
+            return {"protect_content": True}
+        return {}
+
     def _is_callback_user_authorized(
         self,
         user_id: str,
@@ -1186,6 +1197,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # which must not be sent as a stray field on the raw endpoint.
         payload.update({k: v for k, v in thread_kwargs.items() if v is not None})
         payload.update(self._notification_kwargs(metadata))
+        payload.update(self._telegram_secure_kwargs(metadata))
         if getattr(self, "_disable_link_previews", False):
             payload["link_preview_options"] = {"is_disabled": True}
         if reply_to_id is not None:
@@ -2444,6 +2456,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
+                                **self._telegram_secure_kwargs(metadata),
                             )
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
@@ -2458,6 +2471,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
+                                    **self._telegram_secure_kwargs(metadata),
                                 )
                             else:
                                 raise
@@ -2935,6 +2949,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **retry_thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
+                                **self._telegram_secure_kwargs(metadata),
                             )
                             break
                         except Exception as _retry_err:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -758,8 +758,36 @@ class GatewayStreamConsumer:
     _MEDIA_RE = MEDIA_TAG_CLEANUP_RE
 
     @staticmethod
+    def _secure_marker_bounds() -> tuple[str, str]:
+        start = "[[secure]]"
+        end = "[[/secure]]"
+        try:
+            from hermes_cli.config import load_config as _load_config
+            cfg = _load_config()
+            display = cfg.get("display", {}) if isinstance(cfg, dict) else {}
+            secure = display.get("secure_messages", {}) if isinstance(display, dict) else {}
+            if isinstance(secure, dict):
+                start = str(secure.get("marker_start") or start)
+                end = str(secure.get("marker_end") or end)
+        except Exception:
+            pass
+        return start, end
+
+    @staticmethod
+    def _redact_secure_for_display(text: str) -> str:
+        start, end = GatewayStreamConsumer._secure_marker_bounds()
+        if start not in text:
+            return text
+        return re.sub(
+            rf"{re.escape(start)}.*?(?:{re.escape(end)}|$)",
+            "[redacted — secure message omitted from stream]",
+            text,
+            flags=re.DOTALL,
+        )
+
+    @staticmethod
     def _clean_for_display(text: str) -> str:
-        """Strip MEDIA: directives and internal markers from text before display.
+        """Strip MEDIA directives and internal markers from text before display.
 
         The streaming path delivers raw text chunks that may include
         ``MEDIA:<path>`` tags and ``[[audio_as_voice]]`` directives meant for
@@ -768,6 +796,7 @@ class GatewayStreamConsumer:
         stream finishes — we just need to hide the raw directives from the
         user.
         """
+        text = GatewayStreamConsumer._redact_secure_for_display(text)
         if "MEDIA:" not in text and "[[audio_as_voice]]" not in text:
             return text
         cleaned = text.replace("[[audio_as_voice]]", "")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1614,6 +1614,22 @@ DEFAULT_CONFIG = {
         # responses and content messages are never touched.  Default 0
         # (disabled) preserves prior behavior.
         "ephemeral_system_ttl": 0,
+        # Sensitive final replies can opt into a best-effort secure delivery
+        # path by returning gateway.platforms.base.SecureReply or wrapping the
+        # visible text in [[secure]]...[[/secure]]. Gateway sends then apply
+        # platform capabilities where available: Telegram/Discord spoiler
+        # formatting, Telegram protect_content, and post-TTL redaction by edit
+        # or delete. Defaults keep automatic marker behavior off unless a
+        # handler explicitly returns SecureReply/marker text.
+        "secure_messages": {
+            "enabled": False,
+            "ttl_seconds": 300,
+            "spoiler": True,
+            "protect_content": True,
+            "redacted_text": "[redacted — secure message expired]",
+            "marker_start": "[[secure]]",
+            "marker_end": "[[/secure]]",
+        },
         # Per-platform display/streaming overrides. Each key is a gateway
         # platform ("telegram", "discord", "slack", …) mapping to a dict of
         # display settings that override the global value for that platform
@@ -1866,6 +1882,11 @@ DEFAULT_CONFIG = {
         "write_approval": False,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        # Warm memory is durable and retrievable, but never injected into
+        # the system prompt. It absorbs useful overflow without prompt bloat.
+        "warm_memory_enabled": True,
+        "warm_memory_char_limit": 50000,
+        "warm_user_char_limit": 25000,
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".
@@ -2277,6 +2298,12 @@ DEFAULT_CONFIG = {
         # Wrap delivered cron responses with a header (task name) and footer
         # ("The agent cannot see this message").  Set to false for clean output.
         "wrap_response": True,
+        # Persistent memory policy for LLM-driven cron jobs:
+        #   off       — historical behaviour; no MEMORY.md / USER.md injection
+        #   read_only — inject memory snapshot, but keep memory writes disabled
+        #   full      — inject memory and allow memory tools subject to toolsets
+        # Per-job memory_mode can override this for continuity jobs.
+        "memory_mode": "off",
         # Maximum number of due jobs to run in parallel per tick.
         # null/0 = unbounded (limited only by thread count).
         # 1 = serial (pre-v0.9 behaviour).

--- a/tests/agent/test_secure_message_redaction.py
+++ b/tests/agent/test_secure_message_redaction.py
@@ -1,0 +1,36 @@
+from agent.conversation_loop import _redact_secure_markers, _redact_secure_markers_in_messages
+
+
+def test_redact_secure_markers_removes_payload():
+    text = "Password: [[secure]]abc123[[/secure]] after"
+
+    redacted = _redact_secure_markers(text)
+
+    assert "abc123" not in redacted
+    assert "[redacted — secure message omitted from transcript]" in redacted
+    assert redacted.endswith(" after")
+
+
+def test_redact_secure_markers_in_messages_only_assistant_content():
+    messages = [
+        {"role": "user", "content": "[[secure]]user text[[/secure]]"},
+        {"role": "assistant", "content": "token [[secure]]abc123[[/secure]]"},
+        {"role": "tool", "content": "[[secure]]tool text[[/secure]]"},
+    ]
+
+    _redact_secure_markers_in_messages(messages)
+
+    assert messages[0]["content"] == "[[secure]]user text[[/secure]]"
+    assert "abc123" not in messages[1]["content"]
+    assert messages[2]["content"] == "[[secure]]tool text[[/secure]]"
+
+
+def test_redact_secure_markers_honors_configured_bounds(monkeypatch):
+    import agent.conversation_loop as loop
+
+    monkeypatch.setattr(loop, "_secure_marker_bounds", lambda: ("<<secret>>", "<</secret>>"))
+
+    redacted = _redact_secure_markers("token <<secret>>abc123<</secret>>")
+
+    assert "abc123" not in redacted
+    assert "[redacted — secure message omitted from transcript]" in redacted

--- a/tests/gateway/test_ephemeral_reply.py
+++ b/tests/gateway/test_ephemeral_reply.py
@@ -29,6 +29,7 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
     EphemeralReply,
+    SecureReply,
     MessageEvent,
     MessageType,
     SendResult,
@@ -365,3 +366,197 @@ async def test_process_message_plain_string_behaves_unchanged():
     adapter._send_with_retry.assert_called_once()
     assert adapter._send_with_retry.call_args.kwargs["content"] == "plain reply"
     assert adapter.deleted == []  # no auto-delete for plain replies
+
+
+class _EditCapableAdapter(_DeleteCapableAdapter):
+    """Adapter that can edit first, delete as fallback."""
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.edited: list[tuple[str, str, str]] = []
+
+    async def edit_message(self, chat_id: str, message_id: str, content: str, *, finalize: bool = False) -> SendResult:
+        self.edited.append((chat_id, message_id, content))
+        return SendResult(success=True, message_id=message_id)
+
+
+def _edit_adapter():
+    return _EditCapableAdapter(
+        PlatformConfig(enabled=True, token="t"), Platform.TELEGRAM
+    )
+
+
+def test_unwrap_secure_reply_uses_explicit_metadata():
+    adapter = _delete_adapter()
+    text, meta = adapter._unwrap_secure(
+        SecureReply("pw=abc", ttl_seconds=45, redacted_text="pw=[expired]")
+    )
+    assert text == "pw=abc"
+    assert meta == {
+        "ttl_seconds": 45,
+        "redacted_text": "pw=[expired]",
+        "protect_content": True,
+        "spoiler": True,
+    }
+
+
+def test_unwrap_secure_marker_uses_config_defaults():
+    adapter = _delete_adapter()
+    with patch.object(
+        adapter,
+        "_get_secure_message_config",
+        return_value={
+            "ttl_seconds": 12,
+            "redacted_text": "[gone]",
+            "protect_content": False,
+            "spoiler": False,
+            "marker_start": "[[secure]]",
+            "marker_end": "[[/secure]]",
+        },
+    ):
+        text, meta = adapter._unwrap_secure("[[secure]]token=abc[[/secure]]")
+    assert text == "token=abc"
+    assert meta["ttl_seconds"] == 12
+    assert meta["redacted_text"] == "[gone]"
+    assert meta["protect_content"] is False
+    assert meta["spoiler"] is False
+
+
+def test_render_secure_content_spoiler_for_telegram_and_neutralizes_nested_delimiters():
+    adapter = _delete_adapter()
+    rendered = adapter._render_secure_content("alpha || beta", spoiler=True)
+    assert rendered.startswith("||") and rendered.endswith("||")
+    assert "|\u200b|" in rendered
+
+
+@pytest.mark.asyncio
+async def test_schedule_secure_redaction_prefers_edit_over_delete():
+    adapter = _edit_adapter()
+    import gateway.platforms.base as base_module
+
+    _real_sleep = base_module.asyncio.sleep
+
+    async def _fake_sleep(duration):
+        await _real_sleep(0)
+
+    with patch.object(base_module.asyncio, "sleep", _fake_sleep):
+        adapter._schedule_secure_redaction(
+            chat_id="42",
+            message_id="m-2",
+            ttl_seconds=5,
+            redacted_text="[expired]",
+        )
+        for _ in range(5):
+            await _real_sleep(0)
+
+    assert adapter.edited == [("42", "m-2", "[expired]")]
+    assert adapter.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_process_message_secure_reply_wraps_and_schedules_redaction():
+    adapter = _edit_adapter()
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=True, message_id="sent-secure")
+    )
+
+    async def _handler(evt):
+        return SecureReply("Password: abc", ttl_seconds=5, redacted_text="Password: [expired]")
+
+    adapter.set_message_handler(_handler)
+    event = _make_event()
+    session_key = "agent:main:telegram:private:42"
+
+    import gateway.platforms.base as base_module
+    _real_sleep = base_module.asyncio.sleep
+
+    async def _fake_sleep(duration):
+        await _real_sleep(0)
+
+    with patch.object(base_module.asyncio, "sleep", _fake_sleep), patch.object(
+        adapter, "_keep_typing", new=AsyncMock()
+    ):
+        await adapter._process_message_background(event, session_key)
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+    adapter._send_with_retry.assert_called_once()
+    kwargs = adapter._send_with_retry.call_args.kwargs
+    assert kwargs["content"] == "||Password: abc||"
+    assert kwargs["metadata"]["secure_message"]["protect_content"] is True
+    assert ("42", "sent-secure", "Password: [expired]") in adapter.edited
+
+
+@pytest.mark.asyncio
+async def test_secure_reply_media_directive_is_not_uploaded_as_permanent_attachment():
+    adapter = _edit_adapter()
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=True, message_id="sent-secure")
+    )
+    adapter.send_multiple_images = AsyncMock()
+    adapter.send_document = AsyncMock()
+
+    async def _handler(evt):
+        return SecureReply("MEDIA:/tmp/secret.png", ttl_seconds=5)
+
+    adapter.set_message_handler(_handler)
+    event = _make_event()
+    session_key = "agent:main:telegram:private:42"
+
+    import gateway.platforms.base as base_module
+    _real_sleep = base_module.asyncio.sleep
+
+    async def _fake_sleep(duration):
+        await _real_sleep(0)
+
+    with patch.object(base_module.asyncio, "sleep", _fake_sleep), patch.object(
+        adapter, "_keep_typing", new=AsyncMock()
+    ):
+        await adapter._process_message_background(event, session_key)
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+    adapter._send_with_retry.assert_called_once()
+    sent = adapter._send_with_retry.call_args.kwargs["content"]
+    assert "MEDIA:" not in sent
+    assert "secure attachment omitted" in sent
+    adapter.send_multiple_images.assert_not_called()
+    adapter.send_document.assert_not_called()
+    assert any(edit[2] == "[redacted — secure message expired]" for edit in adapter.edited)
+
+
+@pytest.mark.asyncio
+async def test_secure_reply_bare_local_file_path_is_not_uploaded_as_permanent_attachment():
+    adapter = _edit_adapter()
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=True, message_id="sent-secure")
+    )
+    adapter.send_multiple_images = AsyncMock()
+    adapter.send_document = AsyncMock()
+
+    async def _handler(evt):
+        return SecureReply("/tmp/secret.png", ttl_seconds=5)
+
+    adapter.set_message_handler(_handler)
+    event = _make_event()
+    session_key = "agent:main:telegram:private:42"
+
+    import gateway.platforms.base as base_module
+    _real_sleep = base_module.asyncio.sleep
+
+    async def _fake_sleep(duration):
+        await _real_sleep(0)
+
+    with patch.object(base_module.asyncio, "sleep", _fake_sleep), patch.object(
+        adapter, "_keep_typing", new=AsyncMock()
+    ):
+        await adapter._process_message_background(event, session_key)
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+    adapter._send_with_retry.assert_called_once()
+    sent = adapter._send_with_retry.call_args.kwargs["content"]
+    assert "/tmp/secret.png" in sent
+    adapter.send_multiple_images.assert_not_called()
+    adapter.send_document.assert_not_called()
+    assert any(edit[2] == "[redacted — secure message expired]" for edit in adapter.edited)

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -507,3 +507,13 @@ class TestRichAwareOverflow:
         assert consumer._message_id == "final1"
         assert consumer._preview_message_ids == set()
         assert consumer.final_response_sent is True
+
+
+def test_stream_clean_for_display_redacts_secure_marker_payload():
+    cleaned = GatewayStreamConsumer._clean_for_display(
+        "prefix [[secure]]secret123[[/secure]] suffix"
+    )
+
+    assert "secret123" not in cleaned
+    assert "[redacted — secure message omitted from stream]" in cleaned
+    assert cleaned.endswith(" suffix")

--- a/tests/gateway/test_telegram_send_path_health.py
+++ b/tests/gateway/test_telegram_send_path_health.py
@@ -87,3 +87,31 @@ async def test_reconnect_storm_sets_and_heartbeat_clears_flag(monkeypatch):
     with patch("gateway.platforms.telegram.asyncio.sleep", new_callable=AsyncMock):
         await adapter._verify_polling_after_reconnect()
     assert adapter._send_path_degraded is False
+
+
+@pytest.mark.asyncio
+async def test_secure_send_sets_protect_content():
+    adapter = _make_adapter()
+
+    result = await adapter.send(
+        "123",
+        "secret hello",
+        metadata={"secure_message": {"protect_content": True}},
+    )
+
+    assert result.success is True
+    assert adapter._bot is not None
+    kwargs = adapter._bot.send_message.await_args.kwargs
+    assert kwargs["protect_content"] is True
+
+
+@pytest.mark.asyncio
+async def test_normal_send_omits_protect_content():
+    adapter = _make_adapter()
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is True
+    assert adapter._bot is not None
+    kwargs = adapter._bot.send_message.await_args.kwargs
+    assert "protect_content" not in kwargs

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -313,6 +313,16 @@ def test_write_json_drops_detached_ws_frames(monkeypatch):
         server._sessions.pop("detached-sid", None)
 
 
+def test_tui_secure_marker_redacts_local_display_and_history_text():
+    text = "Password: [[secure]]abc123[[/secure]] after"
+
+    redacted = server._redact_secure_markers_for_local(text)
+
+    assert "abc123" not in redacted
+    assert "[redacted — secure message omitted from local transcript]" in redacted
+    assert redacted.endswith(" after")
+
+
 def test_tui_verbose_tool_details_fail_closed_when_redaction_fails(monkeypatch):
     redact_module = types.ModuleType("agent.redact")
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import queue
+import re
 import subprocess
 import sys
 import threading
@@ -4137,6 +4138,42 @@ def _start_inflight_turn(session: dict, text: Any) -> None:
     }
 
 
+def _secure_marker_bounds_for_local() -> tuple[str, str]:
+    start = "[[secure]]"
+    end = "[[/secure]]"
+    try:
+        from hermes_cli.config import load_config as _load_config
+        cfg = _load_config()
+        display = cfg.get("display", {}) if isinstance(cfg, dict) else {}
+        secure = display.get("secure_messages", {}) if isinstance(display, dict) else {}
+        if isinstance(secure, dict):
+            start = str(secure.get("marker_start") or start)
+            end = str(secure.get("marker_end") or end)
+    except Exception:
+        pass
+    return start, end
+
+
+def _redact_secure_markers_for_local(text: Any) -> Any:
+    """Redact secure marker blocks for local/TUI display/history.
+
+    Messaging adapters can use platform controls plus TTL redaction. The local
+    TUI has no remote message to edit later, so it never displays/persists the
+    marked secret body in the first place.
+    """
+    if not isinstance(text, str):
+        return text
+    start, end = _secure_marker_bounds_for_local()
+    if start not in text:
+        return text
+    return re.sub(
+        rf"{re.escape(start)}.*?(?:{re.escape(end)}|$)",
+        "[redacted — secure message omitted from local transcript]",
+        text,
+        flags=re.DOTALL,
+    )
+
+
 def _append_inflight_delta(session: dict, delta: Any) -> None:
     text = "" if delta is None else str(delta)
     if not text:
@@ -6477,11 +6514,26 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 else:
                     run_message = _enrich_with_attached_images(prompt, images)
 
+            _secure_stream = {"raw": "", "emitted": ""}
+
             def _stream(delta):
+                delta_text = "" if delta is None else str(delta)
+                _secure_stream["raw"] += delta_text
+                redacted_stream = _redact_secure_markers_for_local(_secure_stream["raw"])
+                emitted = _secure_stream["emitted"]
+                if isinstance(redacted_stream, str) and redacted_stream.startswith(emitted):
+                    safe_delta = redacted_stream[len(emitted):]
+                    _secure_stream["emitted"] = redacted_stream
+                else:
+                    safe_delta = _redact_secure_markers_for_local(delta_text)
+                    if isinstance(safe_delta, str):
+                        _secure_stream["emitted"] += safe_delta
+                if not safe_delta:
+                    return
                 with session["history_lock"]:
-                    _append_inflight_delta(session, delta)
-                payload = {"text": delta}
-                if streamer and (r := streamer.feed(delta)) is not None:
+                    _append_inflight_delta(session, safe_delta)
+                payload = {"text": safe_delta}
+                if streamer and (r := streamer.feed(safe_delta)) is not None:
                     payload["rendered"] = r
                 _emit("message.delta", sid, payload)
 
@@ -6500,10 +6552,18 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             status_note = None
             if isinstance(result, dict):
                 if isinstance(result.get("messages"), list):
+                    redacted_messages = []
+                    for _msg in result["messages"]:
+                        if isinstance(_msg, dict) and _msg.get("role") == "assistant":
+                            _copy = dict(_msg)
+                            _copy["content"] = _redact_secure_markers_for_local(_copy.get("content"))
+                            redacted_messages.append(_copy)
+                        else:
+                            redacted_messages.append(_msg)
                     with session["history_lock"]:
                         current_version = int(session.get("history_version", 0))
                         if current_version == history_version:
-                            session["history"] = result["messages"]
+                            session["history"] = redacted_messages
                             session["history_version"] = history_version + 1
                         else:
                             # History mutated externally during the turn
@@ -6535,7 +6595,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     sid, session, clear_pending_title=False, restart_slash_worker=True,
                 )
 
-                raw = result.get("final_response", "")
+                raw = _redact_secure_markers_for_local(result.get("final_response", ""))
                 status = (
                     "interrupted"
                     if result.get("interrupted")


### PR DESCRIPTION
## Summary

Fixes #49194.

Adds a platform-neutral secure-message lane for short-lived sensitive gateway replies:

- `SecureReply(...)` for handler-returned sensitive replies.
- `[[secure]]...[[/secure]]` marker unwrapping/redaction support.
- Telegram `protect_content=True` plus spoiler formatting for secure text.
- Post-TTL edit-to-redacted-marker, with delete fallback when edit is unavailable.
- Durable transcript / trajectory / external-memory redaction of secure marker payloads.
- Local TUI display/history redaction for secure marker payloads.
- Graceful text-only handling for secure replies on platforms without secure attachment expiry.

## Tests

- `python -m pytest tests/agent/test_secure_message_redaction.py tests/gateway/test_ephemeral_reply.py tests/gateway/test_telegram_send_path_health.py tests/gateway/test_stream_consumer_draft.py::test_stream_clean_for_display_redacts_secure_marker_payload tests/test_tui_gateway_server.py::test_tui_secure_marker_redacts_local_display_and_history_text -q`
  - `31 passed`
- `python -m py_compile agent/conversation_loop.py agent/turn_finalizer.py gateway/platforms/base.py gateway/platforms/telegram.py gateway/stream_consumer.py tui_gateway/server.py hermes_cli/config.py`
- `git diff --check`

## Review status

Codex review was run twice. Earlier findings about trajectory redaction, native media extraction, custom marker bounds, and Telegram rich send kwargs were addressed in this branch.

Current known review concern before marking ready: streamed `[[secure]]...[[/secure]]` model output can be redacted in the stream path, but the streaming path does not yet re-deliver the original secret through the protected TTL lane. Keeping this PR draft until that edge is resolved or explicitly scoped out.
