### PR TITLE
fix(telegram): read entity offsets as UTF-16 code units, not code points

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -145,6 +145,20 @@ def utf16_len(s: str) -> int:
     return len(s.encode("utf-16-le")) // 2
 
 
+def utf16_slice(s: str, offset: int, length: int) -> str:
+    """Extract a substring by UTF-16 code-unit ``offset``/``length``.
+
+    Platform message entities (Telegram ``MessageEntity``, Signal styles, …)
+    address text in UTF-16 code units, not Python code-points. Slicing the
+    ``str`` directly with those values (``s[offset:offset+length]``) misaligns
+    as soon as a non-BMP character (emoji, CJK Ext-B, …) precedes the span,
+    because Python counts it as one index while the platform counts it as two.
+    Encode to UTF-16, slice on code-unit boundaries, then decode back.
+    """
+    u = s.encode("utf-16-le")
+    return u[offset * 2: (offset + length) * 2].decode("utf-16-le", errors="ignore")
+
+
 def _prefix_within_utf16_limit(s: str, limit: int) -> str:
     """Return the longest prefix of *s* whose UTF-16 length ≤ *limit*.
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -81,6 +81,7 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     utf16_len,
+    utf16_slice,
 )
 from gateway.platforms.telegram_network import (
     TelegramFallbackTransport,
@@ -5444,7 +5445,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 if offset < 0 or length <= 0:
                     continue
 
-                entity_text = source_text[offset:offset + length].strip()
+                # Entity offset/length are UTF-16 code units; slice accordingly
+                # so a leading emoji/non-BMP char can't misalign the span.
+                entity_text = utf16_slice(source_text, offset, length).strip()
                 if entity_type == "mention":
                     handle = entity_text.lstrip("@").lower()
                     if re.fullmatch(r"[a-z0-9_]{2,29}bot", handle, re.IGNORECASE):
@@ -5499,7 +5502,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     length = int(getattr(entity, "length", 0))
                     if offset < 0 or length <= 0:
                         continue
-                    if source_text[offset:offset + length].strip().lower() == expected:
+                    # UTF-16 code-unit offsets: a leading emoji would otherwise
+                    # shift the slice and hide a real @mention of the bot.
+                    if utf16_slice(source_text, offset, length).strip().lower() == expected:
                         return True
                 elif entity_type == "text_mention":
                     user = getattr(entity, "user", None)
@@ -5519,7 +5524,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     length = int(getattr(entity, "length", 0))
                     if offset < 0 or length <= 0:
                         continue
-                    command_text = source_text[offset:offset + length]
+                    command_text = utf16_slice(source_text, offset, length)
                     at_index = command_text.find("@")
                     if at_index < 0:
                         continue

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -12,9 +12,27 @@ from gateway.platforms.base import (
     MessageEvent,
     safe_url_for_log,
     utf16_len,
+    utf16_slice,
     _log_safe_path,
     _prefix_within_utf16_limit,
 )
+
+
+class TestUtf16Slice:
+    def test_bmp_only_matches_plain_slice(self):
+        s = "hey @hermes_bot there"
+        off = s.index("@hermes_bot")
+        assert utf16_slice(s, off, len("@hermes_bot")) == "@hermes_bot"
+
+    def test_non_bmp_prefix_keeps_alignment(self):
+        # "😀 " is 3 UTF-16 code units (emoji = 2, space = 1).
+        s = "😀 @hermes_bot hi"
+        assert utf16_slice(s, 3, utf16_len("@hermes_bot")) == "@hermes_bot"
+
+    def test_extracts_span_with_emoji_inside(self):
+        s = "a😀b"
+        # full string: a(1) + 😀(2) + b(1) = 4 UTF-16 units
+        assert utf16_slice(s, 0, 4) == "a😀b"
 
 
 class TestSecretCaptureGuidance:

--- a/tests/gateway/test_telegram_mention_boundaries.py
+++ b/tests/gateway/test_telegram_mention_boundaries.py
@@ -31,6 +31,18 @@ def _mention_entity(text, mention="@hermes_bot"):
     return SimpleNamespace(type="mention", offset=offset, length=len(mention))
 
 
+def _mention_entity_utf16(text, mention="@hermes_bot"):
+    """Build a MENTION entity using UTF-16 code-unit coordinates, the way
+    Telegram's server actually reports them (offsets shift past non-BMP chars)."""
+    from gateway.platforms.base import utf16_len
+    cp_index = text.index(mention)
+    return SimpleNamespace(
+        type="mention",
+        offset=utf16_len(text[:cp_index]),
+        length=utf16_len(mention),
+    )
+
+
 def _text_mention_entity(offset, length, user_id):
     """Build a TEXT_MENTION entity (used when the target user has no public @handle)."""
     return SimpleNamespace(
@@ -78,6 +90,15 @@ class TestRealMentionsAreDetected:
         adapter = _make_adapter()
         caption = "photo for @hermes_bot"
         msg = _message(caption=caption, caption_entities=[_mention_entity(caption)])
+        assert adapter._message_mentions_bot(msg) is True
+
+    def test_mention_after_leading_emoji(self):
+        # A non-BMP char before the mention shifts the UTF-16 entity offset past
+        # what Python code-point indexing expects. Code-point slicing would miss
+        # the mention and the bot would ignore a message that @-addressed it.
+        adapter = _make_adapter()
+        text = "😀 @hermes_bot can you help?"
+        msg = _message(text=text, entities=[_mention_entity_utf16(text)])
         assert adapter._message_mentions_bot(msg) is True
 
     def test_text_mention_entity_targets_bot(self):


### PR DESCRIPTION
## What

Telegram mention / command detection now slices message entities by UTF-16 code units, matching how Telegram reports `MessageEntity` offsets.

## Why

`MessageEntity.offset`/`length` are UTF-16 code units, but the parsing did `source_text[offset:offset+length]` — treating them as Python code-point indices. A single non-BMP character before the span (a leading emoji, CJK Ext-B, …) shifts the UTF-16 offset past the code-point index, so the slice misaligns. The concrete impact: in a `require_mention` group, a message like `😀 @hermes_bot help` has its `@mention` entity slice land on the wrong text, `_message_mentions_bot` returns False, and the bot silently ignores a message that explicitly addressed it.

## Change

- Add `utf16_slice()` next to `utf16_len()` in `gateway/platforms/base.py`.
- Use it at all three entity-slicing sites in `telegram.py` (`_extract_bot_mention_usernames` and `_message_mentions_bot`).

I checked the other adapters for the same class: Signal already converts code-point offsets to UTF-16 when building outbound entities, and Discord / Matrix don't address text by offset — so the three Telegram sites are the full surface.

## Tests

- `TestUtf16Slice` in `tests/gateway/test_platform_base.py` — slicing across non-BMP prefixes/spans.
- `test_mention_after_leading_emoji` in `tests/gateway/test_telegram_mention_boundaries.py` — a mention preceded by an emoji is now detected (fails before this change).