### PR TITLE
feat: add opt-in execution receipts

### DIFF
--- a/agent/execution_receipts.py
+++ b/agent/execution_receipts.py
@@ -1,0 +1,220 @@
+"""Execution receipt construction and hook emission.
+
+This module is intentionally small and passive. It builds metadata-only
+execution receipts and emits them to the plugin system when a plugin has opted
+in to the ``execution_receipt`` observer hook. It must never affect tool
+execution: all hook/serialization failures are fail-open.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+import json
+import logging
+import uuid
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = "hermes.execution_receipt.v0"
+REDACTION_POLICY_VERSION = "execution_receipts.v0"
+HOOK_NAME = "execution_receipt"
+
+
+def emit_tool_execution_receipt(
+    *,
+    session_id: str = "",
+    task_id: str = "",
+    turn_id: str = "",
+    api_request_id: str = "",
+    tool_call_id: str = "",
+    tool_name: str = "",
+    status: str = "ok",
+    duration_ms: int | None = None,
+    args: Any = None,
+    result: Any = None,
+    sequence_number: int | None = None,
+    trace_id: str | None = None,
+    parent_span_id: str | None = None,
+    links: Sequence[Mapping[str, Any]] | None = None,
+    evidence_gaps: Sequence[str] | None = None,
+    error_type: str | None = None,
+    error_message: str | None = None,
+) -> dict[str, Any] | None:
+    """Emit a metadata-only tool-complete execution receipt.
+
+    Returns the receipt when it was built, or ``None`` when no plugin listens
+    for receipt events. The caller must not depend on delivery: plugin hook
+    failures are logged at debug level and swallowed.
+    """
+    try:
+        from hermes_cli import plugins
+
+        if not plugins.has_hook(HOOK_NAME):
+            return None
+    except Exception as exc:
+        logger.debug("execution receipt hook check failed: %s", exc)
+        return None
+
+    receipt = _build_tool_execution_receipt(
+        session_id=session_id,
+        task_id=task_id,
+        turn_id=turn_id,
+        api_request_id=api_request_id,
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        status=status,
+        duration_ms=duration_ms,
+        args=args,
+        result=result,
+        sequence_number=sequence_number,
+        trace_id=trace_id,
+        parent_span_id=parent_span_id,
+        links=links,
+        evidence_gaps=evidence_gaps,
+        error_type=error_type,
+        error_message=error_message,
+    )
+
+    try:
+        plugins.invoke_hook(HOOK_NAME, receipt=receipt)
+    except Exception as exc:
+        logger.debug("execution receipt hook failed: %s", exc, exc_info=True)
+    return receipt
+
+
+def _build_tool_execution_receipt(
+    *,
+    session_id: str = "",
+    task_id: str = "",
+    turn_id: str = "",
+    api_request_id: str = "",
+    tool_call_id: str = "",
+    tool_name: str = "",
+    status: str = "ok",
+    duration_ms: int | None = None,
+    args: Any = None,
+    result: Any = None,
+    sequence_number: int | None = None,
+    trace_id: str | None = None,
+    parent_span_id: str | None = None,
+    links: Sequence[Mapping[str, Any]] | None = None,
+    evidence_gaps: Sequence[str] | None = None,
+    error_type: str | None = None,
+    error_message: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "receipt_id": f"receipt-{uuid.uuid4().hex}",
+        "receipt_type": "tool_complete",
+        "trace_id": trace_id or f"trace-{uuid.uuid4().hex}",
+        "span_id": f"span-{uuid.uuid4().hex}",
+        "parent_span_id": parent_span_id,
+        "sequence_number": int(sequence_number or 0),
+        "timestamp": _now_iso(),
+        "session_id": str(session_id or ""),
+        "task_id": str(task_id or ""),
+        "turn_id": str(turn_id or ""),
+        "api_request_id": str(api_request_id or ""),
+        "tool_call_id": str(tool_call_id or ""),
+        "tool_name": str(tool_name or ""),
+        "status": str(status or "ok"),
+        "duration_ms": _coerce_duration_ms(duration_ms),
+        "args": _redacted_payload_metadata(args),
+        "result": _redacted_payload_metadata(result),
+        "links": _normalize_links(links),
+        "evidence_gaps": _normalize_evidence_gaps(evidence_gaps),
+        "redaction_policy_version": REDACTION_POLICY_VERSION,
+        "redaction_status": "ok",
+        "error_type": str(error_type) if error_type else None,
+        "error_message": None,
+        "error_message_metadata": _redacted_error_message_metadata(error_message),
+    }
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _coerce_duration_ms(duration_ms: int | None) -> int | None:
+    if duration_ms is None:
+        return None
+    try:
+        coerced = int(duration_ms)
+    except Exception:
+        return None
+    return max(coerced, 0)
+
+
+def _redacted_payload_metadata(payload: Any) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "redacted": True,
+        "kind": type(payload).__name__ if payload is not None else "none",
+        "size_bytes": _payload_size_bytes(payload),
+    }
+    if isinstance(payload, Mapping):
+        metadata["field_names"] = sorted(str(key) for key in payload.keys())[:50]
+        metadata["field_count"] = len(payload)
+    elif isinstance(payload, (list, tuple, set, frozenset)):
+        metadata["item_count"] = len(payload)
+    elif isinstance(payload, str):
+        metadata["char_count"] = len(payload)
+    return metadata
+
+
+def _payload_size_bytes(payload: Any) -> int:
+    if payload is None:
+        return 0
+    if isinstance(payload, bytes):
+        return len(payload)
+    if isinstance(payload, str):
+        return len(payload.encode("utf-8", errors="replace"))
+    try:
+        serialized = json.dumps(payload, ensure_ascii=False, default=str)
+    except Exception:
+        serialized = str(type(payload).__name__)
+    return len(serialized.encode("utf-8", errors="replace"))
+
+
+def _normalize_links(links: Sequence[Mapping[str, Any]] | None) -> list[dict[str, str]]:
+    normalized: list[dict[str, str]] = []
+    if not links:
+        return normalized
+    for link in links[:50]:
+        if not isinstance(link, Mapping):
+            continue
+        item: dict[str, str] = {}
+        for key in ("type", "id", "trace_id", "session_id", "task_id", "subagent_id"):
+            value = link.get(key)
+            if value is not None:
+                item[key] = str(value)
+        if item:
+            normalized.append(item)
+    return normalized
+
+
+def _normalize_evidence_gaps(evidence_gaps: Sequence[str] | None) -> list[str]:
+    if not evidence_gaps:
+        return []
+    return [str(gap) for gap in evidence_gaps if gap][:50]
+
+
+def _redacted_error_message_metadata(error_message: str | None) -> dict[str, Any] | None:
+    if not error_message:
+        return None
+    text = str(error_message)
+    return {
+        "redacted": True,
+        "kind": type(error_message).__name__,
+        "char_count": len(text),
+        "size_bytes": len(text.encode("utf-8", errors="replace")),
+    }
+
+
+__all__ = [
+    "HOOK_NAME",
+    "REDACTION_POLICY_VERSION",
+    "SCHEMA_VERSION",
+    "emit_tool_execution_receipt",
+]

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -19,6 +19,7 @@ import os
 import random
 import threading
 import time
+import uuid
 from typing import Any, Optional
 
 from agent.display import (
@@ -93,6 +94,78 @@ def _emit_terminal_post_tool_call(
         pass
 
 
+def _execution_receipt_trace_id(agent) -> str:
+    trace_id = getattr(agent, "_execution_receipt_trace_id", None)
+    if not trace_id:
+        trace_id = f"trace-{uuid.uuid4().hex}"
+        try:
+            setattr(agent, "_execution_receipt_trace_id", trace_id)
+        except Exception:
+            pass
+    return str(trace_id)
+
+
+def _next_execution_receipt_sequence(agent) -> int:
+    try:
+        current = int(getattr(agent, "_execution_receipt_sequence", 0) or 0) + 1
+        setattr(agent, "_execution_receipt_sequence", current)
+        return current
+    except Exception:
+        return 0
+
+
+def _tool_call_args_for_receipt(tool_call) -> dict:
+    try:
+        parsed = json.loads(getattr(tool_call.function, "arguments", "{}"))
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _emit_terminal_execution_receipt(
+    agent,
+    *,
+    function_name: str,
+    function_args: dict,
+    result: Any,
+    effective_task_id: str,
+    tool_call_id: str,
+    duration_ms: int | None,
+    status: str,
+    error_type: str | None = None,
+    error_message: str | None = None,
+) -> None:
+    try:
+        from hermes_cli import plugins
+
+        if not plugins.has_hook("execution_receipt"):
+            return
+    except Exception:
+        return
+
+    try:
+        from agent.execution_receipts import emit_tool_execution_receipt
+
+        emit_tool_execution_receipt(
+            session_id=getattr(agent, "session_id", "") or "",
+            task_id=effective_task_id or "",
+            turn_id=getattr(agent, "_current_turn_id", "") or "",
+            api_request_id=getattr(agent, "_current_api_request_id", "") or "",
+            tool_call_id=tool_call_id or "",
+            tool_name=function_name,
+            status=status,
+            duration_ms=duration_ms,
+            args=function_args if isinstance(function_args, dict) else {},
+            result=result,
+            sequence_number=_next_execution_receipt_sequence(agent),
+            trace_id=_execution_receipt_trace_id(agent),
+            error_type=error_type,
+            error_message=error_message,
+        )
+    except Exception:
+        logger.debug("execution receipt emission failed", exc_info=True)
+
+
 def _cancelled_tool_result(reason: str = "user interrupt") -> str:
     return json.dumps(
         {
@@ -116,6 +189,7 @@ def _emit_cancelled_terminal_post_tool_call(
     middleware_trace: Optional[list[dict[str, Any]]] = None,
 ) -> str:
     result = _cancelled_tool_result(reason)
+    duration_ms = int((time.time() - start_time) * 1000)
     _emit_terminal_post_tool_call(
         agent,
         function_name=function_name,
@@ -123,11 +197,23 @@ def _emit_cancelled_terminal_post_tool_call(
         result=result,
         effective_task_id=effective_task_id,
         tool_call_id=tool_call_id,
-        duration_ms=int((time.time() - start_time) * 1000),
+        duration_ms=duration_ms,
         status="cancelled",
         error_type=error_type,
         error_message=f"Tool execution cancelled by {reason}",
         middleware_trace=list(middleware_trace or []),
+    )
+    _emit_terminal_execution_receipt(
+        agent,
+        function_name=function_name,
+        function_args=function_args,
+        result=result,
+        effective_task_id=effective_task_id,
+        tool_call_id=tool_call_id,
+        duration_ms=duration_ms,
+        status="cancelled",
+        error_type=error_type,
+        error_message=f"Tool execution cancelled by {reason}",
     )
     return result
 
@@ -253,9 +339,23 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     if agent._interrupt_requested:
         print(f"{agent.log_prefix}⚡ Interrupt: skipping {num_tools} tool call(s)")
         for tc in tool_calls:
+            skipped_name = tc.function.name
+            skipped_result = f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]"
+            _emit_terminal_execution_receipt(
+                agent,
+                function_name=skipped_name,
+                function_args=_tool_call_args_for_receipt(tc),
+                result=skipped_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=tc.id,
+                duration_ms=0,
+                status="cancelled",
+                error_type="keyboard_interrupt",
+                error_message="Tool execution cancelled by user interrupt",
+            )
             messages.append(make_tool_result_message(
-                tc.function.name,
-                f"[Tool execution cancelled — {tc.function.name} was skipped due to user interrupt]",
+                skipped_name,
+                skipped_result,
                 tc.id,
             ))
         return
@@ -628,8 +728,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         blocked = False
         if r is None:
             # Tool was cancelled (interrupt) or thread didn't return
+            function_name = name
+            function_args = args
+            is_error = True
+            blocked = False
             if agent._interrupt_requested:
                 function_result = f"[Tool execution cancelled — {name} was skipped due to user interrupt]"
+                receipt_status = "cancelled"
+                receipt_error_type = "keyboard_interrupt"
+                receipt_error_message = "Tool execution cancelled by user interrupt"
                 _emit_terminal_post_tool_call(
                     agent,
                     function_name=name,
@@ -644,6 +751,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 )
             else:
                 function_result = f"Error executing tool '{name}': thread did not return a result"
+                receipt_status = "error"
+                receipt_error_type = "thread_missing_result"
+                receipt_error_message = function_result
                 _emit_terminal_post_tool_call(
                     agent,
                     function_name=name,
@@ -659,6 +769,16 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             tool_duration = 0.0
         else:
             function_name, function_args, function_result, tool_duration, is_error, blocked, middleware_trace = r
+            receipt_status = "blocked" if blocked else ("error" if is_error else "ok")
+            if blocked:
+                receipt_error_type = "guardrail_block" if blocked_by_guardrail else "plugin_block"
+                receipt_error_message = _multimodal_text_summary(function_result)[:200]
+            elif is_error:
+                receipt_error_type = "tool_error"
+                receipt_error_message = None
+            else:
+                receipt_error_type = None
+                receipt_error_message = None
 
             if not blocked:
                 function_result = agent._append_guardrail_observation(
@@ -697,6 +817,19 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if agent.verbose_logging:
                 logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
                 logging.debug(f"Tool result ({len(function_result)} chars): {function_result}")
+
+        _emit_terminal_execution_receipt(
+            agent,
+            function_name=function_name,
+            function_args=function_args,
+            result=function_result,
+            effective_task_id=effective_task_id,
+            tool_call_id=getattr(tc, "id", "") or "",
+            duration_ms=int(tool_duration * 1000),
+            status=receipt_status,
+            error_type=receipt_error_type,
+            error_message=receipt_error_message,
+        )
 
         # Print cute message per tool
         if agent._should_emit_quiet_tool_messages():
@@ -779,10 +912,23 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {len(remaining_calls)} tool call(s)", force=True)
             for skipped_tc in remaining_calls:
                 skipped_name = skipped_tc.function.name
+                skipped_content = f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]"
+                _emit_terminal_execution_receipt(
+                    agent,
+                    function_name=skipped_name,
+                    function_args=_tool_call_args_for_receipt(skipped_tc),
+                    result=skipped_content,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=skipped_tc.id,
+                    duration_ms=0,
+                    status="cancelled",
+                    error_type="keyboard_interrupt",
+                    error_message="Tool execution cancelled by user interrupt",
+                )
                 skip_msg = {
                     "role": "tool",
                     "name": skipped_name,
-                    "content": f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]",
+                    "content": skipped_content,
                     "tool_call_id": skipped_tc.id,
                 }
                 messages.append(skip_msg)
@@ -1336,6 +1482,38 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         else:
             logger.info("tool %s completed (%.2fs, %d chars)", function_name, tool_duration, _result_len)
 
+        if _execution_blocked:
+            _receipt_status = "blocked"
+            if _block_msg is not None:
+                _receipt_error_type = _block_error_type
+                _receipt_error_message = _block_msg
+            else:
+                _receipt_error_type = "guardrail_block"
+                _receipt_error_message = (
+                    getattr(_guardrail_block_decision, "message", None)
+                    or "Tool blocked by guardrail policy"
+                )
+        elif _is_error_result:
+            _receipt_status = "error"
+            _receipt_error_type = "tool_error"
+            _receipt_error_message = None
+        else:
+            _receipt_status = "ok"
+            _receipt_error_type = None
+            _receipt_error_message = None
+        _emit_terminal_execution_receipt(
+            agent,
+            function_name=function_name,
+            function_args=function_args,
+            result=function_result,
+            effective_task_id=effective_task_id,
+            tool_call_id=getattr(tool_call, "id", "") or "",
+            duration_ms=int(tool_duration * 1000),
+            status=_receipt_status,
+            error_type=_receipt_error_type,
+            error_message=_receipt_error_message,
+        )
+
         # Track file-mutation outcome for the turn-end verifier.  See
         # the concurrent path for the rationale; both paths must feed
         # the same state so the footer reflects every tool call in the
@@ -1412,9 +1590,22 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)", force=True)
             for skipped_tc in assistant_message.tool_calls[i:]:
                 skipped_name = skipped_tc.function.name
+                skipped_content = f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]"
+                _emit_terminal_execution_receipt(
+                    agent,
+                    function_name=skipped_name,
+                    function_args=_tool_call_args_for_receipt(skipped_tc),
+                    result=skipped_content,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=skipped_tc.id,
+                    duration_ms=0,
+                    status="cancelled",
+                    error_type="user_interrupt",
+                    error_message="Tool execution skipped because user sent a new message",
+                )
                 messages.append(make_tool_result_message(
                     skipped_name,
-                    f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
+                    skipped_content,
                     skipped_tc.id,
                 ))
             break

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -24,6 +24,7 @@ def register(ctx):
     ctx.register_hook("post_api_request", on_post_api_request)
     ctx.register_hook("pre_tool_call", on_pre_tool_call)
     ctx.register_hook("post_tool_call", on_post_tool_call)
+    ctx.register_hook("execution_receipt", on_execution_receipt)
 ```
 
 Every hook callback receives keyword arguments. Plugins should accept
@@ -184,6 +185,46 @@ Tool hooks describe individual tool calls:
 `post_tool_call` is emitted for blocked and cancelled paths so telemetry
 plugins can close spans cleanly.
 
+### Execution Receipts
+
+Execution receipts are a separate metadata-only evidence stream for plugins
+that need a durable, local record of agent-loop tool outcomes without storing
+raw arguments or raw results.
+
+| Hook | When it fires |
+| --- | --- |
+| `execution_receipt` | After Hermes has built a redacted `tool_complete` receipt for a tool outcome. |
+
+The callback receives one keyword argument:
+
+```python
+def on_execution_receipt(receipt: dict, **kwargs):
+    ...
+```
+
+The v0 receipt envelope includes identifiers (`session_id`, `task_id`,
+`turn_id`, `api_request_id`, `tool_call_id`), `trace_id`, `span_id`,
+`sequence_number`, `tool_name`, `status`, `duration_ms`, redacted `args` and
+`result` metadata, `links`, `evidence_gaps`, and redaction fields. It does not
+include raw terminal output, prompts, file contents, environment variables, raw
+error messages, or full tool arguments/results by default.
+
+Hermes ships an optional local JSONL sink:
+
+```bash
+hermes plugins enable observability/execution_receipts
+```
+
+When enabled, receipts are appended to:
+
+```text
+$HERMES_HOME/execution-receipts/receipts.jsonl
+```
+
+The plugin also registers `/receipts status`, `/receipts tail [N]`, and
+`/receipts gaps`. P1 receipts are best-effort local telemetry only: they do not
+route work, enforce policy, or cryptographically sign records.
+
 ### Approval Lifecycle
 
 Approval hooks describe dangerous-command approval prompts:
@@ -264,6 +305,7 @@ def register(ctx):
     ctx.register_hook("post_api_request", on_post_api_request)
     ctx.register_hook("pre_tool_call", on_pre_tool_call)
     ctx.register_hook("post_tool_call", on_post_tool_call)
+    ctx.register_hook("execution_receipt", on_execution_receipt)
 
 
 def on_pre_api_request(**kwargs):
@@ -298,6 +340,15 @@ def on_post_tool_call(**kwargs):
         result=kwargs.get("result"),
         status=kwargs.get("status"),
         duration_ms=kwargs.get("duration_ms"),
+    )
+
+
+def on_execution_receipt(**kwargs):
+    receipt = kwargs.get("receipt") or {}
+    persist_local_receipt_summary(
+        sequence=receipt.get("sequence_number"),
+        tool=receipt.get("tool_name"),
+        status=receipt.get("status"),
     )
 ```
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -139,6 +139,7 @@ VALID_HOOKS: Set[str] = {
     "pre_api_request",
     "post_api_request",
     "api_request_error",
+    "execution_receipt",
     "on_session_start",
     "on_session_end",
     "on_session_finalize",

--- a/plugins/observability/execution_receipts/__init__.py
+++ b/plugins/observability/execution_receipts/__init__.py
@@ -1,0 +1,288 @@
+"""Local JSONL sink for Hermes execution receipts.
+
+The plugin is deliberately passive: it listens for already-redacted
+``execution_receipt`` observer payloads and writes them to a local, profile-
+scoped JSONL file. It never blocks or changes agent execution.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping
+import json
+from pathlib import Path
+import threading
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+SCHEMA_VERSION = "hermes.execution_receipt.v0"
+DEFAULT_RELATIVE_PATH = Path("execution-receipts") / "receipts.jsonl"
+_MAX_RECEIPT_BYTES = 64 * 1024
+_SAFE_PAYLOAD_METADATA_KEYS = {
+    "redacted",
+    "kind",
+    "size_bytes",
+    "field_names",
+    "field_count",
+    "item_count",
+    "char_count",
+    "unsafe_payload_dropped",
+    "oversized_payload_dropped",
+}
+_WRITE_LOCK = threading.Lock()
+_writer_errors = 0
+
+_HELP_TEXT = """Usage: /receipts [status|tail [N]|gaps|help]
+
+Inspect local Hermes execution receipts.
+
+Commands:
+  status     Summarize receipt counts, corrupt lines, sequence gaps, writer errors
+  tail [N]   Show the latest N receipt summaries without args/results
+  gaps       Show missing sequence numbers, corrupt lines, and evidence-gap codes
+""".strip()
+
+
+def _receipt_path() -> Path:
+    return get_hermes_home() / DEFAULT_RELATIVE_PATH
+
+
+def _ensure_storage(path: Path) -> None:
+    path.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+    try:
+        path.parent.chmod(0o700)
+    except OSError:
+        pass
+    if not path.exists():
+        path.touch(mode=0o600, exist_ok=True)
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def _sanitize_payload_metadata(value: Any) -> dict[str, Any]:
+    if not (isinstance(value, Mapping) and value.get("redacted") is True):
+        return {"redacted": True, "unsafe_payload_dropped": True}
+
+    safe: dict[str, Any] = {"redacted": True}
+    for key in _SAFE_PAYLOAD_METADATA_KEYS:
+        if key == "redacted" or key not in value:
+            continue
+        item = value.get(key)
+        if key == "field_names" and isinstance(item, list):
+            safe[key] = [str(name) for name in item[:50]]
+        elif isinstance(item, (str, int, float, bool)) or item is None:
+            safe[key] = item
+    return safe
+
+
+def _sanitize_receipt(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    sanitized = dict(receipt)
+    sanitized.setdefault("schema_version", SCHEMA_VERSION)
+    sanitized.setdefault("receipt_type", "tool_complete")
+    sanitized.setdefault("links", [])
+    sanitized.setdefault("evidence_gaps", [])
+    sanitized.setdefault("redaction_status", "ok")
+    sanitized.setdefault("redaction_policy_version", "execution_receipts.v0")
+
+    # The receipt builder emits metadata-only payload descriptors. Defense in
+    # depth: whitelist descriptor keys so a buggy caller cannot smuggle raw
+    # args/results in a mapping that merely sets ``redacted: true``.
+    for field in ("args", "result"):
+        before = sanitized.get(field)
+        sanitized[field] = _sanitize_payload_metadata(before)
+        if sanitized[field].get("unsafe_payload_dropped"):
+            sanitized["redaction_status"] = "unsafe_payload_dropped"
+    return sanitized
+
+
+def _write_receipt(receipt: Mapping[str, Any]) -> bool:
+    global _writer_errors
+    try:
+        if not isinstance(receipt, Mapping):
+            raise TypeError("receipt must be a mapping")
+        sanitized = _sanitize_receipt(receipt)
+        encoded = json.dumps(sanitized, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        if len(encoded.encode("utf-8", errors="replace")) > _MAX_RECEIPT_BYTES:
+            minimal = {
+                "schema_version": SCHEMA_VERSION,
+                "receipt_type": sanitized.get("receipt_type", "tool_complete"),
+                "receipt_id": sanitized.get("receipt_id", ""),
+                "trace_id": sanitized.get("trace_id", ""),
+                "span_id": sanitized.get("span_id", ""),
+                "sequence_number": sanitized.get("sequence_number", 0),
+                "timestamp": sanitized.get("timestamp", ""),
+                "session_id": sanitized.get("session_id", ""),
+                "task_id": sanitized.get("task_id", ""),
+                "tool_call_id": sanitized.get("tool_call_id", ""),
+                "tool_name": sanitized.get("tool_name", ""),
+                "status": sanitized.get("status", ""),
+                "redaction_status": "oversized_minimal",
+                "redaction_policy_version": "execution_receipts.v0",
+                "args": {"redacted": True, "oversized_payload_dropped": True},
+                "result": {"redacted": True, "oversized_payload_dropped": True},
+                "links": [],
+                "evidence_gaps": ["receipt_oversized"],
+            }
+            encoded = json.dumps(minimal, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        path = _receipt_path()
+        with _WRITE_LOCK:
+            _ensure_storage(path)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(encoded + "\n")
+        return True
+    except Exception:
+        _writer_errors += 1
+        return False
+
+
+def _on_execution_receipt(*, receipt: Mapping[str, Any] | None = None, **_: Any) -> None:
+    if not isinstance(receipt, Mapping):
+        _write_receipt({} if receipt is None else receipt)  # type: ignore[arg-type]
+        return
+    _write_receipt(receipt)
+
+
+def _read_receipt_file() -> tuple[list[dict[str, Any]], int]:
+    path = _receipt_path()
+    if not path.exists():
+        return [], 0
+    receipts: list[dict[str, Any]] = []
+    corrupt = 0
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError:
+                    corrupt += 1
+                    continue
+                if isinstance(parsed, dict):
+                    receipts.append(parsed)
+                else:
+                    corrupt += 1
+    except OSError:
+        return [], 1
+    return receipts, corrupt
+
+
+def _sequence_gaps(receipts: list[dict[str, Any]]) -> list[int]:
+    seqs: list[int] = []
+    for receipt in receipts:
+        raw_sequence = receipt.get("sequence_number")
+        if isinstance(raw_sequence, int):
+            seqs.append(raw_sequence)
+        elif isinstance(raw_sequence, str) and raw_sequence.isdigit():
+            seqs.append(int(raw_sequence))
+    seqs.sort()
+    if len(seqs) < 2:
+        return []
+    missing: list[int] = []
+    seen = set(seqs)
+    for expected in range(seqs[0], seqs[-1] + 1):
+        if expected not in seen:
+            missing.append(expected)
+    return missing
+
+
+def _evidence_gap_counts(receipts: list[dict[str, Any]]) -> Counter:
+    counts: Counter = Counter()
+    for receipt in receipts:
+        gaps = receipt.get("evidence_gaps") or []
+        if isinstance(gaps, list):
+            counts.update(str(gap) for gap in gaps if gap)
+    return counts
+
+
+def _format_status() -> str:
+    receipts, corrupt = _read_receipt_file()
+    gaps = _sequence_gaps(receipts)
+    statuses = Counter(str(receipt.get("status", "unknown")) for receipt in receipts)
+    status_bits = ", ".join(f"{key}:{value}" for key, value in sorted(statuses.items())) or "none"
+    return (
+        "Execution receipts: "
+        f"total={len(receipts)} corrupt={corrupt} gaps={len(gaps)} "
+        f"writer_errors={_writer_errors} statuses={status_bits} "
+        f"path={_receipt_path()}"
+    )
+
+
+def _format_tail(limit: int = 10) -> str:
+    receipts, corrupt = _read_receipt_file()
+    if not receipts:
+        return f"Execution receipts: no receipts recorded (corrupt={corrupt}, writer_errors={_writer_errors})."
+    limit = max(1, min(int(limit), 100))
+    lines = [f"Latest {min(limit, len(receipts))} execution receipts:"]
+    for receipt in receipts[-limit:]:
+        gaps = receipt.get("evidence_gaps") or []
+        gap_text = ",".join(str(gap) for gap in gaps[:3]) if isinstance(gaps, list) and gaps else "-"
+        lines.append(
+            "# {seq} {tool} {status} session={session} call={call} duration_ms={duration} gaps={gaps}".format(
+                seq=receipt.get("sequence_number", "?"),
+                tool=receipt.get("tool_name", "?"),
+                status=receipt.get("status", "?"),
+                session=receipt.get("session_id", ""),
+                call=receipt.get("tool_call_id", ""),
+                duration=receipt.get("duration_ms", ""),
+                gaps=gap_text,
+            )
+        )
+    if corrupt:
+        lines.append(f"corrupt_lines={corrupt}")
+    return "\n".join(lines)
+
+
+def _format_gaps() -> str:
+    receipts, corrupt = _read_receipt_file()
+    missing = _sequence_gaps(receipts)
+    evidence_counts = _evidence_gap_counts(receipts)
+    lines: list[str] = []
+    if missing:
+        lines.extend(f"missing sequence {seq}" for seq in missing[:100])
+    else:
+        lines.append("no sequence gaps detected")
+    if corrupt:
+        lines.append(f"corrupt lines: {corrupt}")
+    if evidence_counts:
+        lines.append("evidence gaps: " + ", ".join(f"{gap}:{count}" for gap, count in sorted(evidence_counts.items())))
+    lines.append(f"writer_errors={_writer_errors}")
+    return "\n".join(lines)
+
+
+def _handle_slash(raw_args: str = "") -> str:
+    argv = (raw_args or "").strip().split()
+    command = argv[0].lower() if argv else "status"
+    if command in {"help", "-h", "--help"}:
+        return _HELP_TEXT
+    if command == "status":
+        return _format_status()
+    if command == "tail":
+        limit = 10
+        if len(argv) > 1:
+            try:
+                limit = int(argv[1])
+            except ValueError:
+                return "Usage: /receipts tail [N]"
+        return _format_tail(limit)
+    if command == "gaps":
+        return _format_gaps()
+    return _HELP_TEXT
+
+
+def register(ctx) -> None:
+    ctx.register_hook("execution_receipt", _on_execution_receipt)
+    ctx.register_command(
+        "receipts",
+        handler=_handle_slash,
+        description="Inspect local Hermes execution receipt summaries.",
+    )
+
+
+__all__ = [
+    "register",
+]

--- a/plugins/observability/execution_receipts/plugin.yaml
+++ b/plugins/observability/execution_receipts/plugin.yaml
@@ -1,0 +1,6 @@
+name: execution_receipts
+version: "0.1.0"
+description: "Optional local execution receipt JSONL sink for Hermes. Enable with `hermes plugins enable observability/execution_receipts`."
+author: NousResearch
+hooks:
+  - execution_receipt

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -85,6 +85,13 @@ def _make_plugin_dir(base: Path, name: str, *, register_body: str = "pass",
     return plugin_dir
 
 
+# ── Hook contract ──────────────────────────────────────────────────────────
+
+
+def test_execution_receipt_is_valid_hook():
+    assert "execution_receipt" in VALID_HOOKS
+
+
 # ── TestPluginDiscovery ────────────────────────────────────────────────────
 
 

--- a/tests/plugins/test_execution_receipts_plugin.py
+++ b/tests/plugins/test_execution_receipts_plugin.py
@@ -1,0 +1,201 @@
+"""Tests for the bundled observability/execution_receipts plugin."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "observability" / "execution_receipts"
+
+
+class FakePluginContext:
+    def __init__(self):
+        self.hooks = {}
+        self.commands = {}
+
+    def register_hook(self, name, callback):
+        self.hooks[name] = callback
+
+    def register_command(self, name, *, handler, description=""):
+        self.commands[name] = SimpleNamespace(handler=handler, description=description)
+
+
+def _load_plugin():
+    importlib.invalidate_caches()
+    return importlib.import_module("plugins.observability.execution_receipts")
+
+
+def _sample_receipt(sequence_number=1, *, tool_name="terminal", status="ok"):
+    return {
+        "schema_version": "hermes.execution_receipt.v0",
+        "receipt_id": f"receipt-{sequence_number}",
+        "receipt_type": "tool_complete",
+        "trace_id": "trace-1",
+        "span_id": f"span-{sequence_number}",
+        "parent_span_id": None,
+        "sequence_number": sequence_number,
+        "timestamp": "2026-06-18T00:00:00Z",
+        "session_id": "session-1",
+        "task_id": "task-1",
+        "turn_id": "turn-1",
+        "api_request_id": "api-1",
+        "tool_call_id": f"call-{sequence_number}",
+        "tool_name": tool_name,
+        "status": status,
+        "duration_ms": 12,
+        "args": {"redacted": True, "field_names": ["command"]},
+        "result": {"redacted": True, "size_bytes": 200},
+        "links": [],
+        "evidence_gaps": [],
+        "redaction_policy_version": "execution_receipts.v0",
+        "redaction_status": "ok",
+    }
+
+
+def test_plugin_manifest_declares_execution_receipt_hook():
+    data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text())
+
+    assert data["name"] == "execution_receipts"
+    assert data["hooks"] == ["execution_receipt"]
+
+
+def test_register_exposes_hook_and_receipts_command(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    mod = _load_plugin()
+    ctx = FakePluginContext()
+
+    mod.register(ctx)
+
+    assert set(ctx.hooks) == {"execution_receipt"}
+    assert "receipts" in ctx.commands
+    assert "execution receipt" in ctx.commands["receipts"].description.lower()
+
+
+def test_bundled_plugin_is_discovered_but_disabled_by_default(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    from hermes_cli import plugins as pmod
+
+    mgr = pmod.PluginManager()
+    mgr.discover_and_load()
+
+    loaded = mgr._plugins["observability/execution_receipts"]
+    assert loaded.manifest.source == "bundled"
+    assert not loaded.enabled
+    assert loaded.error and "not enabled" in loaded.error
+
+
+def test_bundled_plugin_loads_when_enabled(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["observability/execution_receipts"]}}),
+        encoding="utf-8",
+    )
+    from hermes_cli import plugins as pmod
+
+    mgr = pmod.PluginManager()
+    mgr.discover_and_load()
+
+    loaded = mgr._plugins["observability/execution_receipts"]
+    assert loaded.enabled
+    assert "execution_receipt" in loaded.hooks_registered
+    assert "receipts" in loaded.commands_registered
+
+
+def test_execution_receipt_hook_writes_owner_only_jsonl(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    path = hermes_home / "execution-receipts" / "receipts.jsonl"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    mod = _load_plugin()
+
+    mod._on_execution_receipt(receipt=_sample_receipt())
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["tool_name"] == "terminal"
+    assert stat.S_IMODE(path.parent.stat().st_mode) & 0o077 == 0
+    assert stat.S_IMODE(path.stat().st_mode) & 0o077 == 0
+
+
+def test_receipts_status_tail_and_gaps_are_safe(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    path = hermes_home / "execution-receipts" / "receipts.jsonl"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    mod = _load_plugin()
+    first = _sample_receipt(1, tool_name="terminal")
+    second = _sample_receipt(3, tool_name="delegate_task", status="error")
+    second["evidence_gaps"] = ["child_trace_unavailable"]
+    # Simulate a buggy caller/plugin attempting to smuggle raw data; the
+    # writer/commands must not surface it in summaries.
+    second["args"] = {"raw": "do not show this secret"}
+
+    mod._on_execution_receipt(receipt=first)
+    mod._on_execution_receipt(receipt=second)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("{not json}\n")
+
+    status = mod._handle_slash("status")
+    tail = mod._handle_slash("tail 5")
+    gaps = mod._handle_slash("gaps")
+
+    assert "total=2" in status
+    assert "corrupt=1" in status
+    assert "gaps=1" in status
+    assert "terminal" in tail
+    assert "delegate_task" in tail
+    assert "do not show this secret" not in tail
+    assert "missing sequence 2" in gaps
+    assert "child_trace_unavailable" in gaps
+
+
+def test_receipt_writer_strips_smuggled_payload_fields(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    path = hermes_home / "execution-receipts" / "receipts.jsonl"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    mod = _load_plugin()
+    receipt = _sample_receipt()
+    receipt["args"] = {
+        "redacted": True,
+        "kind": "dict",
+        "field_names": ["command"],
+        "raw": "secret command must not survive",
+    }
+    receipt["result"] = {
+        "redacted": True,
+        "size_bytes": 200,
+        "raw_output": "secret output must not survive",
+    }
+
+    mod._on_execution_receipt(receipt=receipt)
+
+    written = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    serialized = json.dumps(written)
+    assert written["args"] == {"redacted": True, "kind": "dict", "field_names": ["command"]}
+    assert written["result"] == {"redacted": True, "size_bytes": 200}
+    assert "secret command" not in serialized
+    assert "secret output" not in serialized
+
+
+def test_receipt_writer_fail_open_on_malformed_receipt(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    path = hermes_home / "execution-receipts" / "receipts.jsonl"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    mod = _load_plugin()
+
+    mod._on_execution_receipt(receipt="raw secret that must not be written")
+
+    assert not path.exists()
+    status = mod._handle_slash("status")
+    assert "writer_errors=1" in status
+    assert "raw secret" not in status

--- a/tests/run_agent/test_execution_receipts.py
+++ b/tests/run_agent/test_execution_receipts.py
@@ -1,0 +1,395 @@
+"""Tests for Hermes execution receipt construction and emission."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+
+def test_emit_tool_execution_receipt_noops_without_listener(monkeypatch):
+    from agent.execution_receipts import emit_tool_execution_receipt
+
+    calls = []
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: False)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    receipt = emit_tool_execution_receipt(
+        session_id="session-1",
+        task_id="task-1",
+        tool_name="terminal",
+        tool_call_id="call-1",
+        status="ok",
+        duration_ms=3,
+        args={"command": "echo secret"},
+        result="secret output",
+    )
+
+    assert receipt is None
+    assert calls == []
+
+
+def test_emit_tool_execution_receipt_builds_redacted_envelope(monkeypatch):
+    from agent.execution_receipts import emit_tool_execution_receipt
+
+    calls = []
+    monkeypatch.setattr(
+        "hermes_cli.plugins.has_hook",
+        lambda name: name == "execution_receipt",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda name, **kwargs: calls.append((name, kwargs)) or [],
+    )
+
+    receipt = emit_tool_execution_receipt(
+        session_id="session-1",
+        task_id="task-1",
+        turn_id="turn-1",
+        api_request_id="api-1",
+        tool_name="terminal",
+        tool_call_id="call-1",
+        status="ok",
+        duration_ms=3,
+        sequence_number=7,
+        trace_id="trace-1",
+        args={"command": "echo secret", "workdir": "/tmp/private-project"},
+        result="secret output",
+    )
+
+    assert len(calls) == 1
+    assert calls[0][0] == "execution_receipt"
+    assert calls[0][1]["receipt"] == receipt
+    assert receipt["schema_version"] == "hermes.execution_receipt.v0"
+    assert receipt["receipt_type"] == "tool_complete"
+    assert receipt["receipt_id"]
+    assert receipt["trace_id"] == "trace-1"
+    assert receipt["span_id"]
+    assert receipt["parent_span_id"] is None
+    assert receipt["sequence_number"] == 7
+    assert receipt["timestamp"]
+    assert receipt["session_id"] == "session-1"
+    assert receipt["task_id"] == "task-1"
+    assert receipt["turn_id"] == "turn-1"
+    assert receipt["api_request_id"] == "api-1"
+    assert receipt["tool_call_id"] == "call-1"
+    assert receipt["tool_name"] == "terminal"
+    assert receipt["status"] == "ok"
+    assert receipt["duration_ms"] == 3
+    assert receipt["links"] == []
+    assert receipt["evidence_gaps"] == []
+    assert receipt["redaction_policy_version"] == "execution_receipts.v0"
+    assert receipt["redaction_status"] == "ok"
+    assert receipt["args"]["redacted"] is True
+    assert receipt["result"]["redacted"] is True
+
+    serialized = json.dumps(receipt)
+    assert "echo secret" not in serialized
+    assert "/tmp/private-project" not in serialized
+    assert "secret output" not in serialized
+
+
+def test_emit_tool_execution_receipt_is_fail_open(monkeypatch):
+    from agent.execution_receipts import emit_tool_execution_receipt
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.has_hook",
+        lambda name: name == "execution_receipt",
+    )
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("observer failed")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", boom)
+
+    receipt = emit_tool_execution_receipt(
+        session_id="session-1",
+        task_id="task-1",
+        tool_name="terminal",
+        tool_call_id="call-1",
+        status="error",
+        duration_ms=5,
+        args={"command": "false"},
+        result="error output",
+        error_type="tool_error",
+        error_message="failed with token secret-token-123",
+    )
+
+    assert receipt is not None
+    assert receipt["status"] == "error"
+    assert receipt["error_type"] == "tool_error"
+    assert receipt["error_message"] is None
+    assert receipt["error_message_metadata"] == {
+        "redacted": True,
+        "kind": "str",
+        "char_count": len("failed with token secret-token-123"),
+        "size_bytes": len("failed with token secret-token-123"),
+    }
+    assert "secret-token-123" not in json.dumps(receipt)
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent(*tool_names: str):
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    setattr(agent, "session_id", "session-1")
+    setattr(agent, "_current_turn_id", "turn-1")
+    setattr(agent, "_current_api_request_id", "api-1")
+    return agent
+
+
+def _mock_tool_call(name="web_search", args=None, call_id="call-1"):
+    return SimpleNamespace(
+        id=call_id,
+        function=SimpleNamespace(
+            name=name,
+            arguments=json.dumps(args or {}),
+        ),
+    )
+
+
+def _mock_assistant_msg(*tool_calls):
+    return SimpleNamespace(content="", tool_calls=list(tool_calls))
+
+
+def _capture_receipts(monkeypatch, *, block_tool_name: str | None = None):
+    receipts = []
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.has_hook",
+        lambda name: name == "execution_receipt",
+    )
+
+    def fake_invoke_hook(name, **kwargs):
+        if name == "pre_tool_call" and kwargs.get("tool_name") == block_tool_name:
+            return [{"action": "block", "message": "blocked for test"}]
+        if name == "execution_receipt":
+            receipts.append(kwargs["receipt"])
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+    return receipts
+
+
+def test_sequential_tool_execution_noops_without_receipt_listener(monkeypatch):
+    agent = _make_agent("web_search")
+    messages = []
+    assistant = _mock_assistant_msg(
+        _mock_tool_call("web_search", {"q": "top secret query"}, call_id="call-noop")
+    )
+
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: False)
+
+    def fail_if_invoked(*args, **kwargs):
+        raise AssertionError("execution_receipt hook should not be invoked")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fail_if_invoked)
+
+    with patch("run_agent.handle_function_call", return_value='{"ok": true}'):
+        agent._execute_tool_calls_sequential(assistant, messages, "task-1")
+
+    assert not hasattr(agent, "_execution_receipt_sequence")
+    assert not hasattr(agent, "_execution_receipt_trace_id")
+
+
+def test_sequential_tool_execution_emits_redacted_receipt(monkeypatch):
+    receipts = _capture_receipts(monkeypatch)
+    agent = _make_agent("web_search")
+    messages = []
+    assistant = _mock_assistant_msg(
+        _mock_tool_call(
+            "web_search",
+            {"q": "top secret query"},
+            call_id="call-web-search",
+        )
+    )
+
+    with patch("run_agent.handle_function_call", return_value='{"ok": true}'):
+        agent._execute_tool_calls_sequential(assistant, messages, "task-1")
+
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["schema_version"] == "hermes.execution_receipt.v0"
+    assert receipt["receipt_type"] == "tool_complete"
+    assert receipt["session_id"] == "session-1"
+    assert receipt["task_id"] == "task-1"
+    assert receipt["turn_id"] == "turn-1"
+    assert receipt["api_request_id"] == "api-1"
+    assert receipt["tool_call_id"] == "call-web-search"
+    assert receipt["tool_name"] == "web_search"
+    assert receipt["status"] == "ok"
+    assert receipt["sequence_number"] == 1
+    assert receipt["trace_id"].startswith("trace-")
+    assert receipt["duration_ms"] >= 0
+    assert "top secret query" not in json.dumps(receipt)
+
+
+def test_sequential_blocked_tool_emits_blocked_receipt(monkeypatch):
+    receipts = _capture_receipts(monkeypatch, block_tool_name="web_search")
+    agent = _make_agent("web_search")
+    messages = []
+    assistant = _mock_assistant_msg(
+        _mock_tool_call("web_search", {"q": "blocked secret"}, call_id="call-blocked")
+    )
+
+    with patch("run_agent.handle_function_call") as mock_handle:
+        agent._execute_tool_calls_sequential(assistant, messages, "task-1")
+
+    mock_handle.assert_not_called()
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt["tool_call_id"] == "call-blocked"
+    assert receipt["status"] == "blocked"
+    assert receipt["error_type"] == "plugin_block"
+    assert receipt["error_message"] is None
+    assert receipt["error_message_metadata"]["redacted"] is True
+    assert "blocked secret" not in json.dumps(receipt)
+    assert "blocked for test" not in json.dumps(receipt)
+
+
+def test_sequential_interrupt_skip_emits_cancelled_receipts(monkeypatch):
+    receipts = _capture_receipts(monkeypatch)
+    agent = _make_agent("web_search", "read_file")
+    agent._interrupt_requested = True
+    messages = []
+    assistant = _mock_assistant_msg(
+        _mock_tool_call("web_search", {"q": "skip secret"}, call_id="call-skip-1"),
+        _mock_tool_call("read_file", {"path": "/tmp/skip-secret"}, call_id="call-skip-2"),
+    )
+
+    agent._execute_tool_calls_sequential(assistant, messages, "task-1")
+
+    assert len(receipts) == 2
+    assert {receipt["status"] for receipt in receipts} == {"cancelled"}
+    assert {receipt["tool_call_id"] for receipt in receipts} == {"call-skip-1", "call-skip-2"}
+    serialized = json.dumps(receipts)
+    assert "skip secret" not in serialized
+    assert "/tmp/skip-secret" not in serialized
+
+
+def test_concurrent_interrupt_skip_emits_cancelled_receipts(monkeypatch):
+    receipts = _capture_receipts(monkeypatch)
+    agent = _make_agent("web_search", "read_file")
+    agent._interrupt_requested = True
+    messages = []
+    assistant = _mock_assistant_msg(
+        _mock_tool_call("web_search", {"q": "skip secret"}, call_id="call-skip-1"),
+        _mock_tool_call("read_file", {"path": "/tmp/skip-secret"}, call_id="call-skip-2"),
+    )
+
+    agent._execute_tool_calls_concurrent(assistant, messages, "task-1")
+
+    assert len(receipts) == 2
+    assert {receipt["status"] for receipt in receipts} == {"cancelled"}
+    assert {receipt["tool_call_id"] for receipt in receipts} == {"call-skip-1", "call-skip-2"}
+    serialized = json.dumps(receipts)
+    assert "skip secret" not in serialized
+    assert "/tmp/skip-secret" not in serialized
+
+
+def test_sequential_post_tool_interrupt_emits_cancelled_receipt_for_remaining(monkeypatch):
+    receipts = _capture_receipts(monkeypatch)
+    agent = _make_agent("web_search", "read_file")
+    messages = []
+    assistant = _mock_assistant_msg(
+        _mock_tool_call("web_search", {"q": "first secret"}, call_id="call-1"),
+        _mock_tool_call("read_file", {"path": "/tmp/remaining-secret"}, call_id="call-2"),
+    )
+
+    def interrupt_after_first(*args, **kwargs):
+        agent._interrupt_requested = True
+        return '{"ok": true}'
+
+    with patch("run_agent.handle_function_call", side_effect=interrupt_after_first):
+        agent._execute_tool_calls_sequential(assistant, messages, "task-1")
+
+    assert len(receipts) == 2
+    by_id = {receipt["tool_call_id"]: receipt for receipt in receipts}
+    assert by_id["call-1"]["status"] == "ok"
+    assert by_id["call-2"]["status"] == "cancelled"
+    assert by_id["call-2"]["error_type"] == "user_interrupt"
+    serialized = json.dumps(receipts)
+    assert "first secret" not in serialized
+    assert "/tmp/remaining-secret" not in serialized
+
+
+def test_enabled_plugin_writes_receipt_from_agent_loop(monkeypatch, tmp_path):
+    from hermes_cli import plugins as pmod
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "plugins:\n  enabled:\n    - observability/execution_receipts\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(pmod, "_plugin_manager", None)
+    pmod.discover_plugins(force=True)
+
+    agent = _make_agent("web_search")
+    messages = []
+    assistant = _mock_assistant_msg(
+        _mock_tool_call("web_search", {"q": "integration secret"}, call_id="call-integrated")
+    )
+
+    with patch("run_agent.handle_function_call", return_value='{"ok": true}'):
+        agent._execute_tool_calls_sequential(assistant, messages, "task-1")
+
+    path = hermes_home / "execution-receipts" / "receipts.jsonl"
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    receipt = json.loads(lines[0])
+    assert receipt["tool_call_id"] == "call-integrated"
+    assert receipt["tool_name"] == "web_search"
+    assert receipt["status"] == "ok"
+    assert "integration secret" not in lines[0]
+
+
+def test_concurrent_tool_execution_emits_one_receipt_per_tool(monkeypatch):
+    receipts = _capture_receipts(monkeypatch)
+    agent = _make_agent("web_search", "read_file")
+    messages = []
+    assistant = _mock_assistant_msg(
+        _mock_tool_call("web_search", {"q": "secret one"}, call_id="call-1"),
+        _mock_tool_call("read_file", {"path": "/tmp/secret-two"}, call_id="call-2"),
+    )
+
+    with patch("run_agent.handle_function_call", return_value='{"ok": true}'):
+        agent._execute_tool_calls_concurrent(assistant, messages, "task-1")
+
+    assert len(receipts) == 2
+    assert {receipt["tool_call_id"] for receipt in receipts} == {"call-1", "call-2"}
+    assert {receipt["tool_name"] for receipt in receipts} == {"web_search", "read_file"}
+    assert sorted(receipt["sequence_number"] for receipt in receipts) == [1, 2]
+    assert len({receipt["trace_id"] for receipt in receipts}) == 1
+    serialized = json.dumps(receipts)
+    assert "secret one" not in serialized
+    assert "/tmp/secret-two" not in serialized

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -59,6 +59,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `security-guidance` | hooks | Pattern-match dangerous code on `write_file`/`patch` and append a security warning (or block) — 25 rules (Apache-2.0 fork of Anthropic's `claude-plugins-official` patterns) |
 | `observability/langfuse` | hooks | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
 | `observability/nemo_relay` | hooks | Relay observability events (turns / LLM calls / tools) to an NVIDIA NeMo endpoint |
+| `observability/execution_receipts` | hook + slash command | Persist redacted local execution receipts and inspect them with `/receipts` |
 | `teams_pipeline` | standalone | Microsoft Teams meeting pipeline — Graph-backed, transcript-first meeting summaries |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
@@ -68,7 +69,33 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `hermes-achievements` | dashboard tab | Steam-style collectible badges generated from your real Hermes session history |
 | `kanban/dashboard` | dashboard tab | Kanban board UI for the multi-agent dispatcher — tasks, comments, fan-out, board switching. See [Kanban Multi-Agent](./kanban.md). |
 
-Memory providers (`plugins/memory/*`) and context engines (`plugins/context_engine/*`) are listed separately on [Memory Providers](./memory-providers.md) — they're managed through `hermes memory` and `hermes plugins` respectively. The full per-plugin detail for the two long-running hooks-based plugins follows.
+Memory providers (`plugins/memory/*`) and context engines (`plugins/context_engine/*`) are listed separately on [Memory Providers](./memory-providers.md) — they're managed through `hermes memory` and `hermes plugins` respectively. The full per-plugin detail for selected hooks-based plugins follows.
+
+### observability/execution_receipts
+
+Persists redacted, metadata-only execution receipts to local JSONL. This is useful when you want a durable local evidence stream of what Hermes attempted and how each tool outcome ended without sending telemetry to an external service.
+
+**How it works:**
+
+| Hook | Behaviour |
+|---|---|
+| `execution_receipt` | Appends one sanitized `tool_complete` receipt per agent-loop tool outcome. Raw args/results are dropped if a caller accidentally passes them. |
+
+**State:** receipts live at `$HERMES_HOME/execution-receipts/receipts.jsonl`. The plugin creates the directory as owner-only (`0700`) and the JSONL file as owner-only (`0600`) where the platform supports chmod.
+
+**Slash command** — `/receipts` available in both CLI and gateway sessions:
+
+```text
+/receipts status        # total/corrupt/gaps/writer_errors/status counts
+/receipts tail [N]      # latest safe receipt summaries, no raw args/results
+/receipts gaps          # missing sequence numbers and evidence-gap codes
+```
+
+**Privacy/non-goals:** P1 receipts do not store raw terminal output, file contents, prompts, environment variables, tokens, child summaries, raw error messages, or full tool arguments/results. They are best-effort local telemetry only: no routing, no policy enforcement, and no cryptographic signing.
+
+**Enabling:** `hermes plugins enable observability/execution_receipts`.
+
+**Disabling again:** `hermes plugins disable observability/execution_receipts`.
 
 ### disk-cleanup
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -360,6 +360,7 @@ the [Plugins guide](/docs/user-guide/features/plugins).
 def register(ctx):
     ctx.register_hook("pre_tool_call", my_tool_observer)
     ctx.register_hook("post_tool_call", my_tool_logger)
+    ctx.register_hook("execution_receipt", my_receipt_sink)
     ctx.register_hook("pre_llm_call", my_memory_callback)
     ctx.register_hook("post_llm_call", my_sync_callback)
     ctx.register_hook("on_session_start", my_init_callback)
@@ -379,6 +380,7 @@ def register(ctx):
 |------|-----------|---------|
 | [`pre_tool_call`](#pre_tool_call) | Before any tool executes | `{"action": "block", "message": str}` to veto the call |
 | [`post_tool_call`](#post_tool_call) | After any tool returns | ignored |
+| [`execution_receipt`](#execution_receipt) | After Hermes builds a redacted local execution receipt for a tool outcome | ignored |
 | [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend context to the user message |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
@@ -502,6 +504,32 @@ def track_metrics(tool_name, result, duration_ms=0, **kwargs):
 def register(ctx):
     ctx.register_hook("post_tool_call", track_metrics)
 ```
+
+---
+
+### `execution_receipt`
+
+Fires after Hermes has built a redacted `tool_complete` receipt for an agent-loop tool outcome. This hook is for durable local evidence streams and audit-style summaries; it is separate from `post_tool_call` so plugins do not need to store raw tool arguments or raw tool results.
+
+**Callback signature:**
+
+```python
+def my_callback(receipt: dict, **kwargs):
+```
+
+`receipt` is a v0 JSON-compatible object containing IDs (`session_id`, `task_id`, `turn_id`, `api_request_id`, `tool_call_id`), `trace_id`, `span_id`, `sequence_number`, `timestamp`, `tool_name`, `status`, `duration_ms`, redacted `args` and `result` metadata, `links`, `evidence_gaps`, and redaction fields.
+
+**Return value:** Ignored.
+
+**Privacy defaults:** Receipts do not include raw terminal output, file contents, prompts, environment variables, tokens, raw error messages, or full tool arguments/results by default.
+
+**Built-in sink:** Enable the bundled local JSONL plugin with:
+
+```bash
+hermes plugins enable observability/execution_receipts
+```
+
+It writes to `$HERMES_HOME/execution-receipts/receipts.jsonl` and adds `/receipts status`, `/receipts tail [N]`, and `/receipts gaps`. These receipts are best-effort local telemetry only: no routing, policy enforcement, or cryptographic signing.
 
 ---
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -193,6 +193,7 @@ Plugins can register callbacks for these lifecycle events. See the **[Event Hook
 |------|-----------|
 | [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes |
 | [`post_tool_call`](/user-guide/features/hooks#post_tool_call) | After any tool returns |
+| [`execution_receipt`](/user-guide/features/hooks#execution_receipt) | After Hermes builds a redacted local execution receipt for a tool outcome |
 | [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the LLM loop — can return `{"context": "..."}` to [inject context into the user message](/user-guide/features/hooks#pre_llm_call) |
 | [`post_llm_call`](/user-guide/features/hooks#post_llm_call) | Once per turn, after the LLM loop (successful turns only) |
 | [`on_session_start`](/user-guide/features/hooks#on_session_start) | New session created (first turn only) |


### PR DESCRIPTION
## Why this is useful

Hermes can already run long, multi-tool, delegated sessions across CLI, desktop, and gateways, but today there is no small built-in evidence stream that answers basic post-run questions without storing raw tool payloads:

- Which tools actually ran in this agent turn?
- Did each tool complete, error, get blocked by a plugin, or get cancelled/skipped?
- How long did it take, and which session/task/tool call did it belong to?
- Were there explicit evidence gaps that a UI or later audit feature should surface?

This PR adds that minimal substrate as an opt-in, local-only observability primitive. It is intentionally not an analytics/exporter feature and not a signing/provenance system yet. The value is giving Hermes plugins, local dashboards, and future audit/provenance work a stable redacted event shape to build on without asking them to persist raw `post_tool_call` args/results.

Refs #6642 and #5041.

## Summary

Adds an opt-in local execution-receipts substrate for agent-loop tool outcomes:

- new `execution_receipt` plugin hook with a cheap no-op path when no listener is registered
- metadata-only receipt builder for tool outcomes (`ok`, `error`, `blocked`, `cancelled`)
- bundled disabled-by-default `observability/execution_receipts` plugin that writes owner-only local JSONL under `$HERMES_HOME/execution-receipts/receipts.jsonl`
- `/receipts status`, `/receipts tail [N]`, and `/receipts gaps` helper commands
- docs and focused coverage for redaction, plugin enablement, disabled/default behavior, skipped/cancelled paths, and end-to-end enabled-plugin writing

## Alternatives / existing overlaps

- Existing `post_tool_call` hooks are the closest integration seam today. They already power observability plugins, but intentionally pass raw `args` and `result` to observers. This PR adds a narrower redacted envelope so durable local evidence sinks do not each need to invent their own redaction contract.
- Existing `observability/langfuse` and `observability/nemo_relay` plugins provide richer tracing/export paths. They are great for tracing, but are external/dependency-oriented and not a minimal local JSONL receipt stream.
- Existing session history / trajectories capture conversation state and tool messages for resume, replay, and training workflows. They are not a metadata-only, redacted, append-only outcome stream with explicit evidence-gap reporting.
- Broader audit/telemetry proposals such as #1155, #5041, #11116, and #38824 remain useful follow-ups. This PR is a small substrate those can build on, not a replacement for full audit logging, cryptographic signing, per-tool analytics, or OTEL export.

## Safety / privacy defaults

This is intentionally a small P1:

- disabled by default
- local-only; no external network calls/exporter
- fail-open hook/plugin behavior
- no raw terminal output, file contents, prompts, environment variables, tokens, child summaries, raw error messages, or full tool args/results
- plugin sink whitelists the redacted `args`/`result` metadata shape before writing, so a buggy caller cannot smuggle raw payload fields by setting `redacted: true`
- no new user-facing `HERMES_*` env vars or `.env` configuration

## Non-goals in this PR

- no cryptographic signing / HMAC / hash chaining
- no policy enforcement or routing
- no remote telemetry backend
- no OpenTelemetry/Langfuse exporter
- no durable provenance claim beyond best-effort local JSONL

## Design question for maintainers

I used a dedicated `execution_receipt` hook instead of extending `post_tool_call` because receipts are redacted durable evidence records, while `post_tool_call` remains useful for observers that intentionally receive raw tool args/results. Happy to collapse this into the existing hook surface if maintainers prefer fewer hook names.

## Test plan

Final local validation after rebasing onto current `origin/main`:

```bash
/Users/sma/.local/bin/uv run --extra dev pytest \
  tests/run_agent/test_execution_receipts.py \
  tests/plugins/test_execution_receipts_plugin.py \
  tests/hermes_cli/test_plugins.py::test_execution_receipt_is_valid_hook \
  -q -o 'addopts='
# 20 passed

/Users/sma/.local/bin/uv run --extra dev ruff check \
  agent/execution_receipts.py \
  agent/tool_executor.py \
  hermes_cli/plugins.py \
  plugins/observability/execution_receipts/__init__.py \
  tests/run_agent/test_execution_receipts.py \
  tests/plugins/test_execution_receipts_plugin.py \
  tests/hermes_cli/test_plugins.py
# All checks passed!

/Users/sma/.local/bin/uv run --extra dev pytest \
  tests/hermes_cli/test_plugins.py \
  tests/plugins/test_execution_receipts_plugin.py \
  tests/run_agent/test_execution_receipts.py \
  tests/run_agent/test_run_agent.py \
  -q -o 'addopts='
# 490 passed
```
