### PR TITLE
fix(mcp): keep OAuth storage usable without SDK types

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -3,7 +3,9 @@
 import json
 import os
 import stat
+import subprocess
 import sys
+import textwrap
 from io import BytesIO
 from unittest.mock import patch, MagicMock
 
@@ -108,6 +110,70 @@ class TestHermesTokenStorage:
 
         client_path = tmp_path / "mcp-tokens" / "test-server.client.json"
         assert client_path.exists()
+
+    def test_cached_storage_readable_without_optional_sdk_types(self, tmp_path):
+        """Cached token/client JSON stays readable when MCP OAuth types are absent."""
+        script = textwrap.dedent(
+            """
+            import asyncio
+            import json
+            import os
+            import sys
+            from pathlib import Path
+
+            class BlockMcpImports:
+                def find_spec(self, fullname, path=None, target=None):
+                    if fullname == "mcp" or fullname.startswith("mcp."):
+                        raise ImportError(f"blocked optional MCP SDK import: {fullname}")
+                    return None
+
+            sys.meta_path.insert(0, BlockMcpImports())
+
+            from tools.mcp_oauth import HermesTokenStorage, _OAUTH_AVAILABLE, build_oauth_auth
+
+            assert _OAUTH_AVAILABLE is False
+            token_dir = Path(os.environ["HERMES_HOME"]) / "mcp-tokens"
+            token_dir.mkdir(parents=True)
+            (token_dir / "cached.json").write_text(json.dumps({
+                "access_token": "cached-access",
+                "token_type": "Bearer",
+                "refresh_token": "cached-refresh",
+                "expires_in": 3600,
+            }))
+            (token_dir / "cached.client.json").write_text(json.dumps({
+                "client_id": "cached-client",
+                "client_secret": "cached-secret",
+                "token_endpoint_auth_method": "client_secret_post",
+                "redirect_uris": ["http://127.0.0.1:54321/callback"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+            }))
+
+            storage = HermesTokenStorage("cached")
+            tokens = asyncio.run(storage.get_tokens())
+            client_info = asyncio.run(storage.get_client_info())
+
+            assert tokens.access_token == "cached-access"
+            assert tokens.model_dump(exclude_none=True)["refresh_token"] == "cached-refresh"
+            assert client_info.client_id == "cached-client"
+            assert client_info.token_endpoint_auth_method == "client_secret_post"
+            assert build_oauth_auth("cached", "https://example.com/mcp") is None
+            """
+        )
+
+        env = os.environ.copy()
+        env["HERMES_HOME"] = str(tmp_path)
+        env["PYTHONPATH"] = os.getcwd()
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
 
     def test_remove_cleans_up(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -46,7 +46,7 @@ import time
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Self
 from urllib.parse import parse_qs, urlparse
 from hermes_constants import secure_parent_dir
 
@@ -56,8 +56,9 @@ logger = logging.getLogger(__name__)
 # Lazy imports -- MCP SDK with OAuth support is optional
 # ---------------------------------------------------------------------------
 
-_OAUTH_AVAILABLE=False
-try:
+_OAUTH_AVAILABLE: bool = False
+
+if TYPE_CHECKING:
     from mcp.client.auth import OAuthClientProvider
     from mcp.shared.auth import (
         OAuthClientInformationFull,
@@ -65,10 +66,60 @@ try:
         OAuthMetadata,
         OAuthToken,
     )
+else:
+    _OAUTH_AVAILABLE=False
+    try:
+        from mcp.client.auth import OAuthClientProvider
+        from mcp.shared.auth import (
+            OAuthClientInformationFull,
+            OAuthClientMetadata,
+            OAuthMetadata,
+            OAuthToken,
+        )
 
-    _OAUTH_AVAILABLE=True
-except ImportError:
-    logger.debug("MCP OAuth types not available -- OAuth MCP auth disabled")
+        _OAUTH_AVAILABLE=True
+    except ImportError:
+        logger.debug("MCP OAuth types not available -- OAuth MCP auth disabled")
+
+        class OAuthClientProvider:
+            """Placeholder when the optional MCP OAuth SDK surface is absent."""
+
+            def __init__(self, *_: Any, **__: Any) -> None:
+                raise RuntimeError("MCP OAuth SDK support is not available")
+
+        class _FallbackOAuthModel:
+            """Tiny pydantic-shaped stand-in used when MCP OAuth is unavailable.
+
+            Token storage helpers and unit tests still need to round-trip cached
+            JSON even in environments without the optional SDK auth types.
+            Runtime OAuth remains disabled through ``_OAUTH_AVAILABLE=False``.
+            """
+
+            def __init__(self, **data: Any) -> None:
+                self._data = dict(data)
+                for key, value in data.items():
+                    setattr(self, key, value)
+
+            @classmethod
+            def model_validate(cls, data: dict[str, Any]) -> Self:
+                return cls(**dict(data))
+
+            def model_dump(self, *, exclude_none: bool = False, **_: Any) -> dict[str, Any]:
+                if exclude_none:
+                    return {k: v for k, v in self._data.items() if v is not None}
+                return dict(self._data)
+
+        class OAuthClientInformationFull(_FallbackOAuthModel):
+            pass
+
+        class OAuthClientMetadata(_FallbackOAuthModel):
+            pass
+
+        class OAuthMetadata(_FallbackOAuthModel):
+            pass
+
+        class OAuthToken(_FallbackOAuthModel):
+            pass
 
 try:
     from pydantic import AnyUrl


### PR DESCRIPTION
## Summary
- keep MCP OAuth token storage helpers usable when the optional MCP SDK OAuth types are missing
- add tiny pydantic-shaped fallback models for cached token/client/metadata JSON round-trips while keeping runtime OAuth disabled without SDK support
- add a subprocess regression that blocks `mcp.*` imports and proves cached token/client JSON still loads

## Tests
- `scripts/run_tests.sh tests/tools/test_mcp_oauth.py -- -q --tb=short`
- `scripts/run_tests.sh tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_integration.py tests/tools/test_mcp_oauth_metadata.py tests/tools/test_mcp_oauth_bidirectional.py tests/tools/test_mcp_oauth_cold_load_expiry.py -- -q --tb=short`
