### PR TITLE
docs(mcp): fix stale 0.75s discovery-wait reference after #49208

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3512,7 +3512,8 @@ def _schedule_mcp_late_refresh(sid: str, agent) -> None:
 
     The agent snapshots ``agent.tools`` once at build time and never re-reads
     the registry (run_agent/agent_init). ``_make_agent`` briefly joins the
-    background MCP discovery thread (``wait_for_mcp_discovery``, ~0.75s) so
+    background MCP discovery thread (``wait_for_mcp_discovery``, bounded by the
+    ``mcp_discovery_timeout`` config value, default 1.5s) so
     already-spawning servers land in that snapshot — but a server that takes
     longer than the bound to connect (common for an HTTP MCP server on first
     connect) lands *after* the agent is built. Its tools are then absent from


### PR DESCRIPTION
## Summary
Corrects a stale docstring reference left after #49208 made the MCP discovery wait configurable. The `_schedule_mcp_late_refresh` docstring in `tui_gateway/server.py` still cited the old `~0.75s` flat bound; the wait is now bounded by the config-driven `mcp_discovery_timeout` (default `1.5s`).

## Changes
- `tui_gateway/server.py`: docstring `~0.75s` → `bounded by the mcp_discovery_timeout config value, default 1.5s`.

## Context
Follow-up to #49208. The original #49160 description also narrated a `5.0s` default that never matched the shipped code (`1.5s`); that text lived only in the (now-closed) PR description, not in the repo, so there's nothing else to correct in-tree. This was the one stale value that actually landed in code.

Docs-only; no behavior change.


## Infographic

![docstring-fix-stale-wait](https://v3b.fal.media/files/b/0a9ef4f3/jLoienAT4g6v8qyzV22f9_Ok6IUo0w.png)
