### PR TITLE
feat: add hermes-best-practices optional skill

### DIFF
--- a/optional-skills/hermes/hermes-best-practices/SKILL.md
+++ b/optional-skills/hermes/hermes-best-practices/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: hermes-best-practices
+description: Practical habits for reliable Hermes Agent operation.
+platforms: [linux, macos]
+category: hermes
+triggers:
+  - "好习惯"
+  - "best practices"
+  - "检查一下有没有违规"
+  - "audit my config"
+  - "safety check"
+  - "compliance review"
+toolsets:
+  - terminal
+  - file
+metadata:
+  hermes:
+    tags: [hermes, best-practices, safety, memory, telegram, configuration]
+---
+
+# Hermes Agent Best Practices
+
+> Core philosophy: config files are supplementary guardrails, not absolute guarantees.
+> Especially on Telegram (known SOUL.md loading instability — Issue #5200), the core habit
+> is "verify regularly, persist proactively, human-in-the-loop as last defense."
+
+## When to Use
+
+Load this skill when:
+- Self-auditing agent compliance or reviewing operational habits
+- Reviewing past mistakes and hardening workflows
+- User asks "check if I've violated any rules" or requests a safety review
+- Configuring a new Hermes profile and want to avoid common pitfalls
+
+## Prerequisites
+
+- Hermes Agent installed and operational
+- Read access to `~/.hermes/config.yaml`
+- Familiarity with SOUL.md / AGENTS.md / MEMORY.md conventions
+
+## Quick Reference
+
+| Category | Top Habit |
+|----------|-----------|
+| Config | Verify SOUL/AGENTS loaded after edit (new session) |
+| Memory | Monitor MEMORY.md budget — 50% safe, 70% watch, 85% clean |
+| Delegation | Verify dangerous ops (delete/send/funds) actually trigger confirmation |
+| Telegram | Restart gateway weekly; review allowed users periodically |
+| Trust | Don't treat agent confirmations as absolute safety net |
+| Anti-hallucination | Verify facts (date/price/news) with tools before output |
+
+## Procedures
+
+### 1. Configuration Maintenance
+
+**1.1 Verify SOUL.md / AGENTS.md after changes**
+After editing, start a new session and ask the agent to recite its current SOUL.md
+path and key content. Never assume changes took effect — especially on Telegram
+where auto-loading is unstable (Issue #5200).
+
+**1.2 Change one config category at a time**
+Don't modify multiple config files simultaneously then verify all at once. Change
+one, verify, then move to the next.
+
+**1.3 Backup before changes**
+Before editing config files, save the current full content locally so you can
+roll back directly rather than reconstructing from memory.
+
+**1.4 Monitor MEMORY.md / USER.md character budget**
+Let the agent self-report character usage regularly (weekly):
+- MEMORY.md cap: 8,000 chars (50% safe / 70% watch / 85% clean)
+- USER.md cap: 3,000 chars (50% safe / 70% watch / 85% clean)
+
+⚠️ **memory replace truncation risk**: `memory action=replace` replaces the
+*entire* matching entry, not just the old_text portion. If old_text only matches
+part of an entry, the rest is lost. Safer: delete old entry then `action=add` rebuild.
+
+**1.5 Harness consistency audit**
+Audit SOUL/AGENTS/MEMORY/config.yaml against external frameworks (Rahul Harness
+Engineering / Karpathy CLAUDE.md) for version drift, missing constraints, and
+scene-mismatched rules. See `references/harness-audit-checklist.md`.
+Key check: config.yaml embedded personality version ≠ SOUL.md version.
+
+**1.6 Agent proactive reminders**
+The agent should proactively remind when: SOUL/AGENTS edited → verify loading;
+MEMORY >80% → clean; dangerous operations → verify rules active;
+long tasks → progress checkpoints; ambiguous instructions → clarify boundaries;
+weekly → restart gateway; monthly → audit memory.
+
+**1.7 `tool_use_enforcement` scope**
+`tool_use_enforcement: auto` matches model names against `TOOL_USE_ENFORCEMENT_MODELS`
+in `agent/prompt_builder.py`. Current list (as of v0.13.0):
+```
+gpt, codex, gemini, gemma, grok, glm, qwen, deepseek
+```
+Claude models are NOT in this list. Verify with:
+```bash
+grep "tool_use_enforcement" ~/.hermes/config.yaml
+grep -n "TOOL_USE_ENFORCEMENT_MODELS" ~/.hermes/hermes-agent/agent/prompt_builder.py
+```
+
+### 2. Delegation & Daily Tasks
+
+**2.1 First-time dangerous op verification**
+The first time a delete/send/funds/production operation triggers, manually observe
+whether the agent actually stops to confirm. Trust rules only after seeing them
+work in a real scenario.
+
+**2.2 Phased progress for long tasks**
+Multi-step, long-running tasks should report progress in phases. Catch errors
+early rather than at the end.
+
+**2.3 Clear instruction boundaries**
+Give explicit scope: "delete temp files under test/" is safer than "clean up."
+
+**2.4 Post-refactor chain verification**
+After restructuring (script migrations/path changes/file renames), verify the
+ENTIRE call chain, not just file existence. A filename mismatch in one link
+(e.g., `optical_share` vs `optical_module_share`) only surfaces when running the
+full pipeline.
+
+**2.5 Scan first, then advise; verify first, then act**
+- **Scan before advising**: When asked to "plan" or "suggest," scan the current
+  state comprehensively first. Skipping this leads to unrealistic proposals.
+- **Verify before acting**: When the user says "double-check," that means go through
+  it a second time — not just a courtesy pause. Issues found during verification
+  (e.g., rsync `--delete` traps, misspelled directory names) must be addressed
+  before execution.
+
+**2.6 Commands suggested to users must be verified first**
+Any CLI command the agent recommends (e.g., `hermes config get`) must be tested
+in its own environment before suggesting. Recommending unverified commands leads
+to `invalid choice` errors. Similarly, before claiming "you can check with command X,"
+confirm: (a) the command exists, (b) the feature exists, (c) the parameters are correct.
+
+### 3. Telegram-Specific
+
+**3.1 Sensitive ops in DM**
+Sensitive or high-privilege commands should be sent via DM, not in group chats
+where context is more easily misread and privacy mode may drop messages.
+
+**3.2 Periodically review allowed users**
+Regularly check TELEGRAM_ALLOWED_USERS — this list doesn't auto-sync with external changes.
+
+**3.3 Periodic gateway restart**
+Restart the gateway regularly (weekly recommended), especially after config.yaml
+changes, to avoid runtime/disk config mismatch.
+
+**3.4 Subdirectory AGENTS.md progressive discovery**
+Subdirectory AGENTS.md files under Telegram gateway are NOT completely unreadable.
+`subdirectory_hints.py` triggers scanning on any write operation (`terminal` with
+writes, `write_file`). Pure reads and network calls don't trigger. Session startup
+only loads CWD's AGENTS.md. See `references/subdirectory-agents-discovery.md`.
+
+### 4. Memory & Long-Term Information
+
+**4.1 Explicitly persist important info**
+Don't assume the agent will "remember" one-off important info. If you want it
+retained long-term, explicitly say "save this to memory."
+
+**4.2 Periodic manual memory audit**
+Monthly: have the agent output full MEMORY.md and USER.md content. Review for
+stale/wrong/unimportant entries and manually clean rather than letting auto-accumulation continue.
+
+**4.3 No sensitive info in memory**
+Health, financial details, and other sensitive information should NOT be written
+to MEMORY.md/USER.md. These files are read in full every session — the longer they
+persist, the larger the exposure surface.
+
+### 5. Trust Boundaries
+
+**5.1 Confirmation is not an absolute safety net**
+Don't treat agent confirmations as absolutely reliable — especially when SOUL.md/
+AGENTS.md is known to sometimes not load correctly. The last line of defense for
+critical operations is human judgment.
+
+**5.2 Periodic Hard Constraints review**
+Quarterly review of SOUL.md Hard Constraints — are they still appropriate for
+current usage patterns? Rules written once aren't forever; adjust as needs evolve.
+
+### 6. Anti-Hallucination & Fact-Checking
+
+**6.1 Verify facts before output containing them**
+Any output containing dates, weather, stock prices, news, file paths, or other
+verifiable facts (TTS voice, message body, file content) MUST have the
+corresponding tool executed BEFORE generating the text. Don't stuff unverified
+info as "decorative filler."
+
+- **Trigger**: Output contains specific numbers (time/date/price/quantity/version)
+- **TTS specific**: Separate emotional content (greetings) from factual content —
+  greetings handle mood, facts must be accurate.
+
+**6.2 Mark sources item-by-item when asked to verify**
+When the user explicitly asks "verify each item, answer separately, explain each
+individually," distinguish every item as "executed/verified" vs "inferred/speculated."
+Inferred items must be clearly labeled "this is speculation, no factual basis" —
+don't pad with explanations to appear comprehensive. Don't replace actual execution
+results with "it should..." If a command fails, report the error as-is.
+
+**6.3 Confirm existence before claiming a feature or command**
+CLI commands recommended to users must be run in the agent's own environment first.
+Claims about config functionality must be backed by actual config.yaml fields or
+official documentation. Never recommend based on "Hermes should have this feature."
+
+**6.4 Config descriptions should match actual config.yaml**
+Documentation summaries may be outdated or truncated. When describing current system
+configuration, prefer actual `hermes config show` or `grep` output from config.yaml.
+See `references/fact-verification-guide.md`.
+
+## Pitfalls
+
+- **SOUL.md / AGENTS.md auto-load on Telegram is unreliable** — known bug (Issue #5200).
+  Verification method: ask agent directly "SOUL.md path + key content" rather than
+  observing behavior.
+- **memory replace destroys entries** — use delete+add pattern for safety.
+- **vault-sync is an archive, not a pipeline config directory** — don't touch its
+  subdirectories when refactoring push systems.
+- **Scan before advising** — different scenarios need different harness patterns.
+  Don't blindly copy coding-scene harness artifacts to content operations.
+
+## Verification
+
+After applying these practices:
+1. Ask the agent to self-report MEMORY.md / USER.md character usage and percentage.
+2. Start a new session after editing SOUL.md and verify the agent recites new content.
+3. Test one dangerous operation to confirm the confirmation gate triggers.
+4. Run a cron pipeline end-to-end after any restructuring.
+5. Grep `TOOL_USE_ENFORCEMENT_MODELS` to confirm your current model's status.

--- a/optional-skills/hermes/hermes-best-practices/references/fact-verification-guide.md
+++ b/optional-skills/hermes/hermes-best-practices/references/fact-verification-guide.md
@@ -1,0 +1,50 @@
+# Fact Verification Guide
+
+> How to verify facts before including them in agent output.
+> Based on real failure modes observed in production use.
+
+## Core Principle
+
+Any output containing **verifiable facts** (dates, weather, stock prices, news,
+file paths, version numbers, quantities) MUST have the corresponding tool executed
+BEFORE generating the text. Unverified facts are not "decorative filler" — they
+are misinformation.
+
+## Common Failure Modes
+
+### 1. Date/Time Fabrication
+- **Symptom**: TTS voice says "Happy Friday!" when it's actually Saturday.
+- **Root cause**: Agent generated text without running `date` first.
+- **Fix**: Always run `date` before any output mentioning day of week, date, or time.
+
+### 2. Command Non-Existence
+- **Symptom**: Agent recommends `hermes config get <key>` → user gets `invalid choice: 'get'`
+- **Root cause**: Agent assumed subcommand exists without checking `--help`.
+- **Fix**: Run `command --help` before recommending any CLI command to a user.
+
+### 3. Config Field Non-Existence
+- **Symptom**: Agent claims "you can check with `hermes config <fake_subcommand>`"
+- **Root cause**: Inferring config structure from memory rather than actual config.yaml.
+- **Fix**: Grep config.yaml or run `hermes config show` before describing config state.
+
+## Verification Checklist
+
+When output includes any of the following, verify first:
+
+| Category | Tool to Run | Example |
+|----------|------------|---------|
+| Date/time | `date` | "Today is..." |
+| Weather | web_search | "It's sunny in..." |
+| Stock price | web_search / API | "AAPL is at..." |
+| File path | `ls` / `stat` | "The file at ~/.hermes/..." |
+| CLI command | `command --help` | "You can use `hermes config get`" |
+| Config field | `grep config.yaml` | "Your config has X set to Y" |
+| Version | `command --version` | "Hermes v0.13.0 supports..." |
+
+## TTS-Specific Guidance
+
+Voice output has two layers:
+- **Emotional layer** (greetings, tone, personality) — creative, no verification needed
+- **Factual layer** (dates, weather, news, data) — must be verified before inclusion
+
+Keep them separate: greetings handle mood, facts must be accurate.

--- a/optional-skills/hermes/hermes-best-practices/references/harness-audit-checklist.md
+++ b/optional-skills/hermes/hermes-best-practices/references/harness-audit-checklist.md
@@ -1,0 +1,37 @@
+# Harness Consistency Audit Checklist
+
+> Based on Rahul "Harness Engineering" + Karpathy CLAUDE.md practical audit framework.
+> Don't blindly apply coding-scene standards — only audit what's active in YOUR actual usage pattern.
+
+## Audit Steps
+
+### 1. Config File Consistency
+- [ ] Does config.yaml `personalities.<name>` match SOUL.md version?
+- [ ] Is SOUL.md version current? (check `> Last updated` line)
+- [ ] Do AGENTS.md Key Paths point to real, existing files?
+- [ ] No two config sources defining the same constraint with different content (e.g., SOUL v3.0 vs v3.3)
+
+### 2. Harness Artifacts (applicable items only)
+
+| Artifact | Check |
+|----------|-------|
+| AGENTS.md / CLAUDE.md | Exists? Has project context + paths + safety gates? |
+| Session init flow | Under Telegram, does SOUL/AGENTS actually load? (Issue #5200) |
+| Plan/execute separation | Cron reports: generate → push separated? Complex tasks: proposal first? |
+| Feedback loops | Push audit script running? approvals.mode active? checkpoints enabled? |
+
+### 3. Karpathy 4 Rules Assessment
+
+| Rule | Check |
+|------|-------|
+| Think before write | Does SOUL/AGENTS have "judgment over response" / "mark confidence when uncertain"? |
+| Simple first | Is there explicit anti-overengineering constraint? |
+| Surgical changes | Does AGENTS.md Safety Gates include "don't touch adjacent config / only operate on explicitly asked targets"? |
+| Goal-driven | Does Workflow have "understand goal first" / "preserve completed work on failure"? |
+
+### 4. Harness Decay Signals
+
+- [ ] Memory usage (>70% watch, >85% immediate clean)
+- [ ] Skills have curator auto-expiry (168h interval)
+- [ ] Quarterly review of SOUL Hard Constraints
+- [ ] config.yaml has no stale model references

--- a/optional-skills/hermes/hermes-best-practices/references/subdirectory-agents-discovery.md
+++ b/optional-skills/hermes/hermes-best-practices/references/subdirectory-agents-discovery.md
@@ -1,0 +1,34 @@
+# Subdirectory AGENTS.md Progressive Discovery
+
+> How Hermes discovers AGENTS.md in subdirectories during sessions.
+
+## Official Mechanism
+
+Per the [Prompt Assembly docs](https://hermes-agent.nousresearch.com/docs/developer-guide/prompt-assembly) (Layer 8: Context Files):
+
+> AGENTS.md (CWD at startup; subdirectories discovered progressively during the session via agent/subdirectory_hints.py)
+
+## Trigger Conditions
+
+| Tool | Operation Type | Triggers Discovery? |
+|------|---------------|---------------------|
+| `terminal` (mkdir + write) | Create dir + write file | ✅ |
+| `write_file` (new file) | Create dir + write file | ✅ |
+| `terminal` (read-only) | Pure read | ❌ |
+| `web_search` / `web_extract` | Network only | ❌ |
+| `read_file` | Read existing | ❌ |
+
+## Key Takeaways
+
+- **Session startup**: Only CWD's AGENTS.md is loaded.
+- **Mid-session**: Write operations trigger nearby subdirectory scanning.
+- **Telegram gateway**: CWD is forced to `$HOME`; subdirectory AGENTS.md requires
+  a write operation within the session to be discovered.
+- **CLI mode**: CWD is user's current directory; subdirectory discovery works the same way.
+
+## Verification Method
+
+To confirm subdirectory AGENTS.md loading:
+1. Create a subdirectory with an AGENTS.md containing a unique marker phrase.
+2. Perform a write operation inside or near that subdirectory.
+3. Ask the agent to recite the marker phrase — if loaded, the phrase appears in context.


### PR DESCRIPTION
## Summary

Adds `hermes-best-practices` as an official **optional skill** — a comprehensive operational habits checklist for Hermes Agent users.

## What's Included

### SKILL.md
- 6 categories covering: configuration maintenance, delegation habits, Telegram-specific guidance, memory management, trust boundaries, and anti-hallucination workflows
- Structured per CONTRIBUTING.md format: When to Use → Prerequisites → Quick Reference → Procedures → Pitfalls → Verification
- Includes `tool_use_enforcement` scope documentation with current model list from `agent/prompt_builder.py`
- References Telegram SOUL.md loading instability (Issue #5200)

### Reference Docs
- **harness-audit-checklist.md** — Harness Engineering consistency audit framework
- **fact-verification-guide.md** — Anti-hallucination verification procedures (dates, commands, config)
- **subdirectory-agents-discovery.md** — Subdirectory AGENTS.md progressive discovery mechanism

## Why Optional?

This is a reference/checklist skill — useful for self-auditing and hardening workflows, but not needed in every session. Users install via `hermes skills install official/hermes/hermes-best-practices`.

## Validation

- Skill loads correctly with `skill_view('hermes-best-practices')`
- All reference paths resolve correctly
- No user-specific content — all examples are generalized