### PR TITLE
fix(telegram): truncate outbound captions by UTF-16 length, not codepoints

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -81,6 +81,7 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     utf16_len,
+    _prefix_within_utf16_limit,
 )
 from gateway.platforms.telegram_network import (
     TelegramFallbackTransport,
@@ -4475,7 +4476,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         {
                             "chat_id": int(chat_id),
                             "voice": audio_file,
-                            "caption": caption[:1024] if caption else None,
+                            "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                             "reply_to_message_id": reply_to_id,
                             **voice_thread_kwargs,
                             **self._notification_kwargs(metadata),
@@ -4501,7 +4502,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         {
                             "chat_id": int(chat_id),
                             "audio": audio_file,
-                            "caption": caption[:1024] if caption else None,
+                            "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                             "reply_to_message_id": reply_to_id,
                             **audio_thread_kwargs,
                             **self._notification_kwargs(metadata),
@@ -4597,7 +4598,7 @@ class TelegramAdapter(BasePlatformAdapter):
             opened_files: List[Any] = []
             try:
                 for image_url, alt_text in chunk:
-                    caption = alt_text[:1024] if alt_text else None
+                    caption = _prefix_within_utf16_limit(alt_text, 1024) if alt_text else None
                     if image_url.startswith("file://"):
                         local_path = _unquote(image_url[7:])
                         if not os.path.exists(local_path):
@@ -4698,7 +4699,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     {
                         "chat_id": int(chat_id),
                         "photo": image_file,
-                        "caption": caption[:1024] if caption else None,
+                        "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
@@ -4795,7 +4796,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "chat_id": int(chat_id),
                         "document": f,
                         "filename": display_name,
-                        "caption": caption[:1024] if caption else None,
+                        "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
@@ -4842,7 +4843,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     {
                         "chat_id": int(chat_id),
                         "video": f,
-                        "caption": caption[:1024] if caption else None,
+                        "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
@@ -4894,7 +4895,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 {
                     "chat_id": int(chat_id),
                     "photo": image_url,
-                    "caption": caption[:1024] if caption else None,
+                    "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                     "reply_to_message_id": reply_to_id,
                     **photo_thread_kwargs,
                     **self._notification_kwargs(metadata),
@@ -4931,7 +4932,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     {
                         "chat_id": int(chat_id),
                         "photo": image_data,
-                        "caption": caption[:1024] if caption else None,
+                        "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                         "reply_to_message_id": reply_to_id,
                         **upload_thread_kwargs,
                         **self._notification_kwargs(metadata),
@@ -4978,7 +4979,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 {
                     "chat_id": int(chat_id),
                     "animation": animation_url,
-                    "caption": caption[:1024] if caption else None,
+                    "caption": _prefix_within_utf16_limit(caption, 1024) if caption else None,
                     "reply_to_message_id": reply_to_id,
                     **animation_thread_kwargs,
                     **self._notification_kwargs(metadata),

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -614,6 +614,74 @@ class TestSendDocument:
         assert call_kwargs["caption"] == "Here's the report"
 
     @pytest.mark.asyncio
+    async def test_send_document_caption_truncated_by_utf16_length(
+        self, connected_adapter, tmp_path
+    ):
+        """Captions must be truncated to <=1024 UTF-16 code units, not codepoints.
+
+        Telegram measures caption length in UTF-16 code units (1024 cap).
+        Astral-plane chars (emoji, CJK Ext-B) encode as surrogate pairs and so
+        consume two units each. A naive ``caption[:1024]`` codepoint slice lets
+        a 700-emoji caption (700 codepoints == 1400 UTF-16 units) pass unchanged,
+        and Telegram then rejects the whole send with
+        ``Bad Request: message caption is too long``.
+        """
+        from gateway.platforms.base import utf16_len
+
+        test_file = tmp_path / "report.pdf"
+        test_file.write_bytes(b"%PDF-1.4 fake content")
+
+        # 700 emoji = 700 codepoints but 1400 UTF-16 code units.
+        long_caption = "\U0001F600" * 700
+        assert utf16_len(long_caption) == 1400  # sanity: exceeds the 1024 cap
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 101
+        connected_adapter._bot.send_document = AsyncMock(return_value=mock_msg)
+
+        result = await connected_adapter.send_document(
+            chat_id="12345",
+            file_path=str(test_file),
+            caption=long_caption,
+        )
+
+        assert result.success is True
+        connected_adapter._bot.send_document.assert_called_once()
+        sent_caption = connected_adapter._bot.send_document.call_args[1]["caption"]
+        # Codepoint slice would leave 1024 codepoints == 2048 UTF-16 units.
+        assert utf16_len(sent_caption) <= 1024
+        # The truncated caption must remain a valid prefix (no half surrogate).
+        assert long_caption.startswith(sent_caption)
+
+    @pytest.mark.asyncio
+    async def test_send_video_caption_truncated_by_utf16_length(
+        self, connected_adapter, tmp_path
+    ):
+        """Sibling site: send_video must apply the same UTF-16 caption cap."""
+        from gateway.platforms.base import utf16_len
+
+        test_file = tmp_path / "clip.mp4"
+        test_file.write_bytes(b"\x00\x00\x00\x18ftypmp42")
+
+        long_caption = "\U0001F600" * 700  # 1400 UTF-16 units
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 102
+        connected_adapter._bot.send_video = AsyncMock(return_value=mock_msg)
+
+        result = await connected_adapter.send_video(
+            chat_id="12345",
+            video_path=str(test_file),
+            caption=long_caption,
+        )
+
+        assert result.success is True
+        connected_adapter._bot.send_video.assert_called_once()
+        sent_caption = connected_adapter._bot.send_video.call_args[1]["caption"]
+        assert utf16_len(sent_caption) <= 1024
+        assert long_caption.startswith(sent_caption)
+
+    @pytest.mark.asyncio
     async def test_send_document_custom_filename(self, connected_adapter, tmp_path):
         """The file_name parameter overrides the basename for display."""
         test_file = tmp_path / "doc_abc123_ugly.csv"

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -648,7 +648,9 @@ class TestSendDocument:
         assert result.success is True
         connected_adapter._bot.send_document.assert_called_once()
         sent_caption = connected_adapter._bot.send_document.call_args[1]["caption"]
-        # Codepoint slice would leave 1024 codepoints == 2048 UTF-16 units.
+        # A naive caption[:1024] codepoint slice leaves all 700 emoji intact
+        # (700 < 1024), i.e. 1400 UTF-16 units — still over the 1024 cap. A
+        # correct UTF-16-aware truncation must bring this back to <=1024.
         assert utf16_len(sent_caption) <= 1024
         # The truncated caption must remain a valid prefix (no half surrogate).
         assert long_caption.startswith(sent_caption)


### PR DESCRIPTION
## What does this PR do?

Telegram measures **caption** length in UTF-16 code units (1024 cap) — the same way it measures the 4096-unit message-text cap. Characters outside the Basic Multilingual Plane (emoji, CJK Extension B, musical symbols, …) encode as surrogate pairs and consume **two** UTF-16 code units each, while a Python `str` slice counts codepoints.

The nine outbound caption sites in `gateway/platforms/telegram.py` truncated with a naive `caption[:1024]` (and one `alt_text[:1024]`) codepoint slice. A caption of ≤1024 codepoints containing astral-plane characters therefore passes the slice unchanged yet exceeds 1024 UTF-16 units, and Telegram rejects the **entire send** with `Bad Request: message caption is too long`.

Repro: a caption of `'😀' * 700` is 700 codepoints but **1400 UTF-16 units** — the codepoint slice leaves it untouched, the send fails.

The repo already solved this exact discrepancy for message *text* via `utf16_len()` and `_prefix_within_utf16_limit()` in `gateway/platforms/base.py` (the latter binary-searches a surrogate-safe prefix). But `_prefix_within_utf16_limit` had **zero call sites** — it was written and never wired in. This PR wires the existing helper into the nine caption sites, preserving the existing `if caption else None` guards.

## Related Issue

<!-- code-originated, no filed issue -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: import `_prefix_within_utf16_limit` from `gateway.platforms.base` (alongside the already-imported `utf16_len`), and replace `caption[:1024]` / `alt_text[:1024]` at the nine outbound caption sites (`send_voice`, `send_audio`, `send_multiple_images` alt_text, `send_image_file`, `send_document`, `send_video`, the `send_image` / animation paths) with `_prefix_within_utf16_limit(..., 1024)`.
- `tests/gateway/test_telegram_documents.py`: regression tests for `send_document` and `send_video` asserting a 700-emoji caption (1400 UTF-16 units) is truncated to ≤1024 UTF-16 units and remains a valid surrogate-safe prefix.

## How to Test

1. Send a Telegram document/photo/video with a caption of `'😀' * 700` (1400 UTF-16 units).
2. Before this change: Telegram rejects the send with `Bad Request: message caption is too long`. After: the caption is truncated to ≤1024 UTF-16 units and the send succeeds.
3. `pytest tests/gateway/test_telegram_documents.py -q` — all pass; the two new tests fail before the prod hunk (caption stays at 1400 units) and pass after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A