### PR TITLE
fix: exclude current session from session_search newest window

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3390,6 +3390,7 @@ class SessionDB:
         query: str,
         source_filter: List[str] = None,
         exclude_sources: List[str] = None,
+        exclude_session_id: str = None,
         role_filter: List[str] = None,
         limit: int = 20,
         offset: int = 0,
@@ -3454,6 +3455,9 @@ class SessionDB:
         params: list = [query]
         if not include_inactive:
             where_clauses.append("m.active = 1")
+        if exclude_session_id:
+            where_clauses.append("m.session_id != ?")
+            params.append(exclude_session_id)
 
         if source_filter is not None:
             source_placeholders = ",".join("?" for _ in source_filter)
@@ -3536,6 +3540,9 @@ class SessionDB:
                 tri_params: list = [trigram_query]
                 if not include_inactive:
                     tri_where.append("m.active = 1")
+                if exclude_session_id:
+                    tri_where.append("m.session_id != ?")
+                    tri_params.append(exclude_session_id)
                 if source_filter is not None:
                     tri_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                     tri_params.extend(source_filter)
@@ -3593,6 +3600,9 @@ class SessionDB:
                     )
                     like_params += [f"%{esc}%", f"%{esc}%", f"%{esc}%"]
                 like_where = [f"({' OR '.join(token_clauses)})"]
+                if exclude_session_id:
+                    like_where.append("m.session_id != ?")
+                    like_params.append(exclude_session_id)
                 if source_filter is not None:
                     like_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                     like_params.extend(source_filter)

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -204,6 +204,37 @@ class TestDiscoveryShape:
         sids = [r["session_id"] for r in result["results"]]
         assert "s_newest" not in sids
 
+    def test_current_session_excluded_before_newest_fetch_window(self, db):
+        _seed_modpack_sessions(db)
+
+        db.create_session("s_current", source="cli")
+        now = int(time.time())
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+            (now, "Current Modpack Debugging", "s_current"),
+        )
+        for idx in range(60):
+            db.append_message(
+                "s_current",
+                role="user",
+                content=f"modpack regression note {idx}",
+                timestamp=now + idx,
+            )
+        db._conn.commit()
+
+        result = json.loads(
+            session_search(
+                query="modpack",
+                limit=2,
+                sort="newest",
+                db=db,
+                current_session_id="s_current",
+            )
+        )
+
+        assert result["count"] == 2
+        assert [r["session_id"] for r in result["results"]] == ["s_newest", "s_middle"]
+
 
 class TestDiscoverySort:
     def test_sort_newest_orders_by_recency(self, db):

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -407,6 +407,7 @@ def _discover(
             query=query,
             role_filter=role_list,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            exclude_session_id=current_session_id,
             limit=50,  # widen so dedup-by-lineage can find distinct sessions
             offset=0,
             sort=sort,


### PR DESCRIPTION
## Summary
- exclude the active session at SQL time before the 50-row discovery fetch window is filled
- thread the current session id through `session_search` discovery calls
- add a regression test covering >50 current-session hits with `sort="newest"`

## Testing
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest -o addopts= tests/tools/test_session_search.py -q`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m ruff check hermes_state.py tools/session_search_tool.py tests/tools/test_session_search.py`
- `git diff --check`

Closes #36238