### PR TITLE
fix(mcp): deregister tools when reconnection retries are exhausted

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -538,6 +538,72 @@ class TestMCPInitialConnectionRetry:
 
         asyncio.get_event_loop().run_until_complete(_run())
 
+    def test_reconnect_give_up_deregisters_tools(self):
+        """When reconnection retries are exhausted, previously registered
+        tools must be removed from the registry so the agent stops
+        advertising unreachable tools to the LLM."""
+        from tools.mcp_tool import (
+            MCPServerTask, _MAX_RECONNECT_RETRIES,
+            _mcp_tool_server_names,
+        )
+        from tools.registry import registry
+
+        call_count = 0
+        tool_name = "mcp_test_deregister_fake_tool"
+
+        async def _run():
+            nonlocal call_count
+            server = MCPServerTask("test-deregister")
+
+            async def fake_run_stdio(self_inner, config):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    # First call succeeds — simulate a working session.
+                    self_inner._ready.set()
+                    await asyncio.sleep(0.05)
+                    # Simulate the connection dropping.
+                    raise ConnectionError("connection lost")
+                # All subsequent calls fail (reconnect attempts).
+                raise ConnectionError("still down")
+
+            with patch.object(MCPServerTask, '_run_stdio', fake_run_stdio), \
+                 patch.object(MCPServerTask, '_run_http', fake_run_stdio), \
+                 patch('tools.mcp_tool._MAX_BACKOFF_SECONDS', 0), \
+                 patch('asyncio.sleep', return_value=None):
+                # Pre-register a fake tool to simulate an already-connected
+                # server that had its tools registered at startup.
+                registry.register(
+                    tool_name, "mcp_test_deregister",
+                    {"type": "object", "properties": {}},
+                    lambda **kw: "",
+                )
+                server._registered_tool_names = [tool_name]
+                _mcp_tool_server_names[tool_name] = "test_deregister"
+
+                assert registry.get_entry(tool_name) is not None
+                assert tool_name in _mcp_tool_server_names
+
+                task = asyncio.ensure_future(server.run({"command": "fake"}))
+                await server._ready.wait()
+                # run() continues in the background; wait for it to exhaust
+                # reconnect retries and exit.
+                await task
+
+                # After give-up, tools must be deregistered.
+                assert registry.get_entry(tool_name) is None, (
+                    "Tool should have been deregistered after reconnect give-up"
+                )
+                assert tool_name not in _mcp_tool_server_names, (
+                    "Tool-server mapping should have been forgotten"
+                )
+                assert server._registered_tool_names == []
+                # 1 initial success-then-drop + _MAX_RECONNECT_RETRIES reconnect
+                # failures + 1 final failure that exceeds the limit
+                assert call_count == _MAX_RECONNECT_RETRIES + 1
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
     def test_initial_connect_retry_respects_shutdown(self):
         """Shutdown during initial retry backoff aborts cleanly."""
         from tools.mcp_tool import MCPServerTask

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2344,6 +2344,7 @@ class MCPServerTask:
                         "giving up: %s",
                         self.name, _MAX_RECONNECT_RETRIES, exc,
                     )
+                    self._deregister_tools()
                     return
 
                 logger.warning(
@@ -2368,10 +2369,23 @@ class MCPServerTask:
         if self._error:
             raise self._error
 
-    async def shutdown(self):
-        """Signal the Task to exit and wait for clean resource teardown."""
+    def _deregister_tools(self) -> None:
+        """Remove this server's tools from the global registry.
+
+        Safe to call more than once (idempotent).  Used by both the
+        reconnect-give-up path inside ``run()`` and the explicit
+        ``shutdown()`` teardown so dead servers never leave phantom
+        tool definitions in the agent's tool snapshot.
+        """
         from tools.registry import registry
 
+        for tool_name in list(getattr(self, "_registered_tool_names", [])):
+            registry.deregister(tool_name)
+            _forget_mcp_tool_server(tool_name)
+        self._registered_tool_names = []
+
+    async def shutdown(self):
+        """Signal the Task to exit and wait for clean resource teardown."""
         self._shutdown_event.set()
         # Defensive: if _wait_for_lifecycle_event is blocking, we need ANY
         # event to unblock it. _shutdown_event alone is sufficient (the
@@ -2397,10 +2411,7 @@ class MCPServerTask:
                 task.cancel()
             await asyncio.gather(*self._pending_refresh_tasks, return_exceptions=True)
             self._pending_refresh_tasks.clear()
-        for tool_name in list(getattr(self, "_registered_tool_names", [])):
-            registry.deregister(tool_name)
-            _forget_mcp_tool_server(tool_name)
-        self._registered_tool_names = []
+        self._deregister_tools()
         self.session = None
 
 


### PR DESCRIPTION
## Summary

- When a previously-connected MCP server loses its connection and exhausts `_MAX_RECONNECT_RETRIES`, the `run()` give-up path returned without deregistering the server's tools from the global registry.
- This left phantom tool definitions that the agent advertised to the LLM on every subsequent turn — wasting prompt-cache space and tokens, and producing `"MCP server '<name>' is not connected"` errors on every call the model attempted.
- The only way to clear this state was a manual `/reload-mcp` or full session restart.

## What changed

- Extracted a `_deregister_tools()` helper on `MCPServerTask` (idempotent, mirrors the cleanup already done in `shutdown()`).
- Called it from the reconnect give-up branch so tool cleanup happens in all exit paths — not just explicit shutdown.
- `shutdown()` now delegates to the same helper, removing code duplication.

## Validation

- `uv run --frozen python -m pytest tests/tools/test_mcp_stability.py -x -q` → **22 passed**
- `uv run --frozen python -m pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_dynamic_discovery.py tests/tools/test_mcp_circuit_breaker.py tests/tools/test_mcp_reconnect_signal.py tests/test_tui_mcp_late_refresh.py tests/tools/test_refresh_agent_mcp_tools.py -x -q` → **236 passed**
- `git diff --check upstream/main` → clean
- `python -m py_compile tools/mcp_tool.py tests/tools/test_mcp_stability.py` → clean

## Test plan

- [x] New test `test_reconnect_give_up_deregisters_tools` verifies that after reconnect exhaustion, tools are removed from the registry and the server-name mapping is cleared
- [x] All existing MCP stability, dynamic discovery, circuit breaker, reconnect, and late-refresh tests continue to pass