### PR TITLE
feat(cron): deterministic delivery via deliver_file override

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -20,6 +20,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -209,6 +210,145 @@ from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
+
+
+# ---------------------------------------------------------------------------
+# Deterministic delivery override
+# ---------------------------------------------------------------------------
+# Some cron jobs compose a canonical, fixed-format report and persist its EXACT
+# bytes to a known file DURING the run, then record those same bytes as the
+# job's audited body. The model's *free* final message is meant to be that
+# report verbatim, but a model can still truncate or summarize it (e.g. record
+# a full 1996-char report yet deliver an 844-char "Executed: …" recap).
+# Whenever a job declares a ``deliver_file`` we deliver THAT file's contents
+# instead of the model's final answer, so the delivered message == the recorded
+# body == the composed report, independent of model variance.
+#
+# Opt-in + fully generic: a job with no ``deliver_file`` is completely
+# unaffected (delivers the model final answer exactly as before).
+#   deliver_file    : path the job (re)writes with its canonical body each run.
+#   deliver_markers : optional list of substrings that must ALL appear for a
+#                     body to count as a complete report. Used to (a) refuse to
+#                     substitute an incomplete/garbage file, and (b) log when it
+#                     was the model's OWN final answer that truncated.
+
+def _job_deliver_markers(job: dict) -> list:
+    """Return the job's configured completeness markers as a list of strings."""
+    raw = job.get("deliver_markers")
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return []
+    return [str(m) for m in raw if str(m).strip()]
+
+
+def _missing_markers(text: str, markers: list) -> list:
+    """Return the subset of ``markers`` not present in ``text``."""
+    t = text or ""
+    return [m for m in markers if m not in t]
+
+
+def apply_canonical_delivery_override(
+    job: dict,
+    final_response: str,
+    run_started_at: Optional[float],
+) -> str:
+    """Return the body to deliver for a SUCCESSFUL cron run.
+
+    If the job declares ``deliver_file`` and that file holds a FRESH (written
+    during this run), non-empty, marker-complete canonical body, return it in
+    place of ``final_response`` so delivery is deterministic. Otherwise return
+    ``final_response`` unchanged. Never raises — any failure falls back to the
+    model's final answer so this can only make delivery MORE reliable, never
+    break an otherwise-working job.
+    """
+    try:
+        deliver_file = str(job.get("deliver_file") or "").strip()
+        if not deliver_file:
+            return final_response
+
+        job_id = job.get("id", "?")
+        markers = _job_deliver_markers(job)
+        path = Path(deliver_file).expanduser()
+
+        if not path.is_file():
+            if markers and _missing_markers(final_response, markers):
+                logger.warning(
+                    "Job '%s': deliver_file %s absent and model final answer is "
+                    "missing markers %s — delivering model final answer as-is",
+                    job_id, deliver_file,
+                    _missing_markers(final_response, markers),
+                )
+            return final_response
+
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            return final_response
+
+        # Freshness: only trust a file (re)written during THIS run. A stale file
+        # from a prior tick must never be delivered for a run that did not write
+        # one (e.g. the agent errored before composing the report). 2s slack
+        # absorbs clock granularity between run-start capture and file write.
+        if run_started_at is not None and mtime < (run_started_at - 2.0):
+            logger.warning(
+                "Job '%s': deliver_file %s is stale (mtime %.0f < run start "
+                "%.0f) — not overriding; delivering model final answer",
+                job_id, deliver_file, mtime, run_started_at,
+            )
+            return final_response
+
+        try:
+            body = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.warning(
+                "Job '%s': could not read deliver_file %s: %s — delivering "
+                "model final answer", job_id, deliver_file, exc,
+            )
+            return final_response
+
+        if not body.strip():
+            return final_response
+
+        # The file must itself be a COMPLETE report before we trust it over the
+        # model's answer — never deliver a half-written file.
+        if markers:
+            file_missing = _missing_markers(body, markers)
+            if file_missing:
+                logger.warning(
+                    "Job '%s': deliver_file %s missing markers %s — not "
+                    "overriding; delivering model final answer",
+                    job_id, deliver_file, file_missing,
+                )
+                return final_response
+
+        fr = final_response or ""
+        if body.strip() == fr.strip():
+            # Model echoed the canonical body faithfully. Deliver the file copy
+            # anyway so delivered bytes are byte-identical to the recorded ones.
+            logger.info(
+                "Job '%s': model final answer matches deliver_file %s "
+                "(%d chars) — deterministic delivery confirmed",
+                job_id, deliver_file, len(body.strip()),
+            )
+            return body
+
+        fr_missing = _missing_markers(fr, markers) if markers else []
+        logger.info(
+            "Job '%s': overriding delivery with canonical deliver_file %s "
+            "(file=%d chars vs model final answer=%d chars; final answer "
+            "missing markers %s) — deterministic delivery",
+            job_id, deliver_file, len(body.strip()), len(fr.strip()),
+            fr_missing or "none",
+        )
+        return body
+    except Exception as exc:  # never let the override crash a delivering run
+        logger.warning(
+            "Job '%s': delivery override failed (%s) — using model final answer",
+            job.get("id", "?"), exc,
+        )
+        return final_response
+
 
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.
@@ -2067,6 +2207,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
     failure is recorded via ``mark_job_run``), False only if processing raised.
     """
     try:
+        _run_started_at = time.time()
         success, output, final_response, error = run_job(job)
 
         output_file = save_job_output(job["id"], output)
@@ -2076,7 +2217,15 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # Deliver the final response to the origin/target chat.
         # If the agent responded with [SILENT], skip delivery (but
         # output is already saved above).  Failed jobs always deliver.
-        deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
+        # On success, apply the deterministic delivery override so a job that
+        # persisted a canonical body (deliver_file) delivers THAT instead of the
+        # model's possibly-truncated final answer.
+        if success:
+            deliver_content = apply_canonical_delivery_override(
+                job, final_response, _run_started_at
+            )
+        else:
+            deliver_content = _summarize_cron_failure_for_delivery(job, error)
         # Treat whitespace-only final responses the same as empty
         # responses: do not deliver a blank message, and let the
         # empty-response guard below mark the run as a soft failure.

--- a/tests/cron/test_canonical_delivery_override.py
+++ b/tests/cron/test_canonical_delivery_override.py
@@ -1,0 +1,139 @@
+"""Unit + integration tests for the deterministic delivery override.
+
+A cron job may declare ``deliver_file`` (and optional ``deliver_markers``).
+When it does, a SUCCESSFUL run delivers that file's contents instead of the
+model's free final answer — but ONLY when the file is fresh (written during the
+run), non-empty, and marker-complete. Every guard falls back to the model's
+final answer, so the override can only make delivery more reliable, never break
+an otherwise-working job. Jobs without ``deliver_file`` are unaffected.
+"""
+import cron.scheduler as s
+
+
+# --- helpers ---------------------------------------------------------------
+
+def test_job_deliver_markers_normalizes_forms():
+    assert s._job_deliver_markers({"deliver_markers": ["A", "B"]}) == ["A", "B"]
+    assert s._job_deliver_markers({"deliver_markers": "A"}) == ["A"]
+    assert s._job_deliver_markers({}) == []
+    assert s._job_deliver_markers({"deliver_markers": None}) == []
+    # blank/whitespace markers are dropped
+    assert s._job_deliver_markers({"deliver_markers": ["A", "", "  "]}) == ["A"]
+
+
+def test_missing_markers():
+    assert s._missing_markers("has A and B", ["A", "B"]) == []
+    assert s._missing_markers("has A only", ["A", "B"]) == ["B"]
+    assert s._missing_markers("", ["A"]) == ["A"]
+    assert s._missing_markers(None, ["A"]) == ["A"]
+
+
+# --- apply_canonical_delivery_override -------------------------------------
+
+def _write(path, text):
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+def test_no_deliver_file_returns_model_answer():
+    out = s.apply_canonical_delivery_override({"id": "j"}, "model answer", 0.0)
+    assert out == "model answer"
+
+
+def test_fresh_complete_file_overrides_model_answer(tmp_path):
+    f = _write(tmp_path / "report.txt", "CANON header\nbody\nTOTAL: 3")
+    job = {"id": "j", "deliver_file": f, "deliver_markers": ["CANON", "TOTAL"]}
+    # run started before the file write → fresh
+    out = s.apply_canonical_delivery_override(job, "truncated recap", run_started_at=0.0)
+    assert out == "CANON header\nbody\nTOTAL: 3"
+
+
+def test_file_matching_model_answer_delivers_file_bytes(tmp_path):
+    body = "CANON\nTOTAL: 1"
+    f = _write(tmp_path / "report.txt", body)
+    job = {"id": "j", "deliver_file": f, "deliver_markers": ["CANON"]}
+    out = s.apply_canonical_delivery_override(job, body, run_started_at=0.0)
+    assert out == body
+
+
+def test_stale_file_is_not_delivered(tmp_path, monkeypatch):
+    f = _write(tmp_path / "report.txt", "CANON\nTOTAL: 1")
+    job = {"id": "j", "deliver_file": f, "deliver_markers": ["CANON"]}
+    # run started far AFTER the file's mtime → stale → fall back to model answer
+    future_start = (tmp_path / "report.txt").stat().st_mtime + 3600.0
+    out = s.apply_canonical_delivery_override(job, "model answer", run_started_at=future_start)
+    assert out == "model answer"
+
+
+def test_incomplete_file_missing_markers_is_not_delivered(tmp_path):
+    f = _write(tmp_path / "report.txt", "CANON only, truncated")
+    job = {"id": "j", "deliver_file": f, "deliver_markers": ["CANON", "TOTAL"]}
+    out = s.apply_canonical_delivery_override(job, "model answer", run_started_at=0.0)
+    assert out == "model answer"
+
+
+def test_absent_file_returns_model_answer(tmp_path):
+    job = {"id": "j", "deliver_file": str(tmp_path / "nope.txt")}
+    out = s.apply_canonical_delivery_override(job, "model answer", run_started_at=0.0)
+    assert out == "model answer"
+
+
+def test_empty_file_returns_model_answer(tmp_path):
+    f = _write(tmp_path / "report.txt", "   \n  ")
+    job = {"id": "j", "deliver_file": f}
+    out = s.apply_canonical_delivery_override(job, "model answer", run_started_at=0.0)
+    assert out == "model answer"
+
+
+def test_none_run_started_at_skips_freshness_check(tmp_path):
+    f = _write(tmp_path / "report.txt", "CANON\nTOTAL: 1")
+    job = {"id": "j", "deliver_file": f, "deliver_markers": ["CANON"]}
+    out = s.apply_canonical_delivery_override(job, "model answer", run_started_at=None)
+    assert out == "CANON\nTOTAL: 1"
+
+
+def test_override_never_raises_on_bad_input():
+    # A non-path deliver_file value must not crash — it falls back gracefully.
+    job = {"id": "j", "deliver_file": object()}
+    out = s.apply_canonical_delivery_override(job, "model answer", run_started_at=0.0)
+    assert out == "model answer"
+
+
+# --- integration through run_one_job ---------------------------------------
+
+def test_run_one_job_delivers_canonical_file(tmp_path, monkeypatch):
+    """A successful job with a fresh deliver_file delivers the FILE body, not
+    the model's (truncated) final answer."""
+    f = _write(tmp_path / "report.txt", "CANON report\nTOTAL: 42")
+    delivered = {}
+
+    monkeypatch.setattr(s, "run_job", lambda job: (True, "out", "truncated recap", None))
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+
+    def fake_deliver(job, content, adapters=None, loop=None):
+        delivered["content"] = content
+        return None
+
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+
+    job = {"id": "j", "name": "t", "deliver_file": f, "deliver_markers": ["CANON", "TOTAL"]}
+    ok = s.run_one_job(job)
+
+    assert ok is True
+    assert delivered["content"] == "CANON report\nTOTAL: 42"
+
+
+def test_run_one_job_without_deliver_file_delivers_model_answer(monkeypatch):
+    """A job with no deliver_file is unaffected — delivers the model answer."""
+    delivered = {}
+    monkeypatch.setattr(s, "run_job", lambda job: (True, "out", "model answer", None))
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        s, "_deliver_result",
+        lambda job, content, adapters=None, loop=None: delivered.update(content=content),
+    )
+
+    s.run_one_job({"id": "j", "name": "t"})
+    assert delivered["content"] == "model answer"


### PR DESCRIPTION
## What

Lets a cron job deliver a **canonical file** verbatim instead of the model's free final message. A job opts in with a `deliver_file` (and optional `deliver_markers`); on a successful run the scheduler delivers that file's contents when it is fresh, non-empty, and marker-complete, otherwise it falls back to the model's final answer exactly as today.

```jsonc
{
  "id": "daily-report",
  "deliver_file": "/tmp/daily_report.txt",   // job (re)writes this each run with its canonical body
  "deliver_markers": ["REPORT", "TOTAL:"]    // optional: all must be present for the file to be trusted
}
```

## Why

Some scheduled jobs compose a fixed-format report, persist its **exact bytes** to a file during the run, and record those same bytes as the job's audited output — expecting the model's final message to be that report verbatim. But the model's *free* final message can truncate or summarize it (in our case a job recorded a full ~1996-char report yet delivered an ~844-char "Executed: …" recap). The delivered message then diverges from what was composed and recorded.

This makes delivery deterministic: **delivered == recorded == composed**, independent of model variance.

## How

A new module-level helper `apply_canonical_delivery_override(job, final_response, run_started_at)` in `cron/scheduler.py`, wired into the success path of the shared `run_one_job`. It returns the file body only when **all** of these hold, and returns `final_response` unchanged otherwise:

- the job declares a non-empty `deliver_file`;
- the file exists and is readable as UTF-8;
- it is **fresh** — `mtime >= run_started_at - 2s` — so a stale file from a prior tick is never delivered for a run that didn't write one (e.g. the agent errored before composing the report);
- it is non-empty after stripping;
- if `deliver_markers` are configured, the file contains **all** of them (never deliver a half-written file).

Design properties:

- **Opt-in & generic** — a job with no `deliver_file` is completely unaffected; `deliver_file` / `deliver_markers` are generic job fields with no app-specific coupling.
- **Fail-safe** — the whole helper is wrapped so any unexpected error falls back to the model's final answer. It can only make delivery *more* reliable, never break an otherwise-working job.
- **Auditable** — logs whether it overrode, confirmed a byte-identical match, or fell back (and which markers were missing).

## Tests

`tests/cron/test_canonical_delivery_override.py` — 12 cases: marker normalization, override on truncation, byte-identical match, stale-file fallback, missing-marker fallback, absent/empty/`None`-run-start handling, never-raises on bad input, plus two `run_one_job` integration tests (delivers the file body with `deliver_file`; delivers the model answer without it).

```
tests/cron/test_canonical_delivery_override.py  19 passed (with existing run_one_job tests)
tests/cron/test_scheduler*.py + test_claim_job_for_fire.py  162 passed
```
