### PR TITLE
fix(anthropic): use platform.claude.com for OAuth token exchange

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1349,18 +1349,36 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "code_verifier": verifier,
         }).encode()
 
-        req = urllib.request.Request(
+        # Anthropic migrated the OAuth token endpoint to platform.claude.com;
+        # console.anthropic.com/v1/oauth/token now returns 404. Try the new
+        # host first and fall back to the legacy one (mirrors token refresh).
+        token_endpoints = [
+            "https://platform.claude.com/v1/oauth/token",
             _OAUTH_TOKEN_URL,
-            data=exchange_data,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
-            },
-            method="POST",
-        )
+        ]
+        result = None
+        last_error = None
+        for endpoint in token_endpoints:
+            req = urllib.request.Request(
+                endpoint,
+                data=exchange_data,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                },
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    result = json.loads(resp.read().decode())
+                break
+            except Exception as exc:
+                last_error = exc
+                logger.debug("Anthropic token exchange failed at %s: %s", endpoint, exc)
+                continue
 
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
+        if result is None:
+            raise last_error if last_error is not None else ValueError("Token exchange failed")
     except Exception as e:
         print(f"Token exchange failed: {e}")
         return None


### PR DESCRIPTION
## Summary

`hermes auth add anthropic --type oauth` fails at the token-exchange step with:

```
Token exchange failed: HTTP Error 404: Not Found
Anthropic OAuth login did not return credentials.
```

### Root cause

`run_hermes_oauth_login_pure()` in `agent/anthropic_adapter.py` POSTs the authorization code to `https://console.anthropic.com/v1/oauth/token` (`_OAUTH_TOKEN_URL`). Anthropic has retired that endpoint — it now returns HTTP 404. The browser authorize step and PKCE/state validation all succeed; only the exchange fails.

Notably, the token **refresh** path (`refresh_anthropic_oauth_pure`) was already updated to try `platform.claude.com` first with the console host as fallback. The login exchange was missed.

### Fix

Make the login token exchange try `https://platform.claude.com/v1/oauth/token` first, falling back to the legacy console host — mirroring the existing refresh logic. If all endpoints fail, the last error is surfaced as before.

## Test plan

- [x] Reproduced the 404 on the old single-endpoint path
- [x] With the fix, `hermes auth add anthropic --type oauth` completes: `Added anthropic OAuth credential`, and `hermes auth status anthropic` reports `logged in`
- [x] Lint clean