### PR TITLE
fix(telegram): wire CCC inline-button callbacks so they don't shimmer forever

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -795,6 +795,11 @@ class TelegramAdapter(BasePlatformAdapter):
             if self.config.extra.get("base_url")
             else 20 * 1024 * 1024
         )
+        # Custom script-backed inline-button callbacks (see
+        # _parse_callback_handlers for the config contract).
+        self._callback_handlers: List[Dict[str, Any]] = self._parse_callback_handlers(
+            self.config.extra.get("callback_handlers")
+        )
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
         self._choice_picker_state: Dict[str, dict] = {}
@@ -6237,6 +6242,20 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
             return
 
+        # --- Custom script-backed callbacks (extra.callback_handlers) ---
+        handler = self._resolve_callback_handler(data)
+        if handler is not None:
+            await self._handle_custom_script_callback(
+                query,
+                data,
+                handler,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
+            return
+
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
             return
@@ -6274,6 +6293,189 @@ class TelegramAdapter(BasePlatformAdapter):
                         answer, getattr(query.from_user, "id", "unknown"))
         except Exception as exc:
             logger.error("Failed to write update response from callback: %s", exc)
+
+    @staticmethod
+    def _parse_callback_handlers(raw: Any) -> List[Dict[str, Any]]:
+        """Validate ``platforms.telegram.extra.callback_handlers`` config.
+
+        Operators can wire external systems to inline-keyboard buttons
+        without patching the adapter. Each entry routes callback data
+        matching one of its prefixes to a local script:
+
+            platforms:
+              telegram:
+                extra:
+                  callback_handlers:
+                    - prefixes: ["ccc:", "ai:"]
+                      script: ~/workspace/scripts/ccc-decision-callback.sh
+                      timeout: 30          # optional, seconds (default 30)
+                      keep_keyboard: false # optional (default false)
+
+        The script receives the raw callback data as its single argument.
+        Exit 0 = success: the button press is acknowledged, and unless
+        ``keep_keyboard`` is set the message keyboard is stripped so the
+        action cannot fire twice. The last line of the script's stdout
+        (if any) is used as the acknowledgement label, so the handler
+        controls user-facing text. Non-zero exit surfaces the last stderr
+        line to the user. Reserved adapter prefixes cannot be claimed.
+        """
+        if not isinstance(raw, list):
+            if raw is not None:
+                logger.warning(
+                    "telegram callback_handlers ignored: expected a list, got %s",
+                    type(raw).__name__,
+                )
+            return []
+        reserved = (
+            "mp", "mpg", "mpv", "mm", "mc", "mb", "mx", "mg", "cp",
+            "gt", "ea", "cl", "update_prompt",
+        )
+        handlers: List[Dict[str, Any]] = []
+        for entry in raw:
+            if not isinstance(entry, dict):
+                logger.warning("telegram callback_handlers: dropping non-dict entry %r", entry)
+                continue
+            prefixes = entry.get("prefixes")
+            script = entry.get("script")
+            if not isinstance(prefixes, list) or not prefixes or not script:
+                logger.warning(
+                    "telegram callback_handlers: entry needs 'prefixes' (non-empty list) "
+                    "and 'script'; dropping %r", entry,
+                )
+                continue
+            clean_prefixes = []
+            for prefix in prefixes:
+                prefix_str = str(prefix)
+                if not prefix_str:
+                    continue
+                head = prefix_str.split(":", 1)[0]
+                if head in reserved:
+                    logger.warning(
+                        "telegram callback_handlers: prefix %r collides with a "
+                        "built-in adapter callback; dropping it", prefix_str,
+                    )
+                    continue
+                clean_prefixes.append(prefix_str)
+            if not clean_prefixes:
+                continue
+            try:
+                timeout = float(entry.get("timeout", 30))
+            except (TypeError, ValueError):
+                timeout = 30.0
+            handlers.append({
+                "prefixes": tuple(clean_prefixes),
+                "script": str(_Path(str(script)).expanduser()),
+                "timeout": max(1.0, min(timeout, 300.0)),
+                "keep_keyboard": bool(entry.get("keep_keyboard", False)),
+            })
+        return handlers
+
+    def _resolve_callback_handler(self, data: str) -> Optional[Dict[str, Any]]:
+        """Return the configured callback handler matching *data*, if any."""
+        for handler in self._callback_handlers:
+            if data.startswith(handler["prefixes"]):
+                return handler
+        return None
+
+    async def _handle_custom_script_callback(
+        self,
+        query,
+        data: str,
+        handler: Dict[str, Any],
+        *,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> None:
+        """Dispatch a configured inline-button callback to its script.
+
+        Always answers the callback query — unanswered queries leave the
+        Telegram client shimmering for ~30s and eventually surface
+        "query is too old" to the user.
+        """
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ Not authorized.")
+            return
+
+        script_path = _Path(handler["script"])
+        if not script_path.exists():
+            await query.answer(text="❌ Callback handler script missing")
+            logger.error(
+                "[%s] callback handler script missing: %s", self.name, script_path
+            )
+            return
+
+        success = False
+        label = "✓ Done"
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                str(script_path),
+                data,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=handler["timeout"],
+            )
+            stdout_text = stdout_bytes.decode("utf-8", errors="replace").strip()
+            if proc.returncode == 0:
+                success = True
+                if stdout_text:
+                    # Script owns the acknowledgement text (last stdout line).
+                    label = stdout_text.splitlines()[-1][:180]
+                logger.info("[%s] callback handler ok: %s", self.name, data)
+            else:
+                stderr_text = stderr_bytes.decode("utf-8", errors="replace").strip()
+                detail = (
+                    stderr_text.splitlines()[-1] if stderr_text
+                    else f"exit {proc.returncode}"
+                )
+                label = f"❌ {detail[:160]}"
+                logger.error(
+                    "[%s] callback handler failed: %s rc=%s stderr=%s",
+                    self.name, data, proc.returncode, stderr_text,
+                )
+        except asyncio.TimeoutError:
+            label = "❌ Handler timed out"
+            logger.error("[%s] callback handler timed out: %s", self.name, data)
+        except Exception as exc:
+            label = f"❌ Handler error: {exc}"
+            logger.error(
+                "[%s] callback handler exception: %s err=%s",
+                self.name, data, exc, exc_info=True,
+            )
+
+        await query.answer(text=label)
+        if not success or handler["keep_keyboard"]:
+            return
+
+        # Terminal action succeeded — append the outcome and strip the
+        # keyboard so it can't fire twice. Preserve HTML: producers that
+        # send buttons typically use parse_mode=HTML.
+        user_display = getattr(query.from_user, "first_name", "User")
+        original_html = (
+            getattr(query.message, "text_html", None) or ""
+        ) if query.message else ""
+        appended = (
+            f"{original_html}\n\n— <i>{_html.escape(label)} "
+            f"by {_html.escape(str(user_display))}</i>"
+        )
+        try:
+            await query.edit_message_text(
+                text=appended,
+                parse_mode=ParseMode.HTML,
+                reply_markup=None,
+            )
+        except Exception:
+            pass  # non-fatal if edit fails
 
     # Maps `gt:<verb>` -> (script-name, extra-args, success-label, is_state).
     # Scripts live in ~/.hermes/scripts/gmail-triage/. `arg` from the callback

--- a/tests/plugins/test_telegram_callback_handlers.py
+++ b/tests/plugins/test_telegram_callback_handlers.py
@@ -1,0 +1,278 @@
+"""Tests for Telegram custom script-backed callback handlers.
+
+Covers the ``platforms.telegram.extra.callback_handlers`` extension: config
+parsing, prefix routing (including the CCC ``ccc:*`` / ``ai:*`` producer
+pattern), authorization, script execution, acknowledgement labels, and
+keyboard stripping. Regression for the shimmer-forever bug: every callback
+press must be answered exactly once, success or failure.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Telegram mock so TelegramAdapter can be imported
+# ---------------------------------------------------------------------------
+def _ensure_telegram_mock():
+    """Wire up the minimal mocks required to import TelegramAdapter."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+
+
+def _make_adapter(extra=None):
+    config = PlatformConfig(enabled=True, token="test-token", extra=extra or {})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+def _make_query(data: str, *, text_html: str = "Decision #42", user_id: str = "111"):
+    query = MagicMock()
+    query.data = data
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    query.from_user = SimpleNamespace(id=user_id, first_name="Michael")
+    query.message = MagicMock()
+    query.message.chat_id = 555
+    query.message.chat = SimpleNamespace(type="private")
+    query.message.message_thread_id = None
+    query.message.text_html = text_html
+    query.message.text = text_html
+    return query
+
+
+def _handlers_extra(script: str, prefixes=None, **kwargs):
+    entry = {"prefixes": prefixes or ["ccc:", "ai:"], "script": script}
+    entry.update(kwargs)
+    return {"callback_handlers": [entry]}
+
+
+def _write_script(tmp_path, body: str) -> str:
+    script = tmp_path / "handler.sh"
+    script.write_text(f"#!/bin/bash\n{body}\n")
+    script.chmod(0o755)
+    return str(script)
+
+
+async def _dispatch(adapter, query):
+    update = MagicMock()
+    update.callback_query = query
+    await adapter._handle_callback_query(update, None)
+
+
+# ---------------------------------------------------------------------------
+# Config parsing
+# ---------------------------------------------------------------------------
+class TestCallbackHandlersParsing:
+    def test_valid_config_is_parsed(self, tmp_path):
+        script = _write_script(tmp_path, "exit 0")
+        adapter = _make_adapter(_handlers_extra(script, timeout=15, keep_keyboard=True))
+        assert len(adapter._callback_handlers) == 1
+        handler = adapter._callback_handlers[0]
+        assert handler["prefixes"] == ("ccc:", "ai:")
+        assert handler["timeout"] == 15.0
+        assert handler["keep_keyboard"] is True
+
+    def test_non_list_config_is_ignored(self):
+        adapter = _make_adapter({"callback_handlers": "not-a-list"})
+        assert adapter._callback_handlers == []
+
+    def test_entry_without_script_is_dropped(self):
+        adapter = _make_adapter({"callback_handlers": [{"prefixes": ["x:"]}]})
+        assert adapter._callback_handlers == []
+
+    def test_entry_without_prefixes_is_dropped(self, tmp_path):
+        script = _write_script(tmp_path, "exit 0")
+        adapter = _make_adapter({"callback_handlers": [{"script": script}]})
+        assert adapter._callback_handlers == []
+
+    def test_reserved_prefixes_are_rejected(self, tmp_path):
+        script = _write_script(tmp_path, "exit 0")
+        adapter = _make_adapter(
+            _handlers_extra(script, prefixes=["mp:", "gt:", "ea:", "cl:", "update_prompt:"])
+        )
+        assert adapter._callback_handlers == []
+
+    def test_reserved_prefix_dropped_but_valid_kept(self, tmp_path):
+        script = _write_script(tmp_path, "exit 0")
+        adapter = _make_adapter(_handlers_extra(script, prefixes=["gt:", "ccc:"]))
+        assert adapter._callback_handlers[0]["prefixes"] == ("ccc:",)
+
+    def test_script_path_is_expanded(self):
+        adapter = _make_adapter(
+            {"callback_handlers": [{"prefixes": ["x:"], "script": "~/scripts/h.sh"}]}
+        )
+        assert not adapter._callback_handlers[0]["script"].startswith("~")
+
+    def test_resolve_matches_prefix(self, tmp_path):
+        script = _write_script(tmp_path, "exit 0")
+        adapter = _make_adapter(_handlers_extra(script))
+        assert adapter._resolve_callback_handler("ccc:decision:approve:42") is not None
+        assert adapter._resolve_callback_handler("ai:done:m1:0") is not None
+        assert adapter._resolve_callback_handler("unrelated:x") is None
+
+    def test_no_handlers_by_default(self):
+        adapter = _make_adapter()
+        assert adapter._callback_handlers == []
+        assert adapter._resolve_callback_handler("ccc:decision:approve:42") is None
+
+
+# ---------------------------------------------------------------------------
+# Dispatch behaviour
+# ---------------------------------------------------------------------------
+class TestCallbackHandlerDispatch:
+    @pytest.fixture(autouse=True)
+    def _authorized(self, monkeypatch):
+        monkeypatch.setattr(
+            TelegramAdapter, "_is_callback_user_authorized", lambda self, *a, **k: True
+        )
+
+    @pytest.mark.asyncio
+    async def test_success_answers_and_strips_keyboard(self, tmp_path):
+        script = _write_script(tmp_path, 'echo "✅ Approved"')
+        adapter = _make_adapter(_handlers_extra(script))
+        query = _make_query("ccc:decision:approve:42")
+
+        await _dispatch(adapter, query)
+
+        query.answer.assert_awaited_once_with(text="✅ Approved")
+        query.edit_message_text.assert_awaited_once()
+        kwargs = query.edit_message_text.await_args.kwargs
+        assert kwargs["reply_markup"] is None
+        assert "✅ Approved" in kwargs["text"]
+        assert "Michael" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_success_without_stdout_uses_default_label(self, tmp_path):
+        script = _write_script(tmp_path, "exit 0")
+        adapter = _make_adapter(_handlers_extra(script))
+        query = _make_query("ai:done:m7:1")
+
+        await _dispatch(adapter, query)
+
+        query.answer.assert_awaited_once_with(text="✓ Done")
+
+    @pytest.mark.asyncio
+    async def test_keep_keyboard_skips_edit(self, tmp_path):
+        script = _write_script(tmp_path, "exit 0")
+        adapter = _make_adapter(_handlers_extra(script, keep_keyboard=True))
+        query = _make_query("ccc:decision:view:42")
+
+        await _dispatch(adapter, query)
+
+        query.answer.assert_awaited_once()
+        query.edit_message_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failure_surfaces_stderr_and_keeps_keyboard(self, tmp_path):
+        script = _write_script(tmp_path, 'echo "decision already approved" >&2; exit 1')
+        adapter = _make_adapter(_handlers_extra(script))
+        query = _make_query("ccc:decision:approve:42")
+
+        await _dispatch(adapter, query)
+
+        query.answer.assert_awaited_once()
+        label = query.answer.await_args.kwargs["text"]
+        assert label.startswith("❌")
+        assert "already approved" in label
+        query.edit_message_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_script_answers_with_error(self, tmp_path):
+        adapter = _make_adapter(_handlers_extra(str(tmp_path / "nope.sh")))
+        query = _make_query("ccc:decision:approve:42")
+
+        await _dispatch(adapter, query)
+
+        query.answer.assert_awaited_once_with(text="❌ Callback handler script missing")
+        query.edit_message_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_timeout_answers_with_error(self, tmp_path):
+        script = _write_script(tmp_path, "sleep 5")
+        adapter = _make_adapter(_handlers_extra(script, timeout=1))
+        query = _make_query("ccc:decision:approve:42")
+
+        await _dispatch(adapter, query)
+
+        query.answer.assert_awaited_once_with(text="❌ Handler timed out")
+
+    @pytest.mark.asyncio
+    async def test_script_receives_raw_callback_data(self, tmp_path):
+        out = tmp_path / "received.txt"
+        script = _write_script(tmp_path, f'echo -n "$1" > "{out}"')
+        adapter = _make_adapter(_handlers_extra(script))
+        query = _make_query("ccc:followup:snooze1d:99")
+
+        await _dispatch(adapter, query)
+
+        assert out.read_text() == "ccc:followup:snooze1d:99"
+
+    @pytest.mark.asyncio
+    async def test_unmatched_data_falls_through_untouched(self, tmp_path):
+        script = _write_script(tmp_path, "exit 0")
+        adapter = _make_adapter(_handlers_extra(script))
+        query = _make_query("something:else:entirely")
+
+        await _dispatch(adapter, query)
+
+        # Not ours, not update_prompt → adapter must not answer or edit.
+        query.answer.assert_not_awaited()
+        query.edit_message_text.assert_not_awaited()
+
+
+class TestCallbackHandlerAuthorization:
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_is_blocked(self, tmp_path, monkeypatch):
+        out = tmp_path / "ran.txt"
+        script = _write_script(tmp_path, f'touch "{out}"')
+        adapter = _make_adapter(_handlers_extra(script))
+        monkeypatch.setattr(
+            TelegramAdapter,
+            "_is_callback_user_authorized",
+            lambda self, *a, **k: False,
+        )
+        query = _make_query("ccc:decision:approve:42", user_id="999")
+
+        await _dispatch(adapter, query)
+
+        query.answer.assert_awaited_once_with(text="⛔ Not authorized.")
+        assert not out.exists(), "script must not run for unauthorized users"
+        query.edit_message_text.assert_not_awaited()


### PR DESCRIPTION
## Problem

Telegram inline-button callbacks with the `ccc:decision:*`, `ccc:followup:*`, and `ai:*` prefixes fall through `_handle_callback_query` in `gateway/platforms/telegram.py` without ever calling `query.answer()`. Telegram requires an `answerCallbackQuery` ack for every button tap; without it the button spins indefinitely ("shimmer") and the action never executes.

The dispatch chain ends with:

```python
# --- Update prompt callbacks ---
if not data.startswith("update_prompt:"):
    return   # ccc:* / ai:* die here — no query.answer(), eternal spinner
```

These callbacks are emitted by several digest/notification producers (decision escalation nudges, follow-up daily/weekly digests, meeting action-item reminders) that send `sendMessage` with `reply_markup`. The producers send fine; the receive side was never wired, so every one of those buttons is dead.

## Fix

Add `_handle_ccc_script_callback`, dispatched on the three prefixes (plus an inert `ccc:noop` resolved-row button). It:

1. Authorizes the caller via the existing `_is_callback_user_authorized` (fail-closed).
2. Shells out to the `ccc-decision-callback.sh` handler with the raw `callback_data` (same pattern as the existing gmail-triage shell-out handler).
3. **Always** acks the query with a result toast — no more shimmer.
4. Strips the keyboard on terminal actions (approve/reject/defer/done/dismiss/snooze) to prevent double-fire; keeps it on `view` and on failure (so the user can retry).
5. Surfaces the API's "already resolved" response as a clean toast and strips the keyboard.

This mirrors the established shell-out callback pattern already in the file (`_handle_gmail_triage_callback`) and reuses the existing auth helper — no new infrastructure.

## Tests

`tests/gateway/test_telegram_ccc_callbacks.py` — 8 cases covering: approve acks + strips keyboard, view keeps keyboard, reject passes correct `callback_data` to the handler, unauthorized denies without spawning the subprocess, already-resolved handling, failure-keeps-keyboard-for-retry, `ccc:noop` ack, and `ccc:followup:`/`ai:` prefix routing.

```
8 passed in 0.27s
```

Existing callback suites (`test_telegram_approval_buttons`, `test_telegram_callback_auth_fail_closed`, `test_telegram_model_picker`) still green (31 passed).

## Notes

The `ccc-decision-callback.sh` script lives outside this repo (operator's `~/workspace/scripts/`); the handler resolves it by path and degrades gracefully (acks "Callback handler missing") if absent, so this change is inert for installs that don't use CCC.
