### PR TITLE
fix(qqbot): honor markdown_support in standalone fallback _send_qqbot()

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1837,7 +1837,21 @@ async def _send_qqbot(pconfig, chat_id, message):
                 "Authorization": f"QQBot {access_token}",
                 "Content-Type": "application/json",
             }
-            payload = {"content": message[:4000], "msg_type": 0}
+            # Honor markdown_support config (default: True) — same logic as
+            # QQBotAdapter._build_text_body().  Previously hardcoded to msg_type=0
+            # (plain text), causing inconsistent rendering between the live-adapter
+            # path (msg_type=2) and this standalone fallback path (msg_type=0).
+            markdown_support = bool(extra.get("markdown_support", True))
+            if markdown_support:
+                import time as _time
+                _msg_seq = int(_time.time() * 1000) % 2147483647
+                payload = {
+                    "markdown": {"content": message[:4000]},
+                    "msg_type": 2,
+                    "msg_seq": _msg_seq,
+                }
+            else:
+                payload = {"content": message[:4000], "msg_type": 0}
 
             # Try channel endpoint first (works for guild channels)
             url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"


### PR DESCRIPTION
## Bug: `_send_qqbot` standalone fallback ignores `markdown_support`, causing inconsistent Markdown rendering in cron deliveries

### Problem

The QQ Bot adapter (`QQBotAdapter._build_text_body`) correctly respects the `markdown_support` config — when enabled (default `True`), messages are sent with `msg_type=2` (Markdown); otherwise `msg_type=0` (plain text).

However, the **standalone fallback** function `_send_qqbot()` in `tools/send_message_tool.py` **hardcoded `msg_type=0`**, completely ignoring the `markdown_support` setting.

This causes an inconsistency in the cron delivery pipeline (`cron/scheduler.py::_deliver_result`):

| Path | Trigger | msg_type | Markdown rendered? |
|------|---------|----------|-------------------|
| Live adapter | Gateway event loop available | 2 (Markdown) | Yes |
| Standalone fallback | Gateway busy | 0 (plain text) | No |

The same cron job produces **different message formatting** depending on whether the gateway event loop was available — a race condition users cannot control.

### Fix

Read `markdown_support` from `pconfig.extra` (default: True) and use `msg_type=2` with the markdown payload structure when enabled, matching `QQBotAdapter._build_text_body()`.