### PR TITLE
fix docs: update memory tool action list

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -17,7 +17,7 @@ Entry delimiter: § (section sign). Entries can be multiline.
 Character limits (not tokens) because char counts are model-independent.
 
 Design:
-- Single `memory` tool with action parameter: add, replace, remove, read
+- Single `memory` tool with action parameter: add, replace, remove
 - replace/remove use short unique substring matching (not full text or IDs)
 - Behavioral guidance lives in the tool schema description
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state


### PR DESCRIPTION
## Summary

Updates the `tools/memory_tool.py` module docstring so the listed memory tool actions match the current schema.

This is a documentation-only cleanup and does not change runtime behavior.

References #32848
