### PR TITLE
fix(gateway): prevent infinite restart loop on session resume

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15231,14 +15231,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     else "a gateway interruption"
                 )
                 _persist_user_message_override = message
+                if not message:
+                    _msg_guidance = (
+                        "Inform the user that the session has been restored successfully, "
+                        "summarize the status of any background work, and ask for further instructions."
+                    )
+                else:
+                    _msg_guidance = "Address the user's NEW message below FIRST. Focus on what the user is asking now."
+
                 message = (
-                    f"[System note: A new message has arrived. The previous turn "
-                    f"was interrupted by {_reason_phrase}. "
-                    f"Address the user's NEW message below FIRST. "
-                    f"Do NOT re-execute old tool calls — skip any unfinished "
-                    f"work from the conversation history and focus on what the "
-                    f"user is asking now.]\n\n"
-                    + message
+                    f"[System note: The previous turn was interrupted by {_reason_phrase}. "
+                    f"If the last action in the conversation history was a command to restart, stop, or shutdown "
+                    f"the gateway or container, it has already executed successfully and the gateway is now back online; "
+                    f"do NOT re-execute it and do NOT run any command to verify it. "
+                    f"{_msg_guidance} "
+                    f"Do NOT re-execute old tool calls — skip any unfinished work from the conversation history.]"
+                    + (f"\n\n{message}" if message else "")
                 )
             elif _has_fresh_tool_tail:
                 _persist_user_message_override = message

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,7 +47,9 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     "victor@rocketfueldev.com": "victor-kyriazakos",
     "87440198+JoaoMarcos44@users.noreply.github.com": "JoaoMarcos44",
+    "joaomarcosdias444@gmail.com": "JoaoMarcos44",
     "286497132+srojk34@users.noreply.github.com": "srojk34",
+
     "59806492+sitkarev@users.noreply.github.com": "sitkarev",
     "zheng@omegasys.eu": "omegazheng",
     "220877172+james47kjv@users.noreply.github.com": "james47kjv",

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -153,14 +153,22 @@ def _simulate_note_injection(
             if reason == "shutdown_timeout"
             else "a gateway interruption"
         )
+        if not message:
+            _msg_guidance = (
+                "Inform the user that the session has been restored successfully, "
+                "summarize the status of any background work, and ask for further instructions."
+            )
+        else:
+            _msg_guidance = "Address the user's NEW message below FIRST. Focus on what the user is asking now."
+
         message = (
-            f"[System note: A new message has arrived. The previous turn "
-            f"was interrupted by {reason_phrase}. "
-            f"Address the user's NEW message below FIRST. "
-            f"Do NOT re-execute old tool calls — skip any unfinished "
-            f"work from the conversation history and focus on what the "
-            f"user is asking now.]\n\n"
-            + message
+            f"[System note: The previous turn was interrupted by {reason_phrase}. "
+            f"If the last action in the conversation history was a command to restart, stop, or shutdown "
+            f"the gateway or container, it has already executed successfully and the gateway is now back online; "
+            f"do NOT re-execute it and do NOT run any command to verify it. "
+            f"{_msg_guidance} "
+            f"Do NOT re-execute old tool calls — skip any unfinished work from the conversation history.]"
+            + (f"\n\n{message}" if message else "")
         )
     elif has_fresh_tool_tail:
         message = (
@@ -653,6 +661,27 @@ class TestResumePendingSystemNote:
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=None)
         assert result == "ping"
+
+    def test_resume_pending_empty_message_guidance(self):
+        """When the user message is empty (auto-resume startup turn), we instruct
+        the model to report successful recovery and ask for instructions,
+        and warn against re-executing restart/shutdown commands.
+        """
+        entry = self._pending_entry(reason="restart_timeout")
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "in progress", "timestamp": time.time()},
+            ],
+            user_message="",
+            resume_entry=entry,
+        )
+        assert "[System note:" in result
+        assert "gateway restart" in result
+        assert "restored successfully" in result
+        assert "ask for further instructions" in result
+        assert "If the last action in the conversation history was a command to restart" in result
+        assert "Do NOT re-execute" in result
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Description

Fixes #49201

This PR resolves an issue where the gateway falls into an infinite boot-loop when resuming a session that was interrupted by a gateway restart or shutdown command.


### Cause
When the gateway container is abruptly restarted, the process is killed. Upon reboot, the gateway auto-resumes the pending session. Because the transcript ends with a terminal command (e.g., `ssh docker restart ...` or `reboot`) with a `[Result unavailable...]` stub, the LLM assumes the command failed or got lost and re-runs it, triggering another restart/shutdown.

### Solution
We modified the system note injection logic for resume-pending turns in `gateway/run.py` (`_handle_message_with_agent`):
1. **Empty User Message (Startup Turn)**: If the startup turn has an empty message, we instruct the model to report successful recovery to the user and ask for further instructions, rather than attempting to resume the last command.
2. **Restart Loop Prevention Warning**: For all resume-pending cases, we inject a clear instruction:
   > If the last action in the conversation history was a command to restart, stop, or shutdown the gateway or container, it has already executed successfully and the gateway is now back online; do NOT re-execute it and do NOT run any command to verify it. Do NOT re-execute old tool calls — skip any unfinished work from the conversation history.

This cleanly breaks the loop at the cognitive level of the model without modifying global database schemas or core CLI configurations.

### Verification & Tests

- Added a new unit test case `test_resume_pending_empty_message_guidance` to `tests/gateway/test_restart_resume_pending.py` to verify prompt injection and instructions on empty message recovery turns.
- Verified that all **74** tests in `tests/gateway/test_restart_resume_pending.py` pass successfully.
- Verified that related component test suites pass without regression:
  - `tests/gateway/test_session.py` (79/79 passed)
  - `tests/gateway/test_restart_drain.py`, `test_restart_notification.py`, `test_restart_redelivery_dedup.py` (55/55 passed)
  - `tests/gateway/test_gateway_shutdown.py` (17/17 passed)
  - `tests/gateway/test_auto_continue.py` (10/10 passed)
