### PR TITLE
fix(send-message): use markdown msgtype for DingTalk webhook delivery

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1628,7 +1628,7 @@ async def _send_dingtalk(extra, chat_id, message):
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(
                 webhook_url,
-                json={"msgtype": "text", "text": {"content": message}},
+                json={"msgtype": "markdown", "markdown": {"title": "Hermes", "text": message}},
             )
             resp.raise_for_status()
             data = resp.json()


### PR DESCRIPTION
## Summary

`_send_dingtalk` in `tools/send_message_tool.py` sends webhook messages with `msgtype: "text"`, which means Markdown formatting is not rendered for cron notifications and cross-platform forwards.

The gateway's DingTalk adapter (`gateway/platforms/dingtalk.py:900`) already uses `msgtype: "markdown"` correctly. This PR aligns the webhook fallback to match.

### Change
- `tools/send_message_tool.py`: change `msgtype: "text"` to `msgtype: "markdown"` with correct payload structure

Fixes #49409
