### PR TITLE
fix(gateway): correct sys.path insertion in plugins to prevent cron namespace collision (#49410)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -98,7 +98,7 @@ except ImportError:
 
 import sys
 from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 

--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -36,7 +36,7 @@ except ImportError:
 
 import sys
 from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (


### PR DESCRIPTION
Fixes #49410. The gateway crashes on startup because plugins/platforms/discord/adapter.py inserts plugins/ into sys.path instead of the project root. This causes Python to import plugins/cron/ instead of the top-level cron/ package when gateway/run.py tries to import cron.scheduler_provider. Fixed by changing parents[2] to parents[3] in both discord and raft adapter plugins.