### PR TITLE
feat(desktop): notify renderer when GPU acceleration is disabled due to remote display

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -150,6 +150,8 @@ if (REMOTE_DISPLAY_REASON) {
   )
 }
 
+ipcMain.handle('hermes:get-remote-display-reason', () => REMOTE_DISPLAY_REASON)
+
 // Keep the renderer running at full speed while the window is in the background
 // or occluded. The chat transcript streams to screen through a
 // requestAnimationFrame-gated flush; Chromium pauses rAF (and clamps timers)

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -140,6 +140,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     return () => ipcRenderer.removeListener('hermes:bootstrap:event', listener)
   },
   getVersion: () => ipcRenderer.invoke('hermes:version'),
+  getRemoteDisplayReason: () => ipcRenderer.invoke('hermes:get-remote-display-reason'),
   uninstall: {
     summary: () => ipcRenderer.invoke('hermes:uninstall:summary'),
     run: mode => ipcRenderer.invoke('hermes:uninstall:run', { mode })

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -8,6 +8,7 @@ import { DesktopInstallOverlay } from '@/components/desktop-install-overlay'
 import { DesktopOnboardingOverlay } from '@/components/desktop-onboarding-overlay'
 import { GatewayConnectingOverlay } from '@/components/gateway-connecting-overlay'
 import { Pane, PaneMain } from '@/components/pane-shell'
+import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { useSkinCommand } from '@/themes/use-skin-command'
 
@@ -956,6 +957,7 @@ export function DesktopController() {
 
   const overlays = (
     <>
+      <RemoteDisplayBanner />
       {!isSecondaryWindow() && <DesktopInstallOverlay />}
       {!isSecondaryWindow() && (
         <DesktopOnboardingOverlay

--- a/apps/desktop/src/components/remote-display-banner.tsx
+++ b/apps/desktop/src/components/remote-display-banner.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { useI18n } from '@/i18n'
+import { Info } from '@/lib/icons'
+
+export function RemoteDisplayBanner() {
+  const { t } = useI18n()
+  const [reason, setReason] = useState<string | null>(null)
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    void window.hermesDesktop?.getRemoteDisplayReason?.().then(result => setReason(result))
+  }, [])
+
+  if (!reason || dismissed) {
+    return null
+  }
+
+  return (
+    <div className="pointer-events-none fixed left-1/2 top-[calc(var(--titlebar-height,34px)+0.75rem)] z-[200] w-[min(32rem,calc(100%-2rem))] -translate-x-1/2">
+      <Alert className="pointer-events-auto grid-cols-[auto_minmax(0,1fr)_auto] border-(--stroke-nous) bg-popover/95 pr-2.5 shadow-nous backdrop-blur-md">
+        <Info className="text-muted-foreground" />
+        <AlertDescription className="col-start-2">
+          <p className="m-0">{t.remoteDisplayBanner.message(reason)}</p>
+        </AlertDescription>
+        <Button
+          aria-label={t.remoteDisplayBanner.dismiss}
+          className="col-start-3 -mr-1 text-muted-foreground"
+          onClick={() => setDismissed(true)}
+          size="icon-xs"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="close" size="0.875rem" />
+        </Button>
+      </Alert>
+    </div>
+  )
+}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -102,6 +102,7 @@ declare global {
       cancelBootstrap: () => Promise<{ ok: boolean; cancelled: boolean }>
       onBootstrapEvent: (callback: (payload: DesktopBootstrapEvent) => void) => () => void
       getVersion: () => Promise<DesktopVersionInfo>
+      getRemoteDisplayReason?: () => Promise<string | null>
       updates: {
         check: () => Promise<DesktopUpdateStatus>
         apply: (opts?: DesktopUpdateApplyOptions) => Promise<DesktopUpdateApplyResult>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -146,6 +146,12 @@ export const en: Translations = {
     }
   },
 
+  remoteDisplayBanner: {
+    message: reason =>
+      `Software rendering active — remote display detected (${reason}). GPU acceleration is disabled to prevent flickering.`,
+    dismiss: 'Dismiss'
+  },
+
   titlebar: {
     hideSidebar: 'Hide sidebar',
     showSidebar: 'Show sidebar',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -147,6 +147,12 @@ export const ja = defineLocale({
     }
   },
 
+  remoteDisplayBanner: {
+    message: reason =>
+      `ソフトウェアレンダリングが有効です — リモートディスプレイを検出しました（${reason}）。ちらつきを防ぐため GPU アクセラレーションは無効化されています。`,
+    dismiss: '閉じる'
+  },
+
   titlebar: {
     hideSidebar: 'サイドバーを非表示',
     showSidebar: 'サイドバーを表示',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -159,6 +159,11 @@ export interface Translations {
     }
   }
 
+  remoteDisplayBanner: {
+    message: (reason: string) => string
+    dismiss: string
+  }
+
   titlebar: {
     hideSidebar: string
     showSidebar: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -142,6 +142,11 @@ export const zhHant = defineLocale({
     }
   },
 
+  remoteDisplayBanner: {
+    message: reason => `軟體繪圖已啟用 — 偵測到遠端顯示（${reason}）。為防止畫面閃爍，已停用 GPU 加速。`,
+    dismiss: '關閉'
+  },
+
   titlebar: {
     hideSidebar: '隱藏側邊欄',
     showSidebar: '顯示側邊欄',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -142,6 +142,11 @@ export const zh: Translations = {
     }
   },
 
+  remoteDisplayBanner: {
+    message: reason => `软件渲染已启用 — 检测到远程显示（${reason}）。为防止画面闪烁，已禁用 GPU 加速。`,
+    dismiss: '关闭'
+  },
+
   titlebar: {
     hideSidebar: '隐藏侧边栏',
     showSidebar: '显示侧边栏',


### PR DESCRIPTION
## What does this PR do?

When Hermes Desktop detects a remote display (RDP, SSH X11-forwarding), it silently disables GPU hardware acceleration to prevent Chromium compositor flicker. The detection and disable already worked correctly, but the renderer had no way to know — only a `console.log` was written to the main process log.

This PR surfaces that information to the user via a dismissible banner:

- Adds `hermes:get-remote-display-reason` IPC handler in `main.cjs` returning the already-computed `REMOTE_DISPLAY_REASON` string (or `null` in normal sessions)
- Exposes it via `preload.cjs` as `window.hermesDesktop.getRemoteDisplayReason()`
- Adds `getRemoteDisplayReason?` to the `hermesDesktop` type in `global.d.ts`
- New `<RemoteDisplayBanner />` component: calls the IPC on mount, shows a dismissible Alert only when reason is non-null — e.g. `"Software rendering active — RDP session detected. GPU acceleration is disabled to prevent flickering."`
- Rendered at shell root in `desktop-controller.tsx` alongside other overlays (same pattern as NotificationStack)
- i18n key `remoteDisplayBanner` added to `en.ts`, `types.ts`, `zh.ts`, `zh-hant.ts`, and `ja.ts`

In a normal local session `REMOTE_DISPLAY_REASON` is `null` and the banner never renders — zero overhead for the common case.

## Related Issue

Related: #37932 (merged — detects remote displays and disables GPU acceleration to stop flicker; this PR surfaces that already-computed reason to the renderer, the user-facing layer #37932 lacked) and #45341 (open — Windows GPU crash --no-angle + HERMES_DESKTOP_DISABLE_GPU, complementary mechanism).

## Type of Change

- [x] ✨ New feature

## Changes Made

- `apps/desktop/electron/main.cjs` — add `hermes:get-remote-display-reason` IPC handler
- `apps/desktop/electron/preload.cjs` — expose `getRemoteDisplayReason`
- `apps/desktop/src/global.d.ts` — type declaration
- `apps/desktop/src/components/remote-display-banner.tsx` — new dismissible banner component
- `apps/desktop/src/app/desktop-controller.tsx` — render banner at shell root
- `apps/desktop/src/i18n/en.ts` — banner i18n strings
- `apps/desktop/src/i18n/types.ts` — i18n type definitions
- `apps/desktop/src/i18n/zh.ts`, `zh-hant.ts`, `ja.ts` — translations

## How to Test

1. On Windows, open an RDP session and launch Hermes Desktop — banner should appear with the RDP reason
2. On Linux, SSH with X11 forwarding (`ssh -X`) and launch — banner should appear with `ssh-session` reason
3. In a normal local session — banner should not appear
4. Set `HERMES_DESKTOP_DISABLE_GPU=1` — banner should appear with `override` reason
5. Click dismiss — banner disappears for the session
6. `node --check` and `tsc --noEmit` both pass clean

## Checklist

- [x] Contributing Guide read
- [x] Conventional Commits format
- [x] Duplicate PR check done (no existing PR surfaces remote-display reason to renderer)
- [x] `node --check apps/desktop/electron/main.cjs && node --check apps/desktop/electron/preload.cjs` passed
- [x] `npx tsc --noEmit` passed clean
- [x] Platform: Windows 11 + WSL2 Ubuntu