### PR TITLE
Recover missed low-frequency cron fires

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -59,6 +59,7 @@ _jobs_file_lock = threading.RLock()
 _jobs_lock_state = threading.local()
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
+LOW_FREQUENCY_CRON_RECOVERY_SECONDS = 12 * 60 * 60
 
 
 def _jobs_lock_file() -> Path:
@@ -451,6 +452,36 @@ def _compute_grace_seconds(schedule: dict) -> int:
             pass
 
     return MIN_GRACE
+
+
+def _cron_period_seconds(schedule: dict) -> Optional[int]:
+    """Return the approximate period for a cron schedule, when available."""
+    if schedule.get("kind") != "cron" or not HAS_CRONITER:
+        return None
+    try:
+        now = _hermes_now()
+        cron = croniter(schedule["expr"], now)
+        first = cron.get_next(datetime)
+        second = cron.get_next(datetime)
+        return int((second - first).total_seconds())
+    except Exception:
+        return None
+
+
+def _should_recover_stale_recurring_fire(schedule: dict) -> bool:
+    """Return True when a stale recurring fire should run once on recovery.
+
+    Frequent jobs are usually watchdogs or pollers; if the gateway was down,
+    replaying stale executions is more likely to create noise than value.
+    Low-frequency cron jobs are commonly human-facing digests and reviews. For
+    those, silently fast-forwarding after a gateway outage loses the only daily
+    signal, so recover one missed fire and then advance normally before run.
+    """
+    period_seconds = _cron_period_seconds(schedule)
+    return (
+        period_seconds is not None
+        and period_seconds >= LOW_FREQUENCY_CRON_RECOVERY_SECONDS
+    )
 
 
 def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None) -> Optional[str]:
@@ -1199,6 +1230,18 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             # the next future occurrence instead of firing a stale run.
             grace = _compute_grace_seconds(schedule)
             if kind in {"cron", "interval"} and (now - next_run_dt).total_seconds() > grace:
+                if kind == "cron" and _should_recover_stale_recurring_fire(schedule):
+                    logger.warning(
+                        "Job '%s' missed its scheduled time (%s, grace=%ds). "
+                        "Recovering one low-frequency cron fire instead of "
+                        "silently fast-forwarding.",
+                        job.get("name", job["id"]),
+                        next_run,
+                        grace,
+                    )
+                    due.append(job)
+                    continue
+
                 # Job is past its catch-up grace window — this is a stale missed run.
                 # Grace scales with schedule period: daily=2h, hourly=30m, 10min=5m.
                 new_next = compute_next_run(schedule, now.isoformat())

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -704,6 +704,56 @@ class TestGetDueJobs:
         next_dt = _ensure_aware(datetime.fromisoformat(updated["next_run_at"]))
         assert next_dt > _hermes_now()
 
+    def test_stale_weekday_digest_cron_recovers_one_missed_fire(self, tmp_cron_dir, monkeypatch):
+        """A missed low-frequency weekday cron must not silently fast-forward.
+
+        Regression coverage for an autonomy digest that last ran Wednesday,
+        missed Thu/Fri while the gateway was unavailable, then restarted after
+        the normal 2h grace window on Saturday morning. The scheduler should
+        return the stale fire once so the run is visible/recoverable; the
+        pre-run advance path will move the next occurrence forward before
+        execution.
+        """
+        pytest.importorskip("croniter")
+        madrid = timezone(timedelta(hours=2))
+        now = datetime(2026, 6, 20, 6, 23, 55, tzinfo=madrid)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs(
+            [{
+                "id": "autonomy-afternoon",
+                "name": "autonomy-inbox-afternoon",
+                "prompt": "script-only autonomy afternoon digest",
+                "schedule": {
+                    "kind": "cron",
+                    "expr": "30 15 * * 1-5",
+                    "display": "30 15 * * 1-5",
+                },
+                "schedule_display": "30 15 * * 1-5",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-06-15T08:00:00+02:00",
+                "next_run_at": "2026-06-18T15:30:00+02:00",
+                "last_run_at": "2026-06-17T15:30:49+02:00",
+                "last_status": "ok",
+                "last_error": None,
+                "deliver": "telegram",
+                "origin": None,
+            }]
+        )
+
+        due = get_due_jobs()
+
+        assert [job["id"] for job in due] == ["autonomy-afternoon"]
+        assert get_job("autonomy-afternoon")["next_run_at"] == "2026-06-18T15:30:00+02:00"
+
+        assert advance_next_run("autonomy-afternoon") is True
+        advanced = datetime.fromisoformat(get_job("autonomy-afternoon")["next_run_at"])
+        assert advanced > now
+
     def test_future_not_returned(self, tmp_cron_dir):
         create_job(prompt="Not yet", schedule="every 1h")
         due = get_due_jobs()


### PR DESCRIPTION
## Summary

- Recover one stale fire for low-frequency cron schedules instead of silently fast-forwarding them after the gateway was down beyond grace.
- Keep the existing fast-forward behavior for interval and high-frequency cron jobs to avoid replay bursts for watchdogs/pollers.
- Add a regression test for the LIB-558 incident shape: `autonomy-inbox-afternoon` last ran Wednesday, missed Thu/Fri, then the gateway restarted Saturday morning.

## Root Cause

Hermes `get_due_jobs()` treated every recurring job older than its dynamic grace window as stale and fast-forwarded `next_run_at` to the next future occurrence. For weekday digests such as `30 15 * * 1-5`, a gateway outage during Thu/Fri followed by a restart after grace moved the job to Monday without executing or surfacing the missed fire.

## Verification

```bash
uv run --with pytest --with croniter python -m pytest tests/cron/test_jobs.py -q
# 88 passed in 0.84s
```

No external messages were sent and no live Hermes cron state was modified.
