### PR TITLE
fix(agent): harden provider retry and gateway typing behavior

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -23,6 +23,7 @@ Methods covered:
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import logging
 import re
@@ -1180,6 +1181,10 @@ def dump_api_request_debug(
             "timestamp": datetime.now().isoformat(),
             "session_id": agent.session_id,
             "reason": reason,
+            "provider": getattr(agent, "provider", "") or "",
+            "model": getattr(agent, "model", "") or "",
+            "api_mode": getattr(agent, "api_mode", "") or "",
+            "base_url": getattr(agent, "base_url", "") or "",
             "request": {
                 "method": "POST",
                 "url": f"{agent.base_url.rstrip('/')}{'/responses' if agent.api_mode == 'codex_responses' else '/chat/completions'}",
@@ -1241,6 +1246,113 @@ def dump_api_request_debug(
             logger.warning(f"Failed to dump API request debug payload: {dump_error}")
         return None
 
+
+
+def _stable_json(value: Any) -> str:
+    if value is None or not isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, default=str)
+    if isinstance(value, list):
+        return "[" + ",".join(_stable_json(v) for v in value) + "]"
+    return "{" + ",".join(
+        json.dumps(k, ensure_ascii=False) + ":" + _stable_json(value[k])
+        for k in sorted(value)
+    ) + "}"
+
+
+def _request_fingerprint(agent, api_kwargs: Dict[str, Any], *, status_code: Optional[int] = None) -> str:
+    body = copy.deepcopy(api_kwargs or {})
+    body.pop("timeout", None)
+    body = {k: v for k, v in body.items() if v is not None}
+    normalized = {
+        "provider": getattr(agent, "provider", "") or "",
+        "model": body.get("model") or getattr(agent, "model", "") or "",
+        "api_mode": getattr(agent, "api_mode", "") or "",
+        "base_url": str(getattr(agent, "base_url", "") or "").rstrip("/"),
+        "status_code": status_code,
+        "body": body.get("messages") or body.get("input") or body.get("prompt") or body,
+    }
+    return hashlib.sha1(_stable_json(normalized).encode("utf-8")).hexdigest()[:16]
+
+
+def _fingerprint_cache(agent) -> Dict[str, Dict[str, Any]]:
+    cache = getattr(agent, "_non_retryable_request_fingerprints", None)
+    if not isinstance(cache, dict):
+        cache = {}
+        setattr(agent, "_non_retryable_request_fingerprints", cache)
+    return cache
+
+
+def check_non_retryable_request_fingerprint(
+    agent,
+    api_kwargs: Dict[str, Any],
+    *,
+    ttl_seconds: float = 3600.0,
+) -> Dict[str, Any]:
+    """Return prior non-retryable match for this request, if still fresh."""
+    now = time.time()
+    cache = _fingerprint_cache(agent)
+    body_fp = _request_fingerprint(agent, api_kwargs, status_code=None)
+    for key, value in list(cache.items()):
+        if now - float(value.get("last_seen", 0.0) or 0.0) > ttl_seconds:
+            cache.pop(key, None)
+    for value in cache.values():
+        if value.get("body_fingerprint") == body_fp:
+            return {
+                "blocked": True,
+                "fingerprint": value.get("fingerprint"),
+                "body_fingerprint": body_fp,
+                "count": int(value.get("count", 1)),
+                "status_code": value.get("status_code"),
+                "first_seen": value.get("first_seen"),
+                "last_seen": value.get("last_seen"),
+            }
+    return {"blocked": False, "body_fingerprint": body_fp}
+
+
+def record_non_retryable_request_fingerprint(
+    agent,
+    api_kwargs: Dict[str, Any],
+    *,
+    status_code: Optional[int],
+    ttl_seconds: float = 3600.0,
+) -> Dict[str, Any]:
+    """Remember a 400/401/403/404 request fingerprint and report duplicates."""
+    if status_code not in {400, 401, 403, 404}:
+        return {"blocked": False, "status_code": status_code, "fingerprint": ""}
+    now = time.time()
+    cache = _fingerprint_cache(agent)
+    body_fp = _request_fingerprint(agent, api_kwargs, status_code=None)
+    fingerprint = _request_fingerprint(agent, api_kwargs, status_code=status_code)
+    existing = cache.get(fingerprint)
+    if existing and now - float(existing.get("last_seen", 0.0) or 0.0) <= ttl_seconds:
+        existing["count"] = int(existing.get("count", 1)) + 1
+        existing["last_seen"] = now
+        return {
+            "blocked": True,
+            "fingerprint": fingerprint,
+            "body_fingerprint": body_fp,
+            "count": existing["count"],
+            "status_code": status_code,
+            "first_seen": existing.get("first_seen"),
+            "last_seen": now,
+        }
+    cache[fingerprint] = {
+        "fingerprint": fingerprint,
+        "body_fingerprint": body_fp,
+        "status_code": status_code,
+        "count": 1,
+        "first_seen": now,
+        "last_seen": now,
+    }
+    return {
+        "blocked": False,
+        "fingerprint": fingerprint,
+        "body_fingerprint": body_fp,
+        "count": 1,
+        "status_code": status_code,
+        "first_seen": now,
+        "last_seen": now,
+    }
 
 
 def anthropic_prompt_cache_policy(
@@ -2604,6 +2716,8 @@ __all__ = [
     "restore_primary_runtime",
     "extract_reasoning",
     "dump_api_request_debug",
+    "check_non_retryable_request_fingerprint",
+    "record_non_retryable_request_fingerprint",
     "anthropic_prompt_cache_policy",
     "create_openai_client",
     "switch_model",

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -931,6 +931,33 @@ class _CodexChatShim:
         self.completions = adapter
 
 
+class _BlockedCodexChatCompletions:
+    """Local guard for raw Codex clients.
+
+    Raw Codex clients are allowed only for callers that use the Responses API
+    directly (for example the main agent streaming loop). If a side path calls
+    chat.completions on chatgpt.com/backend-api/codex, the backend returns the
+    forbidden legacy endpoint (/chat/completions). Block locally instead.
+    """
+
+    def create(self, **kwargs) -> Any:
+        raise RuntimeError(
+            "OpenAI Codex OAuth backend requires the Responses API; "
+            "chat.completions is blocked for chatgpt.com/backend-api/codex."
+        )
+
+
+class _RawCodexResponsesOnlyClient:
+    """Proxy a raw OpenAI client while disabling chat.completions."""
+
+    def __init__(self, real_client: Any):
+        self._client = real_client
+        self.chat = SimpleNamespace(completions=_BlockedCodexChatCompletions())
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client, name)
+
+
 class CodexAuxiliaryClient:
     """OpenAI-client-compatible wrapper that routes through Codex Responses API.
 
@@ -3646,7 +3673,7 @@ def resolve_provider_client(
                 base_url=_CODEX_AUX_BASE_URL,
                 default_headers=_codex_cloudflare_headers(codex_token),
             )
-            return (raw_client, final_model)
+            return (_RawCodexResponsesOnlyClient(raw_client), final_model)
         # Standard path: wrap in CodexAuxiliaryClient adapter
         client, default = _build_codex_client(model)
         if client is None:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1064,6 +1064,33 @@ def run_conversation(
                 if env_var_enabled("HERMES_DUMP_REQUESTS"):
                     agent._dump_api_request_debug(api_kwargs, reason="preflight")
 
+                _dedupe_hit = agent._check_non_retryable_request_fingerprint(api_kwargs)
+                if _dedupe_hit.get("blocked"):
+                    _status = _dedupe_hit.get("status_code") or "unknown"
+                    _fp = _dedupe_hit.get("fingerprint") or "unknown"
+                    _count = _dedupe_hit.get("count") or 1
+                    agent._emit_status(
+                        f"⛔ Duplicate non-retryable request blocked locally "
+                        f"(HTTP {_status}, fingerprint {_fp}, seen {_count}×)."
+                    )
+                    agent._dump_api_request_debug(
+                        api_kwargs,
+                        reason="duplicate_non_retryable_blocked",
+                    )
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": (
+                            "Duplicate non-retryable provider request blocked locally "
+                            f"(HTTP {_status}, fingerprint {_fp})."
+                        ),
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "error": "duplicate_non_retryable_blocked",
+                        "failure_reason": "non_retryable_client_error",
+                    }
+
                 # Always prefer the streaming path — even without stream
                 # consumers.  Streaming gives us fine-grained health
                 # checking (90s stale-stream detection, 60s read timeout)
@@ -2261,6 +2288,61 @@ def run_conversation(
                 if recovered_with_pool:
                     continue
 
+                # Reset-aware usage-limit gate.
+                #
+                # Some providers (notably chatgpt.com/backend-api/codex) return
+                # HTTP 429 bodies with a durable quota wall (`usage_limit_reached`
+                # plus reset metadata). Retrying those immediately just burns the
+                # same request two more times before `max_retries_exhausted` and
+                # creates noisy request_dump artifacts. If no credential-pool
+                # rotation recovered above, try fallback once; otherwise stop with
+                # an actionable reset/backoff message instead of short-loop retrying.
+                _rate_limit_reason = str((error_context or {}).get("reason") or "").lower()
+                _rate_limit_message = str((error_context or {}).get("message") or api_error or "").lower()
+                _has_usage_limit_wall = (
+                    classified.reason == FailoverReason.rate_limit
+                    and (
+                        "usage_limit_reached" in _rate_limit_reason
+                        or "gousagelimit" in _rate_limit_reason
+                        or "usage limit reached" in _rate_limit_message
+                        or "usage limit has been reached" in _rate_limit_message
+                    )
+                )
+                if _has_usage_limit_wall:
+                    if agent._has_pending_fallback():
+                        agent._buffer_status("⏱️ Usage limit reached — trying fallback instead of retrying same provider...")
+                    if agent._try_activate_fallback():
+                        retry_count = 0
+                        compression_attempts = 0
+                        _retry.primary_recovery_attempted = False
+                        continue
+                    _reset_at = (error_context or {}).get("reset_at")
+                    _reset_hint = ""
+                    if _reset_at not in {None, ""}:
+                        _reset_hint = f" Reset/backoff signal: {_reset_at}."
+                    if api_kwargs is not None:
+                        agent._dump_api_request_debug(
+                            api_kwargs, reason="rate_limit_reset_backoff", error=api_error,
+                        )
+                    agent._flush_status_buffer()
+                    _final_summary = agent._summarize_api_error(api_error)
+                    agent._emit_status(f"❌ Usage limit reached — not retrying until reset. {_final_summary}")
+                    agent._vprint(
+                        f"{agent.log_prefix}⏱️ Usage limit wall detected; suppressed immediate retries."
+                        f"{_reset_hint}",
+                        force=True,
+                    )
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": f"Usage limit reached; retry paused until reset/backoff window. {_final_summary}{_reset_hint}",
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "error": _final_summary,
+                        "failure_reason": classified.reason.value,
+                    }
+
                 # Image-too-large recovery: shrink oversized native image
                 # parts in-place and retry once.  Triggered by Anthropic's
                 # per-image 5 MB ceiling (400 with "image exceeds 5 MB
@@ -3191,6 +3273,10 @@ def run_conversation(
                         _retry.primary_recovery_attempted = False
                         continue
                     if api_kwargs is not None:
+                        _dedupe_record = agent._record_non_retryable_request_fingerprint(
+                            api_kwargs,
+                            status_code=status_code,
+                        )
                         agent._dump_api_request_debug(
                             api_kwargs, reason="non_retryable_client_error", error=api_error,
                         )

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -141,6 +141,17 @@ _USAGE_LIMIT_PATTERNS = [
     "key limit exceeded",
 ]
 
+# Status-less provider overload / transient server-side capacity messages.
+# Some SDKs and streaming transports surface these as plain Exceptions without
+# HTTP 503/529, so status-based classification never runs.
+_OVERLOADED_PATTERNS = [
+    "currently overloaded",
+    "server is overloaded",
+    "servers are overloaded",
+    "service is overloaded",
+    "overloaded. please try again later",
+]
+
 # Patterns confirming usage limit is transient (not billing)
 _USAGE_LIMIT_TRANSIENT_SIGNALS = [
     "try again",
@@ -823,16 +834,17 @@ def _classify_by_status(
                 retryable=False,
                 should_fallback=True,
             )
-        # Generic 404 with no "model not found" signal — could be a wrong
+        # Generic 404 with no "model not found" signal — usually a wrong
         # endpoint path (common with local llama.cpp / Ollama / vLLM when
-        # the URL is slightly misconfigured), a proxy routing glitch, or
-        # a transient backend issue.  Classifying these as model_not_found
-        # silently falls back to a different provider and tells the model
-        # the model is missing, which is wrong and wastes a turn.  Treat
-        # as unknown so the retry loop surfaces the real error instead.
+        # the URL is slightly misconfigured) or an unavailable route. It is
+        # not safely a model_not_found diagnosis, but retrying the identical
+        # POST will not repair a missing route. Fail fast as a non-retryable
+        # format/config error, while still allowing a configured fallback
+        # provider to handle the turn.
         return result_fn(
-            FailoverReason.unknown,
-            retryable=True,
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=True,
         )
 
     if status_code == 413:
@@ -1211,6 +1223,12 @@ def _classify_by_message(
             should_rotate_credential=True,
             should_fallback=True,
         )
+
+    # Status-less overload/capacity errors — retryable, but classify distinctly
+    # from unknown so diagnostics and dashboards can separate provider overload
+    # from unclassified failures.
+    if any(p in error_msg for p in _OVERLOADED_PATTERNS):
+        return result_fn(FailoverReason.overloaded, retryable=True)
 
     # Context overflow patterns
     if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3142,12 +3142,15 @@ class BasePlatformAdapter(ABC):
         interval: float = 2.0,
         metadata=None,
         stop_event: asyncio.Event | None = None,
+        max_active_seconds: float | None = 120.0,
     ) -> None:
         """
         Continuously send typing indicator until cancelled.
         
         Telegram/Discord typing status expires after ~5 seconds, so we refresh every 2
-        to recover quickly after progress messages interrupt it.
+        to recover quickly after progress messages interrupt it. For long-running turns,
+        stop refreshing after ``max_active_seconds`` so messaging clients do not show an
+        endless "typing" state while the agent is doing background tool work.
         
         Skips send_typing when the chat is in ``_typing_paused`` (e.g. while
         the agent is waiting for dangerous-command approval).  This is critical
@@ -3167,11 +3170,18 @@ class BasePlatformAdapter(ABC):
         # gated on network health.  Must stay below ``interval`` so a slow
         # call gets abandoned before the next scheduled tick.
         _send_typing_timeout = max(0.25, min(1.5, interval - 0.25))
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
         try:
             while True:
                 if stop_event is not None and stop_event.is_set():
                     return
-                if chat_id not in self._typing_paused:
+                typing_window_open = (
+                    max_active_seconds is None
+                    or max_active_seconds <= 0
+                    or (loop.time() - started_at) < max_active_seconds
+                )
+                if typing_window_open and chat_id not in self._typing_paused:
                     try:
                         await asyncio.wait_for(
                             self.send_typing(chat_id, metadata=metadata),

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2227,9 +2227,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 from hermes_cli.commands import telegram_menu_commands
                 # Telegram allows up to 100 commands but has an undocumented
-                # payload size limit (~4KB total).  Limit to 30 core commands
-                # to stay well under the threshold while covering all categories.
-                menu_commands, hidden_count = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
+                # payload size limit (~4KB total). Keep the menu compact, but
+                # reserve the top slots for user-defined quick_commands so
+                # local /q... commands are discoverable in Telegram's slash UI.
+                quick_menu_commands = self._telegram_quick_menu_commands()
+                core_limit = max(0, MAX_COMMANDS_PER_SCOPE - len(quick_menu_commands))
+                menu_commands, hidden_count = telegram_menu_commands(max_commands=core_limit)
+                seen_commands = {name for name, _ in quick_menu_commands}
+                menu_commands = quick_menu_commands + [
+                    (name, desc) for name, desc in menu_commands if name not in seen_commands
+                ]
                 bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
                 # Register for all scopes independently — Telegram picks the
                 # narrowest matching scope per chat type (forum topics fall
@@ -5925,6 +5932,50 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         return self._message_matches_mention_patterns(message)
 
+    def _telegram_quick_menu_commands(self) -> list[tuple[str, str]]:
+        """Return gateway quick_commands for Telegram's slash-command menu.
+
+        Quick commands are user/profile-local commands from config.yaml. They
+        are executable by the gateway already, but COMMAND_REGISTRY does not
+        know about them, so they would otherwise never appear in Telegram's
+        native command suggestions.
+        """
+        if isinstance(self.config, dict):
+            quick_commands = self.config.get("quick_commands", {}) or {}
+        else:
+            quick_commands = getattr(self.config, "quick_commands", {}) or {}
+        if not isinstance(quick_commands, dict):
+            return []
+
+        defaults = {
+            "qstatus": "Quill status",
+            "qlogs": "Recent Quill logs",
+            "qrestart": "Restart Hermes gateway",
+            "qcost": "Quill cost/status",
+            "qimg": "Generate image",
+            "qvec": "Generate vector/SVG",
+            "qcodex": "Codex account status",
+            "qclaude": "Claude CLI status",
+            "qguard": "Model routing guard status",
+        }
+        commands: list[tuple[str, str]] = []
+        for name, qcmd in sorted(quick_commands.items()):
+            command = str(name or "").strip().lower().lstrip("/")
+            # Telegram BotCommand names: 1-32 chars, lowercase latin letters,
+            # digits and underscores only. Skip invalid local aliases rather
+            # than failing the entire menu registration.
+            if not command or len(command) > 32:
+                continue
+            if any(ch not in "abcdefghijklmnopqrstuvwxyz0123456789_" for ch in command):
+                continue
+            desc = ""
+            if isinstance(qcmd, dict):
+                desc = str(qcmd.get("description") or "").strip()
+            if not desc:
+                desc = defaults.get(command) or "Quick command"
+            commands.append((command, desc[:256]))
+        return commands[:MAX_COMMANDS_PER_SCOPE]
+
     async def _ensure_forum_commands(self, message) -> None:
         """Lazy-register bot commands for forum supergroups.
 
@@ -5942,7 +5993,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     return
                 from telegram import BotCommand, BotCommandScopeChat
                 from hermes_cli.commands import telegram_menu_commands
-                menu_commands, _ = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
+                quick_menu_commands = self._telegram_quick_menu_commands()
+                core_limit = max(0, MAX_COMMANDS_PER_SCOPE - len(quick_menu_commands))
+                menu_commands, _ = telegram_menu_commands(max_commands=core_limit)
+                seen_commands = {name for name, _ in quick_menu_commands}
+                menu_commands = quick_menu_commands + [
+                    (name, desc) for name, desc in menu_commands if name not in seen_commands
+                ]
                 bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
                 await self._bot.set_my_commands(bot_commands, scope=BotCommandScopeChat(chat_id=chat_id))
                 self._forum_command_registered.add(chat_id)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2234,6 +2234,16 @@ class AIAgent:
         from agent.agent_runtime_helpers import dump_api_request_debug
         return dump_api_request_debug(self, api_kwargs, reason=reason, error=error)
 
+    def _check_non_retryable_request_fingerprint(self, api_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Forwarder — see ``agent.agent_runtime_helpers.check_non_retryable_request_fingerprint``."""
+        from agent.agent_runtime_helpers import check_non_retryable_request_fingerprint
+        return check_non_retryable_request_fingerprint(self, api_kwargs)
+
+    def _record_non_retryable_request_fingerprint(self, api_kwargs: Dict[str, Any], *, status_code: Optional[int]) -> Dict[str, Any]:
+        """Forwarder — see ``agent.agent_runtime_helpers.record_non_retryable_request_fingerprint``."""
+        from agent.agent_runtime_helpers import record_non_retryable_request_fingerprint
+        return record_non_retryable_request_fingerprint(self, api_kwargs, status_code=status_code)
+
     @staticmethod
     def _clean_session_content(content: str) -> str:
         """Convert REASONING_SCRATCHPAD to think tags and clean up whitespace."""

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3987,3 +3987,71 @@ class TestAuxiliaryMaxTokensParam:
         ):
             assert auxiliary_max_tokens_param(4096, model="") == {"max_tokens": 4096}
             assert auxiliary_max_tokens_param(4096, model=None) == {"max_tokens": 4096}
+
+
+class TestProviderRoutingRegression:
+    def test_runtime_pool_entry_routes_codex_and_anthropic_to_native_modes(self):
+        """Provider runtime resolution must not regress to chat_completions."""
+        from hermes_cli.runtime_provider import _resolve_runtime_from_pool_entry
+
+        codex_entry = SimpleNamespace(
+            runtime_base_url="https://chatgpt.com/backend-api/codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            runtime_api_key="codex-token",
+            access_token="codex-token",
+            source="unit",
+        )
+        anthropic_entry = SimpleNamespace(
+            runtime_base_url="https://api.anthropic.com",
+            base_url="https://api.anthropic.com",
+            runtime_api_key="anthropic-key",
+            access_token="anthropic-key",
+            source="unit",
+        )
+
+        codex = _resolve_runtime_from_pool_entry(
+            provider="openai-codex",
+            entry=codex_entry,
+            requested_provider="openai-codex",
+            model_cfg={"provider": "openai-codex", "default": "gpt-5.5"},
+            target_model="gpt-5.5",
+        )
+        anthropic = _resolve_runtime_from_pool_entry(
+            provider="anthropic",
+            entry=anthropic_entry,
+            requested_provider="anthropic",
+            model_cfg={"provider": "anthropic", "default": "claude-sonnet-4-6"},
+            target_model="claude-sonnet-4-6",
+        )
+
+        assert codex["api_mode"] == "codex_responses"
+        assert codex["base_url"] == "https://chatgpt.com/backend-api/codex"
+        assert anthropic["api_mode"] == "anthropic_messages"
+        assert anthropic["base_url"] == "https://api.anthropic.com"
+
+    def test_raw_codex_client_blocks_chat_completions_before_network(self, monkeypatch):
+        """raw_codex=True may expose responses.*, but never chat.completions."""
+        import agent.auxiliary_client as aux
+
+        class FakeChatCompletions:
+            def create(self, **kwargs):
+                return "network would have happened"
+
+        class FakeOpenAI:
+            def __init__(self, **kwargs):
+                self.api_key = kwargs.get("api_key")
+                self.base_url = kwargs.get("base_url")
+                self.chat = SimpleNamespace(completions=FakeChatCompletions())
+                self.responses = SimpleNamespace(create=MagicMock(name="responses_create"))
+
+        monkeypatch.setattr(aux, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(aux, "OpenAI", FakeOpenAI)
+
+        client, model = resolve_provider_client(
+            "openai-codex", model="gpt-5.5", raw_codex=True,
+        )
+
+        assert model == "gpt-5.5"
+        assert client.responses is not None
+        with pytest.raises(RuntimeError, match="Responses API"):
+            client.chat.completions.create(model="gpt-5.5", messages=[])

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -347,6 +347,12 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.overloaded
 
+    def test_statusless_overloaded_message(self):
+        e = Exception("Our servers are currently overloaded. Please try again later.")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+
     # ── 5xx that are actually request-validation errors ──
     # Some OpenAI-compatible gateways (e.g. codex.nekos.me) return
     # request-validation failures with a 5xx status. These are
@@ -416,14 +422,22 @@ class TestClassifyApiError:
 
     def test_404_generic(self):
         # Generic 404 with no "model not found" signal — common for local
-        # llama.cpp/Ollama/vLLM endpoints with slightly wrong paths.  Treat
-        # as unknown (retryable) so the real error surfaces, rather than
-        # claiming the model is missing and silently falling back.
+        # llama.cpp/Ollama/vLLM endpoints with slightly wrong paths, or for
+        # missing proxy routes that only report "Error code: 404". Retrying
+        # the identical POST will not repair a missing route, but a configured
+        # fallback provider may still handle the turn.
         e = MockAPIError("Not Found", status_code=404)
         result = classify_api_error(e)
-        assert result.reason == FailoverReason.unknown
-        assert result.retryable is True
-        assert result.should_fallback is False
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_404_status_only_is_non_retryable(self):
+        e = MockAPIError("Error code: 404", status_code=404)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is True
 
     # ── Provider policy-block (OpenRouter privacy/guardrail) ──
 

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -200,6 +200,33 @@ class TestKeepTypingTimeoutPerTick:
         )
 
     @pytest.mark.asyncio
+    async def test_typing_refresh_stops_after_active_window(self, monkeypatch):
+        """Long turns should keep running without refreshing typing forever."""
+        adapter = _StubAdapter()
+        calls = []
+
+        async def recording_send_typing(chat_id, metadata=None):
+            calls.append(asyncio.get_running_loop().time())
+
+        monkeypatch.setattr(adapter, "send_typing", recording_send_typing)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+
+        stop_event = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._keep_typing(
+                chat_id="long-chat",
+                interval=0.2,
+                stop_event=stop_event,
+                max_active_seconds=0.55,
+            )
+        )
+        await asyncio.sleep(1.2)
+        stop_event.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+        assert 2 <= len(calls) <= 4
+
+    @pytest.mark.asyncio
     async def test_stop_typing_refresh_blocks_late_cancel_tick(self, monkeypatch):
         """Final cleanup must not let a cancelled refresh loop send typing again."""
         adapter = _StubAdapter()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -54,6 +54,54 @@ def test_is_destructive_command_treats_install_as_mutating():
     assert run_agent._is_destructive_command("install template.env .env") is True
 
 
+def test_request_debug_dump_includes_runtime_routing_metadata(agent, tmp_path):
+    """Request dumps must identify provider/model/api_mode/base_url.
+
+    URL-only dumps made provider-routing forensics ambiguous: native
+    Anthropic failures and Codex chat-completions failures could only be
+    inferred from the request URL.  Future dumps should carry the runtime
+    routing decision explicitly.
+    """
+    agent.logs_dir = tmp_path
+    agent.provider = "openai-codex"
+    agent.model = "gpt-5.5"
+    agent.api_mode = "codex_responses"
+    agent.base_url = "https://chatgpt.com/backend-api/codex"
+    agent.session_id = "routing-meta"
+    agent.client = MagicMock(api_key="***")
+
+    dump_path = agent._dump_api_request_debug(
+        {"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}]},
+        reason="unit_test",
+    )
+
+    payload = json.loads(Path(dump_path).read_text(encoding="utf-8"))
+    assert payload["provider"] == "openai-codex"
+    assert payload["model"] == "gpt-5.5"
+    assert payload["api_mode"] == "codex_responses"
+    assert payload["base_url"] == "https://chatgpt.com/backend-api/codex"
+
+
+def test_non_retryable_fingerprint_blocks_repeated_request(agent):
+    """Repeated 400/401/403/404 fingerprints should be blocked locally."""
+    agent.provider = "openai-codex"
+    agent.model = "gpt-5.5"
+    agent.api_mode = "codex_responses"
+    agent.base_url = "https://chatgpt.com/backend-api/codex"
+    api_kwargs = {
+        "model": "gpt-5.5",
+        "messages": [{"role": "user", "content": "same failing payload"}],
+    }
+
+    first = agent._record_non_retryable_request_fingerprint(api_kwargs, status_code=403)
+    second = agent._record_non_retryable_request_fingerprint(api_kwargs, status_code=403)
+
+    assert first["blocked"] is False
+    assert second["blocked"] is True
+    assert second["count"] == 2
+    assert second["status_code"] == 403
+
+
 @pytest.fixture()
 def agent():
     """Minimal AIAgent with mocked OpenAI client and tool loading."""


### PR DESCRIPTION
## Summary
- restore Telegram quick commands menu injection
- cap gateway typing refresh duration so slow/stuck typing refreshes cannot block indefinitely
- harden provider retry/routing behavior for Codex OAuth and non-retryable provider errors

## Verification
- `python -m pytest tests/agent/test_auxiliary_client.py::TestProviderRoutingRegression tests/agent/test_error_classifier.py::TestClassifyApiError::test_statusless_overloaded_message tests/agent/test_error_classifier.py::TestClassifyApiError::test_404_generic tests/agent/test_error_classifier.py::TestClassifyApiError::test_404_status_only_is_non_retryable tests/run_agent/test_run_agent.py::test_request_debug_dump_includes_runtime_routing_metadata tests/run_agent/test_run_agent.py::test_non_retryable_fingerprint_blocks_repeated_request tests/gateway/test_keep_typing_timeout.py -q`
- Result: `13 passed in 22.52s`
