### PR TITLE
fix(gemini): strip thought_signature when falling back to Gemma (#36907)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -113,19 +113,22 @@ def _is_gemini_openai_compat_base_url(base_url: Any) -> bool:
 
 
 def _model_consumes_thought_signature(model: Any) -> bool:
-    """True when the outgoing model is a Gemini family model that requires
-    ``extra_content`` (thought_signature) to be replayed on tool calls.
+    """True when the outgoing model requires ``extra_content``
+    (thought_signature) to be replayed on tool calls.
 
     Gemini 3 thinking models attach ``extra_content`` to each tool call and
     reject subsequent requests with HTTP 400 if it is missing. Every other
-    strict OpenAI-compatible provider (Fireworks, Mistral, ...) rejects the
-    request with 400 if ``extra_content`` *is* present. So the field must be
-    kept only when the target model is itself Gemini-family, and stripped
-    otherwise — including when a non-Gemini model inherits stale Gemini
-    ``extra_content`` from earlier in a mixed-provider session.
+    strict provider rejects the request with 400 if ``extra_content`` *is*
+    present — and that includes Google's own **Gemma** models, which do not use
+    the Gemini-3 thinking format: replaying a Gemini thought_signature to
+    ``gemma-4-31b-it`` (e.g. a cross-model fallback from ``gemini-3-flash``)
+    returns ``400 INVALID_ARGUMENT``. So the field is kept only for genuine
+    ``gemini`` models and stripped for everything else — Gemma included, and
+    any non-Gemini model that inherited stale Gemini ``extra_content`` earlier
+    in a mixed-provider session. (#36907)
     """
     m = str(model or "").lower()
-    return "gemini" in m or "gemma" in m
+    return "gemini" in m
 
 
 class ChatCompletionsTransport(ProviderTransport):

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -201,12 +201,22 @@ def _is_openai_api_base_url(base_url: Any) -> bool:
 
 
 def _model_consumes_thought_signature(model: Any) -> bool:
-    """True for Gemini-family targets, which require tool-call ``extra_content`` (thought_signature) replay.
+    """True when the outgoing model requires ``extra_content``
+    (thought_signature) to be replayed on tool calls.
 
-    Every other strict provider rejects it, so it is stripped for non-Gemini targets.
+    Gemini 3 thinking models attach ``extra_content`` to each tool call and
+    reject subsequent requests with HTTP 400 if it is missing. Every other
+    strict provider rejects the request with 400 if ``extra_content`` *is*
+    present — and that includes Google's own **Gemma** models, which do not use
+    the Gemini-3 thinking format: replaying a Gemini thought_signature to
+    ``gemma-4-31b-it`` (e.g. a cross-model fallback from ``gemini-3-flash``)
+    returns ``400 INVALID_ARGUMENT``. So the field is kept only for genuine
+    ``gemini`` models and stripped for everything else — Gemma included, and
+    any non-Gemini model that inherited stale Gemini ``extra_content`` earlier
+    in a mixed-provider session. (#36907)
     """
     m = str(model or "").lower()
-    return "gemini" in m or "gemma" in m
+    return "gemini" in m
 
 
 def _attr_or_model_extra(obj: Any, name: str) -> Any:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -52,7 +52,50 @@ class TestChatCompletionsBasic:
 
 
 
+    def test_convert_messages_keeps_extra_content_for_gemini(self, transport):
+        """Gemini 3 thinking models require the thought_signature replayed on
+        every turn — stripping it would 400. Keep extra_content for Gemini
+        targets (including aggregator slugs like google/gemini-3-pro).
+        """
+        for model in ("gemini-3-pro", "google/gemini-3-pro-preview", "gemini-3-flash"):
+            msgs = self._msg_with_extra_content()
+            result = transport.convert_messages(msgs, model=model)
+            assert result[0]["tool_calls"][0]["extra_content"] == {
+                "google": {"thought_signature": "SIG_123"}
+            }, model
 
+    def test_convert_messages_strips_extra_content_for_gemma(self, transport):
+        """Gemma models do NOT use the Gemini-3 thinking format and 400 on
+        ``extra_content``. A cross-model fallback (gemini-3-flash → gemma-4-31b-it)
+        carries a stale Gemini thought_signature in tool-call history; it must be
+        stripped before reaching Gemma. (#36907)
+        """
+        for model in ("gemma-4-31b-it", "google/gemma-3-27b"):
+            msgs = self._msg_with_extra_content()
+            result = transport.convert_messages(msgs, model=model)
+            assert "extra_content" not in result[0]["tool_calls"][0], model
+            # Original list untouched (deepcopy-on-demand)
+            assert "extra_content" in msgs[0]["tool_calls"][0], model
+
+    def test_convert_messages_strips_tool_name(self, transport):
+        """Internal `tool_name` (used for FTS indexing in the SQLite store) is
+        not part of the OpenAI Chat Completions schema. Strict providers like
+        Moonshot/Kimi reject it with HTTP 400 'Extra inputs are not permitted'.
+        """
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "call_1", "type": "function",
+                             "function": {"name": "execute_code", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_1", "tool_name": "execute_code",
+             "content": "result"},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "tool_name" not in result[2]
+        assert result[2]["content"] == "result"
+        assert result[2]["tool_call_id"] == "call_1"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[2]["tool_name"] == "execute_code"
 
 
     def test_convert_messages_strips_timestamp(self, transport):

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -118,7 +118,50 @@ class TestChatCompletionsBasic:
 
 
 
+    def test_convert_messages_keeps_extra_content_for_gemini(self, transport):
+        """Gemini 3 thinking models require the thought_signature replayed on
+        every turn — stripping it would 400. Keep extra_content for Gemini
+        targets (including aggregator slugs like google/gemini-3-pro).
+        """
+        for model in ("gemini-3-pro", "google/gemini-3-pro-preview", "gemini-3-flash"):
+            msgs = self._msg_with_extra_content()
+            result = transport.convert_messages(msgs, model=model)
+            assert result[0]["tool_calls"][0]["extra_content"] == {
+                "google": {"thought_signature": "SIG_123"}
+            }, model
 
+    def test_convert_messages_strips_extra_content_for_gemma(self, transport):
+        """Gemma models do NOT use the Gemini-3 thinking format and 400 on
+        ``extra_content``. A cross-model fallback (gemini-3-flash → gemma-4-31b-it)
+        carries a stale Gemini thought_signature in tool-call history; it must be
+        stripped before reaching Gemma. (#36907)
+        """
+        for model in ("gemma-4-31b-it", "google/gemma-3-27b"):
+            msgs = self._msg_with_extra_content()
+            result = transport.convert_messages(msgs, model=model)
+            assert "extra_content" not in result[0]["tool_calls"][0], model
+            # Original list untouched (deepcopy-on-demand)
+            assert "extra_content" in msgs[0]["tool_calls"][0], model
+
+    def test_convert_messages_strips_tool_name(self, transport):
+        """Internal `tool_name` (used for FTS indexing in the SQLite store) is
+        not part of the OpenAI Chat Completions schema. Strict providers like
+        Moonshot/Kimi reject it with HTTP 400 'Extra inputs are not permitted'.
+        """
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "call_1", "type": "function",
+                             "function": {"name": "execute_code", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_1", "tool_name": "execute_code",
+             "content": "result"},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "tool_name" not in result[2]
+        assert result[2]["content"] == "result"
+        assert result[2]["tool_call_id"] == "call_1"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[2]["tool_name"] == "execute_code"
 
 
     def test_convert_messages_strips_timestamp(self, transport):

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -258,6 +258,24 @@ class TestBuildApiKwargsOpenRouter:
 
 
 
+    def test_sanitize_tool_calls_strips_extra_content_for_gemma(self, monkeypatch):
+        """Gemma does not use the Gemini-3 thinking format and 400s on a leaked
+        thought_signature (cross-model fallback gemini-3-flash → gemma-4-31b-it,
+        #36907). The shared ``_model_consumes_thought_signature`` predicate must
+        strip extra_content for Gemma on this run_agent path too — parity with
+        the transport's convert_messages — while leaving canonical history intact.
+        """
+        agent = _make_agent(monkeypatch, "openrouter")
+        for model in ("gemma-4-31b-it", "google/gemma-3-27b"):
+            api_msg = self._api_msg_with_extra_content()
+            source_tool_call = api_msg["tool_calls"][0]
+            result = agent._sanitize_tool_calls_for_strict_api(api_msg, model=model)
+            assert "extra_content" not in result["tool_calls"][0], model
+            # Copy-on-write: the source tool_call dict keeps its extra_content.
+            assert source_tool_call["extra_content"] == {
+                "google": {"thought_signature": "SIG_123"}
+            }, model
+
 
 class TestDeveloperRoleSwap:
     """GPT-5 and Codex models should get 'developer' instead of 'system' role."""


### PR DESCRIPTION
## Problem

A `gemini-3-flash` thinking-mode tool call attaches `extra_content.google.thought_signature`. When a fallback chain (or subagent / mid-session model switch) routes that tool-call history to a Google model that does **not** use the Gemini-3 thinking format — e.g. `gemma-4-31b-it` — the request 400s:

```
HTTP 400 INVALID_ARGUMENT: Request contains an invalid argument
```

Repro: primary `gemini-3-flash` makes a tool call (emits `extra_content`), then fails retriably so fallback activates to `gemma-4-31b-it`; the first fallback turn 400s. Also reproducible via any cross-provider replay of Gemini-3 tool-call history through a non-Gemini-3 model.

## Root cause

`convert_messages()` in `agent/transports/chat_completions.py` decides whether to strip the Gemini-specific `extra_content` via `_model_consumes_thought_signature()`, which returned:

```python
return "gemini" in m or "gemma" in m
```

So **any** `gemma-*` model matched and the stale thought_signature was kept — but Gemma rejects the unknown field. The function's own docstring says the field should be kept *"only when the target model is itself Gemini-family"*; Gemma is a separate model family that doesn't use the Gemini-3 thinking format, so the `"gemma"` term was the bug.

## Fix

Narrow the predicate to genuine Gemini models:

```python
return "gemini" in m
```

Now Gemma (and any non-Gemini model that inherited stale Gemini `extra_content` earlier in a mixed-provider session) strips the field, while real Gemini-3 targets still replay it. The Gemini **native** adapter reads `extra_content` on the *response* side only, so request-side stripping here does not affect legitimate Gemini replay.

## Test plan

- [x] New `test_convert_messages_strips_extra_content_for_gemma` — `gemma-4-31b-it` and `google/gemma-3-27b` strip the signature (original message list untouched).
- [x] Updated `test_convert_messages_keeps_extra_content_for_gemini` to assert keep for `gemini-3-pro` / `google/gemini-3-pro-preview` / `gemini-3-flash` (no longer asserts the buggy gemma-keeps behavior).
- [x] `scripts/run_tests.sh tests/agent/transports/test_chat_completions.py` — 82/82 pass.

Closes #36907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
