### PR TITLE
fix(terminal): prevent shell prompt duplication on first keystroke after mouse click

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -531,16 +531,18 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
 
     const dataDisposable = term.onData(data => {
       const id = sessionIdRef.current
-
-      if (id) {
-        // Once the user submits a line, real output may follow — stop the
-        // pristine-prompt gap cleanup so we never clear command scrollback.
-        if (promptPristine && data.includes('\r')) {
-          promptPristine = false
-        }
-
-        void terminalApi.write(id, data)
+      if (!id) {
+        return
       }
+
+      // Any user input means the prompt is no longer pristine.
+      // Waiting for Enter kept the prompt cleanup logic active during
+      // the first keystroke, which could duplicate the shell prompt.
+      if (promptPristine) {
+        promptPristine = false
+      }
+
+      void terminalApi.write(id, data)
     })
 
     cleanup.push(() => dataDisposable.dispose())


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the built-in desktop terminal where the shell prompt was duplicated when the user clicked into the terminal with the mouse and then typed the first character.

**Problem:**
- Open terminal (`Ctrl + ~`)
- Click inside the terminal with mouse
- Type first character → prompt duplicates:  
  `PS C:\Users\Aleksandr> PS C:\Users\Aleksandr> t`

The issue was caused by the `promptPristine` flag being reset only after pressing Enter. Clicking with the mouse activated the terminal, but the first keystroke still triggered the old prompt cleanup logic.

**Solution:**
Moved the reset of `promptPristine` to happen immediately on **any** user input (first keystroke).

## Type of Change
<!-- Check the one that applies. -->
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts` — updated `onData` handler in `useTerminalSession`

## How to Test
1. Open desktop application
2. Open built-in terminal with `Ctrl + ~`
3. Click with the mouse inside the terminal
4. Type any character (e.g. `t`)
5. Confirm that the prompt **does not duplicate**
6. Press Enter and continue working — terminal should behave normally

**Before:** `PS C:\Users\Aleksandr> PS C:\Users\Aleksandr> t`  
**After:** `PS C:\Users\Aleksandr> t`

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping
<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->
- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before**


https://github.com/user-attachments/assets/d50f98c3-d528-4de4-8438-f51783a1cad3

**After**


https://github.com/user-attachments/assets/d826e140-11d9-4b9c-910a-07c377d5ee8a

