### PR TITLE
fix(tui): handle dispatch payloads from slash exec

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -694,6 +694,42 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.send).toHaveBeenCalledWith(skillMessage)
   })
 
+  it('handles command.dispatch payloads returned directly by slash.exec', async () => {
+    patchUiState({ sid: 'sid-abc' })
+
+    const ctx = buildCtx({
+      gateway: {
+        gw: {
+          getLogTail: vi.fn(() => ''),
+          request: vi.fn((method: string) => {
+            if (method === 'slash.exec') {
+              return Promise.resolve({
+                message: 'complete all the steps and provide a final report',
+                notice: '⊙ Goal set (20-turn budget): complete all the steps and provide a final report',
+                type: 'send'
+              })
+            }
+
+            return Promise.resolve({})
+          })
+        },
+        rpc: vi.fn(() => Promise.resolve({}))
+      }
+    })
+
+    const h = createSlashHandler(ctx)
+    expect(h('/goal complete all the steps and provide a final report')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith(
+        '⊙ Goal set (20-turn budget): complete all the steps and provide a final report'
+      )
+    })
+    expect(ctx.transcript.send).toHaveBeenCalledWith('complete all the steps and provide a final report')
+    expect(ctx.transcript.sys).not.toHaveBeenCalledWith('/goal: no output')
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+  })
+
   it('/history pages the current TUI transcript (user + assistant)', () => {
     const ctx = buildCtx({
       local: {

--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -74,10 +74,55 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
       }
     }
 
+    const handleDispatch = (raw: unknown): void => {
+      const d = asCommandDispatch(raw)
+
+      if (!d) {
+        return sys('error: invalid response: command.dispatch')
+      }
+
+      if (d.type === 'exec' || d.type === 'plugin') {
+        return sys(d.output || '(no output)')
+      }
+
+      if (d.type === 'alias') {
+        return void handler(`/${d.target}${argTail}`)
+      }
+
+      if (d.type === 'skill') {
+        sys(`⚡ loading skill: ${d.name}`)
+
+        return d.message?.trim() ? send(d.message) : sys(`/${parsed.name}: skill payload missing message`)
+      }
+
+      if (d.type === 'send') {
+        if (d.notice?.trim()) {
+          sys(d.notice)
+        }
+        return d.message?.trim() ? send(d.message) : sys(`/${parsed.name}: empty message`)
+      }
+
+      if (d.type === 'prefill') {
+        // /undo returns prefill: drop the backed-up message text into
+        // the composer so the user can edit and resubmit, instead of
+        // submitting it immediately like 'send'.
+        if (d.notice?.trim()) {
+          sys(d.notice)
+        }
+        if (d.message) {
+          ctx.composer.setInput(d.message)
+        }
+      }
+    }
+
     gw.request<SlashExecResponse>('slash.exec', { command: cmd.slice(1), session_id: sid })
       .then(r => {
         if (stale()) {
           return
+        }
+
+        if (asCommandDispatch(r)) {
+          return handleDispatch(r)
         }
 
         const body = r?.output || `/${parsed.name}: no output`
@@ -93,45 +138,7 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
               return
             }
 
-            const d = asCommandDispatch(raw)
-
-            if (!d) {
-              return sys('error: invalid response: command.dispatch')
-            }
-
-            if (d.type === 'exec' || d.type === 'plugin') {
-              return sys(d.output || '(no output)')
-            }
-
-            if (d.type === 'alias') {
-              return handler(`/${d.target}${argTail}`)
-            }
-
-            if (d.type === 'skill') {
-              sys(`⚡ loading skill: ${d.name}`)
-
-              return d.message?.trim() ? send(d.message) : sys(`/${parsed.name}: skill payload missing message`)
-            }
-
-            if (d.type === 'send') {
-              if (d.notice?.trim()) {
-                sys(d.notice)
-              }
-              return d.message?.trim() ? send(d.message) : sys(`/${parsed.name}: empty message`)
-            }
-
-            if (d.type === 'prefill') {
-              // /undo returns prefill: drop the backed-up message text into
-              // the composer so the user can edit and resubmit, instead of
-              // submitting it immediately like 'send'.
-              if (d.notice?.trim()) {
-                sys(d.notice)
-              }
-              if (d.message) {
-                ctx.composer.setInput(d.message)
-              }
-              return
-            }
+            handleDispatch(raw)
           })
           .catch(guardedErr)
       })


### PR DESCRIPTION
## What does this PR do?

Fixes the TUI slash-command success path so it can handle structured `command.dispatch` payloads returned directly from `slash.exec`.

`slash.exec` now routes pending-input commands like `/goal` to `command.dispatch` server-side. That can return `{ type: "send", notice, message }`, but the TUI success handler still only read `{ output }`, so `/goal ...` could render `/goal: no output` instead of showing the goal notice and submitting the kickoff message.

This reuses the existing dispatch-payload handling on both the successful `slash.exec` path and the fallback `command.dispatch` path.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/app/createSlashHandler.ts`: normalize successful `slash.exec` dispatch payloads through the existing dispatch handler before falling back to `{ output }`.
- `ui-tui/src/__tests__/createSlashHandler.test.ts`: add a regression for `/goal` returning `{ type: "send", notice, message }` without rendering `/goal: no output`.

## How to Test

1. Run `npm --prefix ui-tui test -- src/__tests__/createSlashHandler.test.ts`.
2. Run `npm --prefix ui-tui run typecheck`.
3. In TUI, submit `/goal complete all the steps and provide a final report`; it should render the goal notice and submit the kickoff prompt instead of printing `/goal: no output`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / WSL, focused TUI test and typecheck

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Validated with:

- `npm --prefix ui-tui test -- src/__tests__/createSlashHandler.test.ts`
- `npm --prefix ui-tui run typecheck`

Full `pytest tests/ -q` was not run; this change is scoped to the TypeScript TUI handler and regression test.
