### PR TITLE
Kill Kanban worker process trees on Windows timeout

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -6,6 +6,7 @@ Built on gateway startup, refreshed periodically (every 5 min), and saved to
 action="list" and for resolving human-friendly channel names to numeric IDs.
 """
 
+import asyncio
 import json
 import logging
 from datetime import datetime
@@ -65,14 +66,15 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     """
     from gateway.config import Platform
 
-    platforms: Dict[str, List[Dict[str, str]]] = {}
+    platforms: Dict[str, List[Dict[str, Any]]] = {}
+    session_entries_by_platform = await asyncio.to_thread(_build_sessions_by_platform)
 
     for platform, adapter in adapters.items():
         try:
             if platform == Platform.DISCORD:
-                platforms["discord"] = _build_discord(adapter)
+                platforms["discord"] = _build_discord(adapter, session_entries_by_platform)
             elif platform == Platform.SLACK:
-                platforms["slack"] = await _build_slack(adapter)
+                platforms["slack"] = await _build_slack(adapter, session_entries_by_platform)
         except Exception as e:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
@@ -84,7 +86,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
         plat_name = plat.value
         if plat_name in _SKIP_SESSION_DISCOVERY or plat_name in platforms:
             continue
-        platforms[plat_name] = _build_from_sessions(plat_name)
+        platforms[plat_name] = _sessions_for_platform(plat_name, session_entries_by_platform)
 
     # Include plugin-registered platforms (dynamic enum members aren't in
     # Platform.__members__, so the loop above misses them).
@@ -92,7 +94,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
         from gateway.platform_registry import platform_registry
         for entry in platform_registry.plugin_entries():
             if entry.name not in _SKIP_SESSION_DISCOVERY and entry.name not in platforms:
-                platforms[entry.name] = _build_from_sessions(entry.name)
+                platforms[entry.name] = _sessions_for_platform(entry.name, session_entries_by_platform)
     except Exception:
         pass
 
@@ -102,14 +104,17 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     }
 
     try:
-        atomic_json_write(DIRECTORY_PATH, directory)
+        await asyncio.to_thread(atomic_json_write, DIRECTORY_PATH, directory)
     except Exception as e:
         logger.warning("Channel directory: failed to write: %s", e)
 
     return directory
 
 
-def _build_discord(adapter) -> List[Dict[str, str]]:
+def _build_discord(
+    adapter,
+    session_entries_by_platform: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+) -> List[Dict[str, Any]]:
     """Enumerate all text channels and forum channels the Discord bot can see."""
     channels = []
     client = getattr(adapter, "_client", None)
@@ -142,11 +147,14 @@ def _build_discord(adapter) -> List[Dict[str, str]]:
         # feasible via guild enumeration; those come from sessions.
 
     # Merge any DMs from session history
-    channels.extend(_build_from_sessions("discord"))
+    channels.extend(_sessions_for_platform("discord", session_entries_by_platform))
     return channels
 
 
-async def _build_slack(adapter) -> List[Dict[str, Any]]:
+async def _build_slack(
+    adapter,
+    session_entries_by_platform: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+) -> List[Dict[str, Any]]:
     """List Slack channels the bot has joined across all workspaces.
 
     Uses ``users.conversations`` against each workspace's web client. Pulls
@@ -156,7 +164,7 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
     """
     team_clients = getattr(adapter, "_team_clients", None) or {}
     if not team_clients:
-        return _build_from_sessions("slack")
+        return _sessions_for_platform("slack", session_entries_by_platform)
 
     channels: List[Dict[str, Any]] = []
     seen_ids: set = set()
@@ -200,7 +208,7 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
             continue
 
     # Merge in DM/group entries discovered from session history.
-    for entry in _build_from_sessions("slack"):
+    for entry in _sessions_for_platform("slack", session_entries_by_platform):
         if entry.get("id") not in seen_ids:
             channels.append(entry)
             seen_ids.add(entry.get("id"))
@@ -208,36 +216,54 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
     return channels
 
 
-def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:
+def _build_from_sessions(platform_name: str) -> List[Dict[str, Any]]:
+    """Pull known channels/contacts from sessions.json origin data."""
+    return _sessions_for_platform(platform_name, _build_sessions_by_platform())
+
+
+def _sessions_for_platform(
+    platform_name: str,
+    session_entries_by_platform: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+) -> List[Dict[str, Any]]:
+    if session_entries_by_platform is None:
+        session_entries_by_platform = _build_sessions_by_platform()
+    return [dict(entry) for entry in session_entries_by_platform.get(platform_name, [])]
+
+
+def _build_sessions_by_platform() -> Dict[str, List[Dict[str, Any]]]:
     """Pull known channels/contacts from sessions.json origin data."""
     sessions_path = get_hermes_home() / "sessions" / "sessions.json"
     if not sessions_path.exists():
-        return []
+        return {}
 
-    entries = []
+    entries_by_platform: Dict[str, List[Dict[str, Any]]] = {}
+    seen_ids_by_platform: Dict[str, set] = {}
     try:
         with open(sessions_path, encoding="utf-8") as f:
             data = json.load(f)
 
-        seen_ids = set()
         for _key, session in data.items():
             origin = session.get("origin") or {}
-            if origin.get("platform") != platform_name:
+            platform_name = origin.get("platform")
+            if not platform_name:
                 continue
             entry_id = _session_entry_id(origin)
-            if not entry_id or entry_id in seen_ids:
+            if not entry_id:
+                continue
+            seen_ids = seen_ids_by_platform.setdefault(platform_name, set())
+            if entry_id in seen_ids:
                 continue
             seen_ids.add(entry_id)
-            entries.append({
+            entries_by_platform.setdefault(platform_name, []).append({
                 "id": entry_id,
                 "name": _session_entry_name(origin),
                 "type": session.get("chat_type", "dm"),
                 "thread_id": origin.get("thread_id"),
             })
     except Exception as e:
-        logger.debug("Channel directory: failed to read sessions for %s: %s", platform_name, e)
+        logger.debug("Channel directory: failed to read sessions: %s", e)
 
-    return entries
+    return entries_by_platform
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5087,14 +5087,14 @@ def _terminate_reclaimed_worker(
     signal_fn=None,
 ) -> dict[str, Any]:
     """Best-effort host-local worker termination for reclaim paths."""
-    import signal
-
     info: dict[str, Any] = {
         "prev_pid": int(pid) if pid else None,
         "host_local": False,
         "termination_attempted": False,
         "terminated": False,
         "sigkill": False,
+        "process_tree": False,
+        "termination_method": None,
     }
     if not pid or pid <= 0 or not claim_lock:
         return info
@@ -5103,6 +5103,62 @@ def _terminate_reclaimed_worker(
     if not str(claim_lock).startswith(host_prefix):
         return info
     info["host_local"] = True
+
+    info.update(_terminate_worker_pid(int(pid), signal_fn=signal_fn))
+    return info
+
+
+def _terminate_worker_pid(
+    pid: int,
+    *,
+    signal_fn=None,
+) -> dict[str, Any]:
+    """Terminate a Kanban worker, including descendants on Windows.
+
+    ``os.kill(pid, SIGTERM)`` on Windows maps to ``TerminateProcess`` for only
+    the direct process. Kanban workers often own stdio MCP children (Node, npx,
+    Playwright, AgentMemory); killing only the parent leaves those servers
+    orphaned. Use ``taskkill /T`` for real Windows runtime cleanup, while
+    preserving the signal hook path for unit tests.
+    """
+    import signal
+
+    info: dict[str, Any] = {
+        "termination_attempted": False,
+        "terminated": False,
+        "sigkill": False,
+        "process_tree": False,
+        "termination_method": None,
+    }
+    if pid <= 0:
+        return info
+
+    if signal_fn is None and _IS_WINDOWS:
+        info["termination_attempted"] = True
+        info["process_tree"] = True
+        info["termination_method"] = "taskkill_tree"
+        try:
+            proc = subprocess.run(
+                ["taskkill.exe", "/PID", str(int(pid)), "/T", "/F"],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=10,
+                check=False,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+            )
+            info["taskkill_returncode"] = int(proc.returncode)
+        except (OSError, subprocess.SubprocessError, TimeoutError):
+            info["termination_method"] = "taskkill_tree_failed"
+            # Fall through to the stdlib kill path below.
+        else:
+            for _ in range(10):
+                if not _pid_alive(pid):
+                    info["terminated"] = True
+                    return info
+                time.sleep(0.5)
+            info["terminated"] = not _pid_alive(pid)
+            return info
 
     kill = signal_fn if signal_fn is not None else (
         os.kill if hasattr(os, "kill") else None
@@ -5204,7 +5260,6 @@ def enforce_max_runtime(
     (same reasoning as ``detect_crashed_workers``). ``signal_fn`` is a
     test hook; defaults to ``os.kill`` on POSIX.
     """
-    import signal
     timed_out: list[str] = []
     now = int(time.time())
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
@@ -5232,31 +5287,7 @@ def enforce_max_runtime(
 
         pid = int(row["worker_pid"])
         tid = row["id"]
-        # SIGTERM then SIGKILL. Keep it simple: 5 s grace. Workers that
-        # want a cleaner shutdown can install their own SIGTERM handler
-        # before the grace expires.
-        killed = False
-        kill = signal_fn if signal_fn is not None else (
-            os.kill if hasattr(os, "kill") else None
-        )
-        if kill is not None:
-            try:
-                kill(pid, signal.SIGTERM)
-            except (ProcessLookupError, OSError):
-                pass
-            # Short polling wait — no time.sleep on the write txn.
-            for _ in range(10):
-                if not _pid_alive(pid):
-                    break
-                time.sleep(0.5)
-            if _pid_alive(pid):
-                try:
-                    # signal.SIGKILL doesn't exist on Windows.
-                    _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-                    kill(pid, _sigkill)
-                    killed = True
-                except (ProcessLookupError, OSError):
-                    pass
+        termination = _terminate_worker_pid(pid, signal_fn=signal_fn)
 
         with write_txn(conn):
             cur = conn.execute(
@@ -5271,8 +5302,9 @@ def enforce_max_runtime(
                     "pid": pid,
                     "elapsed_seconds": int(elapsed),
                     "limit_seconds": int(row["max_runtime_seconds"]),
-                    "sigkill": killed,
+                    "sigkill": bool(termination.get("sigkill")),
                 }
+                payload.update(termination)
                 run_id = _end_run(
                     conn, tid,
                     outcome="timed_out", status="timed_out",
@@ -5295,7 +5327,12 @@ def enforce_max_runtime(
                 outcome="timed_out",
                 release_claim=False,
                 end_run=False,
-                event_payload_extra={"pid": pid, "sigkill": killed},
+                event_payload_extra={
+                    "pid": pid,
+                    "sigkill": bool(termination.get("sigkill")),
+                    "process_tree": bool(termination.get("process_tree")),
+                    "termination_method": termination.get("termination_method"),
+                },
             )
     return timed_out
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -105,6 +105,36 @@ def _clean_discord_id(entry: str) -> str:
     return entry.strip()
 
 
+_DISCORD_VISIBLE_USER_MENTION_RE = re.compile(r"<@!?(\d+)>")
+
+
+def _discord_visible_mention_ids(message: Any) -> set[str]:
+    """Return raw Discord user mention IDs visible in message content."""
+    content = getattr(message, "content", "") or ""
+    return {match.group(1) for match in _DISCORD_VISIBLE_USER_MENTION_RE.finditer(content)}
+
+
+def _discord_message_mentions_user(message: Any, user: Any) -> bool:
+    """Return True when a Discord message explicitly mentions *user*.
+
+    Discord may omit a user from ``message.mentions`` when the sender used
+    ``allowed_mentions`` to render a visible ``<@id>`` token without sending a
+    notification.  Gateway routing still needs to treat that visible token as
+    an explicit handoff/mention.
+    """
+    if user is None:
+        return False
+
+    user_id = str(getattr(user, "id", "") or "").strip()
+    for mention in getattr(message, "mentions", []) or []:
+        if mention == user:
+            return True
+        if user_id and str(getattr(mention, "id", "") or "") == user_id:
+            return True
+
+    return bool(user_id and user_id in _discord_visible_mention_ids(message))
+
+
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available.
 
@@ -794,7 +824,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
+                        if not _discord_message_mentions_user(message, self._client.user):
                             return
                     # "all" falls through; bot is permitted — skip the
                     # human-user allowlist below (bots aren't in it).
@@ -822,11 +852,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 # This replaces the older DISCORD_IGNORE_NO_MENTION logic
                 # with bot-aware filtering that works correctly when multiple
                 # agents share a channel.
-                if not isinstance(message.channel, discord.DMChannel) and message.mentions:
-                    _self_mentioned = (
-                        self._client.user is not None
-                        and self._client.user in message.mentions
-                    )
+                _visible_mention_ids = _discord_visible_mention_ids(message)
+                if not isinstance(message.channel, discord.DMChannel) and (
+                    message.mentions or _visible_mention_ids
+                ):
+                    _self_mentioned = _discord_message_mentions_user(message, self._client.user)
                     _other_bots_mentioned = any(
                         m.bot and m != self._client.user
                         for m in message.mentions
@@ -4730,6 +4760,7 @@ class DiscordAdapter(BasePlatformAdapter):
         raw_content = message.content.strip()
         normalized_content = raw_content
         mention_prefix = False
+        self_user = self._client.user if self._client else None
 
         snapshot_attachments = []
         if hasattr(message, "message_snapshots") and message.message_snapshots:
@@ -4741,10 +4772,13 @@ class DiscordAdapter(BasePlatformAdapter):
             if snapshot_text_parts and not raw_content:
                 raw_content = "\n".join(snapshot_text_parts)
                 normalized_content = raw_content
-        if self._client.user and self._client.user in message.mentions:
+        if _discord_message_mentions_user(message, self_user):
             mention_prefix = True
-            normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
-            normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
+            normalized_content = re.sub(
+                rf"<@!?{re.escape(str(self_user.id))}>",
+                "",
+                normalized_content,
+            ).strip()
             message.content = normalized_content
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}
@@ -4794,7 +4828,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
 
             if require_mention and not is_free_channel and not in_bot_thread:
-                if self._client.user not in message.mentions and not mention_prefix:
+                if not mention_prefix:
                     return
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -3,9 +3,11 @@
 import asyncio
 import json
 import os
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from gateway import channel_directory as channel_directory_module
 from gateway.channel_directory import (
     build_channel_directory,
     lookup_channel_type,
@@ -49,6 +51,70 @@ class TestLoadDirectory:
 
 
 class TestBuildChannelDirectoryWrites:
+    def test_session_scan_does_not_block_event_loop(self, tmp_path, monkeypatch):
+        def slow_sessions():
+            time.sleep(0.08)
+            return {
+                "telegram": [{"id": "123", "name": "Alice", "type": "dm"}],
+            }
+
+        ticks = asyncio.run(self._run_build_with_ticker(
+            tmp_path,
+            monkeypatch,
+            slow_sessions=slow_sessions,
+        ))
+
+        assert ticks >= 3
+
+    def test_directory_write_does_not_block_event_loop(self, tmp_path, monkeypatch):
+        def slow_write(_path, _directory):
+            time.sleep(0.08)
+
+        ticks = asyncio.run(self._run_build_with_ticker(
+            tmp_path,
+            monkeypatch,
+            slow_write=slow_write,
+        ))
+
+        assert ticks >= 3
+
+    async def _run_build_with_ticker(
+        self,
+        tmp_path,
+        monkeypatch,
+        slow_sessions=None,
+        slow_write=None,
+    ):
+        tick_count = 0
+        stop = asyncio.Event()
+
+        async def ticker():
+            nonlocal tick_count
+            while not stop.is_set():
+                tick_count += 1
+                await asyncio.sleep(0.01)
+
+        ticker_task = asyncio.create_task(ticker())
+        await asyncio.sleep(0)
+
+        if slow_sessions is not None:
+            monkeypatch.setattr(
+                channel_directory_module,
+                "_build_sessions_by_platform",
+                slow_sessions,
+            )
+        if slow_write is not None:
+            monkeypatch.setattr(channel_directory_module, "atomic_json_write", slow_write)
+
+        try:
+            with patch("gateway.channel_directory.DIRECTORY_PATH", tmp_path / "channel_directory.json"):
+                await build_channel_directory({})
+        finally:
+            stop.set()
+            await ticker_task
+
+        return tick_count
+
     def test_failed_write_preserves_previous_cache(self, tmp_path, monkeypatch):
         cache_file = _write_directory(tmp_path, {
             "telegram": [{"id": "123", "name": "Alice", "type": "dm"}]

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -4,6 +4,8 @@ import os
 import unittest
 from unittest.mock import MagicMock
 
+from plugins.platforms.discord.adapter import _discord_message_mentions_user
+
 
 def _make_author(*, bot: bool = False, is_self: bool = False):
     """Create a mock Discord author."""
@@ -51,7 +53,7 @@ class TestDiscordBotFilter(unittest.TestCase):
             if allow == "none":
                 return False
             elif allow == "mentions":
-                if not client_user or client_user not in message.mentions:
+                if not _discord_message_mentions_user(message, client_user):
                     return False
             # "all" falls through
         
@@ -96,6 +98,27 @@ class TestDiscordBotFilter(unittest.TestCase):
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, mentions=[our_user])
         self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_accepts_visible_mention_token(self):
+        """Visible <@id> tokens count even when Discord parsed mentions is empty."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content=f"<@{our_user.id}> help", mentions=[])
+        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_accepts_visible_nickname_mention_token(self):
+        """Legacy <@!id> Discord mention tokens also count."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content=f"<@!{our_user.id}> help", mentions=[])
+        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_rejects_other_visible_mention_token(self):
+        """A visible mention for another user must not wake this bot."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content="<@11111> help", mentions=[])
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -125,8 +125,8 @@ def adapter(monkeypatch):
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None, msg_type=None):
-    author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
+def make_message(*, channel, content: str, mentions=None, msg_type=None, author=None):
+    author = author or SimpleNamespace(id=42, display_name="Jezza", name="Jezza", bot=False)
     return SimpleNamespace(
         id=123,
         content=content,
@@ -823,6 +823,30 @@ async def test_discord_shared_channel_backfill_prepends_context(adapter, monkeyp
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "hello with mention"
     assert event.channel_context == "[Recent channel messages]\n[Alice] context"
+
+
+@pytest.mark.asyncio
+async def test_discord_visible_mention_token_without_parsed_mentions_counts(adapter, monkeypatch):
+    """Bot-authored messages may render <@id> while Discord leaves mentions empty."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter.config.extra["history_backfill"] = False
+
+    bot_user = adapter._client.user
+    other_bot = SimpleNamespace(id=43, display_name="FreeMoney", name="FreeMoney", bot=True)
+    message = make_message(
+        channel=FakeTextChannel(channel_id=321),
+        content=f"<@{bot_user.id}> reconnect the bridge",
+        mentions=[],
+        author=other_bot,
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "reconnect the bridge"
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -928,6 +928,44 @@ def test_max_runtime_uses_current_run_start_after_retry(kanban_home, monkeypatch
         assert kb.get_task(conn, t).status == "running"
 
 
+def test_terminate_worker_pid_uses_taskkill_tree_on_windows(monkeypatch):
+    calls = []
+
+    class Result:
+        returncode = 0
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return Result()
+
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setattr(kb.subprocess, "run", fake_run)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+    info = kb._terminate_worker_pid(1234)
+
+    assert calls[0][0] == ["taskkill.exe", "/PID", "1234", "/T", "/F"]
+    assert info["termination_attempted"] is True
+    assert info["process_tree"] is True
+    assert info["termination_method"] == "taskkill_tree"
+    assert info["terminated"] is True
+
+
+def test_terminate_worker_pid_preserves_signal_hook(monkeypatch):
+    signals = []
+
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+    info = kb._terminate_worker_pid(5678, signal_fn=lambda pid, sig: signals.append((pid, sig)))
+
+    assert signals
+    assert signals[0][0] == 5678
+    assert info["process_tree"] is False
+    assert info["termination_method"] is None
+    assert info["terminated"] is True
+
+
 def test_heartbeat_extends_claim(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 from tools.environments import local as local_mod
 from tools.environments.local import (
     LocalEnvironment,
+    _find_bash,
     _msys_to_windows_path,
     _resolve_safe_cwd,
 )
@@ -68,6 +69,32 @@ class TestMsysToWindowsPath:
     def test_empty_string(self, monkeypatch):
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
         assert _msys_to_windows_path("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _find_bash — WindowsApps WSL shim rejection
+# ---------------------------------------------------------------------------
+
+class TestFindBashWindows:
+    def test_prefers_real_git_bash_over_windowsapps_wsl_shim(self, monkeypatch):
+        """WindowsApps ``bash.exe`` is the WSL launcher, not Git Bash."""
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.delenv("HERMES_GIT_BASH_PATH", raising=False)
+        monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\NVIDIA\AppData\Local")
+        monkeypatch.setenv("ProgramFiles", r"C:\Program Files")
+        monkeypatch.setenv("ProgramFiles(x86)", r"C:\Program Files (x86)")
+        monkeypatch.setattr(
+            local_mod.shutil,
+            "which",
+            lambda name: r"C:\Users\NVIDIA\AppData\Local\Microsoft\WindowsApps\bash.exe",
+        )
+        monkeypatch.setattr(
+            local_mod.os.path,
+            "isfile",
+            lambda path: path == r"C:\Program Files\Git\bin\bash.exe",
+        )
+
+        assert _find_bash() == r"C:\Program Files\Git\bin\bash.exe"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -247,8 +247,14 @@ def _find_bash() -> str:
             or "/bin/sh"
         )
 
+    def _is_windowsapps_bash_shim(path: str | None) -> bool:
+        if not path:
+            return False
+        normalized = path.replace("/", "\\").casefold()
+        return "\\microsoft\\windowsapps\\bash.exe" in normalized
+
     custom = os.environ.get("HERMES_GIT_BASH_PATH")
-    if custom and os.path.isfile(custom):
+    if custom and os.path.isfile(custom) and not _is_windowsapps_bash_shim(custom):
         return custom
 
     # Prefer our own portable Git install first — this way a broken or
@@ -270,10 +276,6 @@ def _find_bash() -> str:
             if os.path.isfile(candidate):
                 return candidate
 
-    found = shutil.which("bash")
-    if found:
-        return found
-
     for candidate in (
         os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
         os.path.join(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin", "bash.exe"),
@@ -281,6 +283,10 @@ def _find_bash() -> str:
     ):
         if candidate and os.path.isfile(candidate):
             return candidate
+
+    found = shutil.which("bash")
+    if found and not _is_windowsapps_bash_shim(found):
+        return found
 
     raise RuntimeError(
         "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"


### PR DESCRIPTION
## Summary
- On Windows, terminate Kanban worker process trees with `taskkill /T /F` when max-runtime or reclaim cleanup kills a worker.
- Preserve the existing `signal_fn` hook path for unit tests and non-Windows behavior.
- Record process-tree cleanup metadata in timeout/reclaim event payloads.

## Why
A dispatcher timeout can kill only the recorded worker PID while leaving stdio MCP descendants alive (`node`, `npx`, Playwright MCP, AgentMemory MCP, local runtime MCP). That leaks tool servers after a Kanban card times out and degrades the host.

## Verification
- `C:\Users\m_t_c\.hermes-sdgd\venv\Scripts\python.exe -m pytest -o addopts= -p no:timeout tests\hermes_cli\test_kanban_db.py -k "max_runtime or terminate_worker_pid"`
