### PR TITLE
fix(gateway): honor raw telegram topic rename config

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11366,15 +11366,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         Controlled via ``gateway.platforms.telegram.extra.disable_topic_auto_rename``.
         Default is False (auto-rename enabled, preserves prior behaviour).
+        The gateway may hold config as typed objects or as the raw dict loaded
+        from config.yaml, so support both shapes.
         """
-        platform_cfg = (
-            self.config.platforms.get(source.platform)
-            if getattr(self, "config", None) and getattr(self.config, "platforms", None)
-            else None
-        )
+
+        def _field(obj, key, default=None):
+            if isinstance(obj, dict):
+                return obj.get(key, default)
+            return getattr(obj, key, default)
+
+        config = getattr(self, "config", None)
+        platforms = _field(config, "platforms", {})
+        platform_cfg = None
+        if isinstance(platforms, dict):
+            candidate_keys = [source.platform, str(source.platform)]
+            platform_value = getattr(source.platform, "value", None)
+            if platform_value is not None:
+                candidate_keys.append(platform_value)
+            for key in candidate_keys:
+                platform_cfg = platforms.get(key)
+                if platform_cfg is not None:
+                    break
         if platform_cfg is None:
             return False
-        extra = getattr(platform_cfg, "extra", None) or {}
+        extra = _field(platform_cfg, "extra", None) or {}
+        if not isinstance(extra, dict):
+            return False
         value = extra.get("disable_topic_auto_rename")
         if value is None:
             return False

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1002,6 +1002,26 @@ def test_telegram_topic_auto_rename_disabled_string_truthy(tmp_path):
     assert runner._telegram_topic_auto_rename_disabled(source) is False
 
 
+def test_telegram_topic_auto_rename_disabled_reads_raw_config_dict(tmp_path):
+    """Live gateway config may be a raw dict, not typed PlatformConfig objects."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    runner = _make_runner(session_db=db)
+    source = _make_source(thread_id="42")
+    setattr(
+        runner,
+        "config",
+        {
+            "platforms": {
+                "telegram": {
+                    "extra": {"disable_topic_auto_rename": True},
+                }
+            }
+        },
+    )
+
+    assert runner._telegram_topic_auto_rename_disabled(source) is True
+
+
 def test_general_topic_is_treated_as_root_lobby(tmp_path):
     """Messages in the Telegram General topic (thread_id=1) route to the lobby, not a lane."""
     db = SessionDB(db_path=tmp_path / "state.db")


### PR DESCRIPTION
## Summary
- Fix Telegram topic auto-rename disable lookup when gateway config is loaded as a raw dict.
- Preserve existing typed config behavior and truthy string handling.
- Add a regression test for the raw dict live-config path.

## Tests
- `scripts/run_tests.sh tests/gateway/test_telegram_topic_mode.py`

## Risk
- Low: helper remains default-off and only changes lookup shape handling for an existing config flag.
