### PR TITLE
fix(desktop): refresh profile rail after deletion (#49289)

### DIFF
--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -17,7 +17,6 @@ import { Textarea } from '@/components/ui/textarea'
 import {
   createProfile,
   deleteProfile,
-  getProfiles,
   getProfileSetupCommand,
   getProfileSoul,
   type ProfileInfo,
@@ -28,6 +27,7 @@ import { useI18n } from '@/i18n'
 import { AlertTriangle, Pencil, Save, Terminal, Trash2, Users } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
+import { refreshProfiles } from '@/store/profile'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { OverlayMain, OverlayNewButton, OverlaySidebar, OverlaySplitLayout } from '../overlays/overlay-split-layout'
@@ -54,7 +54,7 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
 
   const refresh = useCallback(async () => {
     try {
-      const { profiles: list } = await getProfiles()
+      const list = await refreshProfiles()
       setProfiles(list)
       setSelectedName(current => {
         if (current && list.some(p => p.name === current)) {

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesConnection } from '@/global'
+import type { ProfileInfo } from '@/types/hermes'
 
 // Keep profile.ts's side-effecting imports inert: the gateway socket layer and
 // the REST query client must not run for real in a unit test.
@@ -15,8 +16,19 @@ vi.mock('@/hermes', () => ({
 }))
 vi.mock('@/lib/query-client', () => ({ queryClient: { invalidateQueries: vi.fn() } }))
 
-const { $activeGatewayProfile, ensureGatewayProfile } = await import('./profile')
+const { $activeGatewayProfile, $profiles, ensureGatewayProfile, refreshProfiles } = await import('./profile')
 const { $connection } = await import('./session')
+const { getProfiles } = await import('@/hermes')
+
+const profile = (name: string, isDefault = false): ProfileInfo => ({
+  has_env: false,
+  is_default: isDefault,
+  model: null,
+  name,
+  path: `/tmp/hermes/${name}`,
+  provider: null,
+  skill_count: 0
+})
 
 const remoteConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
   ({ baseUrl: 'https://hermes-roy.tail.ts.net', mode: 'remote', profile: 'vps-remote', ...over }) as HermesConnection
@@ -32,6 +44,7 @@ beforeEach(() => {
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
+  $profiles.set([])
   vi.stubGlobal('window', { hermesDesktop: { getConnection } })
 })
 
@@ -85,5 +98,26 @@ describe('ensureGatewayProfile → $connection sync (#46651)', () => {
     expect(getConnection).not.toHaveBeenCalled()
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
     expect($connection.get()?.mode).toBe('remote')
+  })
+})
+
+
+describe('refreshProfiles shared rail list (#49289)', () => {
+  it('removes a deleted profile from the shared $profiles cache after Manage Profiles refreshes', async () => {
+    $profiles.set([profile('default', true), profile('test1')])
+    vi.mocked(getProfiles).mockResolvedValueOnce({ profiles: [profile('default', true)] })
+
+    await refreshProfiles()
+
+    expect($profiles.get().map(profile => profile.name)).toEqual(['default'])
+  })
+
+  it('leaves the shared $profiles cache intact when the refresh fails', async () => {
+    $profiles.set([profile('default', true), profile('test1')])
+    vi.mocked(getProfiles).mockRejectedValueOnce(new Error('backend unavailable'))
+
+    await expect(refreshProfiles()).rejects.toThrow('backend unavailable')
+
+    expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'test1'])
   })
 })

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -37,6 +37,13 @@ export function setActiveProfile(name: string): void {
   $activeProfile.set(name || 'default')
 }
 
+export async function refreshProfiles(): Promise<ProfileInfo[]> {
+  const { profiles } = await getProfiles()
+  $profiles.set(profiles)
+
+  return profiles
+}
+
 // ── Rail order ─────────────────────────────────────────────────────────────
 // User-defined order for the named (non-default) profile squares in the rail.
 // Names absent from the list fall back to alphabetical, appended at the tail —
@@ -110,8 +117,7 @@ export async function refreshActiveProfile(): Promise<void> {
   }
 
   try {
-    const { profiles } = await getProfiles()
-    $profiles.set(profiles)
+    await refreshProfiles()
   } catch {
     // Leave the cached list in place.
   }


### PR DESCRIPTION
## Summary
- add a shared `refreshProfiles()` helper that updates the global `$profiles` atom from the authoritative desktop profile API
- use that helper from Manage Profiles refreshes so the chat profile rail drops deleted profiles immediately after overlay mutations
- keep failed refresh behavior non-destructive so stale-but-valid cached profiles are not cleared on backend errors

## Verification
- `npm run test:ui -- --run src/store/profile.test.ts --reporter=verbose` — 6 passed
- `npm run typecheck` — passed
- `npx eslint src/store/profile.ts src/store/profile.test.ts src/app/profiles/index.tsx` — passed
- `git rev-list --left-right --count upstream/main...HEAD` — `0 1`

## Duplicate / competitor check
- Same-author PR search for `49289 in:title,body`: none
- Same-author branch search for `Tranquil-Flow:fix/49289*`: none before publish
- Open PR issue search for `49289 in:title,body`: none
- Topic search for `deleted profile icon profile rail Manage Profiles`: none

Auto-published by Moonsong via Path B automated pipeline.
