### PR TITLE
fix(memory): gate external provider bridge on successful committed writes

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1850,8 +1850,21 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 store=agent._memory_store,
             )
             # Bridge: notify external memory provider of built-in memory writes.
-            # Covers both the single-op shape and each add/replace inside a batch.
-            if agent._memory_manager:
+            # Only forward writes that actually committed — skip failed
+            # batches (budget exceeded, malformed ops) and staged-but-not-
+            # yet-approved writes so external providers stay in sync with
+            # the built-in store.
+            _bridge = False
+            try:
+                _parsed = json.loads(result) if isinstance(result, str) else result
+                _bridge = (
+                    isinstance(_parsed, dict)
+                    and _parsed.get("success") is True
+                    and not _parsed.get("staged")
+                )
+            except (json.JSONDecodeError, TypeError, ValueError):
+                pass
+            if agent._memory_manager and _bridge:
                 if operations:
                     _mem_ops = [
                         op for op in operations

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1023,8 +1023,21 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     store=agent._memory_store,
                 )
                 # Bridge: notify external memory provider of built-in memory writes.
-                # Covers both the single-op shape and each add/replace inside a batch.
-                if agent._memory_manager:
+                # Only forward writes that actually committed — skip failed
+                # batches (budget exceeded, malformed ops) and staged-but-not-
+                # yet-approved writes so external providers stay in sync with
+                # the built-in store.
+                _bridge = False
+                try:
+                    _parsed = json.loads(result) if isinstance(result, str) else result
+                    _bridge = (
+                        isinstance(_parsed, dict)
+                        and _parsed.get("success") is True
+                        and not _parsed.get("staged")
+                    )
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    pass
+                if agent._memory_manager and _bridge:
                     if operations:
                         _mem_ops = [
                             op for op in operations

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1491,3 +1491,76 @@ class TestContextEngineToolsetGate:
         """Gate is moot without a context_compressor."""
         tools, names, engine_names = self._run_context_engine_injection(None, None)
         assert tools == []
+
+
+# ---------------------------------------------------------------------------
+# Memory bridge result-gating — phantom-write prevention
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryBridgeResultGating:
+    """The external-provider bridge in tool_executor / agent_runtime_helpers
+    must only forward writes that actually committed to the built-in store.
+    Failed batches (budget exceeded, malformed ops) and staged-but-not-yet-
+    approved writes must NOT be forwarded, otherwise the external provider
+    diverges from the built-in store.
+
+    These tests exercise the gating logic directly rather than going through
+    the full agent loop.
+    """
+
+    @staticmethod
+    def _should_bridge(result: str) -> bool:
+        """Reproduce the gating logic from tool_executor.py."""
+        import json as _json
+        try:
+            parsed = _json.loads(result) if isinstance(result, str) else result
+            return (
+                isinstance(parsed, dict)
+                and parsed.get("success") is True
+                and not parsed.get("staged")
+            )
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return False
+
+    def test_successful_single_op_bridges(self):
+        result = json.dumps({"success": True, "message": "Added."})
+        assert self._should_bridge(result) is True
+
+    def test_successful_batch_bridges(self):
+        result = json.dumps({"success": True, "message": "Applied 3 operation(s)."})
+        assert self._should_bridge(result) is True
+
+    def test_failed_batch_does_not_bridge(self):
+        result = json.dumps({
+            "success": False,
+            "error": "Over the limit.",
+            "current_entries": [],
+            "usage": "5000/4000",
+        })
+        assert self._should_bridge(result) is False
+
+    def test_staged_batch_does_not_bridge(self):
+        result = json.dumps({
+            "success": True,
+            "staged": True,
+            "pending_id": "abc123",
+            "message": "Queued for approval.",
+        })
+        assert self._should_bridge(result) is False
+
+    def test_staged_single_op_does_not_bridge(self):
+        result = json.dumps({
+            "success": True,
+            "staged": True,
+            "pending_id": "xyz789",
+            "message": "Memory write queued for review.",
+        })
+        assert self._should_bridge(result) is False
+
+    def test_malformed_result_does_not_bridge(self):
+        assert self._should_bridge("not json at all") is False
+
+    def test_error_string_does_not_bridge(self):
+        result = json.dumps({"error": "Memory is not available.", "success": False})
+        assert self._should_bridge(result) is False


### PR DESCRIPTION
## Summary

- The external memory-provider bridge in `tool_executor.py` and `agent_runtime_helpers.py` forwarded every add/replace op to external providers (RetainDB, Honcho, Supermemory, OpenViking) unconditionally — without checking whether the built-in store actually committed the write.
- This caused two divergence paths:
  1. **Failed batches** (budget exceeded, malformed ops, ambiguous match) wrote nothing to the built-in store but pushed every op to the external provider — phantom writes that accumulate on retries.
  2. **Staged (not-yet-approved) batches** were persisted externally before the user approved, or even if they later rejected — violating the write-approval gate contract.
- The fix parses the `memory_tool` result and only bridges when `success=True` and `staged` is not set. Both the sequential (`tool_executor.py`) and concurrent (`agent_runtime_helpers.py`) execution paths are patched identically.

## Validation

- `uv run --frozen python -m pytest tests/agent/test_memory_provider.py tests/tools/test_memory_tool.py -x -q` → **173 passed**
- `git diff --check upstream/main` → clean
- `python -m py_compile agent/tool_executor.py agent/agent_runtime_helpers.py tests/agent/test_memory_provider.py` → clean

## Test plan

- [x] `test_successful_single_op_bridges` — successful single-op write bridges correctly
- [x] `test_successful_batch_bridges` — successful batch bridges correctly
- [x] `test_failed_batch_does_not_bridge` — budget-exceeded batch is NOT forwarded
- [x] `test_staged_batch_does_not_bridge` — staged (unapproved) batch is NOT forwarded
- [x] `test_staged_single_op_does_not_bridge` — staged single op is NOT forwarded
- [x] `test_malformed_result_does_not_bridge` — malformed/non-JSON result is NOT forwarded
- [x] `test_error_string_does_not_bridge` — error result is NOT forwarded
- [x] All 173 existing memory tests continue to pass