### PR TITLE
fix(responses): clamp call_id to 64 chars and sanitize replayed fn names

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -191,6 +191,52 @@ def _deterministic_call_id(fn_name: str, arguments: str, index: int = 0) -> str:
     return f"call_{digest}"
 
 
+def _clamp_call_id(call_id: str) -> str:
+    """Clamp a Responses API call_id to the 64-character hard limit.
+
+    The Responses API rejects call_ids longer than 64 characters with a
+    non-retryable HTTP 400 (``Invalid input[N].call_id: string too long,
+    max 64``).  This can happen in the background-review replay path: when
+    a tool call is stored with only a ``response_item_id`` (an ``fc_``
+    string, typically ~67 characters) and no explicit ``call_id``, the
+    reconstruction in ``_chat_messages_to_responses_input`` synthesises
+    ``"call_" + fc_id[3:]`` — which is ``5 + 64 = 69`` characters, well
+    over the limit.
+
+    The clamp is deterministic: a ``function_call`` and its paired
+    ``function_call_output`` share the same raw call_id string, so hashing
+    identically keeps the pair matched and the API's pairing requirement
+    intact.  Short ids (≤ 64 chars) are returned unchanged, preserving
+    prompt-cache prefix hits.
+    """
+    cid = (call_id or "").strip()
+    if len(cid) <= 64:
+        return cid
+    prefix = "fc_" if cid.startswith("fc_") else "call_"
+    digest = hashlib.sha256(cid.encode("utf-8", errors="replace")).hexdigest()[:24]
+    return f"{prefix}{digest}"
+
+
+def _sanitize_fn_name(name: str) -> str:
+    """Sanitize a replayed function_call name to the Responses API contract.
+
+    The Responses API requires function names to match ``^[a-zA-Z0-9_-]+$``.
+    When a background-review replay carries a name with invalid characters
+    (e.g. dots or spaces from an earlier degeneration), the API rejects the
+    request with a non-retryable HTTP 400.  This helper coerces the name at
+    the last normalisation point (``_preflight_codex_input_items``) so the
+    replay can proceed.
+
+    This applies only to *replayed* function_call input items, not to live
+    tool definitions — live tool names must match the tool registry and must
+    not be mutated.  Pairing is by call_id, so renaming a replayed name does
+    not break function_call / function_call_output correspondence.
+    """
+    n = re.sub(r"[^A-Za-z0-9_-]", "_", (name or "").strip())
+    n = re.sub(r"_+", "_", n).strip("_")
+    return n[:64] or "fn"
+
+
 def _split_responses_tool_id(raw_id: Any) -> tuple[Optional[str], Optional[str]]:
     """Split a stored tool id into (call_id, response_item_id)."""
     if not isinstance(raw_id, str):
@@ -605,8 +651,8 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
             normalized.append(
                 {
                     "type": "function_call",
-                    "call_id": call_id.strip(),
-                    "name": name.strip(),
+                    "call_id": _clamp_call_id(call_id),
+                    "name": _sanitize_fn_name(name),
                     "arguments": arguments,
                 }
             )
@@ -646,7 +692,7 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 normalized.append(
                     {
                         "type": "function_call_output",
-                        "call_id": call_id.strip(),
+                        "call_id": _clamp_call_id(call_id),
                         "output": cleaned if cleaned else "",
                     }
                 )
@@ -657,7 +703,7 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
             normalized.append(
                 {
                     "type": "function_call_output",
-                    "call_id": call_id.strip(),
+                    "call_id": _clamp_call_id(call_id),
                     "output": output,
                 }
             )


### PR DESCRIPTION
## Problem

When the background-review replay path fires in a long-running Codex app-server session, the gateway crashes with a `BrokenPipeError` that kills the entire turn:

```
openai.BadRequestError: 400 Invalid input[N].call_id: string too long, max 64
BrokenPipeError: [Errno 32] Broken pipe
```

A second, related 400 fires when a replayed function_call carries an invalid name:

```
openai.BadRequestError: 400 Invalid input[N].name: string does not match pattern '^[a-zA-Z0-9_-]+'
```

Both errors are **non-retryable** — the Responses API returns HTTP 400, not 429 or 5xx — so neither the retry loop nor the credential pool recovers. The gateway turn is lost.

## Root cause

**call_id overflow** — `agent/codex_responses_adapter.py`, `_chat_messages_to_responses_input` (assistant tool_calls block):

When a tool call is stored with only a `response_item_id` (an `fc_` string, typically ~67 characters) and no explicit `call_id`, the reconstruction synthesises:

```python
call_id = f"call_{embedded_response_item_id[len('fc_'):]}"
# → "call_" + ~64 chars = ~69 chars — over the 64-char limit
```

This synthesised value is then passed unchanged through `_preflight_codex_input_items` (`call_id.strip()`) and emitted directly to the API.

**Invalid function name** — same file, same function, function_call replay item:

A replayed function_call carries the `name` as-is from conversation history. If the model degenerated on a previous turn and emitted a name containing dots, spaces, or other characters outside `^[a-zA-Z0-9_-]+`, the replay fails with a 400.

## Fix

Two new helpers added in `agent/codex_responses_adapter.py`, in the ID-helpers section alongside `_deterministic_call_id`:

**`_clamp_call_id(call_id: str) -> str`**
- Returns the id unchanged when `len(cid) <= 64` (the common case — no regression, prompt-cache prefix hits preserved).
- For longer ids: deterministic SHA-256 hash-clamp, prefix-preserving (`call_` or `fc_`).
- **Determinism is the key invariant**: a `function_call` and its paired `function_call_output` carry the *same raw call_id string*, so hashing identically maps both to the same clamped value, keeping the pair matched as required by the Responses API.

**`_sanitize_fn_name(name: str) -> str`**
- Replaces characters outside `[A-Za-z0-9_-]` with `_`, collapses runs, strips leading/trailing underscores, truncates to 64 chars.
- Applied only to *replayed* function_call input items — **not** to live tool definitions (which must match the tool registry exactly and must not be mutated). Pairing is by `call_id`, so renaming a replayed name is safe.

Both helpers are applied in `_preflight_codex_input_items`, the single normalisation choke-point executed immediately before every Responses API request.

## Repro

1. Run a Codex app-server session (`api_mode = "codex_app_server"`) for several turns involving tool calls with long `fc_` ids (e.g. `fc_` + 64 hex chars = 67 chars total).
2. Trigger background-review (memory review or skill nudge interval). The replay path in `_chat_messages_to_responses_input` reconstructs `call_id` as `"call_" + fc_id[3:]` → 69 chars.
3. `_preflight_codex_input_items` emits the 69-char value verbatim.
4. The Responses API returns HTTP 400; the app-server pipe breaks.

Without this fix the gateway logs show:

```
openai.BadRequestError: 400 Invalid input[3].call_id: string too long, max 64
BrokenPipeError: [Errno 32] Broken pipe
```

## Test plan

- [ ] Unit: `_clamp_call_id("call_" + "x" * 60)` → `len(...) == 64`; `"call_" + "x" * 10` passes unchanged; same input always maps to same output (determinism); `function_call` and `function_call_output` with the same raw id clamp identically.
- [ ] Unit: `_sanitize_fn_name("exec.command")` → `"exec_command"`; `_sanitize_fn_name("a" * 70)` → `len == 64`; empty / all-invalid → `"fn"`.
- [ ] Integration: mock a `function_call` in the input list with a 69-char `call_id`; assert `_preflight_codex_input_items` no longer raises and the output `call_id` is `<= 64` chars.
- [ ] Regression: existing tests for `_preflight_codex_input_items` still pass; normal short call_ids are not mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)