### PR TITLE
fix(whatsapp): prefer Hermes-managed Node over system PATH for the bridge

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -206,16 +206,41 @@ def _file_content_hash(path: Path) -> str:
         return ""
 
 
+def _resolve_node() -> Optional[str]:
+    """Resolve the node executable, preferring Hermes-managed Node over PATH.
+
+    On Windows a broken, elevated, stale, or incompatible system Node on PATH
+    can make the WhatsApp bridge fail to start even though Hermes installed its
+    own Node under ``$HERMES_HOME/node``. Prefer the managed binary, then the
+    ``HERMES_NODE`` override, then fall back to PATH (which respects PATHEXT for
+    ``node.exe``). (#49242)
+    """
+    env_node = os.environ.get("HERMES_NODE")
+    if env_node and os.path.isfile(env_node) and os.access(env_node, os.X_OK):
+        return env_node
+    try:
+        from hermes_constants import get_hermes_home
+        home = get_hermes_home()
+        # Windows: npm -g --prefix drops node.exe in the prefix dir.
+        # POSIX: install.sh puts it under node/bin/.
+        for candidate in (home / "node" / "node.exe", home / "node" / "bin" / "node"):
+            if candidate.is_file():
+                return str(candidate)
+    except Exception:
+        pass
+    return shutil.which("node")
+
+
 def check_whatsapp_requirements() -> bool:
     """
     Check if WhatsApp dependencies are available.
-    
+
     WhatsApp requires a Node.js bridge for most implementations.
     """
-    # Check for Node.js.  Resolve via shutil.which so we respect PATHEXT
-    # (node.exe vs node) and get a meaningful "not installed" signal
-    # instead of spawning a cmd flash on Windows.
-    _node = shutil.which("node")
+    # Prefer Hermes-managed Node, then HERMES_NODE, then PATH (which respects
+    # PATHEXT for node.exe and gives a meaningful "not installed" signal
+    # instead of spawning a cmd flash on Windows). (#49242)
+    _node = _resolve_node()
     if not _node:
         return False
     try:
@@ -506,9 +531,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env["HERMES_AUDIO_CACHE_DIR"] = str(_get_audio_dir())
             bridge_env["HERMES_DOCUMENT_CACHE_DIR"] = str(_get_doc_dir())
 
+            # Launch with Hermes-managed Node when present so a broken/elevated
+            # system Node on PATH can't stop the bridge from starting (#49242).
+            node_bin = _resolve_node() or "node"
             self._bridge_process = subprocess.Popen(
                 [
-                    "node",
+                    node_bin,
                     str(bridge_path),
                     "--port", str(self._bridge_port),
                     "--session", str(self._session_path),

--- a/tests/gateway/test_whatsapp_node_resolution.py
+++ b/tests/gateway/test_whatsapp_node_resolution.py
@@ -1,0 +1,47 @@
+"""WhatsApp bridge should prefer Hermes-managed Node over system PATH (#49242).
+
+On Windows a broken/elevated/incompatible system Node on PATH could stop the
+bridge from starting even though Hermes installed its own Node under
+$HERMES_HOME/node. _resolve_node() prefers the managed binary, then HERMES_NODE,
+then PATH.
+"""
+
+import os
+from unittest.mock import patch
+
+from gateway.platforms import whatsapp
+
+
+def test_prefers_hermes_env_override(tmp_path, monkeypatch):
+    node = tmp_path / "custom-node"
+    node.write_text("#!/bin/sh\n")
+    node.chmod(0o755)
+    monkeypatch.setenv("HERMES_NODE", str(node))
+    assert whatsapp._resolve_node() == str(node)
+
+
+def test_prefers_managed_windows_node(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_NODE", raising=False)
+    managed = tmp_path / "node" / "node.exe"
+    managed.parent.mkdir(parents=True)
+    managed.write_text("")
+    with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        assert whatsapp._resolve_node() == str(managed)
+
+
+def test_prefers_managed_posix_node(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_NODE", raising=False)
+    managed = tmp_path / "node" / "bin" / "node"
+    managed.parent.mkdir(parents=True)
+    managed.write_text("")
+    with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        assert whatsapp._resolve_node() == str(managed)
+
+
+def test_falls_back_to_path(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_NODE", raising=False)
+    # Managed home with no node installed → fall back to PATH lookup.
+    with patch("hermes_constants.get_hermes_home", return_value=tmp_path), \
+         patch("gateway.platforms.whatsapp.shutil.which", return_value="/usr/bin/node") as which:
+        assert whatsapp._resolve_node() == "/usr/bin/node"
+        which.assert_called_with("node")


### PR DESCRIPTION
## What

The WhatsApp gateway now resolves Node by preferring the Hermes-managed install before falling back to system PATH.

## Why

On Windows a broken, elevated, stale, or incompatible system Node on PATH could stop the bridge from starting — the gateway then logged "Node.js not installed" and skipped WhatsApp entirely, even though Hermes had its own Node under `$HERMES_HOME/node`.

## Change

I added `_resolve_node()`, which prefers the managed binary (`$HERMES_HOME/node/node.exe` on Windows, `node/bin/node` on POSIX), then the `HERMES_NODE` override, then falls back to `shutil.which("node")`. It's used both in `check_whatsapp_requirements()` and when launching the bridge process.

Scoped to the WhatsApp gateway runtime here; the setup-side npm/QR paths in `hermes_cli/main.py` mentioned in the issue can follow separately.

## Tests

`tests/gateway/test_whatsapp_node_resolution.py` — managed Node (Windows/POSIX) and `HERMES_NODE` are preferred, with a clean fall back to PATH. Existing WhatsApp tests still pass.

Part of #49242.