### PR TITLE
fix(desktop): remove max-w-40 from model pill to prevent name truncation

### DIFF
--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -20,7 +20,7 @@ import {
 import type { ChatBarState } from './types'
 
 const PILL = cn(
-  'h-(--composer-control-size) max-w-40 shrink-0 gap-1 rounded-md px-2 text-xs font-normal',
+  'h-(--composer-control-size) max-w-56 shrink-0 gap-1 rounded-md px-2 text-xs font-normal',
   'text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground'
 )
 


### PR DESCRIPTION
## Description

The model selector pill in the composer bar had `max-w-40` (160px), which truncated model names that include session-state suffixes like `"DeepSeek V4 Flash · Med"`. Increased to `max-w-56` (224px), which accommodates the longest typical model-status labels (~170px) with headroom while keeping a hard bound to protect the text input column from being squeezed too narrow on compact viewports.

**Before:** `"DeepSeek V4 Flash ·…"` (truncated with ellipsis)  
**After:** `"DeepSeek V4 Flash · Med"` (full label visible)

Closes #49340
