### PR TITLE
fix(cron): sanitize env for job script subprocesses

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -121,10 +121,11 @@ outside the supported security posture.
 ### 2.3 Credential Scoping
 
 Hermes Agent filters the environment it passes to its lower-trust
-in-process components: shell subprocesses, MCP subprocesses, and
-the code-execution child. Credentials like provider API keys and
-gateway tokens are stripped by default; variables explicitly
-declared by the operator or by a loaded skill are passed through.
+in-process components: shell subprocesses, MCP subprocesses,
+cron job scripts, and the code-execution child. Credentials like
+provider API keys and gateway tokens are stripped by default;
+variables explicitly declared by the operator or by a loaded
+skill are passed through.
 
 This reduces casual exfiltration. It is not containment. Any
 component running inside the agent process (skills, plugins, hook

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1035,7 +1035,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             text=True,
             timeout=script_timeout,
             cwd=str(path.parent),
-            env=_sanitize_subprocess_env(os.environ),
+            env=_sanitize_subprocess_env(os.environ.copy()),
             **popen_kwargs,
         )
         stdout = (result.stdout or "").strip()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -961,6 +961,10 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     Shell support lets ``no_agent=True`` jobs ship classic bash watchdogs
     (the `memory-watchdog.sh` pattern) without wrapping them in Python.
 
+    Subprocess environment is passed through ``_sanitize_subprocess_env`` so
+    provider credentials and other Hermes-managed secrets are not inherited
+    (SECURITY.md §2.3), matching terminal and MCP child processes.
+
     Args:
         script_path: Path to the script.  Relative paths are resolved
             against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
@@ -1022,6 +1026,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         argv = [sys.executable, str(path)]
 
     try:
+        from tools.environments.local import _sanitize_subprocess_env
+
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
         result = subprocess.run(
             argv,
@@ -1029,6 +1035,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             text=True,
             timeout=script_timeout,
             cwd=str(path.parent),
+            env=_sanitize_subprocess_env(os.environ),
             **popen_kwargs,
         )
         stdout = (result.stdout or "").strip()

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -132,6 +132,29 @@ class TestRunJobScript:
         assert "exited with code 1" in output
         assert "error info" in output
 
+    def test_script_subprocess_env_sanitized(self, cron_env, monkeypatch):
+        """Cron scripts must not inherit Hermes provider env (SECURITY.md §2.3)."""
+        from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+        from cron.scheduler import _run_job_script
+
+        blocked_var = next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST))
+        monkeypatch.setenv(blocked_var, "must_not_leak")
+
+        script = cron_env / "scripts" / "env_probe.py"
+        script.write_text(
+            textwrap.dedent(
+                f"""\
+                import os
+                key = {blocked_var!r}
+                print("PRESENT" if os.environ.get(key) else "ABSENT")
+                """
+            )
+        )
+
+        success, output = _run_job_script("env_probe.py")
+        assert success is True
+        assert output == "ABSENT"
+
     def test_script_empty_output(self, cron_env):
         from cron.scheduler import _run_job_script
 

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -137,7 +137,9 @@ class TestRunJobScript:
         from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
         from cron.scheduler import _run_job_script
 
-        blocked_var = next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST))
+        # sorted() so the probed var is deterministic across runs
+        # (frozenset iteration order varies with PYTHONHASHSEED).
+        blocked_var = sorted(_HERMES_PROVIDER_ENV_BLOCKLIST)[0]
         monkeypatch.setenv(blocked_var, "must_not_leak")
 
         script = cron_env / "scripts" / "env_probe.py"


### PR DESCRIPTION
## Summary
Cron `no_agent` watchdogs and pre-check/wake-gate scripts now run with provider credentials and Hermes-managed secrets stripped from their environment, matching terminal, MCP, and code-execution children (SECURITY.md §2.3).

Salvage of #49125 by @0z1-ghb, cherry-picked onto current `main` with authorship preserved, plus review follow-ups.

## Changes
- `cron/scheduler.py` (`fix`, @0z1-ghb): pass `env=_sanitize_subprocess_env(...)` to the `subprocess.run` in `_run_job_script` — covers both `no_agent` runs and the wake-gate pre-check (both funnel through this one helper).
- `tests/cron/test_cron_script.py` (`fix`, @0z1-ghb): regression test asserting a blocklisted provider var reads `ABSENT` in the child process.
- `test(cron)`: make the env-sanitize probe var deterministic — `sorted(blocklist)[0]` instead of `next(iter(frozenset))`, which picked a different var each run under `PYTHONHASHSEED`. Keeps the invariant-style assertion, makes failures reproducible.
- `refactor(cron)`: pass `os.environ.copy()` to match the `env=` callsite convention at the other sanitized spawns (cua_backend, gateway). Functionally equivalent — the helper never mutates its input.
- `docs(security)`: enumerate cron job scripts in §2.3's credential-scoping component list, so the `_run_job_script` docstring's §2.3 citation is fully accurate.

## Validation
| | Before | After |
|---|---|---|
| Provider key (e.g. `OPENAI_API_KEY`) visible to cron script | yes | no |
| `PATH` / `HERMES_HOME` available to script | yes | yes (HERMES_HOME re-injected) |
| `tests/cron/test_cron_script.py` | 36 | 37 passed |

Mutation-checked: the new guard test fails on pre-fix `cron/scheduler.py` and passes on the full stack.

Closes #49125
