### PR TITLE
Improve desktop accessibility semantics

### DIFF
--- a/apps/bootstrap-installer/src-tauri/tauri.conf.json
+++ b/apps/bootstrap-installer/src-tauri/tauri.conf.json
@@ -13,7 +13,7 @@
     "windows": [
       {
         "label": "main",
-        "title": "Hermes",
+        "title": "Hermes Setup",
         "width": 880,
         "height": 620,
         "minWidth": 720,

--- a/apps/bootstrap-installer/src/routes/progress.tsx
+++ b/apps/bootstrap-installer/src/routes/progress.tsx
@@ -57,6 +57,21 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
     : 'This is a one-time setup. The Hermes installer is downloading dependencies and configuring your machine. Subsequent launches will skip this step.'
 
   const pct = Math.round(progress.fraction * 100)
+  const currentStage =
+    bootstrap.currentStage != null
+      ? bootstrap.stages[bootstrap.currentStage]
+      : null
+  const currentStageTitle =
+    bootstrap.status === 'running'
+      ? currentStage
+        ? currentStage.info.title
+        : 'Preparing…'
+      : bootstrap.status === 'completed'
+        ? 'Done'
+        : isUpdate
+          ? 'Updating'
+          : 'Installing'
+  const progressText = `${progress.done} of ${progress.total} steps — ${currentStageTitle}`
 
   return (
     <div className="hermes-fade-in flex h-full flex-col">
@@ -75,13 +90,25 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
               pt-2 matches the log header's py-2 so the "steps complete" line and
               the "Live output" header share a baseline. */}
           <div className="mb-4">
-            <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+            <div
+              aria-atomic="true"
+              aria-live="polite"
+              className="mb-1 flex items-center justify-between text-xs text-muted-foreground"
+              role="status"
+            >
               <span className={clsx(bootstrap.status === 'running' && 'shimmer')}>
                 {progress.done} of {progress.total} steps complete
               </span>
               <span className="tabular-nums">{pct}%</span>
             </div>
-            <div className="h-1.5 w-full overflow-hidden rounded-full bg-(--ui-bg-tertiary)">
+            <div
+              aria-valuemax={progress.total}
+              aria-valuemin={0}
+              aria-valuenow={progress.done}
+              aria-valuetext={progressText}
+              className="h-1.5 w-full overflow-hidden rounded-full bg-(--ui-bg-tertiary)"
+              role="progressbar"
+            >
               <div
                 className="h-full bg-primary transition-all duration-300 ease-out"
                 style={{ width: `${Math.max(2, progress.fraction * 100)}%` }}
@@ -107,6 +134,7 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
 
               return (
                 <li
+                  aria-label={`${rec.info.title}, ${stageStateLabel(rec.state ?? null)}`}
                   className={clsx(
                     'flex items-center gap-2.5 px-3 py-1.5 text-sm',
                     rec.state === 'running'
@@ -116,6 +144,7 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
                   key={name}
                 >
                   {rec.state === 'running' && <Loader className="-ml-2 size-6 shrink-0" />}
+                  <span className="sr-only">{stageStateLabel(rec.state ?? null)}: </span>
                   <span className="flex-1 truncate">{rec.info.title}</span>
                   {meta && <span className="text-xs tabular-nums text-muted-foreground/70">{meta}</span>}
                   <StateIcon state={rec.state ?? null} />
@@ -126,12 +155,21 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
         </div>
 
         {showLogs && (
-          <div className="flex w-1/2 flex-col border-l border-(--stroke-nous)">
+          <div
+            aria-label="Installation details"
+            className="flex w-1/2 flex-col border-l border-(--stroke-nous)"
+            id="install-log-panel"
+            role="region"
+          >
             <div className="flex shrink-0 items-center justify-between border-b border-(--stroke-nous) px-3 py-2 text-xs">
               <span className="font-medium text-foreground/80">Live output</span>
               <span className="tabular-nums text-muted-foreground">{bootstrap.logs.length} lines</span>
             </div>
-            <div className="flex-1 overflow-y-auto px-3 py-2 font-mono text-[10.5px] leading-relaxed">
+            <div
+              aria-label="Installation log"
+              className="flex-1 overflow-y-auto px-3 py-2 font-mono text-[10.5px] leading-relaxed"
+              role="log"
+            >
               {bootstrap.logs.map((entry, idx) => (
                 <div
                   className={clsx(
@@ -151,13 +189,15 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
 
       <div className="flex shrink-0 items-center justify-between border-t border-(--stroke-nous) px-6 py-3">
         <button
-          className="inline-flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          aria-controls="install-log-panel"
+          aria-expanded={showLogs}
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           onClick={() => setShowLogs((v) => !v)}
           type="button"
         >
-          <FileText size={14} />
+          <FileText aria-hidden="true" size={14} />
           {showLogs ? 'Hide details' : 'Show details'}
-          <ChevronRight className={clsx('transition-transform', showLogs && 'rotate-90')} size={12} />
+          <ChevronRight aria-hidden="true" size={12} className={clsx('transition-transform', showLogs && 'rotate-90')} />
         </button>
 
         {bootstrap.status === 'running' && (
@@ -175,18 +215,26 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
 // spinner on the left; pending stays icon-less.
 function StateIcon({ state }: { state: StageState | null }) {
   if (state === 'succeeded') {
-    return <Check className="shrink-0 text-muted-foreground" size={13} />
+    return <Check aria-hidden="true" size={13} className="shrink-0 text-muted-foreground" />
   }
 
   if (state === 'skipped') {
-    return <Check className="shrink-0 text-muted-foreground/50" size={13} />
+    return <Check aria-hidden="true" size={13} className="shrink-0 text-muted-foreground/50" />
   }
 
   if (state === 'failed') {
-    return <X className="shrink-0 text-destructive" size={13} />
+    return <X aria-hidden="true" size={13} className="shrink-0 text-destructive" />
   }
 
   return null
+}
+
+function stageStateLabel(state: StageState | null): string {
+  if (state === 'running') return 'Running'
+  if (state === 'succeeded') return 'Completed'
+  if (state === 'skipped') return 'Skipped'
+  if (state === 'failed') return 'Failed'
+  return 'Pending'
 }
 
 function formatDuration(ms: number): string {

--- a/apps/bootstrap-installer/src/routes/progress.tsx
+++ b/apps/bootstrap-installer/src/routes/progress.tsx
@@ -59,6 +59,21 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
 
   const pct = Math.round(progress.fraction * 100)
 
+  const currentStage = bootstrap.currentStage != null ? bootstrap.stages[bootstrap.currentStage] : null
+
+  const currentStageTitle =
+    bootstrap.status === 'running'
+      ? currentStage
+        ? currentStage.info.title
+        : 'Preparing…'
+      : bootstrap.status === 'completed'
+        ? 'Done'
+        : isUpdate
+          ? 'Updating'
+          : 'Installing'
+
+  const progressText = `${progress.done} of ${progress.total} steps — ${currentStageTitle}`
+
   return (
     <div className="hermes-fade-in flex h-full flex-col">
       {/* Header: brand + title + description, matching the desktop install overlay. */}
@@ -76,13 +91,25 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
               pt-2 matches the log header's py-2 so the "steps complete" line and
               the "Live output" header share a baseline. */}
           <div className="mb-4">
-            <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+            <div
+              aria-atomic="true"
+              aria-live="polite"
+              className="mb-1 flex items-center justify-between text-xs text-muted-foreground"
+              role="status"
+            >
               <span className={clsx(bootstrap.status === 'running' && 'shimmer')}>
                 {progress.done} of {progress.total} steps complete
               </span>
               <span className="tabular-nums">{pct}%</span>
             </div>
-            <div className="h-1.5 w-full overflow-hidden rounded-full bg-(--ui-bg-tertiary)">
+            <div
+              aria-valuemax={progress.total}
+              aria-valuemin={0}
+              aria-valuenow={progress.done}
+              aria-valuetext={progressText}
+              className="h-1.5 w-full overflow-hidden rounded-full bg-(--ui-bg-tertiary)"
+              role="progressbar"
+            >
               <div
                 className="h-full bg-primary transition-all duration-300 ease-out"
                 style={{ width: `${Math.max(2, progress.fraction * 100)}%` }}
@@ -94,10 +121,12 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
               muted. Running loader overhangs left so labels stay aligned; the
               terminal check/cross sits right of the label. */}
           <ol className="space-y-0.5">
-            {bootstrap.stageOrder.map((name) => {
+            {bootstrap.stageOrder.map(name => {
               const rec = bootstrap.stages[name]
 
-              if (!rec) {return null}
+              if (!rec) {
+                return null
+              }
 
               const meta =
                 rec.state === 'running' && rec.startedAt != null
@@ -108,15 +137,15 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
 
               return (
                 <li
+                  aria-label={`${rec.info.title}, ${stageStateLabel(rec.state ?? null)}`}
                   className={clsx(
                     'flex items-center gap-2.5 px-3 py-1.5 text-sm',
-                    rec.state === 'running'
-                      ? 'font-medium text-foreground'
-                      : 'text-muted-foreground'
+                    rec.state === 'running' ? 'font-medium text-foreground' : 'text-muted-foreground'
                   )}
                   key={name}
                 >
                   {rec.state === 'running' && <Loader className="-ml-2 size-6 shrink-0" />}
+                  <span className="sr-only">{stageStateLabel(rec.state ?? null)}: </span>
                   <span className="flex-1 truncate">{rec.info.title}</span>
                   {meta && <span className="text-xs tabular-nums text-muted-foreground/70">{meta}</span>}
                   <StateIcon state={rec.state ?? null} />
@@ -127,12 +156,21 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
         </div>
 
         {showLogs && (
-          <div className="flex w-1/2 flex-col border-l border-(--stroke-nous)">
+          <div
+            aria-label="Installation details"
+            className="flex w-1/2 flex-col border-l border-(--stroke-nous)"
+            id="install-log-panel"
+            role="region"
+          >
             <div className="flex shrink-0 items-center justify-between border-b border-(--stroke-nous) px-3 py-2 text-xs">
               <span className="font-medium text-foreground/80">Live output</span>
               <span className="tabular-nums text-muted-foreground">{bootstrap.logs.length} lines</span>
             </div>
-            <div className="flex-1 overflow-y-auto px-3 py-2 font-mono text-[10.5px] leading-relaxed">
+            <div
+              aria-label="Installation log"
+              className="flex-1 overflow-y-auto px-3 py-2 font-mono text-[10.5px] leading-relaxed"
+              role="log"
+            >
               {bootstrap.logs.map((entry, idx) => (
                 <div
                   className={clsx(
@@ -152,13 +190,19 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
 
       <div className="flex shrink-0 items-center justify-between border-t border-(--stroke-nous) px-6 py-3">
         <button
-          className="inline-flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-          onClick={() => setShowLogs((v) => !v)}
+          aria-controls="install-log-panel"
+          aria-expanded={showLogs}
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          onClick={() => setShowLogs(v => !v)}
           type="button"
         >
-          <FileText size={14} />
+          <FileText aria-hidden="true" size={14} />
           {showLogs ? 'Hide details' : 'Show details'}
-          <ChevronRight className={clsx('transition-transform', showLogs && 'rotate-90')} size={12} />
+          <ChevronRight
+            aria-hidden="true"
+            className={clsx('transition-transform', showLogs && 'rotate-90')}
+            size={12}
+          />
         </button>
 
         {bootstrap.status === 'running' && (
@@ -176,17 +220,36 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
 // spinner on the left; pending stays icon-less.
 function StateIcon({ state }: { state: StageState | null }) {
   if (state === 'succeeded') {
-    return <Check className="shrink-0 text-muted-foreground" size={13} />
+    return <Check aria-hidden="true" className="shrink-0 text-muted-foreground" size={13} />
   }
 
   if (state === 'skipped') {
-    return <Check className="shrink-0 text-muted-foreground/50" size={13} />
+    return <Check aria-hidden="true" className="shrink-0 text-muted-foreground/50" size={13} />
   }
 
   if (state === 'failed') {
-    return <X className="shrink-0 text-destructive" size={13} />
+    return <X aria-hidden="true" className="shrink-0 text-destructive" size={13} />
   }
 
   return null
 }
 
+function stageStateLabel(state: StageState | null): string {
+  if (state === 'running') {
+    return 'Running'
+  }
+
+  if (state === 'succeeded') {
+    return 'Completed'
+  }
+
+  if (state === 'skipped') {
+    return 'Skipped'
+  }
+
+  if (state === 'failed') {
+    return 'Failed'
+  }
+
+  return 'Pending'
+}

--- a/apps/bootstrap-installer/src/routes/progress.tsx
+++ b/apps/bootstrap-installer/src/routes/progress.tsx
@@ -6,13 +6,7 @@ import { useEffect, useRef, useState } from 'react'
 import { BrandMark } from '../components/brand-mark'
 import { Button } from '../components/button'
 import { Loader } from '../components/loader'
-import {
-  $mode,
-  $progress,
-  type BootstrapStateModel,
-  cancelInstall,
-  type StageState
-} from '../store'
+import { $mode, $progress, type BootstrapStateModel, cancelInstall, type StageState } from '../store'
 
 interface ProgressProps {
   bootstrap: BootstrapStateModel
@@ -57,10 +51,9 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
     : 'This is a one-time setup. The Hermes installer is downloading dependencies and configuring your machine. Subsequent launches will skip this step.'
 
   const pct = Math.round(progress.fraction * 100)
-  const currentStage =
-    bootstrap.currentStage != null
-      ? bootstrap.stages[bootstrap.currentStage]
-      : null
+
+  const currentStage = bootstrap.currentStage != null ? bootstrap.stages[bootstrap.currentStage] : null
+
   const currentStageTitle =
     bootstrap.status === 'running'
       ? currentStage
@@ -71,6 +64,7 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
         : isUpdate
           ? 'Updating'
           : 'Installing'
+
   const progressText = `${progress.done} of ${progress.total} steps — ${currentStageTitle}`
 
   return (
@@ -120,10 +114,12 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
               muted. Running loader overhangs left so labels stay aligned; the
               terminal check/cross sits right of the label. */}
           <ol className="space-y-0.5">
-            {bootstrap.stageOrder.map((name) => {
+            {bootstrap.stageOrder.map(name => {
               const rec = bootstrap.stages[name]
 
-              if (!rec) {return null}
+              if (!rec) {
+                return null
+              }
 
               const meta =
                 rec.state === 'running' && rec.startedAt != null
@@ -137,9 +133,7 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
                   aria-label={`${rec.info.title}, ${stageStateLabel(rec.state ?? null)}`}
                   className={clsx(
                     'flex items-center gap-2.5 px-3 py-1.5 text-sm',
-                    rec.state === 'running'
-                      ? 'font-medium text-foreground'
-                      : 'text-muted-foreground'
+                    rec.state === 'running' ? 'font-medium text-foreground' : 'text-muted-foreground'
                   )}
                   key={name}
                 >
@@ -192,12 +186,16 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
           aria-controls="install-log-panel"
           aria-expanded={showLogs}
           className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-          onClick={() => setShowLogs((v) => !v)}
+          onClick={() => setShowLogs(v => !v)}
           type="button"
         >
           <FileText aria-hidden="true" size={14} />
           {showLogs ? 'Hide details' : 'Show details'}
-          <ChevronRight aria-hidden="true" size={12} className={clsx('transition-transform', showLogs && 'rotate-90')} />
+          <ChevronRight
+            aria-hidden="true"
+            className={clsx('transition-transform', showLogs && 'rotate-90')}
+            size={12}
+          />
         </button>
 
         {bootstrap.status === 'running' && (
@@ -215,32 +213,48 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
 // spinner on the left; pending stays icon-less.
 function StateIcon({ state }: { state: StageState | null }) {
   if (state === 'succeeded') {
-    return <Check aria-hidden="true" size={13} className="shrink-0 text-muted-foreground" />
+    return <Check aria-hidden="true" className="shrink-0 text-muted-foreground" size={13} />
   }
 
   if (state === 'skipped') {
-    return <Check aria-hidden="true" size={13} className="shrink-0 text-muted-foreground/50" />
+    return <Check aria-hidden="true" className="shrink-0 text-muted-foreground/50" size={13} />
   }
 
   if (state === 'failed') {
-    return <X aria-hidden="true" size={13} className="shrink-0 text-destructive" />
+    return <X aria-hidden="true" className="shrink-0 text-destructive" size={13} />
   }
 
   return null
 }
 
 function stageStateLabel(state: StageState | null): string {
-  if (state === 'running') return 'Running'
-  if (state === 'succeeded') return 'Completed'
-  if (state === 'skipped') return 'Skipped'
-  if (state === 'failed') return 'Failed'
+  if (state === 'running') {
+    return 'Running'
+  }
+
+  if (state === 'succeeded') {
+    return 'Completed'
+  }
+
+  if (state === 'skipped') {
+    return 'Skipped'
+  }
+
+  if (state === 'failed') {
+    return 'Failed'
+  }
+
   return 'Pending'
 }
 
 function formatDuration(ms: number): string {
-  if (ms < 1000) {return `${ms}ms`}
+  if (ms < 1000) {
+    return `${ms}ms`
+  }
 
-  if (ms < 60000) {return `${(ms / 1000).toFixed(1)}s`}
+  if (ms < 60000) {
+    return `${(ms / 1000).toFixed(1)}s`
+  }
   const m = Math.floor(ms / 60000)
   const s = Math.round((ms % 60000) / 1000)
 
@@ -251,7 +265,9 @@ function formatDuration(ms: number): string {
 function formatElapsed(ms: number): string {
   const s = Math.max(0, Math.floor(ms / 1000))
 
-  if (s < 60) {return `${s}s`}
+  if (s < 60) {
+    return `${s}s`
+  }
   const m = Math.floor(s / 60)
 
   return `${m}:${String(s - m * 60).padStart(2, '0')}`

--- a/apps/bootstrap-installer/src/routes/progress.tsx
+++ b/apps/bootstrap-installer/src/routes/progress.tsx
@@ -255,6 +255,7 @@ function formatDuration(ms: number): string {
   if (ms < 60000) {
     return `${(ms / 1000).toFixed(1)}s`
   }
+
   const m = Math.floor(ms / 60000)
   const s = Math.round((ms % 60000) / 1000)
 
@@ -268,6 +269,7 @@ function formatElapsed(ms: number): string {
   if (s < 60) {
     return `${s}s`
   }
+
   const m = Math.floor(s / 60)
 
   return `${m}:${String(s - m * 60).padStart(2, '0')}`

--- a/apps/bootstrap-installer/src/styles.css
+++ b/apps/bootstrap-installer/src/styles.css
@@ -52,6 +52,12 @@
   );
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .hermes-fade-in {
+    animation: none;
+  }
+}
+
 /*
  * Dark appearance — Nous dark seeds.
  *

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -995,11 +995,23 @@ export function ChatBar({
     />
   )
 
+  const triggerKindId = trigger?.kind === '@' ? 'at' : trigger?.kind === ':' ? 'emoji' : 'slash'
+  const triggerListboxId = `composer-${triggerKindId}-completion-listbox`
+  const triggerOptionIdPrefix = `composer-${triggerKindId}-completion`
+
+  const activeTriggerOptionId =
+    trigger && !argStageEmpty && triggerItems[triggerActive] ? `${triggerOptionIdPrefix}-${triggerActive}` : undefined
+
   const input = (
     <div className={cn('relative', stacked ? 'w-full' : 'min-w-(--composer-input-inline-min-width) flex-1')}>
       <div
+        aria-activedescendant={activeTriggerOptionId}
+        aria-autocomplete="list"
+        aria-controls={trigger && !argStageEmpty ? triggerListboxId : undefined}
         aria-disabled={inputDisabled ? true : undefined}
+        aria-expanded={trigger && !argStageEmpty ? true : undefined}
         aria-label={t.composer.message}
+        aria-multiline="true"
         autoCapitalize="off"
         autoCorrect="off"
         className={cn(
@@ -1214,9 +1226,11 @@ export function ChatBar({
                 activeIndex={triggerActive}
                 items={triggerItems}
                 kind={trigger.kind}
+                listboxId={triggerListboxId}
                 loading={triggerLoading}
                 onHover={setTriggerActive}
                 onPick={replaceTriggerWithChip}
+                optionIdPrefix={triggerOptionIdPrefix}
                 scope={trigger.scope}
               />
             )}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -937,11 +937,23 @@ export function ChatBar({
     />
   )
 
+  const triggerKindId = trigger?.kind === '@' ? 'at' : trigger?.kind === ':' ? 'emoji' : 'slash'
+  const triggerListboxId = `composer-${triggerKindId}-completion-listbox`
+  const triggerOptionIdPrefix = `composer-${triggerKindId}-completion`
+
+  const activeTriggerOptionId =
+    trigger && !argStageEmpty && triggerItems[triggerActive] ? `${triggerOptionIdPrefix}-${triggerActive}` : undefined
+
   const input = (
     <div className={cn('relative', stacked ? 'w-full' : 'min-w-(--composer-input-inline-min-width) flex-1')}>
       <div
+        aria-activedescendant={activeTriggerOptionId}
+        aria-autocomplete="list"
+        aria-controls={trigger && !argStageEmpty ? triggerListboxId : undefined}
         aria-disabled={inputDisabled ? true : undefined}
+        aria-expanded={trigger && !argStageEmpty ? true : undefined}
         aria-label={t.composer.message}
+        aria-multiline="true"
         autoCapitalize="off"
         autoCorrect="off"
         className={cn(
@@ -1145,9 +1157,11 @@ export function ChatBar({
                 activeIndex={triggerActive}
                 items={triggerItems}
                 kind={trigger.kind}
+                listboxId={triggerListboxId}
                 loading={triggerLoading}
                 onHover={setTriggerActive}
                 onPick={replaceTriggerWithChip}
+                optionIdPrefix={triggerOptionIdPrefix}
                 scope={trigger.scope}
               />
             )}

--- a/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
@@ -15,9 +15,11 @@ function renderPopover(kind: '@' | '/', loading = false) {
         activeIndex={0}
         items={[]}
         kind={kind}
+        listboxId="test-composer-completion-listbox"
         loading={loading}
         onHover={onHover}
         onPick={onPick}
+        optionIdPrefix="test-composer-completion"
       />
     </I18nProvider>
   )

--- a/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
@@ -15,9 +15,11 @@ function renderPopover(kind: '@' | '/', loading = false) {
         activeIndex={0}
         items={[]}
         kind={kind}
+        listboxId="test-composer-completion-listbox"
         loading={loading}
         onHover={onHover}
         onPick={onPick}
+        optionIdPrefix="test-composer-completion"
       />
     </I18nProvider>
   )
@@ -111,7 +113,7 @@ describe('ComposerTriggerPopover keyboard scrolling', () => {
     const { container, rerender } = render(popover(0))
     const drawer = container.querySelector('[data-slot="composer-completion-drawer"]') as HTMLElement
     const ancestor = drawer.parentElement as HTMLElement
-    const secondRow = screen.getAllByRole('button')[1]
+    const secondRow = screen.getAllByRole('option')[1]
 
     mockDrawerViewport(drawer)
     mockRowPosition(secondRow, 290, 330)
@@ -134,7 +136,7 @@ describe('ComposerTriggerPopover keyboard scrolling', () => {
   it('uses the nearest drawer edge for upward, visible, and oversized rows', () => {
     const { container, rerender } = render(popover(0))
     const drawer = container.querySelector('[data-slot="composer-completion-drawer"]') as HTMLElement
-    const rows = screen.getAllByRole('button')
+    const rows = screen.getAllByRole('option')
 
     mockDrawerViewport(drawer)
     mockRowPosition(rows[1], 80, 120)
@@ -165,7 +167,7 @@ describe('ComposerTriggerPopover keyboard scrolling', () => {
   it('does not scroll for a hover echo and consumes the hover marker', () => {
     const onHover = vi.fn()
     const { container, rerender } = render(popover(0, onHover))
-    const rows = screen.getAllByRole('button')
+    const rows = screen.getAllByRole('option')
     const drawer = container.querySelector('[data-slot="composer-completion-drawer"]') as HTMLElement
 
     mockDrawerViewport(drawer)
@@ -188,7 +190,7 @@ describe('ComposerTriggerPopover keyboard scrolling', () => {
     const onHover = vi.fn()
     const { container, rerender } = render(popover(1, onHover))
     const drawer = container.querySelector('[data-slot="composer-completion-drawer"]') as HTMLElement
-    const activeRow = screen.getAllByRole('button')[1]
+    const activeRow = screen.getAllByRole('option')[1]
 
     mockDrawerViewport(drawer)
     mockRowPosition(activeRow, 311, 331)

--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -55,9 +55,11 @@ interface ComposerTriggerPopoverProps {
   activeIndex: number
   items: readonly Unstable_TriggerItem[]
   kind: '@' | '/' | ':'
+  listboxId?: string
   loading: boolean
   onHover: (index: number) => void
   onPick: (item: Unstable_TriggerItem) => void
+  optionIdPrefix?: string
   placement?: 'bottom' | 'top'
   /** The `@kind:` browse the list is filtered to, when there is one. Rendered
    *  as a header so the scope reads as the mode it is — the raw `@folder:` in
@@ -81,9 +83,11 @@ export function ComposerTriggerPopover({
   activeIndex,
   items,
   kind,
+  listboxId = 'composer-completion-listbox',
   loading,
   onHover,
   onPick,
+  optionIdPrefix = 'composer-completion',
   placement = 'top',
   scope
 }: ComposerTriggerPopoverProps) {
@@ -155,6 +159,7 @@ export function ComposerTriggerPopover({
       className={placement === 'bottom' ? COMPLETION_DRAWER_BELOW_CLASS : COMPLETION_DRAWER_CLASS}
       data-slot="composer-completion-drawer"
       data-state="open"
+      id={listboxId}
       onMouseDown={event => event.preventDefault()}
       ref={listRef}
       role="listbox"
@@ -163,7 +168,7 @@ export function ComposerTriggerPopover({
       {items.length === 0 ? (
         loading ? (
           <div className="flex items-center gap-2 px-2 py-1.5 text-(--ui-text-tertiary)">
-            <GlyphSpinner ariaLabel={copy.lookupLoading} className="text-foreground/70" spinner="braille" />
+            <GlyphSpinner className="text-foreground/70" decorative spinner="braille" />
             <span>{copy.lookupLoading}</span>
           </div>
         ) : (
@@ -195,13 +200,18 @@ export function ComposerTriggerPopover({
           lastGroup = group || lastGroup
           const active = index === activeIndex
           const refKind = referenceKind(rowKind(item, isSlash))
+          const optionId = `${optionIdPrefix}-${index}`
+          const accessibleLabel = description ? `${display}: ${description}` : display
 
           return (
             <Fragment key={item.id}>
               {showHeader && <div className={cn(GROUP_HEADER_CLASS, isFirstHeader ? 'pt-0.5' : 'pt-2')}>{group}</div>}
               <button
+                aria-label={accessibleLabel}
+                aria-selected={active}
                 className={ROW_CLASS}
                 data-highlighted={active ? '' : undefined}
+                id={optionId}
                 onClick={() => onPick(item)}
                 onMouseEnter={() => {
                   // React bails out when hovering the already-active row. Do
@@ -209,6 +219,7 @@ export function ComposerTriggerPopover({
                   hoverIndexRef.current = index === activeIndex ? -1 : index
                   onHover(index)
                 }}
+                role="option"
                 type="button"
               >
                 {isEmoji ? (

--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -55,9 +55,11 @@ interface ComposerTriggerPopoverProps {
   activeIndex: number
   items: readonly Unstable_TriggerItem[]
   kind: '@' | '/' | ':'
+  listboxId: string
   loading: boolean
   onHover: (index: number) => void
   onPick: (item: Unstable_TriggerItem) => void
+  optionIdPrefix: string
   placement?: 'bottom' | 'top'
   /** The `@kind:` browse the list is filtered to, when there is one. Rendered
    *  as a header so the scope reads as the mode it is — the raw `@folder:` in
@@ -81,9 +83,11 @@ export function ComposerTriggerPopover({
   activeIndex,
   items,
   kind,
+  listboxId,
   loading,
   onHover,
   onPick,
+  optionIdPrefix,
   placement = 'top',
   scope
 }: ComposerTriggerPopoverProps) {
@@ -99,6 +103,7 @@ export function ComposerTriggerPopover({
       className={placement === 'bottom' ? COMPLETION_DRAWER_BELOW_CLASS : COMPLETION_DRAWER_CLASS}
       data-slot="composer-completion-drawer"
       data-state="open"
+      id={listboxId}
       onMouseDown={event => event.preventDefault()}
       role="listbox"
     >
@@ -106,7 +111,7 @@ export function ComposerTriggerPopover({
       {items.length === 0 ? (
         loading ? (
           <div className="flex items-center gap-2 px-2 py-1.5 text-(--ui-text-tertiary)">
-            <GlyphSpinner ariaLabel={copy.lookupLoading} className="text-foreground/70" spinner="braille" />
+            <GlyphSpinner className="text-foreground/70" decorative spinner="braille" />
             <span>{copy.lookupLoading}</span>
           </div>
         ) : (
@@ -138,15 +143,21 @@ export function ComposerTriggerPopover({
           lastGroup = group || lastGroup
           const active = index === activeIndex
           const refKind = referenceKind(rowKind(item, isSlash))
+          const optionId = `${optionIdPrefix}-${index}`
+          const accessibleLabel = description ? `${display}: ${description}` : display
 
           return (
             <Fragment key={item.id}>
               {showHeader && <div className={cn(GROUP_HEADER_CLASS, isFirstHeader ? 'pt-0.5' : 'pt-2')}>{group}</div>}
               <button
+                aria-label={accessibleLabel}
+                aria-selected={active}
                 className={ROW_CLASS}
                 data-highlighted={active ? '' : undefined}
+                id={optionId}
                 onClick={() => onPick(item)}
                 onMouseEnter={() => onHover(index)}
+                role="option"
                 type="button"
               >
                 {isEmoji ? (

--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -55,11 +55,11 @@ interface ComposerTriggerPopoverProps {
   activeIndex: number
   items: readonly Unstable_TriggerItem[]
   kind: '@' | '/' | ':'
-  listboxId: string
+  listboxId?: string
   loading: boolean
   onHover: (index: number) => void
   onPick: (item: Unstable_TriggerItem) => void
-  optionIdPrefix: string
+  optionIdPrefix?: string
   placement?: 'bottom' | 'top'
   /** The `@kind:` browse the list is filtered to, when there is one. Rendered
    *  as a header so the scope reads as the mode it is — the raw `@folder:` in
@@ -83,11 +83,11 @@ export function ComposerTriggerPopover({
   activeIndex,
   items,
   kind,
-  listboxId,
+  listboxId = 'composer-completion-listbox',
   loading,
   onHover,
   onPick,
-  optionIdPrefix,
+  optionIdPrefix = 'composer-completion',
   placement = 'top',
   scope
 }: ComposerTriggerPopoverProps) {

--- a/apps/desktop/src/app/right-sidebar/terminal/instance.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/instance.tsx
@@ -41,7 +41,7 @@ export function TerminalInstance({
 }: TerminalInstanceProps) {
   const { t } = useI18n()
 
-  const { addSelectionToChat, hostRef, selection, selectionStyle, status } = useTerminalSession({
+  const { addSelectionToChat, hostRef, selection, selectionStyle, shellName, status } = useTerminalSession({
     id,
     cwd,
     active,
@@ -87,7 +87,12 @@ export function TerminalInstance({
       )}
       {/* Outer div paints the terminal inset; inner div is the xterm host so the
           canvas sizes to the content area and p-2 stays as terminal padding. */}
-      <div className={HOST_CLASS} ref={hostRef} />
+      <div
+        aria-label={`${shellName} terminal`}
+        className={HOST_CLASS}
+        ref={hostRef}
+        role="region"
+      />
     </div>
   )
 }
@@ -110,7 +115,12 @@ export function AgentTerminalInstance({ active, id, procId }: AgentTerminalInsta
       // routes ⌘W here and closes the focused agent tab (not a preview).
       data-terminal=""
     >
-      <div className={HOST_CLASS} ref={hostRef} />
+      <div
+        aria-label="Agent terminal output"
+        className={HOST_CLASS}
+        ref={hostRef}
+        role="region"
+      />
     </div>
   )
 }

--- a/apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts
@@ -70,6 +70,7 @@ export function useAgentTerminal({ active, id, procId }: { active: boolean; id: 
       lineHeight: 1.12,
       linkHandler: terminalLinkHandler,
       minimumContrastRatio: 4.5,
+      screenReaderMode: true,
       scrollback: 1000,
       theme: surfaceTheme()
     })

--- a/apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts
@@ -69,6 +69,7 @@ export function useAgentTerminal({ active, id, procId }: { active: boolean; id: 
       lineHeight: 1.12,
       linkHandler: terminalLinkHandler,
       minimumContrastRatio: 4.5,
+      screenReaderMode: true,
       scrollback: 1000,
       theme: surfaceTheme()
     })

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -543,6 +543,7 @@ export function useTerminalSession({
       // at render time, matching the muted ink-like look of their terminal.
       minimumContrastRatio: 4.5,
       scrollback: 1000,
+      screenReaderMode: true,
       theme: withSurface(initialThemeRef.current)
     })
 

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -542,6 +542,7 @@ export function useTerminalSession({
       // at render time, matching the muted ink-like look of their terminal.
       minimumContrastRatio: 4.5,
       scrollback: 1000,
+      screenReaderMode: true,
       theme: withSurface(initialThemeRef.current)
     })
 

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -226,6 +226,13 @@ const StatusbarItemView = memo(function StatusbarItemView({
 }) {
   const [menuOpen, setMenuOpen] = useState(false)
 
+  const accessibleTitle =
+    item.title ??
+    (typeof item.label === 'string' ? item.label : typeof item.detail === 'string' ? item.detail : undefined)
+
+  const hasVisibleText = typeof item.label === 'string' || typeof item.detail === 'string'
+  const accessibleName = hasVisibleText ? undefined : accessibleTitle
+
   // Render escape hatch: the contribution owns its own chrome/state/tooltip.
   if (item.render) {
     return <ContribRender render={item.render} />
@@ -249,7 +256,13 @@ const StatusbarItemView = memo(function StatusbarItemView({
     // way profile-switcher.tsx stacks Popover/ContextMenu/Tooltip triggers.
     const trigger = (
       <DropdownMenuTrigger asChild>
-        <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} type="button">
+        <button
+          aria-label={accessibleName}
+          className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+          disabled={item.disabled}
+          title={accessibleTitle}
+          type="button"
+        >
           {content}
         </button>
       </DropdownMenuTrigger>
@@ -333,7 +346,14 @@ const StatusbarItemView = memo(function StatusbarItemView({
   if (item.href || item.variant === 'link') {
     return (
       <Tip label={tooltipLabel}>
-        <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
+        <a
+          aria-label={accessibleName}
+          className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+          href={item.href}
+          rel="noreferrer"
+          target="_blank"
+          title={accessibleTitle}
+        >
           {content}
         </a>
       </Tip>
@@ -343,6 +363,7 @@ const StatusbarItemView = memo(function StatusbarItemView({
   return (
     <Tip label={tooltipLabel}>
       <button
+        aria-label={accessibleName}
         className={cn(STATUSBAR_ACTION_CLASS, item.className)}
         disabled={item.disabled}
         onClick={event => {
@@ -352,6 +373,7 @@ const StatusbarItemView = memo(function StatusbarItemView({
 
           item.onSelect?.({ shiftKey: event.shiftKey })
         }}
+        title={accessibleTitle}
         type="button"
       >
         {content}

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -206,6 +206,10 @@ const StatusbarItemView = memo(function StatusbarItemView({
   navigate: ReturnType<typeof useNavigate>
 }) {
   const [menuOpen, setMenuOpen] = useState(false)
+  const accessibleTitle =
+    item.title ?? (typeof item.label === 'string' ? item.label : typeof item.detail === 'string' ? item.detail : undefined)
+  const hasVisibleText = typeof item.label === 'string' || typeof item.detail === 'string'
+  const accessibleName = hasVisibleText ? undefined : accessibleTitle
 
   // Render escape hatch: the contribution owns its own chrome/state/tooltip.
   if (item.render) {
@@ -230,7 +234,13 @@ const StatusbarItemView = memo(function StatusbarItemView({
     // way profile-switcher.tsx stacks Popover/ContextMenu/Tooltip triggers.
     const trigger = (
       <DropdownMenuTrigger asChild>
-        <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} type="button">
+        <button
+          aria-label={accessibleName}
+          className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+          disabled={item.disabled}
+          title={accessibleTitle}
+          type="button"
+        >
           {content}
         </button>
       </DropdownMenuTrigger>
@@ -314,7 +324,14 @@ const StatusbarItemView = memo(function StatusbarItemView({
   if (item.href || item.variant === 'link') {
     return (
       <Tip label={tooltipLabel}>
-        <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
+        <a
+          aria-label={accessibleName}
+          className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+          href={item.href}
+          rel="noreferrer"
+          target="_blank"
+          title={accessibleTitle}
+        >
           {content}
         </a>
       </Tip>
@@ -324,6 +341,7 @@ const StatusbarItemView = memo(function StatusbarItemView({
   return (
     <Tip label={tooltipLabel}>
       <button
+        aria-label={accessibleName}
         className={cn(STATUSBAR_ACTION_CLASS, item.className)}
         disabled={item.disabled}
         onClick={event => {
@@ -333,6 +351,7 @@ const StatusbarItemView = memo(function StatusbarItemView({
 
           item.onSelect?.({ shiftKey: event.shiftKey })
         }}
+        title={accessibleTitle}
         type="button"
       >
         {content}

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -206,8 +206,11 @@ const StatusbarItemView = memo(function StatusbarItemView({
   navigate: ReturnType<typeof useNavigate>
 }) {
   const [menuOpen, setMenuOpen] = useState(false)
+
   const accessibleTitle =
-    item.title ?? (typeof item.label === 'string' ? item.label : typeof item.detail === 'string' ? item.detail : undefined)
+    item.title ??
+    (typeof item.label === 'string' ? item.label : typeof item.detail === 'string' ? item.detail : undefined)
+
   const hasVisibleText = typeof item.label === 'string' || typeof item.detail === 'string'
   const accessibleName = hasVisibleText ? undefined : accessibleTitle
 

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -762,6 +762,11 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
 
   const handleKeyUp = triggerKeyUpHandler(triggerKeyConsumedRef, refreshTrigger)
 
+  const triggerKindId = trigger?.kind === '@' ? 'at-edit' : 'slash-edit'
+  const triggerListboxId = `composer-${triggerKindId}-completion-listbox`
+  const triggerOptionIdPrefix = `composer-${triggerKindId}-completion`
+  const activeTriggerOptionId = trigger && triggerItems[triggerActive] ? `${triggerOptionIdPrefix}-${triggerActive}` : undefined
+
   return (
     <ComposerPrimitive.Root className="contents" data-slot="aui_edit-composer-root">
       <StickyHumanMessageContainer>
@@ -782,9 +787,11 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
               activeIndex={triggerActive}
               items={triggerItems}
               kind={trigger.kind}
+              listboxId={triggerListboxId}
               loading={triggerLoading}
               onHover={setTriggerActive}
               onPick={replaceTriggerWithChip}
+              optionIdPrefix={triggerOptionIdPrefix}
               placement={triggerPlacement}
             />
           )}
@@ -798,7 +805,12 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
             data-expanded={expanded ? 'true' : undefined}
           >
             <div
+              aria-activedescendant={activeTriggerOptionId}
+              aria-autocomplete="list"
+              aria-controls={trigger ? triggerListboxId : undefined}
+              aria-expanded={trigger ? true : undefined}
               aria-label={copy.editMessage}
+              aria-multiline="true"
               autoCapitalize="off"
               autoCorrect="off"
               className={cn(

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -735,6 +735,11 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
     window.setTimeout(refreshTrigger, 0)
   }
 
+  const triggerKindId = trigger?.kind === '@' ? 'at-edit' : 'slash-edit'
+  const triggerListboxId = `composer-${triggerKindId}-completion-listbox`
+  const triggerOptionIdPrefix = `composer-${triggerKindId}-completion`
+  const activeTriggerOptionId = trigger && triggerItems[triggerActive] ? `${triggerOptionIdPrefix}-${triggerActive}` : undefined
+
   return (
     <ComposerPrimitive.Root className="contents" data-slot="aui_edit-composer-root">
       <StickyHumanMessageContainer>
@@ -752,9 +757,11 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
               activeIndex={triggerActive}
               items={triggerItems}
               kind={trigger.kind}
+              listboxId={triggerListboxId}
               loading={triggerLoading}
               onHover={setTriggerActive}
               onPick={replaceTriggerWithChip}
+              optionIdPrefix={triggerOptionIdPrefix}
               placement={triggerPlacement}
             />
           )}
@@ -768,7 +775,12 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
             data-expanded={expanded ? 'true' : undefined}
           >
             <div
+              aria-activedescendant={activeTriggerOptionId}
+              aria-autocomplete="list"
+              aria-controls={trigger ? triggerListboxId : undefined}
+              aria-expanded={trigger ? true : undefined}
               aria-label={copy.editMessage}
+              aria-multiline="true"
               autoCapitalize="off"
               autoCorrect="off"
               className={cn(

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group-keyboard.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group-keyboard.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import { group, split } from '../model'
+import { $layoutTree, declareDefaultTree } from '../store'
+
+import { LayoutTreeRoot } from '.'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  vi.stubGlobal('CSS', { ...globalThis.CSS, escape: (value: string) => value })
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+const disposers: (() => void)[] = []
+
+beforeEach(() => {
+  window.localStorage.clear()
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callback(performance.now())
+
+    return 1
+  })
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+  for (const id of ['workspace', 'preview-tile:alpha', 'preview-tile:beta', 'preview-tile:gamma']) {
+    disposers.push(
+      registry.register({
+        area: 'panes',
+        data: id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
+        id,
+        render: () => <div>{id}</div>,
+        title: id.replace('preview-tile:', '')
+      })
+    )
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  disposers.splice(0).forEach(dispose => dispose())
+  $layoutTree.set(null)
+})
+
+describe('pane tab keyboard semantics', () => {
+  it('uses roving focus and ARIA tab/panel wiring for horizontal preview tile tabs', () => {
+    declareDefaultTree(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'grp-main' }),
+        group(['preview-tile:alpha', 'preview-tile:beta', 'preview-tile:gamma'], {
+          active: 'preview-tile:alpha',
+          id: 'grp-preview'
+        })
+      ])
+    )
+
+    render(<LayoutTreeRoot />)
+
+    const tabs = screen.getAllByRole('tab').filter(tab => ['alpha', 'beta', 'gamma'].includes(tab.textContent ?? ''))
+
+    expect(tabs.map(tab => tab.textContent)).toEqual(['alpha', 'beta', 'gamma'])
+    expect(tabs[0].getAttribute('aria-selected')).toBe('true')
+    expect(tabs[0].getAttribute('tabindex')).toBe('0')
+    expect(tabs[1].getAttribute('tabindex')).toBe('-1')
+
+    const panelId = tabs[0].getAttribute('aria-controls')
+    expect(panelId).toBeTruthy()
+    expect(document.getElementById(panelId!)?.getAttribute('role')).toBe('tabpanel')
+    expect(document.getElementById(panelId!)?.getAttribute('aria-labelledby')).toBe(tabs[0].id)
+
+    fireEvent.keyDown(tabs[0], { key: 'ArrowRight' })
+    expect(screen.getByRole('tab', { name: 'beta' }).getAttribute('aria-selected')).toBe('true')
+    expect(document.activeElement).toBe(screen.getByRole('tab', { name: 'beta' }))
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'beta' }), { key: 'End' })
+    expect(screen.getByRole('tab', { name: 'gamma' }).getAttribute('aria-selected')).toBe('true')
+    expect(document.activeElement).toBe(screen.getByRole('tab', { name: 'gamma' }))
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'gamma' }), { key: 'ArrowRight' })
+    expect(screen.getByRole('tab', { name: 'alpha' }).getAttribute('aria-selected')).toBe('true')
+    expect(document.activeElement).toBe(screen.getByRole('tab', { name: 'alpha' }))
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -10,7 +10,16 @@
  */
 
 import { useStore } from '@nanostores/react'
-import { type CSSProperties, Fragment, type ReactNode, type RefObject, useEffect, useRef, useState } from 'react'
+import {
+  type CSSProperties,
+  Fragment,
+  type KeyboardEvent,
+  type ReactNode,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 
 import { ActionsContextMenu, type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
 import { Codicon } from '@/components/ui/codicon'
@@ -72,6 +81,10 @@ import { type DoubleTapContext, startPaneDrag } from './drag-session'
 import { forceLoneHeaderForPanes } from './lone-header'
 import { useActiveTabVisible } from './tab-strip-scroll'
 import { paneChrome } from './track-model'
+
+function paneDomId(kind: 'panel' | 'tab', groupId: string, paneId: string): string {
+  return `tree-${kind}-${groupId}-${paneId.replace(/[^a-zA-Z0-9_-]/g, char => `-${char.charCodeAt(0).toString(16)}-`)}`
+}
 
 /** Right-click zone menu: the tab verbs (close this / others / to the right /
  *  all) plus the strip's own chrome toggles. Same items and icons as a session
@@ -307,6 +320,87 @@ export function TreeGroup({
   // one the zone menu's Close and ⌘W use.
   const closeTab = (paneId: string) => closeTabPane(paneId)
 
+  const focusTab = (paneId: string) => {
+    window.requestAnimationFrame(() => {
+      document.getElementById(paneDomId('tab', node.id, paneId))?.focus()
+    })
+  }
+
+  const selectAndFocusTab = (paneId: string) => {
+    clearTabSelection()
+
+    if (node.minimized) {
+      restoreTreePane(paneId)
+    } else {
+      activateTreePane(node.id, paneId)
+    }
+
+    focusTab(paneId)
+  }
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLElement>, index: number, vertical = false) => {
+    let nextIndex: number | null = null
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        if (vertical) {
+          return
+        }
+
+        nextIndex = index === 0 ? shown.length - 1 : index - 1
+
+        break
+
+      case 'ArrowRight':
+        if (vertical) {
+          return
+        }
+
+        nextIndex = index === shown.length - 1 ? 0 : index + 1
+
+        break
+
+      case 'ArrowUp':
+        if (!vertical) {
+          return
+        }
+
+        nextIndex = index === 0 ? shown.length - 1 : index - 1
+
+        break
+
+      case 'ArrowDown':
+        if (!vertical) {
+          return
+        }
+
+        nextIndex = index === shown.length - 1 ? 0 : index + 1
+
+        break
+
+      case 'Home':
+        nextIndex = 0
+
+        break
+
+      case 'End':
+        nextIndex = shown.length - 1
+
+        break
+
+      default:
+        return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+    const nextPaneId = shown[nextIndex]
+
+    if (nextPaneId) {
+      selectAndFocusTab(nextPaneId)
+    }
+  }
+
   // A pane whose store owns Close keeps the gesture even when the pane itself
   // is uncloseable — the workspace tab empties to a fresh draft rather than
   // leaving the tree.
@@ -376,7 +470,7 @@ export function TreeGroup({
               className="flex min-h-0 flex-col overflow-y-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
               role="tablist"
             >
-              {shown.map(paneId => {
+              {shown.map((paneId, index) => {
                 const closeable = closeableTab(paneId)
                 const title = paneFor(paneId)?.title ?? paneId
 
@@ -384,16 +478,20 @@ export function TreeGroup({
                   <PaneTab
                     // Match the horizontal minimized strip: no tab is "active"
                     // while collapsed (there's no content surface to merge into).
+                    aria-controls={paneDomId('panel', node.id, paneId)}
                     aria-selected={paneId === activeId}
                     data-tree-tab={paneId}
+                    id={paneDomId('tab', node.id, paneId)}
                     key={paneId}
                     onClick={event => {
                       event.stopPropagation()
                       restoreTreePane(paneId)
                     }}
                     onClose={closeable ? () => closeTab(paneId) : undefined}
+                    onKeyDown={event => handleTabKeyDown(event, index, true)}
                     role="tab"
                     side={railSide}
+                    tabIndex={paneId === activeId ? 0 : -1}
                     vertical
                   >
                     <PaneTabLabel>{title}</PaneTabLabel>
@@ -444,7 +542,7 @@ export function TreeGroup({
               </>
             }
           >
-            {shown.map(paneId => {
+            {shown.map((paneId, index) => {
               const isActive = paneId === activeId && !node.minimized
               const chrome = paneChrome(paneFor(paneId))
               const closeable = closeableTab(paneId)
@@ -454,10 +552,13 @@ export function TreeGroup({
               const tab = (
                 <PaneTab
                   active={isActive}
+                  aria-controls={paneDomId('panel', node.id, paneId)}
                   aria-selected={isActive}
                   data-tree-tab={paneId}
+                  id={paneDomId('tab', node.id, paneId)}
                   key={paneId}
                   onClose={closeable ? () => closeTab(paneId) : undefined}
+                  onKeyDown={e => handleTabKeyDown(e, index)}
                   onPointerDown={e => {
                     // Chrome's tab-selection grammar, ahead of activate/drag:
                     // Shift-click ranges from the anchor, ⌥-click (Ctrl-click
@@ -543,6 +644,7 @@ export function TreeGroup({
                   role="tab"
                   selected={isSelected}
                   style={{ cursor: 'grab' }}
+                  tabIndex={isActive ? 0 : -1}
                 >
                   {chrome.tabLead ? (
                     <span className="ml-2 -mr-1 flex shrink-0 items-center">{chrome.tabLead()}</span>
@@ -611,8 +713,11 @@ export function TreeGroup({
               return (
                 <div
                   aria-hidden={!isActive || undefined}
+                  aria-labelledby={paneDomId('tab', node.id, paneId)}
                   className={cn('absolute inset-0 overflow-auto', !isActive && 'pointer-events-none invisible')}
+                  id={paneDomId('panel', node.id, paneId)}
                   key={paneId}
+                  role="tabpanel"
                   {...hiddenPaneProps(!isActive)}
                 >
                   {pane?.render ? (

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useStore } from '@nanostores/react'
-import { type CSSProperties, Fragment, type ReactNode, type RefObject, useEffect, useRef, useState } from 'react'
+import { type CSSProperties, Fragment, type KeyboardEvent, type ReactNode, type RefObject, useEffect, useRef, useState } from 'react'
 
 import { ActionsContextMenu, type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
 import { Codicon } from '@/components/ui/codicon'
@@ -84,6 +84,10 @@ import { startPaneDrag } from './drag-session'
 import { tabStripVisibleForZone } from './strip-visibility'
 import { useActiveTabVisible } from './tab-strip-scroll'
 import { paneChrome } from './track-model'
+
+function paneDomId(kind: 'panel' | 'tab', groupId: string, paneId: string): string {
+  return `tree-${kind}-${groupId}-${paneId.replace(/[^a-zA-Z0-9_-]/g, char => `-${char.charCodeAt(0).toString(16)}-`)}`
+}
 
 /** Right-click zone menu: the tab verbs (close this / others / to the right /
  *  all) plus the strip's own chrome toggles. Same items and icons as a session
@@ -353,6 +357,87 @@ export function TreeGroup({
   // one the zone menu's Close and ⌘W use.
   const closeTab = (paneId: string) => closeTabPane(paneId)
 
+  const focusTab = (paneId: string) => {
+    window.requestAnimationFrame(() => {
+      document.getElementById(paneDomId('tab', node.id, paneId))?.focus()
+    })
+  }
+
+  const selectAndFocusTab = (paneId: string) => {
+    clearTabSelection()
+
+    if (node.minimized) {
+      restoreTreePane(paneId)
+    } else {
+      activateTreePane(node.id, paneId)
+    }
+
+    focusTab(paneId)
+  }
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLElement>, index: number, vertical = false) => {
+    let nextIndex: number | null = null
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        if (vertical) {
+          return
+        }
+
+        nextIndex = index === 0 ? shown.length - 1 : index - 1
+
+        break
+
+      case 'ArrowRight':
+        if (vertical) {
+          return
+        }
+
+        nextIndex = index === shown.length - 1 ? 0 : index + 1
+
+        break
+
+      case 'ArrowUp':
+        if (!vertical) {
+          return
+        }
+
+        nextIndex = index === 0 ? shown.length - 1 : index - 1
+
+        break
+
+      case 'ArrowDown':
+        if (!vertical) {
+          return
+        }
+
+        nextIndex = index === shown.length - 1 ? 0 : index + 1
+
+        break
+
+      case 'Home':
+        nextIndex = 0
+
+        break
+
+      case 'End':
+        nextIndex = shown.length - 1
+
+        break
+
+      default:
+        return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+    const nextPaneId = shown[nextIndex]
+
+    if (nextPaneId) {
+      selectAndFocusTab(nextPaneId)
+    }
+  }
+
   // A pane whose store owns Close keeps the gesture even when the pane itself
   // is uncloseable — the workspace tab empties to a fresh draft rather than
   // leaving the tree. Hide-only chrome (sessions / Bots) opts out of every
@@ -422,23 +507,27 @@ export function TreeGroup({
               className="flex min-h-0 flex-col overflow-y-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
               role="tablist"
             >
-              {shown.map(paneId => {
+              {shown.map((paneId, index) => {
                 const closeable = closeableTab(paneId)
 
                 return (
                   <PaneTab
                     // Match the horizontal minimized strip: no tab is "active"
                     // while collapsed (there's no content surface to merge into).
+                    aria-controls={paneDomId('panel', node.id, paneId)}
                     aria-selected={paneId === activeId}
                     data-tree-tab={paneId}
+                    id={paneDomId('tab', node.id, paneId)}
                     key={paneId}
                     onClick={event => {
                       event.stopPropagation()
                       restoreTreePane(paneId)
                     }}
                     onClose={closeable ? () => closeTab(paneId) : undefined}
+                    onKeyDown={event => handleTabKeyDown(event, index, true)}
                     role="tab"
                     side={railSide}
+                    tabIndex={paneId === activeId ? 0 : -1}
                     vertical
                   >
                     <PaneTabLabel>{tabLabel(paneId)}</PaneTabLabel>
@@ -484,7 +573,7 @@ export function TreeGroup({
               </>
             }
           >
-            {shown.map(paneId => {
+            {shown.map((paneId, index) => {
               const isActive = paneId === activeId && !node.minimized
               const chrome = paneChrome(paneFor(paneId))
               const closeable = closeableTab(paneId)
@@ -494,10 +583,13 @@ export function TreeGroup({
               const tab = (
                 <PaneTab
                   active={isActive}
+                  aria-controls={paneDomId('panel', node.id, paneId)}
                   aria-selected={isActive}
                   data-tree-tab={paneId}
+                  id={paneDomId('tab', node.id, paneId)}
                   key={paneId}
                   onClose={closeable ? () => closeTab(paneId) : undefined}
+                  onKeyDown={e => handleTabKeyDown(e, index)}
                   onPointerDown={e => {
                     // Chrome's tab-selection grammar, ahead of activate/drag:
                     // Shift-click ranges from the anchor, ⌥-click (Ctrl-click
@@ -581,6 +673,7 @@ export function TreeGroup({
                   role="tab"
                   selected={isSelected}
                   style={{ cursor: 'grab' }}
+                  tabIndex={isActive ? 0 : -1}
                 >
                   {chrome.tabLead ? (
                     <span className="ml-2 -mr-1 flex shrink-0 items-center">{chrome.tabLead()}</span>
@@ -640,8 +733,11 @@ export function TreeGroup({
               return (
                 <div
                   aria-hidden={!isActive || undefined}
+                  aria-labelledby={paneDomId('tab', node.id, paneId)}
                   className={cn('absolute inset-0 overflow-auto', !isActive && 'pointer-events-none invisible')}
+                  id={paneDomId('panel', node.id, paneId)}
                   key={paneId}
+                  role="tabpanel"
                   {...hiddenPaneProps(!isActive)}
                 >
                   {pane?.render ? (

--- a/apps/desktop/src/components/ui/confirm-dialog.tsx
+++ b/apps/desktop/src/components/ui/confirm-dialog.tsx
@@ -30,9 +30,10 @@ interface ConfirmDialogProps {
   dismissOnConfirm?: boolean
 }
 
-// Shared confirmation dialog: Enter confirms (from anywhere in the dialog),
-// Esc/Cancel/backdrop dismiss. Owns the pending → done → close beat and inline
-// error, so callers pass only an async onConfirm that does the work.
+// Shared confirmation dialog. Native button semantics own Enter/Space so a
+// focused Cancel button cannot accidentally trigger the confirm action. Owns
+// the pending → done → close beat and inline error, so callers pass only an
+// async onConfirm that does the work.
 export function ConfirmDialog({
   open,
   onClose,
@@ -94,25 +95,19 @@ export function ConfirmDialog({
 
   return (
     <Dialog onOpenChange={value => !value && !busy && onClose()} open={open}>
-      <DialogContent
-        className="max-w-md"
-        onKeyDown={event => {
-          // Enter/Space confirm regardless of which button holds focus
-          // (preventDefault stops a focused Cancel from swallowing it).
-          if ((event.key === 'Enter' || event.key === ' ') && !busy) {
-            event.preventDefault()
-            void run()
-          }
-        }}
-      >
+      <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {description ? <DialogDescription>{description}</DialogDescription> : null}
         </DialogHeader>
 
         {error && (
-          <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-            <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+          <div
+            aria-atomic="true"
+            className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+            role="alert"
+          >
+            <AlertTriangle aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
             <span>{error}</span>
           </div>
         )}

--- a/apps/desktop/src/components/ui/confirm-dialog.tsx
+++ b/apps/desktop/src/components/ui/confirm-dialog.tsx
@@ -28,6 +28,10 @@ interface ConfirmDialogProps {
   destructive?: boolean
   /** Close as soon as onConfirm resolves — for optimistic actions that finish in the background. */
   dismissOnConfirm?: boolean
+  /** Focus control for dialogs with no input. Pass `preventCloseButtonAutoFocus`
+   *  so opening doesn't land focus on the close/cancel button (which would pop
+   *  its tooltip with no pointer near it). */
+  onOpenAutoFocus?: (event: Event) => void
   /** A third, non-destructive way out, shown between Cancel and Confirm (e.g.
    *  "Remove from sidebar" beside "Delete worktree"). Closes on click. */
   secondaryAction?: ConfirmSecondaryAction
@@ -38,10 +42,9 @@ interface ConfirmSecondaryAction {
   onClick: () => void
 }
 
-// Shared confirmation dialog: opens focused on Confirm, Enter confirms (from
-// anywhere in the dialog), Esc/Cancel/backdrop dismiss. Owns the pending → done
-// → close beat and inline error, so callers pass only an async onConfirm that
-// does the work.
+// Shared confirmation dialog: opens focused on Confirm by default, lets callers
+// override autofocus when needed, and owns the pending → done → close beat plus
+// inline error handling.
 export function ConfirmDialog({
   open,
   onClose,
@@ -54,6 +57,7 @@ export function ConfirmDialog({
   cancelLabel,
   destructive = false,
   dismissOnConfirm = false,
+  onOpenAutoFocus,
   secondaryAction
 }: ConfirmDialogProps) {
   const { t } = useI18n()
@@ -125,6 +129,21 @@ export function ConfirmDialog({
     }
   }
 
+  function handleOpenAutoFocus(event: Event) {
+    if (onOpenAutoFocus) {
+      onOpenAutoFocus(event)
+
+      return
+    }
+
+    // Focus must land inside the dialog or the handler below never sees the
+    // key: it stays on whatever opened the dialog (a menu item, a sidebar row)
+    // and Enter re-triggers that instead. Radix's default would take the X —
+    // confirm is the button Enter maps to.
+    event.preventDefault()
+    confirmRef.current?.focus()
+  }
+
   return (
     <Dialog onOpenChange={value => !value && !busy && onClose()} open={open}>
       <DialogContent
@@ -137,14 +156,7 @@ export function ConfirmDialog({
             void run()
           }
         }}
-        onOpenAutoFocus={event => {
-          // Focus must land inside the dialog or the handler above never sees
-          // the key: it stays on whatever opened the dialog (a menu item, a
-          // sidebar row) and Enter re-triggers that instead. Radix's default
-          // would take the X — confirm is the button Enter maps to.
-          event.preventDefault()
-          confirmRef.current?.focus()
-        }}
+        onOpenAutoFocus={handleOpenAutoFocus}
       >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
@@ -152,8 +164,12 @@ export function ConfirmDialog({
         </DialogHeader>
 
         {error && (
-          <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-            <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+          <div
+            aria-atomic="true"
+            className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+            role="alert"
+          >
+            <AlertTriangle aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
             <span>{error}</span>
           </div>
         )}

--- a/apps/desktop/src/components/ui/glyph-spinner.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.tsx
@@ -49,6 +49,7 @@ interface GlyphSpinnerProps {
    *  keeps it in the tree through a fade-out and does not want it animating
    *  once it is no longer the thing being waited on. */
   paused?: boolean
+  decorative?: boolean
   spinner?: SpinnerName
 }
 
@@ -73,6 +74,7 @@ export function GlyphSpinner({
   ariaLabel = 'Loading',
   className,
   paused = false,
+  decorative = false,
   spinner = 'braille'
 }: GlyphSpinnerProps) {
   const spin = FRAMES_BY_NAME[spinner] ?? FRAMES_BY_NAME.braille!
@@ -94,9 +96,10 @@ export function GlyphSpinner({
 
   return (
     <span
-      aria-label={ariaLabel}
+      aria-hidden={decorative ? true : undefined}
+      aria-label={decorative ? undefined : ariaLabel}
       className={cn('inline-flex items-center justify-center font-mono leading-none tabular-nums', className)}
-      role="status"
+      role={decorative ? undefined : 'status'}
     >
       {/* Hidden from assistive tech: the accessible name is the label above.
           The frames are decorative, and this is a live region — the old

--- a/apps/desktop/src/components/ui/glyph-spinner.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.tsx
@@ -32,6 +32,7 @@ const FRAMES_BY_NAME: Record<SpinnerName, NormalisedSpinner> = (() => {
 interface GlyphSpinnerProps {
   ariaLabel?: string
   className?: string
+  decorative?: boolean
   spinner?: SpinnerName
 }
 
@@ -42,7 +43,12 @@ interface GlyphSpinnerProps {
  * an `inline-flex` cell with `leading-none` and `items-center` so it sits
  * vertically centred inside its parent's line-box.
  */
-export function GlyphSpinner({ ariaLabel = 'Loading', className, spinner = 'braille' }: GlyphSpinnerProps) {
+export function GlyphSpinner({
+  ariaLabel = 'Loading',
+  className,
+  decorative = false,
+  spinner = 'braille'
+}: GlyphSpinnerProps) {
   const spin = FRAMES_BY_NAME[spinner] ?? FRAMES_BY_NAME.braille!
   const glyphRef = useRef<HTMLSpanElement>(null)
   // Pause when this surface is a hidden (kept-alive) tab: N mounted tabs each
@@ -98,10 +104,11 @@ export function GlyphSpinner({ ariaLabel = 'Loading', className, spinner = 'brai
 
   return (
     <span
-      aria-label={ariaLabel}
+      aria-hidden={decorative ? true : undefined}
+      aria-label={decorative ? undefined : ariaLabel}
       className={cn('inline-flex items-center justify-center font-mono leading-none tabular-nums', className)}
       ref={glyphRef}
-      role="status"
+      role={decorative ? undefined : 'status'}
     >
       {spin.frames[0]}
     </span>

--- a/docs/accessibility/desktop-a11y-audit-v0.17.0.md
+++ b/docs/accessibility/desktop-a11y-audit-v0.17.0.md
@@ -1,0 +1,195 @@
+# Hermes Desktop accessibility audit — v0.17.0
+
+Target: Hermes Agent Desktop, tag `v2026.6.19` / v0.17.0.
+
+Scope:
+
+- `apps/desktop/` — Electron + React desktop app.
+- `apps/bootstrap-installer/` — Tauri bootstrap installer.
+
+Method: static source audit against WCAG 2.1 AA with desktop-app checks. This audit intentionally deduplicates findings by reusable component/pattern instead of listing every repeated button instance.
+
+Limitations: static review cannot confirm actual NVDA/Narrator/Orca output, rendered contrast in every state, final tab order, or runtime keyboard traps. Those items need manual validation on Windows and Linux.
+
+## Findings fixed in this PR
+
+### Composer autocomplete combobox/listbox relationship
+
+Files:
+
+- `apps/desktop/src/app/chat/composer/index.tsx`
+- `apps/desktop/src/app/chat/composer/trigger-popover.tsx`
+
+Issue: the contenteditable composer exposed only `role="textbox"`; the `/` and `@` suggestion list was visually connected but not programmatically connected.
+
+Fix:
+
+- Add `aria-autocomplete="list"`, `aria-expanded`, `aria-controls`, `aria-activedescendant`, and `aria-multiline` to the composer textbox.
+- Add stable listbox/option ids.
+- Mark the active suggestion with `aria-selected`.
+- Keep the loading spinner decorative where visible text already says that suggestions are loading.
+
+WCAG: 1.3.1, 4.1.2.
+
+### Preview tabs and panel semantics
+
+File: `apps/desktop/src/app/chat/right-rail/preview.tsx`
+
+Issue: preview tabs had partial tab semantics but no tablist label, no `aria-controls`, and no associated `tabpanel`.
+
+Fix:
+
+- Label the tablist.
+- Connect active tabs to the panel via `aria-controls` / `aria-labelledby`.
+- Add a focus-visible ring for tab buttons.
+
+Remaining manual check: verify ArrowLeft/ArrowRight/Home/End tab navigation at runtime.
+
+WCAG: 1.3.1, 2.1.1, 4.1.2.
+
+### Terminal screen-reader support
+
+Files:
+
+- `apps/desktop/src/app/right-sidebar/terminal/index.tsx`
+- `apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts`
+
+Issue: xterm was visually integrated but the host region had no accessible region name and xterm screen-reader mode was not enabled.
+
+Fix:
+
+- Label the terminal host as a terminal region.
+- Enable `screenReaderMode` for xterm.
+
+Remaining manual check: validate actual xterm behavior with NVDA/Narrator on Windows and Orca on Linux.
+
+WCAG: 4.1.2.
+
+### Statusbar icon-only controls
+
+File: `apps/desktop/src/app/shell/statusbar-controls.tsx`
+
+Issue: statusbar items could provide `title`, but the renderer did not pass it to interactive button/link/menu trigger elements. Icon-only items therefore risked unnamed controls.
+
+Fix:
+
+- Derive an accessible title from `item.title`, text label, or detail.
+- Pass it as `aria-label` and `title` to button/link/menu trigger variants.
+
+WCAG: 2.4.4, 4.1.2.
+
+### Destructive confirmation dialog keyboard behavior and error announcement
+
+File: `apps/desktop/src/components/ui/confirm-dialog.tsx`
+
+Issue: the shared confirmation dialog intercepted Enter/Space anywhere in the dialog and ran the confirm action, even if focus was on Cancel. Inline errors were visual-only.
+
+Fix:
+
+- Remove the dialog-wide Enter/Space override and rely on native button semantics.
+- Expose inline errors with `role="alert"` and decorative alert icons as `aria-hidden`.
+
+WCAG: 2.1.1, 3.2.2, 3.3.1, 4.1.3.
+
+### Cron delete icon button accessible name
+
+File: `apps/desktop/src/app/cron/index.tsx`
+
+Issue: the cron delete button rendered only a trash icon.
+
+Fix: add an accessible name using the existing cron deletion copy.
+
+WCAG: 4.1.2.
+
+### Bootstrap installer progress and details semantics
+
+Files:
+
+- `apps/bootstrap-installer/src/routes/progress.tsx`
+- `apps/bootstrap-installer/src-tauri/tauri.conf.json`
+- `apps/bootstrap-installer/src/styles.css`
+
+Issues:
+
+- Tauri window title was generic (`Hermes`) instead of installer-specific.
+- Progress bar was visual-only.
+- Stage state was icon/color-only.
+- Details disclosure lacked `aria-expanded` / `aria-controls`.
+- Installer fade-in animation ignored reduced-motion preference.
+
+Fixes:
+
+- Rename the window title to `Hermes Setup`.
+- Add `role="progressbar"` with value attributes and `aria-valuetext`.
+- Add a polite status region for current progress.
+- Add text equivalents for stage states and mark status icons decorative.
+- Add disclosure relationship semantics for the log panel.
+- Disable the installer fade animation under `prefers-reduced-motion: reduce`.
+
+WCAG: 1.3.1, 1.4.1, 2.2.2, 2.4.2, 4.1.2, 4.1.3.
+
+## Deduplicated findings still recommended for follow-up
+
+### Shared settings row labels
+
+Pattern: `ListRow` visually pairs labels/descriptions with controls, but many generated switches, selects, inputs, and textareas are not programmatically associated with the row text.
+
+Representative files:
+
+- `apps/desktop/src/app/settings/primitives.tsx`
+- `apps/desktop/src/app/settings/config-settings.tsx`
+- `apps/desktop/src/app/settings/notifications-settings.tsx`
+- `apps/desktop/src/app/skills/index.tsx`
+
+Recommendation: create a shared labeled-row field API that emits ids and connects `aria-labelledby` / `aria-describedby` to the child control.
+
+### Active navigation state semantics
+
+Pattern: several custom navigation rows expose selection only visually.
+
+Representative files:
+
+- `apps/desktop/src/components/ui/text-tab.tsx`
+- `apps/desktop/src/app/settings/primitives.tsx`
+- `apps/desktop/src/app/overlays/overlay-split-layout.tsx`
+- `apps/desktop/src/app/profiles/index.tsx`
+- `apps/desktop/src/app/messaging/index.tsx`
+
+Recommendation: use `aria-current`, `aria-selected`, or proper tab/radio semantics depending on the control pattern.
+
+### Pointer/drag-only workflows
+
+Pattern: some reference insertion and preview line-selection flows rely on mouse selection or drag/drop.
+
+Representative files:
+
+- `apps/desktop/src/app/chat/right-rail/preview-file.tsx`
+- `apps/desktop/src/app/chat/sidebar/session-row.tsx`
+
+Recommendation: add keyboard-equivalent commands for selecting source lines/ranges and inserting session/file/path references.
+
+### Resizable preview console separator
+
+File: `apps/desktop/src/app/chat/right-rail/preview-console.tsx`
+
+Recommendation: make the separator focusable and expose `aria-orientation`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and keyboard resize behavior.
+
+### Live regions for streaming surfaces
+
+Representative files:
+
+- `apps/desktop/src/components/assistant-ui/thread-list.tsx`
+- `apps/desktop/src/app/chat/right-rail/preview-console.tsx`
+
+Recommendation: use a labeled `role="log"` for chat/console output and targeted polite/assertive status messages for progress/errors without announcing every streamed token.
+
+## Manual validation checklist
+
+Validate on Windows with NVDA/Narrator and on Linux with Orca:
+
+- Composer `/` and `@` suggestions: announcement of suggestions, active option, selection, and dismissal.
+- Preview tabs: Tab reachability and arrow-key tab switching.
+- Terminal: xterm screen-reader output, focus entry/exit, selection-to-chat shortcut, and paste/drop alternatives.
+- Statusbar: icon-only controls have names in the screen reader object model.
+- Confirm dialogs: Space/Enter on Cancel does not confirm destructive actions.
+- Installer: title in task switcher, progressbar announcements, details disclosure, failure state announcement, and reduced-motion behavior.


### PR DESCRIPTION
## Summary

This PR applies the first deduplicated static accessibility pass for the new Hermes Desktop surfaces introduced around v0.16/v0.17.

It focuses on reusable component/pattern fixes rather than filing the same issue for every repeated button/control instance.

Changes include:

- add a static audit report at `docs/accessibility/desktop-a11y-audit-v0.17.0.md`
- connect composer `/` and `@` autocomplete popovers to their contenteditable textbox via ARIA combobox/listbox relationships
- improve preview tab/tabpanel semantics
- enable xterm `screenReaderMode` and label the terminal region
- pass statusbar item titles through as `aria-label` / `title` for icon-only controls
- fix shared confirmation dialog keyboard behavior so Enter/Space on Cancel cannot confirm a destructive action
- expose confirmation dialog inline errors with `role="alert"`
- name the cron delete icon button
- improve bootstrap installer progress, log disclosure, stage state text, setup window title, and reduced-motion behavior

## Audit scope

Static review covered:

- `apps/desktop/` Electron + React renderer surfaces: chat, composer, right rail/preview, terminal, shell/statusbar, cron, shared dialog/spinner components
- `apps/bootstrap-installer/` Tauri setup flow: progress, details/log panel, title, motion

The report intentionally groups remaining issues by pattern/component so follow-up work does not duplicate the same inaccessible-control finding across many instances.

## Verification

Passed:

- `npm run typecheck --workspace apps/desktop`
- `npm run typecheck --workspace apps/bootstrap-installer`
- `npx eslint <changed desktop files>` from `apps/desktop/`
- `npx vitest run src/app/chat/composer/trigger-popover.test.tsx --environment jsdom` from `apps/desktop/`
- `npm run build --workspace apps/bootstrap-installer`
- `git diff --check`

Also ran full desktop lint:

- `npm run lint --workspace apps/desktop`

That command still fails on pre-existing unrelated lint errors across untouched files (for example `electron/main.cjs`, settings imports, desktop-fs tests, etc.). Changed desktop files pass targeted ESLint.

## Manual validation still required

Static source review cannot honestly verify runtime screen-reader behavior. Please validate on Windows and Linux:

- NVDA/Narrator/Orca announcements for composer autocomplete and active options
- preview tab keyboard navigation, especially ArrowLeft/ArrowRight/Home/End
- xterm screen-reader behavior and terminal focus entry/exit
- statusbar icon-only control names in the accessibility tree
- destructive confirm dialogs with keyboard focus on Cancel
- installer progress announcements, disclosure state, failure state, and reduced-motion behavior
