### PR TITLE
feat(line): add URL-based send_image method

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1317,6 +1317,23 @@ class LineAdapter(BasePlatformAdapter):
             headers={"Content-Type": content_type or "application/octet-stream"},
         )
 
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not image_url.lower().startswith("https://"):
+            return SendResult(success=False, error=f"LINE image URL must be HTTPS: {image_url}")
+        if not self._client:
+            return SendResult(success=False, error="LINE adapter not connected")
+
+        msgs: List[Dict[str, Any]] = [_image_message(image_url)]
+        if caption:
+            msgs.append(_text_message(caption))
+        return await self._send_messages(chat_id, msgs)
+
     async def send_image_file(
         self,
         chat_id: str,

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -399,6 +399,41 @@ class TestSendRouting:
         assert "https://x.com" in out
 
 
+class TestSendImage:
+
+    @pytest.fixture
+    def adapter(self, monkeypatch):
+        monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+        from gateway.config import PlatformConfig
+        cfg = PlatformConfig(enabled=True, extra={
+            "channel_access_token": "tok",
+            "channel_secret": "sec",
+        })
+        ad = LineAdapter(cfg)
+        ad._client = MagicMock()
+        ad._client.reply = AsyncMock()
+        ad._client.push = AsyncMock()
+        return ad
+
+    def test_send_image_with_https_url_succeeds(self, adapter):
+        result = asyncio.run(adapter.send_image("Uchat", "https://example.com/cat.png"))
+        assert result.success
+        adapter._client.push.assert_called_once()
+
+    def test_send_image_with_http_url_fails(self, adapter):
+        result = asyncio.run(adapter.send_image("Uchat", "http://example.com/cat.png"))
+        assert not result.success
+        assert "HTTPS" in result.error
+        adapter._client.push.assert_not_called()
+
+    def test_send_image_without_client_fails(self, adapter):
+        adapter._client = None
+        result = asyncio.run(adapter.send_image("Uchat", "https://example.com/cat.png"))
+        assert not result.success
+        assert "not connected" in result.error
+
+
 # ---------------------------------------------------------------------------
 # 8. Register() metadata + plugin entry points
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

The LINE adapter had `send_image_file` (local file → registers it and converts to an HTTPS URL) but was missing `send_image` for images that are already hosted at a public HTTPS URL. The base class fallback for a missing `send_image` sends the URL as plain text — which is broken UX.

This PR adds the missing method:

- Validates the URL is HTTPS (LINE's image message type requires a publicly reachable HTTPS URL)
- Builds a LINE image message using the existing `_image_message()` helper
- Appends a caption text message if provided
- Returns a structured `SendResult`

## Related Issue

N/A

## Type of Change

- [x] ✨ New feature

## Changes Made

- `plugins/platforms/line/adapter.py` — add `send_image` method before `send_image_file`
- `tests/gateway/test_line_plugin.py` — 3 new tests: HTTPS URL succeeds, HTTP URL rejected, no-client failure

## How to Test

```bash
python -m pytest tests/gateway/test_line_plugin.py -k 'SendImage' -v
```

All 12 LINE plugin tests pass (including 3 new).

## Checklist

- [x] Contributing Guide read
- [x] Conventional Commits format
- [x] Duplicate PR check done
- [x] Tests pass: `python -m pytest tests/gateway/test_line_plugin.py -v` — 12/12
- [x] Platform: Ubuntu WSL2