### PR TITLE
feat(dashboard): support configurable branding

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1664,6 +1664,16 @@ DEFAULT_CONFIG = {
     # Web dashboard settings
     "dashboard": {
         "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"
+        # Optional user-facing dashboard branding.  Leave blank for the
+        # built-in Hermes Agent labels.  This only affects visible dashboard
+        # copy/wordmarks; protocol names, CLI commands, environment variables,
+        # and filesystem paths remain Hermes for compatibility.
+        "branding": {
+            "app_name": "",  # e.g. "Transformation Lab"; blank -> "Hermes Agent"
+            "assistant_name": "",  # e.g. "Debra"; blank -> "Hermes"
+            "wordmark": [],  # optional 1-2 line sidebar wordmark override
+            "title": "",  # optional browser title override
+        },
         # Hide the token/cost analytics surfaces (Analytics page, token bars and
         # cost figures on the Models page) by default.  The numbers shown there
         # are a local debug estimate: they only count successful main-agent

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -216,6 +216,112 @@ app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
 _SESSION_TOKEN = os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN") or secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 
+_DASHBOARD_BRANDING_DEFAULTS: Dict[str, Any] = {
+    "app_name": "Hermes Agent",
+    "assistant_name": "Hermes",
+    "wordmark_lines": ["Hermes", "Agent"],
+    "title": "Hermes Agent - Dashboard",
+}
+
+
+def _dashboard_clean_brand_text(value: Any, *, max_len: int = 80) -> Optional[str]:
+    """Return a safe one-line branding string or ``None``.
+
+    Branding is injected into HTML as JSON and rendered as React text, but still
+    reject HTML/control characters at the config boundary so bad values fall
+    back to defaults instead of producing surprising chrome.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text or len(text) > max_len:
+        return None
+    if any(ch in text for ch in ("<", ">", "\"", "'", "`")):
+        return None
+    if any(ord(ch) < 32 for ch in text):
+        return None
+    return text
+
+
+def _dashboard_branding_from_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve dashboard branding from ``dashboard.branding`` config.
+
+    Empty or malformed values fall back independently so operators can set only
+    the fields they care about.  ``wordmark`` accepts a list of one or two
+    strings; missing/invalid lines fall back per-position to the default
+    ``["Hermes", "Agent"]``.
+    """
+    dashboard_cfg = config.get("dashboard") if isinstance(config, dict) else {}
+    if not isinstance(dashboard_cfg, dict):
+        dashboard_cfg = {}
+    branding_cfg = dashboard_cfg.get("branding")
+    if not isinstance(branding_cfg, dict):
+        branding_cfg = {}
+
+    app_name = (
+        _dashboard_clean_brand_text(branding_cfg.get("app_name"))
+        or _DASHBOARD_BRANDING_DEFAULTS["app_name"]
+    )
+    assistant_name = (
+        _dashboard_clean_brand_text(branding_cfg.get("assistant_name"))
+        or _DASHBOARD_BRANDING_DEFAULTS["assistant_name"]
+    )
+    title = (
+        _dashboard_clean_brand_text(branding_cfg.get("title"), max_len=120)
+        or _DASHBOARD_BRANDING_DEFAULTS["title"]
+    )
+
+    default_lines = list(_DASHBOARD_BRANDING_DEFAULTS["wordmark_lines"])
+    app_words = app_name.split()
+    derived_lines = app_words if len(app_words) == 2 else [app_name]
+    wordmark_value = branding_cfg.get("wordmark")
+    lines: List[str] = []
+    if isinstance(wordmark_value, list):
+        fallback_lines = derived_lines if app_name != _DASHBOARD_BRANDING_DEFAULTS["app_name"] else default_lines
+        for idx in range(min(2, max(1, len(fallback_lines)))):
+            raw = wordmark_value[idx] if idx < len(wordmark_value) else None
+            fallback = fallback_lines[idx] if idx < len(fallback_lines) else fallback_lines[0]
+            lines.append(_dashboard_clean_brand_text(raw, max_len=40) or fallback)
+    elif app_name != _DASHBOARD_BRANDING_DEFAULTS["app_name"]:
+        lines = derived_lines
+    else:
+        lines = default_lines
+
+    return {
+        "app_name": app_name,
+        "assistant_name": assistant_name,
+        "wordmark_lines": lines,
+        "title": title,
+    }
+
+
+def _dashboard_bootstrap_script(
+    *,
+    token: str,
+    prefix: str,
+    embedded_chat: bool,
+    auth_required: bool,
+    branding: Dict[str, Any],
+) -> str:
+    """Build the SPA bootstrap script injected into ``index.html``."""
+    parts = ["<script>"]
+    if not auth_required:
+        parts.append(f"window.__HERMES_SESSION_TOKEN__={json.dumps(token)};")
+    parts.append(
+        "window.__HERMES_DASHBOARD_EMBEDDED_CHAT__="
+        f"{'true' if embedded_chat else 'false'};"
+    )
+    parts.append(f"window.__HERMES_BASE_PATH__={json.dumps(prefix)};")
+    parts.append(
+        f"window.__HERMES_AUTH_REQUIRED__={'true' if auth_required else 'false'};"
+    )
+    parts.append(
+        "window.__HERMES_DASHBOARD_BRANDING__="
+        f"{json.dumps(branding, ensure_ascii=False, separators=(',', ':'))};"
+    )
+    parts.append("</script>")
+    return "".join(parts)
+
 # In-browser Chat tab (/chat, /api/pty, /api/ws, …).  Always enabled: the
 # desktop app and the dashboard's own Chat tab both drive the agent over the
 # `/api/ws` + `/api/pty` WebSockets, so the embedded-chat surface is an
@@ -11657,25 +11763,22 @@ def mount_spa(application: FastAPI):
         auth scheme for /api/pty and /api/ws (ticket vs token).
         """
         html = _index_path.read_text(encoding="utf-8")
-        chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        gated_js = "true" if gated else "false"
-        if gated:
-            bootstrap_script = (
-                f"<script>"
-                f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
-                f'window.__HERMES_BASE_PATH__="{prefix}";'
-                f"window.__HERMES_AUTH_REQUIRED__={gated_js};"
-                f"</script>"
-            )
-        else:
-            bootstrap_script = (
-                f'<script>window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
-                f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
-                f'window.__HERMES_BASE_PATH__="{prefix}";'
-                f"window.__HERMES_AUTH_REQUIRED__={gated_js};"
-                f"</script>"
-            )
+        branding = _dashboard_branding_from_config(load_config())
+        bootstrap_script = _dashboard_bootstrap_script(
+            token=_SESSION_TOKEN,
+            prefix=prefix,
+            embedded_chat=_DASHBOARD_EMBEDDED_CHAT_ENABLED,
+            auth_required=gated,
+            branding=branding,
+        )
+        html = re.sub(
+            r"<title>.*?</title>",
+            f"<title>{branding['title']}</title>",
+            html,
+            count=1,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
         if prefix:
             # Rewrite absolute asset URLs baked into the Vite build so the
             # browser fetches them through the same proxy prefix.

--- a/tests/hermes_cli/test_dashboard_branding_config.py
+++ b/tests/hermes_cli/test_dashboard_branding_config.py
@@ -1,0 +1,84 @@
+"""Dashboard branding configuration contract tests."""
+
+from hermes_cli import web_server
+
+
+def test_dashboard_branding_defaults_match_current_ui():
+    branding = web_server._dashboard_branding_from_config({})
+
+    assert branding == {
+        "app_name": "Hermes Agent",
+        "assistant_name": "Hermes",
+        "wordmark_lines": ["Hermes", "Agent"],
+        "title": "Hermes Agent - Dashboard",
+    }
+
+
+def test_dashboard_branding_accepts_config_overrides():
+    branding = web_server._dashboard_branding_from_config(
+        {
+            "dashboard": {
+                "branding": {
+                    "app_name": "Transformation Lab",
+                    "assistant_name": "Debra",
+                    "wordmark": ["Transformation", "Lab"],
+                    "title": "Transformation Lab",
+                }
+            }
+        }
+    )
+
+    assert branding == {
+        "app_name": "Transformation Lab",
+        "assistant_name": "Debra",
+        "wordmark_lines": ["Transformation", "Lab"],
+        "title": "Transformation Lab",
+    }
+
+
+def test_dashboard_branding_derives_wordmark_from_two_word_app_name():
+    branding = web_server._dashboard_branding_from_config(
+        {"dashboard": {"branding": {"app_name": "Transformation Lab"}}}
+    )
+
+    assert branding["wordmark_lines"] == ["Transformation", "Lab"]
+
+
+def test_dashboard_branding_rejects_html_injection_and_bad_shapes():
+    branding = web_server._dashboard_branding_from_config(
+        {
+            "dashboard": {
+                "branding": {
+                    "app_name": "<script>alert(1)</script>",
+                    "assistant_name": {"bad": "shape"},
+                    "wordmark": ["Good", "<img src=x onerror=alert(1)>", "Ignored"],
+                    "title": "Bad\nTitle",
+                }
+            }
+        }
+    )
+
+    assert branding["app_name"] == "Hermes Agent"
+    assert branding["assistant_name"] == "Hermes"
+    assert branding["wordmark_lines"] == ["Good", "Agent"]
+    assert branding["title"] == "Hermes Agent - Dashboard"
+
+
+def test_dashboard_bootstrap_includes_safe_json_branding():
+    script = web_server._dashboard_bootstrap_script(
+        token="abc123",
+        prefix="/lab",
+        embedded_chat=False,
+        auth_required=False,
+        branding={
+            "app_name": "Transformation Lab",
+            "assistant_name": "Debra",
+            "wordmark_lines": ["Transformation", "Lab"],
+            "title": "Transformation Lab",
+        },
+    )
+
+    assert 'window.__HERMES_DASHBOARD_BRANDING__={"app_name":"Transformation Lab"' in script
+    assert 'window.__HERMES_BASE_PATH__="/lab";' in script
+    assert 'window.__HERMES_SESSION_TOKEN__="abc123";' in script
+    assert "</script><script>" not in script

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -99,6 +99,7 @@ import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
 import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
+import { getDashboardBranding } from "@/lib/dashboard-branding";
 import { api } from "@/lib/api";
 import type { StatusResponse } from "@/lib/api";
 
@@ -348,6 +349,7 @@ const SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
 
 export default function App() {
   const { t } = useI18n();
+  const branding = useMemo(() => getDashboardBranding(), []);
   const { pathname } = useLocation();
   const { manifests, loading: pluginsLoading } = usePlugins();
   const { theme } = useTheme();
@@ -378,6 +380,10 @@ export default function App() {
   const normalizedPath = pathname.replace(/\/$/, "") || "/";
   const isChatRoute = normalizedPath === "/chat";
   const embeddedChat = isDashboardEmbeddedChatEnabled();
+
+  useEffect(() => {
+    document.title = branding.title;
+  }, [branding.title]);
 
   // `dashboard.show_token_analytics` gates the Analytics nav item.  The
   // page itself remains reachable by URL (it renders an explanation when
@@ -518,7 +524,7 @@ export default function App() {
           className="font-bold text-[0.95rem] leading-[0.95] tracking-[0.05em] text-midground"
           style={{ mixBlendMode: "plus-lighter" }}
         >
-          {t.app.brand}
+          {branding.appName}
         </Typography>
       </header>
 
@@ -577,9 +583,12 @@ export default function App() {
                   className="font-bold text-[1.125rem] leading-[0.95] tracking-[0.0525rem] text-midground uppercase"
                   style={{ mixBlendMode: "plus-lighter" }}
                 >
-                  Hermes
-                  <br />
-                  Agent
+                  {branding.wordmarkLines.map((line, idx) => (
+                    <span key={`${idx}-${line}`}>
+                      {idx > 0 && <br />}
+                      {line}
+                    </span>
+                  ))}
                 </Typography>
               </div>
 

--- a/web/src/lib/dashboard-branding.test.ts
+++ b/web/src/lib/dashboard-branding.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getDashboardBranding, wordmarkLines } from "./dashboard-branding";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function stubWindow(branding?: Window["__HERMES_DASHBOARD_BRANDING__"]) {
+  vi.stubGlobal("window", { __HERMES_DASHBOARD_BRANDING__: branding });
+}
+
+describe("getDashboardBranding", () => {
+  it("returns current Hermes defaults when no branding is injected", () => {
+    stubWindow();
+
+    expect(getDashboardBranding()).toEqual({
+      appName: "Hermes Agent",
+      assistantName: "Hermes",
+      wordmarkLines: ["Hermes", "Agent"],
+      title: "Hermes Agent - Dashboard",
+    });
+  });
+
+  it("uses server-injected branding overrides", () => {
+    stubWindow({
+      app_name: "Transformation Lab",
+      assistant_name: "Debra",
+      wordmark_lines: ["Transformation", "Lab"],
+      title: "Transformation Lab",
+    });
+
+    expect(getDashboardBranding()).toEqual({
+      appName: "Transformation Lab",
+      assistantName: "Debra",
+      wordmarkLines: ["Transformation", "Lab"],
+      title: "Transformation Lab",
+    });
+  });
+});
+
+describe("wordmarkLines", () => {
+  it("splits a two-word app name when no explicit wordmark is provided", () => {
+    expect(wordmarkLines("Transformation Lab", undefined)).toEqual([
+      "Transformation",
+      "Lab",
+    ]);
+  });
+
+  it("falls back to the app name as one line for longer names", () => {
+    expect(wordmarkLines("My Excellent Control Center", undefined)).toEqual([
+      "My Excellent Control Center",
+    ]);
+  });
+});

--- a/web/src/lib/dashboard-branding.ts
+++ b/web/src/lib/dashboard-branding.ts
@@ -1,0 +1,63 @@
+export interface DashboardBranding {
+  appName: string;
+  assistantName: string;
+  wordmarkLines: string[];
+  title: string;
+}
+
+interface InjectedDashboardBranding {
+  app_name?: unknown;
+  assistant_name?: unknown;
+  wordmark_lines?: unknown;
+  title?: unknown;
+}
+
+declare global {
+  interface Window {
+    __HERMES_DASHBOARD_BRANDING__?: InjectedDashboardBranding;
+  }
+}
+
+const DEFAULT_BRANDING: DashboardBranding = {
+  appName: "Hermes Agent",
+  assistantName: "Hermes",
+  wordmarkLines: ["Hermes", "Agent"],
+  title: "Hermes Agent - Dashboard",
+};
+
+function cleanString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function wordmarkLines(appName: string, explicit: unknown): string[] {
+  if (Array.isArray(explicit)) {
+    const lines = explicit
+      .map((line) => cleanString(line))
+      .filter((line): line is string => Boolean(line))
+      .slice(0, 2);
+    if (lines.length > 0) return lines;
+  }
+
+  const words = appName.split(/\s+/).filter(Boolean);
+  if (words.length === 2) return words;
+  return [appName];
+}
+
+export function getDashboardBranding(): DashboardBranding {
+  if (typeof window === "undefined") return DEFAULT_BRANDING;
+
+  const injected = window.__HERMES_DASHBOARD_BRANDING__ || {};
+  const appName = cleanString(injected.app_name) || DEFAULT_BRANDING.appName;
+  const assistantName =
+    cleanString(injected.assistant_name) || DEFAULT_BRANDING.assistantName;
+  const title = cleanString(injected.title) || `${appName} - Dashboard`;
+
+  return {
+    appName,
+    assistantName,
+    wordmarkLines: wordmarkLines(appName, injected.wordmark_lines),
+    title,
+  };
+}

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -41,6 +41,33 @@ hermes dashboard --host 0.0.0.0
 hermes dashboard --no-open
 ```
 
+## Branding
+
+The dashboard shell can be rebranded from `config.yaml` without patching the
+source tree. This is useful for local labs, team workbenches, and hosted control
+centers that want their own visible name while keeping the underlying Hermes CLI,
+API headers, environment variables, and filesystem paths unchanged.
+
+```yaml
+dashboard:
+  branding:
+    app_name: "Transformation Lab"
+    assistant_name: "Debra"
+    wordmark:
+      - "Transformation"
+      - "Lab"
+    title: "Transformation Lab"
+```
+
+Fields are optional:
+
+- `app_name` controls the mobile/top-bar product label.
+- `assistant_name` is exposed to the web app for user-facing copy that wants the assistant name.
+- `wordmark` is an optional one- or two-line sidebar wordmark.
+- `title` controls the browser tab title.
+
+Restart the dashboard after changing these values.
+
 ## Managing multiple profiles
 
 The dashboard is a **machine-level** management surface: one server manages


### PR DESCRIPTION
## Summary
- add dashboard.branding config for app name, assistant name, wordmark, and browser title
- inject sanitized branding into the served SPA bootstrap and render it in the dashboard shell
- document the branding config and add Python/Vitest coverage

## Test Plan
- python -m pytest tests/hermes_cli/test_dashboard_branding_config.py tests/hermes_cli/test_dashboard_profiles_nav_label.py -q
- npm run test -w web -- --run src/lib/dashboard-branding.test.ts
- npm run build -w web