### PR TITLE
fix(test): ensure mtime advances in honcho cache-busting memo test

### DIFF
--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -10,6 +10,7 @@ Verifies that the agent cache correctly:
 """
 
 import threading
+import pytest
 from unittest.mock import MagicMock, patch
 
 
@@ -376,6 +377,16 @@ class TestExtractCacheBustingConfig:
         assert parse_calls == [config_path]
 
         config_path.write_text("{\n  \"changed\": true\n}")
+        # Ensure mtime actually advances — some filesystems (tmpfs, WSL
+        # VHDX) have coarse timestamps so back-to-back writes can land on
+        # the same nanosecond.  Nudge the timestamp forward explicitly.
+        import os, time
+        cur = config_path.stat().st_mtime_ns
+        os.utime(config_path, (time.time() + 1, time.time() + 1))
+        # Verify the nudge worked; if not, the test environment truly has
+        # no resolution and we skip the assertion (CI ext4 always works).
+        if config_path.stat().st_mtime_ns == cur:
+            pytest.skip("mtime did not advance — filesystem has no timestamp resolution")
         third = GatewayRunner._extract_honcho_cache_busting_config()
 
         assert third == first


### PR DESCRIPTION
## Summary

`test_honcho_cache_busting_config_memoized_by_mtime` is flaky on filesystems with coarse timestamp resolution (tmpfs, WSL VHDX, some CI runners). The test writes to a temp file and immediately re-reads `st_mtime_ns` to verify the cache key changed. On coarse-resolution filesystems, back-to-back writes can land on the same nanosecond, causing the memo key to match and the second parse to be skipped.

### Fix

Add `os.utime()` nudge after `write_text` to guarantee the timestamp advances, with a `pytest.skip` fallback if the environment truly has no resolution.

### Test Plan
- [x] `test_honcho_cache_busting_config_memoized_by_mtime` passes
- [x] All 68 tests in `test_agent_cache.py` pass
