### PR TITLE
fix(mcp): pin n8n MCP catalog ref

### DIFF
--- a/optional-mcps/n8n/manifest.yaml
+++ b/optional-mcps/n8n/manifest.yaml
@@ -28,7 +28,7 @@ install:
   type: git
   url: https://github.com/CyberSamuraiX/hermes-n8n-mcp.git
   # Pin to a commit/tag. Required — manifests do not float HEAD.
-  ref: main
+  ref: 7a9ae00795593aa1fdb4e61ecd640e8bfd0c3841
   # Bootstrap commands run inside the cloned directory after clone.
   bootstrap:
     - "python3 -m venv .venv"


### PR DESCRIPTION
## What does this PR do?

Pins the n8n MCP catalog entry's `install.ref` to a specific upstream commit instead of the floating `main` branch.

MCP catalog manifests are the version source of truth for Nous-approved optional MCPs. A manifest that installs from `main` can silently fetch different code when the upstream bridge repository advances, even if the Hermes catalog entry has not changed. Pinning the ref makes catalog installs reproducible and reviewable.

Pinned commit:

```text
7a9ae00795593aa1fdb4e61ecd640e8bfd0c3841
```

That was the current `CyberSamuraiX/hermes-n8n-mcp` `main` commit at the time of this change:

```text
feat: add local n8n MCP bridge for Hermes
2026-05-23
```

## Related Issue

No standalone issue filed for this exact floating n8n catalog ref.

Related PR:

- #49306 updates the same n8n catalog manifest to pass `N8N_MCP_ENV` for the bridge's env-file loader. The two PRs are independent but touch the same manifest file, so whichever merges second may need a trivial rebase.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-mcps/n8n/manifest.yaml`
  - Changes `install.ref` from `main` to the pinned upstream commit SHA `7a9ae00795593aa1fdb4e61ecd640e8bfd0c3841`.

## How to Test

1. Run the MCP catalog tests:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py
   ```

   Result:

   ```text
   35 passed
   ```

2. Verify the manifest parses and `install.ref` is a full commit SHA:

   ```bash
   python - <<'PY'
   from pathlib import Path
   import re, yaml

   manifest = yaml.safe_load(Path('optional-mcps/n8n/manifest.yaml').read_text(encoding='utf-8'))
   ref = manifest['install']['ref']
   assert re.fullmatch(r'[0-9a-f]{40}', ref), ref
   print(ref)
   PY
   ```

3. Check Windows/path footguns:

   ```bash
   python scripts/check-windows-footguns.py optional-mcps/n8n/manifest.yaml
   ```

   Result:

   ```text
   ✓ No Windows footguns found (0 file(s) scanned).
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — existing catalog tests cover manifest parsing
- [x] I've tested on my platform: Linux 7.0.6-2-pve with Python 3.11 via the Hermes-managed venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py
# 35 passed

python scripts/check-windows-footguns.py optional-mcps/n8n/manifest.yaml
# ✓ No Windows footguns found (0 file(s) scanned).
```
