### PR TITLE
fix: honor resolved auxiliary model on cache miss

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4772,7 +4772,9 @@ def _get_cached_client(
                 _client_cache[cache_key] = (client, default_model, bound_loop)
             else:
                 client, default_model, _ = _client_cache[cache_key]
-    return client, model or default_model
+    if client is None:
+        return client, model or default_model
+    return client, _compat_model(client, model, default_model)
 
 
 # Aliases that target direct REST APIs not modeled as first-class providers

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1248,6 +1248,35 @@ class TestAuxiliaryPoolAwareness:
         assert model == "openai/gpt-5.4-mini"
         assert mock_resolve.call_count == 1
 
+    def test_cache_miss_uses_resolved_model_after_auto_drops_bad_override(self):
+        import agent.auxiliary_client as aux
+
+        fake_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fake_client, "glm-4.5-flash"),
+        ) as mock_resolve:
+            aux.shutdown_cached_clients()
+            try:
+                client, model = aux._get_cached_client(
+                    "auto",
+                    "google/gemini-3-flash-preview",
+                )
+            finally:
+                aux.shutdown_cached_clients()
+
+        assert client is fake_client
+        assert model == "glm-4.5-flash"
+        mock_resolve.assert_called_once()
+        args, kwargs = mock_resolve.call_args
+        assert args == ("auto", "google/gemini-3-flash-preview", False)
+        assert kwargs["explicit_base_url"] is None
+        assert kwargs["explicit_api_key"] is None
+        assert kwargs["api_mode"] is None
+        assert kwargs["is_vision"] is False
+        assert kwargs["task"] is None
+
 
 # ── Payment / credit exhaustion fallback ─────────────────────────────────
 


### PR DESCRIPTION
## Summary
- use `_compat_model(...)` on auxiliary client cache misses so the returned model matches the actually resolved provider/model pair
- prevent bad vendor-prefixed overrides like `google/gemini-3-flash-preview` from leaking back out after `auto` routing resolves to a Z.AI model
- add a regression test for the cache-miss path alongside the existing cached slash-model coverage

## Testing
- `pytest -q tests/agent/test_auxiliary_client.py -k 'cached_gmi_client_keeps_explicit_slash_model_override or cache_miss_uses_resolved_model_after_auto_drops_bad_override'`
- `pytest -q tests/agent/test_crossloop_client_cache.py`
