### PR TITLE
fix(agent): clarify file mutation verifier warning

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2639,9 +2639,9 @@ class AIAgent:
             return ""
         lines = [
             "⚠️ File-mutation verifier: "
-            f"{len(failed)} file(s) were NOT modified this turn despite any "
-            "wording above that may suggest otherwise. Run `git status` or "
-            "`read_file` to confirm."
+            f"{len(failed)} unresolved file-mutation failure(s) remain for this turn; "
+            "verify the intended final state despite any wording above that may "
+            "suggest otherwise. Run `git status` or `read_file` to confirm."
         ]
         shown = 0
         for path, info in failed.items():

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -166,6 +166,36 @@ class TestRecordFileMutationResult:
         )
         assert agent._turn_failed_file_mutations == {}
 
+    def test_success_then_failure_keeps_unresolved_failure_without_negating_prior_success(self):
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "write_file",
+            {"path": "/tmp/a.md", "content": "landed content"},
+            json.dumps({"success": True, "bytes_written": 14}),
+            is_error=False,
+        )
+        agent._record_file_mutation_result(
+            "patch",
+            {
+                "mode": "replace",
+                "path": "/tmp/a.md",
+                "old_string": "updated: 2026-06-17",
+                "new_string": "updated: 2026-06-17",
+            },
+            json.dumps({"success": False, "error": "old_string and new_string are identical"}),
+            is_error=True,
+        )
+
+        state = getattr(agent, "_turn_failed_file_mutations")
+        assert "/tmp/a.md" in state
+        assert state["/tmp/a.md"]["tool"] == "patch"
+        assert "old_string and new_string are identical" in state["/tmp/a.md"]["error_preview"]
+
+        footer = AIAgent._format_file_mutation_failure_footer(state)
+        assert "unresolved file-mutation failure(s) remain for this turn" in footer
+        assert "verify the intended final state" in footer
+        assert "were NOT modified this turn" not in footer
+
     def test_write_file_with_lint_error_counts_as_landed(self):
         agent = _bare_agent()
         agent._record_file_mutation_result(
@@ -282,10 +312,11 @@ class TestFormatFooter:
         out = AIAgent._format_file_mutation_failure_footer(
             {"/tmp/a.md": {"tool": "patch", "error_preview": "Could not find old_string"}},
         )
-        assert "1 file(s) were NOT modified" in out
+        assert "1 unresolved file-mutation failure(s) remain" in out
         assert "/tmp/a.md" in out
         assert "Could not find old_string" in out
         assert "git status" in out  # user-actionable hint
+        assert "were NOT modified this turn" not in out
 
     def test_truncation_at_10_entries(self):
         failed = {
@@ -293,7 +324,7 @@ class TestFormatFooter:
             for i in range(15)
         }
         out = AIAgent._format_file_mutation_failure_footer(failed)
-        assert "15 file(s) were NOT modified" in out
+        assert "15 unresolved file-mutation failure(s) remain" in out
         assert "… and 5 more" in out
         # Ten file bullets + header + "and X more" line
         lines = out.split("\n")

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -26,7 +26,10 @@ class TestExactMatch:
     def test_identical_strings(self):
         new, count, _, err = fuzzy_find_and_replace("abc", "abc", "abc")
         assert count == 0
+        assert err is not None
         assert "identical" in err
+        assert "no edit is needed" in err
+        assert "Re-read/verify" in err
 
     def test_multiline_exact(self):
         content = "line1\nline2\nline3"

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -67,7 +67,12 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
         return content, 0, None, "old_string cannot be empty"
 
     if old_string == new_string:
-        return content, 0, None, "old_string and new_string are identical"
+        return (
+            content,
+            0,
+            None,
+            "old_string and new_string are identical; no edit is needed if the file already has the intended content. Re-read/verify the file instead of retrying a no-op patch.",
+        )
 
     # Try each matching strategy in order
     strategies: List[Tuple[str, Callable]] = [


### PR DESCRIPTION
## What does this PR do?

Clarifies the file-mutation verifier footer so it reports the actual state: unresolved file-mutation failures remain and the final file state should be verified.

The previous wording said files "were NOT modified this turn". That is inaccurate when a path was successfully modified earlier in the same turn and then a later patch/write attempt for the same path failed, such as a no-op patch where `old_string == new_string`.

This keeps the verifier's safety behavior intact while avoiding a false claim about prior successful mutations.

## Related Issue

No upstream issue opened. Related prior art found during duplicate search:

- #26073 proposes broader file-mutation verifier recovery reporting.
- #36657, #35559, and #41048 touch adjacent verifier behavior.

This PR is intentionally narrower: wording-only verifier clarification plus a more actionable no-op patch error.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`
  - Changes the verifier footer from "file(s) were NOT modified this turn" to "unresolved file-mutation failure(s) remain for this turn; verify the intended final state".
- `tools/fuzzy_match.py`
  - Expands the `old_string == new_string` error to tell agents that no edit is needed if the file is already current, and to re-read/verify instead of retrying a no-op patch.
- `tests/run_agent/test_file_mutation_verifier.py`
  - Adds coverage for a successful mutation followed by a later failed mutation on the same path.
  - Updates footer wording assertions.
- `tests/tools/test_fuzzy_match.py`
  - Asserts the no-op patch error remains explicit and includes the new re-read/verify guidance.

## How to Test

1. Run syntax checks:
   ```bash
   python -m py_compile run_agent.py tools/fuzzy_match.py
   ```
2. Run targeted verifier/fuzzy-match tests:
   ```bash
   python -m pytest tests/run_agent/test_file_mutation_verifier.py tests/tools/test_fuzzy_match.py -q -o 'addopts='
   ```
3. Optionally run the full suite:
   ```bash
   scripts/run_tests.sh
   ```

Local targeted verification on macOS passed:

```text
python -m py_compile run_agent.py tools/fuzzy_match.py
python -m pytest tests/run_agent/test_file_mutation_verifier.py tests/tools/test_fuzzy_match.py -q -o 'addopts='
83 passed, 1 warning in 1.91s
```

Local full-suite attempt on macOS did not complete cleanly due failures outside this change area, including live-system guard/environment-sensitive tests (`systemctl` unavailable on macOS, gateway/approval guard expectations, and unrelated adapter tests). CI should be treated as authoritative for the full cross-platform suite.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is an agent footer/error-message wording fix with unit coverage.
