### PR TITLE
fix(cli): skip dependency install when no TTY is available

### DIFF
--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -120,6 +120,15 @@ def ensure_dependency(
             print(f"  Install {dep} manually and try again.")
         return False
 
+    if interactive and not sys.stdin.isatty():
+        # No TTY to ask for consent — e.g. the gateway, a scheduled task, or
+        # any non-interactive service. Don't silently run a possibly-blocking
+        # install in a long-running process; skip and let the capability
+        # degrade instead of hanging on a prompt that can never be answered
+        # (#49206). Callers that want an unattended install pass
+        # ``interactive=False`` explicitly.
+        return False
+
     if interactive and sys.stdin.isatty():
         desc = _DEP_DESCRIPTIONS.get(dep, dep)
         try:

--- a/tests/hermes_cli/test_dep_ensure.py
+++ b/tests/hermes_cli/test_dep_ensure.py
@@ -20,6 +20,36 @@ def test_ensure_dependency_returns_false_when_missing_noninteractive():
             assert result is False
 
 
+def test_ensure_dependency_skips_install_without_tty_when_interactive():
+    """Interactive request with no TTY (gateway/scheduled task) must skip the
+    install instead of running it and hanging on an unanswerable prompt."""
+    from hermes_cli.dep_ensure import ensure_dependency
+    with patch("hermes_cli.dep_ensure._DEP_CHECKS", {"browser": lambda: False}), \
+         patch("hermes_cli.dep_ensure._find_install_script",
+               return_value=("/fake/install.sh", "bash")), \
+         patch("subprocess.run") as mock_run, \
+         patch("sys.stdin") as mock_stdin:
+        mock_stdin.isatty.return_value = False
+        result = ensure_dependency("browser", interactive=True)
+        assert result is False
+        mock_run.assert_not_called()
+
+
+def test_ensure_dependency_noninteractive_still_installs_without_tty(tmp_path):
+    """interactive=False is an explicit unattended install — it must NOT be
+    blocked by the no-TTY guard."""
+    from hermes_cli.dep_ensure import ensure_dependency
+    with patch("hermes_cli.dep_ensure._DEP_CHECKS", {"node": lambda: False}), \
+         patch("hermes_cli.dep_ensure._find_install_script",
+               return_value=(tmp_path / "install.sh", "bash")), \
+         patch("subprocess.run") as mock_run, \
+         patch("sys.stdin") as mock_stdin:
+        mock_stdin.isatty.return_value = False
+        mock_run.return_value = type("R", (), {"returncode": 0})()
+        ensure_dependency("node", interactive=False)
+        mock_run.assert_called_once()
+
+
 def test_find_install_script_from_checkout(tmp_path):
     """_find_install_script finds scripts/install.sh in a git checkout."""
     from hermes_cli.dep_ensure import _find_install_script


### PR DESCRIPTION
## What

`ensure_dependency()` no longer runs a blocking install when there's no TTY to confirm it.

## Why

The interactive prompt was already guarded by `sys.stdin.isatty()`, but on a no-TTY path the code skipped the prompt and still fell through to run the install script. In gateway / scheduled-task / service contexts that launched an unconsented, potentially blocking install (e.g. the browser engine) that could hang the process forever.

## Change

When an interactive install is requested but there's no TTY, I skip it and return `False` so the capability degrades gracefully instead of hanging. `interactive=False` stays an explicit unattended-install path and is unaffected.

## Tests

`tests/hermes_cli/test_dep_ensure.py` — a no-TTY interactive request skips the install (no subprocess), while `interactive=False` still installs.

This covers Issue 2 from #49206. I left Issue 1 (the shared-client deadlock) out for now — it reads more like a workaround than a real fix, so it needs more investigation first.