### PR TITLE
feat(desktop): Projects v1 — claude-style folder-bound with sessions history and custom instruction

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5708,6 +5708,24 @@ ipcMain.handle('hermes:readFileText', async (_event, filePath) => {
   }
 })
 
+ipcMain.handle('hermes:writeFileText', async (_event, filePath, text) => {
+  const resolvedPath = resolveRequestedPathForIpc(filePath, { purpose: 'File write' })
+  const ext = path.extname(resolvedPath).toLowerCase()
+  if (ext !== '.md') {
+    const err = new Error(`File write blocked: only .md files may be written (got ${ext || 'no extension'}).`)
+    err.code = 'forbidden-extension'
+    throw err
+  }
+  try {
+    await fs.promises.writeFile(resolvedPath, String(text), 'utf8')
+    return { path: resolvedPath }
+  } catch (error) {
+    const err = new Error(`File write failed: ${error instanceof Error ? error.message : String(error)}`)
+    err.code = error?.code || 'write-error'
+    throw err
+  }
+})
+
 ipcMain.handle('hermes:selectPaths', async (_event, options = {}) => {
   const properties = options?.directories ? ['openDirectory'] : ['openFile']
   if (options?.multiple !== false) properties.push('multiSelections')

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -24,6 +24,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),
   readFileDataUrl: filePath => ipcRenderer.invoke('hermes:readFileDataUrl', filePath),
   readFileText: filePath => ipcRenderer.invoke('hermes:readFileText', filePath),
+  writeFileText: (filePath, text) => ipcRenderer.invoke('hermes:writeFileText', filePath, text),
   selectPaths: options => ipcRenderer.invoke('hermes:selectPaths', options),
   writeClipboard: text => ipcRenderer.invoke('hermes:writeClipboard', text),
   saveImageFromUrl: url => ipcRenderer.invoke('hermes:saveImageFromUrl', url),

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -189,7 +189,7 @@ const NO_MESSAGES: ChatMessage[] = []
  * of re-rendering them by element identity and the stream's render cost stays
  * confined to the streaming message's own subtree.
  */
-function ChatRuntimeBoundary({
+export function ChatRuntimeBoundary({
   busy,
   children,
   onCancel,

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -712,7 +712,21 @@ export function ChatSidebar({
     sessionProfileTotals
   ])
 
-  const displayAgentSessions = agentSessions
+  const nonProjectSessions = useMemo(() => {
+    if (!projects.length) {
+      return agentSessions
+    }
+
+    return agentSessions.filter(s => {
+      if (!s.cwd) {
+        return true
+      }
+
+      return !projects.some(p => s.cwd!.startsWith(p.path))
+    })
+  }, [agentSessions, projects])
+
+  const displayAgentSessions = nonProjectSessions
 
   // Pagination is scope-aware. In "All profiles" mode it tracks the global
   // unified set. When scoped to one profile it must compare that profile's own
@@ -923,10 +937,15 @@ export function ChatSidebar({
 
             {!trimmedQuery && (
               <ProjectsSidebarSection
+                activeSessionId={activeSidebarSessionId}
+                onDeleteSession={onDeleteSession}
                 onNewProject={onNewProject}
+                onResumeSession={onResumeSession}
                 onSelectProject={onSelectProject}
+                onTogglePin={pinSession}
                 projects={projects}
                 selectedProjectId={selectedProjectId}
+                sessions={agentSessions}
               />
             )}
 

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -81,6 +81,7 @@ import {
   newSessionInProfile,
   normalizeProfileKey
 } from '@/store/profile'
+import { $projects } from '@/store/projects'
 import {
   $cronSessions,
   $messagingPlatformTotals,
@@ -103,6 +104,7 @@ import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarLoadMoreRow } from './load-more-row'
 import { resolveManualSessionOrderIds } from './order'
 import { ProfileRail } from './profile-switcher'
+import { ProjectsSidebarSection } from './projects-section'
 import { SidebarSessionRow } from './session-row'
 import { VirtualSessionList } from './virtual-session-list'
 import { type SidebarSessionGroup, type SidebarWorkspaceTree, workspaceTreeFor } from './workspace-groups'
@@ -309,6 +311,9 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onNewSessionInWorkspace: (path: null | string) => void
   onManageCronJob: (jobId: string) => void
   onTriggerCronJob: (jobId: string) => void
+  selectedProjectId: string | null
+  onSelectProject: (id: string) => void
+  onNewProject: () => void
 }
 
 export function ChatSidebar({
@@ -322,7 +327,10 @@ export function ChatSidebar({
   onArchiveSession,
   onNewSessionInWorkspace,
   onManageCronJob,
-  onTriggerCronJob
+  onTriggerCronJob,
+  selectedProjectId,
+  onSelectProject,
+  onNewProject
 }: ChatSidebarProps) {
   const { t } = useI18n()
   const s = t.sidebar
@@ -340,6 +348,7 @@ export function ChatSidebar({
   const sessions = useStore($sessions)
   const cronSessions = useStore($cronSessions)
   const cronJobs = useStore($cronJobs)
+  const projects = useStore($projects)
   const messagingSessions = useStore($messagingSessions)
   const messagingPlatformTotals = useStore($messagingPlatformTotals)
   const messagingTruncated = useStore($messagingTruncated)
@@ -533,6 +542,7 @@ export function ChatSidebar({
 
     if (!next.length && agentOrderIds.length) {
       setSidebarSessionOrderIds([])
+
       return
     }
 
@@ -908,6 +918,15 @@ export function ChatSidebar({
                 rootClassName="min-h-32 flex-1 overflow-hidden p-0"
                 sessions={searchResults}
                 workingSessionIdSet={workingSessionIdSet}
+              />
+            )}
+
+            {!trimmedQuery && (
+              <ProjectsSidebarSection
+                onNewProject={onNewProject}
+                onSelectProject={onSelectProject}
+                projects={projects}
+                selectedProjectId={selectedProjectId}
               />
             )}
 

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -938,6 +938,7 @@ export function ChatSidebar({
             {!trimmedQuery && (
               <ProjectsSidebarSection
                 activeSessionId={activeSidebarSessionId}
+                onArchiveSession={onArchiveSession}
                 onDeleteSession={onDeleteSession}
                 onNewProject={onNewProject}
                 onResumeSession={onResumeSession}

--- a/apps/desktop/src/app/chat/sidebar/projects-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects-section.tsx
@@ -1,27 +1,30 @@
 import { useStore } from '@nanostores/react'
+import { useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
 import { cn } from '@/lib/utils'
 import { $sidebarProjectsOpen, setSidebarProjectsOpen } from '@/store/layout'
+import { removeProject } from '@/store/projects'
 import type { Project } from '@/store/projects'
 
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
 
 interface ProjectsSidebarSectionProps {
+  onNewProject: () => void
+  onSelectProject: (id: string) => void
   projects: Project[]
   selectedProjectId: string | null
-  onSelectProject: (id: string) => void
-  onNewProject: () => void
 }
 
 export function ProjectsSidebarSection({
-  projects,
-  selectedProjectId,
+  onNewProject,
   onSelectProject,
-  onNewProject
+  projects,
+  selectedProjectId
 }: ProjectsSidebarSectionProps) {
   const open = useStore($sidebarProjectsOpen)
 
@@ -81,35 +84,70 @@ function ProjectSidebarRow({
   onClick: () => void
   project: Project
 }) {
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
   return (
-    <button
-      className={cn(
-        'group/project relative flex min-h-[1.625rem] w-full items-center gap-1.5 rounded-md py-0.5 pl-2 pr-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
-        isActive ? 'bg-(--ui-row-active-background) text-foreground' : 'hover:bg-(--chrome-action-hover)'
-      )}
-      onClick={onClick}
-      type="button"
-    >
-      <span className="grid w-3.5 shrink-0 place-items-center">
-        <Codicon
-          className={cn('text-(--ui-text-tertiary)', isActive && 'text-foreground')}
-          name={isActive ? 'folder-opened' : 'folder'}
-          size="0.75rem"
-        />
-      </span>
-      <span className="flex min-w-0 flex-1 flex-col">
-        <span
-          className={cn(
-            'truncate text-[0.8125rem] font-medium leading-snug',
-            isActive ? 'text-foreground' : 'text-(--ui-text-secondary) group-hover/project:text-foreground'
-          )}
-        >
-          {project.title}
-        </span>
-        {project.description && (
-          <span className="truncate text-[0.6875rem] leading-snug text-(--ui-text-tertiary)">{project.description}</span>
+    <>
+      <div
+        className={cn(
+          'group/project relative flex min-h-[1.625rem] w-full items-center gap-1.5 rounded-md py-0.5 pl-2 pr-1',
+          isActive ? 'bg-(--ui-row-active-background) text-foreground' : 'hover:bg-(--chrome-action-hover)'
         )}
-      </span>
-    </button>
+      >
+        <button
+          className="flex min-w-0 flex-1 items-center gap-1.5 bg-transparent text-left focus-visible:outline-none"
+          onClick={onClick}
+          type="button"
+        >
+          <span className="grid w-3.5 shrink-0 place-items-center">
+            <Codicon
+              className={cn('text-(--ui-text-tertiary)', isActive && 'text-foreground')}
+              name={isActive ? 'folder-opened' : 'folder'}
+              size="0.75rem"
+            />
+          </span>
+          <span className="flex min-w-0 flex-1 flex-col group-hover/project:pr-5">
+            <span
+              className={cn(
+                'truncate text-[0.8125rem] font-medium leading-snug',
+                isActive ? 'text-foreground' : 'text-(--ui-text-secondary) group-hover/project:text-foreground'
+              )}
+            >
+              {project.title}
+            </span>
+            {project.description && (
+              <span className="truncate text-[0.6875rem] leading-snug text-(--ui-text-tertiary)">
+                {project.description}
+              </span>
+            )}
+          </span>
+        </button>
+
+        {/* Delete button — revealed on row hover */}
+        <button
+          aria-label={`Delete ${project.title}`}
+          className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-0.5 text-transparent opacity-0 transition-all hover:bg-(--ui-control-active-background) hover:text-destructive group-hover/project:opacity-100 group-hover/project:text-(--ui-text-tertiary) focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          onClick={event => {
+            event.stopPropagation()
+            setDeleteOpen(true)
+          }}
+          type="button"
+        >
+          <Codicon name="trash" size="0.75rem" />
+        </button>
+      </div>
+
+      <ConfirmDialog
+        confirmLabel="Delete"
+        description={`"${project.title}" will be removed from Hermes. The folder and its files will not be deleted.`}
+        destructive
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={() => {
+          removeProject(project.id)
+        }}
+        open={deleteOpen}
+        title={`Delete project?`}
+      />
+    </>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/projects-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects-section.tsx
@@ -8,7 +8,7 @@ import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
 import type { SessionInfo } from '@/hermes'
 import { cn } from '@/lib/utils'
-import { $sidebarProjectsOpen, setSidebarProjectsOpen } from '@/store/layout'
+import { $expandedProjectIds, $sidebarProjectsOpen, setSidebarProjectsOpen, toggleExpandedProjectId } from '@/store/layout'
 import { removeProject } from '@/store/projects'
 import type { Project } from '@/store/projects'
 import { sessionPinId } from '@/store/session'
@@ -19,6 +19,7 @@ import { SidebarSessionRow } from './session-row'
 
 interface ProjectsSidebarSectionProps {
   activeSessionId: string | null
+  onArchiveSession: (sessionId: string) => void
   onDeleteSession: (sessionId: string) => void
   onNewProject: () => void
   onResumeSession: (sessionId: string) => void
@@ -31,6 +32,7 @@ interface ProjectsSidebarSectionProps {
 
 export function ProjectsSidebarSection({
   activeSessionId,
+  onArchiveSession,
   onDeleteSession,
   onNewProject,
   onResumeSession,
@@ -41,6 +43,7 @@ export function ProjectsSidebarSection({
   sessions
 }: ProjectsSidebarSectionProps) {
   const open = useStore($sidebarProjectsOpen)
+  const expandedIds = useStore($expandedProjectIds)
 
   return (
     <SidebarGroup className="shrink-0 p-0 pb-1">
@@ -76,15 +79,19 @@ export function ProjectsSidebarSection({
           ) : (
             projects.map(project => {
               const projectSessions = sessions.filter(s => s.cwd?.startsWith(project.path))
+              const isExpanded = expandedIds.includes(project.id)
 
               return (
                 <div key={project.id}>
                   <ProjectSidebarRow
                     isActive={selectedProjectId === project.id}
+                    isExpanded={isExpanded}
                     onClick={() => onSelectProject(project.id)}
+                    onToggleExpand={() => toggleExpandedProjectId(project.id)}
                     project={project}
+                    sessionCount={projectSessions.length}
                   />
-                  {projectSessions.length > 0 && (
+                  {isExpanded && projectSessions.length > 0 && (
                     <div className="ml-4 flex flex-col gap-px">
                       {projectSessions.map(session => (
                         <SidebarSessionRow
@@ -92,7 +99,7 @@ export function ProjectsSidebarSection({
                           isSelected={activeSessionId === session.id}
                           isWorking={false}
                           key={session.id}
-                          onArchive={() => onDeleteSession(session.id)}
+                          onArchive={() => onArchiveSession(session.id)}
                           onDelete={() => onDeleteSession(session.id)}
                           onPin={() => onTogglePin(sessionPinId(session))}
                           onResume={() => onResumeSession(session.id)}
@@ -113,23 +120,50 @@ export function ProjectsSidebarSection({
 
 function ProjectSidebarRow({
   isActive,
+  isExpanded,
   onClick,
-  project
+  onToggleExpand,
+  project,
+  sessionCount
 }: {
   isActive: boolean
+  isExpanded: boolean
   onClick: () => void
+  onToggleExpand: () => void
   project: Project
+  sessionCount: number
 }) {
   const [deleteOpen, setDeleteOpen] = useState(false)
+  const hasSessions = sessionCount > 0
 
   return (
     <>
       <div
         className={cn(
-          'group/project relative flex min-h-[1.625rem] w-full items-center gap-1.5 rounded-md py-0.5 pl-2 pr-1',
+          'group/project relative flex min-h-[1.625rem] w-full items-center gap-1 rounded-md py-0.5 pl-1 pr-1',
           isActive ? 'bg-(--ui-row-active-background) text-foreground' : 'hover:bg-(--chrome-action-hover)'
         )}
       >
+        {/* Per-project collapse toggle — visible when sessions exist */}
+        <button
+          aria-label={isExpanded ? 'Collapse sessions' : 'Expand sessions'}
+          className={cn(
+            'grid w-3.5 shrink-0 place-items-center bg-transparent focus-visible:outline-none',
+            !hasSessions && 'pointer-events-none opacity-0'
+          )}
+          onClick={event => {
+            event.stopPropagation()
+            onToggleExpand()
+          }}
+          tabIndex={hasSessions ? 0 : -1}
+          type="button"
+        >
+          <DisclosureCaret
+            className={cn('text-(--ui-text-tertiary)', isActive && 'text-foreground')}
+            open={isExpanded}
+          />
+        </button>
+
         <button
           className="flex min-w-0 flex-1 items-center gap-1.5 bg-transparent text-left focus-visible:outline-none"
           onClick={onClick}
@@ -157,6 +191,12 @@ function ProjectSidebarRow({
               </span>
             )}
           </span>
+          {/* Session count badge — shown when collapsed and sessions exist */}
+          {hasSessions && !isExpanded && (
+            <span className="mr-5 shrink-0 rounded-full bg-(--ui-control-active-background) px-1.5 py-0.5 text-[0.6rem] font-medium text-(--ui-text-tertiary)">
+              {sessionCount}
+            </span>
+          )}
         </button>
 
         {/* Delete button — revealed on row hover */}
@@ -187,3 +227,4 @@ function ProjectSidebarRow({
     </>
   )
 }
+

--- a/apps/desktop/src/app/chat/sidebar/projects-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects-section.tsx
@@ -6,25 +6,39 @@ import { Codicon } from '@/components/ui/codicon'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
+import type { SessionInfo } from '@/hermes'
 import { cn } from '@/lib/utils'
 import { $sidebarProjectsOpen, setSidebarProjectsOpen } from '@/store/layout'
 import { removeProject } from '@/store/projects'
 import type { Project } from '@/store/projects'
+import { sessionPinId } from '@/store/session'
 
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
 
+import { SidebarSessionRow } from './session-row'
+
 interface ProjectsSidebarSectionProps {
+  activeSessionId: string | null
+  onDeleteSession: (sessionId: string) => void
   onNewProject: () => void
+  onResumeSession: (sessionId: string) => void
   onSelectProject: (id: string) => void
+  onTogglePin: (sessionId: string) => void
   projects: Project[]
   selectedProjectId: string | null
+  sessions: SessionInfo[]
 }
 
 export function ProjectsSidebarSection({
+  activeSessionId,
+  onDeleteSession,
   onNewProject,
+  onResumeSession,
   onSelectProject,
+  onTogglePin,
   projects,
-  selectedProjectId
+  selectedProjectId,
+  sessions
 }: ProjectsSidebarSectionProps) {
   const open = useStore($sidebarProjectsOpen)
 
@@ -60,14 +74,36 @@ export function ProjectsSidebarSection({
           {projects.length === 0 ? (
             <div className="px-2 py-1 text-[0.6875rem] text-(--ui-text-tertiary)">No projects yet</div>
           ) : (
-            projects.map(project => (
-              <ProjectSidebarRow
-                isActive={selectedProjectId === project.id}
-                key={project.id}
-                onClick={() => onSelectProject(project.id)}
-                project={project}
-              />
-            ))
+            projects.map(project => {
+              const projectSessions = sessions.filter(s => s.cwd?.startsWith(project.path))
+
+              return (
+                <div key={project.id}>
+                  <ProjectSidebarRow
+                    isActive={selectedProjectId === project.id}
+                    onClick={() => onSelectProject(project.id)}
+                    project={project}
+                  />
+                  {projectSessions.length > 0 && (
+                    <div className="ml-4 flex flex-col gap-px">
+                      {projectSessions.map(session => (
+                        <SidebarSessionRow
+                          isPinned={false}
+                          isSelected={activeSessionId === session.id}
+                          isWorking={false}
+                          key={session.id}
+                          onArchive={() => onDeleteSession(session.id)}
+                          onDelete={() => onDeleteSession(session.id)}
+                          onPin={() => onTogglePin(sessionPinId(session))}
+                          onResume={() => onResumeSession(session.id)}
+                          session={session}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )
+            })
           )}
         </SidebarGroupContent>
       )}

--- a/apps/desktop/src/app/chat/sidebar/projects-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects-section.tsx
@@ -1,0 +1,115 @@
+import { useStore } from '@nanostores/react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { DisclosureCaret } from '@/components/ui/disclosure-caret'
+import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
+import { cn } from '@/lib/utils'
+import { $sidebarProjectsOpen, setSidebarProjectsOpen } from '@/store/layout'
+import type { Project } from '@/store/projects'
+
+import { SidebarPanelLabel } from '../../shell/sidebar-label'
+
+interface ProjectsSidebarSectionProps {
+  projects: Project[]
+  selectedProjectId: string | null
+  onSelectProject: (id: string) => void
+  onNewProject: () => void
+}
+
+export function ProjectsSidebarSection({
+  projects,
+  selectedProjectId,
+  onSelectProject,
+  onNewProject
+}: ProjectsSidebarSectionProps) {
+  const open = useStore($sidebarProjectsOpen)
+
+  return (
+    <SidebarGroup className="shrink-0 p-0 pb-1">
+      <div className="group/section flex shrink-0 items-center justify-between pb-1 pt-1.5">
+        <button
+          className="group/section-label flex w-fit items-center gap-1 bg-transparent text-left leading-none"
+          onClick={() => setSidebarProjectsOpen(!open)}
+          type="button"
+        >
+          <SidebarPanelLabel>Projects</SidebarPanelLabel>
+          <span className="text-[0.6875rem] font-medium text-(--ui-text-quaternary)">{projects.length}</span>
+          <DisclosureCaret
+            className="text-(--ui-text-tertiary) opacity-0 transition group-hover/section-label:opacity-100"
+            open={open}
+          />
+        </button>
+        <Button
+          className="h-5 shrink-0 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary) opacity-0 transition hover:text-foreground group-hover/section:opacity-100"
+          onClick={event => {
+            event.stopPropagation()
+            onNewProject()
+          }}
+          size="sm"
+          variant="ghost"
+        >
+          + New
+        </Button>
+      </div>
+      {open && (
+        <SidebarGroupContent className="flex max-h-72 flex-col gap-px overflow-x-hidden overflow-y-auto overscroll-contain pb-1.75 compact:max-h-none compact:overflow-visible">
+          {projects.length === 0 ? (
+            <div className="px-2 py-1 text-[0.6875rem] text-(--ui-text-tertiary)">No projects yet</div>
+          ) : (
+            projects.map(project => (
+              <ProjectSidebarRow
+                isActive={selectedProjectId === project.id}
+                key={project.id}
+                onClick={() => onSelectProject(project.id)}
+                project={project}
+              />
+            ))
+          )}
+        </SidebarGroupContent>
+      )}
+    </SidebarGroup>
+  )
+}
+
+function ProjectSidebarRow({
+  isActive,
+  onClick,
+  project
+}: {
+  isActive: boolean
+  onClick: () => void
+  project: Project
+}) {
+  return (
+    <button
+      className={cn(
+        'group/project relative flex min-h-[1.625rem] w-full items-center gap-1.5 rounded-md py-0.5 pl-2 pr-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
+        isActive ? 'bg-(--ui-row-active-background) text-foreground' : 'hover:bg-(--chrome-action-hover)'
+      )}
+      onClick={onClick}
+      type="button"
+    >
+      <span className="grid w-3.5 shrink-0 place-items-center">
+        <Codicon
+          className={cn('text-(--ui-text-tertiary)', isActive && 'text-foreground')}
+          name={isActive ? 'folder-opened' : 'folder'}
+          size="0.75rem"
+        />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span
+          className={cn(
+            'truncate text-[0.8125rem] font-medium leading-snug',
+            isActive ? 'text-foreground' : 'text-(--ui-text-secondary) group-hover/project:text-foreground'
+          )}
+        >
+          {project.title}
+        </span>
+        {project.description && (
+          <span className="truncate text-[0.6875rem] leading-snug text-(--ui-text-tertiary)">{project.description}</span>
+        )}
+      </span>
+    </button>
+  )
+}

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -1,5 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useQueryClient } from '@tanstack/react-query'
+import type { ReactNode} from 'react';
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom'
 
@@ -199,7 +200,12 @@ export function DesktopController() {
   const navigate = useNavigate()
 
   const [createProjectOpen, setCreateProjectOpen] = useState(false)
-  const [selectedProjectId, setSelectedProjectId] = useState<null | string>(null)
+
+  // Derive the active project directly from the URL so it clears automatically
+  // when the user navigates to a session, new chat, or any other view.
+  const selectedProjectId = location.pathname.startsWith('/project/')
+    ? decodeURIComponent(location.pathname.slice('/project/'.length))
+    : null
 
   const busyRef = useRef(false)
   const creatingSessionRef = useRef(false)
@@ -947,7 +953,6 @@ export function DesktopController() {
       onNewSessionInWorkspace={startSessionInWorkspace}
       onResumeSession={sessionId => navigate(sessionRoute(sessionId))}
       onSelectProject={id => {
-        setSelectedProjectId(id)
         navigate(projectRoute(id))
       }}
       onTriggerCronJob={jobId => {
@@ -992,7 +997,6 @@ export function DesktopController() {
       <CreateProjectDialog
         onClose={() => setCreateProjectOpen(false)}
         onCreated={project => {
-          setSelectedProjectId(project.id)
           navigate(projectRoute(project.id))
         }}
         open={createProjectOpen}
@@ -1214,13 +1218,7 @@ export function DesktopController() {
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="new" />
           <Route element={<LegacySessionRedirect />} path="sessions/:sessionId" />
           <Route
-            element={
-              selectedProjectId ? (
-                <ProjectPageView chatSlot={chatView} projectId={selectedProjectId} />
-              ) : (
-                <Navigate replace to={NEW_CHAT_ROUTE} />
-              )
-            }
+            element={<ProjectPageViewRoute chatView={chatView} />}
             path="project/:id"
           />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="*" />
@@ -1243,4 +1241,14 @@ function LegacySessionRedirect() {
   const { sessionId } = useParams()
 
   return <Navigate replace to={sessionId ? sessionRoute(sessionId) : NEW_CHAT_ROUTE} />
+}
+
+function ProjectPageViewRoute({ chatView }: { chatView: ReactNode }) {
+  const { id } = useParams()
+
+  if (!id) {
+    return <Navigate replace to={NEW_CHAT_ROUTE} />
+  }
+
+  return <ProjectPageView chatSlot={chatView} projectId={decodeURIComponent(id)} />
 }

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -1,6 +1,5 @@
 import { useStore } from '@nanostores/react'
 import { useQueryClient } from '@tanstack/react-query'
-import type { ReactNode} from 'react';
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom'
 
@@ -50,6 +49,7 @@ import {
   normalizeProfileKey,
   refreshActiveProfile
 } from '../store/profile'
+import { getProject } from '../store/projects'
 import {
   $activeSessionId,
   $currentCwd,
@@ -953,7 +953,14 @@ export function DesktopController() {
       onNewSessionInWorkspace={startSessionInWorkspace}
       onResumeSession={sessionId => navigate(sessionRoute(sessionId))}
       onSelectProject={id => {
+        const project = getProject(id)
+
         navigate(projectRoute(id))
+
+        // Seed cwd so the next new session starts in the project folder,
+        // but do NOT call startSessionInWorkspace — that starts a fresh
+        // draft and navigates away, overwriting the project route we just set.
+        if (project) { setCurrentCwd(project.path) }
       }}
       onTriggerCronJob={jobId => {
         void triggerCronJob(jobId)
@@ -1117,7 +1124,8 @@ export function DesktopController() {
   const fileBrowserPane = (
     <Pane
       defaultOpen={false}
-      disabled={!chatOpen}
+      // disabled={!chatOpen || currentView === 'project'}
+      disabled={!chatOpen && currentView !== 'project'}
       forceCollapsed={narrowViewport}
       hoverReveal
       id="file-browser"
@@ -1218,7 +1226,7 @@ export function DesktopController() {
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="new" />
           <Route element={<LegacySessionRedirect />} path="sessions/:sessionId" />
           <Route
-            element={<ProjectPageViewRoute chatView={chatView} />}
+            element={<ProjectPageViewRoute onStartSession={startSessionInWorkspace} />}
             path="project/:id"
           />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="*" />
@@ -1243,12 +1251,12 @@ function LegacySessionRedirect() {
   return <Navigate replace to={sessionId ? sessionRoute(sessionId) : NEW_CHAT_ROUTE} />
 }
 
-function ProjectPageViewRoute({ chatView }: { chatView: ReactNode }) {
+function ProjectPageViewRoute({ onStartSession }: { onStartSession: (path: string) => void }) {
   const { id } = useParams()
 
   if (!id) {
     return <Navigate replace to={NEW_CHAT_ROUTE} />
   }
 
-  return <ProjectPageView chatSlot={chatView} projectId={decodeURIComponent(id)} />
+  return <ProjectPageView onStartSession={onStartSession} projectId={decodeURIComponent(id)} />
 }

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useQueryClient } from '@tanstack/react-query'
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import { BootFailureOverlay } from '@/components/boot-failure-overlay'
@@ -56,8 +56,8 @@ import {
   $gatewayState,
   $messages,
   $messagingSessions,
-  $resumeFailedSessionId,
   $resumeExhaustedSessionId,
+  $resumeFailedSessionId,
   $selectedStoredSessionId,
   $sessions,
   $workingSessionIds,
@@ -104,10 +104,12 @@ import { useKeybinds } from './hooks/use-keybinds'
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from './layout-constants'
 import { ModelPickerOverlay } from './model-picker-overlay'
 import { ModelVisibilityOverlay } from './model-visibility-overlay'
+import { CreateProjectDialog } from './projects/create-project-dialog'
+import { ProjectPageView } from './projects/project-page'
 import { RightSidebarPane } from './right-sidebar'
 import { $terminalTakeover } from './right-sidebar/store'
 import { PersistentTerminal, TerminalSlot } from './right-sidebar/terminal/persistent'
-import { CRON_ROUTE, NEW_CHAT_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE } from './routes'
+import { CRON_ROUTE, NEW_CHAT_ROUTE, projectRoute, routeSessionId, sessionRoute, SETTINGS_ROUTE } from './routes'
 import { SessionPickerOverlay } from './session-picker-overlay'
 import { SessionSwitcher } from './session-switcher'
 import { useContextSuggestions } from './session/hooks/use-context-suggestions'
@@ -195,6 +197,9 @@ export function DesktopController() {
   const queryClient = useQueryClient()
   const location = useLocation()
   const navigate = useNavigate()
+
+  const [createProjectOpen, setCreateProjectOpen] = useState(false)
+  const [selectedProjectId, setSelectedProjectId] = useState<null | string>(null)
 
   const busyRef = useRef(false)
   const creatingSessionRef = useRef(false)
@@ -938,13 +943,19 @@ export function DesktopController() {
         navigate(CRON_ROUTE)
       }}
       onNavigate={selectSidebarItem}
+      onNewProject={() => setCreateProjectOpen(true)}
       onNewSessionInWorkspace={startSessionInWorkspace}
       onResumeSession={sessionId => navigate(sessionRoute(sessionId))}
+      onSelectProject={id => {
+        setSelectedProjectId(id)
+        navigate(projectRoute(id))
+      }}
       onTriggerCronJob={jobId => {
         void triggerCronJob(jobId)
           .then(() => refreshCronJobs())
           .catch(() => undefined)
       }}
+      selectedProjectId={selectedProjectId}
     />
   )
 
@@ -978,6 +989,14 @@ export function DesktopController() {
       <BootFailureOverlay />
       <CommandPalette />
       <SessionSwitcher />
+      <CreateProjectDialog
+        onClose={() => setCreateProjectOpen(false)}
+        onCreated={project => {
+          setSelectedProjectId(project.id)
+          navigate(projectRoute(project.id))
+        }}
+        open={createProjectOpen}
+      />
 
       {settingsOpen && (
         <Suspense fallback={null}>
@@ -1194,6 +1213,16 @@ export function DesktopController() {
           <Route element={null} path="agents" />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="new" />
           <Route element={<LegacySessionRedirect />} path="sessions/:sessionId" />
+          <Route
+            element={
+              selectedProjectId ? (
+                <ProjectPageView chatSlot={chatView} projectId={selectedProjectId} />
+              ) : (
+                <Navigate replace to={NEW_CHAT_ROUTE} />
+              )
+            }
+            path="project/:id"
+          />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="*" />
         </Routes>
       </PaneMain>

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -67,6 +67,7 @@ import {
   mergeSessionPage,
   MESSAGING_SECTION_LIMIT,
   sessionPinId,
+  setActiveSessionId,
   setAwaitingResponse,
   setBusy,
   setCronSessions,
@@ -78,6 +79,7 @@ import {
   setMessagingPlatformTotals,
   setMessagingSessions,
   setMessagingTruncated,
+  setSelectedStoredSessionId,
   setSessionProfileTotals,
   setSessions,
   setSessionsLoading,
@@ -91,6 +93,8 @@ import { isSecondaryWindow } from '../store/windows'
 import { ChatView } from './chat'
 import { requestComposerFocus, requestComposerInsert } from './chat/composer/focus'
 import { useComposerActions } from './chat/hooks/use-composer-actions'
+import type { DroppedFile } from './chat/hooks/use-composer-actions'
+import type { ComposerAttachment } from '@/store/composer'
 import {
   ChatPreviewRail,
   PREVIEW_RAIL_MAX_WIDTH,
@@ -824,6 +828,32 @@ export function DesktopController() {
     [requestGateway, startFreshSessionDraft]
   )
 
+  // The project page is a launcher, mirroring the sidebar's "new session"
+  // action (which clears the active session via startFreshSessionDraft). The
+  // difference: we must NOT navigate to '/' — we stay on /project/:id and seed
+  // the project's cwd, so the chatbar's normal submit (submitText) sees no
+  // active session and mints a NEW one in this project, then navigates straight
+  // to it. Staying put also keeps createBackendSessionForSend's route-token
+  // baseline stable so its abort guard doesn't fire mid-create. currentView is
+  // 'project' here, so useRouteResume is inert and won't bounce us off the page.
+  useEffect(() => {
+    if (!selectedProjectId) {
+      return
+    }
+
+    setActiveSessionId(null)
+    activeSessionIdRef.current = null
+    setSelectedStoredSessionId(null)
+    selectedStoredSessionIdRef.current = null
+    setMessages([])
+
+    const project = getProject(selectedProjectId)
+
+    if (project) {
+      setCurrentCwd(project.path)
+    }
+  }, [activeSessionIdRef, selectedProjectId, selectedStoredSessionIdRef])
+
   const handleSkinCommand = useSkinCommand()
 
   const {
@@ -1226,7 +1256,20 @@ export function DesktopController() {
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="new" />
           <Route element={<LegacySessionRedirect />} path="sessions/:sessionId" />
           <Route
-            element={<ProjectPageViewRoute onStartSession={startSessionInWorkspace} />}
+            element={
+              <ProjectPageViewRoute
+                onAttachDroppedItems={composer.attachDroppedItems}
+                onAttachImageBlob={composer.attachImageBlob}
+                onCancel={cancelRun}
+                onPasteClipboardImage={() => void composer.pasteClipboardImage()}
+                onPickFiles={() => void composer.pickContextPaths('file')}
+                onPickFolders={() => void composer.pickContextPaths('folder')}
+                onPickImages={() => void composer.pickImages()}
+                onRemoveAttachment={id => void composer.removeAttachment(id)}
+                onStartSession={startSessionInWorkspace}
+                onSubmit={submitText}
+              />
+            }
             path="project/:id"
           />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="*" />
@@ -1251,12 +1294,48 @@ function LegacySessionRedirect() {
   return <Navigate replace to={sessionId ? sessionRoute(sessionId) : NEW_CHAT_ROUTE} />
 }
 
-function ProjectPageViewRoute({ onStartSession }: { onStartSession: (path: string) => void }) {
+function ProjectPageViewRoute({
+  onAttachDroppedItems,
+  onAttachImageBlob,
+  onCancel,
+  onPasteClipboardImage,
+  onPickFiles,
+  onPickFolders,
+  onPickImages,
+  onRemoveAttachment,
+  onStartSession,
+  onSubmit
+}: {
+  onAttachDroppedItems: (candidates: DroppedFile[]) => Promise<boolean | void> | boolean | void
+  onAttachImageBlob: (blob: Blob) => Promise<boolean | void> | boolean | void
+  onCancel: () => Promise<void> | void
+  onPasteClipboardImage: () => void
+  onPickFiles: () => void
+  onPickFolders: () => void
+  onPickImages: () => void
+  onRemoveAttachment: (id: string) => void
+  onStartSession: (path: string) => void
+  onSubmit: (value: string, options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean }) => Promise<boolean> | boolean
+}) {
   const { id } = useParams()
 
   if (!id) {
     return <Navigate replace to={NEW_CHAT_ROUTE} />
   }
 
-  return <ProjectPageView onStartSession={onStartSession} projectId={decodeURIComponent(id)} />
+  return (
+    <ProjectPageView
+      onAttachDroppedItems={onAttachDroppedItems}
+      onAttachImageBlob={onAttachImageBlob}
+      onCancel={onCancel}
+      onPasteClipboardImage={onPasteClipboardImage}
+      onPickFiles={onPickFiles}
+      onPickFolders={onPickFolders}
+      onPickImages={onPickImages}
+      onRemoveAttachment={onRemoveAttachment}
+      onStartSession={onStartSession}
+      onSubmit={onSubmit}
+      projectId={decodeURIComponent(id)}
+    />
+  )
 }

--- a/apps/desktop/src/app/projects/create-project-dialog.tsx
+++ b/apps/desktop/src/app/projects/create-project-dialog.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { selectDesktopPaths } from '@/lib/desktop-fs'
+import { projectAgentsMdPath, readDesktopFileText, selectDesktopPaths, writeDesktopFileText } from '@/lib/desktop-fs'
 import { AlertTriangle } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { addProject } from '@/store/projects'
@@ -67,6 +67,25 @@ export function CreateProjectDialog({
     setError(null)
 
     try {
+      // Auto-create AGENTS.md only if it doesn't already exist in the folder.
+      // This preserves instructions in existing repos while giving new projects
+      // a ready-to-edit starter file.
+      const agentsMdPath = projectAgentsMdPath(path)
+
+      const alreadyExists = await readDesktopFileText(agentsMdPath)
+        .then(() => true)
+        .catch(() => false)
+
+      if (!alreadyExists) {
+        const starterContent = [
+          `# ${trimmedTitle}`,
+          trimmedDescription ? `\n${trimmedDescription}` : '',
+          '\n\n<!-- Add project-specific instructions for the AI agent here. -->'
+        ].join('')
+
+        await writeDesktopFileText(agentsMdPath, starterContent)
+      }
+
       const project = addProject({ title: trimmedTitle, description: trimmedDescription, path })
       onCreated(project)
       setStatus('done')

--- a/apps/desktop/src/app/projects/create-project-dialog.tsx
+++ b/apps/desktop/src/app/projects/create-project-dialog.tsx
@@ -6,18 +6,22 @@ import { Input } from '@/components/ui/input'
 import { projectAgentsMdPath, readDesktopFileText, selectDesktopPaths, writeDesktopFileText } from '@/lib/desktop-fs'
 import { AlertTriangle } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { addProject } from '@/store/projects'
+import { addProject, updateProject } from '@/store/projects'
 import type { Project } from '@/store/projects'
 
 export function CreateProjectDialog({
   onClose,
   onCreated,
-  open
+  open,
+  project
 }: {
   onClose: () => void
   onCreated: (project: Project) => void
   open: boolean
+  project?: Project
 }) {
+  const editMode = !!project
+
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
   const [path, setPath] = useState('')
@@ -29,12 +33,12 @@ export function CreateProjectDialog({
       return
     }
 
-    setTitle('')
-    setDescription('')
-    setPath('')
+    setTitle(project?.title ?? '')
+    setDescription(project?.description ?? '')
+    setPath(project?.path ?? '')
     setError(null)
     setStatus('idle')
-  }, [open])
+  }, [open, project])
 
   const busy = status === 'saving' || status === 'done'
   const trimmedTitle = title.trim()
@@ -51,7 +55,7 @@ export function CreateProjectDialog({
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
 
-    if (!path) {
+    if (!editMode && !path) {
       setError('Please choose a folder for the project.')
 
       return
@@ -67,32 +71,36 @@ export function CreateProjectDialog({
     setError(null)
 
     try {
-      // Auto-create AGENTS.md only if it doesn't already exist in the folder.
-      // This preserves instructions in existing repos while giving new projects
-      // a ready-to-edit starter file.
-      const agentsMdPath = projectAgentsMdPath(path)
+      if (editMode) {
+        updateProject(project.id, { title: trimmedTitle, description: trimmedDescription })
+        setStatus('done')
+        window.setTimeout(onClose, 400)
+      } else {
+        // Auto-create AGENTS.md only if it doesn't already exist in the folder.
+        const agentsMdPath = projectAgentsMdPath(path)
 
-      const alreadyExists = await readDesktopFileText(agentsMdPath)
-        .then(() => true)
-        .catch(() => false)
+        const alreadyExists = await readDesktopFileText(agentsMdPath)
+          .then(() => true)
+          .catch(() => false)
 
-      if (!alreadyExists) {
-        const starterContent = [
-          `# ${trimmedTitle}`,
-          trimmedDescription ? `\n${trimmedDescription}` : '',
-          '\n\n<!-- Add project-specific instructions for the AI agent here. -->'
-        ].join('')
+        if (!alreadyExists) {
+          const starterContent = [
+            `# ${trimmedTitle}`,
+            trimmedDescription ? `\n${trimmedDescription}` : '',
+            '\n\n<!-- Add project-specific instructions for the AI agent here. -->'
+          ].join('')
 
-        await writeDesktopFileText(agentsMdPath, starterContent)
+          await writeDesktopFileText(agentsMdPath, starterContent)
+        }
+
+        const created = addProject({ title: trimmedTitle, description: trimmedDescription, path })
+        onCreated(created)
+        setStatus('done')
+        window.setTimeout(onClose, 400)
       }
-
-      const project = addProject({ title: trimmedTitle, description: trimmedDescription, path })
-      onCreated(project)
-      setStatus('done')
-      window.setTimeout(onClose, 400)
     } catch (err) {
       setStatus('idle')
-      setError(err instanceof Error ? err.message : 'Failed to create project.')
+      setError(err instanceof Error ? err.message : editMode ? 'Failed to save project.' : 'Failed to create project.')
     }
   }
 
@@ -100,21 +108,25 @@ export function CreateProjectDialog({
     <Dialog onOpenChange={value => !value && !busy && onClose()} open={open}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>New Project</DialogTitle>
+          <DialogTitle>{editMode ? 'Edit Project' : 'New Project'}</DialogTitle>
           <DialogDescription>
-            Choose a folder for your project. An AGENTS.md file in that folder will be used as project instructions.
+            {editMode
+              ? 'Update the project name and description.'
+              : 'Choose a folder for your project. An AGENTS.md file in that folder will be used as project instructions.'}
           </DialogDescription>
         </DialogHeader>
 
         <form className="grid gap-4" onSubmit={handleSubmit}>
-          <div className="grid gap-1.5">
-            <Button onClick={() => void chooseFolder()} type="button" variant="outline">
-              Choose Folder
-            </Button>
-            <p className={cn('truncate text-xs', path ? 'text-foreground' : 'text-muted-foreground')}>
-              {path || 'No folder selected'}
-            </p>
-          </div>
+          {!editMode && (
+            <div className="grid gap-1.5">
+              <Button onClick={() => void chooseFolder()} type="button" variant="outline">
+                Choose Folder
+              </Button>
+              <p className={cn('truncate text-xs', path ? 'text-foreground' : 'text-muted-foreground')}>
+                {path || 'No folder selected'}
+              </p>
+            </div>
+          )}
 
           <div className="grid gap-1.5">
             <label className="text-xs font-medium" htmlFor="new-project-title">
@@ -154,8 +166,10 @@ export function CreateProjectDialog({
             <Button disabled={busy} onClick={onClose} type="button" variant="ghost">
               Cancel
             </Button>
-            <Button disabled={busy || !trimmedTitle || !path} type="submit">
-              {status === 'saving' ? 'Creating…' : status === 'done' ? 'Created' : 'Create'}
+            <Button disabled={busy || !trimmedTitle || (!editMode && !path)} type="submit">
+              {editMode
+                ? status === 'saving' ? 'Saving…' : status === 'done' ? 'Saved' : 'Save'
+                : status === 'saving' ? 'Creating…' : status === 'done' ? 'Created' : 'Create'}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/desktop/src/app/projects/create-project-dialog.tsx
+++ b/apps/desktop/src/app/projects/create-project-dialog.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { selectDesktopPaths } from '@/lib/desktop-fs'
+import { AlertTriangle } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { addProject } from '@/store/projects'
+import type { Project } from '@/store/projects'
+
+export function CreateProjectDialog({
+  onClose,
+  onCreated,
+  open
+}: {
+  onClose: () => void
+  onCreated: (project: Project) => void
+  open: boolean
+}) {
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [path, setPath] = useState('')
+  const [status, setStatus] = useState<'done' | 'idle' | 'saving'>('idle')
+  const [error, setError] = useState<null | string>(null)
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    setTitle('')
+    setDescription('')
+    setPath('')
+    setError(null)
+    setStatus('idle')
+  }, [open])
+
+  const busy = status === 'saving' || status === 'done'
+  const trimmedTitle = title.trim()
+  const trimmedDescription = description.trim()
+
+  const chooseFolder = async () => {
+    const selected = await selectDesktopPaths({ directories: true, multiple: false })
+
+    if (selected?.[0]) {
+      setPath(selected[0])
+    }
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+
+    if (!path) {
+      setError('Please choose a folder for the project.')
+
+      return
+    }
+
+    if (!trimmedTitle) {
+      setError('Project name is required.')
+
+      return
+    }
+
+    setStatus('saving')
+    setError(null)
+
+    try {
+      const project = addProject({ title: trimmedTitle, description: trimmedDescription, path })
+      onCreated(project)
+      setStatus('done')
+      window.setTimeout(onClose, 400)
+    } catch (err) {
+      setStatus('idle')
+      setError(err instanceof Error ? err.message : 'Failed to create project.')
+    }
+  }
+
+  return (
+    <Dialog onOpenChange={value => !value && !busy && onClose()} open={open}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>New Project</DialogTitle>
+          <DialogDescription>
+            Choose a folder for your project. An AGENTS.md file in that folder will be used as project instructions.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="grid gap-4" onSubmit={handleSubmit}>
+          <div className="grid gap-1.5">
+            <Button onClick={() => void chooseFolder()} type="button" variant="outline">
+              Choose Folder
+            </Button>
+            <p className={cn('truncate text-xs', path ? 'text-foreground' : 'text-muted-foreground')}>
+              {path || 'No folder selected'}
+            </p>
+          </div>
+
+          <div className="grid gap-1.5">
+            <label className="text-xs font-medium" htmlFor="new-project-title">
+              Project Name
+            </label>
+            <Input
+              autoFocus
+              id="new-project-title"
+              onChange={event => setTitle(event.target.value)}
+              placeholder="My Project"
+              value={title}
+            />
+          </div>
+
+          <div className="grid gap-1.5">
+            <label className="text-xs font-medium" htmlFor="new-project-description">
+              Description <span className="font-normal text-muted-foreground">— optional</span>
+            </label>
+            <Input
+              id="new-project-description"
+              maxLength={40}
+              onChange={event => setDescription(event.target.value)}
+              placeholder="Short description of this project"
+              value={description}
+            />
+            <p className="text-[0.66rem] text-muted-foreground">{description.length}/40</p>
+          </div>
+
+          {error && (
+            <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button disabled={busy} onClick={onClose} type="button" variant="ghost">
+              Cancel
+            </Button>
+            <Button disabled={busy || !trimmedTitle || !path} type="submit">
+              {status === 'saving' ? 'Creating…' : status === 'done' ? 'Created' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/app/projects/edit-instructions-dialog.tsx
+++ b/apps/desktop/src/app/projects/edit-instructions-dialog.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Textarea } from '@/components/ui/textarea'
+
+export function EditInstructionsDialog({
+  onClose,
+  onSave,
+  open,
+  projectTitle,
+  value
+}: {
+  onClose: () => void
+  onSave: (text: string) => void
+  open: boolean
+  projectTitle: string
+  value: string
+}) {
+  const [text, setText] = useState(value)
+
+  useEffect(() => {
+    if (open) {
+      setText(value)
+    }
+  }, [open, value])
+
+  return (
+    <Dialog onOpenChange={v => !v && onClose()} open={open}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Instructions</DialogTitle>
+          <DialogDescription>
+            Provide Hermes with relevant instructions and information for chats within {projectTitle}. This will work alongside your agent profile instructions.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Textarea
+          className="min-h-48 resize-none font-mono text-xs leading-5"
+          maxLength={8000}
+          onChange={e => setText(e.target.value)}
+          placeholder="Add project-specific instructions here..."
+          rows={12}
+          value={text}
+        />
+        <p className="text-right text-[0.66rem] text-muted-foreground">{text.length}/8000</p>
+
+        <DialogFooter>
+          <Button onClick={onClose} type="button" variant="ghost">
+            Cancel
+          </Button>
+          <Button onClick={() => onSave(text)} type="button">
+            Save Instructions
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/app/projects/project-page.tsx
+++ b/apps/desktop/src/app/projects/project-page.tsx
@@ -1,20 +1,53 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
+import { ChatRuntimeBoundary } from '@/app/chat'
+import { ChatBar, ChatBarFallback } from '@/app/chat/composer'
+import type { DroppedFile } from '@/app/chat/hooks/use-composer-actions'
+import { SidebarSessionRow } from '@/app/chat/sidebar/session-row'
+import { CreateProjectDialog } from '@/app/projects/create-project-dialog'
+import { EditInstructionsDialog } from '@/app/projects/edit-instructions-dialog'
+import { sessionRoute } from '@/app/routes'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
-import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
+import type { SessionInfo } from '@/hermes'
+import { deleteSession, setSessionArchived } from '@/hermes'
 import { projectAgentsMdPath, readDesktopFileText, writeDesktopFileText } from '@/lib/desktop-fs'
 import { cn } from '@/lib/utils'
-import { $projects, getProject, updateProject } from '@/store/projects'
+import type { ComposerAttachment } from '@/store/composer'
+import { $gateway } from '@/store/gateway'
+import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
+import { $projects, getProject } from '@/store/projects'
+import { $busy, $currentModel, $currentProvider, $gatewayState, $sessions, sessionPinId, setSessions } from '@/store/session'
 
 interface ProjectPageProps {
   projectId: string
   onStartSession?: (projectPath: string) => void
+  onSubmit?: (value: string, options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean }) => Promise<boolean> | boolean
+  onCancel?: () => Promise<void> | void
+  onPickFiles?: () => void
+  onPickFolders?: () => void
+  onPickImages?: () => void
+  onPasteClipboardImage?: () => void
+  onAttachImageBlob?: (blob: Blob) => Promise<boolean | void> | boolean | void
+  onAttachDroppedItems?: (candidates: DroppedFile[]) => Promise<boolean | void> | boolean | void
+  onRemoveAttachment?: (id: string) => void
 }
 
-export function ProjectPageView({ projectId, onStartSession }: ProjectPageProps) {
+export function ProjectPageView({
+  projectId,
+  onStartSession,
+  onSubmit,
+  onCancel,
+  onPickFiles,
+  onPickFolders,
+  onPickImages,
+  onPasteClipboardImage,
+  onAttachImageBlob,
+  onAttachDroppedItems,
+  onRemoveAttachment
+}: ProjectPageProps) {
   useStore($projects)
   const project = getProject(projectId)
 
@@ -28,7 +61,18 @@ export function ProjectPageView({ projectId, onStartSession }: ProjectPageProps)
 
   return (
     <div className="flex h-full w-full min-w-0 overflow-hidden">
-      <ProjectEmptyState projectTitle={project.title} />
+      <ProjectMainPanel
+        onAttachDroppedItems={onAttachDroppedItems}
+        onAttachImageBlob={onAttachImageBlob}
+        onCancel={onCancel}
+        onPasteClipboardImage={onPasteClipboardImage}
+        onPickFiles={onPickFiles}
+        onPickFolders={onPickFolders}
+        onPickImages={onPickImages}
+        onRemoveAttachment={onRemoveAttachment}
+        onSubmit={onSubmit}
+        projectId={projectId}
+      />
       <ProjectSettingsPanel
         onStartSession={onStartSession}
         projectId={projectId}
@@ -37,15 +81,192 @@ export function ProjectPageView({ projectId, onStartSession }: ProjectPageProps)
   )
 }
 
-function ProjectEmptyState({ projectTitle }: { projectTitle: string }) {
+function ProjectMainPanel({
+  onAttachDroppedItems,
+  onAttachImageBlob,
+  onCancel,
+  onPasteClipboardImage,
+  onPickFiles,
+  onPickFolders,
+  onPickImages,
+  onRemoveAttachment,
+  onSubmit,
+  projectId
+}: {
+  onAttachDroppedItems?: (candidates: DroppedFile[]) => Promise<boolean | void> | boolean | void
+  onAttachImageBlob?: (blob: Blob) => Promise<boolean | void> | boolean | void
+  onCancel?: () => Promise<void> | void
+  onPasteClipboardImage?: () => void
+  onPickFiles?: () => void
+  onPickFolders?: () => void
+  onPickImages?: () => void
+  onRemoveAttachment?: (id: string) => void
+  onSubmit?: (value: string, options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean }) => Promise<boolean> | boolean
+  projectId: string
+}) {
+  useStore($projects)
+  const project = getProject(projectId)
+  const allSessions = useStore($sessions)
+  const busy = useStore($busy)
+  const gatewayState = useStore($gatewayState)
+  const currentModel = useStore($currentModel)
+  const currentProvider = useStore($currentProvider)
+  const gateway = useStore($gateway)
+  const pinnedSessionIds = useStore($pinnedSessionIds)
+  const navigate = useNavigate()
+
+  const projectSessions = useMemo<SessionInfo[]>(
+    () => (project ? allSessions.filter(s => s.cwd?.startsWith(project.path)) : []),
+    [allSessions, project]
+  )
+
+  const gatewayOpen = gatewayState === 'open'
+
+  const chatBarState = useMemo(
+    () => ({
+      model: {
+        model: currentModel,
+        provider: currentProvider,
+        canSwitch: gatewayOpen,
+        loading: !gatewayOpen || (!currentModel && !currentProvider)
+      },
+      tools: { enabled: true, label: 'Add context' },
+      voice: { enabled: true, active: false }
+    }),
+    [currentModel, currentProvider, gatewayOpen]
+  )
+
+  const handleSubmit = useMemo(
+    () =>
+      (value: string, options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean }) =>
+        onSubmit?.(value, options) ?? false,
+    [onSubmit]
+  )
+
+  const [editOpen, setEditOpen] = useState(false)
+
+  if (!project) {
+    return null
+  }
+
   return (
-    <div className="flex min-w-0 flex-1 flex-col items-center justify-center gap-3 text-muted-foreground">
-      <Codicon name="folder-opened" size="2rem" />
-      <div className="text-center">
-        <p className="text-sm font-medium text-foreground">{projectTitle}</p>
-        <p className="mt-1 text-xs">
-          Start a new session from the panel on the right to begin working in this project.
-        </p>
+    <div className="flex min-w-0 flex-1 flex-col overflow-hidden pt-(--titlebar-height)">
+      {/* Header: folder icon + title + description */}
+      <div className="flex shrink-0 items-center gap-3 px-6 pb-4 pt-6">
+        <Codicon
+          className="shrink-0 text-(--ui-text-tertiary)"
+          name="folder-opened"
+          size="1.75rem"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-base font-semibold text-foreground" title={project.title}>
+            {project.title}
+          </p>
+          {project.description && (
+            <p className="truncate text-xs text-muted-foreground" title={project.description}>
+              {project.description}
+            </p>
+          )}
+        </div>
+        <Button
+          className="size-6 shrink-0"
+          onClick={() => setEditOpen(true)}
+          size="icon"
+          variant="ghost"
+        >
+          <Codicon name="edit" size="1rem" />
+        </Button>
+      </div>
+
+      <CreateProjectDialog
+        onClose={() => setEditOpen(false)}
+        onCreated={() => undefined}
+        open={editOpen}
+        project={project}
+      />
+
+      {/* Sessions section */}
+      <div className="shrink-0 px-6 py-2">
+        <span className="text-[0.6875rem] font-medium uppercase tracking-wide text-(--ui-text-tertiary)">
+          Sessions
+        </span>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-3">
+        {projectSessions.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              Start a session in <span className="font-medium text-foreground">{project.title}</span>
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-px">
+            {projectSessions.map(session => {
+              const pinId = sessionPinId(session)
+              const isPinned = pinnedSessionIds.includes(pinId)
+
+              return (
+                <SidebarSessionRow
+                  isPinned={isPinned}
+                  isSelected={false}
+                  isWorking={false}
+                  key={session.id}
+                  onArchive={() => {
+                    void setSessionArchived(session.id, true, session.profile).then(() =>
+                      setSessions(prev => prev.filter(s => s.id !== session.id))
+                    )
+                  }}
+                  onDelete={() => {
+                    void deleteSession(session.id, session.profile).then(() =>
+                      setSessions(prev => prev.filter(s => s.id !== session.id))
+                    )
+                  }}
+                  onPin={() => (isPinned ? unpinSession(pinId) : pinSession(pinId))}
+                  onResume={() => navigate(sessionRoute(session.id))}
+                  session={session}
+                />
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* ChatBar — relative container so absolute-positioned ChatBar anchors here.
+           No overflow-hidden: the ChatBar's text input sits near the container's
+           top edge; clipping it would make it unclickable. Width is self-constrained
+           by the ChatBar's own w-[min(--composer-width, calc(100%-2rem))]. */}
+      <div
+        className="relative shrink-0"
+        style={{ height: 'calc(var(--composer-measured-height) + 1.25rem)' }}
+      >
+        <ChatRuntimeBoundary
+          busy={busy}
+          onCancel={onCancel ?? (() => undefined)}
+          onEdit={async () => undefined}
+          onReload={async () => undefined}
+          onThreadMessagesChange={() => undefined}
+          suppressMessages={false}
+        >
+          <Suspense fallback={<ChatBarFallback />}>
+            <ChatBar
+              busy={busy}
+              cwd={project.path}
+              disabled={!gatewayOpen}
+              gateway={gateway}
+              onAttachDroppedItems={onAttachDroppedItems}
+              onAttachImageBlob={onAttachImageBlob}
+              onCancel={onCancel ?? (() => undefined)}
+              onPasteClipboardImage={onPasteClipboardImage}
+              onPickFiles={onPickFiles}
+              onPickFolders={onPickFolders}
+              onPickImages={onPickImages}
+              onRemoveAttachment={onRemoveAttachment}
+              onSubmit={handleSubmit}
+              sessionId={null}
+              state={chatBarState}
+            />
+          </Suspense>
+        </ChatRuntimeBoundary>
       </div>
     </div>
   )
@@ -60,10 +281,10 @@ function ProjectSettingsPanel({
 }) {
   useStore($projects)
   const project = getProject(projectId)
-  const [description, setDescription] = useState(project?.description ?? '')
   const [instructions, setInstructions] = useState('')
   const [instructionsLoaded, setInstructionsLoaded] = useState(false)
   const [instructionsSaving, setInstructionsSaving] = useState(false)
+  const [instructionsDialogOpen, setInstructionsDialogOpen] = useState(false)
 
   const projectPath = project?.path ?? ''
 
@@ -100,15 +321,25 @@ function ProjectSettingsPanel({
     }
   }
 
+  const saveInstructionsText = async (text: string) => {
+    if (!project) { return }
+
+    setInstructionsSaving(true)
+
+    try {
+      await writeDesktopFileText(projectAgentsMdPath(projectPath), text)
+    } catch {
+      // silent
+    } finally {
+      setInstructionsSaving(false)
+    }
+  }
+
   const openFolder = () => {
     // Use hermesDesktop.openExternal with a file:// URL — works cross-platform
     // (Windows, macOS, Linux) via Electron's shell.openPath under the hood.
     const fileUrl = `file://${project.path.replaceAll('\\', '/')}`
     void window.hermesDesktop?.openExternal(fileUrl).catch(() => {})
-  }
-
-  const handleUpdateDescription = () => {
-    updateProject(projectId, { description })
   }
 
   const folderName =
@@ -126,66 +357,47 @@ function ProjectSettingsPanel({
       style={{ maxWidth: 360, minWidth: 200, width: 280 }}
     >
       <div className="flex shrink-0 flex-col gap-0.5 border-b border-(--ui-stroke-secondary) px-3 py-3">
-        <p className="truncate text-sm font-semibold text-foreground" title={project.title}>
-          {project.title}
-        </p>
         <p className="truncate text-[0.68rem] text-muted-foreground" title={project.path}>
-          {folderName}
+          {project.path.split('/').slice(-2).join('/')}
         </p>
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-3 py-3">
         <div className="grid gap-1.5">
-          <div className="flex items-center justify-between">
-            <label className="text-xs font-medium text-foreground">Instructions</label>
-            <Button
-              className="h-5 px-1.5 text-[0.6875rem]"
-              disabled={!instructionsLoaded || instructionsSaving}
-              onClick={() => void saveInstructions()}
-              size="sm"
-              variant="ghost"
-            >
-              {instructionsSaving ? 'Saving...' : 'Save'}
-            </Button>
+          <div
+            className="relative rounded-xl border border-(--ui-stroke-secondary) bg-(--ui-bg-quinary) p-3"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-foreground">Instructions</span>
+              <Button
+                className="size-5"
+                disabled={!instructionsLoaded}
+                onClick={() => setInstructionsDialogOpen(true)}
+                size="icon"
+                variant="ghost"
+              >
+                <Codicon name="edit" size="0.75rem" />
+              </Button>
+            </div>
+            <p className="mt-1.5 text-[0.6875rem] leading-4 text-(--ui-text-tertiary)">
+              {instructions
+                ? instructions.length > 150 ? `${instructions.slice(0, 150)}...` : instructions
+                : 'No instructions set'}
+            </p>
           </div>
-          <p className="text-[0.68rem] text-muted-foreground">Saved as AGENTS.md in the project folder</p>
-          <Textarea
-            className="min-h-28 resize-none font-mono text-xs leading-5"
-            disabled={!instructionsLoaded}
-            onBlur={() => void saveInstructions()}
-            onChange={e => setInstructions(e.target.value)}
-            placeholder="Add instructions for this project... Saved as AGENTS.md in the project folder."
+          <EditInstructionsDialog
+            onClose={() => setInstructionsDialogOpen(false)}
+            onSave={text => {
+              setInstructions(text)
+              setInstructionsDialogOpen(false)
+              void saveInstructionsText(text)
+            }}
+            open={instructionsDialogOpen}
+            projectTitle={project.title}
             value={instructions}
           />
         </div>
 
-        <div className="grid gap-1.5">
-          <label className="text-xs font-medium text-foreground">Description</label>
-          <div className="flex gap-1.5">
-            <Input
-              className="h-7 text-xs"
-              maxLength={40}
-              onChange={event => setDescription(event.target.value)}
-              placeholder="Short description"
-              value={description}
-            />
-            <Button className="h-7 shrink-0 text-xs" onClick={handleUpdateDescription} size="sm" variant="outline">
-              Update
-            </Button>
-          </div>
-        </div>
-      </div>
-
-      <div className="shrink-0 border-t border-(--ui-stroke-secondary) px-3 py-3">
-        <Button
-          className="w-full justify-start gap-1.5 text-xs"
-          onClick={() => onStartSession?.(project.path)}
-          size="sm"
-          variant="outline"
-        >
-          <Codicon name="play" size="0.875rem" />
-          Start A New Session
-        </Button>
       </div>
 
       <div className="shrink-0 border-t border-(--ui-stroke-secondary) px-3 py-3">

--- a/apps/desktop/src/app/projects/project-page.tsx
+++ b/apps/desktop/src/app/projects/project-page.tsx
@@ -1,0 +1,117 @@
+import { useStore } from '@nanostores/react'
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/utils'
+import { $projects, getProject, updateProject } from '@/store/projects'
+
+interface ProjectPageProps {
+  chatSlot: ReactNode
+  projectId: string
+}
+
+export function ProjectPageView({ chatSlot, projectId }: ProjectPageProps) {
+  useStore($projects)
+  const project = getProject(projectId)
+
+  if (!project) {
+    return (
+      <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+        Project not found
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full w-full min-w-0 overflow-hidden">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">{chatSlot}</div>
+      <ProjectSettingsPanel projectId={projectId} />
+    </div>
+  )
+}
+
+function ProjectSettingsPanel({ projectId }: { projectId: string }) {
+  useStore($projects)
+  const project = getProject(projectId)
+  const [description, setDescription] = useState(project?.description ?? '')
+
+  if (!project) {
+    return null
+  }
+
+  const openFolder = () => {
+    // Use hermesDesktop.openExternal with a file:// URL — works cross-platform
+    // (Windows, macOS, Linux) via Electron's shell.openPath under the hood.
+    const fileUrl = `file://${project.path.replaceAll('\\', '/')}`
+    void window.hermesDesktop?.openExternal(fileUrl).catch(() => {})
+  }
+
+  const handleUpdateDescription = () => {
+    updateProject(projectId, { description })
+  }
+
+  const folderName =
+    project.path
+      .split(/[\\/]+/)
+      .filter(Boolean)
+      .pop() ?? project.path
+
+  return (
+    <aside
+      className={cn(
+        'flex h-full flex-col overflow-hidden border-l border-(--ui-stroke-secondary) bg-(--ui-sidebar-surface-background) text-(--ui-text-tertiary)',
+        'pt-(--titlebar-height)'
+      )}
+      style={{ maxWidth: 360, minWidth: 200, width: 280 }}
+    >
+      <div className="flex shrink-0 flex-col gap-0.5 border-b border-(--ui-stroke-secondary) px-3 py-3">
+        <p className="truncate text-sm font-semibold text-foreground" title={project.title}>
+          {project.title}
+        </p>
+        <p className="truncate text-[0.68rem] text-muted-foreground" title={project.path}>
+          {folderName}
+        </p>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-3 py-3">
+        <div className="grid gap-1.5">
+          <label className="text-xs font-medium text-foreground">Instructions</label>
+          <p className="text-[0.68rem] text-muted-foreground">Saved as AGENTS.md in the project folder</p>
+          <Textarea
+            className="min-h-28 resize-none font-mono text-xs leading-5"
+            placeholder="No instructions yet — add them in Phase 3"
+            readOnly
+            value={''}
+          />
+        </div>
+
+        <div className="grid gap-1.5">
+          <label className="text-xs font-medium text-foreground">Description</label>
+          <div className="flex gap-1.5">
+            <Input
+              className="h-7 text-xs"
+              maxLength={40}
+              onChange={event => setDescription(event.target.value)}
+              placeholder="Short description"
+              value={description}
+            />
+            <Button className="h-7 shrink-0 text-xs" onClick={handleUpdateDescription} size="sm" variant="outline">
+              Update
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="shrink-0 border-t border-(--ui-stroke-secondary) px-3 py-3">
+        <Button className="w-full justify-start gap-1.5 text-xs" onClick={openFolder} size="sm" variant="outline">
+          <Codicon name="folder-opened" size="0.875rem" />
+          Open in Explorer
+        </Button>
+      </div>
+    </aside>
+  )
+}

--- a/apps/desktop/src/app/projects/project-page.tsx
+++ b/apps/desktop/src/app/projects/project-page.tsx
@@ -1,20 +1,20 @@
 import { useStore } from '@nanostores/react'
-import type { ReactNode } from 'react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
+import { projectAgentsMdPath, readDesktopFileText, writeDesktopFileText } from '@/lib/desktop-fs'
 import { cn } from '@/lib/utils'
 import { $projects, getProject, updateProject } from '@/store/projects'
 
 interface ProjectPageProps {
-  chatSlot: ReactNode
   projectId: string
+  onStartSession?: (projectPath: string) => void
 }
 
-export function ProjectPageView({ chatSlot, projectId }: ProjectPageProps) {
+export function ProjectPageView({ projectId, onStartSession }: ProjectPageProps) {
   useStore($projects)
   const project = getProject(projectId)
 
@@ -28,19 +28,76 @@ export function ProjectPageView({ chatSlot, projectId }: ProjectPageProps) {
 
   return (
     <div className="flex h-full w-full min-w-0 overflow-hidden">
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">{chatSlot}</div>
-      <ProjectSettingsPanel projectId={projectId} />
+      <ProjectEmptyState projectTitle={project.title} />
+      <ProjectSettingsPanel
+        onStartSession={onStartSession}
+        projectId={projectId}
+      />
     </div>
   )
 }
 
-function ProjectSettingsPanel({ projectId }: { projectId: string }) {
+function ProjectEmptyState({ projectTitle }: { projectTitle: string }) {
+  return (
+    <div className="flex min-w-0 flex-1 flex-col items-center justify-center gap-3 text-muted-foreground">
+      <Codicon name="folder-opened" size="2rem" />
+      <div className="text-center">
+        <p className="text-sm font-medium text-foreground">{projectTitle}</p>
+        <p className="mt-1 text-xs">
+          Start a new session from the panel on the right to begin working in this project.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function ProjectSettingsPanel({
+  onStartSession,
+  projectId
+}: {
+  onStartSession?: (projectPath: string) => void
+  projectId: string
+}) {
   useStore($projects)
   const project = getProject(projectId)
   const [description, setDescription] = useState(project?.description ?? '')
+  const [instructions, setInstructions] = useState('')
+  const [instructionsLoaded, setInstructionsLoaded] = useState(false)
+  const [instructionsSaving, setInstructionsSaving] = useState(false)
+
+  const projectPath = project?.path ?? ''
+
+  useEffect(() => {
+    if (!project || !projectPath) { return }
+
+    setInstructionsLoaded(false)
+    readDesktopFileText(projectAgentsMdPath(projectPath))
+      .then(result => {
+        setInstructions(result.text)
+        setInstructionsLoaded(true)
+      })
+      .catch(() => {
+        setInstructions('')
+        setInstructionsLoaded(true)
+      })
+  }, [projectPath, project])
 
   if (!project) {
     return null
+  }
+
+  const saveInstructions = async () => {
+    if (!project || instructionsSaving) { return }
+
+    setInstructionsSaving(true)
+
+    try {
+      await writeDesktopFileText(projectAgentsMdPath(projectPath), instructions)
+    } catch {
+      // silent
+    } finally {
+      setInstructionsSaving(false)
+    }
   }
 
   const openFolder = () => {
@@ -79,13 +136,26 @@ function ProjectSettingsPanel({ projectId }: { projectId: string }) {
 
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-3 py-3">
         <div className="grid gap-1.5">
-          <label className="text-xs font-medium text-foreground">Instructions</label>
+          <div className="flex items-center justify-between">
+            <label className="text-xs font-medium text-foreground">Instructions</label>
+            <Button
+              className="h-5 px-1.5 text-[0.6875rem]"
+              disabled={!instructionsLoaded || instructionsSaving}
+              onClick={() => void saveInstructions()}
+              size="sm"
+              variant="ghost"
+            >
+              {instructionsSaving ? 'Saving...' : 'Save'}
+            </Button>
+          </div>
           <p className="text-[0.68rem] text-muted-foreground">Saved as AGENTS.md in the project folder</p>
           <Textarea
             className="min-h-28 resize-none font-mono text-xs leading-5"
-            placeholder="No instructions yet — add them in Phase 3"
-            readOnly
-            value={''}
+            disabled={!instructionsLoaded}
+            onBlur={() => void saveInstructions()}
+            onChange={e => setInstructions(e.target.value)}
+            placeholder="Add instructions for this project... Saved as AGENTS.md in the project folder."
+            value={instructions}
           />
         </div>
 
@@ -104,6 +174,18 @@ function ProjectSettingsPanel({ projectId }: { projectId: string }) {
             </Button>
           </div>
         </div>
+      </div>
+
+      <div className="shrink-0 border-t border-(--ui-stroke-secondary) px-3 py-3">
+        <Button
+          className="w-full justify-start gap-1.5 text-xs"
+          onClick={() => onStartSession?.(project.path)}
+          size="sm"
+          variant="outline"
+        >
+          <Codicon name="play" size="0.875rem" />
+          Start A New Session
+        </Button>
       </div>
 
       <div className="shrink-0 border-t border-(--ui-stroke-secondary) px-3 py-3">

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -6,7 +6,7 @@ export const SKILLS_ROUTE = '/skills'
 export const MESSAGING_ROUTE = '/messaging'
 export const ARTIFACTS_ROUTE = '/artifacts'
 export const CRON_ROUTE = '/cron'
-export const PROJECT_ROUTE = '/project/:id'
+export const PROJECT_ROUTE = '/project'
 export const PROFILES_ROUTE = '/profiles'
 export const AGENTS_ROUTE = '/agents'
 
@@ -48,7 +48,7 @@ export const APP_ROUTES = [
   { id: 'messaging', path: MESSAGING_ROUTE, view: 'messaging' },
   { id: 'artifacts', path: ARTIFACTS_ROUTE, view: 'artifacts' },
   { id: 'cron', path: CRON_ROUTE, view: 'cron' },
-  { id: 'project', path: 'project/:id', view: 'project' as AppView },
+  { id: 'project', path: `${PROJECT_ROUTE}/:id`, view: 'project' as AppView },
   { id: 'profiles', path: PROFILES_ROUTE, view: 'profiles' },
   { id: 'agents', path: AGENTS_ROUTE, view: 'agents' }
 ] as const satisfies readonly AppRoute[]
@@ -80,7 +80,7 @@ export function routeSessionId(pathname: string): string | null {
 }
 
 export function projectRoute(id: string): string {
-  return `/project/${id}`
+  return `${PROJECT_ROUTE}/${encodeURIComponent(id)}`
 }
 
 export function sessionRoute(sessionId: string): string {
@@ -90,6 +90,10 @@ export function sessionRoute(sessionId: string): string {
 export function appViewForPath(pathname: string): AppView {
   if (isNewChatRoute(pathname) || routeSessionId(pathname)) {
     return 'chat'
+  }
+
+  if (pathname.startsWith(`${PROJECT_ROUTE}/`)) {
+    return 'project'
   }
 
   return APP_VIEW_BY_PATH.get(pathname) ?? 'chat'

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -6,6 +6,7 @@ export const SKILLS_ROUTE = '/skills'
 export const MESSAGING_ROUTE = '/messaging'
 export const ARTIFACTS_ROUTE = '/artifacts'
 export const CRON_ROUTE = '/cron'
+export const PROJECT_ROUTE = '/project/:id'
 export const PROFILES_ROUTE = '/profiles'
 export const AGENTS_ROUTE = '/agents'
 
@@ -17,6 +18,7 @@ export type AppView =
   | 'cron'
   | 'messaging'
   | 'profiles'
+  | 'project'
   | 'settings'
   | 'skills'
 
@@ -28,6 +30,7 @@ export type AppRouteId =
   | 'messaging'
   | 'new'
   | 'profiles'
+  | 'project'
   | 'settings'
   | 'skills'
 
@@ -45,6 +48,7 @@ export const APP_ROUTES = [
   { id: 'messaging', path: MESSAGING_ROUTE, view: 'messaging' },
   { id: 'artifacts', path: ARTIFACTS_ROUTE, view: 'artifacts' },
   { id: 'cron', path: CRON_ROUTE, view: 'cron' },
+  { id: 'project', path: 'project/:id', view: 'project' as AppView },
   { id: 'profiles', path: PROFILES_ROUTE, view: 'profiles' },
   { id: 'agents', path: AGENTS_ROUTE, view: 'agents' }
 ] as const satisfies readonly AppRoute[]
@@ -73,6 +77,10 @@ export function routeSessionId(pathname: string): string | null {
   const id = pathname.slice(SESSION_ROUTE_PREFIX.length)
 
   return id && !id.includes('/') ? decodeURIComponent(id) : null
+}
+
+export function projectRoute(id: string): string {
+  return `/project/${id}`
 }
 
 export function sessionRoute(sessionId: string): string {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -46,6 +46,7 @@ declare global {
       requestMicrophoneAccess: () => Promise<boolean>
       readFileDataUrl: (filePath: string) => Promise<string>
       readFileText: (filePath: string) => Promise<HermesReadFileTextResult>
+      writeFileText: (filePath: string, text: string) => Promise<{ path: string }>
       selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
       writeClipboard: (text: string) => Promise<boolean>
       saveImageFromUrl: (url: string) => Promise<boolean>

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -21,6 +21,7 @@ function connectionCacheKey(connection: HermesConnection | null) {
   if (!connection) {
     return 'local:'
   }
+
   return `${connection.mode || 'local'}:${connection.profile || ''}:${connection.baseUrl || ''}`
 }
 
@@ -38,45 +39,71 @@ function fsPath(endpoint: string, filePath: string) {
 
 function bridge() {
   const desktop = window.hermesDesktop
+
   if (!desktop) {
     throw new Error('Hermes Desktop bridge is unavailable')
   }
+
   return desktop
 }
 
 export async function readDesktopDir(path: string): Promise<HermesReadDirResult> {
   const desktop = bridge()
+
   if (!isDesktopFsRemoteMode()) {
     return desktop.readDir(path)
   }
+
   return desktop.api<HermesReadDirResult>({ path: fsPath('list', path) })
 }
 
 export async function readDesktopFileText(path: string): Promise<HermesReadFileTextResult> {
   const desktop = bridge()
+
   if (!isDesktopFsRemoteMode()) {
     return desktop.readFileText(path)
   }
+
   return desktop.api<HermesReadFileTextResult>({ path: fsPath('read-text', path) })
+}
+
+export async function writeDesktopFileText(filePath: string, text: string): Promise<{ path: string }> {
+  const desktop = window.hermesDesktop
+
+  if (!desktop) { throw new Error('writeDesktopFileText is only available in the desktop app') }
+
+  return desktop.writeFileText(filePath, text)
+}
+
+// Build the AGENTS.md path for a project folder.
+// Strips any trailing slashes then appends 'AGENTS.md' with a forward slash.
+// resolveRequestedPathForIpc in the main process calls path.resolve() which
+// normalises mixed separators, so this is safe on Windows, macOS, and Linux.
+export function projectAgentsMdPath(folderPath: string): string {
+  return `${folderPath.replace(/[/\\]+$/, '')}/AGENTS.md`
 }
 
 export async function readDesktopFileDataUrl(path: string): Promise<string> {
   const desktop = bridge()
+
   if (!isDesktopFsRemoteMode()) {
     return desktop.readFileDataUrl(path)
   }
 
   const result = await desktop.api<string | { dataUrl?: string }>({ path: fsPath('read-data-url', path) })
+
   return typeof result === 'string' ? result : result.dataUrl || ''
 }
 
 export async function desktopGitRoot(path: string): Promise<string | null> {
   const desktop = bridge()
+
   if (!isDesktopFsRemoteMode()) {
     return desktop.gitRoot ? desktop.gitRoot(path) : null
   }
 
   const result = await desktop.api<{ root: string | null }>({ path: fsPath('git-root', path) })
+
   return result.root
 }
 
@@ -103,11 +130,14 @@ export async function desktopDefaultCwd(): Promise<{ branch: string; cwd: string
 
 export async function selectDesktopPaths(options?: HermesSelectPathsOptions): Promise<string[]> {
   const desktop = bridge()
+
   if (!isDesktopFsRemoteMode()) {
     return desktop.selectPaths(options)
   }
+
   if (!options?.directories || options.multiple !== false) {
     return []
   }
+
   return remotePicker ? remotePicker.selectPaths(options) : []
 }

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -26,6 +26,7 @@ const SIDEBAR_PINNED_STORAGE_KEY = 'hermes.desktop.pinnedSessions'
 const SIDEBAR_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.agentsGroupedByWorkspace'
 const SIDEBAR_CRON_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarCronOpen'
 const SIDEBAR_MESSAGING_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarMessagingOpen'
+const SIDEBAR_EXPANDED_PROJECTS_STORAGE_KEY = 'hermes.desktop.expandedProjectIds'
 const SIDEBAR_SESSION_ORDER_STORAGE_KEY = 'hermes.desktop.sessionOrder'
 const SIDEBAR_SESSION_ORDER_MANUAL_STORAGE_KEY = 'hermes.desktop.sessionOrder.manual'
 const SIDEBAR_WORKSPACE_ORDER_STORAGE_KEY = 'hermes.desktop.workspaceOrder'
@@ -82,6 +83,7 @@ export const $sidebarProjectsOpen = atom(storedBoolean(SIDEBAR_PROJECTS_OPEN_STO
 // tall). We persist the ids the user has *explicitly expanded*, so the default
 // stays collapsed unless they've opened a platform before.
 export const $sidebarMessagingOpenIds = atom<string[]>(storedStringArray(SIDEBAR_MESSAGING_OPEN_STORAGE_KEY))
+export const $expandedProjectIds = atom<string[]>(storedStringArray(SIDEBAR_EXPANDED_PROJECTS_STORAGE_KEY))
 export const $sidebarAgentsGrouped = atom(storedBoolean(SIDEBAR_AGENTS_GROUPED_STORAGE_KEY, false))
 // When true, the sessions sidebar moves to the right and the file browser +
 // preview rail move to the left — a mirror of the default layout.
@@ -93,6 +95,7 @@ $pinnedSessionIds.subscribe(ids => persistStringArray(SIDEBAR_PINNED_STORAGE_KEY
 $sidebarCronOpen.subscribe(open => persistBoolean(SIDEBAR_CRON_OPEN_STORAGE_KEY, open))
 $sidebarProjectsOpen.subscribe(open => persistBoolean(SIDEBAR_PROJECTS_OPEN_STORAGE_KEY, open))
 $sidebarMessagingOpenIds.subscribe(ids => persistStringArray(SIDEBAR_MESSAGING_OPEN_STORAGE_KEY, [...ids]))
+$expandedProjectIds.subscribe(ids => persistStringArray(SIDEBAR_EXPANDED_PROJECTS_STORAGE_KEY, [...ids]))
 $sidebarSessionOrderIds.subscribe(ids => persistStringArray(SIDEBAR_SESSION_ORDER_STORAGE_KEY, [...ids]))
 $sidebarSessionOrderManual.subscribe(manual => persistBoolean(SIDEBAR_SESSION_ORDER_MANUAL_STORAGE_KEY, manual))
 $sidebarWorkspaceOrderIds.subscribe(ids => persistStringArray(SIDEBAR_WORKSPACE_ORDER_STORAGE_KEY, [...ids]))
@@ -168,6 +171,14 @@ export function toggleSidebarMessagingOpen(sourceId: string) {
 
   $sidebarMessagingOpenIds.set(
     current.includes(sourceId) ? current.filter(id => id !== sourceId) : [...current, sourceId]
+  )
+}
+
+export function toggleExpandedProjectId(projectId: string) {
+  const current = $expandedProjectIds.get()
+
+  $expandedProjectIds.set(
+    current.includes(projectId) ? current.filter(id => id !== projectId) : [...current, projectId]
   )
 }
 

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -9,6 +9,8 @@ import {
   storedStringArray
 } from '@/lib/storage'
 
+export const SIDEBAR_PROJECTS_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarProjectsOpen'
+
 import { $paneStates, ensurePaneRegistered, setPaneOpen, setPaneWidthOverride, togglePane } from './panes'
 
 export const SIDEBAR_DEFAULT_WIDTH = 237
@@ -75,6 +77,7 @@ export const $sidebarRecentsOpen = atom(true)
 // default (it only renders at all when cron sessions exist) so the
 // scheduler's `[IMPORTANT: …]` first-message previews don't spam recents.
 export const $sidebarCronOpen = atom(storedBoolean(SIDEBAR_CRON_OPEN_STORAGE_KEY, false))
+export const $sidebarProjectsOpen = atom(storedBoolean(SIDEBAR_PROJECTS_OPEN_STORAGE_KEY, true))
 // Messaging platform sections collapse by default (they can be numerous and
 // tall). We persist the ids the user has *explicitly expanded*, so the default
 // stays collapsed unless they've opened a platform before.
@@ -88,6 +91,7 @@ export const $sessionsLimit = atom(SIDEBAR_SESSIONS_PAGE_SIZE)
 
 $pinnedSessionIds.subscribe(ids => persistStringArray(SIDEBAR_PINNED_STORAGE_KEY, [...ids]))
 $sidebarCronOpen.subscribe(open => persistBoolean(SIDEBAR_CRON_OPEN_STORAGE_KEY, open))
+$sidebarProjectsOpen.subscribe(open => persistBoolean(SIDEBAR_PROJECTS_OPEN_STORAGE_KEY, open))
 $sidebarMessagingOpenIds.subscribe(ids => persistStringArray(SIDEBAR_MESSAGING_OPEN_STORAGE_KEY, [...ids]))
 $sidebarSessionOrderIds.subscribe(ids => persistStringArray(SIDEBAR_SESSION_ORDER_STORAGE_KEY, [...ids]))
 $sidebarSessionOrderManual.subscribe(manual => persistBoolean(SIDEBAR_SESSION_ORDER_MANUAL_STORAGE_KEY, manual))
@@ -153,6 +157,10 @@ export function setSidebarRecentsOpen(open: boolean) {
 
 export function setSidebarCronOpen(open: boolean) {
   $sidebarCronOpen.set(open)
+}
+
+export function setSidebarProjectsOpen(open: boolean) {
+  $sidebarProjectsOpen.set(open)
 }
 
 export function toggleSidebarMessagingOpen(sourceId: string) {

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $projects,
+  addProject,
+  getProject,
+  PROJECTS_STORAGE_KEY,
+  removeProject,
+  setProjects,
+  updateProject
+} from './projects'
+
+beforeEach(() => {
+  setProjects([])
+})
+
+afterEach(() => {
+  setProjects([])
+})
+
+describe('addProject', () => {
+  it('creates a project with auto id and createdAt', () => {
+    const before = Date.now()
+    const project = addProject({ title: 'My Project', description: 'A test project', path: '/home/user/project' })
+    const after = Date.now()
+
+    expect(project.id).toBeTypeOf('string')
+    expect(project.id.length).toBeGreaterThan(0)
+    expect(project.createdAt).toBeGreaterThanOrEqual(before)
+    expect(project.createdAt).toBeLessThanOrEqual(after)
+    expect(project.title).toBe('My Project')
+    expect(project.description).toBe('A test project')
+    expect(project.path).toBe('/home/user/project')
+  })
+
+  it('adds the project to the store', () => {
+    addProject({ title: 'P1', description: 'desc', path: '/p1' })
+    addProject({ title: 'P2', description: 'desc2', path: '/p2' })
+
+    expect($projects.get()).toHaveLength(2)
+  })
+
+  it('assigns unique ids', () => {
+    const p1 = addProject({ title: 'A', description: '', path: '/a' })
+    const p2 = addProject({ title: 'B', description: '', path: '/b' })
+
+    expect(p1.id).not.toBe(p2.id)
+  })
+})
+
+describe('updateProject', () => {
+  it('changes the specified fields', () => {
+    const p = addProject({ title: 'Old Title', description: 'old', path: '/old' })
+
+    updateProject(p.id, { title: 'New Title', description: 'new' })
+
+    const updated = getProject(p.id)
+
+    expect(updated?.title).toBe('New Title')
+    expect(updated?.description).toBe('new')
+    expect(updated?.path).toBe('/old')
+  })
+
+  it('does not mutate id or createdAt', () => {
+    const p = addProject({ title: 'T', description: 'd', path: '/t' })
+
+    updateProject(p.id, { title: 'T2' })
+
+    const updated = getProject(p.id)
+
+    expect(updated?.id).toBe(p.id)
+    expect(updated?.createdAt).toBe(p.createdAt)
+  })
+
+  it('ignores unknown id', () => {
+    addProject({ title: 'T', description: 'd', path: '/t' })
+
+    expect(() => updateProject('nonexistent-id', { title: 'X' })).not.toThrow()
+    expect($projects.get()).toHaveLength(1)
+  })
+})
+
+describe('removeProject', () => {
+  it('deletes project by id', () => {
+    const p1 = addProject({ title: 'A', description: '', path: '/a' })
+    const p2 = addProject({ title: 'B', description: '', path: '/b' })
+
+    removeProject(p1.id)
+
+    const remaining = $projects.get()
+
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].id).toBe(p2.id)
+  })
+
+  it('does nothing for unknown id', () => {
+    addProject({ title: 'A', description: '', path: '/a' })
+
+    removeProject('nonexistent-id')
+
+    expect($projects.get()).toHaveLength(1)
+  })
+})
+
+describe('getProject', () => {
+  it('returns the correct project by id', () => {
+    const p = addProject({ title: 'Find Me', description: 'here', path: '/find' })
+    const found = getProject(p.id)
+
+    expect(found).toBeDefined()
+    expect(found?.id).toBe(p.id)
+    expect(found?.title).toBe('Find Me')
+  })
+
+  it('returns undefined for unknown id', () => {
+    expect(getProject('nope')).toBeUndefined()
+  })
+})
+
+describe('persistence key', () => {
+  it('uses the correct storage key', () => {
+    expect(PROJECTS_STORAGE_KEY).toBe('hermes.desktop.projects')
+  })
+
+  it('persists projects to localStorage on change', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+
+    addProject({ title: 'Persisted', description: 'desc', path: '/p' })
+
+    expect(setItemSpy).toHaveBeenCalledWith(PROJECTS_STORAGE_KEY, expect.any(String))
+
+    setItemSpy.mockRestore()
+  })
+})

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -1,0 +1,82 @@
+import { atom } from 'nanostores'
+
+export const PROJECTS_STORAGE_KEY = 'hermes.desktop.projects'
+
+export interface Project {
+  id: string
+  title: string
+  description: string
+  path: string
+  createdAt: number
+}
+
+function storedProjects(): Project[] {
+  try {
+    const value = window.localStorage.getItem(PROJECTS_STORAGE_KEY)
+
+    if (!value) {
+      return []
+    }
+
+    const parsed = JSON.parse(value)
+
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+
+    return parsed.filter(
+      (item): item is Project =>
+        item &&
+        typeof item === 'object' &&
+        typeof item.id === 'string' &&
+        typeof item.title === 'string' &&
+        typeof item.description === 'string' &&
+        typeof item.path === 'string' &&
+        typeof item.createdAt === 'number'
+    )
+  } catch {
+    return []
+  }
+}
+
+function persistProjects(projects: Project[]) {
+  try {
+    if (projects.length === 0) {
+      window.localStorage.removeItem(PROJECTS_STORAGE_KEY)
+    } else {
+      window.localStorage.setItem(PROJECTS_STORAGE_KEY, JSON.stringify(projects))
+    }
+  } catch {
+    // Local preference; restricted storage should not break the app.
+  }
+}
+
+export const $projects = atom<Project[]>(storedProjects())
+
+export const setProjects = (projects: Project[]) => $projects.set(projects)
+
+export function addProject(data: Omit<Project, 'id' | 'createdAt'>): Project {
+  const project: Project = {
+    ...data,
+    id: crypto.randomUUID(),
+    createdAt: Date.now()
+  }
+
+  $projects.set([...$projects.get(), project])
+
+  return project
+}
+
+export function updateProject(id: string, updates: Partial<Omit<Project, 'id' | 'createdAt'>>): void {
+  $projects.set($projects.get().map(p => (p.id === id ? { ...p, ...updates } : p)))
+}
+
+export function removeProject(id: string): void {
+  $projects.set($projects.get().filter(p => p.id !== id))
+}
+
+export function getProject(id: string): Project | undefined {
+  return $projects.get().find(p => p.id === id)
+}
+
+$projects.subscribe(projects => persistProjects([...projects]))


### PR DESCRIPTION
 Introduces Projects — a first-class workspace concept for the Hermes desktop app.
  
Just like Claude Projects and Codex workspaces let you bind a persistent context to a codebase, Projects brings that same power to Hermes — but with full agent capabilities. Point Hermes at any local folder, write custom instructions in AGENTS.md, and every session you start inside that project automatically inherits that context. No manual loading, no copy-pasting prompts, no hunting through a flat session list to find where you left off.
  
This is V1 — the foundation. The data model, routing, sidebar section, and project page are all in place. More is coming: project-level skills, URLs, memory, templates, multi-profile support, and richer session analytics. This PR establishes the architecture that future iterations will build on.

> Note on persistence: Projects are currently stored in localStorage. This was intentional for V1 to keep the scope tight, but I'm aware it diverges from Hermes' profile-aware get_hermes_home() pattern. Happy to migrate to a flat JSON file under ~/.hermes/ before merge if preferred — or treat it as a tracked follow-up for V2.

**Related Issue:**  
https://github.com/NousResearch/hermes-agent/issues/40297
https://github.com/NousResearch/hermes-agent/issues/41553
https://github.com/NousResearch/hermes-agent/issues/40297
https://github.com/NousResearch/hermes-agent/issues/42525
https://github.com/NousResearch/hermes-agent/issues/47374
https://github.com/NousResearch/hermes-agent/issues/46116

**Type of Change**
  - [x] ✨ New feature (non-breaking change that adds functionality)

**Changes Made**
  
  - store/projects.ts — Project data model, localStorage persistence, CRUD actions (addProject, updateProject, removeProject, getProject)
  - store/layout.ts — sidebar projects open/collapsed state + per-project expand state
  - app/projects/project-page.tsx — two-panel project page: session list with working pin/archive/delete, ChatBar bound to project cwd, settings
  panel with AGENTS.md read/write
  - app/projects/create-project-dialog.tsx — folder picker + title/description form
  - app/projects/edit-instructions-dialog.tsx — inline AGENTS.md editor dialog
  - app/chat/sidebar/projects-section.tsx — collapsible Projects section in sidebar with per-project session expansion, session count badge, and
  delete confirm
  - app/chat/sidebar/index.tsx — wire onArchiveSession into ProjectsSidebarSection (bug fix: archive was calling delete)
  - app/desktop-controller.tsx — useEffect that seeds setCurrentCwd when navigating to a project, so the ChatBar creates sessions in the right
  folder
  - electron/main.cjs + preload.cjs — hermes:writeFileText IPC handler (.md-only guard) for writing AGENTS.md from the renderer
  - lib/desktop-fs.ts — writeDesktopFileText() mirroring the existing read pattern
  - app/routes.ts — /project/:id route
  - store/projects.test.ts — 12 tests covering CRUD, persistence, and validation

  **How to Test**
  
  1. Open the Hermes desktop app and click + New in the Projects sidebar section
  2. Pick any local folder, give it a title and description, click Create — you'll land on the project page
  3. Type instructions in the settings panel → they save to AGENTS.md in that folder
  4. Start a chat from the project page — confirm the session appears under the project in the sidebar
  5. Right-click a session row → verify Pin, Archive, and Delete each work correctly
  6. Reload the app — confirm projects and instructions persist

  Checklist
  
  Code
  
  - [x] I've read the Contributing Guide
  - [x] My commit messages follow Conventional Commits
  - [x] I searched for existing PRs to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this feature
  - [x] I've added tests for my changes
  - [x] Tested on: macOS 15, Windows 11, Ubuntu

  Documentation & Housekeeping
  
  - [x] I've updated relevant documentation — N/A (desktop-only UI feature)
  - [x] cli-config.yaml.example — N/A
  - [x] Cross-platform impact considered — folder paths use path.join / IPC; Windows-compatible
  - [x] Tool descriptions/schemas — N/A

  Screenshots / Logs
<img width="1007" height="607" alt="Screenshot 2026-06-20 at 12 23 02 pm" src="https://github.com/user-attachments/assets/2ededbda-811f-4d9d-9fd9-fc7aa2f0eeda" />

<img width="1200" height="771" alt="Screenshot 2026-06-20 at 12 29 29 pm" src="https://github.com/user-attachments/assets/6bbc11d0-5815-4d20-8f2c-4861f2ec9329" />

<img width="1197" height="771" alt="Screenshot 2026-06-20 at 1 28 56 pm" src="https://github.com/user-attachments/assets/ee32b137-d25d-4ebf-a241-30278ce1c834" />

