### PR TITLE
fix(tools): never let a model whitelist strip the prompt / source images

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -106,6 +106,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "275304381+hakanpak@users.noreply.github.com": "hakanpak",
     "ludo.galabru@solana.org": "lgalabru",
     "johnjacobkenny@users.noreply.github.com": "johnjacobkenny",
     "chanyoung.kim@nota.ai": "channkim",

--- a/tests/tools/test_image_generation_image_to_image.py
+++ b/tests/tools/test_image_generation_image_to_image.py
@@ -79,6 +79,40 @@ class TestFalEditPayload:
         assert FAL_MODELS["fal-ai/nano-banana-pro"].get("edit_endpoint")
 
 
+class TestMandatoryKeysSurviveWhitelist:
+    """A model whose whitelist forgets the mandatory keys must not produce a
+    request with the prompt / source images silently stripped."""
+
+    _SIZES = {"square": "1024x1024", "landscape": "1536x1024", "portrait": "1024x1536"}
+
+    def test_edit_keeps_prompt_and_image_urls(self, monkeypatch):
+        from tools import image_generation_tool as t
+
+        fake = {
+            "size_style": "image_size_preset",
+            "sizes": self._SIZES,
+            "edit_supports": {"seed"},  # intentionally omits prompt + image_urls
+        }
+        monkeypatch.setitem(t.FAL_MODELS, "test/edit-model", fake)
+        payload = t._build_fal_edit_payload(
+            "test/edit-model", "make it blue", ["https://x/y.png"], "square",
+        )
+        assert payload["prompt"] == "make it blue"
+        assert payload["image_urls"] == ["https://x/y.png"]
+
+    def test_text_keeps_prompt(self, monkeypatch):
+        from tools import image_generation_tool as t
+
+        fake = {
+            "size_style": "image_size_preset",
+            "sizes": self._SIZES,
+            "supports": {"seed"},  # intentionally omits prompt
+        }
+        monkeypatch.setitem(t.FAL_MODELS, "test/text-model", fake)
+        payload = t._build_fal_payload("test/text-model", "a cat", aspect_ratio="square")
+        assert payload["prompt"] == "a cat"
+
+
 class TestFalRouting:
     def _patch_submit(self, monkeypatch, image_tool, capture: dict):
         class _Handler:

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -607,7 +607,13 @@ def _build_fal_payload(
                 payload[k] = v
 
     supports = meta["supports"]
-    return {k: v for k, v in payload.items() if k in supports}
+    # ``prompt`` is required by every FAL text-to-image endpoint; keep it even
+    # if a model's ``supports`` whitelist omits it, so a missing whitelist entry
+    # can't silently strip the prompt and send an empty request.
+    return {
+        k: v for k, v in payload.items()
+        if k in supports or k == "prompt"
+    }
 
 
 def _build_fal_edit_payload(
@@ -656,7 +662,15 @@ def _build_fal_edit_payload(
             if v is not None:
                 payload[k] = v
 
-    return {k: v for k, v in payload.items() if k in edit_supports}
+    # ``prompt`` and ``image_urls`` are required by every FAL edit endpoint;
+    # keep them even if a model's ``edit_supports`` whitelist omits them, so a
+    # missing whitelist entry can't silently drop the prompt or the source
+    # images and send a broken edit request.
+    _required = {"prompt", "image_urls"}
+    return {
+        k: v for k, v in payload.items()
+        if k in edit_supports or k in _required
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
FAL image payload builders now always keep the mandatory request keys, so a model whose `supports`/`edit_supports` whitelist forgets one can never silently strip the prompt or the source images.

Root cause: `_build_fal_payload` / `_build_fal_edit_payload` assemble the request, then filter it down to the model's whitelist (`tools/image_generation_tool.py:610,659`). That filter also covers `prompt` (text path) and `prompt` + `image_urls` (edit path) — keys every FAL endpoint requires. All 7 current model configs happen to list them, so it works today; a single missing entry would send a request with no prompt or no source image — a broken generation, no error raised.

Salvage of #49282 by @hakanpak, cherry-picked onto current `main` with authorship preserved.

## Audit (the "check all other routes" part)
Confirmed this is the entire surface for the bug class — the two FAL builders are the only whitelist-filtered payload paths:
- `_build_fal_payload` (FAL text-to-image) — fixed
- `_build_fal_edit_payload` (FAL image-to-image / edit) — fixed
- `tools/video_generation_tool.py` (text-to-video, image-to-video, refs) — immune by construction: builds kwargs explicitly, drops only `None`, passes `prompt` as a required positional with an upfront guard. No whitelist filter.
- `plugins/image_gen/fal/` — delegates to the two core builders above; no own filter.
- `plugins/image_gen/krea/` — builds payload explicitly; no whitelist filter.
- `tools/fal_common.py` — pure transport; no payload filtering.

## Changes
- `tools/image_generation_tool.py`: keep `prompt` in the text builder and `prompt` + `image_urls` in the edit builder regardless of the whitelist — the filter can now only drop optional knobs.
- `tests/tools/test_image_generation_image_to_image.py`: a model whose whitelist omits the mandatory keys still gets `prompt` (and `image_urls` for edits) in both builders.
- `scripts/release.py`: AUTHOR_MAP entry for @hakanpak.

## Validation
| | Before | After |
|---|---|---|
| model whitelist omits `prompt` | request sent with no prompt | `prompt` kept |
| edit whitelist omits `image_urls` | request sent with no source image | `image_urls` kept |
| `tests/tools/test_image_generation_image_to_image.py` | 15 pass | 17 pass |

## Infographic

![fal-payload-mandatory-keys](https://v3b.fal.media/files/b/0a9efae7/Ybo_6V2zMgUUFi7mslwX__JpO5Ti6E.png)
