### PR TITLE
fix(agent): catch RuntimeError in subdirectory hint path resolution

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -144,7 +144,7 @@ class SubdirectoryHintTracker:
                 if parent == p:
                     break  # filesystem root
                 p = parent
-        except (OSError, ValueError):
+        except (OSError, ValueError, RuntimeError):
             pass
 
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):


### PR DESCRIPTION
## Problem

`Path(raw_path).expanduser()` in `_add_path_candidate` raises:

```
RuntimeError: Could not determine home directory.
```

when the `HOME` environment variable is not set. This happens in containerized or systemd-managed gateway processes where env vars are stripped.

The existing `except (OSError, ValueError)` clause did not catch `RuntimeError`, so it propagated up through `_extract_paths_from_command` → `_extract_directories` → `check_tool_call` → `execute_tool_calls_sequential` and crashed the conversation loop.

Observed in production logs:
```
2026-06-19 15:34:38 ERROR agent.conversation_loop: Outer loop error in API call #7
RuntimeError: Could not determine home directory.
  File "agent/subdirectory_hints.py", line 130, in _add_path_candidate
    p = Path(raw_path).expanduser()
```

## Fix

Add `RuntimeError` to the caught exception tuple:

```python
except (OSError, ValueError, RuntimeError):
    pass
```

## Test Plan

- [ ] Existing tests pass: `pytest tests/ -k subdirectory -v`
- [ ] Manual: unset HOME env var, run a tool call with a `~/`-prefixed path — should not crash