### PR TITLE
fix(agent): stop deterministic fallback summary from triplicating the latest user ask (#49307)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1245,7 +1245,7 @@ Recovered from a deterministic fallback because the LLM context summarizer was u
 Unknown from deterministic fallback. Inspect current repository/session state if needed.
 
 {HISTORICAL_IN_PROGRESS_HEADING}
-{active_task}
+Unknown from deterministic fallback. Inspect current repository/session state if needed.
 
 ## Blocked
 {_bullets(blockers, limit=5)}
@@ -1257,7 +1257,7 @@ None recoverable from deterministic fallback.
 None recoverable from deterministic fallback.
 
 {HISTORICAL_PENDING_ASKS_HEADING}
-{active_task}
+None recoverable from deterministic fallback.
 
 ## Relevant Files
 {_bullets(relevant_files, limit=12)}

--- a/tests/agent/test_compressor_assistant_tail_anchor.py
+++ b/tests/agent/test_compressor_assistant_tail_anchor.py
@@ -516,3 +516,45 @@ class TestSourceGuardrail:
 
     def test_issue_number_referenced(self, source):
         assert "#29824" in source
+
+
+class TestFallbackSummaryNoAskDuplication:
+    """Regression for #49307: the deterministic fallback summary must keep the
+    latest user ask under the Historical Task Snapshot only, not echo it
+    verbatim under the In-Progress and Pending headings. The triplication gave
+    the model a strong structural signal to re-answer the (already-answered or
+    superseded) ask after a failed compaction, causing answer repetition and
+    new-instruction loss."""
+
+    @staticmethod
+    def _section(summary: str, heading: str) -> str:
+        """Body text under ``heading`` (matched as a standalone section header,
+        not the quoted mention inside SUMMARY_PREFIX)."""
+        import re
+
+        marker = "\n" + heading + "\n"
+        start = summary.index(marker) + len(marker)
+        rest = summary[start:]
+        m = re.search(r"\n#{2,} ", rest)
+        return rest[: m.start()] if m else rest
+
+    def test_latest_ask_not_duplicated_under_in_progress_or_pending(self, compressor):
+        from agent.context_compressor import (
+            HISTORICAL_IN_PROGRESS_HEADING,
+            HISTORICAL_PENDING_ASKS_HEADING,
+            HISTORICAL_TASK_HEADING,
+        )
+
+        ask = "Refactor the auth module to use JWT instead of sessions"
+        turns = [
+            {"role": "user", "content": ask},
+            {"role": "assistant", "content": "Looking into it."},
+        ]
+
+        summary = compressor._build_static_fallback_summary(turns)
+
+        # Preserved exactly where it belongs: the single most-important field.
+        assert ask in self._section(summary, HISTORICAL_TASK_HEADING)
+        # NOT echoed under In-Progress / Pending (the re-answer trigger).
+        assert ask not in self._section(summary, HISTORICAL_IN_PROGRESS_HEADING)
+        assert ask not in self._section(summary, HISTORICAL_PENDING_ASKS_HEADING)


### PR DESCRIPTION
Fixes #49307.

When the LLM context summarizer fails, `_build_static_fallback_summary` writes the verbatim latest user ask (`active_task` = `User asked: '<ask>'`) into **three** sections of the handoff: `## Historical Task Snapshot`, `## Historical In-Progress State`, and `## Historical Pending User Asks`. That triplication is a strong structural signal for the model to re-answer the (already-handled or superseded) ask after compaction — the answer-repetition + new-instruction-loss reported here.

The function's adjacent sections already use neutral fallback phrasing — `## Active State` says "Unknown from deterministic fallback…" and `## Key Decisions` / `## Resolved Questions` say "None recoverable from deterministic fallback." — and the `SUMMARY_PREFIX` guard explicitly tells the model to "discard stale items from … Historical Pending User Asks … entirely". The In-Progress / Pending echoes work directly against that.

This keeps the ask under `Historical Task Snapshot` only (which the summarizer template documents as "the single most important field"), and neutralizes the other two to match the sections beside them. Adds a deterministic regression test that drives `_build_static_fallback_summary` and asserts the ask appears under Historical Task Snapshot but not under the In-Progress / Pending headings.

Scoped to the source-verified deterministic-fallback triplication; the broader LLM-summarizer-path items in the issue (force summary role, strip verbatim quotes) are left as separate follow-ups to keep this diff precise.

Thanks to @DavidMetcalfe for the file:line root-cause analysis.