### PR TITLE
fix(cron): fail pre-run script errors

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1517,6 +1517,21 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     if script_path:
         prerun_script = _run_job_script(script_path)
         _ran_ok, _script_output = prerun_script
+        if not _ran_ok:
+            now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+            output = f"""# Cron Job: {job_name} (FAILED)
+
+**Job ID:** {job_id}
+**Run Time:** {now_iso}
+**Schedule:** {job.get('schedule_display', 'N/A')}
+
+## Pre-run Script Error
+
+```
+{_script_output}
+```
+"""
+            return False, output, "", f"pre-run script failed: {_script_output}"
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
                 "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1544,6 +1544,36 @@ class TestRunJobConfigLogging:
         assert any("failed to parse prefill messages" in r.message for r in caplog.records), \
             f"Expected 'failed to parse prefill messages' warning in logs, got: {[r.message for r in caplog.records]}"
 
+    def test_run_one_job_marks_prerun_script_failure_as_error(self, tmp_path):
+        """A failed pre-run script must short-circuit the agent path and mark the job failed."""
+        from cron.scheduler import run_one_job
+
+        job = {
+            "id": "script-fail-job",
+            "name": "script fail test",
+            "prompt": "summarize the collected data",
+            "script": "collect.py",
+            "deliver": "local",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("cron.scheduler._run_job_script", return_value=(False, "collector exploded")), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.mark_job_run") as mark_job_run_mock, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            processed = run_one_job(job, verbose=False)
+
+        assert processed is True
+        mock_agent_cls.assert_not_called()
+        mark_job_run_mock.assert_called_once()
+        assert mark_job_run_mock.call_args.args[0] == "script-fail-job"
+        assert mark_job_run_mock.call_args.args[1] is False
+        assert "pre-run script failed" in mark_job_run_mock.call_args.args[2]
+        assert "collector exploded" in mark_job_run_mock.call_args.args[2]
+
 
 class TestRunJobConfigEnvVarExpansion:
     """Verify that ${VAR} references in config.yaml are expanded when running cron jobs."""


### PR DESCRIPTION
## Summary
- short-circuit agent-mode cron jobs when the pre-run script exits non-zero
- surface the script failure directly in cron job output instead of continuing into AIAgent
- add a regression test that proves the job is marked failed and the agent path is skipped

Fixes #20301.

## Verification
- `uv run --frozen pytest tests/cron/test_scheduler.py -k prerun_script_failure_as_error`
- `uv run --frozen ruff check cron/scheduler.py tests/cron/test_scheduler.py`
- `git diff --check`

## CI Attribution
- No shared red baseline observed in the freshest LeonSGP43 PRs (#48916, #48967); this diff was validated locally with targeted cron coverage.