### PR TITLE
fix(ci): skip native rebuild in typecheck jobs to stop node-pty flake

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -24,7 +24,14 @@ jobs:
         with:
           node-version: 22
           cache: npm
-      - run: npm ci
+      # --ignore-scripts skips native postinstall (node-pty has no linux-x64
+      # prebuild, so a bare `npm ci` rebuilds it from source via node-gyp on
+      # every run; that download flakes intermittently — e.g. an undici
+      # `assert(!this.paused)` crash — turning the same commit green in a PR
+      # but red on main). These jobs only need TypeScript types + the renderer
+      # bundle, never the compiled node-pty binary, so skipping the rebuild is
+      # both faster and deterministic.
+      - run: npm ci --ignore-scripts
       - run: npm run --prefix ${{ matrix.package }} typecheck
 
   # Production build of the desktop renderer. `typecheck` runs `tsc` only,
@@ -41,5 +48,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
-      - run: npm ci
+      # See the typecheck job above: --ignore-scripts avoids the flaky
+      # from-source node-pty rebuild. The renderer `vite build` this job
+      # exercises does not link node-pty (it lives in the Electron main
+      # process), so the build is unaffected.
+      - run: npm ci --ignore-scripts
       - run: npm run --prefix apps/desktop build


### PR DESCRIPTION
## Summary

The **Typecheck** workflow's `npm ci` rebuilds `node-pty` **from source** on every run, because `node-pty@1.1.0` ships no linux-x64 prebuild. That `node-gyp` build downloads the Node headers and intermittently crashes mid-download with an undici `assert(!this.paused)` failure. The result: the **identical commit** goes green in its PR run and red once it lands on `main` — "green in PR, red in commit log".

Proven on the most recent occurrence (PR #49208 → main `16642e276`):

| Check | PR #49208 (in-PR) | main `16642e276` |
|---|---|---|
| `typecheck (apps/shared)` | ✅ pass | ❌ failure (in `npm ci`, not `tsc`) |
| all other typecheck/build jobs | ✅ pass | ✅ pass |

Same code, opposite result — the failing run died in the `node-pty` rebuild, never reaching `tsc`.

## Fix

Add `--ignore-scripts` to `npm ci` in the **typecheck** matrix and **desktop-build** jobs. None of these jobs need the compiled `node-pty` binary:
- the matrix runs `tsc` only (types come from `.d.ts`, present regardless of native build);
- `desktop-build` runs the renderer `vite build`, and `node-pty` lives in the Electron **main** process, not the renderer bundle.

Skipping the from-source rebuild makes these jobs **deterministic** and faster, and is scoped to CI only (runtime/install behavior elsewhere is untouched).

## Test plan

Verified locally against a clean `origin/main` worktree with `npm ci --ignore-scripts`:

- [x] `typecheck (ui-tui)` passes
- [x] `typecheck (web)` passes
- [x] `typecheck (apps/bootstrap-installer)` passes
- [x] `typecheck (apps/desktop)` passes
- [x] `typecheck (apps/shared)` passes
- [x] `apps/desktop` production `vite build` passes
- [ ] CI green on this PR

## Note (out of scope)

`main` is currently **unprotected** (no required status checks), so a PR merges regardless of typecheck status and a red result can sit on `main` unblocked. That's a separate process gap worth addressing, but not part of this fix.