### PR TITLE
fix(agent): guard repeated skill read tool calls

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -24,6 +24,8 @@ IDEMPOTENT_TOOL_NAMES = frozenset(
         "web_search",
         "web_extract",
         "session_search",
+        "skills_list",
+        "skill_view",
         "browser_snapshot",
         "browser_console",
         "browser_get_images",

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -228,6 +228,33 @@ def test_hard_stop_enabled_blocks_idempotent_no_progress_future_repeat():
     assert blocked.code == "idempotent_no_progress_block"
 
 
+def test_skill_discovery_tools_are_idempotent_for_no_progress_guardrail():
+    cases = [
+        ("skills_list", {"query": "git"}, '[{"name":"git"}]'),
+        ("skill_view", {"name": "git"}, "# Git Skill\nUse git carefully."),
+    ]
+
+    for tool_name, args, result in cases:
+        controller = ToolCallGuardrailController(
+            ToolCallGuardrailConfig(
+                hard_stop_enabled=True,
+                no_progress_warn_after=2,
+                no_progress_block_after=2,
+            )
+        )
+
+        assert controller.before_call(tool_name, args).action == "allow"
+        assert controller.after_call(tool_name, args, result, failed=False).action == "allow"
+        assert controller.before_call(tool_name, args).action == "allow"
+        warn = controller.after_call(tool_name, args, result, failed=False)
+        assert warn.action == "warn"
+        assert warn.code == "idempotent_no_progress_warning"
+
+        blocked = controller.before_call(tool_name, args)
+        assert blocked.action == "block"
+        assert blocked.code == "idempotent_no_progress_block"
+
+
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)


### PR DESCRIPTION
## Summary
- Fixes #49075
- Treat `skills_list` and `skill_view` as idempotent read tools for the no-progress loop guardrail
- Add a regression test covering warning and hard-stop behavior for repeated identical skill discovery results

## Tests
- `scripts/run_tests.sh tests/agent/test_tool_guardrails.py -- -q`
- `.venv/bin/ruff check agent/tool_guardrails.py tests/agent/test_tool_guardrails.py`
- `git diff --check`
- `.venv/bin/python scripts/check-windows-footguns.py --all`