### PR TITLE
fix(cli): export Feishu card profile env

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -499,6 +499,8 @@ def _apply_profile_override() -> None:
             )
             return
         os.environ["HERMES_HOME"] = hermes_home
+        if profile_name != "default":
+            os.environ.setdefault("HERMES_FEISHU_CARD_PROFILE_ID", profile_name)
         # Strip the flag from argv so argparse doesn't choke
         if consume > 0 and profile_index is not None:
             start = profile_index + 1  # +1 because argv is sys.argv[1:]

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -41,6 +41,7 @@ def _run_apply_profile_override(
         monkeypatch.setenv("HERMES_HOME", hermes_home)
     else:
         monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("HERMES_FEISHU_CARD_PROFILE_ID", raising=False)
 
     monkeypatch.setattr(sys, "argv", argv or ["hermes", "gateway", "start"])
 
@@ -213,6 +214,22 @@ class TestApplyProfileOverrideHermesHomeGuard:
         assert result.endswith("coder")
         assert sys.argv == ["hermes", "chat", "-q", "hello"]
 
+    def test_explicit_named_profile_sets_feishu_card_profile_env(
+        self, tmp_path, monkeypatch
+    ):
+        """The Feishu streaming-card hook runtime needs the active profile id."""
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile="coder",
+            argv=["hermes", "-p", "coder", "gateway", "run"],
+        )
+
+        assert result is not None
+        assert result.endswith("coder")
+        assert os.environ.get("HERMES_FEISHU_CARD_PROFILE_ID") == "coder"
+
     def test_top_level_profile_after_value_flag_is_consumed(self, tmp_path, monkeypatch):
         """Top-level --profile still works after other top-level value flags."""
         result = _run_apply_profile_override(
@@ -322,4 +339,3 @@ class TestSupervisedChildIgnoresStickyProfile:
         result = os.environ.get("HERMES_HOME")
         assert result is not None
         assert result.endswith("coder")
-


### PR DESCRIPTION
## What does this PR do?

- Sets `HERMES_FEISHU_CARD_PROFILE_ID` when `_apply_profile_override()` resolves a non-default profile.
- Uses `setdefault()` so an explicitly supplied Feishu card profile env remains authoritative.
- Adds regression coverage for `hermes -p coder gateway run`.

Fixes #49402

## Testing

- `python3 -m pytest -o addopts= tests/hermes_cli/test_apply_profile_override.py -q`
- `python3 -m py_compile hermes_cli/main.py tests/hermes_cli/test_apply_profile_override.py`
- `git diff --check`

## Duplicate check

- Guarded PR gate passed for exact issue/env-var search before creating this PR.
- Manually reviewed broad `profile` false-positive candidates; none touched this Feishu card profile env behavior.
