### PR TITLE
fix(qqbot): approval button clicks rejected for DM sessions

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1092,7 +1092,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:


### PR DESCRIPTION
## Problem

QQ Bot approval button clicks are **always rejected** in DM (private chat) sessions, causing the agent to wait the full 60-second approval timeout on every tool call that requires approval.

**Root cause:** `build_session_key` (in `gateway/session.py`) uses `"dm"` as the chat_type for private chats, producing session keys like:
```
agent:main:qqbot:dm:3760DA980EE3BBA3476394E834F7A3AE
```

But `_is_authorized_interaction_for_session` (in `gateway/platforms/qqbot/adapter.py`) checks for `"c2c"`:
```python
if chat_type == "c2c":  # "dm" != "c2c" → always returns False
```

This means every approval button click is rejected as unauthorized. The agent falls back to waiting for the 60-second timeout, adding massive latency to any operation involving tool approval.

## Evidence

From gateway logs — 72 total approval rejections, all with the same pattern:
```
[QQBot:1903948564] Rejected unauthorized approval click for session
agent:main:qqbot:dm:3760DA980EE3BBA3476394E834F7A3AE
(operator=3760DA980EE3BBA3476394E834F7A3AE)
```

Average response time was **277 seconds** (median 56s), with the worst case at **3744 seconds** (~62 minutes). After the fix, operations that don't need tool approval complete in 10-40 seconds.

## Fix

Accept both `"c2c"` (QQ API native term) and `"dm"` (canonical session key form) in the authorization check:

```python
# Before
if chat_type == "c2c":
# After
if chat_type in {"c2c", "dm"}:
```

Only the authorization check in `_is_authorized_interaction_for_session` is changed. The other `chat_type == "c2c"` checks in the message sending path (lines 2475, 2602, 2924) correctly use `_guess_chat_type()` which returns QQ-native types — those are unaffected.

## Testing

Verified by analyzing 113 QQ bot responses from gateway logs spanning June 3-20, 2026. The fix is live on my instance and approval buttons now work correctly in DM sessions.