### PR TITLE
fix(doctor): resolve effective terminal backend from config.yaml

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1391,6 +1391,19 @@ def run_doctor(args):
         check_info(f"Install for faster search: {_system_package_install_cmd('ripgrep')}")
     
     # Docker (optional)
+    # Bridge config.yaml's terminal.backend into TERMINAL_ENV so the backend
+    # reachability checks below reflect what the runtime actually resolves.
+    # A user who sets `terminal: {backend: docker}` in config.yaml with no env
+    # var would otherwise be diagnosed as the default "local" backend, so the
+    # docker/ssh/daytona checks would be silently skipped. This mirrors the
+    # canonical bridge already wired into the TUI launch and web_server paths.
+    try:
+        from hermes_cli.config import apply_terminal_config_to_env
+        apply_terminal_config_to_env()
+    except Exception:
+        # Never let a config read failure break the diagnostic; fall back to the
+        # env-only view, which is what the doctor did before this bridge.
+        pass
     terminal_env = os.getenv("TERMINAL_ENV", "local")
     try:
         from hermes_constants import is_container as _is_container

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1400,10 +1400,17 @@ def run_doctor(args):
     try:
         from hermes_cli.config import apply_terminal_config_to_env
         apply_terminal_config_to_env()
-    except Exception:
+    except Exception as exc:
         # Never let a config read failure break the diagnostic; fall back to the
-        # env-only view, which is what the doctor did before this bridge.
-        pass
+        # env-only view, which is what the doctor did before this bridge. Unlike
+        # the sibling TUI/dashboard bridges (which debug-log this), doctor has no
+        # logger and its whole job is surfacing diagnostics, so emit a lightweight
+        # warning so a regression (e.g. import/signature change) is visible rather
+        # than silently downgrading to the env-only backend view.
+        check_warn(
+            "Could not read terminal.backend from config.yaml",
+            f"({type(exc).__name__}: {exc}; using env-only TERMINAL_ENV)",
+        )
     terminal_env = os.getenv("TERMINAL_ENV", "local")
     try:
         from hermes_constants import is_container as _is_container

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -355,6 +355,75 @@ def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkey
     assert "docker not found (optional)" not in out
 
 
+def test_run_doctor_resolves_docker_backend_from_config_yaml(monkeypatch, tmp_path):
+    """doctor must honor config.yaml's `terminal.backend` when TERMINAL_ENV is unset.
+
+    Regression: the backend reachability checks keyed entirely off the
+    TERMINAL_ENV env var, so a user who selected the docker backend purely via
+    config.yaml (`terminal: {backend: docker}`) was diagnosed as the default
+    "local" backend. doctor then took the "(optional)" docker branch and never
+    emitted the required-daemon failure, silently hiding a misconfigured sandbox
+    for exactly the users it should warn. The fix bridges config.yaml into the
+    resolved backend via the canonical `apply_terminal_config_to_env` helper.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+
+    import yaml
+
+    (home / "config.yaml").write_text(
+        yaml.dump({"terminal": {"backend": "docker"}}), encoding="utf-8"
+    )
+
+    # The config bridge resolves via get_hermes_home(), which reads the
+    # HERMES_HOME env var — not the module-level doctor_mod.HERMES_HOME attr.
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    # Make docker appear absent so the docker branch resolves to a definite
+    # outcome: required-failure (after fix) vs optional-warn (before fix).
+    real_which = doctor_mod.shutil.which
+
+    def fake_which(cmd):
+        if cmd == "docker":
+            return None
+        return real_which(cmd)
+
+    monkeypatch.setattr(doctor_mod.shutil, "which", fake_which)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+
+    # After the fix doctor resolves the docker backend from config.yaml and
+    # emits the required-daemon failure.
+    assert "docker not found" in out
+    assert "(required for TERMINAL_ENV=docker)" in out
+    # And it must NOT treat docker as merely optional.
+    assert "docker not found (optional)" not in out
+
+
 def test_run_doctor_accepts_named_provider_from_providers_section(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -424,6 +424,58 @@ def test_run_doctor_resolves_docker_backend_from_config_yaml(monkeypatch, tmp_pa
     assert "docker not found (optional)" not in out
 
 
+def test_run_doctor_surfaces_terminal_config_bridge_failure(monkeypatch, tmp_path):
+    """A terminal-config bridge failure must be surfaced, not silently swallowed.
+
+    Regression: the bridge call was wrapped in `except Exception: pass`, so an
+    import/signature regression in `apply_terminal_config_to_env` would silently
+    downgrade doctor to the env-only backend view with no indication — exactly
+    the failure mode the bridge exists to prevent. doctor (whose job is surfacing
+    diagnostics) must emit a lightweight warning and continue, mirroring the
+    sibling TUI/dashboard bridges that debug-report this.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    from hermes_cli import config as _config_mod
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated config bridge regression")
+
+    monkeypatch.setattr(_config_mod, "apply_terminal_config_to_env", _boom)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+
+    # doctor must surface the bridge failure (not swallow it) and keep running.
+    assert "Could not read terminal.backend from config.yaml" in out
+    assert "RuntimeError" in out
+
+
 def test_run_doctor_accepts_named_provider_from_providers_section(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What does this PR do?

`hermes doctor`'s Docker/SSH/Daytona backend reachability checks key entirely off the `TERMINAL_ENV` env var. A user who selects a non-local backend **purely through `config.yaml`** (`terminal: {backend: docker}`) with no env var set is diagnosed as the default `local` backend, so doctor takes the `(optional)` docker branch and **never runs the required-daemon check** — silently hiding a misconfigured sandbox for exactly the users it should warn.

The fix bridges `config.yaml` into the resolved backend using the canonical `apply_terminal_config_to_env()` helper before `terminal_env` is read. This mirrors the same resolver precedence the runtime already uses (and which TUI launch and web_server already invoke): **config.yaml authoritative when a `terminal` section is present** (it overrides env), otherwise defaults only backfill missing env vars — `terminal.backend → TERMINAL_ENV`. The container-override logic that follows is untouched, and the bridge is wrapped so a config read failure can never break the diagnostic.

## Related Issue

<!-- code-originated, no filed issue -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py`: bridge `config.yaml`'s `terminal.backend` into `TERMINAL_ENV` via `apply_terminal_config_to_env()` before resolving `terminal_env`, so the backend reachability checks reflect what the runtime resolves.
- `tests/hermes_cli/test_doctor.py`: regression test — config-only `terminal: {backend: docker}` with `TERMINAL_ENV` unset and docker absent now emits the required-daemon failure instead of the `(optional)` warning.

## How to Test

1. Write `terminal: {backend: docker}` into `~/.hermes/config.yaml`, leave `TERMINAL_ENV` unset, ensure docker is not installed/running.
2. Run `hermes doctor`.
3. Before this change: `⚠ docker not found (optional)`. After: `✗ docker not found (required for TERMINAL_ENV=docker)` — the diagnostic now matches the backend the runtime actually resolves.
4. `pytest tests/hermes_cli/test_doctor.py -q` — all pass; the new test fails before the prod hunk and passes after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new keys; `terminal.backend` already documented)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A