### PR TITLE
feat(desktop): add toggle to disable chat background texture

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -10,12 +10,14 @@ import { cn } from '@/lib/utils'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
+import { $backdropEnabled, setBackdropEnabled } from '@/store/backdrop'
 import { useTheme } from '@/themes/context'
 import { installVscodeThemeFromMarketplace } from '@/themes/install'
 import { isUserTheme, removeUserTheme, resolveTheme } from '@/themes/user-themes'
 
 import { MODE_OPTIONS } from './constants'
 import { ListRow, SectionHeading, SettingsContent } from './primitives'
+import { Switch } from '@/components/ui/switch'
 
 function ThemePreview({ name }: { name: string }) {
   const t = resolveTheme(name)
@@ -137,6 +139,7 @@ export function AppearanceSettings() {
   const { themeName, mode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
   const translucency = useStore($translucency)
+  const backdropEnabled = useStore($backdropEnabled)
   const profiles = useStore($profiles)
   const activeProfileKey = normalizeProfileKey(useStore($activeGatewayProfile))
   const a = t.settings.appearance
@@ -209,6 +212,17 @@ export function AppearanceSettings() {
             }
             description={a.translucencyDesc}
             title={a.translucencyTitle}
+          />
+
+          <ListRow
+            action={
+              <Switch
+                checked={backdropEnabled}
+                onCheckedChange={setBackdropEnabled}
+              />
+            }
+            description={a.backdropDesc}
+            title={a.backdropTitle}
           />
 
           <ListRow

--- a/apps/desktop/src/components/Backdrop.tsx
+++ b/apps/desktop/src/components/Backdrop.tsx
@@ -1,5 +1,8 @@
+import { useStore } from '@nanostores/react'
 import { Leva, useControls } from 'leva'
 import { type CSSProperties, useEffect, useState } from 'react'
+
+import { $backdropEnabled } from '@/store/backdrop'
 
 const BLEND_MODES = [
   'normal',
@@ -25,6 +28,7 @@ const assetPath = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/
 
 export function Backdrop() {
   const [controlsOpen, setControlsOpen] = useState(false)
+  const enabled = useStore($backdropEnabled)
 
   useEffect(() => {
     if (!import.meta.env.DEV) {
@@ -82,6 +86,10 @@ export function Backdrop() {
     },
     { collapsed: true }
   )
+
+  if (!enabled) {
+    return null
+  }
 
   return (
     <>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -366,7 +366,9 @@ export const en: Translations = {
       installError: 'Could not install that theme.',
       installed: name => `Installed “${name}”.`,
       removeTheme: 'Remove theme',
-      importedBadge: 'Imported'
+      importedBadge: 'Imported',
+      backdropTitle: 'Background Texture',
+      backdropDesc: 'Show a subtle decorative image behind the chat. Turn off for a plain solid background.'
     },
     fieldLabels: FIELD_LABELS,
     fieldDescriptions: FIELD_DESCRIPTIONS,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -281,7 +281,9 @@ export const ja = defineLocale({
       installError: 'そのテーマをインストールできませんでした。',
       installed: name => `「${name}」をインストールしました。`,
       removeTheme: 'テーマを削除',
-      importedBadge: 'インポート済み'
+      importedBadge: 'インポート済み',
+      backdropTitle: 'Background Texture',
+      backdropDesc: 'Show a subtle decorative image behind the chat. Turn off for a plain solid background.'
     },
     fieldLabels: defineFieldCopy({
       model: 'デフォルトモデル',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -265,6 +265,8 @@ export interface Translations {
       installed: (name: string) => string
       removeTheme: string
       importedBadge: string
+      backdropTitle: string
+      backdropDesc: string
     }
     fieldLabels: Record<string, string>
     fieldDescriptions: Record<string, string>

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -271,7 +271,9 @@ export const zhHant = defineLocale({
       installError: '無法安裝該主題。',
       installed: name => `已安裝「${name}」。`,
       removeTheme: '移除主題',
-      importedBadge: '已匯入'
+      importedBadge: '已匯入',
+      backdropTitle: 'Background Texture',
+      backdropDesc: 'Show a subtle decorative image behind the chat. Turn off for a plain solid background.'
     },
     fieldLabels: defineFieldCopy({
       model: '預設模型',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -359,7 +359,9 @@ export const zh: Translations = {
       installError: '无法安装该主题。',
       installed: name => `已安装「${name}」。`,
       removeTheme: '移除主题',
-      importedBadge: '已导入'
+      importedBadge: '已导入',
+      backdropTitle: 'Background Texture',
+      backdropDesc: 'Show a subtle decorative image behind the chat. Turn off for a plain solid background.'
     },
     fieldLabels: defineFieldCopy({
       model: '默认模型',

--- a/apps/desktop/src/store/backdrop.ts
+++ b/apps/desktop/src/store/backdrop.ts
@@ -1,0 +1,37 @@
+/**
+ * Background image / texture overlay in the chat surface.
+ *
+ * The default "statue" backdrop (filler-bg0.jpg with difference blend + dither
+ * noise) is a purely decorative effect.  Some users find the faint texture
+ * distracting or reminiscent of a broken display, especially in dark mode.
+ * This toggle lets them switch to a plain solid background.
+ *
+ * Persisted to localStorage so the preference survives restarts.
+ */
+
+import { atom } from 'nanostores'
+
+import { persistString, storedString } from '@/lib/storage'
+
+const KEY = 'hermes.desktop.backdrop.v1'
+
+const read = (): boolean => {
+  const v = storedString(KEY)
+  // Default: on (preserves existing behaviour).
+  if (v === null || v === '') return true
+  return v !== '0'
+}
+
+export const $backdropEnabled = atom<boolean>(
+  typeof window === 'undefined' ? true : read()
+)
+
+export function setBackdropEnabled(enabled: boolean): void {
+  $backdropEnabled.set(enabled)
+}
+
+if (typeof window !== 'undefined') {
+  $backdropEnabled.subscribe(enabled => {
+    persistString(KEY, enabled ? '1' : '0')
+  })
+}


### PR DESCRIPTION
## Problem

The `Backdrop` component renders `filler-bg0.jpg` with `difference` blend mode at 2.5% opacity plus a CSS dither noise pattern behind the chat surface. In dark mode this creates a faint but visible texture that resembles a broken/glitching display. There is no user-facing setting to disable it — the Leva controls are DEV-only.

## Solution

Add a persisted toggle (localStorage) in **Appearance Settings** to disable the decorative background, defaulting to **on** (preserving existing behaviour).

### Changes

| File | What |
|------|------|
| `apps/desktop/src/store/backdrop.ts` | **New** — nanostores atom + localStorage persistence |
| `apps/desktop/src/components/Backdrop.tsx` | Early-return `null` when toggle is off |
| `apps/desktop/src/app/settings/appearance-settings.tsx` | Switch row below translucency slider |
| `apps/desktop/src/i18n/types.ts` | `backdropTitle` + `backdropDesc` type fields |
| `apps/desktop/src/i18n/en.ts` | EN strings |
| `apps/desktop/src/i18n/{zh,zh-hant,ja}.ts` | EN fallback strings |

### Screenshots

Toggle appears in Settings → Appearance, below the Window Translucency slider:

**On** (default) — existing decorative backdrop visible.  
**Off** — plain solid background, no image or dither noise.