### PR TITLE
fix(codex): persist app-server turns to session DB (fixes starved recall)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -319,6 +319,16 @@ def run_codex_app_server_turn(
         "completed": not turn.interrupted and turn.error is None,
         "partial": turn.interrupted or turn.error is not None,
         "error": turn.error,
+        # Signal that the codex app-server runtime did NOT self-persist
+        # its turn messages to the session DB.  The standard conversation_loop
+        # path flushes messages via _flush_messages_to_session_db(), but
+        # run_codex_app_server_turn is an early-return that bypasses that
+        # loop entirely.  Without this flag, gateway/run.py assumes
+        # self._session_db is not None → skip_db=True on every
+        # append_to_transcript call, leaving codex turns persisted nowhere
+        # (state.db gets only session_meta rows, so session_search and
+        # conversation-distill are blind to real gateway conversations).
+        "agent_persisted": False,
         "codex_thread_id": turn.thread_id,
         "codex_turn_id": turn.turn_id,
         **usage_result,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9729,7 +9729,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # The agent already persisted these messages to SQLite via
             # _flush_messages_to_session_db(), so skip the DB write here
             # to prevent the duplicate-write bug (#860 / #42039).
-            agent_persisted = self._session_db is not None
+            # Exception: the codex app-server runtime is an early-return path
+            # that bypasses conversation_loop and never calls
+            # _flush_messages_to_session_db().  It signals this by returning
+            # agent_persisted=False; the gateway then writes the new turn's
+            # messages to state.db so session_search (FTS) and
+            # conversation-distill can see real gateway conversations.
+            # Default True preserves the existing behaviour for the standard
+            # runtime (no duplicate-write regression, #860 / #42039).
+            agent_persisted = agent_result.get("agent_persisted", self._session_db is not None)
 
             # Find only the NEW messages from this turn (skip history we loaded).
             # Use the filtered history length (history_offset) that was actually
@@ -15992,6 +16000,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
                 "response_transformed": result.get("response_transformed", False),
+                # Pass through the agent_persisted flag so the persistence block
+                # above can correctly determine whether the codex app-server path
+                # self-persisted (it didn't — see codex_runtime.py).  Default
+                # True preserves the skip-db behaviour for the standard runtime.
+                "agent_persisted": (result_holder[0].get("agent_persisted", True) if result_holder[0] else True),
             }
         
         # Start progress message sender if enabled


### PR DESCRIPTION
## Problem

Gateway sessions using the `codex_app_server` runtime have no conversation memory: `session_search` (full-text search over `state.db`) and `conversation-distill` return empty results for all turns driven by the Codex app-server path. The agent effectively forgets everything that happened in a conversation.

## Root cause

**`agent/codex_runtime.py` — `run_codex_app_server_turn` is an early-return path that bypasses `conversation_loop`.**

The standard runtime drives every turn through `conversation_loop`, which calls `_flush_messages_to_session_db()` to persist user + assistant + tool messages to `state.db`. The codex app-server path returns early (before `conversation_loop` is entered) and never calls `_flush_messages_to_session_db()`.

**`gateway/run.py` — persistence block assumes the agent self-persisted.**

```python
# gateway/run.py ~line 9732
agent_persisted = self._session_db is not None   # always True
# → skip_db=True on every append_to_transcript call
```

The comment says "the agent already persisted these messages". That assumption is true for the standard runtime, but **false for the codex app-server path**. With `skip_db=True`, the gateway also skips writing to `state.db`. End result: codex turns are written to neither location.

`state.db` accumulates only `session_meta` rows — no user messages, no assistant responses, no tool calls. `session_search` FTS returns nothing; `conversation-distill` has nothing to distill.

**`gateway/run.py` — `agent_persisted` flag is silently dropped in the result rebuild.**

Even if `run_codex_app_server_turn` returned `agent_persisted=False`, the rebuilt result dict at the `return {…}` of `_run_agent` did not include a passthrough for that key. `agent_result.get("agent_persisted", …)` would always see the `…` default.

## Fix

Three backward-compatible changes:

**1. `agent/codex_runtime.py`** — `run_codex_app_server_turn` success return now includes:

```python
"agent_persisted": False,
```

This signals to the gateway that the codex path did NOT self-persist its turn.

**2. `gateway/run.py` — persistence block** now reads the flag instead of hard-coding `True`:

```python
agent_persisted = agent_result.get("agent_persisted", self._session_db is not None)
```

For the standard runtime (which does not set the key), the default `self._session_db is not None` preserves the existing skip-db behaviour — **no duplicate-write regression** (#860 / #42039). For the codex app-server runtime, the flag is `False`, so the gateway writes the new turn's messages to `state.db` and the FTS index.

**3. `gateway/run.py` — result rebuild** now passes the flag through:

```python
"agent_persisted": (result_holder[0].get("agent_persisted", True) if result_holder[0] else True),
```

Without this, the flag returned by `run_codex_app_server_turn` was discarded when `_run_agent` rebuilt the result dict from `result_holder[0]`, so edit 2 would never see `False`.

## Repro

1. Configure a gateway profile with `api_mode = "codex_app_server"` (the Codex CLI runtime).
2. Send several messages through the gateway.
3. Call `session_search` with a keyword from one of those messages.
4. Without this fix: empty results. With this fix: the turn messages are returned.

Alternatively, check `state.db` directly:

```python
import sqlite3, pathlib
db = sqlite3.connect(pathlib.Path("~/.hermes/profiles/<profile>/state.db").expanduser())
rows = db.execute("SELECT role, content FROM messages ORDER BY id DESC LIMIT 10").fetchall()
print(rows)
# Before fix: only session_meta rows
# After fix:  user + assistant + tool rows present
```

## Test plan

- [ ] Unit: mock `run_codex_app_server_turn` to return `{"agent_persisted": False, …}`; assert that `_run_agent`'s return dict contains `"agent_persisted": False`.
- [ ] Unit: mock `agent_result` with `agent_persisted=False` and a non-None `self._session_db`; assert `agent_persisted` local variable is `False` (gateway writes to DB).
- [ ] Unit: mock `agent_result` without `agent_persisted` key (standard runtime); assert `agent_persisted` defaults to `self._session_db is not None` (existing behaviour preserved).
- [ ] Integration: run two turns through a codex app-server gateway session; assert `state.db` contains `role=user` and `role=assistant` rows for both turns.
- [ ] Regression: run two turns through the standard runtime; assert each message appears exactly once in `state.db` (no duplicate-write regression from #860 / #42039).

🤖 Generated with [Claude Code](https://claude.com/claude-code)