### PR TITLE
feat: support persistent webhook sessions

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -663,9 +663,9 @@ class WebhookAdapter(BasePlatformAdapter):
                 status=502,
             )
 
-        # Use delivery_id in session key so concurrent webhooks on the
-        # same route get independent agent runs (not queued/interrupted).
-        session_chat_id = f"webhook:{route_name}:{delivery_id}"
+        session_chat_id = self._session_chat_id(
+            route_name, delivery_id, route_config, payload
+        )
 
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),
@@ -888,6 +888,46 @@ class WebhookAdapter(BasePlatformAdapter):
                 rendered[key] = self._render_prompt(value, payload, "", "")
             else:
                 rendered[key] = value
+        return rendered
+
+    def _session_chat_id(
+        self,
+        route_name: str,
+        delivery_id: str,
+        route_config: dict,
+        payload: dict,
+    ) -> str:
+        """Return the webhook chat id used for gateway session routing.
+
+        By default, each delivery gets its own chat id to preserve existing
+        behavior and avoid unrelated concurrent webhook runs sharing context.
+        Routes that need a persistent external conversation can opt in with a
+        payload-rendered ``session_key`` (or ``session_key_template``) value,
+        for example ``github:{repository.full_name}:issue:{issue.number}``.
+        Every webhook delivery that renders the same value is then routed into
+        the same Hermes session by the gateway's normal chat-id based session
+        key construction.
+        """
+        fallback = f"webhook:{route_name}:{delivery_id}"
+        template = (
+            route_config.get("session_key")
+            or route_config.get("session_key_template")
+            or ""
+        )
+        if not isinstance(template, str) or not template.strip():
+            return fallback
+
+        rendered = self._render_prompt(template, payload, "", route_name).strip()
+        # Unresolved placeholders mean the payload did not contain enough
+        # information to build the stable key. Fall back to per-delivery
+        # isolation rather than accidentally collapsing events into a shared
+        # literal ``{missing.field}`` session.
+        if not rendered or re.search(r"\{[a-zA-Z0-9_.]+\}", rendered):
+            logger.warning(
+                "[webhook] session_key template for route %s could not be fully rendered; using delivery id",
+                route_name,
+            )
+            return fallback
         return rendered
 
     # ------------------------------------------------------------------

--- a/hermes_cli/subcommands/webhook.py
+++ b/hermes_cli/subcommands/webhook.py
@@ -49,6 +49,12 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
         "--secret", default="", help="HMAC secret (auto-generated if omitted)"
     )
     wh_sub.add_argument(
+        "--session-key",
+        default="",
+        help="Payload template for a persistent webhook session key, e.g. "
+        "github:{repository.full_name}:issue:{issue.number}",
+    )
+    wh_sub.add_argument(
         "--deliver-only",
         action="store_true",
         help="Skip the agent — deliver the rendered prompt directly as the "

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -189,6 +189,9 @@ def _cmd_subscribe(args):
             return
         route["deliver_only"] = True
 
+    if getattr(args, "session_key", ""):
+        route["session_key"] = args.session_key
+
     if args.deliver_chat_id:
         route["deliver_extra"] = {"chat_id": args.deliver_chat_id}
 
@@ -237,6 +240,9 @@ def _cmd_list(args):
             print(f"    {desc}")
         print(f"    URL:     {base_url}/webhooks/{name}")
         print(f"    Events:  {events}")
+        session_key = route.get("session_key") or route.get("session_key_template")
+        if session_key:
+            print(f"    Session: {session_key}")
         print(f"    Deliver: {deliver}")
         print()
 

--- a/skills/autonomous-ai-agents/hermes-agent/references/webhooks.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/webhooks.md
@@ -62,6 +62,7 @@ hermes webhook subscribe <name> \
   --skills "skill1,skill2" \
   --deliver telegram \
   --deliver-chat-id "12345" \
+  --session-key "github:{repository.full_name}:issue:{issue.number}" \
   --secret "optional-custom-secret"
 ```
 
@@ -101,6 +102,7 @@ If no prompt is specified, the full JSON payload is dumped into the agent prompt
 hermes webhook subscribe github-issues \
   --events "issues" \
   --prompt "New GitHub issue #{issue.number}: {issue.title}\n\nAction: {action}\nAuthor: {issue.user.login}\nBody:\n{issue.body}\n\nPlease triage this issue." \
+  --session-key "github:{repository.full_name}:issue:{issue.number}" \
   --deliver telegram \
   --deliver-chat-id "-100123456789"
 ```

--- a/tests/gateway/test_webhook_dynamic_routes.py
+++ b/tests/gateway/test_webhook_dynamic_routes.py
@@ -172,3 +172,46 @@ class TestDynamicRouteSecretValidation:
         adapter._reload_dynamic_routes()
         assert "good" in adapter._routes
         assert "bad" not in adapter._routes
+
+
+class TestWebhookSessionRouting:
+    def test_session_key_template_routes_same_issue_to_same_chat_id(self):
+        adapter = _make_adapter()
+        route = {"session_key": "github:{repository.full_name}:issue:{issue.number}"}
+        payload_opened = {
+            "repository": {"full_name": "simplexadjungat/simplexadjungat"},
+            "issue": {"number": 2},
+            "action": "opened",
+        }
+        payload_comment = {
+            "repository": {"full_name": "simplexadjungat/simplexadjungat"},
+            "issue": {"number": 2},
+            "comment": {"body": "approved"},
+            "action": "created",
+        }
+
+        first = adapter._session_chat_id("github-issues", "delivery-open", route, payload_opened)
+        second = adapter._session_chat_id("github-issues", "delivery-comment", route, payload_comment)
+
+        assert first == second
+        assert first == "github:simplexadjungat/simplexadjungat:issue:2"
+
+    def test_without_session_key_template_delivery_id_keeps_existing_isolation(self):
+        adapter = _make_adapter()
+        route = {}
+
+        first = adapter._session_chat_id("github-issues", "delivery-one", route, {})
+        second = adapter._session_chat_id("github-issues", "delivery-two", route, {})
+
+        assert first == "webhook:github-issues:delivery-one"
+        assert second == "webhook:github-issues:delivery-two"
+        assert first != second
+
+    def test_unresolved_session_key_template_falls_back_to_delivery_id(self):
+        adapter = _make_adapter()
+        route = {"session_key": "github:{repository.full_name}:issue:{issue.number}"}
+        payload = {"repository": {"full_name": "simplexadjungat/simplexadjungat"}}
+
+        chat_id = adapter._session_chat_id("github-issues", "delivery-one", route, payload)
+
+        assert chat_id == "webhook:github-issues:delivery-one"

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -34,6 +34,7 @@ def _make_args(**kwargs):
         "deliver": "log",
         "deliver_chat_id": "",
         "secret": "",
+        "session_key": "",
         "payload": "",
     }
     defaults.update(kwargs)
@@ -71,6 +72,17 @@ class TestSubscribe:
             webhook_action="subscribe", name="s", secret="my-secret"
         ))
         assert _load_subscriptions()["s"]["secret"] == "my-secret"
+
+    def test_session_key_template(self):
+        webhook_command(_make_args(
+            webhook_action="subscribe",
+            name="gh-issues",
+            session_key="github:{repository.full_name}:issue:{issue.number}",
+        ))
+        assert (
+            _load_subscriptions()["gh-issues"]["session_key"]
+            == "github:{repository.full_name}:issue:{issue.number}"
+        )
 
     def test_auto_secret(self):
         webhook_command(_make_args(webhook_action="subscribe", name="s"))

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -84,6 +84,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `skills` | No | List of skill names to load for the agent run. |
 | `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
+| `session_key` | No | Payload-rendered template for a persistent webhook session, e.g. `github:{repository.full_name}:issue:{issue.number}`. Events rendering the same value reuse the same Hermes session; routes without this keep the default one-session-per-delivery behavior. |
 | `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. See [Direct Delivery Mode](#direct-delivery-mode) for use cases. Requires `deliver` to be a real target (not `log`). |
 
 ### Full example
@@ -108,6 +109,7 @@ platforms:
             Diff URL: {pull_request.diff_url}
             Action: {action}
           skills: ["github-code-review"]
+          session_key: "github:{repository.full_name}:pr:{pull_request.number}"
           deliver: "github_comment"
           deliver_extra:
             repo: "{repository.full_name}"
@@ -138,6 +140,16 @@ prompt: "PR #{pull_request.number} by {pull_request.user.login}: {__raw__}"
 If no `prompt` template is configured for a route, the entire payload is dumped as indented JSON (truncated at 4000 characters).
 
 The same dot-notation templates work in `deliver_extra` values.
+
+### Persistent webhook sessions
+
+By default, each webhook delivery becomes an independent Hermes session keyed by the provider delivery id. Use `session_key` when an external object should keep context across events:
+
+```yaml
+session_key: "github:{repository.full_name}:issue:{issue.number}"
+```
+
+All deliveries that render the same session key route back into the same Hermes conversation. If the template cannot be fully rendered because the payload is missing a field, Hermes falls back to the default delivery-id session to avoid accidental cross-event context sharing.
 
 ### Forum Topic Delivery
 


### PR DESCRIPTION
## Summary
- Add `session_key` / `session_key_template` support to webhook routes so external objects can route repeated events into one persistent Hermes session.
- Add `hermes webhook subscribe --session-key ...` and show session routing in `hermes webhook list`.
- Preserve existing default isolation by falling back to `webhook:<route>:<delivery_id>` when no session template is configured or when the template cannot be fully rendered.
- Document persistent webhook sessions.

## Test Plan
- `PYTHONPATH=. /tmp/hermes-test-venv/bin/python -m pytest tests/gateway/test_webhook_dynamic_routes.py tests/hermes_cli/test_webhook_cli.py -q`
- `PYTHONPATH=. /tmp/hermes-test-venv/bin/python -m pytest tests/gateway/test_webhook_dynamic_routes.py tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_integration.py tests/hermes_cli/test_webhook_cli.py -q`

Implements the core support needed for issue-scoped sessions tracked in simplexadjungat/simplexadjungat#2.