### PR TITLE
fix(dump): report the effective private-URL policy

### DIFF
--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -242,8 +242,16 @@ def _config_overrides(config: dict) -> dict[str, str]:
             overrides["security.allow_private_urls"] = (
                 "true (SSRF private-IP blocking DISABLED)"
             )
-    except Exception:
+    except ImportError:
+        # url_safety unavailable (e.g. trimmed install) — nothing to report.
         pass
+    except Exception as exc:
+        # The resolver itself failed. Don't silently hide it: a swallowed error
+        # here would defeat the purpose of surfacing the SSRF posture during
+        # support/security triage, so report it explicitly.
+        overrides["security.allow_private_urls"] = (
+            f"unknown ({type(exc).__name__}: error resolving effective policy)"
+        )
 
     # Toolsets (if different from default)
     default_toolsets = DEFAULT_CONFIG.get("toolsets", [])

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -206,7 +206,6 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("terminal", "backend"),
         ("terminal", "docker_image"),
         ("terminal", "persistent_shell"),
-        ("browser", "allow_private_urls"),
         ("compression", "enabled"),
         ("compression", "threshold"),
         ("display", "streaming"),
@@ -225,6 +224,26 @@ def _config_overrides(config: dict) -> dict[str, str]:
         user_val = user_section.get(key)
         if user_val is not None and user_val != default_val:
             overrides[f"{section}.{key}"] = str(user_val)
+
+    # Effective private-URL (SSRF) policy — mirror the runtime resolver's full
+    # precedence (HERMES_ALLOW_PRIVATE_URLS env > security.allow_private_urls >
+    # browser.allow_private_urls legacy) instead of only the legacy config key,
+    # so a relaxed SSRF posture set via the env var or the preferred config key
+    # is not hidden from the support summary.
+    try:
+        from tools.url_safety import (
+            _global_allow_private_urls,
+            _reset_allow_private_cache,
+        )
+
+        # One-shot CLI: read THIS process's config/env, not a stale cache.
+        _reset_allow_private_cache()
+        if _global_allow_private_urls():
+            overrides["security.allow_private_urls"] = (
+                "true (SSRF private-IP blocking DISABLED)"
+            )
+    except Exception:
+        pass
 
     # Toolsets (if different from default)
     default_toolsets = DEFAULT_CONFIG.get("toolsets", [])

--- a/tests/hermes_cli/test_dump_allow_private_urls.py
+++ b/tests/hermes_cli/test_dump_allow_private_urls.py
@@ -41,7 +41,9 @@ def test_dump_surfaces_security_config_key(monkeypatch, capsys, tmp_path):
 
     out = _run(monkeypatch, capsys, tmp_path)
 
-    assert "allow_private_urls" in out
+    # Must report under the effective/preferred key, never the legacy one.
+    assert "security.allow_private_urls" in out
+    assert "browser.allow_private_urls" not in out
     assert "DISABLED" in out
 
 
@@ -53,7 +55,10 @@ def test_dump_surfaces_env_var(monkeypatch, capsys, tmp_path):
 
     out = _run(monkeypatch, capsys, tmp_path)
 
-    assert "allow_private_urls" in out
+    # Even when the env var drives the effective policy, the dump must report it
+    # under the preferred key, not the legacy one.
+    assert "security.allow_private_urls" in out
+    assert "browser.allow_private_urls" not in out
     assert "DISABLED" in out
 
 
@@ -66,3 +71,29 @@ def test_dump_silent_when_locked_down(monkeypatch, capsys, tmp_path):
     out = _run(monkeypatch, capsys, tmp_path)
 
     assert "allow_private_urls" not in out
+
+
+def test_dump_reports_unknown_when_resolver_errors(monkeypatch, capsys, tmp_path):
+    """A resolver failure must surface as an explicit unknown/error value.
+
+    Previously the resolver call was wrapped in ``except Exception: pass``, so a
+    runtime failure resolving the effective SSRF policy was silently hidden —
+    defeating the purpose of surfacing this posture during support/security
+    triage. The dump must now report an explicit ``unknown (...)`` value.
+    """
+    from hermes_cli.config import get_hermes_home
+    from tools import url_safety
+
+    monkeypatch.delenv("HERMES_ALLOW_PRIVATE_URLS", raising=False)
+    _seed(get_hermes_home())
+
+    def _boom() -> bool:
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(url_safety, "_global_allow_private_urls", _boom)
+
+    out = _run(monkeypatch, capsys, tmp_path)
+
+    assert "security.allow_private_urls" in out
+    assert "unknown" in out
+    assert "RuntimeError" in out

--- a/tests/hermes_cli/test_dump_allow_private_urls.py
+++ b/tests/hermes_cli/test_dump_allow_private_urls.py
@@ -1,0 +1,68 @@
+"""`hermes dump` must report the EFFECTIVE private-URL (SSRF) policy.
+
+The runtime resolver ``tools.url_safety._global_allow_private_urls`` honors, in
+priority order, the ``HERMES_ALLOW_PRIVATE_URLS`` env var, then the preferred
+``security.allow_private_urls`` config key, then the legacy
+``browser.allow_private_urls`` key.  The dump used to inspect only the legacy
+config key, so a user who relaxed SSRF private-IP blocking via the env var or
+the modern config key got a dump that hid the override entirely — implying a
+locked-down posture while the agent was actually permitting private/internal-IP
+fetches.  The dump now reports the effective value via the same resolver.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _seed(home: Path, *, config_yaml: str = "", env_text: str = "") -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(config_yaml)
+    (home / ".env").write_text(env_text)
+
+
+def _run(monkeypatch, capsys, tmp_path) -> str:
+    from hermes_cli import dump
+    from tools import url_safety
+
+    # Resolver caches process-wide; reset so case ordering can't leak.
+    url_safety._reset_allow_private_cache()
+    # Keep run_dump's project-.env fallback from touching the real repo.
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+    return capsys.readouterr().out
+
+
+def test_dump_surfaces_security_config_key(monkeypatch, capsys, tmp_path):
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("HERMES_ALLOW_PRIVATE_URLS", raising=False)
+    _seed(get_hermes_home(), config_yaml="security:\n  allow_private_urls: true\n")
+
+    out = _run(monkeypatch, capsys, tmp_path)
+
+    assert "allow_private_urls" in out
+    assert "DISABLED" in out
+
+
+def test_dump_surfaces_env_var(monkeypatch, capsys, tmp_path):
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("HERMES_ALLOW_PRIVATE_URLS", raising=False)
+    _seed(get_hermes_home(), env_text="HERMES_ALLOW_PRIVATE_URLS=true\n")
+
+    out = _run(monkeypatch, capsys, tmp_path)
+
+    assert "allow_private_urls" in out
+    assert "DISABLED" in out
+
+
+def test_dump_silent_when_locked_down(monkeypatch, capsys, tmp_path):
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("HERMES_ALLOW_PRIVATE_URLS", raising=False)
+    _seed(get_hermes_home())
+
+    out = _run(monkeypatch, capsys, tmp_path)
+
+    assert "allow_private_urls" not in out


### PR DESCRIPTION
## This is a sibling follow-up to #46628 (report effective terminal backend)

- #46628 covered: `terminal.backend` — dump now reports the effective value, not the raw config key.
- #46628 did NOT touch: the private-URL / SSRF policy field — same "dump shows a raw config key instead of the effective runtime value" class, different resolver.
- This PR makes `hermes dump` mirror `tools/url_safety._global_allow_private_urls()`'s full precedence (`HERMES_ALLOW_PRIVATE_URLS` env > `security.allow_private_urls` > `browser.allow_private_urls` legacy).

## What does this PR do?

`hermes dump` only inspected the legacy `browser.allow_private_urls` config key, so disabling SSRF private-IP blocking via the preferred `security.allow_private_urls` key or the `HERMES_ALLOW_PRIVATE_URLS` env var produced a dump that hid the override entirely — misleading during support triage of exactly the scenario (agent reaching an internal/metadata IP) where it matters most. dump now reports the EFFECTIVE policy by calling the same resolver the runtime uses, mirroring its full `env > security cfg > browser cfg (legacy)` precedence.

Mirrors `tools/url_safety._global_allow_private_urls()` precedence: `HERMES_ALLOW_PRIVATE_URLS` env > `security.allow_private_urls` > `browser.allow_private_urls` (legacy).

## Related Issue

<!-- Code-originated; no filed issue. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/dump.py`: `_config_overrides()` now resolves the effective private-URL policy via `tools.url_safety._global_allow_private_urls()` (resetting its process cache first so a one-shot CLI reads the current process's config/env), reporting it once as `security.allow_private_urls`. Removed the lone legacy `("browser", "allow_private_urls")` raw-key entry it superseded.
- `tests/hermes_cli/test_dump_allow_private_urls.py`: new regression test.

## How to Test

1. `echo "security:\n  allow_private_urls: true" >> ~/.hermes/config.yaml` then run `hermes dump` — the `config_overrides` block now shows `security.allow_private_urls: true (SSRF private-IP blocking DISABLED)`.
2. Or set `HERMES_ALLOW_PRIVATE_URLS=true` in the environment and run `hermes dump` — same line appears even with no config key set.
3. With neither set, the line is absent. Automated: `pytest tests/hermes_cli/test_dump_allow_private_urls.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused tests for the touched code and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config key; mirrors an existing runtime resolver)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — env/config resolution is platform-agnostic

> Audited siblings: `tools/url_safety._global_allow_private_urls()` is the single resolver; dump now mirrors its full precedence. No other dump field reads this policy. No widening needed.