### PR TITLE
fix(todo): guard _dedupe_by_id against non-dict items from LLM

### DIFF
--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -179,6 +179,10 @@ class TodoStore:
         """Collapse duplicate ids, keeping the last occurrence in its position."""
         last_index: Dict[str, int] = {}
         for i, item in enumerate(todos):
+            # Defensive: if the LLM sends a bare string instead of a dict,
+            # skip it — it's malformed and would crash .get()
+            if not isinstance(item, dict):
+                continue
             item_id = str(item.get("id", "")).strip() or "?"
             last_index[item_id] = i
         return [todos[i] for i in sorted(last_index.values())]


### PR DESCRIPTION
## Problem

When the LLM sends a bare string instead of a dict in the `todos` array, `_dedupe_by_id` calls `item.get("id", "")` which raises:

```
AttributeError: 'str' object has no attribute 'get'
```

This uncaught exception crashes the conversation loop (`agent.conversation_loop: Outer loop error`), killing the active session.

Observed in production logs (gateway running GLM-5.2:cloud):
```
2026-06-19 15:02:10 ERROR agent.conversation_loop: Outer loop error in API call #20
AttributeError: 'str' object has no attribute 'get'
  File "tools/todo_tool.py", line 182, in _dedupe_by_id
    item_id = str(item.get("id", "")).strip() or "?"
```

## Fix

Add `isinstance(item, dict)` guard before calling `.get()`. Malformed items are silently skipped — they can't be deduped or validated without an id anyway.

## Test Plan

- [ ] Existing todo tests pass: `pytest tests/test_todo_tool.py -v`
- [ ] Manual: call todo tool with `todos: ["bare string", {"id": "1", "content": "valid"}]` — should not crash