### PR TITLE
feat(plugins): support interactive clarify slash commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9043,14 +9043,100 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Plugin-registered slash commands
         if command:
             try:
-                from hermes_cli.plugins import get_plugin_command_handler
+                from hermes_cli import plugins as _plugins_mod
+
                 # Normalize underscores to hyphens so Telegram's underscored
                 # autocomplete form matches plugin commands registered with
                 # hyphens. See hermes_cli/commands.py:_build_telegram_menu.
-                plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
+                plugin_command_key = command.replace("_", "-")
+                plugin_command = _plugins_mod.get_plugin_commands().get(plugin_command_key)
+                plugin_handler = (
+                    plugin_command.get("handler") if plugin_command else None
+                )
+                if not plugin_handler and plugin_command:
+                    plugin_handler = _plugins_mod.get_plugin_command_handler(plugin_command_key)
                 if plugin_handler:
                     user_args = event.get_command_args().strip()
-                    result = plugin_handler(user_args)
+                    if plugin_command.get("interactive"):
+                        class _PluginCommandUI:
+                            def __init__(self, runner, source, session_key):
+                                self._runner = runner
+                                self._source = source
+                                self._session_key = session_key
+
+                            async def clarify(self, question: str, choices=None) -> str:
+                                from tools import clarify_gateway as _clarify_mod
+                                import uuid as _uuid
+
+                                adapter = self._runner.adapters.get(self._source.platform)
+                                chat_id = getattr(self._source, "chat_id", None)
+                                if not adapter or not chat_id:
+                                    return "[clarify prompt could not be delivered]"
+
+                                clarify_id = _uuid.uuid4().hex[:10]
+                                choices_list = list(choices) if choices else None
+                                _clarify_mod.register(
+                                    clarify_id=clarify_id,
+                                    session_key=self._session_key or "",
+                                    question=question,
+                                    choices=choices_list,
+                                )
+                                thread_id = getattr(self._source, "thread_id", None)
+                                metadata = {"thread_id": str(thread_id)} if thread_id is not None else None
+                                send_result = await adapter.send_clarify(
+                                    chat_id=str(chat_id),
+                                    question=question,
+                                    choices=choices_list,
+                                    clarify_id=clarify_id,
+                                    session_key=self._session_key or "",
+                                    metadata=metadata,
+                                )
+                                if not getattr(send_result, "success", False):
+                                    _clarify_mod.clear_session(self._session_key or "")
+                                    return "[clarify prompt could not be delivered]"
+                                timeout = _clarify_mod.get_clarify_timeout()
+                                loop = asyncio.get_running_loop()
+                                response_future = loop.create_future()
+
+                                def _finish_response_future(method_name: str, value) -> None:
+                                    if loop.is_closed():
+                                        return
+
+                                    def _finish() -> None:
+                                        if not response_future.done():
+                                            getattr(response_future, method_name)(value)
+
+                                    loop.call_soon_threadsafe(_finish)
+
+                                def _wait_for_clarify_response() -> None:
+                                    try:
+                                        response_value = _clarify_mod.wait_for_response(
+                                            clarify_id,
+                                            float(timeout),
+                                        )
+                                    except Exception as exc:
+                                        _finish_response_future("set_exception", exc)
+                                    else:
+                                        _finish_response_future("set_result", response_value)
+
+                                import threading as _threading
+
+                                _threading.Thread(
+                                    target=_wait_for_clarify_response,
+                                    name="hermes-plugin-clarify-wait",
+                                    daemon=True,
+                                ).start()
+                                response = await response_future
+                                if response is None or response == "":
+                                    return f"[user did not respond within {int(timeout / 60)}m]"
+                                return response
+
+                        result = plugin_handler(
+                            user_args,
+                            _PluginCommandUI(self, source, _quick_key),
+                        )
+                    else:
+                        result = plugin_handler(user_args)
                     if asyncio.iscoroutine(result):
                         result = await result
                     return str(result) if result else None

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -469,11 +469,15 @@ class PluginContext:
         handler: Callable,
         description: str = "",
         args_hint: str = "",
+        interactive: bool = False,
     ) -> None:
-        """Register a slash command (e.g. ``/lcm``) available in CLI and gateway sessions.
+        """Register a slash command (e.g. ``/lcm``) available in sessions.
 
-        The handler signature is ``fn(raw_args: str) -> str | None``.
+        The default handler signature is ``fn(raw_args: str) -> str | None``.
         It may also be an async callable — the gateway dispatch handles both.
+        Interactive gateway handlers opt in with ``interactive=True`` and
+        receive ``fn(raw_args: str, ui)``, where ``ui`` exposes no-agent
+        prompt helpers such as ``clarify(question, choices=None)``.
 
         Unlike ``register_cli_command()`` (which creates ``hermes <subcommand>``
         terminal commands), this registers in-session slash commands that users
@@ -514,6 +518,7 @@ class PluginContext:
             "description": description or "Plugin command",
             "plugin": self.manifest.name,
             "args_hint": (args_hint or "").strip(),
+            "interactive": bool(interactive),
         }
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
 
@@ -2045,9 +2050,24 @@ def get_plugin_context_engine():
 
 
 def get_plugin_command_handler(name: str) -> Optional[Callable]:
-    """Return the handler for a plugin-registered slash command, or ``None``."""
+    """Return a directly callable plugin slash handler, or ``None``.
+
+    Interactive handlers need a gateway-provided UI object.  Non-gateway
+    callers receive a small fallback handler instead of the raw two-argument
+    callable so existing slash execution paths do not raise ``TypeError``.
+    """
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
-    return entry["handler"] if entry else None
+    if not entry:
+        return None
+    if not entry.get("interactive"):
+        return entry["handler"]
+
+    def _interactive_gateway_only(_raw_args: str) -> str:
+        return (
+            f"Plugin command '/{name}' requires an interactive gateway session."
+        )
+
+    return _interactive_gateway_only
 
 
 _PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS = 30.0

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -219,6 +219,7 @@ class _EngineCollector:
         handler,
         description: str = "",
         args_hint: str = "",
+        interactive: bool = False,
     ) -> None:
         """Forward to the global plugin command registry."""
         clean = (name or "").lower().strip().lstrip("/").replace(" ", "-")
@@ -259,6 +260,7 @@ class _EngineCollector:
                 "description": description or "Context engine command",
                 "plugin": f"context-engine:{self._engine_name}",
                 "args_hint": (args_hint or "").strip(),
+                "interactive": bool(interactive),
             }
             self._registered_commands.append(clean)
             logger.debug(

--- a/tests/agent/test_context_engine_host_contract.py
+++ b/tests/agent/test_context_engine_host_contract.py
@@ -270,9 +270,31 @@ def test_engine_collector_forwards_register_command_to_plugin_manager():
         assert entry["handler"] is handler
         assert entry["args_hint"] == "<msg>"
         assert entry["plugin"] == "context-engine:my-lcm"
+        assert entry["interactive"] is False
     finally:
         # Clean up so we don't leak the registration across tests.
         manager._plugin_commands.pop("my-lcm-test-cmd", None)
+
+
+def test_engine_collector_forwards_interactive_register_command_flag():
+    """Context-engine slash commands preserve the interactive flag."""
+    from plugins.context_engine import _EngineCollector
+    from hermes_cli.plugins import get_plugin_manager
+
+    collector = _EngineCollector(engine_name="my-lcm")
+    collector.register_command(
+        "my-lcm-interactive-cmd",
+        lambda raw_args, ui: "ok",
+        interactive=True,
+    )
+
+    manager = get_plugin_manager()
+    try:
+        entry = manager._plugin_commands["my-lcm-interactive-cmd"]
+        assert entry["interactive"] is True
+    finally:
+        # Clean up so we don't leak the registration across tests.
+        manager._plugin_commands.pop("my-lcm-interactive-cmd", None)
 
 
 def test_engine_collector_rejects_builtin_command_conflicts():

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -17,7 +17,7 @@ import pytest
 
 from gateway.config import Platform
 from gateway.platforms.base import SendResult
-from tests.e2e.conftest import make_event, send_and_capture
+from tests.e2e.conftest import make_event, make_runner, send_and_capture
 
 
 class TestSlashCommands:
@@ -158,6 +158,88 @@ class TestSlashCommands:
         response_text = send.call_args[1].get("content") or send.call_args[0][1]
         assert response_text == "status via alias"
         runner._handle_status_command.assert_awaited_once()
+        runner._handle_message_with_agent.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_interactive_plugin_command_can_clarify_without_agent(
+        self, adapter, runner, platform, monkeypatch
+    ):
+        """Interactive plugin commands can prompt without entering an agent turn."""
+        if platform == Platform.SLACK:
+            pytest.skip("Slack uses the base text fallback; this test covers rich gateway adapters")
+
+        async def _handler(raw_args, ui):
+            choice = await ui.clarify("Choose one", ["alpha", "beta"])
+            return f"{raw_args}:{choice}"
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_plugin_commands",
+            lambda: {
+                "pick": {
+                    "handler": _handler,
+                    "description": "pick",
+                    "plugin": "test",
+                    "args_hint": "",
+                    "interactive": True,
+                }
+            },
+        )
+
+        async def _send_clarify(**kwargs):
+            from tools.clarify_gateway import resolve_gateway_clarify
+
+            resolve_gateway_clarify(kwargs["clarify_id"], "beta")
+            return SendResult(success=True, message_id="clarify-1")
+
+        adapter.send_clarify = AsyncMock(side_effect=_send_clarify)
+
+        send = await send_and_capture(adapter, "/pick value", platform)
+
+        adapter.send_clarify.assert_awaited_once()
+        send.assert_called_once()
+        response_text = send.call_args[1].get("content") or send.call_args[0][1]
+        assert response_text == "value:beta"
+        runner._handle_message_with_agent.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_interactive_plugin_command_can_clarify_on_whatsapp_cloud(
+        self, monkeypatch
+    ):
+        """Interactive plugin commands use the adapter clarify contract on WhatsApp Cloud."""
+        platform = Platform.WHATSAPP_CLOUD
+        runner = make_runner(platform)
+
+        async def _handler(raw_args, ui):
+            choice = await ui.clarify("Choose one", ["alpha", "beta"])
+            return f"{raw_args}:{choice}"
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_plugin_commands",
+            lambda: {
+                "pick": {
+                    "handler": _handler,
+                    "description": "pick",
+                    "plugin": "test",
+                    "args_hint": "",
+                    "interactive": True,
+                }
+            },
+        )
+
+        async def _send_clarify(**kwargs):
+            from tools.clarify_gateway import resolve_gateway_clarify
+
+            resolve_gateway_clarify(kwargs["clarify_id"], "beta")
+            return SendResult(success=True, message_id="clarify-1")
+
+        adapter = MagicMock()
+        adapter.send_clarify = AsyncMock(side_effect=_send_clarify)
+        runner.adapters[platform] = adapter
+
+        result = await runner._handle_message(make_event(platform, "/pick value"))
+
+        adapter.send_clarify.assert_awaited_once()
+        assert result == "value:beta"
         runner._handle_message_with_agent.assert_not_awaited()
 
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1448,6 +1448,16 @@ class TestPluginCommands:
 
         ctx.register_command("status-cmd", lambda a: a)
         assert mgr._plugin_commands["status-cmd"]["description"] == "Plugin command"
+        assert mgr._plugin_commands["status-cmd"]["interactive"] is False
+
+    def test_register_command_interactive_flag(self):
+        """Plugin slash commands may opt into gateway interactive UI."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        ctx.register_command("choose-cmd", lambda a, ui: a, interactive=True)
+        assert mgr._plugin_commands["choose-cmd"]["interactive"] is True
 
     def test_get_plugin_command_handler_found(self):
         """get_plugin_command_handler() returns the handler for a registered command."""
@@ -1461,6 +1471,19 @@ class TestPluginCommands:
         with patch("hermes_cli.plugins._plugin_manager", mgr):
             result = get_plugin_command_handler("mycmd")
             assert result is handler
+
+    def test_get_plugin_command_handler_interactive_gateway_only(self):
+        """Interactive plugin commands return a non-gateway fallback handler."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        ctx.register_command("choose-cmd", lambda args, ui: "ok", interactive=True)
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            result = get_plugin_command_handler("choose-cmd")
+            assert result is not None
+            assert "interactive gateway session" in result("")
 
     def test_get_plugin_command_handler_not_found(self):
         """get_plugin_command_handler() returns None for unregistered commands."""


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in interactive mode for plugin-registered slash commands.

Plugins can now call:

```python
ctx.register_command("pick", handler, interactive=True)
```

Interactive handlers receive `handler(raw_args, ui)` in gateway sessions. The initial UI surface exposes `await ui.clarify(question, choices=None)`, backed by the existing gateway `send_clarify` adapter contract. This lets no-agent plugin slash commands ask the user for a choice without entering an agent turn.

Non-interactive plugin commands keep the existing `handler(raw_args)` behavior. Non-gateway dispatch paths receive a clear gateway-only fallback instead of accidentally calling a two-argument handler.

## Related Issue

N/A

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added `interactive=False` metadata to `PluginContext.register_command()`.
- Added gateway dispatch support for interactive plugin commands via a small `ui.clarify()` helper.
- Preserved legacy one-argument plugin command behavior for non-interactive commands.
- Preserved TUI/CLI safety by returning a gateway-only fallback for interactive commands outside gateway dispatch.
- Forwarded the interactive flag through context-engine command registration.
- Added tests for:
  - plugin command registration metadata
  - non-gateway fallback behavior
  - Telegram and Discord gateway clarify dispatch without entering an agent turn
  - WhatsApp Cloud adapter clarify contract dispatch
  - context-engine command flag forwarding
  - existing plugin command rewrite and TUI plugin command paths

## How to Test

Run the focused plugin/gateway tests:

```bash
python -m pytest \
  tests/gateway/test_unknown_command.py \
  tests/e2e/test_platform_commands.py \
  tests/hermes_cli/test_plugins.py \
  tests/agent/test_context_engine_host_contract.py
```

Run static checks:

```bash
python scripts/check-windows-footguns.py --all
RUFF_CACHE_DIR=/tmp/hermes-ruff-cache python -m ruff check .
git diff --check main...HEAD
```

I also ran the full per-file suite from a fresh clone of this fork branch with an isolated `HOME` and `TMPDIR`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu/Linux, focused gateway tests for Telegram, Discord, and WhatsApp Cloud clarify dispatch

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, API is documented in the method docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — no process/file/terminal primitives added; blocking Windows footgun check passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused tests:

```text
163 passed, 5 skipped
```

Full per-file suite from a fresh fork clone:

```text
32501 passed, 10 failed
```

Failure notes:

- `tests/gateway/test_matrix_voice.py`: 6 failures, reproduced unchanged on upstream `main` (`c253b0738`).
- `tests/tools/test_search_hidden_dirs.py`: 1 failure caused by my first `TMPDIR` name containing `hermes`; rerun with a short neutral `TMPDIR` passed (`9 passed`).
- `tests/tools/test_voice_mode.py`: 3 failures caused by a too-long `TMPDIR` path for AF_UNIX sockets; rerun with a short `TMPDIR` passed (`73 passed`).
- `tests/run_agent/test_run_agent.py`: hit the per-file runner's 140s timeout, but direct pytest passed (`384 passed, 1 warning in 138.23s`).

Static checks:

```text
✓ No Windows footguns found (658 file(s) scanned)
ruff check . -> All checks passed
git diff --check main...HEAD -> clean
```
