### PR TITLE
fix: repair sqlite wal state handling

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -685,6 +685,11 @@ _last_init_error_lock = threading.Lock()
 _wal_fallback_warned_paths: set[str] = set()
 _wal_fallback_warned_lock = threading.Lock()
 
+# Labels for which an indeterminate journal-mode probe has already warned.
+# This remains separate so a later real filesystem fallback is still visible.
+_wal_probe_eio_warned_paths: set[str] = set()
+_wal_probe_eio_warned_lock = threading.Lock()
+
 # Dedup WARNING for the WAL-reset vulnerability fallback (issue #69784).
 _wal_reset_bug_warned_paths: set[str] = set()
 _wal_reset_bug_warned_lock = threading.Lock()
@@ -846,11 +851,15 @@ def format_session_db_unavailable(prefix: str = "Session database not available"
     return f"{prefix}: {cause}{hint}."
 
 
-def _on_disk_journal_mode(conn: sqlite3.Connection) -> Optional[str]:
-    """Read the journal mode from the SQLite DB header on disk.
+def _probe_journal_mode(
+    conn: sqlite3.Connection,
+) -> Tuple[Optional[str], Optional[sqlite3.OperationalError]]:
+    """Read the journal mode and retain the final probe error, if any.
 
-    Returns the mode string (e.g. ``"wal"``, ``"delete"``), or ``None``
-    if the value cannot be determined (new DB, or PRAGMA read failed).
+    Returns ``(mode, error)``. ``mode`` is a normalized string such as
+    ``"wal"`` or ``"delete"``; it is ``None`` when the value cannot be
+    determined. ``error`` retains the final ``OperationalError`` so policy
+    callers can distinguish an indeterminate EIO from an empty result.
 
     A PRAGMA read can fail transiently with ``disk i/o error`` on
     virtualized block devices (XFS on cloud hosts).  Treating that as
@@ -861,30 +870,35 @@ def _on_disk_journal_mode(conn: sqlite3.Connection) -> Optional[str]:
     not.  ``None`` is still returned on final failure so the caller's
     existing "unknown → refuse to downgrade" logic applies.
     """
-    last_exc: Optional[Exception] = None
+    last_exc: Optional[sqlite3.OperationalError] = None
     for _ in range(4):
         try:
             row = conn.execute("PRAGMA journal_mode").fetchone()
         except sqlite3.OperationalError as exc:
             last_exc = exc
             if "disk i/o error" not in str(exc).lower():
-                return None
+                return None, exc
             time.sleep(0.05)
             continue
         if row is None:
-            return None
+            return None, None
         mode = row[0]
         if isinstance(mode, bytes):  # defensive: sqlite3 occasionally returns bytes
             try:
                 mode = mode.decode("ascii")
             except UnicodeDecodeError:
-                return None
-        return str(mode).strip().lower() if mode is not None else None
+                return None, None
+        return str(mode).strip().lower() if mode is not None else None, None
     if last_exc is not None:
         logger.debug(
-            "_on_disk_journal_mode: retries exhausted on disk read (%s)", last_exc
+            "_probe_journal_mode: retries exhausted on disk read (%s)", last_exc
         )
-    return None
+    return None, last_exc
+
+
+def _on_disk_journal_mode(conn: sqlite3.Connection) -> Optional[str]:
+    """Return the probed journal mode while preserving the legacy interface."""
+    return _probe_journal_mode(conn)[0]
 
 
 def _apply_wal_size_limit(conn: sqlite3.Connection) -> None:
@@ -1049,15 +1063,15 @@ def resolve_journal_mode() -> str:
 
 class WalUnsupportedError(sqlite3.OperationalError):
     """Raised by :func:`apply_wal_with_fallback` when ``require_wal=True`` and
-    the filesystem cannot provide WAL journal mode.
+    WAL journal mode cannot be provided or verified safely.
 
     Covers both shapes of WAL refusal on network filesystems (NFS / SMB / FUSE
     / the AgentFS NFS overlay): SQLite *raising* ``SQLITE_PROTOCOL`` ("locking
     protocol"), and the quieter macOS-NFS case where ``PRAGMA journal_mode=WAL``
-    silently returns the still-effective mode without raising.  Subclasses
-    ``sqlite3.OperationalError`` so existing ``except sqlite3.OperationalError``
-    DB-init handling still catches it, while callers that specifically mandate
-    WAL can catch this narrower type.
+    silently returns the still-effective mode without raising. It also covers
+    an indeterminate mode or a non-WAL database on a runtime with the WAL-reset
+    corruption bug. Subclasses ``sqlite3.OperationalError`` so existing
+    ``except sqlite3.OperationalError`` DB-init handling still catches it.
     """
 
 
@@ -1069,7 +1083,9 @@ def apply_wal_with_fallback(
 ) -> str:
     """Set ``journal_mode=WAL`` on ``conn``, falling back to DELETE on failure.
 
-    Returns the journal mode actually set (``"wal"`` or ``"delete"``).
+    Returns the journal mode actually set (``"wal"`` or ``"delete"``), or
+    ``"unknown"`` when a read-only mode probe remains indeterminate and
+    changing the mode would be unsafe.
 
     On WAL-incompatible filesystems (NFS, SMB, some FUSE, ZFS), SQLite either
     raises ``OperationalError("locking protocol")`` /
@@ -1084,6 +1100,12 @@ def apply_wal_with_fallback(
     (issue #69784), refuse to enable WAL on fresh / non-WAL databases
     (prefer DELETE).  If the on-disk DB is already WAL, keep WAL and warn
     — never live-downgrade under possible concurrent openers.
+
+    A persistent ``disk I/O error`` from the initial read-only probe differs
+    from an EIO raised while setting WAL. After the bounded probe retries are
+    exhausted, the persistent mode remains unchanged, WAL-only optimizations
+    are disabled for this connection, and ordinary database access continues.
+    No query-that-sets journal-mode PRAGMA is issued on that path.
 
     This gate (#70055) is deliberately RETAINED. An earlier revision of the
     lock-cancellation fix (#71724) reverted it on the theory that DELETE was
@@ -1111,11 +1133,14 @@ def apply_wal_with_fallback(
     Shared by :class:`SessionDB` and ``hermes_cli.kanban_db.connect`` so
     both databases get identical fallback behavior.
 
-    Never downgrades to DELETE if the on-disk DB header reports WAL — see
-    _on_disk_journal_mode.  That holds for both the NFS path and the
+    Never downgrades to DELETE if the read-only probe reports WAL — see
+    _probe_journal_mode.  That holds for both the NFS path and the
     WAL-reset vulnerability path.
     """
     configured = resolve_journal_mode()
+    # Read-only probe — no flock, no checkpoint, no WAL/SHM unlink. Every
+    # policy branch below consumes this same observation and retained error.
+    current_mode, probe_error = _probe_journal_mode(conn)
 
     # Vulnerable SQLite: do not enable WAL on new/non-WAL files. Resolve the
     # operator setting first so an explicit DELETE request still verifies that
@@ -1125,12 +1150,13 @@ def apply_wal_with_fallback(
         return _apply_delete_for_wal_reset_bug(
             conn,
             db_label=db_label,
+            current_mode=current_mode,
+            probe_error=probe_error,
             require_delete=configured == "delete",
+            require_wal=require_wal,
         )
 
-    # Read-only probe — no flock, no checkpoint, no WAL/SHM unlink.
     # Skipping the set-pragma prevents WAL-init from unlinking files other connections hold open.
-    current_mode = _on_disk_journal_mode(conn)
     if current_mode == "wal":
         _apply_wal_size_limit(conn)
         _apply_macos_checkpoint_barrier(conn)
@@ -1149,16 +1175,26 @@ def apply_wal_with_fallback(
             # operator explicitly requested DELETE and we cannot verify it.
             raise sqlite3.OperationalError(
                 "could not verify journal mode before applying configured "
-                "journal_mode=delete (database is locked — possible "
-                "concurrent openers); refusing to downgrade a database "
+                f"journal_mode=delete (probe failed: {probe_error or 'no result'}; "
+                "possible concurrent openers); refusing to downgrade a database "
                 "this process does not exclusively own"
-            )
+            ) from probe_error
         actual = _set_journal_mode_no_wait(conn, "DELETE")
         if actual != "delete":
             raise sqlite3.OperationalError(
                 f"could not set configured journal_mode=delete (got {actual or 'no result'})"
             )
         return actual
+
+    if probe_error is not None and "disk i/o error" in str(probe_error).lower():
+        if require_wal:
+            raise WalUnsupportedError(
+                f"could not verify journal_mode=WAL ({probe_error})"
+            ) from probe_error
+        _apply_macos_checkpoint_barrier(conn)
+        _enforce_macos_synchronous_full(conn)
+        _log_wal_probe_eio_once(db_label, probe_error)
+        return "unknown"
 
     try:
         # ``PRAGMA journal_mode=WAL`` is a query-that-sets: it RETURNS the
@@ -1281,24 +1317,24 @@ def _apply_delete_for_wal_reset_bug(
     conn: sqlite3.Connection,
     *,
     db_label: str,
+    current_mode: Optional[str],
+    probe_error: Optional[sqlite3.OperationalError],
     require_delete: bool = False,
+    require_wal: bool = False,
 ) -> str:
     """Avoid enabling WAL when the linked SQLite has the WAL-reset bug.
 
     - Already-WAL on disk: leave WAL alone (no live downgrade) and warn.
-    - Mode unreadable (probe blocked by a concurrent opener's locks):
-      ownership is not provably exclusive — leave the journal mode alone
-      and warn.  Never treat "could not read the mode" as "not WAL": that
-      exact confusion let a vulnerable-SQLite process flip a live WAL
-      state.db to DELETE under a concurrent WAL writer, destroying its
-      committed-but-uncheckpointed transactions.
+    - Mode unreadable (probe EIO or blocked by a concurrent opener's locks):
+      ownership is not provably exclusive — leave the journal mode alone,
+      return ``"unknown"``, and warn. Never treat "could not read the mode"
+      as "not WAL": that exact confusion can flip a live WAL state.db to
+      DELETE under a concurrent writer.
     - Otherwise: set DELETE (refusing to wait out concurrent openers) and
       warn.
     - For an explicit operator request, verify SQLite accepted DELETE.
     """
-    current = _on_disk_journal_mode(conn)
-
-    if current == "wal":
+    if current_mode == "wal":
         # Do not TRUNCATE / journal_mode=DELETE while other processes may
         # still hold this WAL DB open — same safety rule as the NFS path.
         _log_wal_reset_bug_once(db_label, kept_wal=True)
@@ -1307,19 +1343,32 @@ def _apply_delete_for_wal_reset_bug(
         _enforce_macos_synchronous_full(conn)
         return "wal"
 
-    if current is None:
-        # The mode probe itself failed — another opener's locks are the
-        # most likely cause, and the DB may well be in WAL under a live
-        # writer.  Never flip a journal mode we cannot even read.
+    if current_mode is None:
+        # The mode probe itself failed, and the DB may well be in WAL under a
+        # live writer. Never flip a journal mode we cannot even read.
         if require_delete:
             raise sqlite3.OperationalError(
                 "could not verify journal mode before applying configured "
-                "journal_mode=delete (database is locked — possible "
-                "concurrent openers); refusing to downgrade a database "
+                f"journal_mode=delete (probe failed: {probe_error or 'no result'}; "
+                "possible concurrent openers); refusing to downgrade a database "
                 "this process does not exclusively own"
-            )
+            ) from probe_error
+        if require_wal:
+            raise WalUnsupportedError(
+                f"could not verify journal_mode=WAL ({probe_error or 'no result'})"
+            ) from probe_error
+        _apply_macos_checkpoint_barrier(conn)
+        _enforce_macos_synchronous_full(conn)
+        if probe_error is not None and "disk i/o error" in str(probe_error).lower():
+            _log_wal_probe_eio_once(db_label, probe_error)
         _log_wal_reset_bug_once(db_label, kept_wal=True, indeterminate=True)
-        return "wal"
+        return "unknown"
+
+    if require_wal:
+        raise WalUnsupportedError(
+            "linked SQLite has the WAL-reset corruption bug; refusing to enable "
+            "journal_mode=WAL"
+        )
 
     actual = ""
     try:
@@ -1333,7 +1382,7 @@ def _apply_delete_for_wal_reset_bug(
             # (or already held the DB): SQLite refused the exclusive lock.
             # Leave the journal mode exactly as it is.
             _log_wal_reset_bug_once(db_label, kept_wal=True, indeterminate=True)
-            return current or "delete"
+            return current_mode or "delete"
         # Best-effort for the automatic vulnerable-runtime fallback: DELETE is
         # normally already the default for new file-backed databases.
     if require_delete and actual != "delete":
@@ -1387,7 +1436,7 @@ def _log_wal_reset_bug_once(
     if indeterminate:
         action = (
             "journal mode could not be verified or exclusively switched "
-            "(database is locked — possible concurrent openers); leaving the "
+            "(possible concurrent openers or filesystem I/O failure); leaving the "
             "journal mode untouched (no live downgrade under concurrent "
             "openers)"
         )
@@ -1412,6 +1461,22 @@ def _log_wal_reset_bug_once(
         sqlite3.sqlite_version,
         action,
         repair_hint,
+    )
+
+
+def _log_wal_probe_eio_once(db_label: str, exc: Exception) -> None:
+    """Warn once when journal mode is left unchanged after a probe EIO."""
+    with _wal_probe_eio_warned_lock:
+        if db_label in _wal_probe_eio_warned_paths:
+            return
+        _wal_probe_eio_warned_paths.add(db_label)
+    logger.warning(
+        "%s: SQLite journal-mode probe failed (%s) — journal mode unchanged; "
+        "WAL-only optimizations disabled for this connection. Ordinary "
+        "database access will continue. This message fires once per process "
+        "per database.",
+        db_label,
+        exc,
     )
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -534,6 +534,12 @@ _last_init_error_lock = threading.Lock()
 _wal_fallback_warned_paths: set[str] = set()
 _wal_fallback_warned_lock = threading.Lock()
 
+# Labels for which an indeterminate journal-mode probe has already warned.
+# This is separate from the fallback dedup: no fallback or mode change occurs
+# on this path, and a later real filesystem fallback must remain visible.
+_wal_probe_eio_warned_paths: set[str] = set()
+_wal_probe_eio_warned_lock = threading.Lock()
+
 # Dedup WARNING for the WAL-reset vulnerability fallback (issue #69784).
 _wal_reset_bug_warned_paths: set[str] = set()
 _wal_reset_bug_warned_lock = threading.Lock()
@@ -695,25 +701,33 @@ def format_session_db_unavailable(prefix: str = "Session database not available"
     return f"{prefix}: {cause}{hint}."
 
 
-def _on_disk_journal_mode(conn: sqlite3.Connection) -> Optional[str]:
-    """Read the journal mode from the SQLite DB header on disk.
+def _probe_journal_mode(
+    conn: sqlite3.Connection,
+) -> Tuple[Optional[str], Optional[sqlite3.OperationalError]]:
+    """Read the journal mode and retain an OperationalError from the probe."""
 
-    Returns the mode string (e.g. ``"wal"``, ``"delete"``), or ``None``
-    if the value cannot be determined (new DB, or PRAGMA read failed).
-    """
     try:
         row = conn.execute("PRAGMA journal_mode").fetchone()
-    except sqlite3.OperationalError:
-        return None
+    except sqlite3.OperationalError as exc:
+        return None, exc
     if row is None:
-        return None
+        return None, None
     mode = row[0]
     if isinstance(mode, bytes):  # defensive: sqlite3 occasionally returns bytes
         try:
             mode = mode.decode("ascii")
         except UnicodeDecodeError:
-            return None
-    return str(mode).strip().lower() if mode is not None else None
+            return None, None
+    return str(mode).strip().lower() if mode is not None else None, None
+
+
+def _on_disk_journal_mode(conn: sqlite3.Connection) -> Optional[str]:
+    """Read the journal mode reported by SQLite for the main database.
+
+    Returns the mode string (e.g. ``"wal"``, ``"delete"``), or ``None``
+    if the value cannot be determined (new DB, or PRAGMA read failed).
+    """
+    return _probe_journal_mode(conn)[0]
 
 
 def _apply_macos_checkpoint_barrier(conn: sqlite3.Connection) -> None:
@@ -839,15 +853,16 @@ def resolve_journal_mode() -> str:
 
 class WalUnsupportedError(sqlite3.OperationalError):
     """Raised by :func:`apply_wal_with_fallback` when ``require_wal=True`` and
-    the filesystem cannot provide WAL journal mode.
+    WAL journal mode cannot be provided safely.
 
     Covers both shapes of WAL refusal on network filesystems (NFS / SMB / FUSE
     / the AgentFS NFS overlay): SQLite *raising* ``SQLITE_PROTOCOL`` ("locking
     protocol"), and the quieter macOS-NFS case where ``PRAGMA journal_mode=WAL``
-    silently returns the still-effective mode without raising.  Subclasses
-    ``sqlite3.OperationalError`` so existing ``except sqlite3.OperationalError``
-    DB-init handling still catches it, while callers that specifically mandate
-    WAL can catch this narrower type.
+    silently returns the still-effective mode without raising. It also covers
+    an indeterminate mode or a non-WAL database on a runtime with the WAL-reset
+    corruption bug. Subclasses ``sqlite3.OperationalError`` so existing
+    ``except sqlite3.OperationalError`` DB-init handling still catches it,
+    while callers that specifically mandate WAL can catch this narrower type.
     """
 
 
@@ -859,7 +874,9 @@ def apply_wal_with_fallback(
 ) -> str:
     """Set ``journal_mode=WAL`` on ``conn``, falling back to DELETE on failure.
 
-    Returns the journal mode actually set (``"wal"`` or ``"delete"``).
+    Returns the journal mode actually set (``"wal"`` or ``"delete"``), or
+    ``"unknown"`` when a read-only mode probe fails and changing the mode
+    would be unsafe.
 
     On WAL-incompatible filesystems (NFS, SMB, some FUSE, ZFS), SQLite either
     raises ``OperationalError("locking protocol")`` /
@@ -874,6 +891,15 @@ def apply_wal_with_fallback(
     (issue #69784), refuse to enable WAL on fresh / non-WAL databases
     (prefer DELETE).  If the on-disk DB is already WAL, keep WAL and warn
     — never live-downgrade under possible concurrent openers.
+
+    A ``disk I/O error`` from the initial read-only journal-mode probe is
+    different from an EIO raised while setting WAL.  The initial probe leaves
+    the persistent mode unchanged, returns ``"unknown"``, disables WAL-only
+    optimizations for the caller, and logs a WARNING.  When a confirmed
+    non-WAL mode later raises EIO while setting WAL, the existing retry and
+    guarded fallback behavior still applies.  An explicit configured DELETE
+    request remains strict: if the current mode cannot be verified, fail
+    instead of claiming the operator's setting was applied.
 
     This gate (#70055) is deliberately RETAINED. An earlier revision of the
     lock-cancellation fix (#71724) reverted it on the theory that DELETE was
@@ -901,11 +927,14 @@ def apply_wal_with_fallback(
     Shared by :class:`SessionDB` and ``hermes_cli.kanban_db.connect`` so
     both databases get identical fallback behavior.
 
-    Never downgrades to DELETE if the on-disk DB header reports WAL — see
-    _on_disk_journal_mode.  That holds for both the NFS path and the
-    WAL-reset vulnerability path.
+    Never downgrades to DELETE if the read-only probe reports WAL — see
+    _probe_journal_mode.  That holds for both the NFS path and the WAL-reset
+    vulnerability path.
     """
     configured = resolve_journal_mode()
+    # Read-only probe — no flock, no checkpoint, no WAL/SHM unlink.
+    # Every policy branch below uses this same observation and retained error.
+    current_mode, probe_error = _probe_journal_mode(conn)
 
     # Vulnerable SQLite: do not enable WAL on new/non-WAL files. Resolve the
     # operator setting first so an explicit DELETE request still verifies that
@@ -915,12 +944,13 @@ def apply_wal_with_fallback(
         return _apply_delete_for_wal_reset_bug(
             conn,
             db_label=db_label,
+            current_mode=current_mode,
+            probe_error=probe_error,
             require_delete=configured == "delete",
+            require_wal=require_wal,
         )
 
-    # Read-only probe — no flock, no checkpoint, no WAL/SHM unlink.
     # Skipping the set-pragma prevents WAL-init from unlinking files other connections hold open.
-    current_mode = _on_disk_journal_mode(conn)
     if current_mode == "wal":
         _apply_macos_checkpoint_barrier(conn)
         _enforce_macos_synchronous_full(conn)
@@ -938,16 +968,30 @@ def apply_wal_with_fallback(
             # operator explicitly requested DELETE and we cannot verify it.
             raise sqlite3.OperationalError(
                 "could not verify journal mode before applying configured "
-                "journal_mode=delete (database is locked — possible "
-                "concurrent openers); refusing to downgrade a database "
+                f"journal_mode=delete (probe failed: {probe_error or 'no result'}; "
+                "possible concurrent openers); refusing to downgrade a database "
                 "this process does not exclusively own"
-            )
+            ) from probe_error
         actual = _set_journal_mode_no_wait(conn, "DELETE")
         if actual != "delete":
             raise sqlite3.OperationalError(
                 f"could not set configured journal_mode=delete (got {actual or 'no result'})"
             )
         return actual
+
+    if probe_error is not None and "disk i/o error" in str(probe_error).lower():
+        # The connection is otherwise usable, but the persistent journal state
+        # is indeterminate. Do not issue a query-that-sets PRAGMA: a concurrent
+        # process may own a live WAL, and switching modes here could destroy its
+        # committed-but-uncheckpointed transactions.
+        if require_wal:
+            raise WalUnsupportedError(
+                f"could not verify journal_mode=WAL ({probe_error})"
+            ) from probe_error
+        _apply_macos_checkpoint_barrier(conn)
+        _enforce_macos_synchronous_full(conn)
+        _log_wal_probe_eio_once(db_label, probe_error)
+        return "unknown"
 
     try:
         # ``PRAGMA journal_mode=WAL`` is a query-that-sets: it RETURNS the
@@ -1068,24 +1112,25 @@ def _apply_delete_for_wal_reset_bug(
     conn: sqlite3.Connection,
     *,
     db_label: str,
+    current_mode: Optional[str],
+    probe_error: Optional[sqlite3.OperationalError],
     require_delete: bool = False,
+    require_wal: bool = False,
 ) -> str:
     """Avoid enabling WAL when the linked SQLite has the WAL-reset bug.
 
     - Already-WAL on disk: leave WAL alone (no live downgrade) and warn.
-    - Mode unreadable (probe blocked by a concurrent opener's locks):
-      ownership is not provably exclusive — leave the journal mode alone
-      and warn.  Never treat "could not read the mode" as "not WAL": that
-      exact confusion let a vulnerable-SQLite process flip a live WAL
-      state.db to DELETE under a concurrent WAL writer, destroying its
-      committed-but-uncheckpointed transactions.
+    - Mode unreadable (probe EIO or blocked by a concurrent opener's locks):
+      ownership is not provably exclusive — leave the journal mode alone,
+      return ``"unknown"``, and warn.  Never treat "could not read the mode"
+      as "not WAL": that exact confusion let a vulnerable-SQLite process flip
+      a live WAL state.db to DELETE under a concurrent WAL writer, destroying
+      its committed-but-uncheckpointed transactions.
     - Otherwise: set DELETE (refusing to wait out concurrent openers) and
       warn.
     - For an explicit operator request, verify SQLite accepted DELETE.
     """
-    current = _on_disk_journal_mode(conn)
-
-    if current == "wal":
+    if current_mode == "wal":
         # Do not TRUNCATE / journal_mode=DELETE while other processes may
         # still hold this WAL DB open — same safety rule as the NFS path.
         _log_wal_reset_bug_once(db_label, kept_wal=True)
@@ -1093,19 +1138,33 @@ def _apply_delete_for_wal_reset_bug(
         _enforce_macos_synchronous_full(conn)
         return "wal"
 
-    if current is None:
-        # The mode probe itself failed — another opener's locks are the
-        # most likely cause, and the DB may well be in WAL under a live
-        # writer.  Never flip a journal mode we cannot even read.
+    if current_mode is None:
+        # The mode probe itself failed (for example EIO or another opener's
+        # locks), and the DB may well be in WAL under a live writer. Never
+        # flip a journal mode we cannot even read.
         if require_delete:
             raise sqlite3.OperationalError(
                 "could not verify journal mode before applying configured "
-                "journal_mode=delete (database is locked — possible "
-                "concurrent openers); refusing to downgrade a database "
+                f"journal_mode=delete (probe failed: {probe_error or 'no result'}; "
+                "possible concurrent openers); refusing to downgrade a database "
                 "this process does not exclusively own"
-            )
+            ) from probe_error
+        if require_wal:
+            raise WalUnsupportedError(
+                f"could not verify journal_mode=WAL ({probe_error or 'no result'})"
+            ) from probe_error
+        _apply_macos_checkpoint_barrier(conn)
+        _enforce_macos_synchronous_full(conn)
+        if probe_error is not None and "disk i/o error" in str(probe_error).lower():
+            _log_wal_probe_eio_once(db_label, probe_error)
         _log_wal_reset_bug_once(db_label, kept_wal=True, indeterminate=True)
-        return "wal"
+        return "unknown"
+
+    if require_wal:
+        raise WalUnsupportedError(
+            "linked SQLite has the WAL-reset corruption bug; refusing to enable "
+            "journal_mode=WAL"
+        )
 
     actual = ""
     try:
@@ -1119,7 +1178,7 @@ def _apply_delete_for_wal_reset_bug(
             # (or already held the DB): SQLite refused the exclusive lock.
             # Leave the journal mode exactly as it is.
             _log_wal_reset_bug_once(db_label, kept_wal=True, indeterminate=True)
-            return current or "delete"
+            return current_mode or "delete"
         # Best-effort for the automatic vulnerable-runtime fallback: DELETE is
         # normally already the default for new file-backed databases.
     if require_delete and actual != "delete":
@@ -1173,7 +1232,7 @@ def _log_wal_reset_bug_once(
     if indeterminate:
         action = (
             "journal mode could not be verified or exclusively switched "
-            "(database is locked — possible concurrent openers); leaving the "
+            "(possible concurrent openers or filesystem I/O failure); leaving the "
             "journal mode untouched (no live downgrade under concurrent "
             "openers)"
         )
@@ -1198,6 +1257,22 @@ def _log_wal_reset_bug_once(
         sqlite3.sqlite_version,
         action,
         repair_hint,
+    )
+
+
+def _log_wal_probe_eio_once(db_label: str, exc: Exception) -> None:
+    """Warn once when journal mode is left unchanged after a probe EIO."""
+    with _wal_probe_eio_warned_lock:
+        if db_label in _wal_probe_eio_warned_paths:
+            return
+        _wal_probe_eio_warned_paths.add(db_label)
+    logger.warning(
+        "%s: SQLite journal-mode probe failed (%s) — journal mode unchanged; "
+        "WAL-only optimizations disabled for this connection. Ordinary "
+        "database access will continue. This message fires once per process "
+        "per database.",
+        db_label,
+        exc,
     )
 
 

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -45,6 +45,19 @@ def _make_blocking_factory(reason: str, attempt_counter: list):
     return _WalBlockingConnection
 
 
+def _make_probe_eio_factory(statements: list[str]):
+    """Return a connection subclass whose journal-mode statements raise EIO."""
+
+    class _JournalModeProbeEIOConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            if "journal_mode" in sql.lower():
+                statements.append(sql)
+                raise sqlite3.OperationalError("disk I/O error")
+            return super().execute(sql, *args, **kwargs)
+
+    return _JournalModeProbeEIOConnection
+
+
 def _open_blocking(path, reason="locking protocol", **kwargs):
     """Open a connection whose WAL pragma raises ``reason``.
 
@@ -89,8 +102,10 @@ def _reset_last_init_error():
 def _reset_wal_fallback_warned_paths():
     """Reset the WAL-fallback warned-paths set so dedup doesn't leak between tests."""
     hermes_state._wal_fallback_warned_paths.clear()
+    hermes_state._wal_probe_eio_warned_paths.clear()
     yield
     hermes_state._wal_fallback_warned_paths.clear()
+    hermes_state._wal_probe_eio_warned_paths.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -268,6 +283,100 @@ class TestApplyWalWithFallback:
         finally:
             check.close()
 
+    def test_indeterminate_probe_preserves_macos_durability(
+        self, tmp_path, monkeypatch
+    ):
+        """Unknown mode still applies settings required by a possible live WAL."""
+        target = tmp_path / "darwin-wal.db"
+        seed = sqlite3.connect(str(target), isolation_level=None)
+        try:
+            assert seed.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+            seed.execute("CREATE TABLE t (value TEXT)")
+        finally:
+            seed.close()
+
+        executed: list[str] = []
+
+        class _DarwinProbeEIOConnection(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                executed.append(sql)
+                if "journal_mode" in sql.lower():
+                    raise sqlite3.OperationalError("disk I/O error")
+                return super().execute(sql, *args, **kwargs)
+
+        monkeypatch.setattr(hermes_state.sys, "platform", "darwin")
+        conn = sqlite3.connect(
+            str(target),
+            factory=_DarwinProbeEIOConnection,
+            isolation_level=None,
+        )
+        try:
+            assert apply_wal_with_fallback(conn) == "unknown"
+            assert executed == [
+                "PRAGMA journal_mode",
+                "PRAGMA journal_mode",
+                "PRAGMA journal_mode",
+                "PRAGMA journal_mode",
+                "PRAGMA checkpoint_fullfsync=1",
+                "PRAGMA synchronous=FULL",
+            ]
+        finally:
+            conn.close()
+
+    def test_indeterminate_probe_warning_is_deduplicated(self, tmp_path, caplog):
+        """Repeated healthy opens emit one warning for the degraded read path."""
+        target = tmp_path / "probe-eio.db"
+        seed = sqlite3.connect(str(target))
+        seed.execute("CREATE TABLE t (value TEXT)")
+        seed.close()
+
+        with caplog.at_level("WARNING", logger="hermes_state"):
+            for _ in range(2):
+                statements: list[str] = []
+                conn = sqlite3.connect(
+                    str(target),
+                    factory=_make_probe_eio_factory(statements),
+                    isolation_level=None,
+                )
+                try:
+                    assert (
+                        apply_wal_with_fallback(conn, db_label="state.db") == "unknown"
+                    )
+                    assert statements == ["PRAGMA journal_mode"] * 4
+                finally:
+                    conn.close()
+
+        warnings = [
+            record
+            for record in caplog.records
+            if record.levelname == "WARNING" and "state.db" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "disk I/O error" in message
+        assert "journal mode unchanged" in message
+        assert "WAL-only optimizations disabled" in message
+
+    def test_probe_eio_rejects_configured_delete_with_cause(
+        self, tmp_path, monkeypatch
+    ):
+        """Explicit DELETE remains strict and reports why mode is unknown."""
+        monkeypatch.setattr(hermes_state, "resolve_journal_mode", lambda: "delete")
+        statements: list[str] = []
+        conn = sqlite3.connect(
+            str(tmp_path / "probe-eio-delete.db"),
+            factory=_make_probe_eio_factory(statements),
+            isolation_level=None,
+        )
+        try:
+            with pytest.raises(sqlite3.OperationalError) as raised:
+                apply_wal_with_fallback(conn)
+            assert "refusing to downgrade" in str(raised.value)
+            assert "disk I/O error" in str(raised.value)
+            assert statements == ["PRAGMA journal_mode"] * 4
+        finally:
+            conn.close()
+
     def test_does_not_downgrade_when_disk_says_wal(self, tmp_path):
         """Refuse to downgrade an already-WAL DB even if the set-pragma path
         would have raised a downgrade-eligible marker.
@@ -414,6 +523,26 @@ class TestRequireWal:
         finally:
             conn.close()
 
+    def test_raises_when_journal_mode_probe_is_indeterminate(self, tmp_path):
+        """A caller requiring WAL must not accept an unverified journal mode."""
+        target = tmp_path / "indeterminate.db"
+        seed = sqlite3.connect(str(target))
+        seed.execute("CREATE TABLE t (value TEXT)")
+        seed.close()
+
+        statements: list[str] = []
+        conn = sqlite3.connect(
+            str(target),
+            factory=_make_probe_eio_factory(statements),
+            isolation_level=None,
+        )
+        try:
+            with pytest.raises(WalUnsupportedError, match="could not verify"):
+                apply_wal_with_fallback(conn, require_wal=True)
+            assert statements == ["PRAGMA journal_mode"] * 4
+        finally:
+            conn.close()
+
     def test_error_is_operationalerror_subclass(self, tmp_path):
         """WalUnsupportedError must stay catchable as sqlite3.OperationalError
         so existing DB-init handlers (e.g. SessionDB.__init__) still catch it."""
@@ -486,6 +615,41 @@ class TestFormatSessionDbUnavailable:
 
 
 class TestSessionDbUsesWalFallback:
+    def test_sessiondb_survives_persistent_journal_mode_probe_eio(self, tmp_path):
+        """A healthy persisted WAL DB remains usable after probe EIO retries."""
+        target = tmp_path / "live-wal.db"
+        seed = sqlite3.connect(str(target), isolation_level=None)
+        try:
+            assert seed.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+            seed.execute("CREATE TABLE incident_probe (value TEXT NOT NULL)")
+            seed.execute("INSERT INTO incident_probe VALUES ('healthy')")
+        finally:
+            seed.close()
+
+        real_connect = sqlite3.connect
+        statements: list[str] = []
+        factory = _make_probe_eio_factory(statements)
+
+        def gated_connect(*args, **kwargs):
+            kwargs.pop("factory", None)
+            return real_connect(str(target), factory=factory, **kwargs)
+
+        with patch("hermes_state.sqlite3.connect", side_effect=gated_connect):
+            db = SessionDB(db_path=target)
+
+        try:
+            assert db._wal_active is False
+            assert (
+                db._conn.execute("SELECT value FROM incident_probe").fetchone()[0]
+                == "healthy"
+            )
+            db.create_session(session_id="eio-session", source="dashboard")
+            assert db.get_session("eio-session")["source"] == "dashboard"
+            assert get_last_init_error() is None
+            assert statements == ["PRAGMA journal_mode"] * 4
+        finally:
+            db.close()
+
     def test_sessiondb_works_when_wal_unavailable(self, tmp_path):
         """E2E: SessionDB initializes and performs a write on a WAL-blocked FS."""
         target = tmp_path / "nfs_style.db"

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -45,6 +45,19 @@ def _make_blocking_factory(reason: str, attempt_counter: list):
     return _WalBlockingConnection
 
 
+def _make_probe_eio_factory(statements: list[str]):
+    """Return a connection subclass whose journal-mode statements raise EIO."""
+
+    class _JournalModeProbeEIOConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            if "journal_mode" in sql.lower():
+                statements.append(sql)
+                raise sqlite3.OperationalError("disk I/O error")
+            return super().execute(sql, *args, **kwargs)
+
+    return _JournalModeProbeEIOConnection
+
+
 def _open_blocking(path, reason="locking protocol", **kwargs):
     """Open a connection whose WAL pragma raises ``reason``.
 
@@ -89,8 +102,10 @@ def _reset_last_init_error():
 def _reset_wal_fallback_warned_paths():
     """Reset the WAL-fallback warned-paths set so dedup doesn't leak between tests."""
     hermes_state._wal_fallback_warned_paths.clear()
+    hermes_state._wal_probe_eio_warned_paths.clear()
     yield
     hermes_state._wal_fallback_warned_paths.clear()
+    hermes_state._wal_probe_eio_warned_paths.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -268,6 +283,77 @@ class TestApplyWalWithFallback:
         finally:
             check.close()
 
+    def test_indeterminate_probe_preserves_macos_durability(
+        self, tmp_path, monkeypatch
+    ):
+        """Unknown mode still applies settings required by a possible live WAL."""
+        target = tmp_path / "darwin-wal.db"
+        seed = sqlite3.connect(str(target), isolation_level=None)
+        try:
+            assert seed.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+            seed.execute("CREATE TABLE t (value TEXT)")
+        finally:
+            seed.close()
+
+        executed: list[str] = []
+
+        class _DarwinProbeEIOConnection(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                executed.append(sql)
+                if "journal_mode" in sql.lower():
+                    raise sqlite3.OperationalError("disk I/O error")
+                return super().execute(sql, *args, **kwargs)
+
+        monkeypatch.setattr(hermes_state.sys, "platform", "darwin")
+        conn = sqlite3.connect(
+            str(target),
+            factory=_DarwinProbeEIOConnection,
+            isolation_level=None,
+        )
+        try:
+            assert apply_wal_with_fallback(conn) == "unknown"
+            assert executed == [
+                "PRAGMA journal_mode",
+                "PRAGMA checkpoint_fullfsync=1",
+                "PRAGMA synchronous=FULL",
+            ]
+        finally:
+            conn.close()
+
+    def test_indeterminate_probe_warning_is_deduplicated(self, tmp_path, caplog):
+        """Repeated healthy opens emit one warning for the degraded read path."""
+        target = tmp_path / "probe-eio.db"
+        seed = sqlite3.connect(str(target))
+        seed.execute("CREATE TABLE t (value TEXT)")
+        seed.close()
+
+        with caplog.at_level("WARNING", logger="hermes_state"):
+            for _ in range(2):
+                statements: list[str] = []
+                conn = sqlite3.connect(
+                    str(target),
+                    factory=_make_probe_eio_factory(statements),
+                    isolation_level=None,
+                )
+                try:
+                    assert (
+                        apply_wal_with_fallback(conn, db_label="state.db") == "unknown"
+                    )
+                    assert statements == ["PRAGMA journal_mode"]
+                finally:
+                    conn.close()
+
+        warnings = [
+            record
+            for record in caplog.records
+            if record.levelname == "WARNING" and "state.db" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "disk I/O error" in message
+        assert "journal mode unchanged" in message
+        assert "WAL-only optimizations disabled" in message
+
     def test_does_not_downgrade_when_disk_says_wal(self, tmp_path):
         """Refuse to downgrade an already-WAL DB even if the set-pragma path
         would have raised a downgrade-eligible marker.
@@ -414,6 +500,26 @@ class TestRequireWal:
         finally:
             conn.close()
 
+    def test_raises_when_journal_mode_probe_is_indeterminate(self, tmp_path):
+        """A caller requiring WAL must not accept an unverified journal mode."""
+        target = tmp_path / "indeterminate.db"
+        seed = sqlite3.connect(str(target))
+        seed.execute("CREATE TABLE t (value TEXT)")
+        seed.close()
+
+        statements: list[str] = []
+        conn = sqlite3.connect(
+            str(target),
+            factory=_make_probe_eio_factory(statements),
+            isolation_level=None,
+        )
+        try:
+            with pytest.raises(WalUnsupportedError, match="could not verify"):
+                apply_wal_with_fallback(conn, require_wal=True)
+            assert statements == ["PRAGMA journal_mode"]
+        finally:
+            conn.close()
+
     def test_error_is_operationalerror_subclass(self, tmp_path):
         """WalUnsupportedError must stay catchable as sqlite3.OperationalError
         so existing DB-init handlers (e.g. SessionDB.__init__) still catch it."""
@@ -486,6 +592,41 @@ class TestFormatSessionDbUnavailable:
 
 
 class TestSessionDbUsesWalFallback:
+    def test_sessiondb_survives_journal_mode_probe_eio(self, tmp_path):
+        """A healthy persisted WAL DB remains usable when its mode probe raises EIO."""
+        target = tmp_path / "live-wal.db"
+        seed = sqlite3.connect(str(target), isolation_level=None)
+        try:
+            assert seed.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+            seed.execute("CREATE TABLE incident_probe (value TEXT NOT NULL)")
+            seed.execute("INSERT INTO incident_probe VALUES ('healthy')")
+        finally:
+            seed.close()
+
+        real_connect = sqlite3.connect
+        statements: list[str] = []
+        factory = _make_probe_eio_factory(statements)
+
+        def gated_connect(*args, **kwargs):
+            kwargs.pop("factory", None)
+            return real_connect(str(target), factory=factory, **kwargs)
+
+        with patch("hermes_state.sqlite3.connect", side_effect=gated_connect):
+            db = SessionDB(db_path=target)
+
+        try:
+            assert db._wal_active is False
+            assert (
+                db._conn.execute("SELECT value FROM incident_probe").fetchone()[0]
+                == "healthy"
+            )
+            db.create_session(session_id="eio-session", source="dashboard")
+            assert db.get_session("eio-session")["source"] == "dashboard"
+            assert get_last_init_error() is None
+            assert statements == ["PRAGMA journal_mode"]
+        finally:
+            db.close()
+
     def test_sessiondb_works_when_wal_unavailable(self, tmp_path):
         """E2E: SessionDB initializes and performs a write on a WAL-blocked FS."""
         target = tmp_path / "nfs_style.db"

--- a/tests/test_sqlite_wal_reset_gate.py
+++ b/tests/test_sqlite_wal_reset_gate.py
@@ -28,8 +28,23 @@ from hermes_state import (
 @pytest.fixture(autouse=True)
 def _reset_wal_reset_bug_warnings():
     hermes_state._wal_reset_bug_warned_paths.clear()
+    hermes_state._wal_probe_eio_warned_paths.clear()
     yield
     hermes_state._wal_reset_bug_warned_paths.clear()
+    hermes_state._wal_probe_eio_warned_paths.clear()
+
+
+def _open_with_journal_mode_eio(path, statements: list[str]) -> sqlite3.Connection:
+    class _JournalModeEIOConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            if "journal_mode" in sql.lower():
+                statements.append(sql)
+                raise sqlite3.OperationalError("disk I/O error")
+            return super().execute(sql, *args, **kwargs)
+
+    return sqlite3.connect(
+        str(path), factory=_JournalModeEIOConnection, isolation_level=None
+    )
 
 
 class TestIsSqliteWalResetVulnerable:
@@ -104,7 +119,122 @@ class TestApplyWalWalResetGate:
         finally:
             conn.close()
 
+    def test_probe_eio_leaves_mode_unknown_when_vulnerable(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "is_sqlite_wal_reset_vulnerable",
+            lambda version_info=None: True,
+        )
+        statements: list[str] = []
+        conn = _open_with_journal_mode_eio(tmp_path / "probe_eio.db", statements)
+        try:
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                mode = apply_wal_with_fallback(conn, db_label="probe_eio.db")
+            assert mode == "unknown"
+            assert statements == ["PRAGMA journal_mode"] * 4
+            messages = [record.getMessage() for record in caplog.records]
+            assert any("journal mode unchanged" in message for message in messages)
+            wal_reset_messages = [
+                message for message in messages if "WAL-reset" in message
+            ]
+            assert len(wal_reset_messages) == 1
+            assert "filesystem I/O failure" in wal_reset_messages[0]
+        finally:
+            conn.close()
 
+    def test_probe_eio_rejects_required_wal_when_vulnerable(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "is_sqlite_wal_reset_vulnerable",
+            lambda version_info=None: True,
+        )
+        statements: list[str] = []
+        conn = _open_with_journal_mode_eio(
+            tmp_path / "probe_eio_required.db", statements
+        )
+        try:
+            with pytest.raises(
+                hermes_state.WalUnsupportedError, match="could not verify"
+            ):
+                apply_wal_with_fallback(conn, require_wal=True)
+            assert statements == ["PRAGMA journal_mode"] * 4
+        finally:
+            conn.close()
+
+    def test_non_wal_mode_rejects_required_wal_when_vulnerable(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "is_sqlite_wal_reset_vulnerable",
+            lambda version_info=None: True,
+        )
+        conn = sqlite3.connect(str(tmp_path / "required_wal.db"))
+        try:
+            with pytest.raises(hermes_state.WalUnsupportedError, match="WAL-reset"):
+                apply_wal_with_fallback(conn, require_wal=True)
+        finally:
+            conn.close()
+
+    def test_probe_eio_rejects_configured_delete_when_vulnerable(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "is_sqlite_wal_reset_vulnerable",
+            lambda version_info=None: True,
+        )
+        monkeypatch.setattr(hermes_state, "resolve_journal_mode", lambda: "delete")
+        statements: list[str] = []
+        conn = _open_with_journal_mode_eio(
+            tmp_path / "probe_eio_delete.db", statements
+        )
+        try:
+            with pytest.raises(sqlite3.OperationalError, match="refusing to downgrade"):
+                apply_wal_with_fallback(conn)
+            assert statements == ["PRAGMA journal_mode"] * 4
+        finally:
+            conn.close()
+
+    def test_probe_eio_preserves_macos_durability_when_vulnerable(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "is_sqlite_wal_reset_vulnerable",
+            lambda version_info=None: True,
+        )
+        monkeypatch.setattr(hermes_state.sys, "platform", "darwin")
+        executed: list[str] = []
+
+        class _DarwinJournalModeEIOConnection(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                executed.append(sql)
+                if "journal_mode" in sql.lower():
+                    raise sqlite3.OperationalError("disk I/O error")
+                return super().execute(sql, *args, **kwargs)
+
+        conn = sqlite3.connect(
+            str(tmp_path / "darwin_probe_eio.db"),
+            factory=_DarwinJournalModeEIOConnection,
+            isolation_level=None,
+        )
+        try:
+            assert apply_wal_with_fallback(conn) == "unknown"
+            assert executed == [
+                "PRAGMA journal_mode",
+                "PRAGMA journal_mode",
+                "PRAGMA journal_mode",
+                "PRAGMA journal_mode",
+                "PRAGMA checkpoint_fullfsync=1",
+                "PRAGMA synchronous=FULL",
+            ]
+        finally:
+            conn.close()
 
     def test_warning_deduped_per_label(self, tmp_path, monkeypatch, caplog):
         monkeypatch.setattr(
@@ -239,7 +369,7 @@ class TestNoDowngradeUnderConcurrentOpeners:
                     conn.execute("PRAGMA journal_mode").fetchone()
                 with caplog.at_level("WARNING", logger="hermes_state"):
                     mode = apply_wal_with_fallback(conn, db_label="locked_wal.db")
-                assert mode == "wal"
+                assert mode == "unknown"
                 assert any(
                     "concurrent openers" in r.getMessage() for r in caplog.records
                 )

--- a/tests/test_sqlite_wal_reset_gate.py
+++ b/tests/test_sqlite_wal_reset_gate.py
@@ -19,6 +19,7 @@ import pytest
 
 import hermes_state
 from hermes_state import (
+    WalUnsupportedError,
     apply_wal_with_fallback,
     is_sqlite_wal_reset_vulnerable,
     sqlite_source_id,
@@ -28,8 +29,23 @@ from hermes_state import (
 @pytest.fixture(autouse=True)
 def _reset_wal_reset_bug_warnings():
     hermes_state._wal_reset_bug_warned_paths.clear()
+    hermes_state._wal_probe_eio_warned_paths.clear()
     yield
     hermes_state._wal_reset_bug_warned_paths.clear()
+    hermes_state._wal_probe_eio_warned_paths.clear()
+
+
+def _open_with_journal_mode_eio(path, statements: list[str]) -> sqlite3.Connection:
+    class _JournalModeEIOConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            if "journal_mode" in sql.lower():
+                statements.append(sql)
+                raise sqlite3.OperationalError("disk I/O error")
+            return super().execute(sql, *args, **kwargs)
+
+    return sqlite3.connect(
+        str(path), factory=_JournalModeEIOConnection, isolation_level=None
+    )
 
 
 class TestIsSqliteWalResetVulnerable:
@@ -104,7 +120,111 @@ class TestApplyWalWalResetGate:
         finally:
             conn.close()
 
+    def test_probe_eio_leaves_mode_unknown_when_vulnerable(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "is_sqlite_wal_reset_vulnerable",
+            lambda version_info=None: True,
+        )
+        statements: list[str] = []
+        conn = _open_with_journal_mode_eio(tmp_path / "probe_eio.db", statements)
+        try:
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                mode = apply_wal_with_fallback(conn, db_label="probe_eio.db")
+            assert mode == "unknown"
+            assert statements == ["PRAGMA journal_mode"]
+            messages = [record.getMessage() for record in caplog.records]
+            assert any("journal mode unchanged" in message for message in messages)
+            assert any("WAL-reset" in message for message in messages)
+        finally:
+            conn.close()
 
+    def test_probe_eio_rejects_required_wal_when_vulnerable(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "is_sqlite_wal_reset_vulnerable",
+            lambda version_info=None: True,
+        )
+        statements: list[str] = []
+        conn = _open_with_journal_mode_eio(
+            tmp_path / "probe_eio_required.db", statements
+        )
+        try:
+            with pytest.raises(WalUnsupportedError, match="could not verify"):
+                apply_wal_with_fallback(conn, require_wal=True)
+            assert statements == ["PRAGMA journal_mode"]
+        finally:
+            conn.close()
+
+    def test_non_wal_mode_rejects_required_wal_when_vulnerable(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "is_sqlite_wal_reset_vulnerable",
+            lambda version_info=None: True,
+        )
+        conn = sqlite3.connect(str(tmp_path / "required_wal.db"))
+        try:
+            with pytest.raises(WalUnsupportedError, match="WAL-reset"):
+                apply_wal_with_fallback(conn, require_wal=True)
+        finally:
+            conn.close()
+
+    def test_probe_eio_rejects_configured_delete_when_vulnerable(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "is_sqlite_wal_reset_vulnerable",
+            lambda version_info=None: True,
+        )
+        monkeypatch.setattr(hermes_state, "resolve_journal_mode", lambda: "delete")
+        statements: list[str] = []
+        conn = _open_with_journal_mode_eio(tmp_path / "probe_eio_delete.db", statements)
+        try:
+            with pytest.raises(sqlite3.OperationalError, match="refusing to downgrade"):
+                apply_wal_with_fallback(conn)
+            assert statements == ["PRAGMA journal_mode"]
+        finally:
+            conn.close()
+
+    def test_probe_eio_preserves_macos_durability_when_vulnerable(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "is_sqlite_wal_reset_vulnerable",
+            lambda version_info=None: True,
+        )
+        monkeypatch.setattr(hermes_state.sys, "platform", "darwin")
+        executed: list[str] = []
+
+        class _DarwinJournalModeEIOConnection(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                executed.append(sql)
+                if "journal_mode" in sql.lower():
+                    raise sqlite3.OperationalError("disk I/O error")
+                return super().execute(sql, *args, **kwargs)
+
+        conn = sqlite3.connect(
+            str(tmp_path / "darwin_probe_eio.db"),
+            factory=_DarwinJournalModeEIOConnection,
+            isolation_level=None,
+        )
+        try:
+            assert apply_wal_with_fallback(conn) == "unknown"
+            assert executed == [
+                "PRAGMA journal_mode",
+                "PRAGMA checkpoint_fullfsync=1",
+                "PRAGMA synchronous=FULL",
+            ]
+        finally:
+            conn.close()
 
     def test_warning_deduped_per_label(self, tmp_path, monkeypatch, caplog):
         monkeypatch.setattr(
@@ -194,7 +314,7 @@ class TestNoDowngradeUnderConcurrentOpeners:
             finally:
                 conn.close()
         finally:
-            done.write_text("done")
+            done.write_text("done", encoding="utf-8")
             holder.wait(timeout=30)
 
         check = sqlite3.connect(str(db))
@@ -239,7 +359,7 @@ class TestNoDowngradeUnderConcurrentOpeners:
                     conn.execute("PRAGMA journal_mode").fetchone()
                 with caplog.at_level("WARNING", logger="hermes_state"):
                     mode = apply_wal_with_fallback(conn, db_label="locked_wal.db")
-                assert mode == "wal"
+                assert mode == "unknown"
                 assert any(
                     "concurrent openers" in r.getMessage() for r in caplog.records
                 )


### PR DESCRIPTION
## Summary
- Rework the persistent journal-mode probe EIO path on current `main` (`fcbd1076a`) without raw DB/WAL/SHM header reads or cached pre-open evidence.
- Preserve the existing four-attempt read-only `PRAGMA journal_mode` retry. If every attempt raises `disk I/O error`, leave the persistent journal mode unchanged, return `unknown`, disable WAL-only optimization for that connection, and let ordinary `SessionDB` access continue.
- Preserve the WAL size limit, no-live-downgrade protections, WAL-reset vulnerability gate, and macOS `checkpoint_fullfsync=1` / `synchronous=FULL` durability behavior.
- Keep strict caller contracts: `require_wal=True` raises when WAL cannot be verified or safely enabled, and configured `database.journal_mode=delete` refuses to change an indeterminate database.
- Emit a deduplicated warning for the degraded probe path.

The availability behavior was not intentionally superseded. Current `main` retained bounded probe retries but, after persistent EIO, continued into `PRAGMA journal_mode=WAL`; that setter raised the same EIO and aborted `SessionDB` initialization. This change stops before any journal-mode setter when the probe remains indeterminate.

This deliberately does not restore the previous sidecar/header shortcut. Raw open/close after a tracked SQLite connection exists can cancel POSIX locks, while pre-open or cached evidence can become stale after path replacement or a cross-process WAL-to-DELETE switch.

## Regression Coverage
- Real file-backed `SessionDB` database persisted in WAL mode, with every `journal_mode` statement forced to raise `OperationalError("disk I/O error")`; schema reads, session writes, and session reads remain healthy.
- Exact assertion that the degraded path executes four bounded read-only `PRAGMA journal_mode` attempts and no mode-changing PRAGMA.
- macOS durability PRAGMAs on both fixed and WAL-reset-vulnerable runtime paths.
- Warning deduplication, `require_wal=True`, configured DELETE, concurrent opener, POSIX lock-safety, NOTADB self-heal, and kanban connection coverage.

## Test Plan
- `scripts/run_tests.sh -j 4 tests/test_hermes_state.py tests/test_hermes_state_wal_fallback.py tests/test_sqlite_wal_reset_gate.py tests/test_state_db_notadb_selfheal.py tests/test_journal_mode_config.py tests/test_sqlite_lock_safe_inspection.py tests/hermes_cli/test_kanban_db.py -q` (`356 passed`, `3 Windows-only skipped`)
- `.venv/bin/ruff check hermes_state.py tests/test_hermes_state_wal_fallback.py tests/test_sqlite_wal_reset_gate.py`
- `git diff --check`