### PR TITLE
fix(agent): make budget exhaustion visibly incomplete

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1308,8 +1308,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
     summary_request = (
         "You've reached the maximum number of tool-calling iterations allowed. "
-        "Please provide a final response summarizing what you've found and accomplished so far, "
-        "without calling any more tools."
+        "This turn is not verified complete. Provide a concise progress summary only: "
+        "what changed, what is still uncertain, and the next concrete step. "
+        "Do not claim the task is done unless the transcript already proves it, "
+        "and do not call any more tools."
     )
     messages.append({"role": "user", "content": summary_request})
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -27,6 +27,46 @@ import os
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 
 
+def _budget_snapshot(agent, api_call_count: int) -> tuple[int, int]:
+    """Return the best stable budget counters for user/result metadata."""
+    budget = getattr(agent, "iteration_budget", None)
+    if budget is not None:
+        return int(getattr(budget, "used", 0) or 0), int(getattr(budget, "max_total", 0) or 0)
+    return int(api_call_count), int(getattr(agent, "max_iterations", 0) or 0)
+
+
+def _budget_exhaustion_reason(agent, api_call_count: int) -> str | None:
+    """Classify max-iteration/shared-budget exhaustion, if present."""
+    max_iterations = int(getattr(agent, "max_iterations", 0) or 0)
+    if max_iterations > 0 and api_call_count >= max_iterations:
+        return f"max_iterations_reached({api_call_count}/{max_iterations})"
+
+    budget = getattr(agent, "iteration_budget", None)
+    if budget is not None and getattr(budget, "remaining", 1) <= 0:
+        used, maximum = _budget_snapshot(agent, api_call_count)
+        return f"iteration_budget_exhausted({used}/{maximum})"
+
+    return None
+
+
+def _format_budget_exhausted_response(progress_summary: str | None) -> str:
+    """Runtime-owned incomplete-state wording for exhausted turns."""
+    lines = [
+        "⚠️ Iteration budget exhausted — task is not verified complete.",
+        "I stopped because the per-turn tool/API iteration budget ran out. "
+        "The work may be partially done, but this is not a verified final answer.",
+        "Send `continue` to resume from the current transcript, or raise `max_iterations` for this task.",
+    ]
+    summary = (progress_summary or "").strip()
+    if summary:
+        lines.extend([
+            "",
+            "Progress summary from the model (not completion authority):",
+            summary,
+        ])
+    return "\n".join(lines)
+
+
 def finalize_turn(
     agent,
     *,
@@ -50,24 +90,30 @@ def finalize_turn(
     """
     from agent.conversation_loop import logger
 
-    if final_response is None and (
-        api_call_count >= agent.max_iterations
-        or agent.iteration_budget.remaining <= 0
-    ):
+    _budget_exhausted_reason = _budget_exhaustion_reason(agent, api_call_count)
+    _budget_exhausted = _budget_exhausted_reason is not None
+    _budget_used, _budget_max = _budget_snapshot(agent, api_call_count)
+    if _budget_exhausted:
+        _turn_exit_reason = _budget_exhausted_reason
+
+    if final_response is None and _budget_exhausted:
         # Budget exhausted — ask the model for a summary via one extra
         # API call with tools stripped.  _handle_max_iterations injects a
         # user message and makes a single toolless request.
-        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
         agent._emit_status(
-            f"⚠️ Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
+            f"⚠️ Iteration budget exhausted ({_budget_used}/{_budget_max}) "
             "— asking model to summarise"
         )
         if not agent.quiet_mode:
             agent._safe_print(
-                f"\n⚠️  Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
+                f"\n⚠️  Iteration budget exhausted ({_budget_used}/{_budget_max}) "
                 "— requesting summary..."
             )
-        final_response = agent._handle_max_iterations(messages, api_call_count)
+        try:
+            final_response = agent._handle_max_iterations(messages, api_call_count)
+        except Exception:
+            logger.warning("Failed to get budget-exhausted progress summary", exc_info=True)
+            final_response = ""
 
         # If running as a kanban worker, signal the dispatcher that the
         # worker could not complete (rather than treating it as a
@@ -93,7 +139,7 @@ def finalize_turn(
                         _kanban_task,
                         error=(
                             f"Iteration budget exhausted "
-                            f"({api_call_count}/{agent.max_iterations}) — "
+                            f"({_budget_used}/{_budget_max}) — "
                             "task could not complete within the allowed "
                             "iterations"
                         ),
@@ -101,13 +147,13 @@ def finalize_turn(
                         release_claim=True,
                         end_run=True,
                         event_payload_extra={
-                            "budget_used": api_call_count,
-                            "budget_max": agent.max_iterations,
+                            "budget_used": _budget_used,
+                            "budget_max": _budget_max,
                         },
                     )
                     logger.info(
                         "recorded budget-exhausted failure for task %s (%d/%d)",
-                        _kanban_task, api_call_count, agent.max_iterations,
+                        _kanban_task, _budget_used, _budget_max,
                     )
                 finally:
                     try:
@@ -125,6 +171,7 @@ def finalize_turn(
     completed = (
         final_response is not None
         and api_call_count < agent.max_iterations
+        and not _budget_exhausted
         and not failed
     )
 
@@ -162,8 +209,6 @@ def finalize_turn(
         if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
     )
     _resp_len = len(final_response) if final_response else 0
-    _budget_used = agent.iteration_budget.used if agent.iteration_budget else 0
-    _budget_max = agent.iteration_budget.max_total if agent.iteration_budget else 0
 
     _diag_msg = (
         "Turn ended: reason=%s model=%s api_calls=%d/%d budget=%d/%d "
@@ -284,6 +329,9 @@ def finalize_turn(
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
 
+    if _budget_exhausted and not interrupted:
+        final_response = _format_budget_exhausted_response(final_response)
+
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.
     # Plugins can use this to persist conversation data (e.g. sync
@@ -330,6 +378,10 @@ def finalize_turn(
         "api_calls": api_call_count,
         "completed": completed,
         "turn_exit_reason": _turn_exit_reason,
+        "budget_exhausted": _budget_exhausted,
+        "budget_used": _budget_used,
+        "budget_max": _budget_max,
+        "failure_reason": "budget_exhausted" if _budget_exhausted else None,
         "failed": failed,
         "partial": False,  # True only when stopped due to invalid tool calls
         "interrupted": interrupted,

--- a/docs/plans/2026-06-19-001-fix-budget-exhaustion-finalizer-plan.md
+++ b/docs/plans/2026-06-19-001-fix-budget-exhaustion-finalizer-plan.md
@@ -1,0 +1,309 @@
+---
+title: "fix: Make iteration-budget exhaustion visibly incomplete"
+status: completed
+date: 2026-06-19
+type: fix
+target_repo: hermes-agent
+---
+
+# fix: Make iteration-budget exhaustion visibly incomplete
+
+## Summary
+
+Fix the practical failure mode where Hermes exhausts its iteration budget and returns a fluent, model-authored summary that can read like successful completion. The plan keeps the solution small: make budget exhaustion an explicit incomplete turn state, add deterministic user-facing wording, preserve existing resume/failure semantics, and leave startup context audit work out of the fix.
+
+---
+
+## Problem Frame
+
+Hermes already detects iteration exhaustion in the agent loop and finalizer, but the current finalizer asks the model for a toolless “final response” summarizing what it accomplished. That extra summary can overclaim, especially after a tool result or mid-plan state, even though `completed` is often false internally.
+
+This is not a startup-context sizing problem. Exhaustion should be uncommon in normal interactive turns with the default budget, but it matters when it occurs: long coding tasks, constrained `max_turns`, cron/kanban workers, subagents, and runaway tool loops are exactly the cases where a false “done” is costly. The right fix is a narrow runtime contract, not a new startup order book.
+
+---
+
+## Requirements
+
+### User-facing completion truth
+
+- R1. When a turn stops because `max_iterations` or `IterationBudget` is exhausted, the final visible response must state that the task is incomplete.
+- R2. A model-generated progress summary, if retained, must be labeled as progress/handoff text and must not be the authority on completion.
+- R3. Budget exhaustion after a tool result must not look like a verified final answer.
+
+### Runtime result semantics
+
+- R4. Both `max_iterations` exhaustion and `IterationBudget.remaining <= 0` exhaustion must return `completed=False`.
+- R5. The result dict must expose structured budget-exhaustion metadata that gateway, cron, kanban, and tests can rely on without parsing prose.
+- R6. Existing cron and kanban failure behavior must continue to treat budget exhaustion as unsuccessful work.
+
+### Scope discipline
+
+- R7. The fix must not introduce startup context audit, automatic tool disabling, model/provider changes, auto-resume loops, or a new session-resume subsystem.
+- R8. The fix must be covered by focused regression tests at the finalizer and gateway status seams.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Fix the finalizer seam, not startup context assembly. `agent/turn_finalizer.py` already owns post-loop completion, result assembly, kanban timeout recording, verifier footers, turn explanations, and plugin hooks.
+- KTD2. Use deterministic runtime wording for budget exhaustion. Model prompts are advisory; runtime-owned prefix/footer text is what prevents false “done” claims.
+- KTD3. Preserve `_handle_max_iterations()` only as optional progress summary plumbing. It can still produce text if the implementation chooses, but its output must be wrapped or demoted under an incomplete-state warning.
+- KTD4. Treat `IterationBudget` exhaustion the same as `max_iterations` exhaustion for completion state. The current `completed` calculation can incorrectly return true when shared budget reaches zero before `api_call_count` reaches `max_iterations`.
+- KTD5. Do not reuse `resume_pending` for budget exhaustion. Budget exhaustion is a clean turn end with a resume recommendation, not a gateway restart interruption.
+- KTD6. Keep cross-system changes metadata-first. Add budget fields to the agent result before touching gateway events or plugin hooks; a dedicated hook is follow-up material unless tests prove an immediate consumer needs it.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A[Agent loop runs tool/API turns] --> B{Budget available?}
+  B -->|yes| C[Normal final response path]
+  B -->|no| D[Budget-exhausted finalizer branch]
+  D --> E[Set completed=false and budget_exhausted metadata]
+  E --> F[Build runtime-owned incomplete response]
+  F --> G[Optionally attach labeled progress summary]
+  G --> H[Record kanban timeout when applicable]
+  H --> I[Persist transcript and return result]
+  I --> J[Gateway/cron/hooks consume metadata, not prose]
+```
+
+```mermaid
+sequenceDiagram
+  participant L as conversation_loop
+  participant F as turn_finalizer
+  participant S as optional summary helper
+  participant G as gateway/cron/kanban
+
+  L->>F: final_response=None, budget remaining=0 or max hit
+  F->>F: classify budget_exhausted
+  opt progress summary retained
+    F->>S: request toolless progress summary
+    S-->>F: model-authored progress text
+  end
+  F->>F: prepend/append runtime incomplete warning
+  F-->>G: completed=false, budget_exhausted=true, final_response=handoff
+  G->>G: do not treat as success or clear recovery markers
+```
+
+---
+
+## Implementation Units
+
+### U1. Normalize budget-exhausted turn state in the finalizer
+
+**Goal:** Make both budget systems produce the same incomplete result semantics.
+
+**Requirements:** R1, R3, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- `agent/turn_finalizer.py`
+- `tests/agent/test_turn_finalizer_budget_exhaustion.py`
+
+**Approach:**
+- Add a local budget-exhausted classification in `finalize_turn()` that distinguishes `max_iterations` and `IterationBudget` exhaustion but treats both as incomplete.
+- Ensure `completed=False` whenever budget exhaustion was detected, even when `api_call_count < agent.max_iterations`.
+- Add result metadata such as `budget_exhausted`, `budget_used`, `budget_max`, and a stable `failure_reason` or `turn_exit_reason` value.
+- Keep existing kanban timeout recording in this branch and make it fire for both max-iteration and shared-budget exhaustion.
+
+**Execution note:** Start with finalizer unit tests that reproduce `IterationBudget.remaining == 0` with `api_call_count < max_iterations`; that is the subtle false-success path.
+
+**Patterns to follow:**
+- Existing finalizer result assembly and diagnostic logging in `agent/turn_finalizer.py`.
+- Existing file-mutation verifier footer pattern in `agent/turn_finalizer.py`.
+- Existing `IterationBudget` counters in `agent/iteration_budget.py`.
+
+**Test scenarios:**
+- Max iterations hit with `final_response=None` returns `completed=False`, `budget_exhausted=True`, and a budget-related `turn_exit_reason`.
+- Shared `IterationBudget` exhausted while `api_call_count < max_iterations` returns `completed=False`, not the current success-shaped result.
+- Messages ending with a tool result still produce incomplete metadata and do not get treated as a normal successful final answer.
+- Kanban task environment set during budget exhaustion records a timed-out task failure for both exhaustion sources.
+
+**Verification:** Finalizer tests prove metadata and completion state are correct without depending on prose wording alone.
+
+### U2. Add deterministic incomplete-response wording
+
+**Goal:** Prevent fluent summaries from becoming false “done” claims.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** U1
+
+**Files:**
+- `agent/turn_finalizer.py`
+- `agent/chat_completion_helpers.py`
+- `tests/run_agent/test_turn_completion_explainer.py`
+- `tests/agent/test_turn_finalizer_budget_exhaustion.py`
+
+**Approach:**
+- Build a runtime-owned budget-exhausted message that leads with “iteration budget exhausted” and “not verified complete”.
+- If `_handle_max_iterations()` remains in the default path, demote its output under a label such as “Progress summary from the model”.
+- Tighten the summary request wording in `handle_max_iterations()` so it asks for progress and remaining uncertainty, not a “final response”.
+- Avoid extra summary retries becoming the primary fix; if summary generation fails, the deterministic handoff text must still be enough.
+
+**Patterns to follow:**
+- `AIAgent._format_turn_completion_explanation(...)` and its tests for abnormal-turn explanations.
+- Existing post-response footer pattern in `agent/turn_finalizer.py`.
+
+**Test scenarios:**
+- `_handle_max_iterations()` returns `Done, everything is complete.` and the final visible response still contains the runtime-owned incomplete warning.
+- `_handle_max_iterations()` returns empty or raises, and the final visible response still explains budget exhaustion with resume guidance.
+- A normal short successful reply such as `Done.` does not receive the budget-exhaustion warning.
+- A budget-exhausted response includes a clear resume instruction such as “send continue” without promising automatic continuation.
+
+**Verification:** Tests assert the warning survives overclaiming model text and that healthy turns stay quiet.
+
+### U3. Preserve gateway, cron, and resume semantics
+
+**Goal:** Ensure downstream consumers do not treat budget exhaustion as success.
+
+**Requirements:** R4, R5, R6, R8
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `gateway/run.py`
+- `cron/scheduler.py`
+- `tests/gateway/test_restart_resume_pending.py`
+- `tests/gateway/test_run_progress_topics.py` or the closest existing gateway final-send test
+- Relevant cron scheduler test module if one already covers agent result failure handling
+
+**Approach:**
+- Prefer relying on `completed=False` and structured metadata so `gateway/run.py` and `cron/scheduler.py` need little or no behavior change.
+- Add a regression test proving `_should_clear_resume_pending_after_turn()` returns false for budget-exhausted results.
+- Only touch gateway final-send suppression if tests show a budget-exhausted explanation can be suppressed after interim streamed content.
+- Keep cron’s existing `completed=False` failure rule; add coverage for shared-budget exhaustion if current tests miss it.
+
+**Patterns to follow:**
+- `_should_clear_resume_pending_after_turn(...)` in `gateway/run.py`.
+- Cron result failure handling in `cron/scheduler.py`.
+- Existing stream final-delivery truth conventions in `gateway/stream_consumer.py`.
+
+**Test scenarios:**
+- Gateway resume-pending clearing rejects `{"completed": False, "budget_exhausted": True}`.
+- Gateway does not suppress the budget-exhausted explanation solely because interim commentary or tool-progress text was streamed earlier.
+- Cron treats a non-empty budget-exhausted final response as job failure because `completed=False`.
+- Existing successful final responses still clear resume markers and are not affected by budget metadata fields being absent.
+
+**Verification:** Gateway and cron tests demonstrate result metadata drives success/failure state, not message fluency.
+
+### U4. Carry budget metadata only through existing result consumers
+
+**Goal:** Keep downstream consumers honest without creating a new hook system.
+
+**Requirements:** R5, R7
+
+**Dependencies:** U1
+
+**Files:**
+- `agent/turn_finalizer.py`
+- `gateway/run.py`
+- `tests/gateway/test_restart_resume_pending.py`
+- Existing gateway event tests if they already cover `agent:end`
+
+**Approach:**
+- Keep the first PR centered on the `result` dict returned by `finalize_turn()`.
+- Add budget metadata to gateway `agent:end` only if implementation finds an existing observer that needs the signal there.
+- Do not add a new `on_turn_budget_exhausted` hook in the first PR.
+- Do not expand plugin hook signatures unless a current test or plugin consumer fails without the metadata.
+
+**Patterns to follow:**
+- Existing result dict assembly in `agent/turn_finalizer.py`.
+- Gateway `agent:end` event emission in `gateway/run.py`.
+
+**Test scenarios:**
+- Budget metadata is present in the finalizer result.
+- Gateway resume-pending and final-send decisions use `completed=False` rather than parsing warning text.
+- If `agent:end` is extended, it carries `completed=False` and `budget_exhausted=True` without changing response text.
+- Existing plugin hook tests remain unchanged unless implementation touches hook payloads.
+
+**Verification:** Result and gateway tests prove metadata is available to current consumers without introducing a new extension surface.
+
+### U5. Split or draft the startup context audit PR as observability-only
+
+**Goal:** Keep PR #49183 from masquerading as the budget-exhaustion fix.
+
+**Requirements:** R7
+
+**Dependencies:** None
+
+**Files:**
+- PR #49183 metadata/body
+- `agent/context_audit.py`
+- `agent/system_prompt.py`
+- `tests/agent/test_context_audit.py`
+- `tests/cli/test_context_audit_command.py`
+- `website/docs/user-guide/features/context-audit.md`
+
+**Approach:**
+- Draft or retitle PR #49183 so it is explicitly “startup context audit observability”, not a fix for iteration-budget exhaustion.
+- If the audit is still desired, keep it opt-in, redacted, and diagnostic only.
+- Do not couple the budget-exhaustion PR to context audit metrics, startup ordering, or automatic optimization recommendations.
+- If scope pressure is high, close #49183 and open a smaller observability proposal later.
+
+**Patterns to follow:**
+- Existing context-audit redaction and opt-in tests.
+- Hermes planning rule that startup context audits must separate visible prompt from hidden schema load.
+
+**Test scenarios:**
+- Test expectation: none for PR disposition itself; existing context-audit tests remain the quality gate if the observability PR survives.
+
+**Verification:** The active budget-exhaustion fix PR has no dependency on startup context audit code or configuration.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- Budget-exhausted finalization for `max_iterations` and `IterationBudget` exhaustion.
+- Runtime-owned incomplete wording and resume guidance.
+- Structured result metadata for downstream consumers.
+- Focused gateway, cron, and kanban regression tests.
+- PR disposition guidance for #49183.
+
+### Out of Scope
+
+- Startup prompt/context optimization as a prerequisite for this fix.
+- Automatic tool disabling or provider/model changes.
+- New auto-resume loops after budget exhaustion.
+- Broad rewrite of the conversation loop, stream consumer, or session store.
+- Durable task-state reconstruction beyond what the existing transcript and todo state already provide.
+
+### Deferred to Follow-Up Work
+
+- A richer handoff artifact writer if real usage shows the deterministic response is not enough.
+- A dedicated `on_turn_budget_exhausted` hook if real plugin consumers need it.
+- Context-audit observability as a separate opt-in feature if #49183 is still valuable.
+
+---
+
+## System-Wide Impact
+
+Interactive gateway users get an honest incomplete-state message instead of a plausible “done” summary. Cron and kanban workers keep treating exhausted turns as unsuccessful. Existing plugin behavior should remain unchanged in the first PR. The change reduces trust damage from rare exhaustion events without increasing startup cost or adding a second planning/order-book system.
+
+---
+
+## Risks & Mitigations
+
+- Risk: The warning becomes noisy for harmless turns that merely hit a configured low budget. Mitigation: fire only on explicit budget exhaustion and keep normal text responses untouched.
+- Risk: Marking budget exhaustion as failed could overstate interactive partial progress. Mitigation: use `completed=False` and `budget_exhausted=True` as the stable contract; only set `failed=True` where existing cron/kanban semantics require it.
+- Risk: Extension-surface work bloats a rare-edge fix. Mitigation: keep hook changes deferred unless an existing consumer needs budget metadata immediately.
+- Risk: Removing `_handle_max_iterations()` outright would lose useful progress context. Mitigation: demote it first rather than deleting it; deletion can be a follow-up if summaries remain harmful.
+
+---
+
+## Sources & Research
+
+- `agent/conversation_loop.py` — main loop budget gate and `_turn_exit_reason` assignment.
+- `agent/turn_finalizer.py` — post-loop finalization, kanban timeout handling, verifier footers, result dict assembly, plugin hooks.
+- `agent/chat_completion_helpers.py` — `_handle_max_iterations()` prompt and toolless summary call.
+- `agent/iteration_budget.py` — shared budget counters and `remaining` semantics.
+- `gateway/run.py` — final response normalization, resume-pending clearing, gateway `agent:end` emission.
+- `cron/scheduler.py` — cron job failure handling for `completed=False`.
+- `tests/run_agent/test_turn_completion_explainer.py` — existing abnormal-turn explanation pattern.
+- `tests/gateway/test_restart_resume_pending.py` — gateway recovery marker semantics.
+- `docs/plans/2026-06-09-003-fix-telegram-stream-overflow-continuations-plan.md` — prior narrow gateway/final-delivery plan style to mirror.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2269,6 +2269,31 @@ def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:
     return True
 
 
+def _should_suppress_normal_final_send(agent_result: dict, stream_consumer: Any) -> bool:
+    """Return True when streamed/previewed final delivery already reached chat.
+
+    Budget-exhausted turns are deliberately excluded even though they are not
+    marked ``failed``: the deterministic incomplete-state response is new
+    runtime-owned content and must not be suppressed just because earlier
+    interim text or token streaming reached the user.
+    """
+    if not isinstance(agent_result, dict):
+        return False
+    if agent_result.get("failed") or agent_result.get("budget_exhausted"):
+        return False
+
+    final_response = agent_result.get("final_response") or ""
+    is_empty_sentinel = not final_response or final_response == "(empty)"
+    transformed = bool(agent_result.get("response_transformed"))
+    if is_empty_sentinel or transformed:
+        return False
+
+    streamed = bool(stream_consumer and getattr(stream_consumer, "final_response_sent", False))
+    previewed = bool(agent_result.get("response_previewed"))
+    content_delivered = bool(stream_consumer and getattr(stream_consumer, "final_content_delivered", False))
+    return streamed or previewed or content_delivered
+
+
 def _preserve_queued_followup_history_offset(
     current_result: dict,
     followup_result: dict,
@@ -16575,12 +16600,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 pass
                         except Exception as e:
                             logger.debug("Stream consumer wait before queued message failed: %s", e)
-                    _previewed = bool(result.get("response_previewed"))
-                    _already_streamed = bool(
-                        (_sc and getattr(_sc, "final_response_sent", False))
-                        or _previewed
-                        or (_sc and getattr(_sc, "final_content_delivered", False))
-                    )
+                    _already_streamed = _should_suppress_normal_final_send(result, _sc)
                     first_response = result.get("final_response", "")
                     if first_response and not _already_streamed:
                         try:
@@ -16737,9 +16757,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # If streaming already delivered the response, mark it so the
         # caller's send() is skipped (avoiding duplicate messages).
-        # BUT: never suppress delivery when the agent failed — the error
-        # message is new content the user hasn't seen, and it must reach
-        # them even if streaming had sent earlier partial output.
+        # BUT: never suppress delivery when the agent failed or exhausted its
+        # iteration budget — the error/incomplete-state message is new content
+        # the user hasn't seen, and it must reach them even if streaming had
+        # sent earlier partial output.
         #
         # Also never suppress when the final response is "(empty)" — this
         # means the model failed to produce content after tool calls (common
@@ -16749,32 +16770,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # final answer.  Suppressing delivery here leaves the user staring
         # at silence.  (#10xxx — "agent stops after web search")
         _sc = stream_consumer_holder[0]
-        if isinstance(response, dict) and not response.get("failed"):
-            _final = response.get("final_response") or ""
-            _is_empty_sentinel = not _final or _final == "(empty)"
+        if _should_suppress_normal_final_send(response, _sc):
             _streamed = bool(
                 _sc and getattr(_sc, "final_response_sent", False)
             )
-            # response_previewed means the interim_assistant_callback already
-            # sent the final text via the adapter (non-streaming path).
             _previewed = bool(response.get("response_previewed"))
             _content_delivered = bool(
                 _sc and getattr(_sc, "final_content_delivered", False)
             )
-            # Plugin hooks (e.g. transform_llm_output) may have appended content
-            # after streaming finished — when the response was transformed, always
-            # send the final version so the appended content reaches the client.
+            logger.info(
+                "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
+                session_key or "?",
+                _streamed,
+                _previewed,
+                _content_delivered,
+            )
+            response["already_sent"] = True
+        elif isinstance(response, dict) and not response.get("failed") and not response.get("budget_exhausted"):
+            _final = response.get("final_response") or ""
+            _is_empty_sentinel = not _final or _final == "(empty)"
             _transformed = bool(response.get("response_transformed"))
-            if not _is_empty_sentinel and not _transformed and (_streamed or _previewed or _content_delivered):
-                logger.info(
-                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
-                    session_key or "?",
-                    _streamed,
-                    _previewed,
-                    _content_delivered,
-                )
-                response["already_sent"] = True
-            elif not _is_empty_sentinel and _transformed and _sc is not None:
+            if not _is_empty_sentinel and _transformed and _sc is not None:
                 # Plugin hooks transformed the response after streaming — edit the
                 # existing streamed message instead of sending a duplicate.
                 _sc_msg_id = _sc.message_id

--- a/run_agent.py
+++ b/run_agent.py
@@ -2746,7 +2746,7 @@ class AIAgent:
                 + "the request was interrupted mid-call before a reply was "
                 "received. Send `continue` to retry."
             )
-        if reason == "budget_exhausted":
+        if reason == "budget_exhausted" or reason.startswith("iteration_budget_exhausted"):
             return (
                 prefix
                 + "the per-turn iteration/cost budget was exhausted before a "

--- a/tests/agent/test_turn_finalizer_budget_exhaustion.py
+++ b/tests/agent/test_turn_finalizer_budget_exhaustion.py
@@ -1,0 +1,180 @@
+"""Regression tests for budget-exhausted turn finalization."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from agent.iteration_budget import IterationBudget
+from agent.turn_finalizer import finalize_turn
+from run_agent import AIAgent
+
+
+class FakeAgent:
+    def __init__(self, *, max_iterations=10, budget_max=10, budget_used=0, summary="progress"):
+        self.max_iterations = max_iterations
+        self.iteration_budget = IterationBudget(budget_max)
+        for _ in range(budget_used):
+            assert self.iteration_budget.consume()
+        self.summary = summary
+        self.quiet_mode = True
+        self.model = "test/model"
+        self.session_id = "session-1"
+        self.provider = "test-provider"
+        self.base_url = "https://example.invalid"
+        self.session_input_tokens = 0
+        self.session_output_tokens = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.session_cost_status = "unknown"
+        self.session_cost_source = "none"
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self._tool_guardrail_halt_decision = None
+        self._response_was_previewed = False
+        self._interrupt_message = None
+        self._stream_callback = Mock()
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self.valid_tool_names = []
+        self._turn_failed_file_mutations = {}
+
+        self._emit_status = Mock()
+        self._safe_print = Mock()
+        self._save_trajectory = Mock()
+        self._cleanup_task_resources = Mock()
+        self._drop_trailing_empty_response_scaffolding = Mock()
+        self._persist_session = Mock()
+        self.clear_interrupt = Mock()
+        self._sync_external_memory_for_turn = Mock()
+        self._spawn_background_review = Mock()
+
+    def _handle_max_iterations(self, messages, api_call_count):
+        return self.summary
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return True
+
+    @staticmethod
+    def _format_turn_completion_explanation(reason):
+        return AIAgent._format_turn_completion_explanation(reason)
+
+    def _drain_pending_steer(self):
+        return None
+
+
+def _finalize(agent, *, final_response=None, api_call_count=0, messages=None, reason="loop_exited"):
+    return finalize_turn(
+        agent,
+        final_response=final_response,
+        api_call_count=api_call_count,
+        interrupted=False,
+        failed=False,
+        messages=messages or [{"role": "user", "content": "do work"}],
+        conversation_history=[],
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="do work",
+        original_user_message="do work",
+        _should_review_memory=False,
+        _turn_exit_reason=reason,
+    )
+
+
+def test_max_iterations_exhaustion_returns_incomplete_metadata_and_warning():
+    agent = FakeAgent(max_iterations=2, budget_max=10, budget_used=1, summary="Done, everything is complete.")
+
+    result = _finalize(agent, api_call_count=2)
+
+    assert result["completed"] is False
+    assert result["budget_exhausted"] is True
+    assert result["failure_reason"] == "budget_exhausted"
+    assert result["turn_exit_reason"] == "max_iterations_reached(2/2)"
+    assert result["budget_used"] == 1
+    assert result["budget_max"] == 10
+    assert "Iteration budget exhausted" in result["final_response"]
+    assert "not verified complete" in result["final_response"]
+    assert "Progress summary from the model" in result["final_response"]
+    assert "Done, everything is complete." in result["final_response"]
+
+
+def test_shared_iteration_budget_exhaustion_is_not_success_when_api_calls_below_max():
+    agent = FakeAgent(max_iterations=10, budget_max=3, budget_used=3, summary="I think this is done.")
+
+    result = _finalize(agent, api_call_count=2)
+
+    assert result["completed"] is False
+    assert result["budget_exhausted"] is True
+    assert result["failure_reason"] == "budget_exhausted"
+    assert result["turn_exit_reason"] == "iteration_budget_exhausted(3/3)"
+    assert result["budget_used"] == 3
+    assert result["budget_max"] == 3
+    assert "Iteration budget exhausted" in result["final_response"]
+    assert "I think this is done." in result["final_response"]
+
+
+def test_budget_exhaustion_after_tool_result_does_not_look_successful():
+    agent = FakeAgent(max_iterations=10, budget_max=1, budget_used=1, summary="Done.")
+    messages = [
+        {"role": "user", "content": "patch it"},
+        {"role": "assistant", "tool_calls": [{"function": {"name": "patch"}}]},
+        {"role": "tool", "content": "patched"},
+    ]
+
+    result = _finalize(agent, api_call_count=1, messages=messages)
+
+    assert result["completed"] is False
+    assert result["budget_exhausted"] is True
+    assert result["final_response"].startswith("⚠️ Iteration budget exhausted")
+    assert "not verified complete" in result["final_response"]
+
+
+def test_budget_warning_survives_empty_or_failed_summary_generation():
+    class RaisingAgent(FakeAgent):
+        def _handle_max_iterations(self, messages, api_call_count):
+            raise RuntimeError("summary broke")
+
+    agent = RaisingAgent(max_iterations=1, budget_max=1, budget_used=1)
+
+    result = _finalize(agent, api_call_count=1)
+
+    assert result["completed"] is False
+    assert result["budget_exhausted"] is True
+    assert "Iteration budget exhausted" in result["final_response"]
+    assert "summary broke" not in result["final_response"]
+    assert "send `continue`" in result["final_response"].lower()
+
+
+def test_budget_warning_survives_transform_hook_overclaim(monkeypatch):
+    agent = FakeAgent(max_iterations=1, budget_max=1, budget_used=1, summary="progress")
+
+    def fake_invoke_hook(name, **kwargs):
+        if name == "transform_llm_output":
+            return ["Done, everything is complete."]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+    result = _finalize(agent, api_call_count=1)
+
+    assert result["completed"] is False
+    assert result["budget_exhausted"] is True
+    assert result["final_response"].startswith("⚠️ Iteration budget exhausted")
+    assert "not verified complete" in result["final_response"]
+    assert "Progress summary from the model" in result["final_response"]
+    assert "Done, everything is complete." in result["final_response"]
+
+
+def test_non_budget_success_does_not_get_warning():
+    agent = FakeAgent(max_iterations=10, budget_max=10, budget_used=1)
+
+    result = _finalize(agent, final_response="Done.", api_call_count=1, reason="text_response(finish_reason=stop)")
+
+    assert result["completed"] is True
+    assert result["budget_exhausted"] is False
+    assert result["final_response"] == "Done."

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -912,6 +912,44 @@ class TestRunJobSessionPersistence:
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
 
+    def test_run_job_treats_budget_exhaustion_as_failure(self, tmp_path):
+        job = {
+            "id": "budget-job",
+            "name": "budget",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "completed": False,
+                "budget_exhausted": True,
+                "final_response": "⚠️ Iteration budget exhausted — task is not verified complete.",
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is False
+        assert final_response == ""
+        assert "RuntimeError" in error
+        assert "Iteration budget exhausted" in error
+        assert "(FAILED)" in output
+
     def test_run_job_titles_cron_session_from_job_not_important_hint(self, tmp_path):
         # The cron session's first message is the injected "[IMPORTANT: …]"
         # hint, which used to surface as the sidebar/history row label. run_job

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -41,6 +41,7 @@ from gateway.run import (
     _is_fresh_gateway_interruption,
     _last_transcript_timestamp,
     _should_clear_resume_pending_after_turn,
+    _should_suppress_normal_final_send,
 )
 from gateway.session import SessionEntry, SessionSource, SessionStore
 from tests.gateway.restart_test_helpers import (
@@ -66,9 +67,29 @@ def test_resume_pending_is_cleared_only_after_successful_turn():
     assert _should_clear_resume_pending_after_turn({"completed": True}) is True
     assert _should_clear_resume_pending_after_turn({"interrupted": True}) is False
     assert _should_clear_resume_pending_after_turn({"completed": False}) is False
+    assert _should_clear_resume_pending_after_turn(
+        {"completed": False, "budget_exhausted": True, "final_response": "progress"}
+    ) is False
     assert _should_clear_resume_pending_after_turn({"failed": True}) is False
     assert _should_clear_resume_pending_after_turn({"partial": True}) is False
     assert _should_clear_resume_pending_after_turn({"error": "boom"}) is False
+
+
+def test_budget_exhausted_final_response_is_not_suppressed_after_stream_preview():
+    stream_consumer = MagicMock(final_response_sent=True, final_content_delivered=True)
+
+    assert _should_suppress_normal_final_send(
+        {"final_response": "Done.", "response_previewed": True}, stream_consumer
+    ) is True
+    assert _should_suppress_normal_final_send(
+        {
+            "completed": False,
+            "budget_exhausted": True,
+            "final_response": "⚠️ Iteration budget exhausted — task is not verified complete.",
+            "response_previewed": True,
+        },
+        stream_consumer,
+    ) is False
 
 
 def _make_source(platform=Platform.TELEGRAM, chat_id="123", user_id="u1"):

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -99,6 +99,14 @@ def test_explanation_for_max_iterations_reached_prefix_match():
     assert "iteration" in out.lower()
 
 
+def test_explanation_for_iteration_budget_exhausted_prefix_match():
+    out = AIAgent._format_turn_completion_explanation(
+        "iteration_budget_exhausted(3/3)"
+    )
+    assert "iteration" in out.lower()
+    assert "continue" in out.lower()
+
+
 def test_explanation_for_all_retries_exhausted():
     out = AIAgent._format_turn_completion_explanation(
         "all_retries_exhausted_no_response"


### PR DESCRIPTION
## Summary

Budget-exhausted turns now surface as visibly incomplete instead of letting a fluent model summary pass as a verified final answer. Both `max_iterations` and shared `IterationBudget` exhaustion return `completed=false` with structured budget metadata, and the final visible response is wrapped in runtime-owned wording that says the task is not verified complete and can be resumed with `continue`.

This keeps downstream behavior honest without introducing startup-context optimization or a new resume system: gateway resume markers stay uncleared, cron treats the run as failed, and final-send suppression no longer hides the deterministic incomplete-state warning after streamed/interim content.

## Design notes

| Concern | Decision |
|---|---|
| Completion truth | `budget_exhausted=true`, `failure_reason="budget_exhausted"`, `budget_used`, and `budget_max` are emitted on every finalizer result. |
| User-facing response | Model-authored summary text is demoted under “Progress summary from the model”; runtime wording remains the completion authority. |
| Gateway delivery | Budget-exhausted responses bypass normal “already streamed” suppression so the warning reaches chat even after interim content. |
| Scope discipline | The budget fix is independent of startup context audit code/config and does not add provider/model or auto-resume behavior. |

## Tests

- `python -m pytest tests/agent/test_turn_finalizer_budget_exhaustion.py tests/run_agent/test_turn_completion_explainer.py tests/gateway/test_restart_resume_pending.py tests/cron/test_scheduler.py -q -o 'addopts='`
- `python -m py_compile agent/turn_finalizer.py agent/chat_completion_helpers.py gateway/run.py run_agent.py tests/agent/test_turn_finalizer_budget_exhaustion.py tests/run_agent/test_turn_completion_explainer.py tests/gateway/test_restart_resume_pending.py tests/cron/test_scheduler.py`

## Post-Deploy Monitoring & Validation

- **Validation window:** first 24 hours after deployment; owner: Hermes ops.
- **Healthy signals:** exhausted turns include `budget_exhausted=true`, `completed=false`, and user-visible text starting with `Iteration budget exhausted`; cron runs with exhausted budgets record failure rather than `ok`.
- **Log checks:** search gateway/agent logs for `iteration_budget_exhausted`, `max_iterations_reached`, `budget_exhausted`, and `Suppressing normal final send` around exhausted turns.
- **Failure signals:** budget-exhausted turns marked `completed=true`, cron jobs marked successful after exhausted turns, or chat users receiving only interim/tool-progress text without the deterministic warning.
- **Rollback trigger:** any increase in normal successful turns receiving budget warnings, or plugin/gateway delivery errors caused by the new result metadata.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![gpt--5.5](https://img.shields.io/badge/gpt--5.5-000000)
