### PR TITLE
chore: release v0.17.0 (2026.6.19)

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.16.0",
+      "package": "hermes-agent[acp]==0.17.0",
       "args": ["hermes-acp"]
     }
   }

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.16.0"
-__release_date__ = "2026.6.5"
+__version__ = "0.17.0"
+__release_date__ = "2026.6.19"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.16.0"
+version = "0.17.0"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1587,6 +1587,26 @@ AUTHOR_MAP = {
     "infinitycrew39@gmail.com": "infinitycrew39",  # PR #47945 salvage (scope langfuse trace state by turn/request ids; #48292)
     "eurekaxun@163.com": "huangxun375-stack",  # PR #37251 / #48894 structured OpenViking sync
     "218421507+Sahil-SS9@users.noreply.github.com": "Sahil-SS9",  # PR #48466/#44919/#44909/#42209 salvage (cron/checkpoint/kanban/skill)
+    # v0.17.0 additions
+    "2081789787@qq.com": "pengyuyanITYU",  # PR #43618 (harden local file tree paths)
+    "adalsteinni@gmail.com": "AIalliAI",  # PR #44159 (desktop hover-reveal inset)
+    "ameobius@local.host": "ameobius",  # PR #44383 co-author (discord gateway task recovery)
+    "andyfieb@gmail.com": "mollusk",  # PR #44493 (desktop assistant-ui recovery)
+    "drmani215@gmail.com": "bionicbutterfly13",  # direct email match
+    "enesilhaydin@gmail.com": "enesilhaydin",  # direct email match
+    "evisolpxe@gmail.com": "Evisolpxe",  # direct email match
+    "fyzan.shaik@gmail.com": "fyzanshaik",  # direct email match
+    "info@amik.co": "AMIK-coorporations",  # PR #40578 (Urdu README) co-author
+    "info@amikchat.site": "AMIK-coorporations",  # PR #40578 (Urdu README)
+    "kyssta69@gmail.com": "kyssta-exe",  # PR #44282 (Windows dashboard re-exec)
+    "loongfay@foxmail.com": "loongfay",  # PR #43508 (Yuanbao wechat forward msg)
+    "maplestoryjuni222@gmail.com": "BROCCOLO1D",  # PR #42733 (lazy-parse docker env config)
+    "marvin@photon.codes": "underthestars-zhy",  # PR #46907 co-author (Photon Spectrum project ids)
+    "omar@kostudios.io": "OmarB97",  # PR #43977 (desktop session model metadata)
+    "omarbaradei21@gmail.com": "OmarB97",  # PR #43977 (desktop session model metadata)
+    "philip.a.dsouza@gmail.com": "PhilipAD",  # direct email match
+    "qs2816661685@gmail.com": "qingshan89",  # PR #46895 co-author (desktop remote artifact download)
+    "yspdev@gmail.com": "AJ",  # PR #44510 co-author (desktop named-profile boot loop)
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1424,7 +1424,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
Release v0.17.0 (CalVer v2026.6.19) — "The Reach Release". Bumps the three version files + uvx pin + regenerates `uv.lock`, and adds AUTHOR_MAP entries for new v0.17.0 contributors.

## Changes
- `hermes_cli/__init__.py`: `__version__` 0.16.0 → 0.17.0, `__release_date__` → 2026.6.19
- `pyproject.toml`: version 0.16.0 → 0.17.0
- `acp_registry/agent.json`: version + uvx package pin → 0.17.0
- `uv.lock`: regenerated (version self-reference)
- `scripts/release.py`: 19 new AUTHOR_MAP entries (v0.17.0 contributors)

## Validation
| Gate | Result |
|---|---|
| Contributor audit (`--since-tag v2026.6.5`) | 245 contributors, 0 unknown emails, 0 missing |
| `uv lock --check` | clean (regen was version-only) |
| Wheel data files | 76 `plugin.yaml` manifests ship in wheel |
| `rg "0\.16\.0"` (anchored) | 0 stale matches |
| Branch base | 0 commits behind origin/main |

Changelog is published with the GitHub Release (not committed to the repo).

## Infographic

![hermes v0.17.0 the reach release](https://v3b.fal.media/files/b/0a9ef592/oM2D17904ahRj8v1QnJtb_mYwhiWtn.png)
