### PR TITLE
fix(test): clear HERMES_REAL_HOME env leak in copilot ACP home test

### DIFF
--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -180,6 +180,7 @@ def test_run_prompt_preserves_real_home_when_profile_home_available(monkeypatch,
     real_home = tmp_path / "real-home"
     real_home.mkdir()
 
+    monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
     monkeypatch.setenv("HOME", str(real_home))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 


### PR DESCRIPTION
## Summary

The `test_run_prompt_preserves_real_home_when_profile_home_available` test fails when `HERMES_REAL_HOME` is already set in the parent environment (e.g. from an active Hermes session).

### Root Cause

The test monkeypatches `HOME` and `HERMES_HOME` but does not clear `HERMES_REAL_HOME`. The `_iter_real_home_candidates()` function in `hermes_constants.py` reads `HERMES_REAL_HOME` as the highest-priority candidate. When it's set from a prior session (e.g. `HERMES_REAL_HOME=/home/tony`), the function picks that up instead of the monkeypatched `HOME`, causing `get_real_home()` to return the stale value.

### Fix

Add `monkeypatch.delenv("HERMES_REAL_HOME", raising=False)` before setting the test-specific environment variables, ensuring full isolation from the ambient environment.

### Test Plan
- [x] `test_run_prompt_preserves_real_home_when_profile_home_available` passes
- [x] All 7 tests in `test_copilot_acp_client.py` pass
- [x] Full test suite passes (1655+ passed)
