### PR TITLE
fix(agent): warn when configured memory provider fails or is unavailable

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1161,7 +1161,14 @@ def init_agent(
                 from plugins.memory import load_memory_provider as _load_mem
                 agent._memory_manager = _MemoryManager()
                 _mp = _load_mem(_mem_provider_name)
-                if _mp and _mp.is_available():
+                if _mp and not _mp.is_available():
+                    _ra().logger.warning(
+                        "Memory provider '%s' was found but is not available "
+                        "(missing dependencies or broken configuration). "
+                        "Falling back to built-in memory.",
+                        _mem_provider_name,
+                    )
+                elif _mp:
                     agent._memory_manager.add_provider(_mp)
                 if agent._memory_manager.providers:
                     _init_kwargs = {
@@ -1211,10 +1218,19 @@ def init_agent(
                     agent._memory_manager.initialize_all(**_init_kwargs)
                     _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
                 else:
-                    _ra().logger.debug("Memory provider '%s' not found or not available", _mem_provider_name)
+                    if not _mp:
+                        _ra().logger.warning(
+                            "Memory provider '%s' not found in bundled or user plugins. "
+                            "Falling back to built-in memory.",
+                            _mem_provider_name,
+                        )
                     agent._memory_manager = None
         except Exception as _mpe:
-            _ra().logger.warning("Memory provider plugin init failed: %s", _mpe)
+            _ra().logger.warning(
+                "Memory provider plugin init failed: %s. "
+                "Falling back to built-in memory.",
+                _mpe,
+            )
             agent._memory_manager = None
 
     from agent.memory_manager import inject_memory_provider_tools as _inject_memory_provider_tools


### PR DESCRIPTION
## Problem

When `memory.provider` is set in config but the provider fails to load (broken symlink, missing packages, import error) or `is_available()` returns False, the agent silently falls back to built-in flat-file memory (MEMORY.md / USER.md, 2200-char limit). The fallback was logged at DEBUG level, making it invisible to users. This caused silent data loss — new memories were written to the 2200-char flat file instead of the configured provider storage, and could go undetected for days (#49200).

## Changes

In `agent/agent_init.py`, the memory provider loading path now distinguishes three failure modes and logs each at WARNING level:

1. **Provider found but `is_available()` returns False** (missing dependencies, broken config): new WARNING with specific message about the cause
2. **Provider not found** (wrong name, plugin directory missing): WARNING instead of the previous DEBUG
3. **Provider init throws an exception**: existing warning now includes fallback notice

Each warning ends with "Falling back to built-in memory." so operators can correlate the fallback with subsequent memory behavior changes.

## Before / After

```
# Before (invisible):
DEBUG: Memory provider mnemosyne not found or not available

# After (visible):
WARNING: Memory provider mnemosyne was found but is not available (missing dependencies or broken configuration). Falling back to built-in memory.
```

Closes #49200