### PR TITLE
fix(gateway): detect persisted activity before auto-reset notices

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -960,6 +960,7 @@ class SessionStore:
         # All _entries / _loaded mutations are protected by self._lock.
         db_end_session_id = None
         db_create_kwargs = None
+        db_activity_check_session_id = None
 
         with self._lock:
             self._ensure_loaded_locked()
@@ -995,8 +996,20 @@ class SessionStore:
                     # Session is being auto-reset.
                     was_auto_reset = True
                     auto_reset_reason = reset_reason
-                    # Track whether the expired session had any real conversation
-                    reset_had_activity = entry.total_tokens > 0
+                    # Track whether the expired session had any real conversation.
+                    # SessionEntry token counters are lightweight and may be
+                    # stale in gateway sessions; canonical transcript activity
+                    # lives in state.db.
+                    reset_had_activity = any((
+                        entry.total_tokens,
+                        entry.input_tokens,
+                        entry.output_tokens,
+                        entry.cache_read_tokens,
+                        entry.cache_write_tokens,
+                        entry.last_prompt_tokens,
+                    ))
+                    if not reset_had_activity:
+                        db_activity_check_session_id = entry.session_id
                     db_end_session_id = entry.session_id
             else:
                 was_auto_reset = False
@@ -1029,6 +1042,21 @@ class SessionStore:
             }
 
         # SQLite operations outside the lock
+        if self._db and db_activity_check_session_id:
+            try:
+                db_has_activity = self._db.has_active_messages(
+                    db_activity_check_session_id
+                )
+            except Exception as e:
+                logger.debug("Session DB activity check failed: %s", e)
+            else:
+                if db_has_activity:
+                    with self._lock:
+                        current = self._entries.get(session_key)
+                        if current is entry and not current.reset_had_activity:
+                            current.reset_had_activity = True
+                            self._save()
+
         if self._db and db_end_session_id:
             try:
                 self._db.end_session(db_end_session_id, "session_reset")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3850,6 +3850,19 @@ class SessionDB:
                 cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
             return cursor.fetchone()[0]
 
+    def has_active_messages(self, session_id: str) -> bool:
+        """Return whether a session has any active persisted transcript rows."""
+        if not session_id:
+            return False
+
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT 1 FROM messages "
+                "WHERE session_id = ? AND active = 1 LIMIT 1",
+                (session_id,),
+            ).fetchone()
+        return row is not None
+
     # =========================================================================
     # Export and cleanup
     # =========================================================================

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -162,6 +162,51 @@ class TestSessionEntryReason:
         assert entry2.was_auto_reset is True
         assert entry2.reset_had_activity is True
 
+    def test_reset_had_activity_true_when_db_has_messages_without_tokens(self, tmp_path):
+        """Persisted transcript activity counts when SessionEntry counters are stale."""
+        from hermes_state import SessionDB
+
+        store = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=1),
+            tmp_path / "sessions",
+        )
+
+        if store._db:
+            store._db.close()
+        store._db = SessionDB(db_path=tmp_path / "state.db")
+
+        source = _make_source()
+        old_entry = store.get_or_create_session(source)
+        old_session_id = old_entry.session_id
+
+        store._db.append_message(
+            session_id=old_session_id,
+            role="user",
+            content="hello before idle expiry",
+        )
+
+        assert store._db.get_session(old_session_id)["message_count"] == 1
+        assert old_entry.total_tokens == 0
+        assert old_entry.last_prompt_tokens == 0
+
+        old_entry.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+
+        new_entry = store.get_or_create_session(source)
+
+        assert new_entry.was_auto_reset is True
+        assert new_entry.auto_reset_reason == "idle"
+        assert new_entry.session_id != old_session_id
+        assert new_entry.reset_had_activity is True
+
+        # The corrected flag is persisted for a gateway restart.
+        store._loaded = False
+        store._entries.clear()
+        store._ensure_loaded()
+
+        restored = store._entries[new_entry.session_key]
+        assert restored.reset_had_activity is True
+
 
 # ---------------------------------------------------------------------------
 # SessionResetPolicy notify config


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway bug where an automatic session-reset notice can be suppressed even though the expired session contains persisted conversation history.

`SessionStore.get_or_create_session()` currently decides whether the expired session had activity from the lightweight `SessionEntry.total_tokens` field:

```python
reset_had_activity = entry.total_tokens > 0
```

Gateway turns can persist messages directly to `state.db` while the lightweight token fields in `SessionEntry` remain zero or stale. In that state, an idle or daily reset creates the new session with `reset_had_activity=False`, and `gateway/run.py` suppresses the user-facing reset notice.

A representative sequence is:

```text
1. A user has a conversation through a Discord, Telegram, or another gateway adapter.
2. The transcript is persisted in state.db.
3. SessionEntry token counters remain zero.
4. The idle or daily reset policy expires the session.
5. reset_had_activity evaluates to false.
6. gateway/run.py suppresses the automatic-reset notice.
7. The user sees a fresh context without being told why the previous context disappeared.
```

This PR keeps the existing lightweight token check as the fast path and supplements it with persisted transcript evidence when those counters show no activity:

- Add `SessionDB.has_active_messages(session_id)`.
- In the automatic-reset path, query `state.db` only when the lightweight activity fields are all zero.
- Count active persisted rows, including observed rows, because they are part of the transcript currently restored by the gateway.
- Ignore inactive rows left behind by rewind/undo operations.
- Keep the existing notification policy in `gateway/run.py` unchanged.
- Add regression coverage for a DB-backed transcript whose `SessionEntry` token counters are all zero.

The existing behavior remains unchanged:

- Empty expired sessions do not generate notification spam.
- Idle or daily resets with real conversation history notify the user.
- Suspended resets continue to notify regardless of `reset_had_activity`.
- Notification exclusions and `session_reset.notify` continue to be enforced by `gateway/run.py`.

### Related or overlapping work

Related: #5382 changes the activity check from `total_tokens` to `last_prompt_tokens`, but it also bundles an unrelated stream-consumer fix. This PR is a focused alternative that uses the persisted transcript as evidence, so it also covers sessions whose token metadata is entirely absent or stale.

## Related Issue

No issue filed. The bug was reproduced locally against the gateway reset path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

### `hermes_state.py`

Add a small indexed existence check to `SessionDB`:

```python
def has_active_messages(self, session_id: str) -> bool:
    """Return whether a session has any active persisted transcript rows."""
    if not session_id:
        return False

    with self._lock:
        row = self._conn.execute(
            "SELECT 1 FROM messages "
            "WHERE session_id = ? AND active = 1 LIMIT 1",
            (session_id,),
        ).fetchone()
    return row is not None
```

The query uses `active = 1` because gateway transcript replay excludes inactive rows by default. Rewound rows remain in the database for audit purposes and should not make an otherwise empty current context count as active.

Observed rows are intentionally included. The current replay path restores active observed rows and marks them with `observed=True`, so they are still part of the context being cleared by the reset.

### `gateway/session.py`

Prepare an optional persisted-activity lookup while the old session is still available:

```python
db_end_session_id = None
db_create_kwargs = None
db_activity_check_session_id = None
```

Replace the single-field activity heuristic with a compatibility fast path across the lightweight fields that already exist on `SessionEntry`:

```python
reset_had_activity = any((
    entry.total_tokens,
    entry.input_tokens,
    entry.output_tokens,
    entry.cache_read_tokens,
    entry.cache_write_tokens,
    entry.last_prompt_tokens,
))
if not reset_had_activity:
    db_activity_check_session_id = entry.session_id

db_end_session_id = entry.session_id
```

Run the SQLite read outside `SessionStore._lock`, before the existing `end_session()` call. Apply the result only after reacquiring the lock and confirming that the same new entry is still current:

```python
if self._db and db_activity_check_session_id:
    try:
        db_has_activity = self._db.has_active_messages(
            db_activity_check_session_id
        )
    except Exception as e:
        logger.debug("Session DB activity check failed: %s", e)
    else:
        if db_has_activity:
            with self._lock:
                current = self._entries.get(session_key)
                if current is entry and not current.reset_had_activity:
                    current.reset_had_activity = True
                    self._save()
```

This keeps `SessionEntry` mutation under `SessionStore._lock`. If the database lookup fails, the reset still succeeds and retains the lightweight fallback result.

### `tests/gateway/test_session_reset_notify.py`

Add a regression test using an isolated temporary `state.db`.

The test fails on current `main` because the persisted message is ignored when `total_tokens` is zero.

## Why not change `gateway/run.py`?

The notification policy in `gateway/run.py` is already correct. It intentionally suppresses notices for empty expired sessions, respects notification configuration and platform exclusions, and always notifies for suspended resets.

The false negative originates earlier, when `gateway/session.py` computes `reset_had_activity` for the newly created session entry.

## How to Test

```bash
python -m pytest tests/gateway/test_session_reset_notify.py tests/gateway/test_fresh_reset_skill_injection.py -q -o 'addopts='
scripts/run_tests.sh tests/gateway/test_session_reset_notify.py
scripts/run_tests.sh tests/gateway/test_fresh_reset_skill_injection.py
python -m py_compile hermes_state.py gateway/session.py tests/gateway/test_session_reset_notify.py
git diff --check
python3 scripts/check-windows-footguns.py --diff origin/main
```

Local results:

```text
26 passed in 0.36s

scripts/run_tests.sh tests/gateway/test_session_reset_notify.py
17 passed

scripts/run_tests.sh tests/gateway/test_fresh_reset_skill_injection.py
9 passed

python -m py_compile hermes_state.py gateway/session.py tests/gateway/test_session_reset_notify.py
passed

git diff --check
passed

python3 scripts/check-windows-footguns.py --diff origin/main
✓ No Windows footguns found (0 file(s) scanned).
```

## Risk and Concurrency Notes

- The DB query is a bounded `SELECT 1 ... LIMIT 1` and only runs when the lightweight fields show no activity.
- SQLite access remains outside `SessionStore._lock`.
- The new entry is created and saved before the DB fallback completes, so there is a narrow interval in which another caller could observe `reset_had_activity=False`. The gateway's per-session run guard makes this unlikely in normal operation. The identity check prevents the fallback from modifying a newer replacement entry.
- A DB read failure is non-fatal and preserves the existing lightweight result.
- Inactive rewound rows do not count as current transcript activity.
- Active observed rows do count because the gateway currently restores them as part of the transcript.

## Files Changed

```text
hermes_state.py
gateway/session.py
tests/gateway/test_session_reset_notify.py
```

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs and documented the overlap with #5382.
- [x] This PR contains only changes related to the reset-notification bug.
- [ ] I have run `pytest tests/ -q` and all tests pass.
- [x] I added regression coverage for the bug.
- [x] I tested the fix on my platform: WSL/Linux.

### Documentation and Housekeeping

- [x] Documentation changes are not required; behavior and configuration are unchanged.
- [x] `cli-config.yaml.example` changes are not required; no config keys changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are not required; no workflow or architecture changed.
- [x] The change is platform-agnostic and does not introduce path-specific behavior.
- [x] No tool descriptions or schemas changed.

# Reviewer checklist

- [ ] A session with active persisted messages sets `reset_had_activity=True` even when all lightweight token fields are zero.
- [ ] An empty expired session still suppresses the user-facing reset notice.
- [ ] Suspended reset behavior remains unchanged.
- [ ] Inactive rewound rows do not count as active transcript context.
- [ ] Active observed rows follow current gateway replay semantics.
- [ ] SQLite access remains outside `SessionStore._lock`.
- [ ] The regression test fails before the fix and passes after it.
- [ ] The persisted `reset_had_activity` value survives a gateway restart through the existing `SessionEntry` serialization path.
