### PR TITLE
Forward agent session_id as request metadata for OpenAI-wire custom providers

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -575,6 +575,16 @@ def _run_review_in_thread(
             # if a future code path bypasses the cache.
             review_agent.session_start = agent.session_start
             review_agent.session_id = agent.session_id
+            # Carry the parent's ORIGIN session id (or its current id if the
+            # parent never compacted) so the fork attributes to the same root
+            # session even when the parent rotated session_id during a
+            # compaction before forking — the assignment above would otherwise
+            # leave the fork on the parent's post-compaction child id. The fork
+            # never compresses (compression_enabled is set False below), so it
+            # keeps this stable id for its whole single-lifecycle run.
+            review_agent._origin_session_id = (
+                getattr(agent, "_origin_session_id", None) or agent.session_id
+            )
             # Never let the review fork compress. It shares the parent's
             # session_id, so if it won a compression race it would rotate the
             # parent into a NEW child that the gateway never adopts (the fork

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -646,7 +646,10 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             messages=_msgs_for_codex,
             tools=tools_for_api,
             reasoning_config=agent.reasoning_config,
-            session_id=getattr(agent, "session_id", None),
+            # Prefer the stable origin id so the stamp survives a compaction
+            # rotation (conversation_compression rotates agent.session_id mid-run);
+            # falls back to session_id when no compaction has occurred.
+            session_id=getattr(agent, "_origin_session_id", None) or getattr(agent, "session_id", None),
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
             request_overrides=agent.request_overrides,
@@ -753,7 +756,9 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             max_tokens_param_fn=agent._max_tokens_param,
             reasoning_config=agent.reasoning_config,
             request_overrides=agent.request_overrides,
-            session_id=getattr(agent, "session_id", None),
+            # Prefer the stable origin id so the stamp survives a compaction
+            # rotation; falls back to session_id when no compaction has occurred.
+            session_id=getattr(agent, "_origin_session_id", None) or getattr(agent, "session_id", None),
             provider_profile=_profile,
             is_custom_provider=agent.provider == "custom",  # AGT-101
             ollama_num_ctx=agent._ollama_num_ctx,
@@ -786,7 +791,9 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         max_tokens_param_fn=agent._max_tokens_param,
         reasoning_config=agent.reasoning_config,
         request_overrides=agent.request_overrides,
-        session_id=getattr(agent, "session_id", None),
+        # Prefer the stable origin id so the stamp survives a compaction
+        # rotation; falls back to session_id when no compaction has occurred.
+        session_id=getattr(agent, "_origin_session_id", None) or getattr(agent, "session_id", None),
         model_lower=(agent.model or "").lower(),
         is_openrouter=_is_or,
         is_nous=_is_nous,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -653,6 +653,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
+            is_custom_provider=agent.provider == "custom",  # AGT-101
             github_reasoning_extra=agent._github_models_reasoning_extra_body() if is_github_responses else None,
             replay_encrypted_reasoning=bool(
                 getattr(agent, "_codex_reasoning_replay_enabled", True)
@@ -754,6 +755,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             request_overrides=agent.request_overrides,
             session_id=getattr(agent, "session_id", None),
             provider_profile=_profile,
+            is_custom_provider=agent.provider == "custom",  # AGT-101
             ollama_num_ctx=agent._ollama_num_ctx,
             # Context forwarded to profile hooks:
             provider_preferences=_prefs or None,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -567,6 +567,21 @@ def compress_context(
                 old_title = agent._session_db.get_session_title(agent.session_id)
                 agent._session_db.end_session(agent.session_id, "compression")
                 old_session_id = agent.session_id
+                # Preserve the ORIGIN (pre-first-rotation) session id so that any
+                # downstream consumer of the session id which must remain stable
+                # across compaction can read it. The rotation below mints a fresh
+                # auto id and opens a child session (parent_session_id =
+                # old_session_id), so without this capture a request-metadata
+                # stamp keyed on agent.session_id (e.g. an OpenAI-wire gateway
+                # forwarding it as the Langfuse trace sessionId) would switch to
+                # the child id post-compaction, splitting one logical run across a
+                # tagged trace plus an untagged continuation. Captured once (first
+                # rotation only) so it stays the root id through repeated
+                # compactions. If the rotation below is reverted on error this
+                # equals the still-current agent.session_id, so an origin-or-current
+                # read resolves to the same value either way.
+                if not getattr(agent, "_origin_session_id", None):
+                    agent._origin_session_id = old_session_id
                 agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
                 # Ordering contract: the agent thread updates the contextvar here;
                 # the gateway propagates to SessionEntry after run_in_executor returns.

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -447,6 +447,16 @@ class ChatCompletionsTransport(ProviderTransport):
         if additions:
             extra_body.update(additions)
 
+        # AGT-101: forward the Hermes session id as request metadata so an
+        # OpenAI-wire gateway (LiteLLM) attributes the upstream Langfuse trace
+        # to this session (trace sessionId). metadata is a documented OpenAI
+        # chat-completions field consumed by the LiteLLM Langfuse callback;
+        # gated to custom providers (our gateway path) - known providers route
+        # through the profile path above.
+        _session_id = params.get("session_id")
+        if _session_id and params.get("is_custom_provider"):
+            extra_body.setdefault("metadata", {}).setdefault("session_id", _session_id)
+
         if extra_body:
             api_kwargs["extra_body"] = extra_body
 
@@ -563,6 +573,18 @@ class ChatCompletionsTransport(ProviderTransport):
         additions = params.get("extra_body_additions")
         if additions:
             extra_body.update(additions)
+
+        # AGT-101: stamp the Hermes session id as request metadata so an
+        # OpenAI-wire gateway (LiteLLM) sets the Langfuse trace sessionId.
+        # ``metadata`` is a documented OpenAI chat field; gated to our custom
+        # gateway (the CustomProfile path the akasha-trading crons take).
+        _session_id = params.get("session_id")
+        if _session_id and params.get("is_custom_provider"):
+            _md = extra_body.get("metadata")
+            if not isinstance(_md, dict):
+                _md = {}
+            _md.setdefault("session_id", _session_id)
+            extra_body["metadata"] = _md
 
         # Request overrides (user config)
         overrides = params.get("request_overrides")

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -329,6 +329,27 @@ class ResponsesApiTransport(ProviderTransport):
             merged_extra_body.setdefault("prompt_cache_key", session_id)
             kwargs["extra_body"] = merged_extra_body
 
+        # AGT-101: forward the Hermes session id as LiteLLM logging metadata so
+        # an OpenAI-wire gateway (LiteLLM) sets the Langfuse trace sessionId on
+        # the Responses path. The Responses API reserves top-level ``metadata``
+        # for the provider, so LiteLLM reads ``litellm_metadata`` instead - which
+        # is NOT a real OpenAI field, so gate strictly to our custom gateway
+        # (never send it to a direct OpenAI / xAI / GitHub Responses endpoint).
+        if (
+            session_id
+            and params.get("is_custom_provider")
+            and not is_xai_responses
+            and not is_github_responses
+            and not is_codex_backend
+        ):
+            _eb = kwargs.get("extra_body")
+            _eb = dict(_eb) if isinstance(_eb, dict) else {}
+            _llm = _eb.get("litellm_metadata")
+            _llm = dict(_llm) if isinstance(_llm, dict) else {}
+            _llm.setdefault("session_id", session_id)
+            _eb["litellm_metadata"] = _llm
+            kwargs["extra_body"] = _eb
+
         return kwargs
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:

--- a/tests/agent/test_session_id_compaction_continuation.py
+++ b/tests/agent/test_session_id_compaction_continuation.py
@@ -1,0 +1,173 @@
+"""Session-id continuation across a context-compaction rotation.
+
+Background: an OpenAI-wire custom provider (a LiteLLM gateway) forwards the
+agent session id as request metadata so the upstream Langfuse trace carries it
+as ``sessionId`` (see ``ChatCompletionsTransport._build_kwargs_from_profile`` /
+``CodexResponsesTransport.build_kwargs``). When a long run crosses the
+compression threshold, ``conversation_compression`` rotates ``agent.session_id``
+to a fresh auto id and opens a child session. To keep every call in one logical
+run attributed to the SAME root session, ``build_api_kwargs`` stamps
+``agent._origin_session_id`` (captured once, before the first rotation) in
+preference to the rotated ``agent.session_id`` — falling back to
+``session_id`` when no compaction has occurred (a no-op for non-compacting runs).
+
+These tests cover both halves of that contract:
+  1. the custom-provider transport stamps whatever ``session_id`` it is given
+     into ``extra_body.metadata.session_id`` (and not for non-custom providers);
+  2. ``build_api_kwargs`` selects the origin id over a rotated ``session_id``.
+"""
+
+from agent.transports.chat_completions import ChatCompletionsTransport
+from agent.chat_completion_helpers import build_api_kwargs
+from providers import get_provider_profile
+
+
+_MSGS = [{"role": "user", "content": "hi"}]
+_UNSET = object()
+
+
+def _build_chat_kwargs(transport, *, provider_profile, is_custom_provider, session_id):
+    return transport.build_kwargs(
+        model="openai/gpt-5.4-mini",
+        messages=_MSGS,
+        tools=None,
+        provider_profile=provider_profile,
+        max_tokens=None,
+        max_tokens_param_fn=lambda x: {"max_tokens": x} if x else {},
+        timeout=300,
+        reasoning_config=None,
+        request_overrides=None,
+        session_id=session_id,
+        is_custom_provider=is_custom_provider,
+        ollama_num_ctx=None,
+    )
+
+
+def _stamped_session_id(kwargs):
+    extra_body = kwargs.get("extra_body") or {}
+    return (extra_body.get("metadata") or {}).get("session_id")
+
+
+class TestCustomProviderStampsSessionIdMetadata:
+    """The transport forwards session_id as Langfuse metadata, gated to custom providers."""
+
+    def test_profile_path_custom_provider_stamps(self):
+        transport = ChatCompletionsTransport()
+        kwargs = _build_chat_kwargs(
+            transport,
+            provider_profile=get_provider_profile("nvidia"),
+            is_custom_provider=True,
+            session_id="cron_root_123",
+        )
+        assert _stamped_session_id(kwargs) == "cron_root_123"
+
+    def test_profile_path_non_custom_provider_does_not_stamp(self):
+        transport = ChatCompletionsTransport()
+        kwargs = _build_chat_kwargs(
+            transport,
+            provider_profile=get_provider_profile("nvidia"),
+            is_custom_provider=False,
+            session_id="cron_root_123",
+        )
+        assert _stamped_session_id(kwargs) is None
+
+    def test_legacy_path_custom_provider_stamps(self):
+        # provider_profile=None exercises the unregistered/custom legacy path.
+        transport = ChatCompletionsTransport()
+        kwargs = _build_chat_kwargs(
+            transport,
+            provider_profile=None,
+            is_custom_provider=True,
+            session_id="cron_root_123",
+        )
+        assert _stamped_session_id(kwargs) == "cron_root_123"
+
+    def test_legacy_path_non_custom_provider_does_not_stamp(self):
+        transport = ChatCompletionsTransport()
+        kwargs = _build_chat_kwargs(
+            transport,
+            provider_profile=None,
+            is_custom_provider=False,
+            session_id="cron_root_123",
+        )
+        assert _stamped_session_id(kwargs) is None
+
+
+class _RecordingTransport:
+    """Captures the kwargs build_api_kwargs passes to the transport."""
+
+    def __init__(self):
+        self.captured = None
+
+    def build_kwargs(self, **kwargs):
+        self.captured = kwargs
+        return {"_fake": True}
+
+
+class _FakeCodexAgent:
+    """Minimal agent that reaches the codex_responses branch of build_api_kwargs.
+
+    The recording transport stands in for the real one, so the session-id
+    SELECTION is exercised without importing run_agent / hitting the network.
+    """
+
+    api_mode = "codex_responses"
+    tools = None
+    base_url = "http://127.0.0.1:4000/v1"
+    _base_url_lower = "http://127.0.0.1:4000/v1"
+    _base_url_hostname = "127.0.0.1"
+    provider = "custom"
+    model = "openai/gpt-5.4-mini"
+    reasoning_config = None
+    max_tokens = None
+    request_overrides = None
+
+    def __init__(self, session_id, origin=_UNSET):
+        self.session_id = session_id
+        if origin is not _UNSET:
+            self._origin_session_id = origin
+        self._transport = _RecordingTransport()
+
+    def _get_transport(self):
+        return self._transport
+
+    def _prepare_messages_for_non_vision_model(self, messages):
+        return messages
+
+    def _resolved_api_call_timeout(self):
+        return 300
+
+
+def _passed_session_id(agent):
+    build_api_kwargs(agent, list(_MSGS))
+    return agent._transport.captured["session_id"]
+
+
+class TestOriginSessionIdSurvivesCompaction:
+    """build_api_kwargs prefers the stable origin id over a rotated session_id."""
+
+    def test_origin_wins_over_rotated_session_id(self):
+        # After compaction: session_id has rotated to a child auto id, but the
+        # origin id was captured first — the stamp must stay the origin id.
+        agent = _FakeCodexAgent(
+            session_id="20260620_070449_f190a4",
+            origin="cron_6fab2e_20260620_070033",
+        )
+        assert _passed_session_id(agent) == "cron_6fab2e_20260620_070033"
+
+    def test_threads_is_custom_provider(self):
+        agent = _FakeCodexAgent(session_id="s", origin="root")
+        build_api_kwargs(agent, list(_MSGS))
+        assert agent._transport.captured["is_custom_provider"] is True
+
+    def test_falls_back_to_session_id_without_origin(self):
+        # No compaction has happened yet: no _origin_session_id attribute set,
+        # so the stamp is identical to before (pure no-op).
+        agent = _FakeCodexAgent(session_id="cron_6fab2e_20260620_070033")
+        assert _passed_session_id(agent) == "cron_6fab2e_20260620_070033"
+
+    def test_revert_case_origin_equals_current(self):
+        # If a rotation is reverted on error, _origin_session_id equals the
+        # still-current session_id, so origin-or-current resolves the same.
+        agent = _FakeCodexAgent(session_id="cron_root", origin="cron_root")
+        assert _passed_session_id(agent) == "cron_root"


### PR DESCRIPTION
## Problem

When a **custom** (OpenAI-compatible) provider is actually an observability-instrumenting gateway/proxy — e.g. a [LiteLLM](https://github.com/BerriAI/litellm) proxy with a Langfuse callback — there's currently no way to correlate the gateway's per-request traces back to the Hermes session that produced them. The agent's `session_id` never reaches the request body, so the gateway's traces carry `sessionId=null` and have to be matched back to a session heuristically (by timestamp + trace name), which is fragile when more than one session hits the gateway in the same window.

## Change

Thread the existing `agent.session_id` into the request as metadata that such gateways already understand, **gated strictly to custom providers** so first-party endpoints (OpenAI/Anthropic/Gemini/…) are never altered:

- **chat/completions** (both the legacy path and the provider-profile path in `ChatCompletionsTransport`): set `extra_body.metadata.session_id`. `metadata` is a documented OpenAI chat-completions field, and LiteLLM maps `metadata.session_id` → the Langfuse trace `sessionId`.
- **Responses API** (`ResponsesApiTransport`): set `extra_body.litellm_metadata.session_id`. The Responses API reserves top-level `metadata` for the provider, so LiteLLM's logging key there is `litellm_metadata`. Because that is **not** a real OpenAI field, it's additionally gated off the direct OpenAI / xAI / GitHub Responses backends and only emitted for a custom gateway.

`is_custom_provider` is threaded through `build_api_kwargs` into the profile-path and Responses `build_kwargs` calls (the legacy chat path already received it). The change is purely additive — **no behaviour change for non-custom providers**.

## Why `metadata` / `litellm_metadata`

This is the standard request-side mechanism LiteLLM exposes to attach session/trace metadata to its logging callbacks (Langfuse, Helicone, …). No proxy-side configuration is required — the proxy's existing success callback picks `session_id` straight off the request.

## Follow-up — keep the stamp stable across context compaction (2nd commit)

The stamp above keys on `agent.session_id`. But when a long run crosses the compression threshold, `agent/conversation_compression.py` **rotates** `agent.session_id` to a fresh child id and opens a child session (`parent_session_id` = the previous id). Every LLM call after that point — **and** the post-run `background_review` fork, which inherits the rotated id and never compresses itself — was then stamped with the **child** id, so a single logical run split its traces across the originally-tagged trace plus an **untagged continuation** trace. (Observed in production: a run's spend landed ~55% on a separate auto-id continuation trace that no `sessionId` query could find.)

The second commit tracks a stable **origin** session id and stamps that in preference to the rotated one:

- `conversation_compression.py` — before the first rotation, capture `agent._origin_session_id = old_session_id` (once, so it stays the root id through repeated compactions).
- `background_review.py` — propagate `_origin_session_id` to the review fork so it attributes to the same root even when the parent compacted before forking.
- `chat_completion_helpers.py` — the three `build_kwargs` call sites stamp `getattr(agent, "_origin_session_id", None) or getattr(agent, "session_id", None)`.

The `… or session_id` fallback makes it a **no-op until a compaction actually rotates**, so non-compacting runs and direct providers are byte-identical to before. No change to the stamp sites themselves (`chat_completions.py` / the Responses transport) — they already read the `session_id` build-param, which now carries the origin id.

## Validation

Verified end-to-end in production against a LiteLLM proxy with a Langfuse `success_callback`: a real scheduled cron run's traces came back carrying `sessionId == <the agent session id>` on both the chat-completions (Anthropic upstream, `litellm-acompletion`) and Responses (gpt-5.x upstream, `litellm-responses`) paths, where they were previously `null`. The continuation fix was likewise verified live: a compacting run that previously split onto an untagged trace now keeps the origin `sessionId` across the post-compaction + skill-update calls.

A regression test (`tests/agent/test_session_id_compaction_continuation.py`) covers both halves: the custom-provider `metadata.session_id` stamp gating (custom vs non-custom, profile + legacy paths) and the origin-over-rotated selection in `build_api_kwargs` (origin wins post-rotation; falls back to `session_id` with no compaction; stable in the rotation-revert case). `py_compile` clean on all touched files.

## Notes for reviewers

- Opening as a **draft** — happy to adjust the gating (e.g. behind an explicit opt-in flag, or generalised beyond `is_custom_provider`) if you'd prefer a different surface.
- `metadata` is OpenAI-spec, so it's safe for any compliant custom endpoint; `litellm_metadata` is intentionally confined to the custom Responses path for the reason above.
- The inline `# AGT-*` comments reference our internal tracker; happy to strip them before merge if you'd rather keep the tree ref-free.
