### PR TITLE
fix(mcp): pass env file pointer for catalog MCPs

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -32,7 +32,7 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
-from hermes_constants import get_hermes_home, get_optional_mcps_dir
+from hermes_constants import get_env_path, get_hermes_home, get_optional_mcps_dir
 from hermes_cli.colors import Colors, color
 from hermes_cli.config import (
     load_config,
@@ -68,6 +68,11 @@ class AuthSpec:
     provider: Optional[str] = None
     scopes: List[str] = field(default_factory=list)
     env_var: Optional[str] = None
+    # Name of the env var an stdio bridge reads its credentials-file path from
+    # (e.g. n8n's N8N_MCP_ENV). When set, the installer points it at
+    # HERMES_HOME/.env so the prompted `env` secrets are visible to a server
+    # that loads from a file rather than the (allowlist-filtered) process env.
+    env_file_var: Optional[str] = None
 
 
 @dataclass
@@ -206,12 +211,21 @@ def _parse_manifest(path: Path) -> CatalogEntry:
     if not isinstance(env_list_raw, list):
         raise CatalogError(f"{path}: auth.env must be a list")
     env_list = [_parse_env_spec(e) for e in env_list_raw]
+    env_file_var = auth_raw.get("env_file_var")
+    if env_file_var is not None:
+        if not isinstance(env_file_var, str) or not re.match(
+            r"^[A-Za-z_][A-Za-z0-9_]*$", env_file_var
+        ):
+            raise CatalogError(
+                f"{path}: auth.env_file_var must be a valid env var name"
+            )
     auth = AuthSpec(
         type=a_type,
         env=env_list,
         provider=auth_raw.get("provider"),
         scopes=list(auth_raw.get("scopes") or []),
         env_var=auth_raw.get("env_var"),
+        env_file_var=env_file_var,
     )
 
     tools_raw = data.get("tools") or {}
@@ -434,13 +448,18 @@ def _expand_install_dir(value: str, install_dir: Optional[Path]) -> str:
 
 
 def _prompt_env_vars(specs: List[EnvVarSpec]) -> Dict[str, str]:
-    """Walk the env spec list, prompting the user for each. Writes secrets and
-    non-secrets alike to ~/.hermes/.env via save_env_value()."""
+    """Walk the env spec list, prompting the user for each. Writes newly
+    prompted secrets and non-secrets to ~/.hermes/.env via save_env_value().
+
+    Existing values may come from either the process environment or .env;
+    callers that need a real env file (auth.env_file_var) should materialize
+    the returned values with _persist_env_file_credentials().
+    """
     collected: Dict[str, str] = {}
     for spec in specs:
         existing = get_env_value(spec.name)
         if existing:
-            print(color(f"  ✓ {spec.name} already set in .env", Colors.GREEN))
+            print(color(f"  ✓ {spec.name} already configured", Colors.GREEN))
             collected[spec.name] = existing
             continue
         value = _prompt_input(
@@ -457,6 +476,20 @@ def _prompt_env_vars(specs: List[EnvVarSpec]) -> Dict[str, str]:
     return collected
 
 
+def _persist_env_file_credentials(values: Dict[str, str]) -> None:
+    """Ensure collected auth values exist in HERMES_HOME/.env.
+
+    get_env_value() intentionally treats process env as authoritative. That is
+    fine for normal Hermes config interpolation, but stdio bridges using
+    auth.env_file_var are handed a path to HERMES_HOME/.env and load secrets
+    from that file themselves. If a user supplied credentials via shell env,
+    materialize those values into .env before pointing the bridge at it.
+    """
+    for key, value in values.items():
+        if value:
+            save_env_value(key, value)
+
+
 def _build_server_config(
     entry: CatalogEntry, install_dir: Optional[Path]
 ) -> dict:
@@ -468,6 +501,17 @@ def _build_server_config(
         cfg["command"] = _expand_install_dir(t.command or "", install_dir)
         if t.args:
             cfg["args"] = [_expand_install_dir(a, install_dir) for a in t.args]
+        # Some stdio bridges read their credentials from an env *file* rather
+        # than the inherited process env (e.g. n8n's bridge looks for
+        # N8N_MCP_ENV / ~/.config/n8n-mcp/env / ./.env). Hermes filters the
+        # subprocess env down to a safe allowlist before launch, so the
+        # N8N_API_KEY / N8N_BASE_URL we just saved into HERMES_HOME/.env are
+        # invisible to such a server. When the manifest names that pointer var
+        # (auth.env_file_var), point it at Hermes' own .env so the secrets land.
+        # Resolved here (not via a config placeholder) because runtime ${VAR}
+        # interpolation only resolves names present in os.environ.
+        if entry.auth.env_file_var:
+            cfg["env"] = {entry.auth.env_file_var: str(get_env_path())}
     elif t.type == "http":
         cfg["url"] = t.url
         if entry.auth.type == "oauth":
@@ -699,7 +743,9 @@ def install_entry(entry: CatalogEntry, *, enable: bool = True) -> None:
     if entry.auth.type == "api_key":
         print()
         print(color("  Configure credentials:", Colors.CYAN))
-        _prompt_env_vars(entry.auth.env)
+        collected_env = _prompt_env_vars(entry.auth.env)
+        if entry.auth.env_file_var:
+            _persist_env_file_credentials(collected_env)
     elif entry.auth.type == "oauth":
         if entry.auth.provider:
             # Case 2: provider-mediated (Google, GitHub, etc.). We rely on

--- a/optional-mcps/n8n/manifest.yaml
+++ b/optional-mcps/n8n/manifest.yaml
@@ -40,6 +40,15 @@ install:
 #   type: none     — no credentials needed
 auth:
   type: api_key
+  # The bridge reads its credentials from an env file (one of N8N_MCP_ENV,
+  # ~/.config/n8n-mcp/env, ./.env) — NOT the inherited process env, which
+  # Hermes filters down to a safe allowlist before launching stdio servers.
+  # Naming the pointer var here makes the installer write
+  # `env: {N8N_MCP_ENV: <HERMES_HOME>/.env}` into config.yaml, so the
+  # N8N_BASE_URL / N8N_API_KEY collected below are actually visible to the
+  # server. The path is resolved from Hermes home at install time (profile-
+  # aware; no hardcoded user path).
+  env_file_var: N8N_MCP_ENV
   env:
     - name: N8N_BASE_URL
       prompt: "n8n instance URL"

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -70,7 +70,7 @@ def _write_manifest(catalog_dir: Path, name: str, body: dict) -> Path:
     entry_dir = catalog_dir / name
     entry_dir.mkdir(exist_ok=True)
     path = entry_dir / "manifest.yaml"
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         yaml.safe_dump(body, f)
     return path
 
@@ -165,6 +165,36 @@ class TestManifestParsing:
         assert e.install.url == "https://example.com/demo.git"
         assert e.install.ref == "v1.0.0"
         assert e.install.bootstrap == ["pip install -r requirements.txt"]
+
+    def test_auth_env_file_var_parsed(self, catalog_dir):
+        body = _basic_manifest(
+            auth={
+                "type": "api_key",
+                "env_file_var": "N8N_MCP_ENV",
+                "env": [{"name": "N8N_API_KEY", "prompt": "key", "secret": True}],
+            }
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        e = list_catalog()[0]
+        assert e.auth.env_file_var == "N8N_MCP_ENV"
+
+    def test_auth_env_file_var_defaults_none(self, catalog_dir):
+        _write_manifest(catalog_dir, "demo", _basic_manifest())
+        from hermes_cli.mcp_catalog import list_catalog
+
+        assert list_catalog()[0].auth.env_file_var is None
+
+    def test_auth_env_file_var_invalid_name_rejected(self, catalog_dir):
+        body = _basic_manifest(
+            auth={"type": "api_key", "env_file_var": "not a valid name"}
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        # Malformed env_file_var => manifest silently skipped (CI contract).
+        assert list_catalog() == []
 
     def test_invalid_manifest_skipped(self, catalog_dir):
         # Broken: wrong manifest_version
@@ -290,6 +320,100 @@ class TestInstall:
 
         assert get_env_value("DEMO_KEY") == "secret-val"
         assert "demo" in load_config()["mcp_servers"]
+
+    def test_install_writes_env_file_pointer(
+        self, catalog_dir, monkeypatch, _isolate_hermes_home
+    ):
+        """A manifest naming auth.env_file_var makes the installer write an
+        `env` block pointing that var at HERMES_HOME/.env, so a bridge that
+        reads its credentials from a file (e.g. n8n) can see them."""
+        hh = _isolate_hermes_home
+        body = _basic_manifest(
+            auth={
+                "type": "api_key",
+                "env_file_var": "N8N_MCP_ENV",
+                "env": [
+                    {"name": "N8N_BASE_URL", "prompt": "url", "secret": False},
+                    {"name": "N8N_API_KEY", "prompt": "key", "secret": True},
+                ],
+            }
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli import mcp_catalog
+
+        monkeypatch.setattr(mcp_catalog, "_prompt_input", lambda *a, **kw: "x")
+
+        from hermes_cli.mcp_catalog import install_entry
+        from hermes_cli.config import load_config
+
+        install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        # The pointer is resolved to the absolute, profile-aware .env path —
+        # not a literal placeholder or a hardcoded ~/.hermes path.
+        assert server["env"] == {"N8N_MCP_ENV": str(hh / ".env")}
+
+    def test_install_with_env_file_var_persists_process_env_values(
+        self, catalog_dir, monkeypatch, _isolate_hermes_home
+    ):
+        """If credentials already exist only in os.environ, persist them to
+        HERMES_HOME/.env before pointing the bridge at that file."""
+        hh = _isolate_hermes_home
+        monkeypatch.setenv("DEMO_ENV_ONLY_URL", "http://env-only.example")
+        monkeypatch.setenv("DEMO_ENV_ONLY_KEY", "env-only-secret")
+        body = _basic_manifest(
+            auth={
+                "type": "api_key",
+                "env_file_var": "DEMO_MCP_ENV",
+                "env": [
+                    {"name": "DEMO_ENV_ONLY_URL", "prompt": "url", "secret": False},
+                    {"name": "DEMO_ENV_ONLY_KEY", "prompt": "key", "secret": True},
+                ],
+            }
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli import mcp_catalog
+
+        def _unexpected_prompt(*args, **kwargs):
+            raise AssertionError("existing process env values should not prompt")
+
+        monkeypatch.setattr(mcp_catalog, "_prompt_input", _unexpected_prompt)
+
+        from hermes_cli.mcp_catalog import install_entry
+        from hermes_cli.config import load_config
+
+        install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert server["env"] == {"DEMO_MCP_ENV": str(hh / ".env")}
+        env_text = (hh / ".env").read_text()
+        assert "DEMO_ENV_ONLY_URL=http://env-only.example\n" in env_text
+        assert "DEMO_ENV_ONLY_KEY=env-only-secret\n" in env_text
+
+    def test_install_without_env_file_var_writes_no_env_block(self, catalog_dir):
+        """Servers that don't declare auth.env_file_var keep the previous
+        behavior: no `env` block is written (regression guard)."""
+        body = _basic_manifest(
+            auth={
+                "type": "api_key",
+                "env": [{"name": "DEMO_KEY", "prompt": "key", "secret": True}],
+            }
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli import mcp_catalog
+
+        # _prompt_input is patched so the required api_key prompt resolves.
+        import unittest.mock as _mock
+        with _mock.patch.object(mcp_catalog, "_prompt_input", lambda *a, **kw: "x"):
+            from hermes_cli.mcp_catalog import install_entry
+            from hermes_cli.config import load_config
+
+            install_entry(_entry("demo"), enable=True)
+            server = load_config()["mcp_servers"]["demo"]
+            assert "env" not in server
 
     def test_install_http_oauth_writes_auth_marker(self, catalog_dir):
         body = _basic_manifest(

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -77,6 +77,11 @@ Catalog entries can require:
 
 - **API key** — Hermes prompts at install time and writes the value to
   `~/.hermes/.env`. Non-secret values (base URLs) go to the same file.
+- **API key with an env-file pointer** — stdio bridges that read credentials
+  from a file can declare `auth.env_file_var`; Hermes writes that env var into
+  the generated server config and points it at the active profile's `.env`
+  file. This keeps subprocess environments allowlisted while still letting the
+  bridge load the credentials Hermes collected.
 - **OAuth** (remote MCP) — written as `auth: oauth` in your config; the MCP
   client opens a browser on first connection.
 - **OAuth** (third-party provider like Google/GitHub) — Hermes points you at


### PR DESCRIPTION
## What does this PR do?

Adds `auth.env_file_var` to MCP catalog manifests so stdio catalog servers can receive a pointer to the active Hermes `.env` file without inheriting the full Hermes process environment.

The n8n catalog bridge reads credentials from an env file selected by `N8N_MCP_ENV`. Hermes already saves catalog-collected values such as `N8N_BASE_URL` and `N8N_API_KEY` into the active profile's `.env`, but the generated MCP server config did not pass the bridge a pointer to that file. This meant the stdio process could be launched with the right allowlisted environment model but still be unable to find the credentials Hermes collected.

This PR keeps the filtered subprocess environment model and adds a manifest-declared escape hatch for file-based credential loaders:

- catalog manifests may declare `auth.env_file_var`;
- the installer writes that env var into the generated `mcp_servers.<name>.env` block;
- the value points at the active profile's `.env` path;
- if required auth values exist only in `os.environ`, the installer materializes them into `.env` before pointing the server at it.

## Related Issue

No standalone issue filed for this exact n8n catalog env-file pointer case.

Related PR:

- #49323 pins the same n8n catalog entry's upstream `install.ref`. That PR is independent but touches the same manifest file.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/mcp_catalog.py`
  - Adds `AuthSpec.env_file_var`.
  - Parses and validates `auth.env_file_var` as an environment variable name.
  - When present, writes the env-file pointer into the generated MCP server `env` block.
  - Persists auth values that were found only in process env into the profile `.env` before pointing the server at that file.

- `optional-mcps/n8n/manifest.yaml`
  - Declares `auth.env_file_var: N8N_MCP_ENV` for the n8n stdio bridge.

- `tests/hermes_cli/test_mcp_catalog.py`
  - Adds manifest parsing coverage for `auth.env_file_var`.
  - Adds validation coverage for invalid env var names.
  - Adds install coverage proving the generated server config receives the profile-aware `.env` pointer.
  - Adds regression coverage that manifests without `auth.env_file_var` keep the previous behavior and write no `env` block.

- `website/docs/user-guide/features/mcp.md`
  - Documents catalog entries that use an API key plus an env-file pointer.

## How to Test

1. Run the targeted MCP catalog tests:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py
   ```

   Result:

   ```text
   41 passed
   ```

2. Verify syntax:

   ```bash
   python -m py_compile hermes_cli/mcp_catalog.py tests/hermes_cli/test_mcp_catalog.py
   ```

3. Check Windows/path footguns on touched code/test/doc files:

   ```bash
   python scripts/check-windows-footguns.py hermes_cli/mcp_catalog.py optional-mcps/n8n/manifest.yaml tests/hermes_cli/test_mcp_catalog.py website/docs/user-guide/features/mcp.md
   ```

   Result:

   ```text
   ✓ No Windows footguns found (2 file(s) scanned).
   ```

4. Manual reproduction covered by tests:
   - Isolate a temp `HERMES_HOME`.
   - Set required n8n-style auth values only in `os.environ`.
   - Install a manifest declaring `auth.env_file_var`.
   - Verify Hermes writes those values to `.env` and writes the env-file pointer into `mcp_servers.<name>.env`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.0.6-2-pve with Python 3.11 via the Hermes-managed venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `website/docs/user-guide/features/mcp.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py
# 41 passed

python -m py_compile hermes_cli/mcp_catalog.py tests/hermes_cli/test_mcp_catalog.py
# passed

python scripts/check-windows-footguns.py hermes_cli/mcp_catalog.py optional-mcps/n8n/manifest.yaml tests/hermes_cli/test_mcp_catalog.py website/docs/user-guide/features/mcp.md
# ✓ No Windows footguns found (2 file(s) scanned).
```
