### PR TITLE
fix(agent): persist codex app-server turns

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -271,53 +271,13 @@ def run_codex_app_server_turn(
     usage_result = _record_codex_app_server_usage(agent, turn)
     api_calls = 1
 
-    # Now check the skill nudge AFTER iters were incremented — same
-    # pattern the chat_completions path uses (line ~15432).
-    should_review_skills = False
-    if (
-        agent._skill_nudge_interval > 0
-        and agent._iters_since_skill >= agent._skill_nudge_interval
-        and "skill_manage" in agent.valid_tool_names
-    ):
-        should_review_skills = True
-        agent._iters_since_skill = 0
-
-    # External memory provider sync (mirrors line ~15439). Skipped on
-    # interrupt/error to avoid feeding partial transcripts to memory.
-    if not turn.interrupted and turn.error is None:
-        try:
-            agent._sync_external_memory_for_turn(
-                original_user_message=original_user_message,
-                final_response=turn.final_text,
-                interrupted=False,
-                messages=messages,
-            )
-        except Exception:
-            logger.debug("external memory sync raised", exc_info=True)
-
-    # Background review fork — same cadence + signature as the default
-    # path (line ~15449). Only fires when a trigger actually tripped AND
-    # we have a real final response.
-    if (
-        turn.final_text
-        and not turn.interrupted
-        and (should_review_memory or should_review_skills)
-    ):
-        try:
-            agent._spawn_background_review(
-                messages_snapshot=list(messages),
-                review_memory=should_review_memory,
-                review_skills=should_review_skills,
-            )
-        except Exception:
-            logger.debug("background review spawn raised", exc_info=True)
-
     return {
         "final_response": turn.final_text,
         "messages": messages,
         "api_calls": api_calls,
         "completed": not turn.interrupted and turn.error is None,
         "partial": turn.interrupted or turn.error is not None,
+        "interrupted": turn.interrupted,
         "error": turn.error,
         "codex_thread_id": turn.thread_id,
         "codex_turn_id": turn.turn_id,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -545,22 +545,55 @@ def run_conversation(
     truncated_response_parts: List[str] = []
     compression_attempts = 0
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
+    _runtime_result_extras: Dict[str, Any] = {}
 
     # Optional opt-in runtime: if api_mode == codex_app_server, hand the
     # turn to the codex app-server subprocess (terminal/file ops/patching
-    # all run inside Codex). Default Hermes path is bypassed entirely.
+    # all run inside Codex). Unlike the normal provider loop, the helper
+    # already returns the final message list and status shape. We still
+    # run the shared tail below so persistence, turn-end diagnostics, and
+    # post-turn hooks stay identical to every other runtime.
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
-        return agent._run_codex_app_server_turn(
+        _codex_result = agent._run_codex_app_server_turn(
             user_message=user_message,
             original_user_message=original_user_message,
             messages=messages,
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
         )
+        messages = _codex_result.get("messages") or messages
+        api_call_count = int(_codex_result.get("api_calls") or 1)
+        agent._api_call_count = api_call_count
+        final_response = _codex_result.get("final_response")
+        interrupted = bool(_codex_result.get("interrupted"))
+        failed = not bool(_codex_result.get("completed"))
+        _runtime_result_extras = {
+            "partial": bool(_codex_result.get("partial")),
+            "error": _codex_result.get("error"),
+            "codex_thread_id": _codex_result.get("codex_thread_id"),
+            "codex_turn_id": _codex_result.get("codex_turn_id"),
+        }
 
-    while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+        _codex_error = _codex_result.get("error")
+        if interrupted:
+            _turn_exit_reason = "codex_app_server_interrupted"
+        elif _codex_error:
+            _codex_error_preview = str(_codex_error).splitlines()[0][:80]
+            _turn_exit_reason = (
+                f"codex_app_server_error({_codex_error_preview})"
+            )
+        else:
+            _turn_exit_reason = "codex_app_server_turn_completed"
+
+    while (
+        agent.api_mode != "codex_app_server"
+        and (
+            (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0)
+            or agent._budget_grace_call
+        )
+    ):
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
 
@@ -4479,6 +4512,7 @@ def run_conversation(
         original_user_message=original_user_message,
         _should_review_memory=_should_review_memory,
         _turn_exit_reason=_turn_exit_reason,
+        _runtime_result_extras=_runtime_result_extras,
     )
 
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -42,6 +42,7 @@ def finalize_turn(
     original_user_message,
     _should_review_memory,
     _turn_exit_reason,
+    _runtime_result_extras=None,
 ):
     """Run the post-loop finalization and return the turn ``result`` dict.
 
@@ -322,6 +323,8 @@ def finalize_turn(
             last_reasoning = msg["reasoning"]
             break
 
+    runtime_result_extras = dict(_runtime_result_extras or {})
+
     # Build result with interrupt info if applicable
     result = {
         "final_response": final_response,
@@ -331,7 +334,7 @@ def finalize_turn(
         "completed": completed,
         "turn_exit_reason": _turn_exit_reason,
         "failed": failed,
-        "partial": False,  # True only when stopped due to invalid tool calls
+        "partial": bool(runtime_result_extras.get("partial", False)),
         "interrupted": interrupted,
         "response_transformed": _response_transformed,
         "response_previewed": getattr(agent, "_response_was_previewed", False),
@@ -352,6 +355,12 @@ def finalize_turn(
         "cost_source": agent.session_cost_source,
         "session_id": agent.session_id,
     }
+    if "error" in runtime_result_extras:
+        result["error"] = runtime_result_extras.get("error")
+    if runtime_result_extras.get("codex_thread_id"):
+        result["codex_thread_id"] = runtime_result_extras["codex_thread_id"]
+    if runtime_result_extras.get("codex_turn_id"):
+        result["codex_turn_id"] = runtime_result_extras["codex_turn_id"]
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # If a /steer landed after the final assistant turn (no more tool

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -148,6 +148,26 @@ class TestRunConversationCodexPath:
                  and m.get("content") == "echo: hello"]
         assert final, f"expected final assistant message in {msgs}"
 
+    def test_codex_path_persists_projected_assistant_message(self, fake_session):
+        agent = _make_codex_agent()
+        persisted = {}
+
+        def capture_persist(messages, conversation_history=None):
+            persisted["messages"] = list(messages)
+            persisted["conversation_history"] = conversation_history
+
+        with patch.object(agent, "_persist_session", side_effect=capture_persist):
+            with patch.object(agent, "_spawn_background_review", return_value=None):
+                result = agent.run_conversation("persist me")
+
+        saved = persisted.get("messages")
+        assert saved, "codex runtime should still flow through _persist_session()"
+        assert saved == result["messages"]
+        assert any(
+            m.get("role") == "assistant" and m.get("content") == "echo: persist me"
+            for m in saved
+        ), f"expected projected assistant message in persisted transcript: {saved}"
+
     def test_projected_messages_are_synced_to_external_memory(self, fake_session):
         agent = _make_codex_agent()
         agent._memory_manager = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Fixes the `codex_app_server` runtime path so Hermes Desktop/TUI turns still run the shared post-turn finalization path. Before this change, `run_conversation()` returned early for `codex_app_server`, which skipped session persistence, the `Turn ended` diagnostic log, and the standard result shaping that downstream UI/session code expects. That could leave a Desktop session with only the user message persisted and no final assistant turn recorded.

## Related Issue

Fixes #49305

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Routed `codex_app_server` turns back through the shared `run_conversation()` finalization path instead of returning early from [`agent/conversation_loop.py`](agent/conversation_loop.py).
- Kept codex-specific result metadata (`partial`, `error`, `codex_thread_id`, `codex_turn_id`) when the shared finalizer builds the final return object in [`agent/turn_finalizer.py`](agent/turn_finalizer.py).
- Removed duplicate end-of-turn side effects from [`agent/codex_runtime.py`](agent/codex_runtime.py) so external memory sync / background review only fire once.
- Added a regression test proving the projected assistant message is persisted for the codex runtime in [`tests/run_agent/test_codex_app_server_integration.py`](tests/run_agent/test_codex_app_server_integration.py).

## How to Test

1. Run `scripts/run_tests.sh tests/run_agent/test_codex_app_server_integration.py tests/agent/transports/test_codex_app_server_session.py`
2. Confirm all 76 targeted tests pass, including the new persisted-assistant regression.
3. Reproduce the original Desktop/TUI flow from #49305 with `model.openai_runtime: codex_app_server` and verify the assistant turn now persists and the run emits the normal `Turn ended` log.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

- `scripts/run_tests.sh tests/run_agent/test_codex_app_server_integration.py tests/agent/transports/test_codex_app_server_session.py`
- Result: `76 tests passed, 0 failed`
