### PR TITLE
fix(memory): log CLI shutdown hook failures

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -721,9 +721,10 @@ class MemoryManager:
             try:
                 provider.on_session_end(messages)
             except Exception as e:
-                logger.debug(
+                logger.warning(
                     "Memory provider '%s' on_session_end failed: %s",
                     provider.name, e,
+                    exc_info=True,
                 )
 
     def on_session_switch(

--- a/cli.py
+++ b/cli.py
@@ -1031,11 +1031,20 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
             # partially-initialised agents where the attribute is missing.
             _session_msgs = getattr(_active_agent_ref, '_session_messages', None)
             if isinstance(_session_msgs, list):
+                logger.info(
+                    "CLI cleanup calling memory shutdown for session %s with %d message(s)",
+                    getattr(_active_agent_ref, "session_id", None) or "<unknown>",
+                    len(_session_msgs),
+                )
                 _active_agent_ref.shutdown_memory_provider(_session_msgs)
             else:
+                logger.info(
+                    "CLI cleanup calling memory shutdown for session %s without session message list",
+                    getattr(_active_agent_ref, "session_id", None) or "<unknown>",
+                )
                 _active_agent_ref.shutdown_memory_provider()
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("CLI cleanup memory shutdown failed: %s", e, exc_info=True)
 
 
 def _should_emit_cleanup_session_finalize(session_id: str | None) -> bool:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3021,8 +3021,8 @@ class AIAgent:
         if self._memory_manager:
             try:
                 self._memory_manager.on_session_end(messages or [])
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("Memory provider on_session_end failed during shutdown: %s", e, exc_info=True)
             try:
                 self._memory_manager.shutdown_all()
             except Exception:

--- a/tests/cli/test_cli_shutdown_memory_messages.py
+++ b/tests/cli/test_cli_shutdown_memory_messages.py
@@ -16,11 +16,12 @@ other tests keep their existing no-arg behaviour.
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 
 @patch("hermes_cli.plugins.invoke_hook")
-def test_cleanup_forwards_session_messages(mock_invoke_hook):
+def test_cleanup_forwards_session_messages(mock_invoke_hook, caplog):
     """_run_cleanup forwards a populated ``_session_messages`` list."""
     import cli as cli_mod
 
@@ -35,6 +36,7 @@ def test_cleanup_forwards_session_messages(mock_invoke_hook):
 
     cli_mod._active_agent_ref = agent
     cli_mod._cleanup_done = False
+    caplog.set_level(logging.INFO, logger="cli")
     try:
         cli_mod._run_cleanup()
     finally:
@@ -42,6 +44,7 @@ def test_cleanup_forwards_session_messages(mock_invoke_hook):
         cli_mod._cleanup_done = False
 
     agent.shutdown_memory_provider.assert_called_once_with(transcript)
+    assert "CLI cleanup calling memory shutdown for session cli-session-id with 2 message(s)" in caplog.text
 
 
 @patch("hermes_cli.plugins.invoke_hook")


### PR DESCRIPTION
## What does this PR do?

Makes the CLI memory-provider shutdown path observable when custom memory providers do not appear to receive `on_session_end`.

The current shutdown path already attempts to forward `_session_messages` to `shutdown_memory_provider()`, but the useful failure modes are mostly silent: CLI cleanup failures are swallowed, `AIAgent.shutdown_memory_provider()` swallows `on_session_end` failures, and `MemoryManager.on_session_end()` only logs provider hook failures at debug level. That leaves support unable to distinguish "cleanup never reached the agent" from "the provider hook threw" from logs.

This PR does not change the lifecycle contract or provider API. It only logs the existing path clearly enough to diagnose it.

## Related Issue

N/A - Discord support thread: https://discord.com/channels/1053877538025386074/1517322779735752714

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: log when CLI cleanup calls memory shutdown, including session id and message count when available.
- `cli.py`: warning-log CLI memory-shutdown exceptions instead of swallowing them silently.
- `run_agent.py`: warning-log `on_session_end` failures during agent shutdown.
- `agent/memory_manager.py`: warning-log provider-specific `on_session_end` failures with traceback.
- `tests/cli/test_cli_shutdown_memory_messages.py`: assert the CLI cleanup path emits the new shutdown diagnostic while still forwarding `_session_messages`.

## How to Test

1. Run `scripts/run_tests.sh -j 4 tests/cli/test_cli_shutdown_memory_messages.py`.
2. Start a CLI session with a custom memory provider enabled.
3. Send one message, run `/exit`, and verify `agent.log` contains the CLI memory shutdown line or a warning explaining the failure.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux via focused test wrapper

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test run:

---
scripts/run_tests.sh -j 4 tests/cli/test_cli_shutdown_memory_messages.py

[100.0% |     4/4 | ✓4 | ✗0] ✓ tests/cli/test_cli_shutdown_memory_messages.py (4✓, 2.4s)

=== Summary: 1 files, 4 tests passed, 0 failed (100% complete) in 2.4s (4 workers) ===
---
