### PR TITLE
Guard skill deletion against runtime references

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -395,6 +395,25 @@ class TestDeleteSkill:
         assert not (tmp_path / "narrow").exists()
         assert (tmp_path / "umbrella").exists()
 
+    def test_delete_blocks_unmanaged_runtime_reference(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        bin_dir = hermes_home / "bin"
+        bin_dir.mkdir(parents=True)
+        wrapper = bin_dir / "run_daily.sh"
+        wrapper.write_text("hermes chat -s narrow 'run brief'\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with _skill_dir(tmp_path / "skills"):
+            _create_skill("umbrella", VALID_SKILL_CONTENT)
+            _create_skill("narrow", VALID_SKILL_CONTENT)
+            result = _delete_skill("narrow", absorbed_into="umbrella")
+
+        assert result["success"] is False
+        assert "runtime entrypoints" in result["error"]
+        assert result["runtime_references"][0]["path"] == str(wrapper)
+        assert result["runtime_references"][0]["line"] == 1
+        assert (tmp_path / "skills" / "narrow").exists()
+
     def test_delete_with_absorbed_into_empty_string_means_pruned(self, tmp_path):
         with _skill_dir(tmp_path):
             _create_skill("stale-skill", VALID_SKILL_CONTENT)

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -400,19 +400,22 @@ class TestDeleteSkill:
         bin_dir = hermes_home / "bin"
         bin_dir.mkdir(parents=True)
         wrapper = bin_dir / "run_daily.sh"
-        wrapper.write_text("hermes chat -s narrow 'run brief'\n", encoding="utf-8")
+        wrapper.write_text(
+            "hermes chat -s operations/narrow 'run brief'\n",
+            encoding="utf-8",
+        )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         with _skill_dir(tmp_path / "skills"):
             _create_skill("umbrella", VALID_SKILL_CONTENT)
-            _create_skill("narrow", VALID_SKILL_CONTENT)
+            _create_skill("narrow", VALID_SKILL_CONTENT, category="operations")
             result = _delete_skill("narrow", absorbed_into="umbrella")
 
         assert result["success"] is False
         assert "runtime entrypoints" in result["error"]
         assert result["runtime_references"][0]["path"] == str(wrapper)
         assert result["runtime_references"][0]["line"] == 1
-        assert (tmp_path / "skills" / "narrow").exists()
+        assert (tmp_path / "skills" / "operations" / "narrow").exists()
 
     def test_delete_with_absorbed_into_empty_string_means_pruned(self, tmp_path):
         with _skill_dir(tmp_path):
@@ -618,6 +621,53 @@ class TestSkillManageDispatcher:
         result = json.loads(raw)
         assert result["success"] is False
         assert "does not exist" in result["error"]
+
+    def test_delete_via_dispatcher_blocks_cron_reference(self, tmp_path, monkeypatch):
+        from cron.jobs import save_jobs, use_cron_store
+
+        hermes_home = tmp_path / ".hermes"
+        with use_cron_store(hermes_home):
+            save_jobs([
+                {
+                    "id": "job-1",
+                    "name": "daily",
+                    "skills": ["narrow"],
+                    "skill": "narrow",
+                }
+            ])
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        skills_dir = tmp_path / "skills"
+        with _skill_dir(skills_dir):
+            _create_skill("narrow", VALID_SKILL_CONTENT)
+            raw = skill_manage(action="delete", name="narrow")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "runtime entrypoints" in result["error"]
+        assert result["runtime_references"][0]["surface"] == "cron.jobs"
+        assert result["runtime_references"][0]["path"].endswith("jobs.json#job-1")
+        assert (skills_dir / "narrow").exists()
+
+    def test_delete_via_dispatcher_fails_closed_on_corrupt_cron_store(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        cron_dir = hermes_home / "cron"
+        cron_dir.mkdir(parents=True)
+        (cron_dir / "jobs.json").write_text("{not-json", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        skills_dir = tmp_path / "skills"
+        with _skill_dir(skills_dir):
+            _create_skill("narrow", VALID_SKILL_CONTENT)
+            raw = skill_manage(action="delete", name="narrow")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "could not verify" in result["error"]
+        assert result["runtime_scan_errors"][0]["surface"] == "cron.jobs"
+        assert (skills_dir / "narrow").exists()
 
     def test_background_review_delete_refuses_bundled_even_with_absorbed_into(self, tmp_path):
         from tools.skill_provenance import (

--- a/tests/tools/test_skill_runtime_contracts.py
+++ b/tests/tools/test_skill_runtime_contracts.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+
+from tools.skill_runtime_contracts import (
+    blocking_skill_runtime_references,
+    find_skill_runtime_references,
+)
+
+
+def test_finds_wrapper_skill_reference(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    bin_dir = hermes_home / "bin"
+    bin_dir.mkdir(parents=True)
+    wrapper = bin_dir / "run_daily.sh"
+    wrapper.write_text("hermes chat -s legacy-skill 'run brief'\n", encoding="utf-8")
+
+    refs = find_skill_runtime_references("legacy-skill", hermes_home=hermes_home)
+
+    assert len(refs) == 1
+    assert refs[0].surface == "hermes.bin"
+    assert refs[0].path == str(wrapper)
+    assert refs[0].line == 1
+    assert refs[0].auto_migratable is False
+
+
+def test_does_not_match_skill_name_as_substring(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    bin_dir = hermes_home / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "run_daily.sh").write_text(
+        "hermes chat -s legacy-skill-v2 'run brief'\n",
+        encoding="utf-8",
+    )
+
+    assert find_skill_runtime_references("legacy-skill", hermes_home=hermes_home) == []
+
+
+def test_cron_references_are_reported_as_auto_migratable(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    cron_dir = hermes_home / "cron"
+    cron_dir.mkdir(parents=True)
+    (cron_dir / "jobs.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": "job-1",
+                        "name": "daily",
+                        "skills": ["legacy-skill"],
+                        "skill": "legacy-skill",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    refs = find_skill_runtime_references("legacy-skill", hermes_home=hermes_home)
+
+    assert len(refs) == 1
+    assert refs[0].surface == "cron.jobs"
+    assert refs[0].auto_migratable is True
+    assert blocking_skill_runtime_references("legacy-skill", hermes_home=hermes_home) == []

--- a/tests/tools/test_skill_runtime_contracts.py
+++ b/tests/tools/test_skill_runtime_contracts.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
-import json
+import pytest
 
+from cron.jobs import save_jobs, use_cron_store
+
+import tools.skill_runtime_contracts as runtime_contracts
 from tools.skill_runtime_contracts import (
+    SkillRuntimeScanError,
     blocking_skill_runtime_references,
     find_skill_runtime_references,
 )
@@ -21,7 +25,6 @@ def test_finds_wrapper_skill_reference(tmp_path):
     assert refs[0].surface == "hermes.bin"
     assert refs[0].path == str(wrapper)
     assert refs[0].line == 1
-    assert refs[0].auto_migratable is False
 
 
 def test_does_not_match_skill_name_as_substring(tmp_path):
@@ -36,29 +39,231 @@ def test_does_not_match_skill_name_as_substring(tmp_path):
     assert find_skill_runtime_references("legacy-skill", hermes_home=hermes_home) == []
 
 
-def test_cron_references_are_reported_as_auto_migratable(tmp_path):
+def test_finds_supported_shell_invocation_forms(tmp_path):
     hermes_home = tmp_path / ".hermes"
-    cron_dir = hermes_home / "cron"
-    cron_dir.mkdir(parents=True)
-    (cron_dir / "jobs.json").write_text(
-        json.dumps(
-            {
-                "jobs": [
-                    {
-                        "id": "job-1",
-                        "name": "daily",
-                        "skills": ["legacy-skill"],
-                        "skill": "legacy-skill",
-                    }
-                ]
-            }
-        ),
+    bin_dir = hermes_home / "bin"
+    bin_dir.mkdir(parents=True)
+    wrapper = bin_dir / "run_daily.sh"
+    wrapper.write_text(
+        "env MODE=batch /usr/local/bin/hermes chat --skills other,legacy-skill\n"
+        "command hermes chat --skills=legacy-skill\n"
+        "python3 -m hermes_cli.main chat -slegacy-skill\n",
+        encoding="utf-8",
+    )
+
+    refs = find_skill_runtime_references("legacy-skill", hermes_home=hermes_home)
+
+    assert [ref.line for ref in refs] == [1, 2, 3]
+
+
+def test_matches_only_path_identifiers_that_resolve_to_target_skill(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    skills_root = hermes_home / "skills"
+    skill_dir = skills_root / "operations" / "legacy-skill"
+    skill_dir.mkdir(parents=True)
+    outside_skill = tmp_path / "outside" / "legacy-skill"
+    outside_skill.mkdir(parents=True)
+
+    bin_dir = hermes_home / "bin"
+    bin_dir.mkdir(parents=True)
+    wrapper = bin_dir / "run_daily.sh"
+    wrapper.write_text(
+        "hermes chat -s operations/legacy-skill\n"
+        f"hermes chat -s {skill_dir}\n"
+        "hermes chat --skills=other,operations/legacy-skill\n"
+        'hermes chat -s "operations\\legacy-skill"\n'
+        f"hermes chat -s {outside_skill}\n"
+        "hermes chat -s ../outside/legacy-skill\n",
+        encoding="utf-8",
+    )
+
+    refs = find_skill_runtime_references(
+        "legacy-skill",
+        hermes_home=hermes_home,
+        skill_path=skill_dir,
+        skills_root=skills_root,
+    )
+
+    assert [ref.line for ref in refs] == [1, 2, 3, 4]
+
+
+def test_finds_shell_control_flow_functions_and_launch_wrappers(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    bin_dir = hermes_home / "bin"
+    bin_dir.mkdir(parents=True)
+    wrapper = bin_dir / "run_daily.sh"
+    wrapper.write_text(
+        "if ready; then hermes chat -s legacy-skill; fi\n"
+        "run_daily() { hermes chat -s legacy-skill; }\n"
+        "sudo -u root hermes chat -s legacy-skill\n"
+        "nohup hermes chat -s legacy-skill >/tmp/hermes.log 2>&1 &\n"
+        "env -i MODE=batch command hermes chat -s legacy-skill\n"
+        "time -p hermes chat -s legacy-skill\n"
+        "while ready; do exec hermes chat -s legacy-skill; done\n",
+        encoding="utf-8",
+    )
+
+    refs = find_skill_runtime_references("legacy-skill", hermes_home=hermes_home)
+
+    assert [ref.line for ref in refs] == [1, 2, 3, 4, 5, 6, 7]
+
+
+def test_runtime_reference_text_does_not_expose_command_secrets(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    bin_dir = hermes_home / "bin"
+    bin_dir.mkdir(parents=True)
+    secret = "do-not-return-this-token"
+    (bin_dir / "run_daily.sh").write_text(
+        f"API_TOKEN={secret} hermes chat -s legacy-skill\n",
         encoding="utf-8",
     )
 
     refs = find_skill_runtime_references("legacy-skill", hermes_home=hermes_home)
 
     assert len(refs) == 1
+    assert secret not in refs[0].text
+    assert "legacy-skill" in refs[0].text
+
+
+def test_finds_explicit_python_process_invocations(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    scripts_dir = hermes_home / "scripts"
+    scripts_dir.mkdir(parents=True)
+    script = scripts_dir / "run_daily.task"
+    script.write_text(
+        "import os\n"
+        "import subprocess\n"
+        "subprocess.run(['/usr/local/bin/hermes', 'chat', '--skills', 'other,legacy-skill'])\n"
+        "os.system('hermes chat -s legacy-skill')\n",
+        encoding="utf-8",
+    )
+
+    refs = find_skill_runtime_references("legacy-skill", hermes_home=hermes_home)
+
+    assert [ref.line for ref in refs] == [3, 4]
+    assert all(ref.surface == "hermes.scripts" for ref in refs)
+
+
+def test_ignores_comments_prompts_and_data_that_only_mention_skill(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    scripts_dir = hermes_home / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "run_daily.sh").write_text(
+        "# hermes chat -s legacy-skill\n"
+        "PROMPT='Tell the operator to run hermes chat -s legacy-skill'\n"
+        "MULTILINE_PROMPT='\n"
+        "hermes chat -s legacy-skill\n"
+        "'\n"
+        "printf '%s\\n' 'legacy-skill'\n"
+        "cat <<'PROMPT'\n"
+        "hermes chat -s legacy-skill\n"
+        "PROMPT\n"
+        "hermes chat -s legacy-skill-v2\n",
+        encoding="utf-8",
+    )
+    (scripts_dir / "prompt_data.json").write_text(
+        '{"prompt": "hermes chat -s legacy-skill"}\n',
+        encoding="utf-8",
+    )
+    (scripts_dir / "notes.py").write_text(
+        '"""Example: hermes chat -s legacy-skill."""\n'
+        "example = 'hermes chat -s legacy-skill'\n",
+        encoding="utf-8",
+    )
+
+    assert find_skill_runtime_references("legacy-skill", hermes_home=hermes_home) == []
+
+
+def test_cron_references_are_blocking(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    with use_cron_store(hermes_home):
+        save_jobs([
+            {
+                "id": "job-1",
+                "name": "daily",
+                "skills": ["legacy-skill"],
+                "skill": "legacy-skill",
+            }
+        ])
+
+    refs = find_skill_runtime_references("legacy-skill", hermes_home=hermes_home)
+
+    assert len(refs) == 1
     assert refs[0].surface == "cron.jobs"
-    assert refs[0].auto_migratable is True
-    assert blocking_skill_runtime_references("legacy-skill", hermes_home=hermes_home) == []
+    assert (
+        blocking_skill_runtime_references("legacy-skill", hermes_home=hermes_home)
+        == refs
+    )
+
+
+def test_cron_path_identifiers_must_resolve_to_target_skill(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    skills_root = hermes_home / "skills"
+    skill_dir = skills_root / "operations" / "legacy-skill"
+    skill_dir.mkdir(parents=True)
+    outside_skill = tmp_path / "outside" / "legacy-skill"
+    outside_skill.mkdir(parents=True)
+
+    with use_cron_store(hermes_home):
+        save_jobs([
+            {"id": "relative", "skills": ["operations/legacy-skill"]},
+            {"id": "absolute", "skills": [str(skill_dir)]},
+            {"id": "windows", "skills": [r"operations\legacy-skill"]},
+            {"id": "outside", "skills": [str(outside_skill)]},
+            {"id": "traversal", "skills": ["../outside/legacy-skill"]},
+        ])
+
+    refs = find_skill_runtime_references(
+        "legacy-skill",
+        hermes_home=hermes_home,
+        skill_path=skill_dir,
+        skills_root=skills_root,
+    )
+
+    assert [ref.path.rsplit("#", 1)[-1] for ref in refs] == [
+        "relative",
+        "absolute",
+        "windows",
+    ]
+
+
+def test_corrupt_cron_store_fails_closed(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    cron_dir = hermes_home / "cron"
+    cron_dir.mkdir(parents=True)
+    jobs_file = cron_dir / "jobs.json"
+    jobs_file.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(SkillRuntimeScanError) as raised:
+        find_skill_runtime_references("legacy-skill", hermes_home=hermes_home)
+
+    assert raised.value.surface == "cron.jobs"
+    assert raised.value.path == str(jobs_file)
+
+
+def test_unreadable_runtime_contents_fail_closed(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    bin_dir = hermes_home / "bin"
+    bin_dir.mkdir(parents=True)
+    wrapper = bin_dir / "run_daily.sh"
+    wrapper.write_bytes(b"\xff")
+
+    with pytest.raises(SkillRuntimeScanError) as raised:
+        find_skill_runtime_references("legacy-skill", hermes_home=hermes_home)
+
+    assert raised.value.surface == "hermes.bin"
+    assert raised.value.path == str(wrapper)
+
+
+def test_oversized_runtime_file_fails_closed(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    bin_dir = hermes_home / "bin"
+    bin_dir.mkdir(parents=True)
+    wrapper = bin_dir / "run_daily.sh"
+    wrapper.write_bytes(b"#" * (runtime_contracts._MAX_SCAN_BYTES + 1))
+
+    with pytest.raises(SkillRuntimeScanError) as raised:
+        find_skill_runtime_references("legacy-skill", hermes_home=hermes_home)
+
+    assert raised.value.surface == "hermes.bin"
+    assert raised.value.path == str(wrapper)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -45,6 +45,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from hermes_constants import get_hermes_home, display_hermes_home
 from utils import atomic_replace, is_truthy_value
 from hermes_cli.config import cfg_get
+from tools.skill_runtime_contracts import blocking_skill_runtime_references
 
 logger = logging.getLogger(__name__)
 
@@ -1086,6 +1087,24 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if unsafe:
         return {"success": False, "error": unsafe}
 
+    blocking_refs = blocking_skill_runtime_references(name)
+    if blocking_refs:
+        ref_dicts = [ref.to_dict() for ref in blocking_refs]
+        locations = "; ".join(
+            f"{ref.path}:{ref.line}" if ref.line else ref.path
+            for ref in blocking_refs[:5]
+        )
+        more = "" if len(blocking_refs) <= 5 else f" (+{len(blocking_refs) - 5} more)"
+        return {
+            "success": False,
+            "error": (
+                f"Skill '{name}' is still referenced by runtime entrypoints: "
+                f"{locations}{more}. Update those references or leave a "
+                "compatibility skill before deleting it."
+            ),
+            "runtime_references": ref_dicts,
+        }
+
     # During the curator consolidation pass, a verified consolidation must be
     # RECOVERABLE: archival into ~/.hermes/skills/.archive/ is documented as
     # the maximum destructive action the curator may take, and
@@ -1111,7 +1130,6 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
         if is_consolidation:
             message += f" Content absorbed into '{absorbed_target}'."
         return {"success": True, "message": message, "_archived": True}
-
     shutil.rmtree(skill_dir)
 
     # Clean up empty category directories (don't remove the skills root itself)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -45,7 +45,10 @@ from typing import Any, Dict, List, Optional, Tuple
 from hermes_constants import get_hermes_home, display_hermes_home
 from utils import atomic_replace, is_truthy_value
 from hermes_cli.config import cfg_get
-from tools.skill_runtime_contracts import blocking_skill_runtime_references
+from tools.skill_runtime_contracts import (
+    SkillRuntimeScanError,
+    blocking_skill_runtime_references,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1087,7 +1090,21 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if unsafe:
         return {"success": False, "error": unsafe}
 
-    blocking_refs = blocking_skill_runtime_references(name)
+    try:
+        blocking_refs = blocking_skill_runtime_references(
+            name,
+            skill_path=skill_dir,
+            skills_root=skills_root,
+        )
+    except SkillRuntimeScanError as exc:
+        return {
+            "success": False,
+            "error": (
+                f"Skill '{name}' was not deleted because Hermes could not verify "
+                f"its runtime references: {exc}. Fix the scan error and retry."
+            ),
+            "runtime_scan_errors": [exc.to_dict()],
+        }
     if blocking_refs:
         ref_dicts = [ref.to_dict() for ref in blocking_refs]
         locations = "; ".join(
@@ -1130,6 +1147,7 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
         if is_consolidation:
             message += f" Content absorbed into '{absorbed_target}'."
         return {"success": True, "message": message, "_archived": True}
+
     shutil.rmtree(skill_dir)
 
     # Clean up empty category directories (don't remove the skills root itself)

--- a/tools/skill_runtime_contracts.py
+++ b/tools/skill_runtime_contracts.py
@@ -1,0 +1,188 @@
+"""Runtime dependency checks for skill deletion.
+
+Curator can consolidate or prune skills automatically, but deleting a skill is
+only safe when runtime entrypoints that invoke Hermes by skill name have either
+been migrated or are known to be auto-migratable. This module keeps that check
+small and deterministic so it can run before the irreversible filesystem delete.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, List, Optional
+
+from hermes_constants import get_hermes_home
+
+_MAX_SCAN_BYTES = 1_000_000
+_RUNTIME_DIR_NAMES = ("bin", "scripts")
+_TEXT_SUFFIXES = {
+    "",
+    ".bash",
+    ".fish",
+    ".json",
+    ".md",
+    ".py",
+    ".sh",
+    ".txt",
+    ".yaml",
+    ".yml",
+    ".zsh",
+}
+_SECRET_NAMES = {".env", "auth.json", "secrets.json"}
+
+
+@dataclass(frozen=True)
+class SkillRuntimeReference:
+    """A runtime surface that still refers to a skill by name."""
+
+    surface: str
+    path: str
+    line: Optional[int]
+    text: str
+    auto_migratable: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _skill_pattern(skill_name: str) -> re.Pattern[str]:
+    escaped = re.escape(skill_name)
+    return re.compile(rf"(?<![A-Za-z0-9_.-]){escaped}(?![A-Za-z0-9_.-])")
+
+
+def _is_text_candidate(path: Path) -> bool:
+    if path.name in _SECRET_NAMES:
+        return False
+    if path.suffix.lower() in _TEXT_SUFFIXES:
+        return True
+    try:
+        return os.access(path, os.X_OK)
+    except OSError:
+        return False
+
+
+def _iter_runtime_files(hermes_home: Path) -> Iterable[Path]:
+    for dirname in _RUNTIME_DIR_NAMES:
+        root = hermes_home / dirname
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            try:
+                if (
+                    path.is_file()
+                    and _is_text_candidate(path)
+                    and path.stat().st_size <= _MAX_SCAN_BYTES
+                ):
+                    yield path
+            except OSError:
+                continue
+
+
+def _scan_text_file(
+    path: Path,
+    pattern: re.Pattern[str],
+    surface: str,
+) -> List[SkillRuntimeReference]:
+    refs: List[SkillRuntimeReference] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return refs
+
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if pattern.search(line):
+            refs.append(
+                SkillRuntimeReference(
+                    surface=surface,
+                    path=str(path),
+                    line=line_no,
+                    text=line.strip()[:240],
+                    auto_migratable=False,
+                )
+            )
+    return refs
+
+
+def _scan_cron_jobs(hermes_home: Path, skill_name: str) -> List[SkillRuntimeReference]:
+    jobs_file = hermes_home / "cron" / "jobs.json"
+    try:
+        if not jobs_file.exists() or jobs_file.stat().st_size > _MAX_SCAN_BYTES:
+            return []
+    except OSError:
+        return []
+
+    try:
+        payload = json.loads(jobs_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+
+    jobs = payload.get("jobs") if isinstance(payload, dict) else payload
+    if not isinstance(jobs, list):
+        return []
+
+    refs: List[SkillRuntimeReference] = []
+    for index, job in enumerate(jobs):
+        if not isinstance(job, dict):
+            continue
+        skills = job.get("skills")
+        single_skill = job.get("skill")
+        matched = False
+        if isinstance(skills, list) and skill_name in skills:
+            matched = True
+        if single_skill == skill_name:
+            matched = True
+        if not matched:
+            continue
+        job_id = job.get("id") or f"index:{index}"
+        job_name = job.get("name") or "unnamed"
+        refs.append(
+            SkillRuntimeReference(
+                surface="cron.jobs",
+                path=f"{jobs_file}#{job_id}",
+                line=None,
+                text=f"cron job {job_name!r} references skill {skill_name!r}",
+                auto_migratable=True,
+            )
+        )
+    return refs
+
+
+def find_skill_runtime_references(
+    skill_name: str,
+    hermes_home: Optional[Path] = None,
+) -> List[SkillRuntimeReference]:
+    """Find runtime entrypoints that refer to ``skill_name``.
+
+    References in Hermes cron jobs are marked auto-migratable because
+    ``cron.jobs.rewrite_skill_refs`` already rewrites those after a curator run.
+    Script references under ``bin`` and ``scripts`` are blocking because Hermes
+    has no deterministic migrator for arbitrary commands yet.
+    """
+
+    home = Path(hermes_home) if hermes_home is not None else get_hermes_home()
+    pattern = _skill_pattern(skill_name)
+    refs: List[SkillRuntimeReference] = []
+
+    refs.extend(_scan_cron_jobs(home, skill_name))
+    for file_path in _iter_runtime_files(home):
+        surface = f"hermes.{file_path.parent.name}"
+        refs.extend(_scan_text_file(file_path, pattern, surface))
+
+    return refs
+
+
+def blocking_skill_runtime_references(
+    skill_name: str,
+    hermes_home: Optional[Path] = None,
+) -> List[SkillRuntimeReference]:
+    """Return references that deletion cannot safely auto-migrate."""
+
+    return [
+        ref
+        for ref in find_skill_runtime_references(skill_name, hermes_home=hermes_home)
+        if not ref.auto_migratable
+    ]

--- a/tools/skill_runtime_contracts.py
+++ b/tools/skill_runtime_contracts.py
@@ -1,38 +1,57 @@
 """Runtime dependency checks for skill deletion.
 
 Curator can consolidate or prune skills automatically, but deleting a skill is
-only safe when runtime entrypoints that invoke Hermes by skill name have either
-been migrated or are known to be auto-migratable. This module keeps that check
-small and deterministic so it can run before the irreversible filesystem delete.
+only safe after runtime entrypoints that invoke Hermes by skill name have been
+migrated. This module keeps that check small and deterministic so it can run
+before the irreversible filesystem delete.
 """
 
 from __future__ import annotations
 
-import json
+import ast
 import os
-import re
+import shlex
+import stat
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Iterable, List, Optional
+from typing import Any, Iterable, List, Optional, Sequence
 
 from hermes_constants import get_hermes_home
 
 _MAX_SCAN_BYTES = 1_000_000
 _RUNTIME_DIR_NAMES = ("bin", "scripts")
-_TEXT_SUFFIXES = {
-    "",
+_SHELL_SUFFIXES = {
     ".bash",
     ".fish",
-    ".json",
-    ".md",
-    ".py",
     ".sh",
-    ".txt",
-    ".yaml",
-    ".yml",
     ".zsh",
 }
 _SECRET_NAMES = {".env", "auth.json", "secrets.json"}
+_SHELL_SEPARATORS = {";", "&", "&&", "|", "||", "{", "}"}
+_SHELL_CONTROL_PREFIXES = {"!", "if", "then", "elif", "else", "while", "until", "do"}
+_ENV_OPTIONS_WITH_VALUES = {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
+_EXEC_OPTIONS_WITH_VALUES = {"-a"}
+_SUDO_OPTIONS_WITH_VALUES = {
+    "-C",
+    "--close-from",
+    "-D",
+    "--chdir",
+    "-g",
+    "--group",
+    "-h",
+    "--host",
+    "-p",
+    "--prompt",
+    "-r",
+    "--role",
+    "-T",
+    "--command-timeout",
+    "-t",
+    "--type",
+    "-u",
+    "--user",
+}
+_TIME_OPTIONS_WITH_VALUES = {"-f", "--format", "-o", "--output"}
 
 
 @dataclass(frozen=True)
@@ -43,21 +62,82 @@ class SkillRuntimeReference:
     path: str
     line: Optional[int]
     text: str
-    auto_migratable: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 
-def _skill_pattern(skill_name: str) -> re.Pattern[str]:
-    escaped = re.escape(skill_name)
-    return re.compile(rf"(?<![A-Za-z0-9_.-]){escaped}(?![A-Za-z0-9_.-])")
+class SkillRuntimeScanError(RuntimeError):
+    """A runtime surface could not be inspected before skill deletion."""
+
+    def __init__(self, surface: str, path: str, reason: str) -> None:
+        self.surface = surface
+        self.path = path
+        self.reason = reason
+        super().__init__(f"{surface} at {path}: {reason}")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "surface": self.surface,
+            "path": self.path,
+            "error": self.reason,
+        }
 
 
-def _is_text_candidate(path: Path) -> bool:
+@dataclass(frozen=True)
+class _SkillRuntimeTarget:
+    """The exact installed skill whose runtime references are being scanned."""
+
+    name: str
+    hermes_home: Path
+    skill_path: Optional[Path] = None
+    skills_root: Optional[Path] = None
+
+
+def _paths_resolve_equal(left: Path, right: Path) -> bool:
+    try:
+        return left.expanduser().resolve() == right.expanduser().resolve()
+    except (OSError, RuntimeError):
+        return False
+
+
+def _skill_identifier_matches(identifier: str, target: _SkillRuntimeTarget) -> bool:
+    """Match a bare name or a path that resolves to the exact target skill."""
+
+    raw = str(identifier or "").strip()
+    if not raw:
+        return False
+    if raw == target.name:
+        return True
+    if target.skill_path is None:
+        return False
+
+    # Hermes accepts category-relative and trusted absolute skill paths. Treat
+    # backslashes as separators too so the same comparison works on Windows.
+    normalized = raw.replace("\\", "/")
+    if "/" not in normalized or ".." in Path(normalized).parts:
+        return False
+
+    candidate = Path(normalized).expanduser()
+    if candidate.is_absolute():
+        return _paths_resolve_equal(candidate, target.skill_path)
+
+    roots = [target.skills_root, target.hermes_home / "skills"]
+    return any(
+        root is not None and _paths_resolve_equal(root / candidate, target.skill_path)
+        for root in roots
+    )
+
+
+def _is_runtime_candidate(path: Path, runtime_dir: str) -> bool:
     if path.name in _SECRET_NAMES:
         return False
-    if path.suffix.lower() in _TEXT_SUFFIXES:
+    # Cron executes every referenced file under scripts/: .sh/.bash via Bash
+    # and every other suffix via Python.  Parse all of them according to that
+    # same interpreter contract rather than guessing from filename alone.
+    if runtime_dir == "scripts":
+        return True
+    if path.suffix.lower() in _SHELL_SUFFIXES | {".py"}:
         return True
     try:
         return os.access(path, os.X_OK)
@@ -65,112 +145,482 @@ def _is_text_candidate(path: Path) -> bool:
         return False
 
 
-def _iter_runtime_files(hermes_home: Path) -> Iterable[Path]:
+def _iter_runtime_files(hermes_home: Path) -> Iterable[tuple[str, Path]]:
     for dirname in _RUNTIME_DIR_NAMES:
         root = hermes_home / dirname
-        if not root.is_dir():
+        surface = f"hermes.{dirname}"
+        try:
+            root_stat = root.stat()
+        except FileNotFoundError:
             continue
-        for path in root.rglob("*"):
-            try:
-                if (
-                    path.is_file()
-                    and _is_text_candidate(path)
-                    and path.stat().st_size <= _MAX_SCAN_BYTES
-                ):
-                    yield path
-            except OSError:
-                continue
+        except OSError as exc:
+            raise SkillRuntimeScanError(
+                surface,
+                str(root),
+                f"could not inspect runtime directory: {exc}",
+            ) from exc
+        if not stat.S_ISDIR(root_stat.st_mode):
+            continue
+
+        def _walk_error(exc: OSError) -> None:
+            raise SkillRuntimeScanError(
+                surface,
+                str(exc.filename or root),
+                f"could not inspect runtime directory: {exc}",
+            ) from exc
+
+        for dirpath, _dirnames, filenames in os.walk(root, onerror=_walk_error):
+            for filename in filenames:
+                path = Path(dirpath) / filename
+                if not _is_runtime_candidate(path, dirname):
+                    continue
+                try:
+                    path_stat = path.stat()
+                except FileNotFoundError:
+                    # A concurrently removed file cannot remain a dependency.
+                    continue
+                except OSError as exc:
+                    raise SkillRuntimeScanError(
+                        surface,
+                        str(path),
+                        f"could not inspect runtime file: {exc}",
+                    ) from exc
+                if not stat.S_ISREG(path_stat.st_mode):
+                    continue
+                size = path_stat.st_size
+                if size > _MAX_SCAN_BYTES:
+                    raise SkillRuntimeScanError(
+                        surface,
+                        str(path),
+                        f"runtime file exceeds the {_MAX_SCAN_BYTES}-byte scan limit",
+                    )
+                yield dirname, path
 
 
-def _scan_text_file(
+def _is_assignment(token: str) -> bool:
+    """Return whether a shell token is an environment assignment."""
+
+    if "=" not in token:
+        return False
+    name, _value = token.split("=", 1)
+    return (
+        bool(name)
+        and (name[0].isalpha() or name[0] == "_")
+        and all(char.isalnum() or char == "_" for char in name[1:])
+    )
+
+
+def _command_name(token: str) -> str:
+    """Return a command basename for POSIX or Windows-style paths."""
+
+    return token.replace("\\", "/").rsplit("/", 1)[-1].lower()
+
+
+def _skip_prefix_options(
+    tokens: Sequence[str],
+    index: int,
+    options_with_values: set[str],
+) -> int:
+    """Skip wrapper options, including known options with separate values."""
+
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            return index + 1
+        if token == "-" or not token.startswith("-"):
+            return index
+
+        option = token.split("=", 1)[0]
+        index += 1
+        if option in options_with_values and "=" not in token and index < len(tokens):
+            index += 1
+    return index
+
+
+def _command_start(tokens: Sequence[str]) -> Optional[int]:
+    """Return the executable index after supported shell launch prefixes."""
+
+    index = 0
+    while index < len(tokens):
+        while index < len(tokens) and (
+            tokens[index] in _SHELL_CONTROL_PREFIXES or _is_assignment(tokens[index])
+        ):
+            index += 1
+        if index >= len(tokens):
+            return None
+
+        command = _command_name(tokens[index])
+        if command == "env":
+            index = _skip_prefix_options(tokens, index + 1, _ENV_OPTIONS_WITH_VALUES)
+            continue
+        if command == "command":
+            index += 1
+            while index < len(tokens) and tokens[index].startswith("-"):
+                option = tokens[index]
+                if option in {"-v", "-V"}:
+                    return None
+                index += 1
+                if option == "--":
+                    break
+            continue
+        if command == "exec":
+            index = _skip_prefix_options(tokens, index + 1, _EXEC_OPTIONS_WITH_VALUES)
+            continue
+        if command == "sudo":
+            index = _skip_prefix_options(tokens, index + 1, _SUDO_OPTIONS_WITH_VALUES)
+            continue
+        if command == "nohup":
+            index = _skip_prefix_options(tokens, index + 1, set())
+            continue
+        if command == "time":
+            index = _skip_prefix_options(tokens, index + 1, _TIME_OPTIONS_WITH_VALUES)
+            continue
+        return index
+    return None
+
+
+def _is_hermes_executable(token: str) -> bool:
+    return _command_name(token) in {"hermes", "hermes.exe"}
+
+
+def _hermes_argv(tokens: Sequence[str]) -> Optional[Sequence[str]]:
+    """Return Hermes arguments for a supported process invocation.
+
+    This deliberately recognizes only direct Hermes executable calls and the
+    standard ``python -m hermes_cli.main`` equivalent.  A textual mention of a
+    skill is not a runtime dependency.
+    """
+
+    index = _command_start(tokens)
+    if index is None:
+        return None
+    if _is_hermes_executable(tokens[index]):
+        return tokens[index + 1 :]
+
+    executable = _command_name(tokens[index])
+    if not executable.startswith("python"):
+        return None
+    index += 1
+    while index < len(tokens) and tokens[index] in {"-u", "-B", "-E", "-s"}:
+        index += 1
+    if (
+        index + 1 < len(tokens)
+        and tokens[index] == "-m"
+        and tokens[index + 1] == "hermes_cli.main"
+    ):
+        return tokens[index + 2 :]
+    return None
+
+
+def _loads_skill(tokens: Sequence[str], target: _SkillRuntimeTarget) -> bool:
+    """Return whether Hermes argv explicitly preloads the target skill."""
+
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            return False
+        value: Optional[str] = None
+        if token in {"-s", "--skills"} and index + 1 < len(tokens):
+            value = tokens[index + 1]
+            index += 1
+        elif token.startswith("--skills="):
+            value = token.split("=", 1)[1]
+        elif token.startswith("-s") and token != "-s":
+            value = token[2:]
+
+        if value is not None:
+            if any(
+                _skill_identifier_matches(part, target)
+                for part in value.split(",")
+                if part.strip()
+            ):
+                return True
+        index += 1
+    return False
+
+
+def _safe_reference_text(skill_name: str) -> str:
+    """Describe a match without returning source text that may hold secrets."""
+
+    return f"Hermes invocation preloads skill {skill_name!r}"
+
+
+def _shell_segments(command: str) -> Optional[List[List[str]]]:
+    """Split a shell command into simple command argv segments."""
+
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars="|;&<>{}")
+        lexer.whitespace_split = True
+        lexer.commenters = "#"
+        tokens = list(lexer)
+    except ValueError:
+        # An open quote can legitimately continue on a later physical line.
+        return None
+
+    segments: List[List[str]] = []
+    current: List[str] = []
+    for token in tokens:
+        if token in _SHELL_SEPARATORS:
+            if current:
+                segments.append(current)
+                current = []
+        else:
+            current.append(token)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _heredoc_delimiters(tokens: Sequence[str]) -> List[tuple[str, bool]]:
+    """Return literal here-document delimiters and whether tabs are stripped."""
+
+    delimiters: List[tuple[str, bool]] = []
+    index = 0
+    while index + 1 < len(tokens):
+        if tokens[index] != "<<":
+            index += 1
+            continue
+
+        index += 1
+        delimiter = tokens[index]
+        strip_tabs = False
+        if delimiter == "-":
+            strip_tabs = True
+            index += 1
+            if index >= len(tokens):
+                break
+            delimiter = tokens[index]
+        elif delimiter.startswith("-"):
+            strip_tabs = True
+            delimiter = delimiter[1:]
+
+        if delimiter:
+            delimiters.append((delimiter, strip_tabs))
+        index += 1
+    return delimiters
+
+
+def _shell_references(text: str, target: _SkillRuntimeTarget) -> List[tuple[int, str]]:
+    """Find explicit Hermes skill-loading commands in shell-like source."""
+
+    refs: List[tuple[int, str]] = []
+    pending_heredocs: List[tuple[str, bool]] = []
+    logical_line = ""
+    start_line = 1
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if pending_heredocs:
+            delimiter, strip_tabs = pending_heredocs[0]
+            candidate = line.lstrip("\t") if strip_tabs else line
+            if candidate == delimiter:
+                pending_heredocs.pop(0)
+            continue
+
+        if not logical_line:
+            start_line = line_no
+        logical_line += line.rstrip("\\\n")
+        if line.rstrip().endswith("\\"):
+            logical_line += " "
+            continue
+
+        segments = _shell_segments(logical_line)
+        if segments is None:
+            logical_line += "\n"
+            continue
+        for tokens in segments:
+            pending_heredocs.extend(_heredoc_delimiters(tokens))
+            argv = _hermes_argv(tokens)
+            if argv is not None and _loads_skill(argv, target):
+                refs.append((start_line, _safe_reference_text(target.name)))
+        logical_line = ""
+
+    if logical_line:
+        segments = _shell_segments(logical_line)
+        if segments is not None:
+            for tokens in segments:
+                argv = _hermes_argv(tokens)
+                if argv is not None and _loads_skill(argv, target):
+                    refs.append((start_line, _safe_reference_text(target.name)))
+    return refs
+
+
+def _literal_string(node: ast.AST) -> Optional[str]:
+    return (
+        node.value
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        else None
+    )
+
+
+def _literal_argv(node: ast.AST) -> Optional[List[str]]:
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return None
+    values: List[str] = []
+    for item in node.elts:
+        value = _literal_string(item)
+        if value is None:
+            return None
+        values.append(value)
+    return values
+
+
+def _python_references(text: str, target: _SkillRuntimeTarget) -> List[tuple[int, str]]:
+    """Find explicit subprocess or os.system Hermes invocations in Python."""
+
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return []
+
+    refs: List[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        dotted_name = ""
+        if isinstance(node.func, ast.Attribute) and isinstance(
+            node.func.value, ast.Name
+        ):
+            dotted_name = f"{node.func.value.id}.{node.func.attr}"
+        if dotted_name in {
+            "subprocess.run",
+            "subprocess.call",
+            "subprocess.check_call",
+            "subprocess.check_output",
+            "subprocess.Popen",
+        }:
+            argv = _literal_argv(node.args[0])
+            if argv is not None:
+                hermes_args = _hermes_argv(argv)
+                if hermes_args is not None and _loads_skill(hermes_args, target):
+                    refs.append((node.lineno, _safe_reference_text(target.name)))
+                    continue
+            command = _literal_string(node.args[0])
+            shell_true = any(
+                keyword.arg == "shell"
+                and isinstance(keyword.value, ast.Constant)
+                and keyword.value.value is True
+                for keyword in node.keywords
+            )
+            if command is not None and shell_true:
+                refs.extend(
+                    (node.lineno, snippet)
+                    for _line, snippet in _shell_references(command, target)
+                )
+        elif dotted_name == "os.system":
+            command = _literal_string(node.args[0])
+            if command is not None:
+                refs.extend(
+                    (node.lineno, snippet)
+                    for _line, snippet in _shell_references(command, target)
+                )
+    return refs
+
+
+def _is_python_source(path: Path, text: str) -> bool:
+    if path.suffix.lower() == ".py":
+        return True
+    first_line = text.splitlines()[0] if text else ""
+    return first_line.startswith("#!") and "python" in first_line.lower()
+
+
+def _scan_runtime_file(
     path: Path,
-    pattern: re.Pattern[str],
+    target: _SkillRuntimeTarget,
     surface: str,
+    runtime_dir: str,
 ) -> List[SkillRuntimeReference]:
-    refs: List[SkillRuntimeReference] = []
     try:
         text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return refs
+    except (OSError, UnicodeDecodeError) as exc:
+        raise SkillRuntimeScanError(
+            surface,
+            str(path),
+            f"could not read runtime file: {exc}",
+        ) from exc
 
-    for line_no, line in enumerate(text.splitlines(), start=1):
-        if pattern.search(line):
+    if runtime_dir == "scripts":
+        # Keep this aligned with cron.scheduler._run_job_script().
+        is_python = path.suffix.lower() not in {".sh", ".bash"}
+    else:
+        is_python = _is_python_source(path, text)
+
+    if is_python:
+        matches = _python_references(text, target)
+    else:
+        matches = _shell_references(text, target)
+    return [
+        SkillRuntimeReference(
+            surface=surface,
+            path=str(path),
+            line=line_no,
+            text=snippet,
+        )
+        for line_no, snippet in matches
+    ]
+
+
+def _scan_cron_jobs(target: _SkillRuntimeTarget) -> List[SkillRuntimeReference]:
+    jobs_file = target.hermes_home / "cron" / "jobs.json"
+    try:
+        from cron.jobs import _normalize_skill_list, load_jobs, use_cron_store
+
+        with use_cron_store(target.hermes_home):
+            jobs = load_jobs()
+        refs: List[SkillRuntimeReference] = []
+        for index, job in enumerate(jobs):
+            if not isinstance(job, dict):
+                continue
+            skills = _normalize_skill_list(job.get("skill"), job.get("skills"))
+            if not any(_skill_identifier_matches(item, target) for item in skills):
+                continue
+            job_id = job.get("id") or f"index:{index}"
             refs.append(
                 SkillRuntimeReference(
-                    surface=surface,
-                    path=str(path),
-                    line=line_no,
-                    text=line.strip()[:240],
-                    auto_migratable=False,
+                    surface="cron.jobs",
+                    path=f"{jobs_file}#{job_id}",
+                    line=None,
+                    text=f"Cron job references skill {target.name!r}",
                 )
             )
-    return refs
-
-
-def _scan_cron_jobs(hermes_home: Path, skill_name: str) -> List[SkillRuntimeReference]:
-    jobs_file = hermes_home / "cron" / "jobs.json"
-    try:
-        if not jobs_file.exists() or jobs_file.stat().st_size > _MAX_SCAN_BYTES:
-            return []
-    except OSError:
-        return []
-
-    try:
-        payload = json.loads(jobs_file.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return []
-
-    jobs = payload.get("jobs") if isinstance(payload, dict) else payload
-    if not isinstance(jobs, list):
-        return []
-
-    refs: List[SkillRuntimeReference] = []
-    for index, job in enumerate(jobs):
-        if not isinstance(job, dict):
-            continue
-        skills = job.get("skills")
-        single_skill = job.get("skill")
-        matched = False
-        if isinstance(skills, list) and skill_name in skills:
-            matched = True
-        if single_skill == skill_name:
-            matched = True
-        if not matched:
-            continue
-        job_id = job.get("id") or f"index:{index}"
-        job_name = job.get("name") or "unnamed"
-        refs.append(
-            SkillRuntimeReference(
-                surface="cron.jobs",
-                path=f"{jobs_file}#{job_id}",
-                line=None,
-                text=f"cron job {job_name!r} references skill {skill_name!r}",
-                auto_migratable=True,
-            )
-        )
-    return refs
+        return refs
+    except Exception as exc:
+        raise SkillRuntimeScanError(
+            "cron.jobs",
+            str(jobs_file),
+            f"could not load Cron jobs: {exc}",
+        ) from exc
 
 
 def find_skill_runtime_references(
     skill_name: str,
     hermes_home: Optional[Path] = None,
+    skill_path: Optional[Path] = None,
+    skills_root: Optional[Path] = None,
 ) -> List[SkillRuntimeReference]:
     """Find runtime entrypoints that refer to ``skill_name``.
 
-    References in Hermes cron jobs are marked auto-migratable because
-    ``cron.jobs.rewrite_skill_refs`` already rewrites those after a curator run.
-    Script references under ``bin`` and ``scripts`` are blocking because Hermes
-    has no deterministic migrator for arbitrary commands yet.
+    Cron and script references are blocking until their consumers have been
+    updated.  Cron rewrites occur after a curator run and cannot make a direct
+    deletion safe.  Script references are recognized only when they are actual
+    Hermes process invocations, not ordinary text that mentions a skill name.
+
+    Raises ``SkillRuntimeScanError`` when a runtime surface cannot be inspected;
+    callers must not interpret an incomplete scan as safe deletion.
     """
 
     home = Path(hermes_home) if hermes_home is not None else get_hermes_home()
-    pattern = _skill_pattern(skill_name)
+    target = _SkillRuntimeTarget(
+        name=skill_name,
+        hermes_home=home,
+        skill_path=Path(skill_path) if skill_path is not None else None,
+        skills_root=Path(skills_root) if skills_root is not None else None,
+    )
     refs: List[SkillRuntimeReference] = []
 
-    refs.extend(_scan_cron_jobs(home, skill_name))
-    for file_path in _iter_runtime_files(home):
-        surface = f"hermes.{file_path.parent.name}"
-        refs.extend(_scan_text_file(file_path, pattern, surface))
+    refs.extend(_scan_cron_jobs(target))
+    for runtime_dir, file_path in _iter_runtime_files(home):
+        surface = f"hermes.{runtime_dir}"
+        refs.extend(_scan_runtime_file(file_path, target, surface, runtime_dir))
 
     return refs
 
@@ -178,11 +628,14 @@ def find_skill_runtime_references(
 def blocking_skill_runtime_references(
     skill_name: str,
     hermes_home: Optional[Path] = None,
+    skill_path: Optional[Path] = None,
+    skills_root: Optional[Path] = None,
 ) -> List[SkillRuntimeReference]:
-    """Return references that deletion cannot safely auto-migrate."""
+    """Return references that must be cleared before deletion."""
 
-    return [
-        ref
-        for ref in find_skill_runtime_references(skill_name, hermes_home=hermes_home)
-        if not ref.auto_migratable
-    ]
+    return find_skill_runtime_references(
+        skill_name,
+        hermes_home=hermes_home,
+        skill_path=skill_path,
+        skills_root=skills_root,
+    )


### PR DESCRIPTION
## Summary

- add a deterministic runtime-reference check before deleting a skill
- block deletion when Hermes Cron jobs still reference the target skill
- parse supported Hermes skill-loading invocations instead of matching arbitrary text
- recognize bare, category-qualified, absolute-path, and Windows-style skill identifiers
- fail closed when relevant runtime configuration cannot be inspected safely
- add focused regression coverage for valid references and false-positive cases

## Why

A skill could be deleted while shell wrappers, Python launchers, or Hermes Cron jobs still depended on it. This could leave scheduled jobs and other runtime entrypoints pointing to a skill that no longer existed.

The initial implementation treated Cron references as automatically migratable. However, Cron rewriting occurs after a Curator run and is not performed by a direct `skill_manage(delete)` operation. Direct deletion therefore needed to treat Cron references as blocking.

The initial implementation also matched the skill name as an arbitrary text token. Because `$HERMES_HOME/scripts` can contain comments, prompts, and data files, that approach could incorrectly block deletion when a file merely mentioned the skill.

This revision moves a structured dependency check to the deletion boundary, protecting Curator and every other caller of `skill_manage`.

## Changes Made

- add `tools/skill_runtime_contracts.py` for deterministic runtime-reference inspection
- integrate the runtime check into the skill manager’s deletion path
- treat matching Hermes Cron references as blocking dependencies
- parse supported shell and Python skill-loading invocations
- ignore comments, prompts, data files, and non-invocation mentions
- match path-form identifiers only when they resolve to the exact target skill
- reject traversal paths and unrelated same-named paths
- fail closed on corrupt Cron configuration and unreadable or oversized runtime files
- sanitize reported references so command contents and possible secrets are not exposed
- add unit and deletion-path regression tests

## Validation

The focused test suite completed successfully:

```text
scripts/run_tests.sh \
  tests/tools/test_skill_runtime_contracts.py \
  tests/tools/test_skill_manager_tool.py \
  tests/agent/test_curator.py \
  tests/cron/test_jobs.py
```

Result: **324 passed, 0 failed**

Additional successful checks:

- Ruff lint
- Ruff formatting
- ty type checking
- Python compilation
- `git diff --check`
- Windows-footgun inspection

Tested locally on macOS with cross-platform path behavior covered by automated tests.

## Development Disclosure

This contribution was developed with assistance from OpenAI Codex. I directed the scope and design decisions, reviewed the implementation and test results, and approved the final behavior. I take responsibility for the code submitted in this PR.

Thank you for the opportunity!
   
