### PR TITLE
fix(plugins): silence raft check_fn log spam for users without raft CLI

### DIFF
--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -98,12 +98,20 @@ _RAFT_PROMPT_TURN_IDS: set[str] = set()
 
 
 def check_raft_requirements() -> bool:
-    """Check if Raft channel dependencies are available."""
+    """Check if Raft channel dependencies are available.
+
+    Intentionally silent on failure — this is a passive probe registered as
+    the platform's ``check_fn``. It is called on every
+    ``load_gateway_config()`` (message handling, display lookups, agent
+    turns), so logging here floods the logs for every user without the
+    ``raft`` CLI installed. The caller (``gateway/platform_registry.py``
+    ``create_adapter()``) emits its own warning when requirements are not met
+    and an adapter is actually requested. This matches the convention used by
+    other platform adapters (e.g. ``teams/adapter.py``).
+    """
     if not AIOHTTP_AVAILABLE:
-        logger.warning("[raft] aiohttp is not installed — install with: pip install aiohttp")
         return False
     if not shutil.which("raft"):
-        logger.warning("[raft] raft CLI not found in PATH — install from https://raft.build")
         return False
     return True
 

--- a/tests/plugins/test_raft_check_fn_silent.py
+++ b/tests/plugins/test_raft_check_fn_silent.py
@@ -1,0 +1,75 @@
+"""Regression tests for the raft platform plugin's check_fn.
+
+The raft platform adapter's ``check_raft_requirements()`` is registered as
+the platform's ``check_fn``. This function is invoked on every
+``load_gateway_config()`` call (dozens of times during normal gateway
+operation). It must therefore be a *silent* predicate — returning True/False
+without logging — otherwise every user without the ``raft`` CLI installed
+gets their logs flooded with WARNING messages every few seconds.
+
+See: https://github.com/NousResearch/hermes-agent/issues/49234
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def raft_check():
+    """Import check_raft_requirements fresh (adapter self-manages sys.path)."""
+    from plugins.platforms.raft.adapter import check_raft_requirements
+
+    return check_raft_requirements
+
+
+def test_check_returns_false_when_raft_cli_missing(raft_check):
+    """check_fn returns False when raft CLI is not in PATH."""
+    with patch("plugins.platforms.raft.adapter.shutil.which", return_value=None), \
+         patch("plugins.platforms.raft.adapter.AIOHTTP_AVAILABLE", True):
+        assert raft_check() is False
+
+
+def test_check_returns_false_when_aiohttp_missing(raft_check):
+    """check_fn returns False when aiohttp dependency is unavailable."""
+    with patch("plugins.platforms.raft.adapter.AIOHTTP_AVAILABLE", False):
+        assert raft_check() is False
+
+
+def test_check_returns_true_when_all_deps_present(raft_check):
+    """check_fn returns True when all dependencies are available."""
+    with patch("plugins.platforms.raft.adapter.shutil.which", return_value="/usr/bin/raft"), \
+         patch("plugins.platforms.raft.adapter.AIOHTTP_AVAILABLE", True):
+        assert raft_check() is True
+
+
+def test_check_silent_when_raft_cli_missing(raft_check, caplog):
+    """check_fn must NOT log a WARNING when raft CLI is missing.
+
+    This is the regression guard for issue #49234 — logging inside check_fn
+    causes log spam because the function is called on every config load.
+    """
+    with patch("plugins.platforms.raft.adapter.shutil.which", return_value=None), \
+         patch("plugins.platforms.raft.adapter.AIOHTTP_AVAILABLE", True):
+        with caplog.at_level(logging.WARNING, logger="plugins.platforms.raft.adapter"):
+            raft_check()
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == [], (
+        f"check_raft_requirements must be silent (no WARNING logs), "
+        f"but emitted: {[r.getMessage() for r in warnings]}"
+    )
+
+
+def test_check_silent_when_aiohttp_missing(raft_check, caplog):
+    """check_fn must NOT log a WARNING when aiohttp is missing."""
+    with patch("plugins.platforms.raft.adapter.AIOHTTP_AVAILABLE", False):
+        with caplog.at_level(logging.WARNING, logger="plugins.platforms.raft.adapter"):
+            raft_check()
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == [], (
+        f"check_raft_requirements must be silent (no WARNING logs), "
+        f"but emitted: {[r.getMessage() for r in warnings]}"
+    )


### PR DESCRIPTION
## What does this PR do?

Silences the raft platform plugin's `check_fn` so it stops flooding user logs with WARNING messages every ~10 seconds.

The raft plugin (shipped in commit `9028a8c78`) registers `check_raft_requirements()` as its platform `check_fn`. This function logged a WARNING every time it returned `False` (i.e., whenever the `raft` CLI wasn't installed). Since `check_fn` is called on every `load_gateway_config()` — which runs dozens of times during normal gateway operation — **every user who updates and doesn't have the `raft` CLI installed gets their logs flooded**, with no way to suppress it:

- `hermes plugins disable raft-platform` doesn't work — bundled platform plugins auto-load regardless of the disabled list.
- `platforms.raft.enabled: false` in config.yaml doesn't gate the `check_fn` call — it runs before the enablement gate.

**Why this approach:** a platform plugin's `check_fn` is contractually a passive predicate — return `True`/`False`, no side effects. This is documented in `plugins/platforms/teams/adapter.py` (lines 619–622) and followed by every other platform adapter. The raft adapter was the sole violator. The caller in `gateway/platform_registry.py` (`create_adapter()`, line 221–223) already emits its own generic warning when requirements aren't met and an adapter is actually requested — that's the correct place for a user-facing warning (fires once per connect attempt, not once per config load). This fix aligns raft with the existing convention.

## Related Issue

Fixes #49234

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`plugins/platforms/raft/adapter.py`** (lines 100–108): Removed two `logger.warning()` calls from `check_raft_requirements()`. Added an explanatory docstring documenting why the function must be silent (passive probe, called on every config load).
- **`tests/plugins/test_raft_check_fn_silent.py`** (new): 5 regression tests covering return values (True when deps present, False when raft CLI missing, False when aiohttp missing) and the silence contract (no WARNING logs emitted in either failure case).

## How to Test

**Reproduction (before fix):**
1. Be on a Hermes version that includes commit `9028a8c78` (raft platform plugin)
2. Do not have the `raft` CLI installed
3. Start the gateway: `hermes gateway run`
4. Watch logs: `hermes logs --follow`
5. Observe `WARNING hermes_plugins.raft_platform.adapter: [raft] raft CLI not found in PATH — install from https://raft.build` every ~10 seconds

**After fix:**
1. Apply this PR's changes
2. Restart the gateway
3. Observe zero raft-related warnings in logs

**Unit tests:**
```bash
scripts/run_tests.sh tests/plugins/test_raft_check_fn_silent.py
```

**Verification done:** 5 new tests pass; full plugin suite (1340 tests) + gateway config suite (67 tests) — all green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (Trixie) VPS (Linux 6.12.90+deb13.1-amd64)

### Documentation & Housekeeping

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

---


## Screenshots / Logs

**Before (log spam every ~10s):**
```
WARNING hermes_plugins.raft_platform.adapter: [raft] raft CLI not found in PATH — install from https://raft.build
WARNING hermes_plugins.raft_platform.adapter: [raft] raft CLI not found in PATH — install from https://raft.build
WARNING hermes_plugins.raft_platform.adapter: [raft] raft CLI not found in PATH — install from https://raft.build
```

**After:** 
```
zero raft warnings in logs (verified on live gateway for 30+ minutes of observation).
```


## Infographic

![silencing-the-passive-probe](https://v3b.fal.media/files/b/0a9efc59/R9Uji-ioPSpnMkfcnWH9a_n5mFwQON.png)
