### PR TITLE
feat(cli): add /recompile to rebuild the system prompt without losing the thread

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7664,6 +7664,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if retry_msg and hasattr(self, '_pending_input'):
                 # Re-queue the message so process_loop sends it to the agent
                 self._pending_input.put(retry_msg)
+        elif canonical == "recompile":
+            # Rebuild the system prompt in place: reload SOUL.md / MEMORY.md /
+            # USER.md from disk and force a rebuild on the next turn, WITHOUT
+            # touching conversation history. Lets edits to the standing prompt
+            # take effect mid-session — unlike /new (drops the thread) or
+            # /compress (summarizes it). Mirrors the invalidation that context
+            # compression already performs, just exposed as its own command.
+            if self.agent is not None and hasattr(self.agent, "_invalidate_system_prompt"):
+                self.agent._invalidate_system_prompt()
+                _cprint(
+                    "  ↻ System prompt will rebuild on the next turn "
+                    "(SOUL.md / MEMORY.md / USER.md reloaded from disk)."
+                )
+            else:
+                _cprint("  (._.) No active agent — nothing to recompile.")
         elif canonical == "undo":
             # Parse optional turn count: "/undo" → 1, "/undo 3" → 3.
             _undo_n = 1

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -88,6 +88,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("fork",), args_hint="[name]"),
     CommandDef("compress", "Compress conversation context (add 'here [N]' to keep recent N turns)", "Session",
                args_hint="[here [N] | focus topic]"),
+    CommandDef("recompile", "Rebuild the system prompt in place — reload SOUL/MEMORY/USER from disk, keep history", "Session",
+               cli_only=True),
     CommandDef("rollback", "List or restore filesystem checkpoints", "Session",
                args_hint="[number]"),
     CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -175,6 +175,21 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
     cli.agent._invalidate_system_prompt.assert_called_once()
 
 
+def test_recompile_rebuilds_prompt_without_touching_history(tmp_path):
+    cli = _prepare_cli_with_active_session(tmp_path)
+    old_session_id = cli.session_id
+    old_history = list(cli.conversation_history)
+
+    cli.process_command("/recompile")
+
+    # System prompt invalidated → rebuild + disk reload (SOUL/MEMORY/USER) next turn.
+    cli.agent._invalidate_system_prompt.assert_called_once()
+    # ...but the thread and session are untouched — that is the whole point of
+    # /recompile vs /new (drops history) or /compress (summarizes it).
+    assert cli.session_id == old_session_id
+    assert cli.conversation_history == old_history
+
+
 def test_new_command_rotates_hermes_session_id_env_and_context(tmp_path):
     from gateway.session_context import _VAR_MAP, get_session_env
 


### PR DESCRIPTION
### What
Adds a `/recompile` slash command that rebuilds the cached system prompt **in place** — reloading `SOUL.md` / `MEMORY.md` / `USER.md` from disk and forcing a rebuild on the next turn — **without mutating conversation history**.

### Why
Today the system-prompt cache is only rebuilt as a *side effect* of session-lifecycle operations, each of which costs the conversation:

| Trigger | Rebuilds prompt? | Thread cost |
|---|---|---|
| context compression (`/compress`) | yes | thread kept but **summarized** |
| `/undo [n]` | yes | **rewinds** the last n turns |
| `/resume <id>` | yes | swaps to a different thread |
| `/new` | yes | **clears** the thread |
| session branch | yes | continues under a new id |

There's currently no way to pick up edits to the standing prompt (persona in `SOUL.md`, persistent memory in `MEMORY.md`, user profile in `USER.md`) mid-session without sacrificing or altering the conversation.

### How
`/recompile` exposes the **existing** `_invalidate_system_prompt()` machinery — which already clears `_cached_system_prompt` and reloads memory from disk — as its own command. The next turn rebuilds, re-reading all three files, while `conversation_history` is left intact. This mirrors what context compression already does on its rebuild path.

### Changes
- `hermes_cli/commands.py` — register the command (`Session`, `cli_only`).
- `cli.py` — dispatch handler; no mutation of history or session id.
- `tests/cli/test_cli_new_session.py` — asserts invalidation fires and that `session_id` + `conversation_history` are unchanged.

### Testing
`pytest tests/cli/test_cli_new_session.py -k recompile` → **1 passed**.

### Scope
Wired for the CLI (`cli_only=True`); gateway/ACP can be extended in a follow-up. Non-destructive, so no confirmation gate.