### PR TITLE
fix(cli): reject --resume/--continue in oneshot instead of dropping it

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11205,6 +11205,23 @@ def _should_background_mcp_startup(args) -> bool:
     return args.command in {None, "chat", "rl"}
 
 
+def _reject_resume_in_oneshot(args) -> None:
+    """Fail loud when --resume/--continue is combined with -z/--oneshot.
+
+    The oneshot path never hydrates a resumed session's history, so the flag
+    was silently dropped and the prompt ran context-less (#49195; same class
+    as #26633/#31548). Reject it with a clear error instead.
+    """
+    if getattr(args, "resume", None) or getattr(args, "continue_last", None):
+        print(
+            "error: --resume/--continue is not supported with -z/--oneshot — "
+            "the oneshot path does not hydrate prior session history. Re-run "
+            "without -z to resume interactively, or drop --resume/--continue.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
 def _prepare_agent_startup(args) -> None:
     """Discover plugins/MCP/hooks for commands that can run an agent turn."""
     _sub_attr, _sub_set = _AGENT_SUBCOMMANDS.get(args.command, (None, None))
@@ -11326,6 +11343,7 @@ def _try_termux_fast_cli_launch() -> bool:
         return True
 
     if getattr(args, "oneshot", None):
+        _reject_resume_in_oneshot(args)
         _prepare_agent_startup(args)
         from hermes_cli.oneshot import run_oneshot
 
@@ -12560,6 +12578,7 @@ def main():
     # Handle top-level --oneshot / -z: single-shot mode, stdout = final
     # response only, nothing else. Bypasses cli.py entirely.
     if getattr(args, "oneshot", None):
+        _reject_resume_in_oneshot(args)
         from hermes_cli.oneshot import run_oneshot
 
         sys.exit(

--- a/tests/cli/test_oneshot_resume_guard.py
+++ b/tests/cli/test_oneshot_resume_guard.py
@@ -1,0 +1,39 @@
+"""Oneshot (-z) must reject --resume/--continue instead of silently dropping it.
+
+The oneshot path never hydrates a resumed session, so combining it with
+--resume/--continue used to run a context-less session with no warning
+(#49195). The guard fails loud instead.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.main import _reject_resume_in_oneshot
+
+
+def test_resume_in_oneshot_exits_with_error(capsys):
+    args = SimpleNamespace(resume="abc123", continue_last=None)
+    with pytest.raises(SystemExit) as exc:
+        _reject_resume_in_oneshot(args)
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "--resume/--continue is not supported" in err
+
+
+def test_continue_in_oneshot_exits_with_error(capsys):
+    args = SimpleNamespace(resume=None, continue_last=True)
+    with pytest.raises(SystemExit) as exc:
+        _reject_resume_in_oneshot(args)
+    assert exc.value.code == 2
+
+
+def test_plain_oneshot_is_allowed():
+    # No resume/continue → no exit, no output.
+    args = SimpleNamespace(resume=None, continue_last=None)
+    _reject_resume_in_oneshot(args)
+
+
+def test_missing_attrs_are_treated_as_unset():
+    # Defensive: args without the attributes must not raise.
+    _reject_resume_in_oneshot(SimpleNamespace())


### PR DESCRIPTION
## What

`hermes --resume <id> -z <prompt>` (and `--continue`) now fails with a clear error instead of silently running a fresh, context-less session.

## Why

The oneshot (`-z`) dispatch calls `run_oneshot()` and `sys.exit()`s before the `--resume`/`--continue` → chat routing, and `run_oneshot()` never hydrates a resumed session. So the flag was accepted (exit 0, no warning) but ignored — the prompt ran with no prior context. Same "oneshot silently drops a flag" class as the already-fixed #26633 (`--ignore-rules`) and #31548 (`--skills`).

## Change

Add a guard at both oneshot dispatch sites: when `--resume`/`--continue` is set, print a clear error and exit non-zero. This is the minimal "fail loud" fix; full resume hydration in oneshot is left to the maintainers (it touches exact-output replay and compression-lineage concerns noted in the issue).

## Tests

`tests/cli/test_oneshot_resume_guard.py` — resume/continue exit with code 2 and a clear message; plain oneshot is unaffected.

Closes #49195