### PR TITLE
fix(gateway): move cron.scheduler_provider import to module level

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -57,6 +57,10 @@ from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
+# Must be module-level: gateway.platforms.* inserts plugins/ into sys.path
+# at import time, shadowing the real cron package.
+from cron.scheduler_provider import resolve_cron_scheduler
+
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
 # long-lived gateways (each AIAgent holds LLM clients, tool schemas,
@@ -17502,7 +17506,6 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # historical in-process 60s ticker; an external provider (e.g. chronos)
     # may arm a schedule and return. Pass the event loop so cron delivery can
     # use live adapters (E2EE support).
-    from cron.scheduler_provider import resolve_cron_scheduler
     cron_stop = threading.Event()
     cron_provider = resolve_cron_scheduler()
     cron_thread = threading.Thread(

--- a/tests/gateway/test_cron_import_resolution.py
+++ b/tests/gateway/test_cron_import_resolution.py
@@ -1,0 +1,70 @@
+"""Verify cron.scheduler_provider resolves correctly despite the
+discord adapter inserting plugins/ into sys.path[0] at module level.
+
+Regression test for: importing gateway.platforms.* triggers
+plugins/platforms/discord/adapter.py's module-level
+sys.path.insert(0, plugins/). Since plugins/cron/__init__.py exists,
+``from cron.scheduler_provider import ...`` would resolve ``cron`` to
+``plugins/cron/`` (which lacks scheduler_provider.py) instead of the
+real ``cron/`` package. The fix ensures the import is cached at module
+level in gateway/run.py before any platform adapter import fires.
+"""
+
+import importlib
+import sys
+
+
+class TestCronImportResolution:
+    """cron.scheduler_provider must remain importable after the discord
+    adapter inserts plugins/ into sys.path[0] at module import time."""
+
+    def test_discord_adapter_inserts_plugins_into_syspath(self):
+        """Evidence that the root cause exists.
+
+        plugins/platforms/discord/adapter.py:101 does
+        ``sys.path.insert(0, str(Path(__file__).resolve().parents[2]))``
+        at module level, putting plugins/ at sys.path[0].
+        """
+        importlib.import_module("plugins.platforms.discord.adapter")
+
+        assert "plugins" in sys.path[0], (
+            f"Expected plugins/ in sys.path[0], got: {sys.path[0]}"
+        )
+
+    def test_cron_resolves_correctly_when_imported_before_shadow(self, monkeypatch):
+        """The fix: cache cron.scheduler_provider before the discord
+        adapter's sys.path.insert fires, so plugins/cron/ never wins.
+
+        This matches what gateway/run.py does at module level: import
+        cron.scheduler_provider BEFORE any gateway.platforms.* import.
+        Once cron is in sys.modules, the shadowed path is irrelevant.
+        """
+        # Purge any cached cron modules so we start fresh
+        for key in list(sys.modules):
+            if key == "cron" or key.startswith("cron."):
+                monkeypatch.delitem(sys.modules, key, raising=False)
+
+        # Step 1: import cron.scheduler_provider first (like the fix)
+        from cron.scheduler_provider import resolve_cron_scheduler
+
+        assert callable(resolve_cron_scheduler)
+
+        # Confirm it resolved to the real cron/
+        import cron
+        assert "plugins" not in cron.__file__, (
+            f"cron resolved to wrong package: {cron.__file__}"
+        )
+
+        # Step 2: now trigger the discord adapter import, which does
+        # sys.path.insert(0, plugins/) at module level
+        importlib.import_module("plugins.platforms.discord.adapter")
+
+        assert "plugins" in sys.path[0]
+
+        # Step 3: cron must still resolve to the real package because
+        # it's cached in sys.modules — the shadowed path is irrelevant
+        import cron as cron2
+        assert "plugins" not in cron2.__file__, (
+            f"cron was re-resolved to wrong package after shadow: {cron2.__file__}"
+        )
+        assert callable(resolve_cron_scheduler)


### PR DESCRIPTION
## What does this PR do?

Fixes ModuleNotFoundError: No module named 'cron.scheduler_provider' on gateway startup. The module exists on disk and is importable from a REPL, but fails when imported inside start_gateway() during a live gateway run.

Root cause: plugins/platforms/discord/adapter.py:101 has module-level sys.path.insert(0, str(Path(__file__).resolve().parents[2])) which inserts plugins/ at sys.path[0]. Since plugins/cron/__init__.py exists, the later from cron.scheduler_provider import resolve_cron_scheduler inside start_gateway() resolves cron to the wrong package (plugins/cron/ — the provider discovery module, which lacks scheduler_provider.py) instead of the real cron/ package.

Fix: Move the import to module level in gateway/run.py, before any gateway.platforms.* import triggers the sys.path.insert. Once cron is in sys.modules, the shadowed path is never consulted.

## Related Issue

[[Bug]: Gateway crashes on startup with ModuleNotFoundError: No module named 'cron.scheduler_provider'
](https://github.com/NousResearch/hermes-agent/issues/49410)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- gateway/run.py — Added from cron.scheduler_provider import resolve_cron_scheduler at module level (before gateway.platforms.* imports), removed the duplicate import from inside start_gateway()

## How to Test

1. Start the gateway with hermes gateway run (or via systemd)
2. Before this fix: crashes within ~8-12 seconds with ModuleNotFoundError: No module named 'cron.scheduler_provider', restarts indefinitely (restart counter reached 79, 107 crash cycles)
3. After this fix: gateway starts successfully, connects to messaging platforms (Lark/Feishu confirmed), runs continuously

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS 26.11 (Zokor) x86_64

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

