### PR TITLE
feat(email): allow IMAP/SMTP login username to differ from the From address

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -9,7 +9,9 @@ Environment variables:
     EMAIL_IMAP_PORT     — IMAP server port (default: 993)
     EMAIL_SMTP_HOST     — SMTP server host (e.g., smtp.gmail.com)
     EMAIL_SMTP_PORT     — SMTP server port (default: 587)
-    EMAIL_ADDRESS       — Email address for the agent
+    EMAIL_ADDRESS       — Email address for the agent (used as the From address)
+    EMAIL_IMAP_USERNAME — IMAP login username (default: EMAIL_ADDRESS)
+    EMAIL_SMTP_USERNAME — SMTP login username (default: EMAIL_ADDRESS)
     EMAIL_PASSWORD      — Email password or app-specific password
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
     EMAIL_ALLOWED_USERS — Comma-separated list of allowed sender addresses
@@ -308,6 +310,12 @@ class EmailAdapter(BasePlatformAdapter):
 
         self._address = os.getenv("EMAIL_ADDRESS", "")
         self._password = os.getenv("EMAIL_PASSWORD", "")
+        # Some mail servers expect a login username distinct from the From
+        # address — e.g. a short-form Dovecot/IMAP login, a Google Workspace
+        # mailbox, or a catch-all setup. Both default to EMAIL_ADDRESS so
+        # existing deployments are unaffected.
+        self._imap_username = os.getenv("EMAIL_IMAP_USERNAME", "") or self._address
+        self._smtp_username = os.getenv("EMAIL_SMTP_USERNAME", "") or self._address
         self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
         self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
@@ -398,7 +406,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-            imap.login(self._address, self._password)
+            imap.login(self._imap_username, self._password)
             _send_imap_id(imap)
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
@@ -418,7 +426,7 @@ class EmailAdapter(BasePlatformAdapter):
             # Test SMTP connection
             smtp = self._connect_smtp()
             try:
-                smtp.login(self._address, self._password)
+                smtp.login(self._smtp_username, self._password)
             finally:
                 smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
@@ -468,7 +476,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             try:
-                imap.login(self._address, self._password)
+                imap.login(self._imap_username, self._password)
                 _send_imap_id(imap)
                 imap.select("INBOX")
 
@@ -658,7 +666,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         smtp = self._connect_smtp()
         try:
-            smtp.login(self._address, self._password)
+            smtp.login(self._smtp_username, self._password)
             smtp.send_message(msg)
         finally:
             try:
@@ -784,7 +792,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         smtp = self._connect_smtp()
         try:
-            smtp.login(self._address, self._password)
+            smtp.login(self._smtp_username, self._password)
             smtp.send_message(msg)
         finally:
             try:
@@ -862,7 +870,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         smtp = self._connect_smtp()
         try:
-            smtp.login(self._address, self._password)
+            smtp.login(self._smtp_username, self._password)
             smtp.send_message(msg)
         finally:
             try:

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1383,5 +1383,77 @@ class TestConnectSmtp(unittest.TestCase):
         self.assertIs(_socket.getaddrinfo, original_getaddrinfo)
 
 
+class TestLoginUsernameSeparation(unittest.TestCase):
+    """IMAP/SMTP login username can differ from the From address.
+
+    Some mail servers expect a login username distinct from the email
+    address used in the From header — e.g. a short-form Dovecot/IMAP login,
+    a Google Workspace mailbox, or a catch-all setup. EMAIL_IMAP_USERNAME /
+    EMAIL_SMTP_USERNAME override the login username while the From header
+    stays EMAIL_ADDRESS. Both default to EMAIL_ADDRESS so existing
+    deployments are unaffected.
+    """
+
+    def _make_adapter(self, extra_env=None):
+        from gateway.config import PlatformConfig
+        env = {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }
+        if extra_env:
+            env.update(extra_env)
+        # clear=True so an ambient EMAIL_*_USERNAME can't leak into the
+        # "defaults" assertions.
+        with patch.dict(os.environ, env, clear=True):
+            from gateway.platforms.email import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def test_usernames_default_to_address_when_unset(self):
+        """Unset overrides → login username equals the From address."""
+        adapter = self._make_adapter()
+        self.assertEqual(adapter._imap_username, "hermes@test.com")
+        self.assertEqual(adapter._smtp_username, "hermes@test.com")
+
+    def test_username_overrides_applied(self):
+        """Set overrides → usernames take the override; From address unchanged."""
+        adapter = self._make_adapter({
+            "EMAIL_IMAP_USERNAME": "imapuser",
+            "EMAIL_SMTP_USERNAME": "smtpuser",
+        })
+        self.assertEqual(adapter._imap_username, "imapuser")
+        self.assertEqual(adapter._smtp_username, "smtpuser")
+        self.assertEqual(adapter._address, "hermes@test.com")
+
+    def test_imap_polling_uses_imap_username(self):
+        """The IMAP polling path must log in with EMAIL_IMAP_USERNAME, not the address."""
+        adapter = self._make_adapter({"EMAIL_IMAP_USERNAME": "imapuser"})
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            adapter._fetch_new_messages()
+
+        mock_imap.login.assert_called_once_with("imapuser", "secret")
+
+    def test_send_logs_in_as_smtp_username_but_from_is_address(self):
+        """A sent email authenticates as EMAIL_SMTP_USERNAME but From = EMAIL_ADDRESS."""
+        import asyncio
+        adapter = self._make_adapter({"EMAIL_SMTP_USERNAME": "smtpuser"})
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = asyncio.run(adapter.send("user@test.com", "Hello"))
+
+        self.assertTrue(result.success)
+        mock_server.login.assert_called_once_with("smtpuser", "secret")
+        send_call = mock_server.send_message.call_args[0][0]
+        self.assertEqual(send_call["From"], "hermes@test.com")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The email adapter uses `EMAIL_ADDRESS` as **both** the From header and the IMAP/SMTP **login username**:

```python
imap.login(self._address, self._password)
smtp.login(self._address, self._password)
```

This breaks against any mail server that expects a login username distinct from the email address — which is common:

- **Dovecot** and many self-hosted / corporate servers authenticate with a short-form username (`alice`) while mail is addressed to `alice@example.com`.
- **Google Workspace / catch-all** setups where the SMTP auth identity differs from the From address.

On such servers the adapter fails with `AUTHENTICATIONFAILED` and there is no way to configure around it.

## Fix

Add two optional env vars, `EMAIL_IMAP_USERNAME` and `EMAIL_SMTP_USERNAME`, used at the six `imap.login()` / `smtp.login()` call sites. Both **default to `EMAIL_ADDRESS`**, so existing deployments are completely unaffected. The `From` header still uses `EMAIL_ADDRESS`, keeping login identity and From address cleanly separable.

## Backward compatibility

Fully backward-compatible by construction: when the new vars are unset, the login username is `EMAIL_ADDRESS` — identical to today. The existing `TestSendMethods` login assertions pass unchanged.

## Tests

Adds `TestLoginUsernameSeparation` to `tests/gateway/test_email.py`:

- usernames default to the From address when unset
- overrides are applied; the From address is unchanged
- the IMAP polling path logs in with `EMAIL_IMAP_USERNAME`
- a sent email authenticates as `EMAIL_SMTP_USERNAME` but its `From` header stays `EMAIL_ADDRESS`

```
python -m unittest tests.gateway.test_email   # 72 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
