### PR TITLE
fix(cli): respect busy input placeholder mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4326,6 +4326,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """
         return getattr(self, "_voice_record_key_display_cache", None) or "Ctrl+B"
 
+    def _busy_input_placeholder(self) -> str:
+        """Return the inline busy-input hint shown above the composer."""
+        return (
+            f"msg={self.busy_input_mode} · /queue · /bg · /steer · Ctrl+C cancel"
+        )
+
     def set_voice_record_key_cache(self, raw_key: object) -> None:
         """Populate the voice label cache from a raw ``voice.record_key``.
 
@@ -13073,7 +13079,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 status = cli_ref._command_status or "Processing command..."
                 return f"{frame} {status}"
             if cli_ref._agent_running:
-                return "msg=interrupt · /queue · /bg · /steer · Ctrl+C cancel"
+                return cli_ref._busy_input_placeholder()
             if cli_ref._voice_mode:
                 _label = cli_ref._voice_record_key_label()
                 return f"type or {_label} to record"

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -129,6 +129,20 @@ class TestBusyInputMode:
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "bogus"}})
         assert cli.busy_input_mode == "interrupt"
 
+    def test_busy_placeholder_reflects_queue_mode(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
+        assert (
+            cli._busy_input_placeholder()
+            == "msg=queue · /queue · /bg · /steer · Ctrl+C cancel"
+        )
+
+    def test_busy_placeholder_reflects_steer_mode(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "steer"}})
+        assert (
+            cli._busy_input_placeholder()
+            == "msg=steer · /queue · /bg · /steer · Ctrl+C cancel"
+        )
+
     def test_queue_command_works_while_busy(self):
         """When agent is running, /queue should still put the prompt in _pending_input."""
         cli = _make_cli()


### PR DESCRIPTION
## What does this PR do?

Fixes the interactive CLI composer placeholder so it reflects the configured `display.busy_input_mode` instead of always advertising `msg=interrupt` while the agent is running.

## Related Issue

Fixes #49390

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `HermesCLI._busy_input_placeholder()` so the busy composer hint is derived from the live `busy_input_mode`
- Switched the agent-running placeholder path to use the helper instead of a hardcoded `msg=interrupt` string
- Added focused CLI tests covering `queue` and `steer` placeholder rendering in `tests/cli/test_cli_init.py`

## How to Test

1. Set `display.busy_input_mode` to `queue` or `steer`
2. Start an interactive CLI session and wait until the agent is running
3. Confirm the composer placeholder shows `msg=queue` or `msg=steer` instead of `msg=interrupt`
4. Run `./.venv/bin/python -m pytest -q tests/cli/test_cli_init.py -k 'busy_input_mode or busy_placeholder'`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `./.venv/bin/python -m pytest -q tests/cli/test_cli_init.py -k 'busy_input_mode or busy_placeholder'` → `5 passed, 38 deselected in 0.58s`
- `git diff --check`
- `./.venv/bin/python -m py_compile cli.py tests/cli/test_cli_init.py`
