### PR TITLE
feat(providers): declarative reasoning_effort_max for deep-reasoning providers

### DIFF
--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -17,6 +17,7 @@ zai = ProviderProfile(
     ),
     base_url="https://api.z.ai/api/paas/v4",
     default_aux_model="glm-4.5-flash",
+    reasoning_effort_max="max",
 )
 
 register_provider(zai)

--- a/providers/base.py
+++ b/providers/base.py
@@ -93,6 +93,14 @@ class ProviderProfile:
     )
     # empty = use main model
 
+    # ── Reasoning effort mapping ───────────────────────────────
+    # When set, the base build_api_kwargs_extras maps Hermes' "xhigh"
+    # effort to this top-level ``reasoning_effort`` value (e.g. "max").
+    # Providers that expose a deeper-than-default reasoning tier via a
+    # dedicated parameter (Z.AI/GLM, etc.) set this instead of
+    # subclassing build_api_kwargs_extras.
+    reasoning_effort_max: str | None = None
+
     # ── Hooks (override in subclass for complex providers) ───
 
     def get_hostname(self) -> str:
@@ -141,8 +149,19 @@ class ProviderProfile:
         extra_body (OpenRouter: extra_body.reasoning) while others put it
         as top-level api_kwargs (Kimi: api_kwargs.reasoning_effort).
 
-        Default: ({}, {}).
+        Base implementation handles the declarative ``reasoning_effort_max``
+        mapping only: when the provider sets ``reasoning_effort_max`` and the
+        requested effort is ``xhigh``, it emits a top-level
+        ``reasoning_effort`` kwarg with the provider-specific value (e.g.
+        ``"max"`` for Z.AI/GLM). This lets providers that use a single
+        top-level parameter for deep reasoning opt in without overriding the
+        full method. Subclasses with richer needs (Nous, OpenRouter, MiniMax)
+        override entirely.
         """
+        if self.reasoning_effort_max and isinstance(reasoning_config, dict):
+            effort = (reasoning_config.get("effort") or "").strip().lower()
+            if effort == "xhigh" and reasoning_config.get("enabled", True) is not False:
+                return {}, {"reasoning_effort": self.reasoning_effort_max}
         return {}, {}
 
     def get_max_tokens(self, model: str | None) -> int | None:


### PR DESCRIPTION
## What

Some providers (Z.AI/GLM-5.2, etc.) expose a deeper-than-default reasoning tier via a single top-level `reasoning_effort` parameter (e.g. `"max"`). Hermes' `/reasoning xhigh` command had no effect on these providers — they don't override `build_api_kwargs_extras`, so the base method returned `({}, {})` unconditionally.

## How

Add a declarative `reasoning_effort_max: str | None` field to `ProviderProfile`. When set, the base `build_api_kwargs_extras` maps effort=`xhigh` → `reasoning_effort=<value>` as a top-level kwarg. No subclass needed.

```python
# providers/base.py
reasoning_effort_max: str | None = None

# In build_api_kwargs_extras:
if self.reasoning_effort_max and effort == "xhigh":
    return {}, {"reasoning_effort": self.reasoning_effort_max}
return {}, {}
```

```python
# plugins/model-providers/zai/__init__.py
zai = ProviderProfile(
    ...,
    reasoning_effort_max="max",
)
```

## Why not override

The existing pattern is Nous/OpenRouter/MiniMax each overriding `build_api_kwargs_extras` with full custom logic. But providers like Z.AI/GLM only need a single parameter — a full override for one line of actual logic is noise. The declarative field follows the same philosophy as `default_aux_model` and `default_max_tokens`: simple things stay declarative.

## Impact

- Providers that don't set `reasoning_effort_max` → zero change (still `({}, {})`)
- Providers that override `build_api_kwargs_extras` entirely → unaffected (their override wins)
- Only providers that set the field AND don't override → new behavior (intended)
