### PR TITLE
fix(desktop): register linux launcher entry

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5354,6 +5354,96 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")
 
 
+def _desktop_linux_data_dir() -> Path:
+    xdg_data = os.environ.get("XDG_DATA_HOME")
+    if xdg_data:
+        return Path(xdg_data).expanduser()
+    return Path.home() / ".local" / "share"
+
+
+def _desktop_entry_quote(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$").replace("`", "\\`") + '"'
+
+
+def _linux_desktop_cache_tool(name: str) -> str | None:
+    tool = shutil.which(name)
+    if not tool:
+        return None
+    try:
+        if Path(tool).name != name:
+            return None
+    except Exception:
+        return None
+    return tool
+
+
+def _install_linux_desktop_entry(packaged_executable: Path, desktop_dir: Path) -> None:
+    """Install or refresh the per-user desktop launcher for Hermes Desktop."""
+    if sys.platform != "linux":
+        return
+
+    data_dir = _desktop_linux_data_dir()
+    applications_dir = data_dir / "applications"
+    icon_dir = data_dir / "icons" / "hicolor" / "512x512" / "apps"
+    desktop_entry_path = applications_dir / "hermes-desktop.desktop"
+    icon_target_path = icon_dir / "hermes-desktop.png"
+    icon_source = next(
+        (
+            candidate
+            for candidate in (
+                desktop_dir / "assets" / "icon.png",
+                desktop_dir / "public" / "apple-touch-icon.png",
+            )
+            if candidate.exists()
+        ),
+        None,
+    )
+
+    try:
+        applications_dir.mkdir(parents=True, exist_ok=True)
+        icon_dir.mkdir(parents=True, exist_ok=True)
+        if icon_source is not None:
+            shutil.copy2(icon_source, icon_target_path)
+    except OSError as exc:
+        print(f"  ⚠ Failed to stage Hermes Desktop launcher assets: {exc}")
+        return
+
+    icon_value = str(icon_target_path if icon_source is not None else desktop_dir / "assets" / "icon.png")
+    desktop_entry = "\n".join(
+        [
+            "[Desktop Entry]",
+            "Name=Hermes",
+            "Comment=Hermes Agent Desktop",
+            f"Exec={_desktop_entry_quote(str(packaged_executable))} %U",
+            f"TryExec={_desktop_entry_quote(str(packaged_executable))}",
+            f"Icon={icon_value}",
+            "Terminal=false",
+            "Type=Application",
+            "Categories=Development;",
+            "StartupNotify=true",
+            "StartupWMClass=Hermes",
+            "MimeType=x-scheme-handler/hermes;",
+            "",
+        ]
+    )
+    try:
+        if desktop_entry_path.read_text(encoding="utf-8") != desktop_entry:
+            desktop_entry_path.write_text(desktop_entry, encoding="utf-8")
+    except FileNotFoundError:
+        desktop_entry_path.write_text(desktop_entry, encoding="utf-8")
+    except OSError as exc:
+        print(f"  ⚠ Failed to write Hermes Desktop launcher: {exc}")
+        return
+
+    update_desktop_database = _linux_desktop_cache_tool("update-desktop-database")
+    if update_desktop_database:
+        subprocess.run([update_desktop_database, str(applications_dir)], check=False)
+
+    gtk_update_icon_cache = _linux_desktop_cache_tool("gtk-update-icon-cache")
+    if gtk_update_icon_cache:
+        subprocess.run([gtk_update_icon_cache, "-f", "-t", str(data_dir / "icons" / "hicolor")], check=False)
+
+
 def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
     """Configure Electron's Linux SUID sandbox helper when required."""
     if sys.platform != "linux":
@@ -5559,6 +5649,7 @@ def cmd_gui(args: argparse.Namespace):
             print("  Expected an unpacked Electron app for the current OS.")
             sys.exit(1)
         else:
+            _install_linux_desktop_entry(packaged_executable, desktop_dir)
             print(f"✓ Desktop packaged app ready: {packaged_executable} (not launching; --build-only)")
         return
 
@@ -5571,6 +5662,8 @@ def cmd_gui(args: argparse.Namespace):
         print(f"✗ Desktop package build completed but no launchable app was found at: {desktop_dir / 'release'}")
         print("  Expected an unpacked Electron app for the current OS.")
         sys.exit(1)
+
+    _install_linux_desktop_entry(packaged_executable, desktop_dir)
 
     if not _desktop_linux_sandbox_fixup(packaged_executable):
         sys.exit(1)

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -33,6 +33,8 @@ def _make_desktop_tree(tmp_path: Path) -> Path:
     desktop_dir = root / "apps" / "desktop"
     desktop_dir.mkdir(parents=True)
     (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
+    (desktop_dir / "assets").mkdir()
+    (desktop_dir / "assets" / "icon.png").write_bytes(b"png")
     return root
 
 
@@ -44,10 +46,62 @@ def _make_packaged_executable(root: Path, monkeypatch, platform: str = "darwin")
     elif platform == "win32":
         exe = desktop_dir / "release" / "win-unpacked" / "Hermes.exe"
     else:
+        monkeypatch.setenv("XDG_DATA_HOME", str(root / ".xdg-data"))
         exe = desktop_dir / "release" / "linux-unpacked" / "hermes"
     exe.parent.mkdir(parents=True)
     exe.write_text("", encoding="utf-8")
     return exe
+
+
+def test_install_linux_desktop_entry_writes_launcher_and_icon(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+
+    with patch("hermes_cli.main.shutil.which", return_value=None), \
+         patch("hermes_cli.main.subprocess.run") as mock_run:
+        cli_main._install_linux_desktop_entry(packaged_exe, desktop_dir)
+
+    desktop_entry = root / ".xdg-data" / "applications" / "hermes-desktop.desktop"
+    copied_icon = root / ".xdg-data" / "icons" / "hicolor" / "512x512" / "apps" / "hermes-desktop.png"
+
+    assert desktop_entry.exists()
+    assert copied_icon.read_bytes() == b"png"
+    text = desktop_entry.read_text(encoding="utf-8")
+    assert f'Exec="{packaged_exe}" %U' in text
+    assert f'TryExec="{packaged_exe}"' in text
+    assert f"Icon={copied_icon}" in text
+    assert "MimeType=x-scheme-handler/hermes;" in text
+    assert "StartupWMClass=Hermes" in text
+    mock_run.assert_not_called()
+
+
+def test_install_linux_desktop_entry_refreshes_desktop_caches(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+
+    def _which(name: str) -> str | None:
+        mapping = {
+            "update-desktop-database": "/usr/bin/update-desktop-database",
+            "gtk-update-icon-cache": "/usr/bin/gtk-update-icon-cache",
+        }
+        return mapping.get(name)
+
+    with patch("hermes_cli.main.shutil.which", side_effect=_which), \
+         patch("hermes_cli.main.subprocess.run", return_value=subprocess.CompletedProcess([], 0)) as mock_run:
+        cli_main._install_linux_desktop_entry(packaged_exe, desktop_dir)
+
+    assert mock_run.call_args_list[0].args[0] == [
+        "/usr/bin/update-desktop-database",
+        str(root / ".xdg-data" / "applications"),
+    ]
+    assert mock_run.call_args_list[1].args[0] == [
+        "/usr/bin/gtk-update-icon-cache",
+        "-f",
+        "-t",
+        str(root / ".xdg-data" / "icons" / "hicolor"),
+    ]
 
 
 def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
@@ -151,6 +205,17 @@ def test_gui_skip_build_launches_existing_packaged_app_without_npm(tmp_path, mon
     mock_install.assert_not_called()
     mock_run.assert_called_once()
     assert mock_run.call_args.args[0] == [str(packaged_exe)]
+
+
+def test_gui_build_only_registers_linux_desktop_entry(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch, platform="linux")
+
+    with patch("hermes_cli.main.shutil.which", return_value=None):
+        cli_main.cmd_gui(_ns(skip_build=True, build_only=True))
+
+    assert (root / ".xdg-data" / "applications" / "hermes-desktop.desktop").exists()
 
 
 def test_gui_linux_configures_sandbox_before_launch(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Registers a per-user Linux desktop launcher for Hermes Desktop so `hermes desktop` and update rebuilds leave a usable `.desktop` entry and icon in the user's app launcher instead of only producing `linux-unpacked/` output.

## Related Issue

Fixes #49171

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: add a Linux desktop-entry installer that stages the desktop icon, writes `~/.local/share/applications/hermes-desktop.desktop`, and best-effort refreshes desktop caches.
- `hermes_cli/main.py`: run that installer for packaged desktop builds, including `hermes desktop --build-only`, before sandbox setup / launch.
- `tests/hermes_cli/test_gui_command.py`: add focused coverage for launcher file contents, cache refresh hooks, and build-only registration on Linux.

## How to Test

1. `./.venv/bin/python -m py_compile hermes_cli/main.py tests/hermes_cli/test_gui_command.py`
2. `./.venv/bin/python -m pytest -q tests/hermes_cli/test_gui_command.py -k 'install_linux_desktop_entry or build_only_registers_linux_desktop_entry or linux_configures_sandbox_before_launch or skip_build_launches_existing_packaged_app_without_npm'`
3. On Linux, run `hermes desktop --build-only` and verify `~/.local/share/applications/hermes-desktop.desktop` exists and points at the packaged Hermes binary.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (with Linux-targeted launcher tests and build-only registration coverage)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

Not applicable.

## Screenshots / Logs

- Focused proof: `5 passed, 39 deselected` from `tests/hermes_cli/test_gui_command.py` with the launcher-specific selector above.
- Full `tests/hermes_cli/test_gui_command.py -q` is not clean in this local shared venv because unrelated baseline cases fail on missing `pathspec`.
