### PR TITLE
feat: add JSON output for one-shot CLI

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -111,6 +111,16 @@ def build_top_level_parser():
             "auto-bypassed. Intended for scripts / pipes."
         ),
     )
+    parser.add_argument(
+        "--output-format",
+        choices=("text", "json"),
+        default="text",
+        help=(
+            "Output format for -z/--oneshot. 'text' prints only the final "
+            "response (default); 'json' prints a single JSON object with a "
+            "response field for script-safe parsing."
+        ),
+    )
     # --model / --provider are accepted at the top level so they can pair
     # with -z without needing the `chat` subcommand.  If neither -z nor a
     # subcommand consumes them, they fall through harmlessly as None.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11369,6 +11369,7 @@ def _try_termux_fast_cli_launch() -> bool:
                 model=getattr(args, "model", None),
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
+                output_format=getattr(args, "output_format", "text"),
             )
         )
 
@@ -12602,6 +12603,7 @@ def main():
                 model=getattr(args, "model", None),
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
+                output_format=getattr(args, "output_format", "text"),
             )
         )
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -21,6 +21,7 @@ Env var fallbacks (used when the corresponding arg is not passed):
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sys
@@ -127,6 +128,7 @@ def run_oneshot(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     toolsets: object = None,
+    output_format: str = "text",
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -137,6 +139,8 @@ def run_oneshot(
         provider: Optional provider override. Falls back to config.yaml's
             model.provider, then "auto".
         toolsets: Optional comma-separated string or iterable of toolsets.
+        output_format: ``"text"`` for the historical plain final response, or
+            ``"json"`` for a single machine-readable JSON object.
 
     Returns the exit code.  Caller should sys.exit() with the return.
     """
@@ -146,6 +150,10 @@ def run_oneshot(
     # the root logger's handler list, not affected by level), but no
     # bytes reach the terminal.
     logging.disable(logging.CRITICAL)
+
+    if output_format not in {"text", "json"}:
+        sys.stderr.write("hermes -z: --output-format must be one of: text, json\n")
+        return 2
 
     # --provider without --model is ambiguous: carrying the user's configured
     # model across to a different provider is usually wrong (that provider may
@@ -219,9 +227,13 @@ def run_oneshot(
         return 1
 
     assert response is not None  # narrowed by the empty-response guard above
-    real_stdout.write(response)
-    if not response.endswith("\n"):
+    if output_format == "json":
+        real_stdout.write(json.dumps({"response": response}, ensure_ascii=False))
         real_stdout.write("\n")
+    else:
+        real_stdout.write(response)
+        if not response.endswith("\n"):
+            real_stdout.write("\n")
     real_stdout.flush()
     return 0
 

--- a/tests/hermes_cli/test_oneshot_output_format.py
+++ b/tests/hermes_cli/test_oneshot_output_format.py
@@ -1,0 +1,43 @@
+import json
+
+from hermes_cli._parser import build_top_level_parser
+from hermes_cli import oneshot
+
+
+def test_run_oneshot_json_output_emits_single_json_object(monkeypatch, capsys):
+    monkeypatch.setattr(oneshot, "_run_agent", lambda *args, **kwargs: "hello from hermes")
+
+    rc = oneshot.run_oneshot("say hi", output_format="json")
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.err == ""
+    assert json.loads(captured.out) == {"response": "hello from hermes"}
+
+
+def test_run_oneshot_text_output_remains_plain_text(monkeypatch, capsys):
+    monkeypatch.setattr(oneshot, "_run_agent", lambda *args, **kwargs: "plain text")
+
+    rc = oneshot.run_oneshot("say hi", output_format="text")
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == "plain text\n"
+
+
+def test_run_oneshot_rejects_invalid_programmatic_output_format(capsys):
+    rc = oneshot.run_oneshot("say hi", output_format="xml")
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "--output-format must be one of: text, json" in captured.err
+    assert captured.out == ""
+
+
+def test_top_level_parser_accepts_oneshot_output_format():
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+
+    args = parser.parse_args(["--oneshot", "say hi", "--output-format", "json"])
+
+    assert args.oneshot == "say hi"
+    assert args.output_format == "json"

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -379,6 +379,7 @@ def test_termux_fast_cli_launch_oneshot_uses_light_parser(monkeypatch, main_mod)
         "model": "gpt-test",
         "provider": "openai",
         "toolsets": None,
+        "output_format": "text",
     }
 
 
@@ -617,6 +618,7 @@ def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
         "model": None,
         "provider": None,
         "toolsets": "web,terminal",
+        "output_format": "text",
     }
 
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -131,14 +131,18 @@ hermes chat --safe-mode -q "Is this bug mine or Hermes'?"
 
 ### `hermes -z <prompt>` — scripted one-shot
 
-For programmatic callers (shell scripts, CI, cron, parent processes piping in a prompt), `hermes -z` is the purest one-shot entry point: **single prompt in, final response text out, nothing else on stdout or stderr.** No banner, no spinner, no tool previews, no `Session:` line — just the agent's final reply as plain text.
+For programmatic callers (shell scripts, CI, cron, parent processes piping in a prompt), `hermes -z` is the purest one-shot entry point: **single prompt in, final response out, nothing else on stdout or stderr.** No banner, no spinner, no tool previews, no `Session:` line — just the agent's final reply.
 
 ```bash
 hermes -z "What's the capital of France?"
 # → Paris.
 
-# Parent scripts can cleanly capture the response:
+# Parent scripts can cleanly capture the plain-text response:
 answer=$(hermes -z "summarize this" < /path/to/file.txt)
+
+# Or request a single JSON object for machine parsing:
+hermes -z "Return a haiku" --output-format json
+# → {"response":"..."}
 ```
 
 Per-run overrides (no mutation to `~/.hermes/config.yaml`):
@@ -154,7 +158,7 @@ hermes -z "…" --provider openrouter --model openai/gpt-5.5
 HERMES_INFERENCE_MODEL=anthropic/claude-sonnet-4.6 hermes -z "…"
 ```
 
-Same agent, same tools, same skills — just strips every interactive / cosmetic layer. If you need tool output in the transcript too, use `hermes chat -q` instead; `-z` is explicitly for "I only want the final answer".
+Same agent, same tools, same skills — just strips every interactive / cosmetic layer. `--output-format` currently applies only to `-z` / `--oneshot`. If you need tool output in the transcript too, use `hermes chat -q` instead; `-z` is explicitly for "I only want the final answer".
 
 ## `hermes model`
 


### PR DESCRIPTION
## Summary
- Adds a `--output-format` option for one-shot CLI runs.
- Supports structured JSON output for script-safe, machine-readable one-shot usage.
- Documents the new CLI option and covers resume-flow parser behavior.

## Validation
- `venv/bin/python -m pytest tests/hermes_cli/test_oneshot_output_format.py tests/hermes_cli/test_tui_resume_flow.py -q -o 'addopts='`
- Result: `50 passed in 0.90s`

## Notes
- Split out from the previous combined branch so this PR is focused only on one-shot JSON output.
