### PR TITLE
feat(web): add native chat uploads panel

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1288,8 +1288,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             )
 
         agent._buffer_status(
-            f"🔄 Primary model failed — switching to fallback: "
-            f"{fb_model} via {fb_provider}"
+            f"🚨 Paid fallback activated: primary model failed, so this turn is now using "
+            f"{fb_model} via {fb_provider}. OpenRouter/API credits may be charged until the primary works again."
         )
         logger.info(
             "Fallback activated: %s → %s (%s)",

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -621,6 +621,16 @@ PLATFORM_HINTS = {
         "When referring to a file you created or changed, just state its "
         "absolute path in plain text; the user can open it from there."
     ),
+    "tui": (
+        "You are in the Hermes TUI / embedded dashboard chat. Standard Markdown "
+        "is rendered in the chat transcript, including headings, bold, italic, "
+        "inline code, code blocks, links, bullets, numbered lists, block quotes, "
+        "tables, and math. Use readable chat-style formatting when it improves "
+        "clarity — clear spacing, short paragraphs, and emphasis where helpful — "
+        "but do not force every response into bullets or a rigid template. "
+        "File delivery: there is no native attachment channel here; when referring "
+        "to a file you created or changed, state its absolute path plainly."
+    ),
     "sms": (
         "You are communicating via SMS. Keep responses concise and use plain text "
         "only — no markdown, no formatting. SMS messages are limited to ~1600 "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15029,6 +15029,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger=logger,
                 log_message=f"status_callback ({event_type}) scheduling error",
             )
+            # Fallback activation is billing/availability-critical: in topic-based
+            # Telegram workspaces, the normal status callback only lands in the
+            # active topic. Also send a copy to TELEGRAM_HOME_CHANNEL so the
+            # operator is warned even if they are working in a different topic.
+            if (
+                source.platform == Platform.TELEGRAM
+                and event_type == "lifecycle"
+                and "Paid fallback activated" in str(message or "")
+            ):
+                _fallback_home_chat = os.getenv("TELEGRAM_FALLBACK_ALERT_CHANNEL", "").strip() or os.getenv("TELEGRAM_HOME_CHANNEL", "").strip()
+                if _fallback_home_chat and str(_fallback_home_chat) != str(_status_chat_id):
+                    safe_schedule_threadsafe(
+                        _status_adapter.send(
+                            _fallback_home_chat,
+                            prepared_message,
+                            metadata=None,
+                        ),
+                        _loop_for_step,
+                        logger=logger,
+                        log_message="fallback home alert scheduling error",
+                    )
             if _fut is None:
                 return
             if _cleanup_progress:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7458,6 +7458,77 @@ async def prune_sessions_endpoint(body: SessionPrune):
         db.close()
 
 
+_CHAT_UPLOAD_MAX_BYTES = 100 * 1024 * 1024
+_CHAT_UPLOAD_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".heic", ".heif"}
+
+
+def _safe_upload_filename(filename: str) -> str:
+    raw = Path(filename or "upload").name.strip() or "upload"
+    safe = re.sub(r"[^A-Za-z0-9._ -]+", "_", raw).strip(". ")
+    return safe or "upload"
+
+
+@app.post("/api/chat/uploads")
+def upload_chat_file(file: UploadFile = File(...)):
+    """Store a dashboard native-chat upload under the active profile.
+
+    The native chat UI does not ask the user where a file should live. It puts
+    uploads in a profile-scoped staging area and includes the absolute path in
+    the prompt so Hermes can inspect, transform, move, or archive the file as
+    the task requires.
+    """
+    filename = _safe_upload_filename(file.filename or "upload")
+    date_dir = time.strftime("%Y-%m-%d")
+    dest_dir = get_hermes_home() / "uploads" / "dashboard-chat" / date_dir
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    stem = Path(filename).stem or "upload"
+    suffix = Path(filename).suffix
+    dest = dest_dir / filename
+    counter = 1
+    while dest.exists():
+        dest = dest_dir / f"{stem}-{counter}{suffix}"
+        counter += 1
+
+    size = 0
+    try:
+        with dest.open("wb") as out:
+            while True:
+                chunk = file.file.read(1024 * 1024)
+                if not chunk:
+                    break
+                size += len(chunk)
+                if size > _CHAT_UPLOAD_MAX_BYTES:
+                    try:
+                        dest.unlink(missing_ok=True)
+                    except Exception:
+                        pass
+                    raise HTTPException(status_code=413, detail="Uploaded file is larger than 100 MB")
+                out.write(chunk)
+    finally:
+        try:
+            file.file.close()
+        except Exception:
+            pass
+
+    mime_type = file.content_type or "application/octet-stream"
+    is_image = dest.suffix.lower() in _CHAT_UPLOAD_IMAGE_EXTENSIONS or mime_type.startswith("image/")
+    prompt_text = (
+        f"[User uploaded {'image' if is_image else 'file'}: {dest.name}]\n"
+        f"Stored path: {dest}\n"
+        "Use the appropriate file tools to inspect it and decide where it should be stored or moved for this task."
+    )
+    return {
+        "ok": True,
+        "name": dest.name,
+        "path": str(dest),
+        "size": size,
+        "mime_type": mime_type,
+        "is_image": is_image,
+        "prompt_text": prompt_text,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Log viewer endpoint
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -990,6 +990,7 @@ class TestPromptBuilderConstants:
         assert "discord" in PLATFORM_HINTS
         assert "cron" in PLATFORM_HINTS
         assert "cli" in PLATFORM_HINTS
+        assert "tui" in PLATFORM_HINTS
         assert "api_server" in PLATFORM_HINTS
         assert "webui" in PLATFORM_HINTS
 
@@ -1068,6 +1069,13 @@ class TestPromptBuilderConstants:
         assert "MEDIA:" in hint
         assert "Markdown" in hint
         assert "absolute" in hint
+
+    def test_platform_hints_tui_allows_readable_markdown_without_media_tags(self):
+        hint = PLATFORM_HINTS["tui"]
+        assert "Markdown" in hint
+        assert "readable chat-style formatting" in hint
+        assert "do not force every response into bullets" in hint
+        assert "no native attachment channel" in hint
 
 
 # =========================================================================

--- a/web/src/components/NativeChatPanel.tsx
+++ b/web/src/components/NativeChatPanel.tsx
@@ -1,0 +1,381 @@
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Markdown } from "@/components/Markdown";
+import { HERMES_BASE_PATH, buildWsAuthParam, uploadChatFile } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { Paperclip, Send, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+type ChatRole = "user" | "assistant" | "system";
+
+type ChatMessage = {
+  id: string;
+  role: ChatRole;
+  content: string;
+  status?: "streaming" | "complete" | "error";
+};
+
+type UploadAttachment = {
+  name: string;
+  path: string;
+  mime_type: string;
+  size: number;
+  prompt_text: string;
+  is_image: boolean;
+};
+
+type RpcPending = {
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function TypingIndicator() {
+  return (
+    <div className="flex items-center gap-3 text-muted-foreground" aria-label="Hermes is working" role="status">
+      <div className="flex items-center gap-1">
+        <span className="h-2 w-2 animate-bounce rounded-full bg-current [animation-delay:-0.2s]" />
+        <span className="h-2 w-2 animate-bounce rounded-full bg-current [animation-delay:-0.1s]" />
+        <span className="h-2 w-2 animate-bounce rounded-full bg-current" />
+      </div>
+      <span className="text-xs font-medium uppercase tracking-wide">Hermes is working</span>
+    </div>
+  );
+}
+
+function buildNativeWsUrl(authParam: [string, string]): string {
+  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const qs = new URLSearchParams({ [authParam[0]]: authParam[1] });
+  return `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/ws?${qs.toString()}`;
+}
+
+function makeId(prefix: string): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function NativeChatPanel({ active }: { active: boolean }) {
+  const wsRef = useRef<WebSocket | null>(null);
+  const pendingRef = useRef<Map<string | number, RpcPending>>(new Map());
+  const requestSeq = useRef(0);
+  const sessionIdRef = useRef<string | null>(null);
+  const currentAssistantIdRef = useRef<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      id: "welcome",
+      role: "system",
+      content:
+        "Native chat beta is active. Drop or attach files here and Hermes will store them in the profile uploads folder, then reference them in your prompt.",
+    },
+  ]);
+  const [composer, setComposer] = useState("");
+  const [attachments, setAttachments] = useState<UploadAttachment[]>([]);
+  const [connection, setConnection] = useState<"connecting" | "ready" | "error">("connecting");
+  const [busy, setBusy] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  const rpc = useCallback((method: string, params: Record<string, unknown> = {}) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("Native chat socket is not connected"));
+    }
+    const id = ++requestSeq.current;
+    const payload = { jsonrpc: "2.0", id, method, params };
+    return new Promise((resolve, reject) => {
+      pendingRef.current.set(id, { resolve, reject });
+      ws.send(JSON.stringify(payload));
+    });
+  }, []);
+
+  const appendMessage = useCallback((message: ChatMessage) => {
+    setMessages((prev) => [...prev, message]);
+  }, []);
+
+  const updateAssistant = useCallback((updater: (message: ChatMessage) => ChatMessage) => {
+    const id = currentAssistantIdRef.current;
+    if (!id) return;
+    setMessages((prev) => prev.map((msg) => (msg.id === id ? updater(msg) : msg)));
+  }, []);
+
+  useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+    let ws: WebSocket | null = null;
+
+    async function connect() {
+      setConnection("connecting");
+      try {
+        const auth = await buildWsAuthParam();
+        if (cancelled) return;
+        ws = new WebSocket(buildNativeWsUrl(auth));
+        wsRef.current = ws;
+
+        ws.onopen = () => {
+          rpc("session.create", { cols: 96 })
+            .then((result) => {
+              const sessionId = (result as { session_id?: string }).session_id;
+              if (sessionId) sessionIdRef.current = sessionId;
+              setConnection("ready");
+            })
+            .catch((error) => {
+              setConnection("error");
+              appendMessage({ id: makeId("error"), role: "system", content: String(error), status: "error" });
+            });
+        };
+
+        ws.onmessage = (event) => {
+          let data: any;
+          try {
+            data = JSON.parse(event.data);
+          } catch {
+            return;
+          }
+
+          if (data.id !== undefined && pendingRef.current.has(data.id)) {
+            const pending = pendingRef.current.get(data.id)!;
+            pendingRef.current.delete(data.id);
+            if (data.error) pending.reject(new Error(data.error.message || "RPC error"));
+            else pending.resolve(data.result);
+            return;
+          }
+
+          if (data.method !== "event") return;
+          const type = data.params?.type;
+          const payload = data.params?.payload || {};
+
+          if (type === "message.start") {
+            const id = makeId("assistant");
+            currentAssistantIdRef.current = id;
+            appendMessage({ id, role: "assistant", content: "", status: "streaming" });
+            setBusy(true);
+          } else if (type === "message.delta") {
+            const text = String(payload.text || "");
+            updateAssistant((msg) => ({ ...msg, content: msg.content + text, status: "streaming" }));
+          } else if (type === "message.complete") {
+            const text = String(payload.text || "");
+            updateAssistant((msg) => ({
+              ...msg,
+              content: text || msg.content,
+              status: payload.status === "error" ? "error" : "complete",
+            }));
+            currentAssistantIdRef.current = null;
+            setBusy(false);
+          } else if (type === "error") {
+            appendMessage({
+              id: makeId("error"),
+              role: "system",
+              content: String(payload.message || "Hermes reported an error."),
+              status: "error",
+            });
+            setBusy(false);
+          } else if (type === "status.update") {
+            const text = String(payload.text || "").trim();
+            if (text) appendMessage({ id: makeId("status"), role: "system", content: text });
+          }
+        };
+
+        ws.onerror = () => setConnection("error");
+        ws.onclose = () => {
+          if (!cancelled) setConnection("error");
+        };
+      } catch (error) {
+        setConnection("error");
+        appendMessage({ id: makeId("error"), role: "system", content: String(error), status: "error" });
+      }
+    }
+
+    void connect();
+
+    return () => {
+      cancelled = true;
+      for (const pending of pendingRef.current.values()) {
+        pending.reject(new Error("Native chat socket closed"));
+      }
+      pendingRef.current.clear();
+      wsRef.current = null;
+      ws?.close();
+    };
+  }, [active, appendMessage, rpc, updateAssistant]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [messages, busy]);
+
+  const attachmentText = useMemo(() => attachments.map((file) => file.prompt_text).join("\n"), [attachments]);
+
+  const handleFiles = useCallback(async (files: FileList | File[]) => {
+    const selected = Array.from(files);
+    if (selected.length === 0) return;
+    setUploading(true);
+    try {
+      const uploaded: UploadAttachment[] = [];
+      for (const file of selected) {
+        const result = await uploadChatFile(file);
+        uploaded.push(result);
+      }
+      setAttachments((prev) => [...prev, ...uploaded]);
+    } catch (error) {
+      appendMessage({ id: makeId("upload-error"), role: "system", content: `Upload failed: ${error}`, status: "error" });
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  }, [appendMessage]);
+
+  const send = useCallback(async () => {
+    const text = composer.trim();
+    if (!text && attachments.length === 0) return;
+    const sessionId = sessionIdRef.current;
+    if (!sessionId) return;
+
+    const imageAttachments = attachments.filter((file) => file.is_image);
+    for (const image of imageAttachments) {
+      try {
+        await rpc("image.attach", { session_id: sessionId, path: image.path });
+      } catch {
+        // Fall back to including the stored file path in the prompt below.
+      }
+    }
+
+    const nonImageText = attachments
+      .filter((file) => !file.is_image)
+      .map((file) => file.prompt_text)
+      .join("\n");
+    const imageFallbackText = imageAttachments.map((file) => file.prompt_text).join("\n");
+    const prompt = [nonImageText, imageFallbackText, text].filter(Boolean).join("\n\n");
+    const visibleText = [attachmentText, text].filter(Boolean).join("\n\n");
+
+    appendMessage({ id: makeId("user"), role: "user", content: visibleText });
+    setComposer("");
+    setAttachments([]);
+    setBusy(true);
+
+    try {
+      await rpc("prompt.submit", { session_id: sessionId, text: prompt });
+    } catch (error) {
+      setBusy(false);
+      appendMessage({ id: makeId("send-error"), role: "system", content: `Send failed: ${error}`, status: "error" });
+    }
+  }, [appendMessage, attachmentText, attachments, composer, rpc]);
+
+  const showStandaloneTypingIndicator =
+    busy && !messages.some((message) => message.role === "assistant" && message.status === "streaming");
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border/70 bg-background/95 shadow-sm">
+      <div className="flex items-center justify-between border-b border-border/70 px-4 py-3">
+        <div>
+          <div className="text-sm font-semibold">Native chat beta</div>
+          <div className="text-xs text-muted-foreground">
+            {connection === "ready" ? "Connected" : connection === "connecting" ? "Connecting…" : "Connection issue"}
+          </div>
+        </div>
+        <div className="rounded-full border border-border px-2 py-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+          Files route to profile uploads
+        </div>
+      </div>
+
+      <div
+        className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-5"
+        onDragOver={(event) => event.preventDefault()}
+        onDrop={(event) => {
+          event.preventDefault();
+          void handleFiles(event.dataTransfer.files);
+        }}
+      >
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            className={cn("flex", message.role === "user" ? "justify-end" : "justify-start")}
+          >
+            <div
+              className={cn(
+                "max-w-[min(760px,88%)] rounded-2xl px-4 py-3 text-sm shadow-sm",
+                message.role === "user"
+                  ? "bg-primary text-primary-foreground"
+                  : message.role === "system"
+                    ? "border border-border bg-muted/45 text-muted-foreground"
+                    : "border border-border bg-card text-card-foreground",
+              )}
+            >
+              {message.role === "assistant" && message.status === "streaming" && !message.content ? (
+                <TypingIndicator />
+              ) : (
+                <Markdown content={message.content} streaming={message.status === "streaming"} />
+              )}
+            </div>
+          </div>
+        ))}
+        {showStandaloneTypingIndicator && (
+          <div className="flex justify-start">
+            <div className="max-w-[min(760px,88%)] rounded-2xl border border-border bg-card px-4 py-3 text-sm shadow-sm">
+              <TypingIndicator />
+            </div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {attachments.length > 0 && (
+        <div className="flex flex-wrap gap-2 border-t border-border/70 px-4 py-2">
+          {attachments.map((file) => (
+            <span key={file.path} className="inline-flex max-w-full items-center gap-2 rounded-full border border-border bg-muted/60 px-3 py-1 text-xs">
+              <Paperclip className="h-3 w-3 shrink-0" />
+              <span className="truncate">{file.name}</span>
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground"
+                onClick={() => setAttachments((prev) => prev.filter((item) => item.path !== file.path))}
+                aria-label={`Remove ${file.name}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="border-t border-border/70 p-3">
+        <div className="flex items-end gap-2 rounded-2xl border border-border bg-background px-3 py-2 focus-within:ring-2 focus-within:ring-ring/40">
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={(event) => event.target.files && void handleFiles(event.target.files)}
+          />
+          <Button
+            ghost
+            size="icon"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            aria-label="Attach files"
+            title="Attach files"
+          >
+            <Paperclip className="h-4 w-4" />
+          </Button>
+          <textarea
+            value={composer}
+            onChange={(event) => setComposer(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                void send();
+              }
+            }}
+            placeholder="Ask Hermes anything, or attach/drop files here…"
+            className="max-h-40 min-h-10 flex-1 resize-none bg-transparent py-2 text-sm outline-none placeholder:text-muted-foreground"
+            rows={1}
+            disabled={connection !== "ready"}
+          />
+          <Button onClick={() => void send()} disabled={connection !== "ready" || busy || uploading || (!composer.trim() && attachments.length === 0)}>
+            <Send className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -188,6 +188,40 @@ export async function fetchJSON<T>(
   return res.json();
 }
 
+export interface ChatUploadResponse {
+  ok: boolean;
+  name: string;
+  path: string;
+  size: number;
+  mime_type: string;
+  is_image: boolean;
+  prompt_text: string;
+}
+
+export async function uploadChatFile(file: File): Promise<ChatUploadResponse> {
+  const form = new FormData();
+  form.append("file", file);
+
+  const headers = new Headers();
+  const token = window.__HERMES_SESSION_TOKEN__;
+  if (token) {
+    setSessionHeader(headers, token);
+  }
+
+  const res = await fetch(`${BASE}/api/chat/uploads`, {
+    method: "POST",
+    body: form,
+    headers,
+    credentials: "include",
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
 /** Encode a plugin registry key for URL paths (preserves `/` segment separators). */
 function pluginPath(name: string): string {
   return name.split("/").map(encodeURIComponent).join("/");

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -33,6 +33,7 @@ import { useSearchParams } from "react-router-dom";
 
 import { ChatSidebar } from "@/components/ChatSidebar";
 import { ChatSessionList } from "@/components/ChatSessionList";
+import { NativeChatPanel } from "@/components/NativeChatPanel";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
@@ -113,7 +114,9 @@ function terminalFontSizeForWidth(layoutWidthPx: number): number {
 }
 
 function terminalLineHeightForWidth(layoutWidthPx: number): number {
-  return layoutWidthPx < 1024 ? 1.02 : 1.15;
+  if (layoutWidthPx < 420) return 1.18;
+  if (layoutWidthPx < 1024) return 1.22;
+  return 1.28;
 }
 
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
@@ -188,6 +191,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       ? window.matchMedia("(max-width: 1023px)").matches
       : false,
   );
+  const [nativeChatMode, setNativeChatMode] = useState(true);
 
   const { theme } = useTheme();
   const terminalBg = theme.terminalBackground ?? "#000000";
@@ -317,6 +321,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   };
 
   useEffect(() => {
+    if (nativeChatMode) return;
     const host = hostRef.current;
     if (!host) return;
 
@@ -754,7 +759,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, resumeParam, scopedProfile, reconnectNonce]);
+  }, [channel, nativeChatMode, resumeParam, scopedProfile, reconnectNonce]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.
@@ -922,7 +927,29 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         </div>
       )}
 
-      <div className="flex min-h-0 flex-1 flex-col gap-2 lg:flex-row lg:gap-3">
+      <div className="flex items-center justify-end gap-2">
+        <Button
+          ghost={!nativeChatMode}
+          onClick={() => setNativeChatMode(true)}
+          className="px-3 py-1.5 text-xs normal-case tracking-normal"
+        >
+          Native chat beta
+        </Button>
+        <Button
+          ghost={nativeChatMode}
+          onClick={() => setNativeChatMode(false)}
+          className="px-3 py-1.5 text-xs normal-case tracking-normal"
+        >
+          Terminal chat
+        </Button>
+      </div>
+
+      {nativeChatMode ? (
+        <div className="min-h-0 flex-1">
+          <NativeChatPanel active={isActive && nativeChatMode} />
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col gap-2 lg:flex-row lg:gap-3">
         <div
           className={cn(
             "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg",
@@ -1009,7 +1036,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             </div>
           </div>
         )}
-      </div>
+        </div>
+      )}
       <PluginSlot name="chat:bottom" />
     </div>
   );


### PR DESCRIPTION
## Summary
- Add a native React chat beta panel with Markdown-rendered chat bubbles and typing indicator
- Add drag/drop and paperclip file uploads routed to the active Hermes profile uploads folder
- Add dashboard upload API client and FastAPI /api/chat/uploads endpoint
- Add TUI platform Markdown formatting hint and focused tests
- Update fallback status copy to make paid fallback activation explicit

## Test Plan
- python -m pytest tests/agent/test_prompt_builder.py
- npm run build --prefix web

Note: source branch also contains the local fallback-alert commit already present in this checkout.