### PR TITLE
fix(dashboard): prevent flash of default theme on custom YAML theme load

### DIFF
--- a/web/src/themes/context.tsx
+++ b/web/src/themes/context.tsx
@@ -406,6 +406,14 @@ function applyTheme(theme: DashboardTheme) {
 // Provider
 // ---------------------------------------------------------------------------
 
+/** True once we know the active theme is a built-in OR its user
+ *  definition has loaded. Prevents a flash of the default palette when
+ *  the active theme is a user YAML theme whose definition needs to come
+ *  from the server. */
+function isThemeReady(name: string, defs: Record<string, DashboardTheme>): boolean {
+  return name in BUILTIN_THEMES || name in defs;
+}
+
 export function ThemeProvider({ children }: { children: ReactNode }) {
   /** Name of the currently active theme (built-in id or user YAML name). */
   const [themeName, setThemeName] = useState<string>(() => {
@@ -435,6 +443,14 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const [userThemeDefs, setUserThemeDefs] = useState<
     Record<string, DashboardTheme>
   >({});
+
+  /** Guards the first paint: false while the active theme is a user
+   *  theme whose definition hasn't arrived yet. */
+  const [ready, setReady] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true;
+    const stored = window.localStorage.getItem(STORAGE_KEY) ?? 'default';
+    return isThemeReady(migrateThemeName(stored), {});
+  });
 
   /** Active font-override id (independent of theme). `THEME_DEFAULT_FONT_ID`
    *  = no override. Seeded from localStorage so it's applied flash-free. */
@@ -494,6 +510,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
           if (Object.keys(defs).length > 0) setUserThemeDefs(defs);
         }
         if (resp.active) {
+          if (isThemeReady(migrateThemeName(resp.active), defs) && !ready) setReady(true);
           const migratedActive = migrateThemeName(resp.active);
           if (migratedActive !== themeName) {
             setThemeName(migratedActive);
@@ -578,7 +595,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     [themeName, availableThemes, setTheme, resolveTheme, fontId, setFont],
   );
 
-  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+  // Don't render children until we can apply the correct theme — prevents
+  // a visible flash of the default palette when the active theme is a
+  // user YAML theme whose definition is still loading from the server.
+  return <ThemeContext.Provider value={value}>{ready ? children : null}</ThemeContext.Provider>;
 }
 
 export function useTheme(): ThemeContextValue {


### PR DESCRIPTION
## Problem

When a user has a custom YAML theme set as active (via `dashboard.theme` in `config.yaml`), loading the dashboard shows a brief flash of the default Hermes Teal palette before switching to the custom theme.

## Root Cause

In `ThemeProvider` (`web/src/themes/context.tsx`):

1. On mount, `themeName` is initialized from `localStorage` (e.g. `hypershell-signal-v3`)
2. `resolveTheme()` looks up the name in `BUILTIN_THEMES` first, then `userThemeDefs`
3. User themes start with an empty `userThemeDefs = {}` - the definitions arrive asynchronously from `GET /api/dashboard/themes`
4. Until the API response arrives, `resolveTheme()` falls back to `defaultTheme` (Hermes Teal)
5. The `useEffect` calls `applyTheme(defaultTheme)` -> visible flash
6. When the API response arrives, `setUserThemeDefs()` triggers a re-render with the correct theme

## Fix

Add a `ready` guard that prevents rendering children until the active theme's definition is available:

- If the active theme is a built-in, `ready = true` immediately
- If the active theme is a user YAML theme, `ready = false` until the API response arrives with the definition
- Render `null` children while `!ready` (the `ThemeContext.Provider` still mounts so consumers do not break)

## Why client-side

The server already sends the full `definition` for user themes in the API response. The issue is purely a timing gap between first paint and API response arrival. A client-side guard is the minimal, backwards-compatible fix with no API contract changes.

## Testing

- Set a custom YAML theme as active
- Hard-refresh the dashboard (Ctrl+Shift+R to bypass cache)
- Verify no flash of default theme on load
- Switch between built-in themes - no regression
- Switch to another user YAML theme - works correctly
- Clear localStorage - falls back to server active theme without flash