### PR TITLE
fix: route api.anthropic.com custom providers through anthropic_messages on fallback

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1145,7 +1145,16 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
         if fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
-        elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
+        elif (
+            fb_provider == "anthropic"
+            or fb_base_url.rstrip("/").lower().endswith("/anthropic")
+            or base_url_hostname(fb_base_url) == "api.anthropic.com"
+        ):
+            # Custom providers (e.g. cron-anthropic) point at the native
+            # api.anthropic.com host with no "/anthropic" path suffix, so the
+            # name/suffix checks above miss them and they default to
+            # chat_completions → POST /v1/chat/completions → 404. Match the
+            # host the same way determine_api_mode() does on the primary path.
             fb_api_mode = "anthropic_messages"
         elif _fb_is_azure:
             # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -182,6 +182,35 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert mock_rpc.call_args.kwargs["explicit_api_key"] == "env-secret"
 
+    def test_anthropic_host_custom_provider_uses_anthropic_messages(self):
+        """A custom provider on the native api.anthropic.com host (no
+        "/anthropic" path suffix, name != "anthropic") must resolve to the
+        anthropic_messages wire protocol — not default to chat_completions,
+        which POSTs /v1/chat/completions and 404s. Mirrors the primary-path
+        determine_api_mode() host check."""
+        fbs = [
+            {
+                "provider": "cron-anthropic",
+                "model": "claude-sonnet-4-6",
+                "base_url": "https://api.anthropic.com",
+                "key_env": "MY_FALLBACK_KEY",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        with (
+            patch.dict("os.environ", {"MY_FALLBACK_KEY": "env-secret"}, clear=False),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(base_url="https://api.anthropic.com"),
+                    "claude-sonnet-4-6",
+                ),
+            ),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_mode == "anthropic_messages"
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 


### PR DESCRIPTION
## Problem

On the **fallback** provider path, `api_mode` detection misses custom providers that point at the native Anthropic host (`api.anthropic.com`) without a `/anthropic` base-URL suffix.

The fallback resolver only matches:

```python
elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
    fb_api_mode = "anthropic_messages"
```

A custom provider (e.g. one named `cron-anthropic`) whose `base_url` is `https://api.anthropic.com` has neither `provider == "anthropic"` nor a `/anthropic` suffix, so it falls through to `chat_completions` → `POST /v1/chat/completions` → **404** against the Anthropic host on every fallback.

The **primary** path already handles this correctly in `determine_api_mode()` by matching the host. The fallback path just doesn't mirror it.

## Fix

Mirror the primary path's host check in the fallback resolver: also route to `anthropic_messages` when `base_url_hostname(fb_base_url) == "api.anthropic.com"`.

```python
elif (
    fb_provider == "anthropic"
    or fb_base_url.rstrip("/").lower().endswith("/anthropic")
    or base_url_hostname(fb_base_url) == "api.anthropic.com"
):
    fb_api_mode = "anthropic_messages"
```

## Test

Adds `tests/run_agent/test_provider_fallback.py` covering a custom provider pointed at `api.anthropic.com` with no `/anthropic` suffix, asserting it resolves to `anthropic_messages` on fallback (not `chat_completions`). Full file: 23 passed.

Fixes the whole class — name match, suffix match, and host match — not just the one site.
