### PR TITLE
fix(delegate): route bedrock subagents through converse mode

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1125,6 +1125,27 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["provider"], "openrouter")
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_bedrock_provider_uses_bedrock_converse_api_mode(self, mock_resolve):
+        """Bedrock delegation must enter the boto3/Converse init path."""
+        mock_resolve.return_value = {
+            "provider": "bedrock",
+            "model": "global.anthropic.claude-sonnet-4-6",
+            "base_url": None,
+            "api_key": "bedrock-session-token",
+            "api_mode": "anthropic_messages",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "global.anthropic.claude-sonnet-4-6",
+            "provider": "bedrock",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["provider"], "bedrock")
+        self.assertEqual(creds["api_mode"], "bedrock_converse")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_custom_provider_with_empty_configured_provider_falls_back_to_runtime(self, mock_resolve):
         """When configured_provider is empty/None, the early return kicks in and
         we return provider=None regardless of what runtime resolved. The runtime

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2751,12 +2751,19 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             f"Set the appropriate environment variable or run 'hermes auth'."
         )
 
+    api_mode = runtime.get("api_mode")
+    if configured_provider.lower() == "bedrock":
+        # Bedrock's runtime resolver reports the Anthropic wire format, but
+        # child agent construction uses the internal bedrock_converse mode to
+        # route through the boto3/Converse transport.
+        api_mode = "bedrock_converse"
+
     return {
         "model": configured_model or runtime.get("model") or None,
         "provider": configured_provider if runtime.get("provider") == _RUNTIME_PROVIDER_CUSTOM else runtime.get("provider"),
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
-        "api_mode": runtime.get("api_mode"),
+        "api_mode": api_mode,
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
     }


### PR DESCRIPTION
## What does this PR do?

Fixes Bedrock delegation so child agents use Hermes' internal `bedrock_converse` mode instead of the Anthropic wire-format mode returned by runtime provider resolution. This keeps `delegation.provider: bedrock` subagents on the boto3/Converse initialization path instead of falling through toward non-Bedrock provider resolution.

## Related Issue

Fixes #49095

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tools/delegate_tool.py`: maps configured `delegation.provider: bedrock` to `api_mode="bedrock_converse"` after runtime provider resolution.
- `tests/tools/test_delegate.py`: adds a regression test proving Bedrock delegation keeps the Bedrock provider and passes `bedrock_converse` to child agent construction.

## How to Test

1. `python3 -m pytest tests/tools/test_delegate.py -q`
2. `python3 -m pytest tests/agent/test_bedrock_integration.py tests/agent/transports/test_bedrock_transport.py -q`
3. `python3 -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py`
4. `git diff --check`
5. `python3 scripts/check-windows-footguns.py --diff origin/main`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS / Python 3

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

```text
python3 -m pytest tests/tools/test_delegate.py -q
141 passed in 9.24s

python3 -m pytest tests/agent/test_bedrock_integration.py tests/agent/transports/test_bedrock_transport.py -q
74 passed in 1.41s
```