### PR TITLE
fix: harden gateway approvals and usage-limit handling

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -215,12 +215,19 @@ def build_acp_edit_tool_call(proposal: EditProposal):
     import acp
 
     tool_call_id = f"edit-approval-{next(_PERMISSION_REQUEST_IDS)}"
+    explanation = (
+        "What I’m asking to do: Approve the proposed file edit before Hermes writes it.\n"
+        f"Path: {proposal.path}\n\n"
+        "Why permission is required: This changes files in your workspace instead of only reading them.\n"
+        "Risk: The edit could introduce bugs, overwrite work, or modify the wrong file if the diff is not what you intended. Review the diff below before approving."
+    )
     return acp.update_tool_call(
         tool_call_id,
         title=f"Approve edit: {proposal.path}",
         kind="edit",
         status="pending",
         content=[
+            acp.tool_content(acp.text_block(explanation)),
             acp.tool_diff_content(
                 path=proposal.path,
                 old_text=proposal.old_text,

--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -80,8 +80,14 @@ def _build_permission_tool_call(command: str, description: str):
     import acp as _acp
 
     tool_call_id = f"perm-check-{next(_PERMISSION_REQUEST_IDS)}"
-    title = f"{description}: {command}" if description else command
-    content_text = f"{description}\n$ {command}" if description else f"$ {command}"
+    title = f"Approve command: {command}"
+    reason = description or "potentially risky command"
+    content_text = (
+        "What I’m asking to do: Run this command.\n"
+        f"$ {command}\n\n"
+        f"Why permission is required: Hermes flagged it as {reason}.\n"
+        "Risk: It may change files, system state, credentials, or external services depending on what the command does. Approve only if that scope looks right."
+    )
     return _acp.update_tool_call(
         tool_call_id,
         title=title,

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -843,7 +843,22 @@ def _classify_by_status(
         )
 
     if status_code == 429:
-        # Already checked long_context_tier above; this is a normal rate limit
+        # Account/plan usage caps are quota walls, not transient per-minute
+        # throttles. Retrying the identical huge request immediately just burns
+        # attempts and tokens until the reset window. Treat them like billing so
+        # the loop rotates/falls back if possible, otherwise aborts fast.
+        if (
+            "usage_limit_reached" in error_code.lower()
+            or "usage limit has been reached" in error_msg
+            or "usage limit reached" in error_msg
+        ):
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
+            )
+        # Already checked long_context_tier above; this is a normal rate limit.
         return result_fn(
             FailoverReason.rate_limit,
             retryable=True,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -52,6 +52,31 @@ def _float_env(name: str, default: float) -> float:
         return default
 
 
+def _retry_after_seconds(error: str | None) -> float | None:
+    """Extract a platform-advised retry delay from an error string.
+
+    Telegram reports flood control as both ``Retry in 32 seconds`` and, on
+    internal paths, ``flood_control:32``. Generic exponential backoff retries
+    too early for those errors and can burn every retry inside the same flood
+    window. Return ``None`` when no explicit server wait is present.
+    """
+    if not error:
+        return None
+    text = str(error)
+    patterns = (
+        r"flood_control\s*:\s*(\d+(?:\.\d+)?)",
+        r"retry\s+(?:in|after)\s+(\d+(?:\.\d+)?)\s*(?:s|sec|second|seconds)?",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            try:
+                return max(0.0, float(match.group(1)))
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
 def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) -> dict | None:
     """Build platform-aware thread metadata for adapter sends.
 
@@ -3457,9 +3482,15 @@ class BasePlatformAdapter(ABC):
             return result
 
         if is_network:
-            # Retry with exponential backoff for transient errors
+            # Retry with exponential backoff for transient errors. If the
+            # platform gave us an explicit retry-after/flood-control window,
+            # honor it instead of retrying early and exhausting every attempt
+            # inside the same rate-limit bucket.
+            retry_after = _retry_after_seconds(error_str)
             for attempt in range(1, max_retries + 1):
                 delay = base_delay * (2 ** (attempt - 1)) + random.uniform(0, 1)
+                if retry_after is not None:
+                    delay = max(delay, retry_after + 0.25)
                 logger.warning(
                     "[%s] Send failed (attempt %d/%d, retrying in %.1fs): %s",
                     self.name, attempt, max_retries, delay, error_str,
@@ -3477,6 +3508,7 @@ class BasePlatformAdapter(ABC):
                 error_str = result.error or ""
                 if not (result.retryable or self._is_retryable_error(error_str)):
                     break  # error switched to non-transient — fall through to plain-text fallback
+                retry_after = _retry_after_seconds(error_str)
             else:
                 # All retries exhausted (loop completed without break) — notify user
                 logger.error("[%s] Failed to deliver response after %d retries: %s", self.name, max_retries, error_str)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -80,6 +80,7 @@ from gateway.platforms.base import (
     SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES,
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
+    _retry_after_seconds,
     utf16_len,
 )
 from gateway.platforms.telegram_network import (
@@ -2934,6 +2935,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 # send continuations.
                 pass
             else:
+                retry_after = _retry_after_seconds(str(e))
+                if retry_after is not None:
+                    logger.warning(
+                        "[%s] Overflow split: first-chunk edit hit flood control; retrying final delivery after %.1fs",
+                        self.name, retry_after,
+                    )
+                    return SendResult(
+                        success=False,
+                        error=f"flood_control:{retry_after}",
+                        retryable=True,
+                    )
                 logger.error(
                     "[%s] Overflow split: first-chunk edit failed: %s",
                     self.name, e, exc_info=True,
@@ -3284,11 +3296,14 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
+            cmd_preview = command[:3400] + "..." if len(command) > 3400 else command
+            desc = _html.escape(description or "potentially risky command")
             text = (
                 f"⚠️ <b>Command Approval Required</b>\n\n"
+                f"<b>What I’m asking to do:</b> Run this command:\n"
                 f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
-                f"Reason: {_html.escape(description)}"
+                f"<b>Why permission is required:</b> Hermes flagged it as {desc}.\n"
+                f"<b>Risk:</b> It may change files, system state, credentials, or external services depending on what the command does. Approve only if that scope looks right."
             )
 
             # Resolve thread context for thread replies

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15661,11 +15661,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # can actually type (`!approve`) — typed "/" is blocked in
                 # Slack threads and reserved by Matrix clients.
                 _p = getattr(_status_adapter, "typed_command_prefix", "/")
-                cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
+                cmd_preview = cmd[:160] + "..." if len(cmd) > 160 else cmd
                 msg = (
-                    f"⚠️ **Dangerous command requires approval:**\n"
+                    f"⚠️ **Command approval required**\n\n"
+                    f"**What I’m asking to do:** Run this command:\n"
                     f"```\n{cmd_preview}\n```\n"
-                    f"Reason: {desc}\n\n"
+                    f"**Why permission is required:** Hermes flagged it as {desc}.\n"
+                    f"**Risk:** It may change files, system state, credentials, or external services depending on what the command does. Approve only if that scope looks right.\n\n"
                     f"Reply `{_p}approve` to execute, `{_p}approve session` to approve this pattern "
                     f"for the session, `{_p}approve always` to approve permanently, or `{_p}deny` to cancel."
                 )

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -34,8 +34,14 @@ def test_acp_permission_tool_call_uses_edit_kind_and_diff_content():
     assert tool_call.kind == "edit"
     assert tool_call.status == "pending"
     assert tool_call.rawInput == {"tool": "write_file", "arguments": proposal.arguments}
-    assert len(tool_call.content) == 1
-    diff = tool_call.content[0]
+    assert tool_call.content is not None
+    assert len(tool_call.content) == 2
+    explanation = tool_call.content[0].content.text
+    assert "What I’m asking to do" in explanation
+    assert "Why permission is required" in explanation
+    assert "Risk:" in explanation
+    assert "demo.txt" in explanation
+    diff = tool_call.content[1]
     assert diff.path == "demo.txt"
     assert diff.oldText == "old\n"
     assert diff.newText == "new\n"

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -76,9 +76,12 @@ class TestApprovalBridge:
         assert tool_call.tool_call_id.startswith("perm-check-")
         assert tool_call.kind == "execute"
         assert tool_call.status == "pending"
-        assert "dangerous command" in tool_call.title
+        assert "Approve command" in tool_call.title
         assert "rm -rf /" in tool_call.title
         content_text = tool_call.content[0].content.text
+        assert "What I’m asking to do" in content_text
+        assert "Why permission is required" in content_text
+        assert "Risk:" in content_text
         assert "$ rm -rf /" in content_text
         assert "dangerous command" in content_text
         assert tool_call.raw_input == {

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -12,7 +12,7 @@ import pytest
 from unittest.mock import AsyncMock, patch
 
 from gateway.platforms.base import BasePlatformAdapter, SendResult, _RETRYABLE_ERROR_PATTERNS
-from gateway.platforms.base import Platform, PlatformConfig
+from gateway.platforms.base import Platform, PlatformConfig, _retry_after_seconds
 
 
 # ---------------------------------------------------------------------------
@@ -46,6 +46,26 @@ class _StubAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id):
         return {"name": "test", "type": "direct", "chat_id": chat_id}
+
+
+# ---------------------------------------------------------------------------
+# Retry-after parsing
+# ---------------------------------------------------------------------------
+
+class TestRetryAfterSeconds:
+    @pytest.mark.parametrize(
+        ("error", "expected"),
+        [
+            ("Flood control exceeded. Retry in 32 seconds", 32.0),
+            ("Retry after 4", 4.0),
+            ("flood_control:29.5", 29.5),
+        ],
+    )
+    def test_extracts_platform_retry_after(self, error, expected):
+        assert _retry_after_seconds(error) == expected
+
+    def test_returns_none_without_retry_after(self):
+        assert _retry_after_seconds("httpx.ConnectError: refused") is None
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +208,26 @@ class TestSendWithRetryNetworkRetry:
         with patch("asyncio.sleep", new_callable=AsyncMock):
             result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
         assert result.success
+        assert len(adapter._send_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_honors_platform_retry_after_before_retrying(self):
+        """Flood-control errors must wait the server-advised window, not generic 2s backoff."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(
+                success=False,
+                error="Flood control exceeded. Retry in 32 seconds",
+                retryable=True,
+            ),
+            SendResult(success=True, message_id="ok"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
+        assert result.success
+        sleep_args = mock_sleep.await_args
+        assert sleep_args is not None
+        assert sleep_args.args[0] >= 32
         assert len(adapter._send_calls) == 2
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_overflow_partial.py
+++ b/tests/gateway/test_telegram_overflow_partial.py
@@ -96,6 +96,25 @@ async def test_edit_overflow_split_reports_partial_failure_when_continuation_fai
 
 
 @pytest.mark.asyncio
+async def test_edit_overflow_split_returns_retryable_flood_control_for_first_chunk(telegram_adapter):
+    """First-chunk flood control should be retried later, not logged as a hard adapter error."""
+    content = "word " * 120
+    telegram_adapter._bot.edit_message_text = AsyncMock(
+        side_effect=RuntimeError("Flood control exceeded. Retry in 32 seconds")
+    )
+    telegram_adapter._bot.send_message = AsyncMock()
+
+    result = await telegram_adapter._edit_overflow_split(
+        "12345", "201", content, finalize=False, metadata={"thread_id": "77"}
+    )
+
+    assert result.success is False
+    assert result.retryable is True
+    assert result.error == "flood_control:32.0"
+    telegram_adapter._bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_stream_consumer_fallback_sends_tail_after_partial_overflow():
     """A partial overflow edit enters fallback instead of marking final delivered."""
     adapter = MagicMock()

--- a/tests/run_agent/test_usage_limit_429_fast_fail.py
+++ b/tests/run_agent/test_usage_limit_429_fast_fail.py
@@ -1,0 +1,63 @@
+"""Regression tests for account usage-limit 429 handling.
+
+A plan/account usage cap that resets hours later is not a transient per-minute
+rate limit. Retrying the same request burns requests/tokens and still cannot
+succeed before the reset window.
+"""
+
+from types import SimpleNamespace
+
+from agent.error_classifier import FailoverReason, classify_api_error
+
+
+class _UsageLimit429(Exception):
+    status_code = 429
+
+    def __init__(self):
+        super().__init__("HTTP 429: The usage limit has been reached")
+        self.body = {
+            "error": {
+                "type": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+                "resets_in_seconds": 14_000,
+            }
+        }
+        self.response = SimpleNamespace(json=lambda: self.body)
+
+
+def test_usage_limit_429_is_not_retried_as_transient_rate_limit():
+    classified = classify_api_error(
+        _UsageLimit429(),
+        provider="openai-codex",
+        model="gpt-5.5",
+    )
+
+    assert classified.reason == FailoverReason.billing
+    assert classified.retryable is False
+    assert classified.should_rotate_credential is True
+    assert classified.should_fallback is True
+
+
+class _Normal429(Exception):
+    status_code = 429
+
+    def __init__(self):
+        super().__init__("HTTP 429: rate limit exceeded, retry later")
+        self.body = {
+            "error": {
+                "type": "rate_limit_exceeded",
+                "message": "Rate limit exceeded; retry later",
+            }
+        }
+        self.response = SimpleNamespace(json=lambda: self.body)
+
+
+def test_normal_429_still_retries_as_rate_limit():
+    classified = classify_api_error(
+        _Normal429(),
+        provider="openai-codex",
+        model="gpt-5.5",
+    )
+
+    assert classified.reason == FailoverReason.rate_limit
+    assert classified.retryable is True

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -77,7 +78,7 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(os.path.realpath("/tmp/out.txt"), "hello world!\n")
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -155,7 +156,7 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(os.path.realpath("/tmp/f.py"), "foo", "bar", False)
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -168,7 +169,7 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         patch_tool(mode="replace", path="/tmp/f.py",
                    old_string="x", new_string="y", replace_all=True)
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
+        mock_ops.patch_replace.assert_called_once_with(os.path.realpath("/tmp/f.py"), "x", "y", True)
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import tempfile
 import threading
 from pathlib import Path
 
@@ -350,6 +351,30 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
+def _is_under_path(path: str, parent: str) -> bool:
+    """Return True when ``path`` is ``parent`` or a descendant of it."""
+    try:
+        return os.path.commonpath([path, parent]) == parent
+    except (OSError, ValueError):
+        return False
+
+
+def _is_allowed_temp_path(resolved: str, normalized: str) -> bool:
+    """Allow file-tool writes inside the platform temp directory.
+
+    On macOS, ``tempfile.gettempdir()`` commonly resolves under
+    ``/private/var/folders/...``. That prefix is otherwise blocked because it
+    also contains sensitive system databases and logs. The guard should block
+    those system locations without breaking pytest fixtures and normal temp-file
+    workflows.
+    """
+    try:
+        temp_dir = os.path.realpath(tempfile.gettempdir())
+    except (OSError, ValueError):
+        return False
+    return _is_under_path(resolved, temp_dir) or _is_under_path(normalized, temp_dir)
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -361,11 +386,6 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
-    for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
-            return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
-        return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or
     # prompt-injected agent could silently disable exec approval by writing to
@@ -377,6 +397,13 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
+    if _is_allowed_temp_path(resolved, normalized):
+        return None
+    for prefix in _SENSITIVE_PATH_PREFIXES:
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
+            return _err
+    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+        return _err
     return None
 
 


### PR DESCRIPTION
## Summary
- Hardens ACP edit approval and permission behavior for file edits.
- Improves gateway/Telegram send retry and partial-overflow handling.
- Classifies usage-limit 429s as fast-fail errors.
- Allows file-tool writes inside the platform temp directory on macOS while preserving Hermes config and sensitive system path protections.

## Validation
- `venv/bin/python -m pytest tests/acp/test_edit_approval.py tests/acp/test_permissions.py tests/gateway/test_send_retry.py tests/gateway/test_telegram_overflow_partial.py tests/run_agent/test_usage_limit_429_fast_fail.py tests/tools/test_approval.py tests/tools/test_file_tools*.py tests/tools/test_patch_failure_tracking.py -q -o 'addopts='`
- Result: `409 passed in 16.11s`

## Notes
- Split out from the previous combined branch so this PR is focused only on gateway/approval/usage-limit hardening.
