### PR TITLE
feat: add state verification guidance to system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -170,6 +170,16 @@ SESSION_SEARCH_GUIDANCE = (
     "asking them to repeat themselves."
 )
 
+STATE_VERIFICATION_GUIDANCE = (
+    "# State verification before status claims\n"
+    "Before claiming something is running, stopped, configured, or broken, "
+    "verify with a live check of the single most relevant source. Do not rely "
+    "on documentation, memory, or notes that may be stale — if a live check "
+    "contradicts what a document says, trust the live check. Stop after the "
+    "first source if it contradicts; do not search for additional sources to "
+    "find agreement."
+)
+
 SKILLS_GUIDANCE = (
     "After completing a complex task (5+ tool calls), fixing a tricky error, "
     "or discovering a non-trivial workflow, save the approach as a "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -37,6 +37,7 @@ from agent.prompt_builder import (
     PLATFORM_HINTS,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
+    STATE_VERIFICATION_GUIDANCE,
     STEER_CHANNEL_NOTE,
     TASK_COMPLETION_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
@@ -190,6 +191,15 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(MEMORY_GUIDANCE)
     if "session_search" in agent.valid_tool_names:
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
+    live_state_tools = {
+        "terminal",
+        "process",
+        "search_files",
+        "read_file",
+        "cronjob",
+    }
+    if any(name in agent.valid_tool_names for name in live_state_tools):
+        tool_guidance.append(STATE_VERIFICATION_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -31,6 +31,7 @@ from agent.prompt_builder import (
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
+    STATE_VERIFICATION_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
 )
@@ -53,6 +54,26 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_state_verification_guidance_is_concise_and_deployment_agnostic(self):
+        """Guidance must be short and general — no deployment-specific vocabulary.
+
+        This is a design invariant, not a string mirror: if someone adds
+        team-specific kanban labels or debugging anecdotes back into the
+        constant, this test fails because shared core must stay generic.
+        """
+        assert len(STATE_VERIFICATION_GUIDANCE) < 500, (
+            "Guidance should be concise (<500 chars). Deployment-specific "
+            "details belong in skills/memory, not shared system prompt."
+        )
+        text = STATE_VERIFICATION_GUIDANCE.lower()
+        # Core behavioral principle must be present
+        assert "live" in text or "verify" in text
+        # Must NOT contain deployment-specific kanban taxonomy
+        assert "active/soaking" not in text
+        assert "implemented-but-needs-review" not in text
+        # Must NOT contain tool-specific operational anecdotes
+        assert "importerror" not in text
 
 
 # =========================================================================

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1176,6 +1176,97 @@ class TestBuildSystemPrompt:
         assert mock_skills.call_args.kwargs["available_toolsets"] == {"web", "skills"}
 
 
+class TestStateVerificationGuidance:
+    """Tests for stale-state resistance guidance in the system prompt."""
+
+    def test_injected_when_live_state_tools_are_available(self):
+        from agent.prompt_builder import STATE_VERIFICATION_GUIDANCE
+
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("terminal", "search_files", "read_file"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                model="anthropic/claude-opus-4.8",
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+            prompt = agent._build_system_prompt()
+
+        assert STATE_VERIFICATION_GUIDANCE in prompt
+
+    def test_not_injected_when_no_live_state_tools_available(self):
+        """Guidance must NOT be injected when agent has no live-state tools."""
+        from agent.prompt_builder import STATE_VERIFICATION_GUIDANCE
+
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                model="anthropic/claude-opus-4.8",
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+            prompt = agent._build_system_prompt()
+
+        assert STATE_VERIFICATION_GUIDANCE not in prompt, (
+            "State verification guidance should NOT be injected when no "
+            "live-state tools (terminal, process, search_files, read_file, "
+            "cronjob) are available"
+        )
+
+    def test_not_injected_when_only_session_search(self):
+        """session_search is cross-session recall, not live-state verification.
+
+        This is the exact case Opus flagged: an agent with only session_search
+        (which IS in the default toolset) would trip the gate despite having no
+        tool to check live system state. The guidance would then tell it to
+        verify via sources it cannot touch.
+        """
+        from agent.prompt_builder import STATE_VERIFICATION_GUIDANCE
+
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search", "session_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                model="anthropic/claude-opus-4.8",
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+            prompt = agent._build_system_prompt()
+
+        assert STATE_VERIFICATION_GUIDANCE not in prompt, (
+            "session_search is cross-session memory recall, not a live-state "
+            "verification tool — must not trip the guidance gate"
+        )
+
+
 class TestToolUseEnforcementConfig:
     """Tests for the agent.tool_use_enforcement config option."""
 


### PR DESCRIPTION
## Summary

Add concise state-verification guidance to the system prompt when live-state tools are available.

The guidance nudges the agent to verify live state before making operational status claims such as whether something is running, stopped, configured, or broken. If a live check contradicts stale documentation, memory, or notes, the agent should trust the live source and stop rather than searching for agreement.

## Motivation

Agents can confidently answer from stale project notes, memory, or status documents when the user asks for current operational state. That failure is especially costly because the next action is often chosen from the claimed state.

Examples of claims that should be grounded in live evidence:

- whether a job/service/process is running or stopped
- whether a setting is currently configured
- whether a component is broken or healthy
- whether a stale report contradicts the current system

This change makes that verification reflex explicit, while keeping the instruction short and source-agnostic.

## Why this is system-prompt guidance, not a skill

This is a default epistemic behavior, not a multi-step workflow.

A skill only helps after the model has recognized that it should load or apply that skill. The failure mode here happens earlier: the model may not realize that a current-state claim requires live evidence, and may answer directly from stale notes instead.

So the guidance belongs with other baseline operating rules such as “use tools for system state” and “do not claim completion without evidence.” It is intentionally concise and triage-first rather than a detailed playbook:

- default reflex: verify live state before status claims
- one relevant live source first, not exhaustive source-chasing
- trust live contradiction over stale docs/memory/notes
- no deployment-specific source list or Hermes-specific taxonomy

Detailed operational recipes still belong in skills. This block is only the small recognition trigger that should happen before a skill would reliably be selected.

## Implementation

- Adds `STATE_VERIFICATION_GUIDANCE` in `agent/prompt_builder.py`.
- Injects it only when at least one live-state tool is available:
  - `terminal`
  - `process`
  - `search_files`
  - `read_file`
  - `cronjob`
- Leaves `session_search` out of the gate because it recalls past conversations; it is not a live-state verification source.
- Keeps the prompt addition static and resolved during system prompt construction, preserving prompt-cache stability.

## Scope control

This intentionally does **not** include a source-specific checklist such as “check cron for jobs, config.yaml for settings, logs for errors.” The agent already has tool descriptions; this block should teach the epistemic rule, not hardcode one deployment’s operational layout.

It also does not include log-specific instructions such as “read the log directly.” Those are better handled by tool behavior, documentation, or skills. Encoding source-specific anecdotes in the global prompt would make the instruction harder to generalize and more likely to overfit one environment.

## Tests

Targeted tests run against current `origin/main`:

```text
python3 -m pytest tests/agent/test_prompt_builder.py tests/run_agent/test_run_agent.py -q
543 passed, 1 warning in 116.82s
```

Additional checks:

```text
git diff --check origin/main...HEAD
# clean
```

Added-lines security scan found no real credentials. It matched only existing test fixture strings (`test-key-1234567890`).

## Behavioral validation

A small stale-document pilot benchmark showed directional benefit: models with the guidance verified live state more often than the unguided control when stale documents contradicted observable system state.

This benchmark is intentionally treated as directional evidence only, not proof of a universal effect:

- It used a minimal prompt rather than the full production Hermes prompt.
- It tested one model path.
- It used stale-document scenarios by design, so it does not estimate over-verification cost when documentation is accurate.

The PR is therefore justified primarily by the low-cost first-principles behavior and targeted tests, with the pilot benchmark as supporting evidence rather than the central claim.
