### PR TITLE
fix(dashboard): skip large files when resolving profile aliases

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -516,7 +516,13 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
             continue
         if not is_windows and entry.suffix:
             continue
+        # Our profile wrappers are tiny scripts (~40 bytes). Skip large
+        # files so we never read/decode huge binaries that share this dir
+        # (e.g. claude, gh, agy in ~/.local/bin) just to find an alias --
+        # that was starving the dashboard asyncio event loop.
         try:
+            if entry.stat().st_size > 4096:
+                continue
             content = entry.read_text()
         except (OSError, UnicodeDecodeError):
             continue

--- a/tests/hermes_cli/test_find_alias_large_file_skip.py
+++ b/tests/hermes_cli/test_find_alias_large_file_skip.py
@@ -1,0 +1,18 @@
+"""Regression: find_alias_for_profile must skip large files in the wrapper dir.
+
+Pre-fix it read/decoded every extensionless file in ~/.local/bin (including
+huge binaries like `claude`, `gh`, `agy`) just to resolve a profile alias.
+On the dashboard that ran synchronously on the asyncio event loop and starved
+WebSocket delivery, timing out the Hermes Desktop ("loop stalled >10s").
+"""
+from hermes_cli import profiles
+
+
+def test_find_alias_skips_large_files(tmp_path, monkeypatch):
+    monkeypatch.setattr(profiles, "_get_wrapper_dir", lambda: tmp_path)
+    # A real, tiny wrapper for profile "cato".
+    (tmp_path / "cato").write_text('#!/bin/sh\nexec hermes -p cato "$@"\n')
+    # A large extensionless file that also contains the needle and sorts first.
+    # Pre-fix: read in full and wins as a bogus alias. Post-fix: skipped (>4 KiB).
+    (tmp_path / "aaa_big").write_text("x" * 200_000 + '\nexec hermes -p cato\n')
+    assert profiles.find_alias_for_profile("cato") == "cato"


### PR DESCRIPTION
## Problem
On hosts with large extensionless files in `~/.local/bin`, the dashboard's
`/api/cron/jobs?profile=all` endpoint stalls the asyncio event loop for >10s
(`ws write slow (loop stalled >10.0s)`), and the Hermes Desktop fails with
"timed out connecting to hermes backend after 60000ms".

## Root cause
`find_alias_for_profile()` (`hermes_cli/profiles.py`) scans every extensionless
file in `~/.local/bin` and `read_text()`s it in full to find a profile's alias
wrapper. Real wrappers are ~40-byte shell scripts, but `~/.local/bin` commonly
also holds large binaries with no extension (e.g. `claude`, `gh`, `agy`), which
the suffix filter does not skip. `_cron_profile_dicts()` calls `list_profiles()`
synchronously on the event loop, once per profile, and the Desktop polls
`/api/cron/jobs` every 30s — so the loop decodes hundreds of MB and stalls,
starving WebSocket delivery.

Profiled with py-spy during a stall: ~81% of active event-loop samples were in
`list_cron_jobs -> _cron_profile_dicts -> list_profiles -> find_alias_for_profile
-> Path.read_text -> codecs.decode`.

## Fix
Skip files larger than 4 KiB before `read_text()`. Behaviour is unchanged for real
wrappers. On a host with ~500 MB of extensionless binaries in `~/.local/bin`,
`list_profiles()` drops from ~50s to <1s and a single `find_alias_for_profile()`
call from ~3.4s to ~1ms.

## Test
Adds `tests/hermes_cli/test_find_alias_large_file_skip.py`: a large extensionless
file containing the needle must not be returned as the alias (it would be, pre-fix);
the real small wrapper is.

## Follow-ups (optional, not in this PR)
Run all-profile dashboard endpoints via `asyncio.to_thread`, and add a short TTL /
in-flight de-dupe to `/api/cron/jobs`.
