### PR TITLE
docs(agent): document per-event extra keys in shell-hook wire protocol

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -38,6 +38,21 @@ Wire protocol
         "extra":           {...}   # event-specific kwargs
     }
 
+The ``extra`` object carries the event-specific kwargs.  ``_serialize_payload``
+keeps only the top-level keys above and folds everything else into ``extra``,
+so the useful per-event fields live one level down.  Common keys by event:
+
+==================  ============================================================
+Event               ``extra`` keys
+==================  ============================================================
+``post_tool_call``  ``result``, ``status``, ``error_type``, ``error_message``,
+                    ``duration_ms``
+``subagent_stop``   ``child_session_id``, ``child_role``, ``child_summary``,
+                    ``child_status`` (top-level ``session_id`` is the *parent*)
+``on_session_end``  ``completed``, ``interrupted``
+``on_session_start``  ``model``, ``platform``
+==================  ============================================================
+
 **stdout** (JSON, optional — anything else is ignored)::
 
     # Block a pre_tool_call (either shape accepted; normalised internally):


### PR DESCRIPTION
The shell-hook wire-protocol docstring in `agent/shell_hooks.py` documents the top-level stdin shape, including the `extra` object, but not which keys each event puts inside it. Since `_serialize_payload` folds all non-top-level kwargs into `extra`, the genuinely useful per-event fields (tool result/status, the subagent child id, session-end flags) are only reachable there, and a hook author can't discover them without reading the emit sites.

This adds a short per-event table right after the `extra` line listing the common keys for `post_tool_call`, `subagent_stop`, `on_session_end`, and `on_session_start`. Field names verified against the emit sites in `model_tools.py`, `tools/delegate_tool.py`, `agent/turn_finalizer.py`, and `agent/conversation_loop.py`.

Docstring-only; no code change. Happy to move it to the README or a docs page instead, or trim/expand the key list if you'd prefer.

Closes #49370