### PR TITLE
fix(ci): stop save-durations JSON collision from artifact merge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,14 +137,20 @@ jobs:
         with:
           pattern: test-durations-slice-*
           path: durations
-          merge-multiple: true
+          # NOT merge-multiple: every slice uploads a file named exactly
+          # `test_durations.json`, so merging them into one directory collides
+          # all six onto the same path. That overwrite/interleave races and
+          # can leave concatenated JSON, which the merge step below then fails
+          # to parse ("Extra data"). Keeping each artifact in its own
+          # subdirectory (durations/test-durations-slice-N/test_durations.json)
+          # gives six distinct, individually-valid files to merge.
 
       - name: Merge into single durations file
         run: |
           python3 -c "
-          import json, glob, os
+          import json, glob
           merged = {}
-          for f in glob.glob('durations/*test_durations.json'):
+          for f in glob.glob('durations/**/test_durations.json', recursive=True):
             with open(f) as fh:
               merged.update(json.load(fh))
           with open('test_durations.json', 'w') as fh:


### PR DESCRIPTION
## Summary

This is the **post-merge-only** failure behind the red X on recent `main` commits (e.g. `Tests / save-durations (push)` on #49221). It is genuinely invisible in PRs.

The `save-durations` job is gated on the ref:

```yaml
save-durations:
  needs: test
  if: needs.test.result == 'success' && github.ref == 'refs/heads/main'
```

…so it is **skipped on every PR** and only runs after merge. It downloads all six per-slice duration artifacts with `merge-multiple: true`, but each slice uploads a file named identically — `test_durations.json`. Merging them into one directory collapses all six onto a single path; the overwrite/interleave races and can leave concatenated JSON, which the merge step then fails to parse:

```
json.decoder.JSONDecodeError: Extra data: line 422 column 1 (char 22525)
```

Because it's timing-dependent, it fails on some commits and goes green on re-run — which is exactly the "red in the commit log, nothing in the PR" pattern.

## Fix

Drop `merge-multiple` so each artifact downloads into its own subdirectory (`durations/test-durations-slice-N/test_durations.json`), and recurse the merge glob (`durations/**/test_durations.json`). Six distinct, individually-valid files merge cleanly and deterministically.

## Test plan

- [x] Per-slice files are written as a single valid JSON object (`scripts/run_tests_parallel.py::_save_durations`), so the only corruption source was the download collision.
- [x] Simulated the post-fix layout locally: 6 distinct files → 6 merged entries, no "Extra data".
- [x] `tests.yml` is valid YAML.
- [ ] CI green on this PR (note: `save-durations` itself is skipped on PRs by design; it will exercise on the next `main` push).

## Relationship to #49227

Independent root cause / different workflow. #49227 fixes the **node-pty rebuild flake** in `typecheck`; this fixes the **duration-artifact collision** in `tests`. Together they clear both classes of red-on-main-but-green-in-PR you flagged.