### PR TITLE
chore(desktop): sync package.json version fallback to 0.17.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "hermes",
   "productName": "Hermes",
   "private": true,
-  "version": "0.15.1",
+  "version": "0.17.0",
   "description": "Native desktop shell for Hermes Agent.",
   "author": "Nous Research",
   "type": "module",


### PR DESCRIPTION
## Summary
Syncs `apps/desktop/package.json` from a stale 0.15.1 to the current release version 0.17.0. This is the **fallback** version the Electron app reports via `app.getVersion()` — the runtime resolver (`resolveHermesVersion()` in `main.cjs`) already reads the canonical version from `hermes_cli/__init__.py`, so the displayed GUI version was correct; this just keeps the fallback honest for packaged builds that can't read the repo tree.

## Changes
- `apps/desktop/package.json`: version 0.15.1 → 0.17.0

## Why not in the release PR
The desktop `package.json` is a deliberate fallback (historically drifted, which is why the runtime resolver exists) and isn't part of the release skill's canonical version-file set. Follow-up so the fallback matches the latest tag.

## Infographic

![desktop package.json version sync 0.15.1 to 0.17.0](https://v3b.fal.media/files/b/0a9ef5ed/F48KZdOqZjkw5Zi24fCf__q3cvcjvU.png)
