### PR TITLE
docs: add XMemo to external memory providers list (EN + ZH)

### DIFF
--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, Memori, and third-party XMemo"
 ---
 
 # Memory Providers
@@ -576,6 +576,61 @@ hermes memory setup
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud | Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
 | **Memori** | Cloud | Free/Paid | 5 | `hermes-memori` | Tool-aware memory + structured recall |
+
+## Third-party providers
+
+The following memory providers are maintained outside the Hermes repository. Install them into `$HERMES_HOME/plugins/<name>/`.
+
+### XMemo
+
+Identity-aware, user-owned cloud memory with orchestrated recall, semantic search, durable fact storage, working state, built-in memory mirroring, and cross-session restart snapshots.
+
+| | |
+|---|---|
+| **Best for** | Users who want a user-owned cloud memory backend with explicit memory tools |
+| **Requires** | XMemo token from [xmemo.dev](https://xmemo.dev) |
+| **Data storage** | XMemo Cloud |
+| **Cost** | XMemo pricing |
+
+**Tools:** `xmemo_recall_context`, `xmemo_search`, `xmemo_remember`, `xmemo_update_state` (optional: `xmemo_record_event`, `xmemo_create_reminder`, `xmemo_list_reminders`, `xmemo_complete_reminder`, `xmemo_forget`)
+
+**Install:**
+
+```bash
+pip install hermes-xmemo
+hermes-xmemo install
+```
+
+If `$HERMES_HOME` is not `~/.hermes`:
+
+```bash
+HERMES_HOME=/path/to/your/hermes-home hermes-xmemo install
+```
+
+Or install without pip:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/yonro/hermes-xmemo-plugin/main/install-remote.sh | bash
+```
+
+Or clone and run the install script manually:
+
+```bash
+git clone https://github.com/yonro/hermes-xmemo-plugin.git
+cd hermes-xmemo-plugin
+bash install.sh
+```
+
+**Setup:**
+
+```bash
+hermes memory setup xmemo
+# Or manually:
+hermes config set memory.provider xmemo
+echo "XMEMO_KEY=your-token" >> "${HERMES_HOME:-$HOME/.hermes}/.env"
+```
+
+**Config:** `$HERMES_HOME/xmemo.json`
 
 ## Profile Isolation
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "外部记忆提供者插件 — Honcho、OpenViking、Mem0、Hindsight、Holographic、RetainDB、ByteRover、Supermemory"
+description: "外部记忆提供者插件 — Honcho、OpenViking、Mem0、Hindsight、Holographic、RetainDB、ByteRover、Supermemory，以及第三方 XMemo"
 ---
 
 # Memory Providers
@@ -534,6 +534,67 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 | **RetainDB** | 云端 | $20/月 | 5 | `requests` | 增量压缩 |
 | **ByteRover** | 本地/云端 | 免费/付费 | 3 | `brv` CLI | 预压缩提取 |
 | **Supermemory** | 云端 | 付费 | 4 | `supermemory` | 上下文隔离 + 会话图谱导入 + 多容器 |
+
+## 第三方提供者
+
+以下记忆提供者由 Hermes 仓库外部维护。安装到 `$HERMES_HOME/plugins/<name>/` 即可使用。
+
+### XMemo
+
+具备身份感知、用户拥有的云端记忆，支持编排召回、语义搜索、持久化事实存储、工作状态、内置记忆镜像以及跨会话重启快照。
+
+| | |
+|---|---|
+| **适合场景** | 希望使用用户拥有的云端记忆后端，并具备显式记忆工具的用户 |
+| **依赖** | [xmemo.dev](https://xmemo.dev) 的 XMemo token |
+| **数据存储** | XMemo Cloud |
+| **费用** | XMemo 定价 |
+
+**工具：** `xmemo_recall_context`、`xmemo_search`、`xmemo_remember`、`xmemo_update_state`（可选：`xmemo_record_event`、`xmemo_create_reminder`、`xmemo_list_reminders`、`xmemo_complete_reminder`、`xmemo_forget`）
+
+**安装：**
+
+```bash
+pip install hermes-xmemo
+hermes-xmemo install
+```
+
+如果 `$HERMES_HOME` 不是 `~/.hermes`：
+
+```bash
+HERMES_HOME=/path/to/your/hermes-home hermes-xmemo install
+```
+
+或不使用 pip，直接一行命令安装：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/yonro/hermes-xmemo-plugin/main/install-remote.sh | bash
+```
+
+或手动克隆并运行安装脚本：
+
+```bash
+git clone https://github.com/yonro/hermes-xmemo-plugin.git
+cd hermes-xmemo-plugin
+bash install.sh
+```
+
+如果 `$HERMES_HOME` 不是 `~/.hermes`：
+
+```bash
+HERMES_HOME=/path/to/your/hermes-home bash install.sh
+```
+
+**配置：**
+
+```bash
+hermes memory setup xmemo
+# 或手动：
+hermes config set memory.provider xmemo
+echo "XMEMO_KEY=your-token" >> "${HERMES_HOME:-$HOME/.hermes}/.env"
+```
+
+**配置文件：** `$HERMES_HOME/xmemo.json`
 
 ## Profile 隔离
 


### PR DESCRIPTION
## Summary

Adds XMemo as a third-party memory provider to the external memory-providers documentation in both English and Simplified Chinese.

Following the guidance in [CONTRIBUTING.md](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) and the closure of #48239, XMemo is published as a standalone plugin rather than a bundled provider. This PR adds the sanctioned docs-list entry so users can discover and install it.

## What changed

- `website/docs/user-guide/features/memory-providers.md`
  - Added a "Third-party providers" section.
  - Documented XMemo with install/setup instructions and a link to the standalone plugin repo.
- `website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md`
  - Added the corresponding "第三方提供者" / XMemo section in Simplified Chinese.

## Install path

pip install (recommended):

```bash
pip install hermes-xmemo
hermes-xmemo install
hermes memory setup xmemo
```

Or without pip:

```bash
curl -fsSL https://raw.githubusercontent.com/yonro/hermes-xmemo-plugin/main/install-remote.sh | bash
hermes memory setup xmemo
```

Or manually:

```bash
git clone https://github.com/yonro/hermes-xmemo-plugin.git
cd hermes-xmemo-plugin
bash install.sh
hermes memory setup xmemo
```

The standalone plugin repo is published at https://github.com/yonro/hermes-xmemo-plugin.

## Notes

- No bundled provider code is included — this is docs-only.
- Manual setup command uses `${HERMES_HOME:-$HOME/.hermes}/.env` to avoid writing to `/.env` when `HERMES_HOME` is unset.
- Both English and Chinese pages were updated for consistency.
