### PR TITLE
fix(web-server): detach windows dashboard actions

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -44,6 +44,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from hermes_cli import __version__, __release_date__
+from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
 from hermes_cli.config import (
     cfg_get,
     DEFAULT_CONFIG,
@@ -2281,13 +2282,7 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
         "stderr": subprocess.STDOUT,
         "env": {**os.environ, "HERMES_NONINTERACTIVE": "1"},
     }
-    if sys.platform == "win32":
-        popen_kwargs["creationflags"] = (
-            subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
-            | getattr(subprocess, "DETACHED_PROCESS", 0)
-        )
-    else:
-        popen_kwargs["start_new_session"] = True
+    popen_kwargs.update(windows_detach_popen_kwargs())
 
     proc = subprocess.Popen(cmd, **popen_kwargs)
     # The child inherits its own duplicated fd for stdout/stderr, so the

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1102,6 +1102,35 @@ class TestWebServerEndpoints:
         assert resp.json() == {"ok": True, "pid": 12345, "name": "hermes-update"}
         assert calls == [(["update"], "hermes-update")]
 
+    def test_spawn_action_uses_windows_detach_helper(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        captured = {}
+
+        class _Proc:
+            pid = 777
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return _Proc()
+
+        monkeypatch.setattr(web_server, "_ACTION_LOG_DIR", tmp_path)
+        monkeypatch.setattr(
+            web_server, "windows_detach_popen_kwargs", lambda: {"creationflags": 0x12345678}
+        )
+        monkeypatch.setattr(web_server.subprocess, "Popen", fake_popen)
+
+        proc = web_server._spawn_hermes_action(["gateway", "restart"], "gateway-restart")
+
+        assert proc.pid == 777
+        assert captured["cmd"][0] == web_server.sys.executable
+        assert captured["cmd"][1:] == ["-m", "hermes_cli.main", "gateway", "restart"]
+        assert captured["kwargs"]["creationflags"] == 0x12345678
+        assert captured["kwargs"]["stdin"] is web_server.subprocess.DEVNULL
+        assert captured["kwargs"]["stderr"] is web_server.subprocess.STDOUT
+        assert captured["kwargs"]["env"]["HERMES_NONINTERACTIVE"] == "1"
+
     def test_action_status_reaps_completed_process(self, monkeypatch):
         import hermes_cli.web_server as web_server
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows desktop gateway restart path so it reuses the shared detached-process helper instead of spawning a visible console window. This keeps `Cmd+K` / `Ctrl+K` restart behavior aligned with a gateway installed as a headless Windows service.

## Related Issue

Fixes #49294

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/web_server.py` to use `windows_detach_popen_kwargs()` for desktop-triggered background actions on Windows
- Removed the duplicated manual Windows `creationflags` handling from `_spawn_hermes_action`
- Added a regression test in `tests/hermes_cli/test_web_server.py` that verifies the detached Windows spawn helper is forwarded into `subprocess.Popen`

## How to Test

1. Run `uv run --python 3.13 pytest tests/hermes_cli/test_web_server.py -k "spawn_action_uses_windows_detach_helper or update_hermes_spawns_on_non_docker_install or telegram_onboarding_ready_and_apply_never_returns_bot_token or telegram_onboarding_apply_reports_restart_failure_after_save or telegram_onboarding_apply_reuses_inflight_gateway_restart"`
2. Confirm the new regression test passes and existing nearby restart/onboarding checks stay green
3. On Windows, trigger Desktop `Cmd+K` / `Ctrl+K` -> `Restart gateway` after `hermes gateway install` and confirm no persistent `cmd.exe` window is opened

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: macOS 15.x for targeted regression coverage; Windows runtime behavior inferred from code path and helper semantics

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted proof: `5 passed, 302 deselected` from `tests/hermes_cli/test_web_server.py`
