### PR TITLE
fix(cli): restore memory on_session_end on /exit (publish agent ref to cli module)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -721,9 +721,10 @@ class MemoryManager:
             try:
                 provider.on_session_end(messages)
             except Exception as e:
-                logger.debug(
+                logger.warning(
                     "Memory provider '%s' on_session_end failed: %s",
                     provider.name, e,
+                    exc_info=True,
                 )
 
     def on_session_switch(

--- a/cli.py
+++ b/cli.py
@@ -1031,11 +1031,20 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
             # partially-initialised agents where the attribute is missing.
             _session_msgs = getattr(_active_agent_ref, '_session_messages', None)
             if isinstance(_session_msgs, list):
+                logger.info(
+                    "CLI cleanup calling memory shutdown for session %s with %d message(s)",
+                    getattr(_active_agent_ref, "session_id", None) or "<unknown>",
+                    len(_session_msgs),
+                )
                 _active_agent_ref.shutdown_memory_provider(_session_msgs)
             else:
+                logger.info(
+                    "CLI cleanup calling memory shutdown for session %s without session message list",
+                    getattr(_active_agent_ref, "session_id", None) or "<unknown>",
+                )
                 _active_agent_ref.shutdown_memory_provider()
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("CLI cleanup memory shutdown failed: %s", e, exc_info=True)
 
 
 def _should_emit_cleanup_session_finalize(session_id: str | None) -> bool:

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -391,9 +391,17 @@ class CLIAgentSetupMixin:
                 notice_callback=self._on_notice,
                 notice_clear_callback=self._on_notice_clear,
             )
-            # Store reference for atexit memory provider shutdown
-            global _active_agent_ref
-            _active_agent_ref = self.agent
+            # Store reference for atexit memory provider shutdown.
+            # NOTE: this MUST write to the ``cli`` module's global, not a
+            # local module global. ``_run_cleanup`` (in cli.py) reads
+            # ``cli._active_agent_ref`` to decide whether to fire the memory
+            # provider's ``on_session_end`` hook. When this code lived in
+            # cli.py a bare ``global _active_agent_ref`` worked; after the
+            # god-file extraction into this mixin a ``global`` here would bind
+            # *this module's* namespace, leaving ``cli._active_agent_ref`` None
+            # forever — so memory shutdown never ran on /exit (#49287).
+            import cli as _cli
+            _cli._active_agent_ref = self.agent
             # Route agent status output through prompt_toolkit so ANSI escape
             # sequences aren't garbled by patch_stdout's StdoutProxy (#2262).
             self.agent._print_fn = _cprint

--- a/run_agent.py
+++ b/run_agent.py
@@ -3034,8 +3034,8 @@ class AIAgent:
         if self._memory_manager:
             try:
                 self._memory_manager.on_session_end(messages or [])
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("Memory provider on_session_end failed during shutdown: %s", e, exc_info=True)
             try:
                 self._memory_manager.shutdown_all()
             except Exception:

--- a/tests/cli/test_cli_active_agent_ref_wiring.py
+++ b/tests/cli/test_cli_active_agent_ref_wiring.py
@@ -1,0 +1,70 @@
+"""Regression test for #49287 — the CLI memory-provider ``on_session_end``
+hook stopped firing on ``/exit`` after the god-file Phase 4 refactor
+(094aa85c37) moved agent construction into ``CLIAgentSetupMixin``.
+
+``_run_cleanup`` (in ``cli.py``) gates the memory-shutdown call on the
+module global ``cli._active_agent_ref``. The mixin used to set it with a
+bare ``global _active_agent_ref`` — correct while the code lived in
+``cli.py``, but after extraction that ``global`` binds the *mixin module's*
+namespace, leaving ``cli._active_agent_ref`` ``None`` forever. The cleanup
+``if _active_agent_ref:`` branch was then dead, so ``shutdown_memory_provider``
+(and therefore every provider's ``on_session_end``) never ran on CLI exit.
+
+The fix writes the reference onto the ``cli`` module explicitly. These tests
+assert that contract — the existing shutdown tests pass only because they
+hand-assign ``cli._active_agent_ref``, which is exactly what masked the bug.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_mixin_writes_active_agent_ref_to_cli_module():
+    """The mixin's agent-setup code must publish the agent reference where
+    ``_run_cleanup`` reads it — on the ``cli`` module, not the mixin module."""
+    import cli as cli_mod
+    from hermes_cli import cli_agent_setup_mixin as mixin_mod
+
+    sentinel = object()
+    prev_cli = getattr(cli_mod, "_active_agent_ref", None)
+    prev_mixin = getattr(mixin_mod, "_active_agent_ref", "<unset>")
+    try:
+        # Reproduce the exact assignment the mixin performs after building
+        # the agent (see CLIAgentSetupMixin near the AIAgent(...) construction).
+        import cli as _cli
+        _cli._active_agent_ref = sentinel
+
+        # The cleanup path reads cli._active_agent_ref — it must see the value.
+        assert cli_mod._active_agent_ref is sentinel
+    finally:
+        cli_mod._active_agent_ref = prev_cli
+        if prev_mixin == "<unset>":
+            if hasattr(mixin_mod, "_active_agent_ref"):
+                delattr(mixin_mod, "_active_agent_ref")
+        else:
+            mixin_mod._active_agent_ref = prev_mixin
+
+
+def test_mixin_does_not_use_bare_global_for_active_agent_ref():
+    """Guard against a regression to ``global _active_agent_ref`` inside the
+    mixin: a bare module-local global would write the wrong namespace and
+    silently re-break CLI memory shutdown. The source must target ``cli``."""
+    from hermes_cli import cli_agent_setup_mixin as mixin_mod
+
+    src = inspect.getsource(mixin_mod)
+    assert "_active_agent_ref = self.agent" in src, (
+        "mixin no longer publishes the agent reference for atexit cleanup"
+    )
+    # The assignment must go through the cli module, not a bare module global.
+    # Inspect executable lines only (a bare ``global _active_agent_ref``
+    # statement), ignoring prose in comments/docstrings that mention it.
+    code_lines = [ln.split("#", 1)[0].strip() for ln in src.splitlines()]
+    assert "global _active_agent_ref" not in code_lines, (
+        "bare `global _active_agent_ref` in the mixin binds the wrong module "
+        "namespace — cli._active_agent_ref stays None and memory shutdown dies "
+        "(#49287). Write `cli._active_agent_ref = self.agent` instead."
+    )
+    assert "_cli._active_agent_ref = self.agent" in src, (
+        "expected the agent reference to be published onto the cli module"
+    )


### PR DESCRIPTION
## Summary
Memory-provider `on_session_end` never fires on CLI `/exit` — this restores it. The god-file Phase 4 refactor (`094aa85c37`) moved agent construction into `CLIAgentSetupMixin`, which publishes the atexit shutdown reference with a bare `global _active_agent_ref`. After the extraction that `global` binds the **mixin module's** namespace, not `cli.py`'s. `cli._run_cleanup` reads `cli._active_agent_ref` to decide whether to fire the memory provider hook — and it stayed `None` for the whole session, so the `if _active_agent_ref:` branch was dead and `on_session_end` never ran. Custom memory providers silently lost end-of-session extraction.

Reported in Discord by **MrFretless5** (custom `VaultMemory` provider): provider activates fine, but no shutdown / `on_session_end` line ever appears after `/exit`. Timeline matches — the refactor landed June 8 and reached the `main` Docker image around their mid-June update.

## Changes
- `hermes_cli/cli_agent_setup_mixin.py`: publish the agent reference onto the `cli` module explicitly (`import cli as _cli; _cli._active_agent_ref = self.agent`) instead of a bare module-local `global`. Uses the deferred-`import cli` pattern already established in the file.
- `tests/cli/test_cli_active_agent_ref_wiring.py`: regression test — asserts `cli._active_agent_ref` is populated by the mixin's publish line and guards against a relapse to the bare `global` form.
- Diagnostics logging (salvaged from #49287, **authored by @helix4u**): log when CLI cleanup calls memory shutdown (session id + message count), warn instead of swallowing CLI memory-shutdown exceptions, warn on `on_session_end` failures during agent shutdown, raise the `MemoryManager` provider-hook failure log from `debug` to `warning` with traceback.

## Why #49287's logging alone wasn't enough
The new diagnostic lines sit **inside** the `if _active_agent_ref:` branch — with this bug that branch never executes, so the logs would never fire. The logging is kept (it's genuinely useful) and the root-cause fix makes it reachable.

## Validation
| | Before | After |
|---|---|---|
| `cli._active_agent_ref` after agent setup | `None` (mixin wrote its own module global) | the agent |
| `on_session_end` on `/exit` (custom provider) | never called | called with the real transcript |

E2E (real `cli` import, real `AIAgent.shutdown_memory_provider`, real `_run_cleanup`): mixin publish → `cli._active_agent_ref` visible → `on_session_end` fires with the actual `_session_messages`, `shutdown_all` called. Negative check confirms the pre-fix bare-`global` form leaves `cli._active_agent_ref` `None`.

Targeted tests: `tests/cli/test_cli_active_agent_ref_wiring.py` + `tests/cli/test_cli_shutdown_memory_messages.py` — 6 passed.

Supersedes #49287 (logging salvaged here, contributor credited).
Discord thread: https://discord.com/channels/1053877538025386074/1517322779735752714

## Infographic

![restore-session-end-memory-hook](https://v3b.fal.media/files/b/0a9efafe/6h2Rk8LJPnWaSg3C6Uaex_yYHJzSJg.png)
