### PR TITLE
fix(agent): log warning when configured memory provider fails (#49200)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1197,7 +1197,12 @@ def init_agent(
                     agent._memory_manager.initialize_all(**_init_kwargs)
                     _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
                 else:
-                    _ra().logger.debug("Memory provider '%s' not found or not available", _mem_provider_name)
+                    _ra().logger.warning(
+                        "Memory provider '%s' failed to load or is not available — "
+                        "falling back to built-in memory. Check that the provider "
+                        "package is installed and its configuration is correct.",
+                        _mem_provider_name,
+                    )
                     agent._memory_manager = None
         except Exception as _mpe:
             _ra().logger.warning("Memory provider plugin init failed: %s", _mpe)


### PR DESCRIPTION
Fixes #49200. When a configured external memory provider (Mnemosyne, Mem0, Honcho, etc.) fails to load due to missing packages, broken symlinks, or import errors, the gateway now logs a clear warning instead of silently falling back to built-in memory. Changed the log level from debug to warning with actionable guidance.