### PR TITLE
fix(desktop,windows): use pythonw.exe for background actions to avoid console window

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2167,7 +2167,18 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
         f"\n=== {name} started {time.strftime('%Y-%m-%d %H:%M:%S')} ===\n".encode()
     )
 
-    cmd = [sys.executable, "-m", "hermes_cli.main", *subcommand]
+        # Use pythonw.exe on Windows so the spawned process doesn't create a
+    # visible console window. DETACHED_PROCESS alone still flashes a window
+    # with console-subsystem python.exe; pythonw.exe is WINDOWS-subsystem
+    # and never creates a console. Fall back to sys.executable if pythonw
+    # is not available (dev runs outside the installed venv).
+    interpreter = sys.executable
+    if sys.platform == "win32":
+        pythonw = str(Path(interpreter).with_name("pythonw.exe"))
+        if Path(pythonw).is_file():
+            interpreter = pythonw
+
+    cmd = [interpreter, "-m", "hermes_cli.main", *subcommand]
 
     popen_kwargs: Dict[str, Any] = {
         "cwd": str(PROJECT_ROOT),


### PR DESCRIPTION
On Windows, when the desktop GUI triggers background Hermes actions (gateway restart, config migrate, curator run, etc.), the web server spawns them via subprocess. Using `sys.executable` (python.exe, console subsystem) creates a visible console window even with `DETACHED_PROCESS`.

This PR switches to `pythonw.exe` (WINDOWS subsystem) which never attaches to a console, making background actions truly silent. Falls back to `sys.executable` if `pythonw.exe` is not available (dev mode).

**Testing:** Restart gateway from the desktop GUI → no cmd window appears.