### PR TITLE
fix: confirm explicit gateway restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12449,14 +12449,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return None
 
-            platform_cfg = self.config.platforms.get(platform)
-            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
-                logger.info(
-                    "Restart notification suppressed: %s has gateway_restart_notification=false",
-                    platform_str,
-                )
-                return None
-
             metadata = self._thread_metadata_for_target(
                 platform,
                 chat_id,
@@ -12467,7 +12459,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             result = await adapter.send(
                 str(chat_id),
-                "♻ Gateway restarted successfully. Your session continues.",
+                t("gateway.restart.completed"),
                 metadata=_non_conversational_metadata(metadata, platform=platform),
             )
             # adapter.send() catches provider errors (e.g. "Chat not found")

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -231,6 +231,7 @@ gateway:
   restart:
     in_progress:           "⏳ Gateway restart already in progress..."
     restarting:            "♻ Restarting gateway. If you aren't notified within 60 seconds, restart from the console with `hermes gateway restart`."
+    completed:             "♻ Gateway restarted successfully. Your session continues."
 
   resume:
     db_unavailable:        "Session database not available."

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -216,6 +216,7 @@ gateway:
   restart:
     in_progress:           "⏳ 게이트웨이 재시작이 이미 진행 중입니다..."
     restarting:            "♻ 게이트웨이를 재시작 중입니다. 60초 이내에 알림이 오지 않으면 콘솔에서 `hermes gateway restart`로 재시작하세요."
+    completed:             "♻ 게이트웨이 재시작이 완료되었습니다. 세션은 계속 이어집니다."
 
   resume:
     db_unavailable:        "세션 데이터베이스를 사용할 수 없습니다."

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -584,14 +584,14 @@ async def test_send_home_channel_startup_notification_default_flag_true(
 
 
 @pytest.mark.asyncio
-async def test_send_restart_notification_skipped_when_flag_disabled(
+async def test_send_restart_notification_delivered_to_requester_when_flag_disabled(
     tmp_path, monkeypatch
 ):
-    """The /restart originator's notification also honors the per-platform flag.
+    """The /restart requester always gets completion feedback.
 
-    Slack used by end users → flag off → no "Gateway restarted" message even
-    when an end user accidentally triggers /restart. The marker file is still
-    cleaned up so the notification doesn't leak into the next boot.
+    ``gateway_restart_notification=False`` still mutes ambient home-channel
+    and active-session pings, but it must not make an explicit /restart look
+    like a hang to the user who triggered it.
     """
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
@@ -603,12 +603,16 @@ async def test_send_restart_notification_skipped_when_flag_disabled(
 
     runner, adapter = make_restart_runner()
     runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
-    adapter.send = AsyncMock()
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="restart"))
 
     delivered_target = await runner._send_restart_notification()
 
-    assert delivered_target is None
-    adapter.send.assert_not_called()
+    assert delivered_target == ("telegram", "42", None)
+    adapter.send.assert_awaited_once_with(
+        "42",
+        "♻ Gateway restarted successfully. Your session continues.",
+        metadata=None,
+    )
     assert not notify_path.exists()
 
 


### PR DESCRIPTION
## Summary
- Always send a completion acknowledgement to the user who explicitly triggered `/restart`.
- Keep `gateway_restart_notification=false` scoped to ambient startup/home-channel notifications.
- Move the restart completion copy into locale strings.

## Test plan
- `./venv/bin/python -m pytest tests/gateway/test_restart_notification.py -o 'addopts=' -q`

## Notes
This is intentionally a small, focused gateway behavior fix. It does not include private fork documentation or unrelated runtime-context/task-ledger work.
