### PR TITLE
fix(tui): re-show cursor after external process handoff

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/hooks/use-external-process.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/hooks/use-external-process.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import instances from '../instances.js'
+
+// Mock React's useCallback so the test can import the module without React rendering.
+vi.mock('react', () => ({
+  useCallback: <T extends (...args: never[]) => unknown>(fn: T) => fn
+}))
+
+// Capture the bytes written to stdout so the assertion can inspect the
+// terminal-control sequences emitted by withInkSuspended.
+// withInkSuspended calls `process.stdout.write` directly (not via the
+// Ink instance), so we patch the real process.stdout.write for the
+// duration of each test.
+let originalWrite: typeof process.stdout.write
+let stdoutChunks: Buffer[]
+
+function installStdoutSpy() {
+  stdoutChunks = []
+  originalWrite = process.stdout.write.bind(process.stdout)
+  process.stdout.write = ((chunk: string | Uint8Array, ...rest: unknown[]) => {
+    stdoutChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    return true
+  }) as typeof process.stdout.write
+}
+
+function restoreStdout() {
+  if (originalWrite) {
+    process.stdout.write = originalWrite
+  }
+}
+
+let enterAlternateScreen: ReturnType<typeof vi.fn>
+let exitAlternateScreen: ReturnType<typeof vi.fn>
+let fakeStdout: NodeJS.WriteStream
+
+beforeEach(() => {
+  installStdoutSpy()
+  enterAlternateScreen = vi.fn()
+  exitAlternateScreen = vi.fn()
+  // Use process.stdout as the key so `instances.get(process.stdout)`
+  // inside withInkSuspended returns our fake Ink instance.
+  fakeStdout = process.stdout
+  instances.set(fakeStdout, {
+    enterAlternateScreen,
+    exitAlternateScreen
+  } as never)
+})
+
+afterEach(() => {
+  instances.delete(fakeStdout)
+  restoreStdout()
+})
+
+// Importing the module under test AFTER the mock + instance are wired.
+const { withInkSuspended } = await import('./use-external-process.js')
+
+function writtenSoFar(): string {
+  return Buffer.concat(stdoutChunks).toString('binary')
+}
+
+describe('withInkSuspended', () => {
+  it('emits the show-cursor sequence (\\x1b[?25h) after the external process returns', async () => {
+    await withInkSuspended(async () => {
+      // External process body — no-op.
+    })
+
+    // The whole point of the bugfix: the legacy `exitAlternateScreen` ends
+    // with `?25l` (hide) because Ink used to render a synthetic caret via
+    // inverted cells. Since the "rely on native cursor for input" change
+    // the input box parks the real cursor, so leaving it hidden strands
+    // the user with no visible caret. withInkSuspended must re-show it
+    // synchronously after exitAlternateScreen.
+    expect(writtenSoFar()).toContain('\x1b[?25h')
+
+    // exitAlternateScreen should still have run — the show-cursor write is
+    // ADDITIVE, not a replacement for the existing cleanup.
+    expect(exitAlternateScreen).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs the external process between enterAlternateScreen and exitAlternateScreen', async () => {
+    const order: string[] = []
+
+    enterAlternateScreen.mockImplementation(() => order.push('enter'))
+    exitAlternateScreen.mockImplementation(() => order.push('exit'))
+
+    await withInkSuspended(async () => {
+      order.push('run')
+    })
+
+    expect(order).toEqual(['enter', 'run', 'exit'])
+  })
+
+  it('still emits the show-cursor sequence when the external process throws', async () => {
+    await expect(
+      withInkSuspended(async () => {
+        throw new Error('editor crashed')
+      })
+    ).rejects.toThrow('editor crashed')
+
+    expect(writtenSoFar()).toContain('\x1b[?25h')
+  })
+
+  it('runs the external process without Ink teardown when no instance is registered', async () => {
+    instances.delete(fakeStdout)
+    stdoutChunks.length = 0
+
+    let ran = false
+
+    await withInkSuspended(async () => {
+      ran = true
+    })
+
+    expect(ran).toBe(true)
+    expect(enterAlternateScreen).not.toHaveBeenCalled()
+    expect(exitAlternateScreen).not.toHaveBeenCalled()
+    // Non-Ink path doesn't touch stdout either — bypass mode for shells / tests.
+    expect(stdoutChunks).toHaveLength(0)
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/hooks/use-external-process.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/hooks/use-external-process.ts
@@ -19,6 +19,17 @@ export async function withInkSuspended(run: RunExternalProcess): Promise<void> {
     await run()
   } finally {
     ink.exitAlternateScreen()
+
+    // exitAlternateScreen ends with `?25l` (hide cursor) because the
+    // legacy Ink render painted a synthetic caret via inverted cells —
+    // the hardware cursor stayed hidden the whole session. After the
+    // "rely on native cursor for input" change (commit 1c964ed43f) the
+    // composer parks the real cursor in the input box, so the legacy
+    // hide leaves the user with no visible caret after the editor or
+    // setup wizard returns. Re-show the cursor synchronously so the
+    // input field is interactive the moment we resume. Matches the
+    // SHOW_CURSOR write in App.tsx's componentWillUnmount path.
+    process.stdout.write('\x1b[?25h')
   }
 }
 


### PR DESCRIPTION
## Summary

After opening the external editor (Ctrl+E / Ctrl+G) in `hermes --tui` and saving, the cursor vanishes from the input box. The submitted prompt also briefly lingers visually because the native cursor state isn't restored alongside the Ink repaint.

Fix `withInkSuspended` so it re-shows the cursor (`\x1b[?25h`) after `exitAlternateScreen()` returns. Covers both call sites — the `$EDITOR` handoff in `useComposerState.openEditor` and the `/setup` wizard in `setupHandoff`.

## Root cause

`exitAlternateScreen` in `packages/hermes-ink/src/ink/ink.tsx` ends with `'\x1b[?25l'` (hide cursor). The comment says "Ink manages" — true historically, when Ink rendered a synthetic caret via an inverted cell and left the hardware cursor hidden the whole session. That assumption no longer holds:

- Commit [`1c964ed43f`](https://github.com/NousResearch/hermes-agent/commit/1c964ed43f) (`fix(tui): rely on native cursor for input`) switched the composer to park the **real** terminal cursor in the input box.
- The `log-update` render path no longer emits `cursorShow` patches during normal operation (the only `cursorShow` emission in `log-update.ts` is in the deprecated `renderPreviousOutput_DEPRECATED`, called at app unmount).
- Result: after `enterAlternateScreen`/`exitAlternateScreen`, the cursor flag is `?25l` (hidden) and nothing flips it back. The Ink repaint positions the cursor correctly, but the visibility flag is stale, so the user sees no caret.

## Fix

In `withInkSuspended`, write `'\x1b[?25h'` (show cursor) synchronously after `ink.exitAlternateScreen()` in the `finally` block. Mirrors the `SHOW_CURSOR` write in `App.tsx`'s `componentWillUnmount`. Verified end-to-end in tmux by capturing raw escape sequences — the last cursor event after the editor returns is now `?25h` (visible) instead of `?25l` (hidden).

## Tests

Added `use-external-process.test.ts` with 4 cases:
- show-cursor sequence emitted after the external process returns
- `enterAlternateScreen` / `run` / `exitAlternateScreen` ordering preserved
- show-cursor sequence still emitted when the external process throws
- bypass mode (no Ink instance) does not touch stdout

Existing cursor-related tests (`textInputCursorSourceOfTruth`, `cursorDriftRegression`) still pass.

## Steps to verify manually

```bash
hermes --tui
# press Ctrl+E (or Ctrl+G)
# edit the temp file in $EDITOR, :wq
# input field is now interactive — cursor visible, keystrokes land in the right cell
```

## How this was authored

- Diagnosed by reading `useComposerState.openEditor` → `withInkSuspended` → `enterAlternateScreen`/`exitAlternateScreen` → `log-update.render` (no `cursorShow` emission) → `renderer.cursor.visible` (set to `false` on TTY).
- Reproduced in a tmux session and confirmed the bug by capturing raw ANSI output (`enterAlternateScreen` writes `?25h`, `exitAlternateScreen` writes `?25l`, nothing follows).
- Fix + tests written by **Eli**, an AI agent built on Hermes Agent (Nous Research). Trained the patch on the in-repo invariant from the AGENTS.md "fix real bugs, well" rubric: reproduce on current `main`, point to the exact line, fix the whole bug class for both call sites (editor + setup).

## Related

- Closes #20640
- Test plan in the issue matches the reproducer I used (Ctrl+G, nvim, :wq, both Ghostty and WezTerm).
