### PR TITLE
Feature/task context files

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -366,6 +366,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Initial card status. Use 'blocked' for cards "
                                "that require immediate human ops (R3 gate) "
                                "to skip the brief running-to-blocked transition.")
+    p_create.add_argument("--task-context-file", action="append", default=[],
+                          dest="task_context_files", metavar="PATH",
+                          help="Absolute path to a file whose contents are "
+                               "injected into the worker context (after the "
+                               "task body, before prior attempts). Repeatable. "
+                               "Useful for project briefs or checklists the "
+                               "worker should always read. Example: "
+                               "--task-context-file /project/CONTEXT.md "
+                               "--task-context-file /project/HARNESS.md")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- swarm ---
@@ -1347,6 +1356,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            task_context_files=getattr(args, "task_context_files", None) or None,
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -283,6 +283,7 @@ _CTX_MAX_PRIOR_ATTEMPTS = 10      # most recent N prior runs shown in full
 _CTX_MAX_COMMENTS       = 30      # most recent N comments shown in full
 _CTX_MAX_FIELD_BYTES    = 4 * 1024   # 4 KB per summary/error/metadata/result
 _CTX_MAX_BODY_BYTES     = 8 * 1024   # 8 KB per task.body (opening post)
+_CTX_MAX_TASK_CONTEXT_FILES  = 16 * 1024  # 16 KB total across all injected context files
 _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 
 
@@ -879,6 +880,13 @@ class Task:
     # the defaults; empty list = explicitly no extra skills.
     skills: Optional[list] = None
     model_override: Optional[str] = None
+    # Paths to files whose contents are injected verbatim into the worker
+    # context (after the task body, before prior attempts). Useful for
+    # project briefs, checklists, or conventions the worker should always
+    # read without having access to the full project directory.
+    # Stored as a JSON array of absolute path strings. Capped at
+    # _CTX_MAX_TASK_CONTEXT_FILES bytes total across all files.
+    task_context_files: Optional[list[str]] = None
     # Per-task override for the consecutive-failure circuit breaker.
     # The value is the failure count at which the breaker trips — e.g.
     # ``max_retries=1`` blocks on the first failure (zero retries),
@@ -977,6 +985,11 @@ class Task:
             ),
             skills=skills_value,
             model_override=row["model_override"] if "model_override" in keys and row["model_override"] else None,
+            task_context_files=(
+                json.loads(row["task_context_files"])
+                if "task_context_files" in keys and row["task_context_files"]
+                else None
+            ),
             max_retries=(
                 row["max_retries"] if "max_retries" in keys else None
             ),
@@ -1174,7 +1187,13 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- JSON array of absolute file paths whose contents are injected into
+    -- the worker's context (after task body, before prior attempts). Lets
+    -- orchestrators attach project briefs or checklists to specific tasks
+    -- without giving the worker a full directory workspace. NULL = no
+    -- extra files injected.
+    task_context_files   TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1985,6 +2004,20 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    if "task_context_files" not in cols:
+        # JSON array of file paths to inject into worker context. NULL for
+        # existing rows is correct (no change in behaviour for existing tasks).
+        # This field was originally named "context_files"; it was renamed to
+        # "task_context_files" to avoid colliding with the agent-level
+        # context-files concept. On DBs created before the rename, migrate the
+        # old column in place so existing data is preserved; otherwise add fresh.
+        if "context_files" in cols:
+            conn.execute(
+                "ALTER TABLE tasks RENAME COLUMN context_files TO task_context_files"
+            )
+        else:
+            _add_column_if_missing(conn, "tasks", "task_context_files", "task_context_files TEXT")
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2365,6 +2398,7 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    task_context_files: Optional[Iterable[str]] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2388,6 +2422,15 @@ def create_task(
     each name to ``hermes --skills ...``. Use this to pin a task to a
     specialist skill (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``task_context_files`` is an optional list of absolute file paths whose
+    contents are injected verbatim into the worker's context (after the
+    task body, before prior attempts). Useful for attaching project
+    briefs, checklists, or conventions that the worker should always
+    read — without giving it a full directory workspace. Paths that
+    cannot be read at dispatch time are skipped with a warning in the
+    worker context. Total injection is capped at
+    ``_CTX_MAX_TASK_CONTEXT_FILES`` bytes across all files.
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
@@ -2494,6 +2537,13 @@ def create_task(
             )
         skills_list = cleaned
 
+    # Normalise task_context_files: convert to list of non-empty strings.
+    context_files_list: Optional[list[str]] = None
+    if task_context_files is not None:
+        context_files_list = [str(p).strip() for p in task_context_files if str(p).strip()]
+        if not context_files_list:
+            context_files_list = None
+
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
     # and to avoid holding a write lock during the lookup. Race is
@@ -2593,8 +2643,8 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id, task_context_files
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2617,6 +2667,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        json.dumps(context_files_list) if context_files_list is not None else None,
                     ),
                 )
                 for pid in parents:
@@ -7938,6 +7989,26 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             ctype = f", {att.content_type}" if att.content_type else ""
             lines.append(f"- `{att.filename}`{ctype}{size_str} → `{att.stored_path}`")
         lines.append("")
+
+    if task.task_context_files:
+        budget = _CTX_MAX_TASK_CONTEXT_FILES
+        injected: list[tuple[str, str]] = []
+        for fpath in task.task_context_files:
+            if budget <= 0:
+                break
+            try:
+                with open(fpath, "r", errors="replace") as fh:
+                    raw = fh.read(budget)
+                injected.append((fpath, raw))
+                budget -= len(raw)
+            except OSError as exc:
+                injected.append((fpath, f"[unreadable: {exc}]"))
+        if injected:
+            lines.append("## Context files")
+            for fpath, content in injected:
+                lines.append(f"### {fpath}")
+                lines.append(content.rstrip())
+                lines.append("")
 
     # Prior attempts — show closed runs so a retrying worker sees the
     # history. Skip the currently-active run (that's this worker).

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4766,3 +4766,176 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# task_context_files — per-task file injection into worker context
+# ---------------------------------------------------------------------------
+
+def test_task_context_files_roundtrip(kanban_home, tmp_path):
+    """task_context_files is normalised, stored as JSON, and read back as a list."""
+    brief = tmp_path / "BRIEF.md"
+    brief.write_text("brief contents")
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="with context",
+            # Blank/whitespace entries are dropped by normalisation.
+            task_context_files=[str(brief), "  ", ""],
+        )
+        task = kb.get_task(conn, tid)
+    assert task.task_context_files == [str(brief)]
+
+
+def test_task_context_files_none_when_omitted(kanban_home):
+    """Omitting task_context_files stores NULL (no behaviour change for old flows)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="no context")
+        task = kb.get_task(conn, tid)
+    assert task.task_context_files is None
+
+
+def test_task_context_files_injected_into_worker_context(kanban_home, tmp_path):
+    """File contents appear in the worker context under a clear header."""
+    brief = tmp_path / "BRIEF.md"
+    brief.write_text("Use VQZ115-5L1-01T dump valve.")
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="inject", body="do the thing",
+            task_context_files=[str(brief)],
+        )
+        ctx = kb.build_worker_context(conn, tid)
+    assert "## Context files" in ctx
+    assert str(brief) in ctx
+    assert "Use VQZ115-5L1-01T dump valve." in ctx
+
+
+def test_task_context_files_unreadable_path_is_graceful(kanban_home, tmp_path):
+    """An unreadable path emits a visible warning instead of crashing."""
+    good = tmp_path / "GOOD.md"
+    good.write_text("readable content")
+    missing = str(tmp_path / "nope.md")
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="partial", task_context_files=[str(good), missing],
+        )
+        ctx = kb.build_worker_context(conn, tid)
+    assert "readable content" in ctx
+    assert "[unreadable:" in ctx
+
+
+def test_task_context_files_injection_respects_byte_cap(kanban_home, tmp_path):
+    """Total injected bytes are capped at _CTX_MAX_TASK_CONTEXT_FILES."""
+    import re
+
+    written = kb._CTX_MAX_TASK_CONTEXT_FILES + 5000
+    big = tmp_path / "BIG.md"
+    big.write_text("x" * written)
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="big", task_context_files=[str(big)])
+        ctx = kb.build_worker_context(conn, tid)
+    # The injected payload is the single long run of 'x' (path chars in the
+    # header can contribute stray 'x's, so measure the contiguous run).
+    longest_run = max((len(m.group(0)) for m in re.finditer("x+", ctx)), default=0)
+    assert longest_run <= kb._CTX_MAX_TASK_CONTEXT_FILES
+    # And it was genuinely truncated, not injected whole.
+    assert longest_run < written
+
+
+def test_legacy_db_gains_task_context_files_column(tmp_path):
+    """A board predating the field (no column at all) gains it on connect()."""
+    db_path = tmp_path / "legacy-kanban.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            body TEXT,
+            assignee TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0,
+            created_by TEXT,
+            created_at INTEGER NOT NULL,
+            started_at INTEGER,
+            completed_at INTEGER,
+            workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+            workspace_path TEXT,
+            claim_lock TEXT,
+            claim_expires INTEGER
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) "
+        "VALUES ('legacy', 'old task', 'ready', 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    with kb.connect(db_path) as migrated:
+        cols = {row["name"] for row in migrated.execute("PRAGMA table_info(tasks)")}
+        # Legacy row reads back with task_context_files as None (no crash).
+        legacy = kb.get_task(migrated, "legacy")
+    assert "task_context_files" in cols
+    assert legacy.task_context_files is None
+
+
+def test_db_with_old_context_files_column_is_renamed(tmp_path):
+    """A board created with the pre-rename ``context_files`` column has it
+    renamed to ``task_context_files`` in place, preserving existing data."""
+    db_path = tmp_path / "old-column-kanban.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            body TEXT,
+            assignee TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0,
+            created_by TEXT,
+            created_at INTEGER NOT NULL,
+            started_at INTEGER,
+            completed_at INTEGER,
+            workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+            workspace_path TEXT,
+            claim_lock TEXT,
+            claim_expires INTEGER,
+            context_files TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at, context_files) "
+        "VALUES ('old', 'pre-rename task', 'ready', 1, ?)",
+        # Column stores a JSON array string; write it directly to avoid a
+        # module-level json import in the test file.
+        ('["/project/BRIEF.md"]',),
+    )
+    conn.commit()
+    conn.close()
+
+    with kb.connect(db_path) as migrated:
+        cols = {row["name"] for row in migrated.execute("PRAGMA table_info(tasks)")}
+        task = kb.get_task(migrated, "old")
+    # Column renamed in place: new name present, old name gone.
+    assert "task_context_files" in cols
+    assert "context_files" not in cols
+    # Existing data survived the rename.
+    assert task.task_context_files == ["/project/BRIEF.md"]


### PR DESCRIPTION
PR: feat(kanban): add task_context_files field to tasks
Base: NousResearch/hermes-agent:main · Head: Wookie1/hermes-agent:feature/task-context-files Open: https://github.com/NousResearch/hermes-agent/compare/main...Wookie1:hermes-agent:feature/task-context-files?expand=1

Summary
Adds an optional task_context_files field to kanban tasks: a list of absolute file paths whose contents are injected verbatim into the worker context (after the task body, before prior attempts). It lets an orchestrator attach a project brief, checklist, or conventions doc to a specific task without giving the worker a full directory workspace — the surgical alternative to workspace_kind: scratch when a worker just needs to read one document.

Why task_context_files and not context_files
context_files collides with the existing agent-level context-files concept (skip_context_files in agent setup, agent/coding_context.py), which operates at a different layer. The task_ prefix keeps the kanban-task field unambiguous.

Changes
Task dataclass: task_context_files: Optional[list[str]]
DB: new task_context_files TEXT column (JSON array); migration adds it on legacy DBs and renames a pre-existing context_files column in place (preserving data) for boards created on an earlier build of this branch
create_task(): new task_context_files param, stored as JSON
build_worker_context(): injects file contents under a ## Context files header, capped at 16 KB total; unreadable paths emit [unreadable: ...] rather than crashing
CLI: hermes kanban create --task-context-file PATH (repeatable)
Tests
7 tests in tests/hermes_cli/test_kanban_db.py: JSON roundtrip, None-when-omitted, worker-context injection, unreadable-path grace, byte-cap truncation, legacy-DB column add, and in-place rename of a pre-existing context_files column. Full test_kanban_db.py suite: 225 passed on top of release v0.17.0 (2026.6.19).