### PR TITLE
fix: guard remaining float(os.getenv) casts against malformed values

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3838,7 +3838,10 @@ def resolve_codex_runtime_credentials(
 
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
-    refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))
+    try:
+        refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))
+    except (TypeError, ValueError):
+        refresh_timeout_seconds = 20.0
 
     should_refresh = bool(force_refresh)
     if (not should_refresh) and refresh_if_expiring:
@@ -4475,7 +4478,10 @@ def resolve_xai_oauth_runtime_credentials(
     data = _read_xai_oauth_tokens()
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
-    refresh_timeout_seconds = float(os.getenv("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", "20"))
+    try:
+        refresh_timeout_seconds = float(os.getenv("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", "20"))
+    except (TypeError, ValueError):
+        refresh_timeout_seconds = 20.0
     discovery = dict(data.get("discovery") or {})
     token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
     redirect_uri = str(data.get("redirect_uri", "") or "").strip()

--- a/run_agent.py
+++ b/run_agent.py
@@ -1109,7 +1109,10 @@ class AIAgent:
         cfg = get_provider_request_timeout(self.provider, self.model)
         if cfg is not None:
             return cfg
-        return float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
+        try:
+            return float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
+        except (TypeError, ValueError):
+            return 1800.0
 
     def _resolved_api_call_stale_timeout_base(self) -> tuple[float, bool]:
         """Resolve the base non-stream stale timeout and whether it is implicit.


### PR DESCRIPTION
## Summary

`run_agent.py` and `hermes_cli/auth.py` have bare `float(os.getenv(...))` calls that raise `ValueError` on malformed input (e.g. `"abc"`, `""`).

### Fix

Wrap in `try/except (TypeError, ValueError)` to fall back to the default value, matching the pattern already used throughout the codebase.

### Changes
- `run_agent.py`: `HERMES_API_TIMEOUT` (line 1112)
- `hermes_cli/auth.py`: `HERMES_CODEX_REFRESH_TIMEOUT_SECONDS` (line 3841), `HERMES_XAI_REFRESH_TIMEOUT_SECONDS` (line 4478)
