### PR TITLE
Add turn snapshot callback for host adapters

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -31,6 +31,7 @@ from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
+from agent.turn_snapshot import install_turn_snapshot_messages, publish_turn_snapshot
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block
@@ -422,12 +423,16 @@ def run_conversation(
     )
     user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message
-    messages = _ctx.messages
     conversation_history = _ctx.conversation_history
     active_system_prompt = _ctx.active_system_prompt
     effective_task_id = _ctx.effective_task_id
     turn_id = _ctx.turn_id
     current_turn_user_idx = _ctx.current_turn_user_idx
+    messages = install_turn_snapshot_messages(
+        _ctx.messages,
+        callback=getattr(agent, "_turn_snapshot_callback", None),
+        current_turn_user_idx=current_turn_user_idx,
+    )
     _should_review_memory = _ctx.should_review_memory
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
@@ -587,6 +592,11 @@ def run_conversation(
                 repaired_tool_calls,
                 agent.session_id or "-",
             )
+            publish_turn_snapshot(
+                messages,
+                source_path="sanitize_tool_call_arguments",
+                complete=False,
+            )
 
         # Defensive: repair malformed role-alternation before API call.
         # Catches cases where the history got wedged into a
@@ -601,6 +611,11 @@ def run_conversation(
                 "Repaired %s message-alternation violations before request (session=%s)",
                 repaired_seq,
                 agent.session_id or "-",
+            )
+            publish_turn_snapshot(
+                messages,
+                source_path="repair_message_sequence",
+                complete=False,
             )
 
         api_messages = []
@@ -3705,6 +3720,11 @@ def run_conversation(
                         pass
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+                publish_turn_snapshot(
+                    messages,
+                    source_path="execute_tool_calls",
+                    complete=False,
+                )
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
@@ -4196,6 +4216,24 @@ def run_conversation(
                 messages.append({"role": "assistant", "content": final_response})
                 break
     
+    if interrupted:
+        _snapshot_source_path = "interrupted"
+    elif failed:
+        _snapshot_source_path = "fatal"
+    elif final_response is not None:
+        _snapshot_source_path = "normal"
+    else:
+        _snapshot_source_path = "partial"
+    publish_turn_snapshot(
+        messages,
+        source_path=_snapshot_source_path,
+        complete=(
+            final_response is not None
+            and not interrupted
+            and not failed
+        ),
+    )
+
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.

--- a/agent/turn_snapshot.py
+++ b/agent/turn_snapshot.py
@@ -1,0 +1,133 @@
+"""Optional per-turn message snapshot support for host adapters.
+
+The core Hermes loop owns the live chat ``messages`` list. Hosts that need a
+thread-safe view of that list during abnormal exits can install
+``agent._turn_snapshot_callback``. When present, the conversation loop wraps the
+turn-local list in ``TurnSnapshotMessages`` and publishes immutable snapshots
+after list mutations.
+
+This module is intentionally host-neutral: it does not know what the caller
+will persist, and it is a no-op when no callback is installed.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from collections.abc import Iterable
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+SnapshotCallback = Callable[[dict[str, Any]], None]
+
+
+class TurnSnapshotMessages(list):
+    """List subclass that publishes a copied turn snapshot after mutations."""
+
+    def __init__(
+        self,
+        messages: Iterable[Any] = (),
+        *,
+        callback: SnapshotCallback,
+        current_turn_user_idx: int,
+    ) -> None:
+        super().__init__(messages)
+        self._snapshot_callback = callback
+        self._current_turn_user_idx = int(current_turn_user_idx)
+        self._snapshot_revision = 0
+
+    def publish_snapshot(
+        self,
+        *,
+        source_path: str,
+        complete: bool = False,
+    ) -> None:
+        callback = self._snapshot_callback
+        if not callable(callback):
+            return
+        self._snapshot_revision += 1
+        payload = {
+            "messages": copy.deepcopy(list(self)),
+            "current_turn_user_idx": self._current_turn_user_idx,
+            "complete": bool(complete),
+            "source_path": str(source_path or "unknown"),
+            "revision": self._snapshot_revision,
+        }
+        try:
+            callback(payload)
+        except Exception:
+            logger.warning("turn snapshot callback failed", exc_info=True)
+
+    def _publish_mutation(self, source_path: str) -> None:
+        self.publish_snapshot(source_path=source_path, complete=False)
+
+    def append(self, item: Any) -> None:  # type: ignore[override]
+        super().append(item)
+        self._publish_mutation("messages.append")
+
+    def extend(self, items: Iterable[Any]) -> None:  # type: ignore[override]
+        super().extend(items)
+        self._publish_mutation("messages.extend")
+
+    def insert(self, index: int, item: Any) -> None:  # type: ignore[override]
+        super().insert(index, item)
+        self._publish_mutation("messages.insert")
+
+    def pop(self, index: int = -1) -> Any:  # type: ignore[override]
+        item = super().pop(index)
+        self._publish_mutation("messages.pop")
+        return item
+
+    def remove(self, item: Any) -> None:  # type: ignore[override]
+        super().remove(item)
+        self._publish_mutation("messages.remove")
+
+    def clear(self) -> None:  # type: ignore[override]
+        super().clear()
+        self._publish_mutation("messages.clear")
+
+    def __setitem__(self, index: Any, value: Any) -> None:
+        super().__setitem__(index, value)
+        self._publish_mutation("messages.setitem")
+
+    def __delitem__(self, index: Any) -> None:
+        super().__delitem__(index)
+        self._publish_mutation("messages.delitem")
+
+    def __iadd__(self, items: Iterable[Any]):
+        result = super().__iadd__(items)
+        self._publish_mutation("messages.iadd")
+        return result
+
+
+def install_turn_snapshot_messages(
+    messages: list,
+    *,
+    callback: Any,
+    current_turn_user_idx: int,
+) -> list:
+    """Return a snapshot-publishing messages list when a callback exists."""
+
+    if not callable(callback):
+        return messages
+    wrapped = TurnSnapshotMessages(
+        messages,
+        callback=callback,
+        current_turn_user_idx=current_turn_user_idx,
+    )
+    wrapped.publish_snapshot(source_path="turn_context", complete=False)
+    return wrapped
+
+
+def publish_turn_snapshot(
+    messages: list,
+    *,
+    source_path: str,
+    complete: bool = False,
+) -> None:
+    """Publish a snapshot from a wrapped messages list, otherwise no-op."""
+
+    publisher = getattr(messages, "publish_snapshot", None)
+    if callable(publisher):
+        publisher(source_path=source_path, complete=complete)


### PR DESCRIPTION
Adds an optional host-adapter turn snapshot callback for the live run_conversation messages list.\n\nSummary:\n- Adds TurnSnapshotMessages, a list subclass that publishes deep-copied snapshots after list mutations.\n- Installs the wrapper only when agent._turn_snapshot_callback is callable.\n- Publishes central snapshots at turn start, repair/sanitize points, after tool execution, and before finalization.\n\nThis is a no-op for normal Hermes users unless a host adapter installs the callback.