### PR TITLE
ci: retry transient dependency installs + skip native rebuild in typecheck

### DIFF
--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -1,0 +1,50 @@
+name: Retry a flaky command
+description: >-
+  Run a shell command, retrying on non-zero exit. For dependency installs
+  (npm ci, uv sync) whose only failures are transient network/toolchain
+  flakes — a node-gyp header fetch, a registry blip — so CI self-heals
+  instead of needing a manual re-run.
+
+inputs:
+  command:
+    description: Shell command to run (and retry).
+    required: true
+  attempts:
+    description: Max attempts before giving up.
+    default: "3"
+  delay:
+    description: Seconds to wait between attempts.
+    default: "10"
+  working-directory:
+    description: Directory to run in.
+    default: "."
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      # command goes through env, never interpolated into the script body, so
+      # a command with quotes/specials can't break or inject into the runner.
+      env:
+        _CMD: ${{ inputs.command }}
+        _ATTEMPTS: ${{ inputs.attempts }}
+        _DELAY: ${{ inputs.delay }}
+      run: |
+        set -uo pipefail
+        n=0
+        while :; do
+          n=$((n + 1))
+          echo "::group::attempt $n/$_ATTEMPTS: $_CMD"
+          if bash -c "$_CMD"; then
+            echo "::endgroup::"
+            exit 0
+          fi
+          echo "::endgroup::"
+          if [ "$n" -ge "$_ATTEMPTS" ]; then
+            echo "::error::failed after $n attempts: $_CMD"
+            exit 1
+          fi
+          echo "::warning::attempt $n failed; retrying in ${_DELAY}s: $_CMD"
+          sleep "$_DELAY"
+        done

--- a/.github/workflows/docs-site-checks.yml
+++ b/.github/workflows/docs-site-checks.yml
@@ -36,8 +36,10 @@ jobs:
 
       - name: Install website dependencies
         if: steps.changes.outputs.site == 'true'
-        run: npm ci
-        working-directory: website
+        uses: ./.github/actions/retry
+        with:
+          command: npm ci
+          working-directory: website
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         if: steps.changes.outputs.site == 'true'
@@ -46,7 +48,9 @@ jobs:
 
       - name: Install ascii-guard
         if: steps.changes.outputs.site == 'true'
-        run: python -m pip install ascii-guard==2.3.0 pyyaml==6.0.3
+        uses: ./.github/actions/retry
+        with:
+          command: python -m pip install ascii-guard==2.3.0 pyyaml==6.0.3
 
       - name: Extract skill metadata for dashboard
         if: steps.changes.outputs.site == 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,9 +54,9 @@ jobs:
 
       - name: Install ruff + ty
         if: steps.changes.outputs.python == 'true'
-        run: |
-          uv tool install ruff
-          uv tool install ty
+        uses: ./.github/actions/retry
+        with:
+          command: uv tool install ruff && uv tool install ty
 
       - name: Determine base ref
         id: base
@@ -194,7 +194,9 @@ jobs:
 
       - name: Install ruff
         if: steps.changes.outputs.python == 'true'
-        run: uv tool install ruff
+        uses: ./.github/actions/retry
+        with:
+          command: uv tool install ruff
 
       - name: ruff check .
         if: steps.changes.outputs.python == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
           RG_VERSION=15.1.0
           RG_SHA256=1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599
           RG_TARBALL=ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl.tar.gz
-          curl -sSfL -o "$RG_TARBALL" \
+          curl -sSfL --retry 3 --retry-delay 5 -o "$RG_TARBALL" \
             "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/${RG_TARBALL}"
           echo "${RG_SHA256}  ${RG_TARBALL}" | sha256sum -c -
           tar -xzf "$RG_TARBALL"
@@ -92,7 +92,9 @@ jobs:
         # fails if the lock is out of sync with pyproject.toml), giving a
         # reproducible env. It also creates .venv itself, so no separate
         # `uv venv` step is needed.
-        run: uv sync --locked --python 3.11 --extra all --extra dev
+        uses: ./.github/actions/retry
+        with:
+          command: uv sync --locked --python 3.11 --extra all --extra dev
 
       - name: Minimize uv cache
         if: steps.changes.outputs.python == 'true'
@@ -195,7 +197,7 @@ jobs:
           RG_VERSION=15.1.0
           RG_SHA256=1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599
           RG_TARBALL=ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl.tar.gz
-          curl -sSfL -o "$RG_TARBALL" \
+          curl -sSfL --retry 3 --retry-delay 5 -o "$RG_TARBALL" \
             "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/${RG_TARBALL}"
           echo "${RG_SHA256}  ${RG_TARBALL}" | sha256sum -c -
           tar -xzf "$RG_TARBALL"
@@ -227,7 +229,9 @@ jobs:
         # fails if the lock is out of sync with pyproject.toml), giving a
         # reproducible env. It also creates .venv itself, so no separate
         # `uv venv` step is needed.
-        run: uv sync --locked --python 3.11 --extra all --extra dev
+        uses: ./.github/actions/retry
+        with:
+          command: uv sync --locked --python 3.11 --extra all --extra dev
 
       - name: Minimize uv cache
         if: steps.changes.outputs.python == 'true'

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -32,8 +32,14 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      # --ignore-scripts: typecheck only needs the TS sources + type defs, not
+      # native builds. Skipping install scripts drops node-pty's node-gyp
+      # header fetch — the transient flake that killed this job pre-`tsc` — and
+      # is faster. retry covers the remaining registry blips.
       - if: steps.changes.outputs.frontend == 'true'
-        run: npm ci
+        uses: ./.github/actions/retry
+        with:
+          command: npm ci --ignore-scripts
       - if: steps.changes.outputs.frontend == 'true'
         run: npm run --prefix ${{ matrix.package }} typecheck
 
@@ -56,7 +62,11 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      # Keep install scripts here: the production build may need node-pty's
+      # native binary. retry handles the transient install-time fetch flakes.
       - if: steps.changes.outputs.frontend == 'true'
-        run: npm ci
+        uses: ./.github/actions/retry
+        with:
+          command: npm ci
       - if: steps.changes.outputs.frontend == 'true'
         run: npm run --prefix apps/desktop build


### PR DESCRIPTION
> **Stacked on #49272** (base = `bb/ci-affected-only`). GitHub will auto-retarget this to `main` once that merges. Review/merge #49272 first.

## Problem

The most common "red, re-run, green" CI failures here aren't test bugs — they're **transient network/toolchain flakes during dependency install**. The reported case: the `typecheck (ui-tui)` job died in `npm ci` while `node-gyp` rebuilt `node-pty`'s native binary and choked fetching Node headers (an `undici assert(!this.paused)`). It never reached `tsc`.

## Fix

**1. Auto-retry every PR-path network install** — a reusable `.github/actions/retry` composite action wraps a command and retries on non-zero exit (3× / 10s). The command is passed via env (never interpolated into the script body) so it can't break or inject. Applied to:

| Step | Workflow |
|---|---|
| `npm ci` | typecheck, desktop-build, docs-site |
| `uv sync` | tests, e2e |
| `uv tool install ruff/ty` | lint |
| `pip install` | docs-site |

`ripgrep` download switched to `curl --retry 3 --retry-delay 5` (curl-native retry).

**2. Root-cause the typecheck flake** — typecheck now runs `npm ci --ignore-scripts`. `tsc` only needs TS sources + type defs, not compiled native binaries, so skipping install scripts **removes the node-pty rebuild entirely** (eliminating the header-fetch flake) and is faster. `desktop-build` keeps scripts (its production build may need the native binary) and relies on retry.

## Validation
- [x] `npm ci --ignore-scripts` + `tsc` passes for **ui-tui, apps/shared, apps/desktop** (~17s, no native build).
- [x] retry loop semantics unit-checked: succeeds first try, succeeds on the Nth retry, gives up non-zero after N.
- [x] all five touched YAML files parse.

## Out of scope (deliberate)
- `docker-publish` (`uv pip install`) is main-only after #49272, lower flake exposure — follow-up.
- `build-windows-installer` / `upload_to_pypi` / `deploy-site` `npm ci` — release/dispatch flows, low frequency — follow-up.