### PR TITLE
fix(slack): escape special chars in converted link labels

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1612,6 +1612,17 @@ class SlackAdapter(BasePlatformAdapter):
             url = m.group(2).strip()
             if url.startswith("<") and url.endswith(">"):
                 url = url[1:-1].strip()
+            # The entity is stashed behind a placeholder, so it bypasses the
+            # plain-text escape pass (step 6). Slack requires &, <, > inside a
+            # <...> entity to be escaped, else a > in the label closes the
+            # entity early and breaks the link (e.g. a breadcrumb "docs > x").
+            # The URL is left raw so query-string '&' is preserved (Slack
+            # accepts it in the URL component of a link entity).
+            label = (
+                label.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+            )
             return _ph(f"<{url}|{label}>")
 
         text = re.sub(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2027,6 +2027,22 @@ class TestFormatMessage:
             == "<http://x.com|A &lt; B>"
         )
 
+    def test_link_label_escapes_preexisting_entity(self, adapter):
+        # A label that already contains an entity like '&gt;' must have its
+        # leading '&' escaped to '&amp;' so the literal text survives intact
+        # ('&gt;' -> '&amp;gt;'). Because '&' is escaped first, this also
+        # guards against double-unescaping. If the escape order regressed
+        # (e.g. '&' escaped last), the label would collapse to a real '>'
+        # and close the <...> entity early.
+        assert (
+            adapter.format_message("[docs &gt; setup](http://x.com)")
+            == "<http://x.com|docs &amp;gt; setup>"
+        )
+        assert (
+            adapter.format_message("[Tom &amp; Jerry](http://x.com)")
+            == "<http://x.com|Tom &amp;amp; Jerry>"
+        )
+
     def test_preserves_existing_slack_entities(self, adapter):
         text = "Hey <@U123>, see <https://example.com|example> and <!here>"
         assert adapter.format_message(text) == text

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2010,6 +2010,23 @@ class TestFormatMessage:
         result = adapter.format_message("AT&T < 5 > 3")
         assert result == "AT&amp;T &lt; 5 &gt; 3"
 
+    def test_link_label_escapes_special_chars(self, adapter):
+        # The link entity is stashed before the plain-text escape pass, so the
+        # label must be escaped when the entity is built. An unescaped '>' in a
+        # label would otherwise close the <...> entity early and break the link.
+        assert (
+            adapter.format_message("[docs > setup](http://x.com)")
+            == "<http://x.com|docs &gt; setup>"
+        )
+        assert (
+            adapter.format_message("[Tom & Jerry](http://x.com)")
+            == "<http://x.com|Tom &amp; Jerry>"
+        )
+        assert (
+            adapter.format_message("[A < B](http://x.com)")
+            == "<http://x.com|A &lt; B>"
+        )
+
     def test_preserves_existing_slack_entities(self, adapter):
         text = "Hey <@U123>, see <https://example.com|example> and <!here>"
         assert adapter.format_message(text) == text


### PR DESCRIPTION
## What does this PR do?

`SlackAdapter.format_message` converts markdown links `[label](url)` into Slack `<url|label>` entities and stashes them behind a placeholder BEFORE the plain-text escaping pass, so `&`, `<`, and `>` inside the link label are never escaped. Per Slack's API, text inside a `<...>` entity must escape those three characters; an unescaped `>` in a label closes the link entity early and renders a broken link (e.g. a breadcrumb label like `docs > setup`). This PR escapes the label when building the entity, matching the existing plain-text escape and Telegram's sibling behavior.

The URL component is intentionally left raw so a query-string `&` is preserved — that is an existing, tested contract (`test_url_with_query_string_and_ampersand`), and Slack accepts `&` in the URL part of a link entity.

## Related Issue

<!-- Code-originated; no filed issue. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/slack.py`: in `_convert_markdown_link` (inside `format_message`), HTML-escape `&`/`<`/`>` in the link label before building the `<url|label>` entity. URL left raw to preserve query-string ampersands.
- `tests/gateway/test_slack.py`: new `test_link_label_escapes_special_chars`.

## How to Test

1. `pytest tests/gateway/test_slack.py -q` — 197 pass.
2. Targeted: `format_message("[docs > setup](http://x.com)")` now yields `<http://x.com|docs &gt; setup>` (was `<http://x.com|docs > setup>`, which Slack renders as a broken link).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused tests for the touched code and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string transform, platform-agnostic

> Sibling code paths that may need the same fix: none found — `_convert_markdown_link` is the only place a Slack link entity is built from agent markdown. Intentionally scoped to the one converter; happy to widen if preferred.