### PR TITLE
fix: run npm audit fix after npm install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,7 @@ COPY ui-tui/packages/hermes-ink/ ui-tui/packages/hermes-ink/
 ENV npm_config_install_links=false
 
 RUN npm install --prefer-offline --no-audit && \
+    npm audit fix --omit=dev || true && \
     npx playwright install --with-deps chromium --only-shell && \
     npm cache clean --force
 


### PR DESCRIPTION
## Summary

Adds `npm audit fix --omit=dev` after `npm install` in the Dockerfile to resolve the `undici` CVE advisory flagged by `hermes doctor`.

## What changes

- `Dockerfile` line 136: added `npm audit fix --omit=dev || true` after `npm install --prefer-offline --no-audit`

## Why

`hermes doctor` reports a high-severity `undici` vulnerability (GHSA-p88m-4jfj-68fv, GHSA-vxpw-j846-p89q, GHSA-35p6-xmwp-9g52, GHSA-g8m3-5g58-fq7m) in the ui-tui workspace. The vulnerability is in build-time tooling (not runtime — the TUI uses the prebuilt bundle at runtime), but clearing the advisory keeps `hermes doctor` output clean and catches future transitive dep issues early.

## Design choices

- `--omit=dev`: only fixes production dependencies (devDeps are not shipped in the image)
- `|| true`: build does not fail if some issues cannot be resolved upstream
- Runs before the `chmod -R a-w /opt/hermes` immutable-permissions step, so `node_modules` is still writable
