### PR TITLE
fix(desktop): sync global profile store after Manage Profiles mutations

### DIFF
--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -28,6 +28,7 @@ import { useI18n } from '@/i18n'
 import { AlertTriangle, Pencil, Save, Terminal, Trash2, Users } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
+import { refreshActiveProfile } from '@/store/profile'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { OverlayMain, OverlayNewButton, OverlaySidebar, OverlaySplitLayout } from '../overlays/overlay-split-layout'
@@ -56,6 +57,7 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
     try {
       const { profiles: list } = await getProfiles()
       setProfiles(list)
+      void refreshActiveProfile()
       setSelectedName(current => {
         if (current && list.some(p => p.name === current)) {
           return current


### PR DESCRIPTION
## Bug Description

In Hermes Desktop, when a profile is deleted from the **Manage Profiles** overlay, the profile's colored square icon persists in the **profile rail** at the bottom of the main chat view. The stale icon only disappears when the user clicks another profile icon, which triggers a state refresh.

Fixes #49289

## Root Cause

The Manage Profiles overlay (`apps/desktop/src/app/profiles/index.tsx`) maintains its own local `profiles` state via `useState`. When a profile is created, renamed, or deleted, the overlay calls its local `refresh()` callback which fetches from `getProfiles()` and updates the local state — but it never updates the global `$profiles` atom in `apps/desktop/src/store/profile.ts`.

The profile rail (`apps/desktop/src/app/chat/sidebar/profile-switcher.tsx`) reads from the global store via `useStore($profiles)`. When the user returns from Manage Profiles, the rail renders from the stale global atom.

## Fix

Added a call to `refreshActiveProfile()` inside the overlay's `refresh` callback, so the global `$profiles` atom is updated alongside the local state after every mutation (create, rename, delete).

## How to Verify

1. In Hermes Desktop, create a non-default profile (e.g. "test1") via the profile rail's "+" button.
2. Confirm the colored square for "test1" appears in the profile rail.
3. Open **Manage Profiles** (click "…" in the profile rail).
4. Select "test1" in the sidebar, click **Delete**, and confirm.
5. Close Manage Profiles.
6. **Verify:** the "test1" icon should no longer appear in the profile rail — no additional click required.

## Test Plan

- [ ] Existing tests still pass
- [ ] Manual verification of the fix (steps above)

## Risk Assessment

Low — `refreshActiveProfile()` is already called on mount in the `ProfileRail` component (line 180 of `profile-switcher.tsx`). The function is async, fire-and-forget (`void`), and handles its own errors (catching and leaving prior values intact on failure). Adding a second call point after mutations is additive and doesn't change the existing control flow.
