### PR TITLE
fix(web_extract): cap the provider extract() dispatch with a wall-clock timeout

### DIFF
--- a/tests/tools/test_web_extract_timeout.py
+++ b/tests/tools/test_web_extract_timeout.py
@@ -1,0 +1,176 @@
+"""Wall-clock cap on the web_extract provider dispatch.
+
+``web_extract_tool`` awaited ``provider.extract()`` unbounded: the HTTP
+timeouts inside providers cap a single request, but a hung stream or a
+provider that retries internally can stall far past them, hanging the tool
+(and any idle-limited caller above it) indefinitely. The dispatch is now
+capped by ``web.extract_timeout`` (default
+``tools.web_tools.DEFAULT_EXTRACT_TIMEOUT_S``) and degrades to per-URL
+structured timeout errors instead of hanging.
+"""
+
+import asyncio
+import json
+import time
+
+import pytest
+
+from agent import web_search_registry
+from agent.web_search_provider import WebSearchProvider
+from tools import web_tools
+
+_URLS = ["https://example.com/a", "https://example.org/b"]
+
+
+class _BaseFakeProvider(WebSearchProvider):
+    @property
+    def name(self) -> str:
+        return "extract-timeout-test"
+
+    @property
+    def display_name(self) -> str:
+        return "Extract Timeout Test"
+
+    def is_available(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return True
+
+
+class _HangingAsyncProvider(_BaseFakeProvider):
+    """Async extract() that hangs far past the cap (cancelled by wait_for)."""
+
+    async def extract(self, urls, **kwargs):
+        await asyncio.sleep(30)
+        return [{"url": u, "title": "", "content": "SHOULD-NOT-RETURN"} for u in urls]
+
+
+class _HangingSyncProvider(_BaseFakeProvider):
+    """Sync extract() dispatched via asyncio.to_thread.
+
+    The sleep is deliberately short: wait_for abandons the worker thread but
+    cannot kill it, so a long sleep here would stall suite teardown.  2s is
+    still 40x the cap the tests configure.
+    """
+
+    def extract(self, urls, **kwargs):
+        time.sleep(2)
+        return [{"url": u, "title": "", "content": "SHOULD-NOT-RETURN"} for u in urls]
+
+
+class _FastProvider(_BaseFakeProvider):
+    async def extract(self, urls, **kwargs):
+        return [{"url": u, "title": "T", "content": "real content"} for u in urls]
+
+
+def _install(monkeypatch, provider, web_config):
+    with web_search_registry._lock:
+        previous = dict(web_search_registry._providers)
+        web_search_registry._providers.clear()
+    web_search_registry.register_provider(provider)
+    monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(web_tools, "_load_web_config", lambda: web_config)
+
+    async def _safe(_url):
+        return True
+
+    monkeypatch.setattr(web_tools, "async_is_safe_url", _safe)
+    return previous
+
+
+def _restore(previous):
+    with web_search_registry._lock:
+        web_search_registry._providers.clear()
+        web_search_registry._providers.update(previous)
+
+
+@pytest.fixture
+def hanging_async_provider(monkeypatch):
+    provider = _HangingAsyncProvider()
+    previous = _install(
+        monkeypatch,
+        provider,
+        {"extract_backend": provider.name, "extract_timeout": 0.05},
+    )
+    yield provider
+    _restore(previous)
+
+
+@pytest.fixture
+def hanging_sync_provider(monkeypatch):
+    provider = _HangingSyncProvider()
+    previous = _install(
+        monkeypatch,
+        provider,
+        {"extract_backend": provider.name, "extract_timeout": 0.05},
+    )
+    yield provider
+    _restore(previous)
+
+
+@pytest.fixture
+def fast_provider(monkeypatch):
+    provider = _FastProvider()
+    previous = _install(
+        monkeypatch, provider, {"extract_backend": provider.name}
+    )
+    yield provider
+    _restore(previous)
+
+
+def _assert_structured_timeouts(raw: str):
+    result = json.loads(raw)
+    assert [e["url"] for e in result["results"]] == _URLS
+    for entry in result["results"]:
+        assert entry["content"] == ""
+        assert "timed out" in entry["error"]
+    assert "SHOULD-NOT-RETURN" not in raw
+
+
+@pytest.mark.asyncio
+async def test_hanging_async_provider_returns_structured_timeouts(
+    hanging_async_provider,
+):
+    # Outer guard: if the cap is not honored this raises instead of hanging CI.
+    raw = await asyncio.wait_for(web_tools.web_extract_tool(_URLS), timeout=5.0)
+    _assert_structured_timeouts(raw)
+
+
+@pytest.mark.asyncio
+async def test_hanging_sync_provider_returns_structured_timeouts(
+    hanging_sync_provider,
+):
+    raw = await asyncio.wait_for(web_tools.web_extract_tool(_URLS), timeout=5.0)
+    _assert_structured_timeouts(raw)
+
+
+@pytest.mark.asyncio
+async def test_fast_provider_unaffected_by_default_cap(fast_provider):
+    result = json.loads(await web_tools.web_extract_tool(_URLS))
+    assert [e["url"] for e in result["results"]] == _URLS
+    for entry in result["results"]:
+        assert entry["content"] == "real content"
+        assert entry["error"] is None
+
+
+def test_extract_timeout_config(monkeypatch):
+    # Default when the key is absent.
+    monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+    assert web_tools._get_extract_timeout_s() == web_tools.DEFAULT_EXTRACT_TIMEOUT_S
+
+    # Explicit override wins.
+    monkeypatch.setattr(
+        web_tools, "_load_web_config", lambda: {"extract_timeout": 7}
+    )
+    assert web_tools._get_extract_timeout_s() == 7.0
+
+    # Garbage and non-positive values fall back to the default.
+    for bad in ("nope", None, 0, -3):
+        monkeypatch.setattr(
+            web_tools, "_load_web_config", lambda bad=bad: {"extract_timeout": bad}
+        )
+        assert (
+            web_tools._get_extract_timeout_s()
+            == web_tools.DEFAULT_EXTRACT_TIMEOUT_S
+        )

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -447,6 +447,30 @@ def _get_extract_char_limit() -> int:
     return DEFAULT_EXTRACT_CHAR_LIMIT
 
 
+# Aggregate wall-clock cap on one provider extract() batch. The HTTP timeouts
+# inside providers bound a single request, but a hung stream or a provider
+# that retries internally can stall far past them — and the dispatcher awaits
+# extract() with nothing above it, so one bad batch hangs the tool (and any
+# idle-limited caller, e.g. a cron-driven agent) indefinitely. On timeout the
+# batch degrades to per-URL error entries instead. Override via
+# web.extract_timeout in config.yaml.
+DEFAULT_EXTRACT_TIMEOUT_S = 180.0
+
+
+def _get_extract_timeout_s() -> float:
+    """Resolve the extract dispatch cap from config; non-positive/garbage
+    values fall back to the default rather than disabling the cap."""
+    try:
+        configured = _load_web_config().get("extract_timeout")
+        if configured is not None:
+            value = float(configured)
+            if value > 0:
+                return value
+    except (TypeError, ValueError):
+        pass
+    return DEFAULT_EXTRACT_TIMEOUT_S
+
+
 def convert_base64_images_to_links(text: str) -> str:
     """Replace inline base64 image blobs with labeled markdown links.
 
@@ -933,14 +957,45 @@ async def web_extract_tool(
             # Async-or-sync dispatch: parallel + firecrawl have async
             # extract(); exa + tavily are sync.
             import inspect
-            if inspect.iscoroutinefunction(provider.extract):
-                results = await provider.extract(safe_urls, format=format)
-            else:
-                # Run sync extract() in a thread so we don't block the
-                # event loop on network I/O.
-                results = await asyncio.to_thread(
-                    provider.extract, safe_urls, format=format
+            extract_timeout_s = _get_extract_timeout_s()
+            try:
+                if inspect.iscoroutinefunction(provider.extract):
+                    results = await asyncio.wait_for(
+                        provider.extract(safe_urls, format=format),
+                        timeout=extract_timeout_s,
+                    )
+                else:
+                    # Run sync extract() in a thread so we don't block the
+                    # event loop on network I/O. On timeout the thread is
+                    # abandoned, not killed — the caller unblocks and the
+                    # orphan request dies with its connection.
+                    results = await asyncio.wait_for(
+                        asyncio.to_thread(
+                            provider.extract, safe_urls, format=format
+                        ),
+                        timeout=extract_timeout_s,
+                    )
+            except asyncio.TimeoutError:
+                # One hung source must not stall the whole tool. Degrade to
+                # per-URL error entries so the caller gets a structured
+                # result (and the SSRF/invalid entries merged below) instead
+                # of an unbounded wait.
+                logger.warning(
+                    "web_extract via %s exceeded the %.0fs wall-clock cap "
+                    "for %d URL(s); returning timeout errors for this batch "
+                    "(override via web.extract_timeout)",
+                    provider.name, extract_timeout_s, len(safe_urls),
                 )
+                results = [
+                    {
+                        "url": url, "title": "", "content": "",
+                        "error": (
+                            f"Extraction timed out after "
+                            f"{extract_timeout_s:.0f}s"
+                        ),
+                    }
+                    for url in safe_urls
+                ]
 
         # Reconstruct the original input order across invalid, blocked, and
         # provider-processed entries. Providers are expected to preserve the


### PR DESCRIPTION
## Problem

`web_extract_tool` awaits `provider.extract()` with no bound above it. The HTTP timeouts inside providers cap a single request, but a hung stream or a provider that retries internally can stall far past them — one bad batch hangs the tool (and any idle-limited caller above it, e.g. a cron-driven agent) indefinitely.

## Change

- Wrap both dispatch branches (async `extract()`, and sync `extract()` via `asyncio.to_thread`) in `asyncio.wait_for`.
- Cap comes from `web.extract_timeout` (default 180 s), sitting next to the existing `web.extract_char_limit` knob and read through `_load_web_config()`. Garbage or non-positive values fall back to the default rather than disabling the cap.
- On timeout the batch degrades to per-URL structured error entries (`{url, title: "", content: "", error: "Extraction timed out after Ns"}`), so ordering and the SSRF-blocked/invalid merges below keep working and the caller always gets a well-formed result.
- The abandoned `to_thread` worker can't be killed; the caller unblocks and the orphan request dies with its connection (noted in a comment).

## Tests

`tests/tools/test_web_extract_timeout.py`, following the fake-provider/registry-swap pattern from `test_web_tools_dict_urls.py`:

- hanging **async** provider → structured per-URL timeout errors (outer `wait_for` guard so CI can't hang if the cap breaks)
- hanging **sync** provider through the `to_thread` branch → same
- fast provider under the default cap → results pass through untouched
- config parsing: default, override, garbage/non-positive fallback

## History

Earlier revision of this PR also capped the LLM summarization path; that path was removed in ee8cbfdc0 (`web_extract` no longer summarizes), so per review this is retargeted to the current provider dispatch only, and the config moved from the removed `auxiliary.web_extract.*` block to `web.extract_timeout`.