### PR TITLE
fix(acp): resolve compression-rotated session ids

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1138,6 +1138,7 @@ class HermesACPAgent(acp.Agent):
             logger.warning("load_session: session %s not found", session_id)
             return None
         await self._register_session_mcp_servers(state, mcp_servers)
+        session_id = state.session_id
         logger.info("Loaded session %s", session_id)
         # Per ACP spec, `session/load` must stream the prior conversation back
         # to the client via `session/update` notifications BEFORE responding,
@@ -1306,6 +1307,7 @@ class HermesACPAgent(acp.Agent):
         if state is None:
             logger.error("prompt: session %s not found", session_id)
             return PromptResponse(stop_reason="refusal")
+        session_id = state.session_id
 
         user_text = _extract_text(prompt).strip()
         user_content = _content_blocks_to_openai_user_content(prompt)
@@ -1547,7 +1549,12 @@ class HermesACPAgent(acp.Agent):
             # can detect a compression-driven session rotation afterwards. The
             # ACP `session_id` stays the stable client handle; agent.session_id
             # is the live internal head that compression may rotate.
-            pre_turn_hermes_id = getattr(state.agent, "session_id", None)
+            pre_turn_raw_id = getattr(state.agent, "session_id", None)
+            pre_turn_hermes_id = (
+                pre_turn_raw_id.strip()
+                if isinstance(pre_turn_raw_id, str) and pre_turn_raw_id.strip()
+                else None
+            )
             # Wrap the executor call in a fresh copy of the current context so
             # concurrent ACP sessions on the shared ThreadPoolExecutor don't
             # stomp on each other's ContextVar writes (HERMES_SESSION_KEY in
@@ -1561,22 +1568,35 @@ class HermesACPAgent(acp.Agent):
                 state.current_prompt_text = ""
             return PromptResponse(stop_reason="end_turn")
 
+        post_turn_raw_id = result.get("session_id") or getattr(state.agent, "session_id", None)
+        post_turn_hermes_id = (
+            post_turn_raw_id.strip()
+            if isinstance(post_turn_raw_id, str) and post_turn_raw_id.strip()
+            else session_id
+        )
+        rotated_internal_session = bool(
+            post_turn_hermes_id
+            and pre_turn_hermes_id
+            and post_turn_hermes_id != pre_turn_hermes_id
+        )
+        if post_turn_hermes_id and post_turn_hermes_id != session_id:
+            adopted = self.session_manager.adopt_session_id(session_id, post_turn_hermes_id)
+            if adopted is not None:
+                state = adopted
+                session_id = state.session_id
+
         if result.get("messages"):
             state.history = result["messages"]
-            # Persist updated history so sessions survive process restarts.
+            # Persist updated history under the effective ACP/internal id so
+            # compression continuations do not get written back onto the ended
+            # parent session.
             self.session_manager.save_session(session_id)
 
         # Detect a compression-driven internal session rotation. If the agent's
         # DB head moved during the turn, emit a session_info_update carrying
         # _meta.hermes.sessionProvenance so ACP clients can render the boundary
-        # and keep old/new ids in lineage. The ACP session_id is unchanged.
-        post_turn_hermes_id = getattr(state.agent, "session_id", None)
-        if (
-            conn
-            and post_turn_hermes_id
-            and pre_turn_hermes_id
-            and post_turn_hermes_id != pre_turn_hermes_id
-        ):
+        # and keep old/new ids in lineage.
+        if conn and rotated_internal_session:
             try:
                 await self._send_session_info_update(
                     session_id,
@@ -1992,6 +2012,7 @@ class HermesACPAgent(acp.Agent):
         """Switch the model for a session (called by ACP protocol)."""
         state = self.session_manager.get_session(session_id)
         if state:
+            session_id = state.session_id
             current_provider = getattr(state.agent, "provider", None)
             requested_provider, resolved_model = self._resolve_model_selection(
                 model_id,
@@ -2028,6 +2049,7 @@ class HermesACPAgent(acp.Agent):
         if state is None:
             logger.warning("Session %s: mode switch requested for missing session", session_id)
             return None
+        session_id = state.session_id
         normalized_mode = str(mode_id or "").strip()
         if normalized_mode not in self._MODE_TO_EDIT_APPROVAL_POLICY:
             normalized_mode = self._MODE_DEFAULT
@@ -2044,6 +2066,7 @@ class HermesACPAgent(acp.Agent):
         if state is None:
             logger.warning("Session %s: config update requested for missing session", session_id)
             return None
+        session_id = state.session_id
 
         if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
             mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(str(value), self._MODE_DEFAULT)

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -232,14 +232,44 @@ class SessionManager:
         """Return the session for *session_id*, or ``None``.
 
         If the session is not in memory but exists in the database (e.g. after
-        a process restart), it is transparently restored.
+        a process restart), it is transparently restored. Compression-ended ACP
+        ids are treated as aliases for their current compression tip so clients
+        can reconnect with the original ``session/new`` handle.
         """
+        resolved_id = self._resolve_compression_tip(session_id)
         with self._lock:
-            state = self._sessions.get(session_id)
+            state = self._sessions.get(resolved_id) or self._sessions.get(session_id)
         if state is not None:
+            if state.session_id != resolved_id:
+                return self.adopt_session_id(state.session_id, resolved_id) or state
             return state
         # Attempt to restore from database.
-        return self._restore(session_id)
+        return self._restore(resolved_id)
+
+    def adopt_session_id(self, old_session_id: str, new_session_id: str) -> Optional[SessionState]:
+        """Re-key an in-memory ACP session after Hermes internal id rotation.
+
+        Automatic context compression can rotate ``AIAgent.session_id`` to a
+        compression continuation. ACP control paths need the in-memory manager
+        to follow that effective id before persisting history or accepting the
+        next prompt/control call.
+        """
+        if not old_session_id or not new_session_id:
+            return None
+        if old_session_id == new_session_id:
+            with self._lock:
+                return self._sessions.get(new_session_id)
+        with self._lock:
+            state = self._sessions.pop(old_session_id, None)
+            if state is None:
+                state = self._sessions.get(new_session_id)
+                return state
+            state.session_id = new_session_id
+            self._sessions[new_session_id] = state
+        _clear_task_cwd(old_session_id)
+        _register_task_cwd(new_session_id, state.cwd)
+        logger.info("Adopted ACP session id %s -> %s", old_session_id, new_session_id)
+        return state
 
     def remove_session(self, session_id: str) -> bool:
         """Remove a session from memory and database. Returns True if it existed."""
@@ -361,7 +391,7 @@ class SessionManager:
         if state is None:
             return None
         state.cwd = cwd
-        _register_task_cwd(session_id, cwd)
+        _register_task_cwd(state.session_id, cwd)
         self._persist(state)
         return state
 
@@ -419,6 +449,20 @@ class SessionManager:
         except Exception:
             logger.debug("SessionDB unavailable for ACP persistence", exc_info=True)
             return None
+
+    def _resolve_compression_tip(self, session_id: str) -> str:
+        """Resolve compression-ended ACP ids to the current continuation id."""
+        if not session_id:
+            return session_id
+        db = self._get_db()
+        if db is None or not hasattr(db, "get_compression_tip"):
+            return session_id
+        try:
+            tip = db.get_compression_tip(session_id)
+        except Exception:
+            logger.debug("Failed to resolve ACP compression tip for %s", session_id, exc_info=True)
+            return session_id
+        return str(tip or session_id)
 
     def _persist(self, state: SessionState) -> None:
         """Write session state to the database.

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -313,6 +313,40 @@ class TestPersistence:
         # Agent should have been recreated.
         assert restored.agent is not None
 
+    def test_get_session_aliases_compression_parent_to_tip_even_when_parent_has_messages(self, tmp_path):
+        """ACP clients may reconnect with the original session/new id after compression.
+
+        The original row can still have messages (e.g. an older adapter wrote
+        post-compression history back onto the ended parent), so ACP restore
+        must follow the compression tip instead of relying on the older
+        empty-parent-only resume helper.
+        """
+        db = SessionDB(tmp_path / "state.db")
+        db.create_session("root-acp", source="acp", model_config={"cwd": "/work"})
+        db.append_message("root-acp", role="user", content="old parent message")
+        db.end_session("root-acp", "compression")
+        db.create_session(
+            "tip-acp",
+            source="acp",
+            parent_session_id="root-acp",
+            model_config={"cwd": "/work"},
+        )
+        db.append_message("tip-acp", role="user", content="compressed child message")
+
+        manager = SessionManager(agent_factory=_mock_agent, db=db)
+
+        restored = manager.get_session("root-acp")
+
+        assert restored is not None
+        assert restored.session_id == "tip-acp"
+        assert len(restored.history) == 1
+        assert restored.history[0]["role"] == "user"
+        assert restored.history[0]["content"] == "compressed child message"
+
+        listing_ids = {item["session_id"] for item in manager.list_sessions()}
+        assert "tip-acp" in listing_ids
+        assert "root-acp" not in listing_ids
+
     def test_save_session_updates_db(self, manager):
         state = manager.create_session()
         state.history.append({"role": "user", "content": "test"})

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -32,6 +32,19 @@ class FakeAgent:
         return {"final_response": final, "messages": messages}
 
 
+class RotatingFakeAgent(FakeAgent):
+    def run_conversation(self, *, user_message, conversation_history, task_id, **kwargs):
+        result = super().run_conversation(
+            user_message=user_message,
+            conversation_history=conversation_history,
+            task_id=task_id,
+            **kwargs,
+        )
+        self.session_id = "child-after-compression"
+        result["session_id"] = self.session_id
+        return result
+
+
 class CaptureConn:
     def __init__(self):
         self.updates = []
@@ -65,6 +78,28 @@ def make_agent_and_state():
     conn = CaptureConn()
     acp_agent.on_connect(conn)
     return acp_agent, state, fake, conn
+
+
+@pytest.mark.asyncio
+async def test_acp_prompt_adopts_agent_session_id_after_compression_rotation():
+    fake = RotatingFakeAgent()
+    manager = SessionManager(agent_factory=lambda **kwargs: fake, db=NoopDb())
+    acp_agent = HermesACPAgent(session_manager=manager)
+    state = manager.create_session(cwd=".")
+    original_id = state.session_id
+    fake.session_id = original_id
+    conn = CaptureConn()
+    acp_agent.on_connect(conn)
+
+    response = await acp_agent.prompt(
+        session_id=original_id,
+        prompt=[TextContentBlock(type="text", text="trigger compression")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert state.session_id == "child-after-compression"
+    assert "child-after-compression" in manager._sessions
+    assert original_id not in manager._sessions
 
 
 def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):


### PR DESCRIPTION
## Summary

- resolve compression-ended ACP session ids to their current compression tip when restoring or controlling a session
- adopt the effective `result["session_id"]` after a prompt so automatic compression does not leave the ACP manager keyed by the old parent id
- persist post-compression history under the effective continuation id instead of rewriting the ended parent row

Fixes #49226.

## Tests

- RED verified first:
  - `python -m pytest tests/acp/test_session.py::TestPersistence::test_get_session_aliases_compression_parent_to_tip_even_when_parent_has_messages tests/acp_adapter/test_acp_commands.py::test_acp_prompt_adopts_agent_session_id_after_compression_rotation -q -o 'addopts='` failed on current behavior.
- GREEN:
  - `python -m pytest tests/acp/test_session.py::TestPersistence::test_get_session_aliases_compression_parent_to_tip_even_when_parent_has_messages tests/acp_adapter/test_acp_commands.py::test_acp_prompt_adopts_agent_session_id_after_compression_rotation -q -o 'addopts='` → 2 passed
  - `python -m pytest tests/acp/test_session.py tests/acp_adapter/test_acp_commands.py tests/acp/test_session_provenance.py tests/acp/test_server.py::TestPrompt::test_prompt_auto_titles_session tests/acp/test_server.py::TestPrompt::test_prompt_sends_session_info_update_after_auto_title tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback -q -o 'addopts='` → 59 passed
  - `python -m pytest tests/acp/test_server.py tests/acp/test_session.py tests/acp_adapter/test_acp_commands.py tests/acp/test_session_provenance.py -q -o 'addopts='` → 136 passed

## Known unrelated baseline failure

The broader command below still has one order-dependent failure on this branch:

```bash
python -m pytest tests/acp tests/acp_adapter -q -o 'addopts='
```

I verified the same failure reproduces on a clean `upstream/main` detached worktree at `40722058e`:

```text
FAILED tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback
```

That test passes when run alone and appears unrelated to this ACP session-id change.
