### PR TITLE
fix(config): guard WECOM/BlueBubbles port env vars against malformed values

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
 
 from hermes_cli.config import get_hermes_home
-from utils import is_truthy_value
+from utils import env_int, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -1860,7 +1860,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "token": os.getenv("WECOM_CALLBACK_TOKEN", ""),
             "encoding_aes_key": os.getenv("WECOM_CALLBACK_ENCODING_AES_KEY", ""),
             "host": os.getenv("WECOM_CALLBACK_HOST", "0.0.0.0"),
-            "port": int(os.getenv("WECOM_CALLBACK_PORT", "8645")),
+            "port": env_int("WECOM_CALLBACK_PORT", 8645),
         })
 
     # Weixin (personal WeChat via iLink Bot API)
@@ -1916,7 +1916,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "server_url": bluebubbles_server_url.rstrip("/"),
             "password": bluebubbles_password,
             "webhook_host": os.getenv("BLUEBUBBLES_WEBHOOK_HOST", "127.0.0.1"),
-            "webhook_port": int(os.getenv("BLUEBUBBLES_WEBHOOK_PORT", "8645")),
+            "webhook_port": env_int("BLUEBUBBLES_WEBHOOK_PORT", 8645),
             "webhook_path": os.getenv("BLUEBUBBLES_WEBHOOK_PATH", "/bluebubbles-webhook"),
             "send_read_receipts": os.getenv("BLUEBUBBLES_SEND_READ_RECEIPTS", "true").lower() in {"true", "1", "yes"},
         })


### PR DESCRIPTION
## Summary

`WECOM_CALLBACK_PORT` and `BLUEBUBBLES_WEBHOOK_PORT` in `gateway/config.py` use bare `int(os.getenv(...))` which raises `ValueError` if the env var contains a non-numeric string (e.g. `""`, `"abc"`). This crashes the gateway on startup.

### Fix

Replace with `env_int()` from `utils.py` which gracefully falls back to the default value on malformed input. This is the same pattern already used throughout the rest of the codebase.

### Changes
- `gateway/config.py`: import `env_int` from `utils`, replace 2 bare `int(os.getenv(...))` calls

### Test Plan
- [x] Gateway config tests pass (67 passed)
