### PR TITLE
fix(signal): validate live-adapter send acknowledgements

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -818,6 +818,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 adapter_ok = True
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
+                    adapter_label = getattr(runtime_adapter, "name", platform_name.title())
+                    logger.info(
+                        "[%s] Sending response (%d chars) to %s",
+                        adapter_label,
+                        len(text_to_send),
+                        chat_id,
+                    )
                     future = safe_schedule_threadsafe(
                         runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata),
                         loop,

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -162,6 +162,21 @@ def _looks_like_e164_number(value: str) -> bool:
     return digits.isdigit() and 7 <= len(digits) <= 15
 
 
+def _send_rpc_accepted(result: Any) -> tuple[bool, Optional[str]]:
+    """Return whether a Signal send RPC result proves acceptance.
+
+    signal-cli's successful ``send`` RPC response includes a ``timestamp`` in
+    ``result``. Treating any non-``None`` payload as success lets malformed or
+    partial payloads masquerade as delivered, which is especially dangerous for
+    cron live-adapter sends because the scheduler then clears delivery errors.
+    """
+    if not isinstance(result, dict):
+        return False, "Signal RPC send returned malformed result"
+    if result.get("timestamp") is None:
+        return False, "Signal RPC send response missing timestamp"
+    return True, None
+
+
 def check_signal_requirements() -> bool:
     """Check if Signal is configured (has URL and account)."""
     return bool(os.getenv("SIGNAL_HTTP_URL") and os.getenv("SIGNAL_ACCOUNT"))
@@ -993,14 +1008,14 @@ class SignalAdapter(BasePlatformAdapter):
             params["recipient"] = [await self._resolve_recipient(chat_id)]
 
         result = await self._rpc("send", params)
-
-        if result is not None:
+        accepted, error = _send_rpc_accepted(result)
+        if accepted:
             self._track_sent_timestamp(result)
             # Signal has no editable message identifier. Returning None keeps the
             # stream consumer on the non-edit fallback path instead of pretending
             # future edits can remove an in-progress cursor from the chat thread.
             return SendResult(success=True, message_id=None)
-        return SendResult(success=False, error="RPC send failed")
+        return SendResult(success=False, error=error or "RPC send failed")
 
     def _track_sent_timestamp(self, rpc_result) -> None:
         """Record outbound message timestamp for echo-back filtering."""
@@ -1276,10 +1291,11 @@ class SignalAdapter(BasePlatformAdapter):
             params["recipient"] = [await self._resolve_recipient(chat_id)]
 
         result = await self._rpc("send", params)
-        if result is not None:
+        accepted, error = _send_rpc_accepted(result)
+        if accepted:
             self._track_sent_timestamp(result)
             return SendResult(success=True)
-        return SendResult(success=False, error="RPC send with attachment failed")
+        return SendResult(success=False, error=error or "RPC send with attachment failed")
 
     async def _send_attachment(
         self,
@@ -1315,10 +1331,11 @@ class SignalAdapter(BasePlatformAdapter):
             params["recipient"] = [await self._resolve_recipient(chat_id)]
 
         result = await self._rpc("send", params)
-        if result is not None:
+        accepted, error = _send_rpc_accepted(result)
+        if accepted:
             self._track_sent_timestamp(result)
             return SendResult(success=True)
-        return SendResult(success=False, error=f"RPC send {media_label.lower()} failed")
+        return SendResult(success=False, error=error or f"RPC send {media_label.lower()} failed")
 
     async def send_document(
         self,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -788,6 +788,49 @@ class TestDeliverResultWrapping:
         assert "MEDIA:" not in text_sent
         assert "Report" in text_sent
 
+    def test_live_adapter_logs_outbound_send_before_waiting_for_result(self, caplog):
+        """Cron live-adapter sends should emit the same transport trace users
+        look for in gateway logs before waiting on the adapter future."""
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        adapter = AsyncMock()
+        adapter.name = "Signal"
+        adapter.send.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SIGNAL: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(MagicMock(success=True))
+            coro.close()
+            return future
+
+        job = {
+            "id": "signal-job",
+            "deliver": "origin",
+            "origin": {"platform": "signal", "chat_id": "group:abc123=="},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             caplog.at_level(logging.INFO):
+            _deliver_result(
+                job,
+                "Daily brief",
+                adapters={Platform.SIGNAL: adapter},
+                loop=loop,
+            )
+
+        assert "[Signal] Sending response (11 chars) to group:abc123==" in caplog.text
+
     def test_no_mirror_to_session_call(self):
         """Cron deliveries should NOT mirror into the gateway session."""
         from gateway.config import Platform

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -474,7 +474,7 @@ class TestSignalSendImageFile:
         result = await adapter.send_image_file(chat_id="+155****4567", image_path=str(img_path))
 
         assert result.success is False
-        assert "failed" in result.error.lower()
+        assert result.error == "Signal RPC send returned malformed result"
 
 
 class TestSignalRecipientResolution:
@@ -654,7 +654,7 @@ class TestSignalSendVoice:
         result = await adapter.send_voice(chat_id="+155****4567", audio_path=str(audio_path))
 
         assert result.success is False
-        assert "failed" in result.error.lower()
+        assert result.error == "Signal RPC send returned malformed result"
 
 
 # ---------------------------------------------------------------------------
@@ -727,7 +727,7 @@ class TestSignalSendVideo:
         result = await adapter.send_video(chat_id="+155****4567", video_path=str(vid_path))
 
         assert result.success is False
-        assert "failed" in result.error.lower()
+        assert result.error == "Signal RPC send returned malformed result"
 
 
 # ---------------------------------------------------------------------------
@@ -993,8 +993,9 @@ class TestSignalSendReturnsMessageId:
 
         result = await adapter.send(chat_id="+155****4567", content="hello")
 
-        assert result.success is True
+        assert result.success is False
         assert result.message_id is None
+        assert result.error == "Signal RPC send response missing timestamp"
 
     @pytest.mark.asyncio
     async def test_send_returns_none_message_id_for_non_dict(self, monkeypatch):
@@ -1005,8 +1006,24 @@ class TestSignalSendReturnsMessageId:
 
         result = await adapter.send(chat_id="+155****4567", content="hello")
 
-        assert result.success is True
+        assert result.success is False
         assert result.message_id is None
+        assert result.error == "Signal RPC send returned malformed result"
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_requires_timestamp_in_rpc_result(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc, _ = _stub_rpc({})
+        adapter._rpc = mock_rpc
+        adapter._stop_typing_indicator = AsyncMock()
+
+        img_path = tmp_path / "chart.png"
+        img_path.write_bytes(b"\x89PNG" + b"\x00" * 100)
+
+        result = await adapter.send_image_file(chat_id="+155****4567", image_path=str(img_path))
+
+        assert result.success is False
+        assert result.error == "Signal RPC send response missing timestamp"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Tightens Signal live-adapter delivery reporting so cron jobs only clear delivery errors after signal-cli returns a real send acknowledgement, and adds an outbound transport log line for cron live-adapter sends so gateway logs show the dispatch attempt users are trying to verify.

## What changed and why

- `gateway/platforms/signal.py`: added `_send_rpc_accepted()` and applied it to text and attachment sends so malformed / partial JSON-RPC payloads no longer masquerade as successful deliveries.
- `cron/scheduler.py`: log `[Signal] Sending response ...` before waiting on the live-adapter future, which gives cron-triggered Signal sends a timestamped transport trace in gateway logs.
- `tests/gateway/test_signal.py`: updated Signal send-result contract coverage to require a timestamp-bearing acknowledgement and added an attachment regression test.
- `tests/cron/test_scheduler.py`: added coverage for the new cron live-adapter transport log.

## Related Issue

Fixes #49260

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/signal.py`: reject send RPC results that do not include the normal Signal `timestamp` acknowledgement.
- `cron/scheduler.py`: emit an outbound live-adapter send log before waiting on the adapter future.
- `tests/gateway/test_signal.py`: cover missing / malformed Signal send acknowledgements.
- `tests/cron/test_scheduler.py`: verify the cron live-adapter log line is emitted.

## How to Test

1. Run `pytest tests/gateway/test_signal.py -q`
2. Run `pytest tests/cron/test_scheduler.py -q`
3. Run `python scripts/check-windows-footguns.py --diff HEAD^`
4. Run `ruff check cron/scheduler.py gateway/platforms/signal.py tests/cron/test_scheduler.py tests/gateway/test_signal.py`
5. Run `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`
   - In this environment the broad suite aborts during collection in `tests/hermes_cli/test_cron_fire_dashboard.py` because `fastapi` is unavailable, so the changed-module coverage above is the verified local signal.

## What platforms tested on

- macOS / darwin-arm64 (local)
- Cross-platform static check: `python scripts/check-windows-footguns.py --diff HEAD^`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `pytest tests/gateway/test_signal.py -q` → `109 passed`
- `pytest tests/cron/test_scheduler.py -q` → `137 passed`
- `python scripts/check-windows-footguns.py --diff HEAD^` → `No Windows footguns found (4 file(s) scanned).`

<!-- autocontrib:worker-id=issue-new-412b3530 kind=pr-open -->