### PR TITLE
fix(agent): classify Anthropic "extra usage" 400 as billing, not format_error

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -118,6 +118,24 @@ _BILLING_PATTERNS = [
     "not available on the free tier",
 ]
 
+# Anthropic subscription *entitlement* gate, surfaced as HTTP 400.  When a
+# Claude Pro/Max subscription must enable extra usage to keep serving, native
+# Anthropic returns a 400 whose body reads like "Third-party apps now draw from
+# your extra usage. To continue, enable extra usage in your account settings."
+# This is a billing/entitlement condition, not a malformed request — without
+# this it fell through to the generic ``format_error`` bucket, so the user got
+# an opaque "format error" instead of actionable billing guidance and no
+# credential rotation fired.  Patterns are deliberately specific (an account
+# *action* on extra usage) so they do NOT collide with the 429 rolling-cap /
+# long-context tier gate, which is "extra usage" + "long context" and is
+# classified separately as ``long_context_tier`` on the 429 path.
+_ENTITLEMENT_PATTERNS = [
+    "draw from your extra usage",
+    "enable extra usage",
+    "exceed your extra usage",
+    "extra usage allowance",
+]
+
 # Patterns that indicate rate limiting (transient, will resolve)
 _RATE_LIMIT_PATTERNS = [
     "rate limit",
@@ -1150,6 +1168,17 @@ def _classify_400(
             should_rotate_credential=True,
             should_fallback=True,
         )
+    # Anthropic subscription entitlement gate ("extra usage") arrives as a 400.
+    # Treat as billing (rotate + fall back + surface billing guidance) rather
+    # than the generic format_error. Checked before _BILLING_PATTERNS since the
+    # phrasing is distinct; both converge on FailoverReason.billing.
+    if any(p in error_msg for p in _ENTITLEMENT_PATTERNS):
+        return result_fn(
+            FailoverReason.billing,
+            retryable=False,
+            should_rotate_credential=True,
+            should_fallback=True,
+        )
     if any(p in error_msg for p in _BILLING_PATTERNS):
         return result_fn(
             FailoverReason.billing,
@@ -1310,6 +1339,18 @@ def _classify_by_message(
         return result_fn(
             FailoverReason.overloaded,
             retryable=True,
+        )
+
+    # Entitlement gate ("extra usage") when surfaced without a status code.
+    # Must come BEFORE the generic billing check so the specific entitlement
+    # phrasing is classified here. Guard against the long-context tier phrasing
+    # so it isn't swallowed here (that path stays retryable on the 429 branch).
+    if any(p in error_msg for p in _ENTITLEMENT_PATTERNS) and "long context" not in error_msg:
+        return result_fn(
+            FailoverReason.billing,
+            retryable=False,
+            should_rotate_credential=True,
+            should_fallback=True,
         )
 
     # Billing patterns

--- a/tests/agent/test_entitlement_extra_usage_classification.py
+++ b/tests/agent/test_entitlement_extra_usage_classification.py
@@ -1,0 +1,84 @@
+"""Anthropic subscription *entitlement* 400 ("extra usage" / "third-party apps
+now draw from your extra usage") must classify as BILLING, not format_error.
+
+Repro (forensics in this repo's own incident history): when a Claude
+subscription must enable extra usage, native Anthropic returns HTTP 400 with a
+body like "Third-party apps now draw from your extra usage. To continue, enable
+extra usage in your account settings." The generic 400 path classified this as
+``format_error`` — so the user got an opaque "format error" instead of the
+actionable billing/entitlement guidance, and no credential rotation was
+triggered (``should_rotate_credential`` stayed False).
+
+These are behavior-contract tests: the entitlement signal => billing + rotate +
+fallback, while the *rolling-cap* 429 ("extra usage" + "long context") must stay
+``long_context_tier`` (retryable, NOT billing). Guards both the fix and the
+no-collision invariant.
+"""
+
+from agent.error_classifier import FailoverReason, classify_api_error
+
+
+class _FakeResp:
+    def __init__(self, body, status=400):
+        self.status_code = status
+        self._b = body
+
+    def json(self):
+        return self._b
+
+
+class _FakeErr(Exception):
+    def __init__(self, msg, body, status=400):
+        super().__init__(msg)
+        self.status_code = status
+        self.body = body
+        self.response = _FakeResp(body, status)
+
+
+def _classify(msg, status=400):
+    body = {"type": "error", "error": {"type": "invalid_request_error", "message": msg}}
+    return classify_api_error(
+        _FakeErr(msg, body, status),
+        provider="anthropic",
+        model="claude-opus-4-8",
+        approx_tokens=4000,
+        context_length=200000,
+        num_messages=10,
+    )
+
+
+class TestEntitlementExtraUsageIsBilling:
+    def test_third_party_draw_from_extra_usage_is_billing(self):
+        r = _classify(
+            "Third-party apps now draw from your extra usage. To continue, "
+            "enable extra usage in your account settings."
+        )
+        assert r.reason == FailoverReason.billing
+        assert r.should_fallback is True
+        assert r.should_rotate_credential is True
+
+    def test_exceed_extra_usage_allowance_is_billing(self):
+        r = _classify("This request would exceed your extra usage allowance.")
+        assert r.reason == FailoverReason.billing
+        assert r.should_rotate_credential is True
+
+    def test_enable_extra_usage_phrasing_is_billing(self):
+        r = _classify("Please enable extra usage in your account settings to continue.")
+        assert r.reason == FailoverReason.billing
+
+
+class TestNoCollisionWithLongContextTier:
+    """The 429 rolling-cap / long-context tier gate must remain untouched —
+    it is retryable and NOT billing."""
+
+    def test_429_extra_usage_long_context_stays_tier_gate(self):
+        r = _classify(
+            "Request requires extra usage for the long context window.",
+            status=429,
+        )
+        assert r.reason == FailoverReason.long_context_tier
+        assert r.reason != FailoverReason.billing
+
+    def test_real_billing_credit_balance_still_billing(self):
+        r = _classify("Your credit balance is too low to access the Anthropic API.")
+        assert r.reason == FailoverReason.billing


### PR DESCRIPTION
## What & why

When a Claude subscription must **enable extra usage** to keep serving, native Anthropic returns **HTTP 400** with a body like:

> Third-party apps now draw from your extra usage. To continue, enable extra usage in your account settings.

`_classify_400` had no pattern for this, so it fell through to the generic **`format_error`** bucket. Two real consequences:

1. **Wrong user guidance** — the user sees an opaque "format error" instead of the actionable billing/entitlement guidance (`_print_billing_or_entitlement_guidance`).
2. **No credential rotation** — `billing` sets `should_rotate_credential=True`; `format_error` does not. A multi-credential pool never rotates to another entry on this signal.

Both `_classify_400` (status path) and `_classify_by_message` (no-status sibling path) are fixed, so the whole class is covered rather than one call site.

## The fix

Add a dedicated `_ENTITLEMENT_PATTERNS` list and classify these messages as `FailoverReason.billing` (`retryable=False`, `should_rotate_credential=True`, `should_fallback=True`).

Patterns are deliberately **specific to an account *action* on extra usage** (`draw from your extra usage`, `enable extra usage`, `exceed your extra usage`, `extra usage allowance`) so they do **not** collide with the existing **429 rolling-cap / long-context tier gate** (`"extra usage"` + `"long context"` → `long_context_tier`, retryable). The no-status path additionally guards on `"long context"` explicitly.

## How to test

```python
from agent.error_classifier import classify_api_error, FailoverReason
# build a 400 whose body message is:
#   "Third-party apps now draw from your extra usage. ..."
# classify_api_error(...).reason  -> FailoverReason.billing (was format_error)
# .should_rotate_credential       -> True (was False)
```

New test `tests/agent/test_entitlement_extra_usage_classification.py` covers:
- three entitlement phrasings → `billing` + rotate + fallback
- **no-collision invariant**: 429 `extra usage` + `long context` stays `long_context_tier`
- control: real `credit balance` billing still `billing`

`tests/agent/test_error_classifier.py` (161 tests) stays green.

## Platforms

Logic-only change in `agent/error_classifier.py` (string matching + classification flags); no OS-specific paths. Tested on Linux.

---
*Rebased onto current `main` (2026-06-26). Conflict in `agent/error_classifier.py`: main added an `_OVERLOADED_PATTERNS` block at the same no-status classification point; resolved by ordering **overloaded → entitlement → generic billing** so the transient-overload check runs first and the specific entitlement match still wins over generic `_BILLING_PATTERNS`. Verified: `test_error_classifier` + entitlement + failover = **180 passed**.*