### PR TITLE
feat(dashboard): allow creating new env keys from Keys tab

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3764,6 +3764,36 @@ async def get_env_vars(profile: Optional[str] = None):
             # avoid duplicating the (richer) Channels configuration UI.
             "channel_managed": var_name in channel_keys,
         }
+    # Also surface custom keys already present in .env so newly added keys from
+    # the dashboard remain visible/editable after reload, even when they are
+    # not part of OPTIONAL_ENV_VARS.
+    for var_name in sorted(env_on_disk.keys()):
+        if var_name in result:
+            continue
+        if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", var_name):
+            continue
+        is_provider_like = (
+            var_name.endswith("_API_KEY")
+            or var_name.endswith("_TOKEN")
+            or var_name.endswith("_BASE_URL")
+        )
+        value = env_on_disk.get(var_name)
+        result[var_name] = {
+            "is_set": bool(value),
+            "redacted_value": redact_key(value) if value else None,
+            "description": "Custom key from .env",
+            "url": None,
+            "category": "provider" if is_provider_like else "tool",
+            "is_password": bool(
+                var_name.endswith("_API_KEY")
+                or var_name.endswith("_TOKEN")
+                or var_name.endswith("_SECRET")
+                or var_name.endswith("_PASSWORD")
+            ),
+            "tools": [],
+            "advanced": False,
+            "channel_managed": var_name in channel_keys,
+        }
     return result
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1182,6 +1182,22 @@ class TestWebServerEndpoints:
         # Should contain known env var names
         assert any(k.endswith("_API_KEY") or k.endswith("_TOKEN") for k in data.keys())
 
+    def test_set_custom_env_var_is_listed_in_env_keys(self):
+        key = "CUSTOM_DASHBOARD_KEY"
+        value = "custom-value-1234"
+        assert key not in OPTIONAL_ENV_VARS
+
+        put_resp = self.client.put("/api/env", json={"key": key, "value": value})
+        assert put_resp.status_code == 200
+
+        get_resp = self.client.get("/api/env")
+        assert get_resp.status_code == 200
+        data = get_resp.json()
+        assert key in data
+        assert data[key]["is_set"] is True
+        assert data[key]["description"] == "Custom key from .env"
+        assert data[key]["channel_managed"] is False
+
     def test_get_env_vars_marks_channel_managed_keys(self):
         from hermes_cli.web_server import _channel_managed_env_keys
 

--- a/web/src/pages/EnvPage.tsx
+++ b/web/src/pages/EnvPage.tsx
@@ -491,6 +491,9 @@ export default function EnvPage() {
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [revealed, setRevealed] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState<string | null>(null);
+  const [newKeyName, setNewKeyName] = useState("");
+  const [newKeyValue, setNewKeyValue] = useState("");
+  const [creating, setCreating] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(true); // Show all providers by default
   const { toast, showToast } = useToast();
   const { t } = useI18n();
@@ -591,6 +594,68 @@ export default function EnvPage() {
       showToast(`${t.config.failedToSave} ${key}: ${e}`, "error");
     } finally {
       setSaving(null);
+    }
+  };
+
+  const handleCreateKey = async () => {
+    const key = newKeyName.trim();
+    const value = newKeyValue;
+    if (!key) {
+      showToast("Enter a key name first", "error");
+      return;
+    }
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      showToast(`Invalid key name: ${key}`, "error");
+      return;
+    }
+    if (!value) {
+      showToast(t.env.enterValue, "error");
+      return;
+    }
+    if (vars?.[key]?.channel_managed) {
+      showToast("This key is managed on the Channels page", "error");
+      return;
+    }
+
+    setCreating(true);
+    try {
+      await api.setEnvVar(key, value);
+      const isProviderLike =
+        key.endsWith("_API_KEY") ||
+        key.endsWith("_TOKEN") ||
+        key.endsWith("_BASE_URL");
+      const isPasswordLike =
+        key.endsWith("_API_KEY") ||
+        key.endsWith("_TOKEN") ||
+        key.endsWith("_SECRET") ||
+        key.endsWith("_PASSWORD");
+      setVars((prev) =>
+        prev
+          ? {
+              ...prev,
+              [key]: {
+                description: prev[key]?.description ?? "Custom key from .env",
+                url: prev[key]?.url ?? null,
+                category:
+                  prev[key]?.category ??
+                  (isProviderLike ? "provider" : "tool"),
+                is_password: prev[key]?.is_password ?? isPasswordLike,
+                tools: prev[key]?.tools ?? [],
+                advanced: prev[key]?.advanced ?? false,
+                channel_managed: prev[key]?.channel_managed ?? false,
+                is_set: true,
+                redacted_value: value.slice(0, 4) + "..." + value.slice(-4),
+              },
+            }
+          : prev,
+      );
+      setNewKeyName("");
+      setNewKeyValue("");
+      showToast(`${key} ${t.common.save.toLowerCase()}d`, "success");
+    } catch (e) {
+      showToast(`${t.config.failedToSave} ${key}: ${e}`, "error");
+    } finally {
+      setCreating(false);
     }
   };
 
@@ -769,6 +834,55 @@ export default function EnvPage() {
           {showAdvanced ? t.env.hideAdvanced : t.env.showAdvanced}
         </Button>
       </div>
+
+      <Card>
+        <CardHeader className="border-b border-border bg-card">
+          <div className="flex items-center gap-2">
+            <KeyRound className="h-5 w-5 text-muted-foreground" />
+            <CardTitle className="text-base">{t.common.create} key</CardTitle>
+          </div>
+          <CardDescription>
+            Add a new entry to <code>~/.hermes/.env</code>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <form
+            className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] md:items-end"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleCreateKey();
+            }}
+          >
+            <div className="grid gap-1.5">
+              <Label className="font-mono-ui text-xs">Key name</Label>
+              <Input
+                type="text"
+                value={newKeyName}
+                onChange={(e) => setNewKeyName(e.target.value)}
+                placeholder="EXAMPLE_API_KEY"
+                className="font-mono-ui text-xs"
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <Label className="text-xs">{t.common.set} value</Label>
+              <Input
+                type="text"
+                value={newKeyValue}
+                onChange={(e) => setNewKeyValue(e.target.value)}
+                placeholder={t.env.enterValue}
+                className="font-mono-ui text-xs"
+              />
+            </div>
+            <Button
+              type="submit"
+              prefix={<Save />}
+              disabled={creating || !newKeyName.trim() || !newKeyValue}
+            >
+              {creating ? "..." : t.common.create}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
 
       <div id="section-oauth">
         <OAuthProvidersCard


### PR DESCRIPTION
## What does this PR do?
This PR adds support for creating brand-new environment keys from the Dashboard **Keys** tab.

Before this change, the Keys page could only edit keys already known in `OPTIONAL_ENV_VARS`. That meant users could not add a new key from the UI, and newly-created custom keys were not surfaced by `GET /api/env` after reload.

This PR fixes that by:
- Adding a create-key form in the Keys page (`key` + `value`) with validation.
- Persisting new keys through the existing `PUT /api/env` flow.
- Extending `GET /api/env` so custom `.env` keys are returned (with safe default metadata), making them visible/editable after refresh.

This approach reuses existing backend persistence (`save_env_value`) and avoids adding a separate API shape just for custom keys.

## Related Issue
Fixes #14641

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `web/src/pages/EnvPage.tsx`
  - Added a **Create key** card/form to add new `.env` entries from the Dashboard.
  - Added client-side validation for env var key format: `^[A-Za-z_][A-Za-z0-9_]*$`.
  - Added guardrail preventing creation for channel-managed keys.
  - Updated local page state immediately after successful create, so new keys appear without full-page refresh.

- `hermes_cli/web_server.py`
  - Updated `GET /api/env` to include custom keys found in `.env` that are not present in `OPTIONAL_ENV_VARS`.
  - Added safe default metadata for custom keys (`description`, inferred `category`, `is_password`, `channel_managed`, redacted display value).
  - Kept invalid env names filtered out from the response.

- `tests/hermes_cli/test_web_server.py`
  - Added `test_set_custom_env_var_is_listed_in_env_keys` to verify:
    - custom key can be written via `PUT /api/env`
    - custom key is returned by `GET /api/env`
    - metadata includes expected defaults (`description`, `channel_managed`, etc.)

## How to Test
1. Start the dashboard and open **Keys**.
2. In the new **Create key** form, create a key like `CUSTOM_DASHBOARD_KEY` with value `custom-value-1234`.
3. Verify the key appears in the list immediately.
4. Refresh the page and verify the key is still listed (persisted and reloaded via `GET /api/env`).
5. Confirm `.env` contains the new key.
6. Optional API verification:
   - `PUT /api/env` with a custom key/value.
   - `GET /api/env` includes that key with `description: "Custom key from .env"`.

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (N/A)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A)

## Screenshots / Logs
- `npm --prefix web run typecheck` ✅
- `python3 -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server.py` ✅
- `scripts/run_tests.sh ...` could not run in this checkout because no local `.venv`/`venv` was present.
