### PR TITLE
fix(memory): warn when a configured external memory provider fails to load

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1316,10 +1316,37 @@ def init_agent(
                     agent._memory_manager.initialize_all(**_init_kwargs)
                     _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
                 else:
-                    _ra().logger.debug("Memory provider '%s' not found or not available", _mem_provider_name)
+                    # A provider name was explicitly configured but it could not
+                    # be loaded or reported itself unavailable (dangling plugin
+                    # symlink, missing add-on packages, import error). Surface
+                    # this loudly instead of silently downgrading to built-in
+                    # memory -- otherwise new memories quietly go to the wrong
+                    # store for days before anyone notices (#49200).
+                    _warn_msg = (
+                        f"Configured memory provider '{_mem_provider_name}' failed to "
+                        "load and is not active; falling back to built-in memory. "
+                        "Check the plugin install/symlink (`hermes plugins`)."
+                    )
+                    _ra().logger.warning(_warn_msg)
+                    if getattr(agent, "_emit_warning", None):
+                        try:
+                            agent._emit_warning(_warn_msg)
+                        except Exception:
+                            pass
                     agent._memory_manager = None
         except Exception as _mpe:
-            _ra().logger.warning("Memory provider plugin init failed: %s", _mpe)
+            _failed_name = locals().get("_mem_provider_name") or "?"
+            _warn_msg = (
+                f"Configured memory provider '{_failed_name}' failed to load "
+                f"({_mpe}); falling back to built-in memory. "
+                "Check the plugin install/symlink (`hermes plugins`)."
+            )
+            _ra().logger.warning(_warn_msg)
+            if getattr(agent, "_emit_warning", None):
+                try:
+                    agent._emit_warning(_warn_msg)
+                except Exception:
+                    pass
             agent._memory_manager = None
 
     from agent.memory_manager import inject_memory_provider_tools as _inject_memory_provider_tools

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1328,11 +1328,9 @@ def init_agent(
                         "Check the plugin install/symlink (`hermes plugins`)."
                     )
                     _ra().logger.warning(_warn_msg)
-                    if getattr(agent, "_emit_warning", None):
-                        try:
-                            agent._emit_warning(_warn_msg)
-                        except Exception:
-                            pass
+                    # Store for replay after gateway binds status_callback
+                    # (same pattern as _compression_warning replay).
+                    agent._init_memory_warning = _warn_msg
                     agent._memory_manager = None
         except Exception as _mpe:
             _failed_name = locals().get("_mem_provider_name") or "?"
@@ -1342,11 +1340,8 @@ def init_agent(
                 "Check the plugin install/symlink (`hermes plugins`)."
             )
             _ra().logger.warning(_warn_msg)
-            if getattr(agent, "_emit_warning", None):
-                try:
-                    agent._emit_warning(_warn_msg)
-                except Exception:
-                    pass
+            # Store for replay after gateway binds status_callback.
+            agent._init_memory_warning = _warn_msg
             agent._memory_manager = None
 
     from agent.memory_manager import inject_memory_provider_tools as _inject_memory_provider_tools

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -243,6 +243,10 @@ def build_turn_context(
     if agent._compression_warning:
         agent._replay_compression_warning()
         agent._compression_warning = None  # send once
+    # Replay init-time memory provider warning (same late-bound pattern).
+    if getattr(agent, "_init_memory_warning", None):
+        agent._replay_init_memory_warning()
+        # _replay_init_memory_warning clears the attribute on replay
 
     # NOTE: _turns_since_memory and _iters_since_skill are NOT reset here.
     agent.iteration_budget = IterationBudget(agent.max_iterations)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1151,6 +1151,23 @@ class AIAgent:
         from agent.conversation_compression import replay_compression_warning
         replay_compression_warning(self)
 
+    def _replay_init_memory_warning(self) -> None:
+        """Replay the init-time memory provider warning through status_callback.
+
+        During ``AIAgent.__init__`` the gateway's ``status_callback`` is not yet
+        wired, so ``_emit_warning`` would reach nobody.  This method is called
+        at the start of every ``run_conversation()`` — by then the gateway has
+        set the callback, so every platform receives the warning.
+        """
+        msg = getattr(self, "_init_memory_warning", None)
+        cb = getattr(self, "status_callback", None)
+        if msg and cb:
+            try:
+                cb("warn", msg)
+            except Exception:
+                pass
+        self._init_memory_warning = None  # send once
+
     def _is_direct_openai_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets OpenAI's native API."""
         if base_url is not None:

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -165,3 +165,106 @@ def test_aiagent_forwards_warning_callback_to_cli_memory_provider():
     assert provider.init_kwargs["platform"] == "cli"
     assert provider.init_kwargs["warning_callback"] == agent._emit_warning
     assert provider.init_kwargs["status_callback"] == agent._emit_status
+
+
+class UnavailableMemoryProvider:
+    """Provider that loads but reports itself unavailable (broken add-on)."""
+
+    name = "mnemosyne"
+
+    def is_available(self):
+        return False
+
+    def initialize(self, session_id, **kwargs):  # pragma: no cover - never called
+        raise AssertionError("initialize should not run for an unavailable provider")
+
+    def get_tool_schemas(self):
+        return []
+
+    def shutdown(self):
+        pass
+
+
+def test_configured_memory_provider_load_failure_warns(caplog):
+    """A configured provider that fails to load must surface a user-visible warning.
+
+    Regression for the silent fallback to built-in memory (#49200): when
+    memory.provider names a provider but load_memory_provider returns None, the
+    agent used to log only at DEBUG and quietly run built-in memory. The
+    failure must now reach WARNING level and name the configured provider.
+    """
+    import logging
+
+    cfg = {"memory": {"provider": "mnemosyne"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=None),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        with caplog.at_level(logging.WARNING):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+                session_id="sess-fail",
+                platform="cli",
+            )
+
+    assert agent._memory_manager is None
+    warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and "mnemosyne" in r.getMessage()
+    ]
+    assert warnings, (
+        "expected a WARNING naming the configured provider 'mnemosyne'; "
+        f"got: {[r.getMessage() for r in caplog.records]}"
+    )
+
+
+def test_configured_memory_provider_unavailable_warns(caplog):
+    """A provider that loads but is_available() is False must also warn (#49200)."""
+    import logging
+
+    provider = UnavailableMemoryProvider()
+    cfg = {"memory": {"provider": "mnemosyne"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        with caplog.at_level(logging.WARNING):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+                session_id="sess-unavail",
+                platform="cli",
+            )
+
+    assert agent._memory_manager is None
+    warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and "mnemosyne" in r.getMessage()
+    ]
+    assert warnings, (
+        "expected a WARNING naming the unavailable provider 'mnemosyne'; "
+        f"got: {[r.getMessage() for r in caplog.records]}"
+    )

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -191,7 +191,8 @@ def test_configured_memory_provider_load_failure_warns(caplog):
     Regression for the silent fallback to built-in memory (#49200): when
     memory.provider names a provider but load_memory_provider returns None, the
     agent used to log only at DEBUG and quietly run built-in memory. The
-    failure must now reach WARNING level and name the configured provider.
+    failure must now reach WARNING level, name the configured provider, and
+    store the warning for late-bound callback replay.
     """
     import logging
 
@@ -219,6 +220,7 @@ def test_configured_memory_provider_load_failure_warns(caplog):
             )
 
     assert agent._memory_manager is None
+    # WARNING must reach the log.
     warnings = [
         r.getMessage()
         for r in caplog.records
@@ -228,6 +230,11 @@ def test_configured_memory_provider_load_failure_warns(caplog):
         "expected a WARNING naming the configured provider 'mnemosyne'; "
         f"got: {[r.getMessage() for r in caplog.records]}"
     )
+    # Warning must be stored for late-bound callback replay.
+    assert getattr(agent, "_init_memory_warning", None) is not None, (
+        "expected _init_memory_warning to be set for late-bound replay"
+    )
+    assert "mnemosyne" in agent._init_memory_warning
 
 
 def test_configured_memory_provider_unavailable_warns(caplog):
@@ -268,3 +275,124 @@ def test_configured_memory_provider_unavailable_warns(caplog):
         "expected a WARNING naming the unavailable provider 'mnemosyne'; "
         f"got: {[r.getMessage() for r in caplog.records]}"
     )
+    # Warning must be stored for late-bound callback replay.
+    assert getattr(agent, "_init_memory_warning", None) is not None, (
+        "expected _init_memory_warning to be set for late-bound replay"
+    )
+    assert "mnemosyne" in agent._init_memory_warning
+
+
+def test_replay_init_memory_warning_reaches_late_bound_callback():
+    """Stored init memory warning replays when status_callback is set post-construction.
+
+    Regression for the late-bound callback pattern (#49302): the gateway creates
+    AIAgent and assigns agent.status_callback only *after* __init__ returns, so
+    _emit_warning calls during construction have no sink. The warning must be
+    stored on the agent and delivered when _replay_init_memory_warning() is
+    called after the callback is bound (matching the compression-warning pattern).
+    """
+    cfg = {"memory": {"provider": "mnemosyne"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=None),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+            session_id="sess-replay",
+            platform="cli",
+        )
+
+    # Simulate gateway: bind status_callback after construction.
+    callback_events = []
+    agent.status_callback = lambda ev, msg: callback_events.append((ev, msg))
+
+    # Replay the stored warning (as done in run_conversation).
+    agent._replay_init_memory_warning()
+
+    # Must have been delivered through status_callback.
+    assert len(callback_events) == 1, f"expected 1 callback event, got {callback_events}"
+    event_type, msg = callback_events[0]
+    assert event_type == "warn", f"expected 'warn' type, got {event_type!r}"
+    assert "mnemosyne" in msg, f"expected 'mnemosyne' in warning, got {msg!r}"
+
+    # Attribute must be cleared after one replay.
+    assert getattr(agent, "_init_memory_warning", None) is None, (
+        "_init_memory_warning must be cleared after replay"
+    )
+
+
+def test_replay_init_memory_warning_noop_when_no_warning():
+    """_replay_init_memory_warning is a no-op when there's no stored warning."""
+    cfg = {"memory": {"provider": "mnemosyne"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=None),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+            session_id="sess-no-warn",
+            platform="cli",
+        )
+
+    # Clear any stored warning (simulate no-warning state).
+    agent._init_memory_warning = None
+    callback_events = []
+    agent.status_callback = lambda ev, msg: callback_events.append((ev, msg))
+
+    # Must not raise.
+    agent._replay_init_memory_warning()
+
+    assert len(callback_events) == 0, f"expected no events, got {callback_events}"
+
+
+def test_replay_init_memory_warning_without_callback_is_noop():
+    """_replay_init_memory_warning doesn't crash when status_callback is None."""
+    cfg = {"memory": {"provider": "mnemosyne"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=None),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+            session_id="sess-no-cb",
+            platform="cli",
+        )
+
+    agent._init_memory_warning = "some warning"
+    # status_callback is None — must not raise.
+    agent._replay_init_memory_warning()
+    # Attribute should still be cleared.
+    assert getattr(agent, "_init_memory_warning", None) is None


### PR DESCRIPTION
## Problem

When `memory.provider` names an external provider (Mnemosyne, Mem0, Honcho, etc.) but it can't be loaded or reports itself unavailable — a dangling plugin symlink, missing add-on packages, or an import error — agent init logged only at DEBUG and silently fell back to the built-in flat-file memory.

The agent kept running normally, so new memories were written to the wrong store with no error, no warning, and no visible degradation. In the reported case the provider was broken for days before anyone noticed recall had gone stale.

In `agent/agent_init.py`, the external-provider path had two silent branches:

- the `else` (provider not loaded / `is_available()` False) logged `logger.debug(...)` and set `agent._memory_manager = None`
- the hard-exception branch logged a generic `logger.warning(...)` that never reached the user-facing warning channel

## Fix

When a provider name was **explicitly configured** but failed to load or activate, escalate to a user-visible warning instead of swallowing it at DEBUG:

- log at WARNING level
- route the message through the agent's existing `_emit_warning` callback (the same plumbing used for auxiliary/compression degradations), so the warning surfaces to CLI and gateway users
- the hard-exception branch is forwarded the same way

The message names the configured provider and points at the plugin install/symlink (`hermes plugins`). No new config key or env var — it keys entirely off the existing `memory.provider` value.

This is the minimal, fail-loudly step: it does not change the fallback target or refuse to start, it just makes the silent downgrade visible.

## Tests

Adds two regression tests to `tests/run_agent/test_memory_provider_init.py`, built on the existing `test_aiagent_forwards_warning_callback_to_cli_memory_provider` template:

- `test_configured_memory_provider_load_failure_warns` — `load_memory_provider` returns `None`; asserts a WARNING naming the provider is emitted and `_memory_manager is None`.
- `test_configured_memory_provider_unavailable_warns` — provider loads but `is_available()` is False; same assertions.

Both fail on `main` (no WARNING emitted) and pass with this change. Full `tests/run_agent/test_memory_provider_init.py` is green (6 passed).

Fixes #49200


---
Salvages the approach from #43313.
