### PR TITLE
fix(cli): restrict aggregator dedup to custom proxy providers (#49126)

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -181,7 +181,16 @@ def build_models_payload(
         user_models: set[str] = set()
         for row in rows:
             if row.get("is_user_defined"):
-                user_models.update(m.lower() for m in (row.get("models") or []))
+                # Only collect models from custom/local proxy providers
+                # (slug starts with "custom:").  Named third-party providers
+                # like volcengine-agent-plan are independent services, not
+                # local proxies — their models should NOT cause aggregator
+                # dedup, otherwise models silently disappear from aggregators
+                # like OpenCode Go simply because they share a name with a
+                # separate configured provider.  (#49126)
+                slug = row.get("slug", "")
+                if slug.startswith("custom:"):
+                    user_models.update(m.lower() for m in (row.get("models") or []))
         if user_models:
             for row in rows:
                 # A user's own configured provider is never an "aggregator


### PR DESCRIPTION
Fixes #49126. The aggregator dedup in inventory.py was collecting model IDs from ALL user-defined providers and stripping them from aggregator rows. Named third-party providers like volcengine-agent-plan are independent services, not local proxies, so their models should not cause models to disappear from aggregators like OpenCode Go. The fix restricts the dedup source to only custom:* providers (local proxies).