### PR TITLE
Gate COMPLETE on true idle lifecycle

### DIFF
--- a/gateway/final_sentinel.py
+++ b/gateway/final_sentinel.py
@@ -1,0 +1,120 @@
+"""Gateway final-message sentinel helpers.
+
+Telegram/Discord may show a standalone ``COMPLETE`` marker, but that marker
+must mean true-idle rather than merely "the main response was delivered".
+The platform/delivery gate lives here with a small lifecycle snapshot so call
+sites can suppress the marker whenever follow-up work is still pending.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Tuple
+
+
+FINAL_MESSAGE_SENTINEL = "COMPLETE"
+SUPPORTED_FINAL_SENTINEL_PLATFORMS = {"telegram", "discord"}
+
+
+@dataclass(frozen=True)
+class FinalSentinelLifecycleSnapshot:
+    """Minimal true-idle inputs for sending the final gateway sentinel.
+
+    Every field represents known unfinished work.  Unknown work should be
+    modeled by setting the closest field to ``True``; if true idle cannot be
+    proven, callers must suppress the sentinel.
+    """
+
+    active_session: bool = False
+    active_session_task: bool = False
+    pending_message: bool = False
+    drain_task_spawned: bool = False
+    post_delivery_callback_pending: bool = False
+    approval_pending: bool = False
+    running_agent_active: bool = False
+    background_review_pending: bool = False
+    final_report_pending: bool = False
+    gateway_active_run: bool = False
+
+    def blocking_reasons(self) -> Tuple[str, ...]:
+        reasons: list[str] = []
+        for name, value in (
+            ("active_session", self.active_session),
+            ("active_session_task", self.active_session_task),
+            ("pending_message", self.pending_message),
+            ("drain_task_spawned", self.drain_task_spawned),
+            ("post_delivery_callback_pending", self.post_delivery_callback_pending),
+            ("approval_pending", self.approval_pending),
+            ("running_agent_active", self.running_agent_active),
+            ("background_review_pending", self.background_review_pending),
+            ("final_report_pending", self.final_report_pending),
+            ("gateway_active_run", self.gateway_active_run),
+        ):
+            if value:
+                reasons.append(name)
+        return tuple(reasons)
+
+    def is_true_idle(self) -> bool:
+        """Return True only when no known lifecycle work remains."""
+        return not self.blocking_reasons()
+
+
+def platform_name(platform: Any) -> str:
+    """Normalize a Platform enum / raw platform value to lowercase text."""
+    value = getattr(platform, "value", platform)
+    return str(value or "").lower()
+
+
+def is_final_sentinel_platform(platform: Any) -> bool:
+    """Return True when this platform should receive final sentinels."""
+    return platform_name(platform) in SUPPORTED_FINAL_SENTINEL_PLATFORMS
+
+
+def strip_trailing_final_sentinel(text: str) -> str:
+    """Remove a model-produced trailing standalone sentinel if present.
+
+    The durable marker is sent by the gateway as a separate message. If the
+    model includes a final standalone COMPLETE line, strip it from the body so
+    the user does not see duplicates or a marker buried in the main response.
+    """
+    if not isinstance(text, str) or not text:
+        return text
+
+    lines = text.rstrip().splitlines()
+    if not lines:
+        return ""
+    if lines[-1].strip() != FINAL_MESSAGE_SENTINEL:
+        return text
+    return "\n".join(lines[:-1]).rstrip()
+
+
+def should_send_final_sentinel(
+    *,
+    platform: Any,
+    message_type: Any = None,
+    response_delivered: bool = False,
+    is_ephemeral_response: bool = False,
+    failed: bool = False,
+    suppressed_or_stale: bool = False,
+    lifecycle: FinalSentinelLifecycleSnapshot | None = None,
+) -> bool:
+    """Return True when a gateway turn may emit standalone COMPLETE.
+
+    The response must have been visibly delivered *and* lifecycle state must be
+    true-idle.  A missing lifecycle snapshot is treated as not idle because the
+    incident class here is false-positive COMPLETE when idle cannot be proven.
+    """
+    if not is_final_sentinel_platform(platform):
+        return False
+    if not response_delivered:
+        return False
+    if failed or suppressed_or_stale or is_ephemeral_response:
+        return False
+
+    message_type_value = getattr(message_type, "value", message_type)
+    if str(message_type_value or "").lower() == "command":
+        return False
+
+    if lifecycle is None:
+        return False
+    return lifecycle.is_true_idle()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1890,6 +1890,8 @@ class BasePlatformAdapter(ABC):
         # registered by a fresher run for the same session.
         self._post_delivery_callbacks: Dict[str, Any] = {}
         self._expected_cancelled_tasks: set[asyncio.Task] = set()
+        self._final_sentinel_running_agent_checker: Optional[Callable[[str], bool]] = None
+        self._final_sentinel_gateway_active_run_checker: Optional[Callable[[str], bool]] = None
         self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
         # Auto-TTS on voice input: ``_auto_tts_default`` is the global default
         # (``voice.auto_tts`` in config.yaml, pushed by GatewayRunner on connect).
@@ -3388,14 +3390,25 @@ class BasePlatformAdapter(ABC):
         return task_pending or getattr(state, "event", None) is not None
 
     def _known_running_agent_active(self, session_key: str) -> bool:
-        """Call an optional runner-provided active-agent checker if present."""
-        checker = getattr(self, "_final_sentinel_running_agent_checker", None)
+        """Call the runner-provided active-agent checker if present."""
+        checker = self._final_sentinel_running_agent_checker
         if not callable(checker):
             return False
         try:
             return bool(checker(session_key))
         except Exception:
             # Unknown active-agent state is not safe enough for COMPLETE.
+            return True
+
+    def _known_gateway_active_run(self, session_key: str) -> bool:
+        """Call the runner-provided gateway-active-run checker if present."""
+        checker = self._final_sentinel_gateway_active_run_checker
+        if not callable(checker):
+            return False
+        try:
+            return bool(checker(session_key))
+        except Exception:
+            # Unknown gateway-run state is not safe enough for COMPLETE.
             return True
 
     def _final_sentinel_lifecycle_snapshot(
@@ -3422,7 +3435,7 @@ class BasePlatformAdapter(ABC):
             running_agent_active=self._known_running_agent_active(session_key),
             background_review_pending=post_delivery_callback_pending,
             final_report_pending=final_report_pending,
-            gateway_active_run=self._known_running_agent_active(session_key),
+            gateway_active_run=self._known_gateway_active_run(session_key),
         )
 
     # ── Processing lifecycle hooks ──────────────────────────────────────────
@@ -4218,6 +4231,7 @@ class BasePlatformAdapter(ABC):
         suppressed_or_stale_response = False
         drain_task_spawned = False
         post_delivery_callback_unresolved = False
+        final_report_pending = True
         _final_thread_metadata = _thread_metadata_for_source(
             event.source,
             _reply_anchor_for_event(event),
@@ -4756,10 +4770,12 @@ class BasePlatformAdapter(ABC):
                     del self._session_tasks[session_key]
                     self._release_session_guard(session_key, guard=interrupt_event)
 
+            final_report_pending = False
             lifecycle = self._final_sentinel_lifecycle_snapshot(
                 session_key,
                 drain_task_spawned=drain_task_spawned,
                 post_delivery_callback_pending=post_delivery_callback_unresolved,
+                final_report_pending=final_report_pending,
             )
             if should_send_final_sentinel(
                 platform=self.platform,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -491,6 +491,12 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
+from gateway.final_sentinel import (
+    FINAL_MESSAGE_SENTINEL,
+    FinalSentinelLifecycleSnapshot,
+    should_send_final_sentinel,
+    strip_trailing_final_sentinel,
+)
 from gateway.session import SessionSource, build_session_key
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home
 
@@ -3358,6 +3364,67 @@ class BasePlatformAdapter(ABC):
         self._post_delivery_callbacks.pop(session_key, None)
         return entry if callable(entry) else None
 
+    def _has_pending_gateway_approval(self, session_key: str) -> bool:
+        """Best-effort approval-pending check for final sentinel gating."""
+        if not session_key:
+            return False
+        try:
+            from tools.approval import has_blocking_approval
+            return bool(has_blocking_approval(session_key))
+        except Exception:
+            # If approval state cannot be inspected, do not treat it as idle.
+            return True
+
+    def _has_pending_text_debounce(self, session_key: str) -> bool:
+        """Return True when a queued/debounced text follow-up may still flush."""
+        try:
+            state = self._text_debounce_store().get(session_key)
+        except Exception:
+            return True
+        if state is None:
+            return False
+        task = getattr(state, "task", None)
+        task_pending = bool(task is not None and not task.done())
+        return task_pending or getattr(state, "event", None) is not None
+
+    def _known_running_agent_active(self, session_key: str) -> bool:
+        """Call an optional runner-provided active-agent checker if present."""
+        checker = getattr(self, "_final_sentinel_running_agent_checker", None)
+        if not callable(checker):
+            return False
+        try:
+            return bool(checker(session_key))
+        except Exception:
+            # Unknown active-agent state is not safe enough for COMPLETE.
+            return True
+
+    def _final_sentinel_lifecycle_snapshot(
+        self,
+        session_key: str,
+        *,
+        drain_task_spawned: bool = False,
+        post_delivery_callback_pending: bool = False,
+        final_report_pending: bool = False,
+    ) -> FinalSentinelLifecycleSnapshot:
+        """Build the true-idle snapshot used before emitting COMPLETE."""
+        task = self._session_tasks.get(session_key)
+        active_task = bool(task is not None and not task.done())
+        return FinalSentinelLifecycleSnapshot(
+            active_session=session_key in self._active_sessions,
+            active_session_task=active_task,
+            pending_message=(
+                session_key in self._pending_messages
+                or self._has_pending_text_debounce(session_key)
+            ),
+            drain_task_spawned=drain_task_spawned,
+            post_delivery_callback_pending=post_delivery_callback_pending,
+            approval_pending=self._has_pending_gateway_approval(session_key),
+            running_agent_active=self._known_running_agent_active(session_key),
+            background_review_pending=post_delivery_callback_pending,
+            final_report_pending=final_report_pending,
+            gateway_active_run=self._known_running_agent_active(session_key),
+        )
+
     # ── Processing lifecycle hooks ──────────────────────────────────────────
     # Subclasses override these to react to message processing events
     # (e.g. Discord adds 👀/✅/❌ reactions).
@@ -4147,6 +4214,14 @@ class BasePlatformAdapter(ABC):
         # Track delivery outcomes for the processing-complete hook
         delivery_attempted = False
         delivery_succeeded = False
+        is_ephemeral_response = False
+        suppressed_or_stale_response = False
+        drain_task_spawned = False
+        post_delivery_callback_unresolved = False
+        _final_thread_metadata = _thread_metadata_for_source(
+            event.source,
+            _reply_anchor_for_event(event),
+        )
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
@@ -4218,6 +4293,7 @@ class BasePlatformAdapter(ABC):
                     self.name,
                     session_key,
                 )
+                suppressed_or_stale_response = True
                 response = None
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
@@ -4242,7 +4318,9 @@ class BasePlatformAdapter(ABC):
                 # _strip_media_directives shares MEDIA_TAG_CLEANUP_RE, so a MEDIA: tag
                 # with an unknown extension is intentionally left in the body for
                 # extract_local_files below to pick up rather than silently dropped (#34517).
-                text_content = _strip_media_directives(text_content).strip()
+                text_content = strip_trailing_final_sentinel(
+                    _strip_media_directives(text_content).strip()
+                )
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
 
@@ -4521,6 +4599,7 @@ class BasePlatformAdapter(ABC):
                 drain_task = asyncio.create_task(
                     self._process_message_background(pending_event, session_key)
                 )
+                drain_task_spawned = True
                 # Hand ownership of the session to the drain task so
                 # stale-lock detection keeps working while it runs.
                 self._session_tasks[session_key] = drain_task
@@ -4595,7 +4674,7 @@ class BasePlatformAdapter(ABC):
                             timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
                         )
                 except (asyncio.TimeoutError, Exception):
-                    pass
+                    post_delivery_callback_unresolved = True
             # Some adapters keep platform-level typing tasks.  If callback
             # work or a late refresh recreated one, make one final bounded stop
             # before releasing the session guard.
@@ -4642,6 +4721,7 @@ class BasePlatformAdapter(ABC):
                     drain_task = asyncio.create_task(
                         self._process_message_background(late_pending, session_key)
                     )
+                    drain_task_spawned = True
                     # Hand ownership of the session to the drain task so stale-lock
                     # detection keeps working while it runs.
                     self._session_tasks[session_key] = drain_task
@@ -4675,6 +4755,33 @@ class BasePlatformAdapter(ABC):
                 if current_task is not None and self._session_tasks.get(session_key) is current_task:
                     del self._session_tasks[session_key]
                     self._release_session_guard(session_key, guard=interrupt_event)
+
+            lifecycle = self._final_sentinel_lifecycle_snapshot(
+                session_key,
+                drain_task_spawned=drain_task_spawned,
+                post_delivery_callback_pending=post_delivery_callback_unresolved,
+            )
+            if should_send_final_sentinel(
+                platform=self.platform,
+                message_type=event.message_type,
+                response_delivered=delivery_succeeded,
+                is_ephemeral_response=is_ephemeral_response,
+                failed=not delivery_succeeded and delivery_attempted,
+                suppressed_or_stale=suppressed_or_stale_response,
+                lifecycle=lifecycle,
+            ):
+                try:
+                    await self._send_with_retry(
+                        chat_id=event.source.chat_id,
+                        content=FINAL_MESSAGE_SENTINEL,
+                        metadata=_final_thread_metadata,
+                    )
+                except Exception as _sentinel_err:
+                    logger.debug(
+                        "[%s] final sentinel send failed: %s",
+                        self.name,
+                        _sentinel_err,
+                    )
     
     async def cancel_background_tasks(self) -> None:
         """Cancel any in-flight background message-processing tasks.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3930,6 +3930,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if agent is not _AGENT_PENDING_SENTINEL
         }
 
+    def _final_sentinel_running_agent_active(self, session_key: str) -> bool:
+        """Concrete running-agent state for adapter COMPLETE gating."""
+        return bool(session_key and session_key in self._running_agents)
+
+    def _final_sentinel_gateway_active_run(self, session_key: str) -> bool:
+        """Concrete gateway active-run state for adapter COMPLETE gating."""
+        return bool(session_key and session_key in self._active_session_leases)
+
+    def _wire_final_sentinel_lifecycle_checkers(self, adapter: Any) -> None:
+        """Expose runner lifecycle state to platform-level COMPLETE gating."""
+        if adapter is None:
+            return
+        try:
+            adapter._final_sentinel_running_agent_checker = self._final_sentinel_running_agent_active
+            adapter._final_sentinel_gateway_active_run_checker = self._final_sentinel_gateway_active_run
+        except Exception:
+            logger.debug("failed to wire final sentinel lifecycle checkers", exc_info=True)
+
     def _get_max_concurrent_sessions(self) -> Optional[int]:
         """Return the configured active chat session cap, if enabled."""
         try:
@@ -5417,6 +5435,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
+            self._wire_final_sentinel_lifecycle_checkers(adapter)
             adapter._busy_text_mode = self._busy_text_mode
             
             # Try to connect
@@ -6844,6 +6863,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
+            self._wire_final_sentinel_lifecycle_checkers(adapter)
             adapter._busy_text_mode = self._busy_text_mode
 
             try:

--- a/tests/gateway/test_final_message_sentinel.py
+++ b/tests/gateway/test_final_message_sentinel.py
@@ -1,9 +1,29 @@
+from gateway.config import Platform, PlatformConfig
 from gateway.final_sentinel import (
     FINAL_MESSAGE_SENTINEL,
     FinalSentinelLifecycleSnapshot,
     should_send_final_sentinel,
     strip_trailing_final_sentinel,
 )
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+
+class _SentinelTestAdapter(BasePlatformAdapter):
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id: str, content: str, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id: str) -> dict:
+        return {}
+
+
+def _adapter() -> _SentinelTestAdapter:
+    return _SentinelTestAdapter(PlatformConfig(), Platform.TELEGRAM)
 
 
 def _idle_lifecycle() -> FinalSentinelLifecycleSnapshot:
@@ -78,6 +98,70 @@ def test_no_complete_when_drain_or_followup_was_spawned() -> None:
         lifecycle=lifecycle,
     )
     assert lifecycle.blocking_reasons() == ("drain_task_spawned",)
+
+
+def test_no_complete_while_final_report_is_pending() -> None:
+    lifecycle = FinalSentinelLifecycleSnapshot(final_report_pending=True)
+
+    assert not should_send_final_sentinel(
+        platform="telegram",
+        response_delivered=True,
+        lifecycle=lifecycle,
+    )
+    assert lifecycle.blocking_reasons() == ("final_report_pending",)
+
+
+def test_no_complete_while_running_agent_is_active() -> None:
+    lifecycle = FinalSentinelLifecycleSnapshot(running_agent_active=True)
+
+    assert not should_send_final_sentinel(
+        platform="telegram",
+        response_delivered=True,
+        lifecycle=lifecycle,
+    )
+    assert lifecycle.blocking_reasons() == ("running_agent_active",)
+
+
+def test_no_complete_while_gateway_active_run_is_present() -> None:
+    lifecycle = FinalSentinelLifecycleSnapshot(gateway_active_run=True)
+
+    assert not should_send_final_sentinel(
+        platform="telegram",
+        response_delivered=True,
+        lifecycle=lifecycle,
+    )
+    assert lifecycle.blocking_reasons() == ("gateway_active_run",)
+
+
+def test_lifecycle_snapshot_uses_concrete_running_agent_checker() -> None:
+    adapter = _adapter()
+    adapter._final_sentinel_running_agent_checker = lambda session_key: session_key == "s1"
+
+    lifecycle = adapter._final_sentinel_lifecycle_snapshot("s1")
+
+    assert lifecycle.running_agent_active
+    assert not lifecycle.gateway_active_run
+    assert lifecycle.blocking_reasons() == ("running_agent_active",)
+
+
+def test_lifecycle_snapshot_uses_concrete_gateway_active_run_checker() -> None:
+    adapter = _adapter()
+    adapter._final_sentinel_gateway_active_run_checker = lambda session_key: session_key == "s1"
+
+    lifecycle = adapter._final_sentinel_lifecycle_snapshot("s1")
+
+    assert not lifecycle.running_agent_active
+    assert lifecycle.gateway_active_run
+    assert lifecycle.blocking_reasons() == ("gateway_active_run",)
+
+
+def test_lifecycle_snapshot_marks_final_report_pending() -> None:
+    adapter = _adapter()
+
+    lifecycle = adapter._final_sentinel_lifecycle_snapshot("s1", final_report_pending=True)
+
+    assert lifecycle.final_report_pending
+    assert lifecycle.blocking_reasons() == ("final_report_pending",)
 
 
 def test_complete_platform_and_delivery_gate_still_applies() -> None:

--- a/tests/gateway/test_final_message_sentinel.py
+++ b/tests/gateway/test_final_message_sentinel.py
@@ -1,0 +1,100 @@
+from gateway.final_sentinel import (
+    FINAL_MESSAGE_SENTINEL,
+    FinalSentinelLifecycleSnapshot,
+    should_send_final_sentinel,
+    strip_trailing_final_sentinel,
+)
+
+
+def _idle_lifecycle() -> FinalSentinelLifecycleSnapshot:
+    return FinalSentinelLifecycleSnapshot()
+
+
+def test_strip_trailing_model_complete_sentinel() -> None:
+    assert strip_trailing_final_sentinel("answer\nCOMPLETE") == "answer"
+    assert strip_trailing_final_sentinel("answer\n\nCOMPLETE\n") == "answer"
+    assert strip_trailing_final_sentinel("answer COMPLETE") == "answer COMPLETE"
+
+
+def test_complete_requires_true_idle_lifecycle_snapshot() -> None:
+    assert should_send_final_sentinel(
+        platform="telegram",
+        response_delivered=True,
+        lifecycle=_idle_lifecycle(),
+    )
+
+    assert not should_send_final_sentinel(
+        platform="telegram",
+        response_delivered=True,
+        lifecycle=None,
+    )
+
+
+def test_no_complete_when_pending_messages_exist() -> None:
+    lifecycle = FinalSentinelLifecycleSnapshot(pending_message=True)
+
+    assert not should_send_final_sentinel(
+        platform="telegram",
+        response_delivered=True,
+        lifecycle=lifecycle,
+    )
+    assert lifecycle.blocking_reasons() == ("pending_message",)
+
+
+def test_no_complete_while_approval_is_pending() -> None:
+    lifecycle = FinalSentinelLifecycleSnapshot(approval_pending=True)
+
+    assert not should_send_final_sentinel(
+        platform="discord",
+        response_delivered=True,
+        lifecycle=lifecycle,
+    )
+    assert lifecycle.blocking_reasons() == ("approval_pending",)
+
+
+def test_no_complete_before_post_delivery_background_review_resolved() -> None:
+    lifecycle = FinalSentinelLifecycleSnapshot(
+        post_delivery_callback_pending=True,
+        background_review_pending=True,
+    )
+
+    assert not should_send_final_sentinel(
+        platform="telegram",
+        response_delivered=True,
+        lifecycle=lifecycle,
+    )
+    assert lifecycle.blocking_reasons() == (
+        "post_delivery_callback_pending",
+        "background_review_pending",
+    )
+
+
+def test_no_complete_when_drain_or_followup_was_spawned() -> None:
+    lifecycle = FinalSentinelLifecycleSnapshot(drain_task_spawned=True)
+
+    assert not should_send_final_sentinel(
+        platform="telegram",
+        response_delivered=True,
+        lifecycle=lifecycle,
+    )
+    assert lifecycle.blocking_reasons() == ("drain_task_spawned",)
+
+
+def test_complete_platform_and_delivery_gate_still_applies() -> None:
+    assert FINAL_MESSAGE_SENTINEL == "COMPLETE"
+    assert not should_send_final_sentinel(
+        platform="slack",
+        response_delivered=True,
+        lifecycle=_idle_lifecycle(),
+    )
+    assert not should_send_final_sentinel(
+        platform="telegram",
+        response_delivered=False,
+        lifecycle=_idle_lifecycle(),
+    )
+    assert not should_send_final_sentinel(
+        platform="telegram",
+        message_type="command",
+        response_delivered=True,
+        lifecycle=_idle_lifecycle(),
+    )


### PR DESCRIPTION
Fixes a lifecycle-state emission bug where COMPLETE could be emitted before the gateway is truly idle.

Scope:
- Gate final COMPLETE emission on true idle lifecycle conditions.
- Preserve existing final sentinel behavior for non-idle states.
- Add focused gateway sentinel coverage.

Validation:
- Local branch diff against upstream main contains only the three intended files.