### PR TITLE
fix(gateway): elevate MCP discovery failure from DEBUG to WARNING

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24436,7 +24436,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         _loop = asyncio.get_running_loop()
         await _loop.run_in_executor(None, discover_mcp_tools)
     except Exception as e:
-        logger.debug("MCP tool discovery failed: %s", e)
+        logger.warning("MCP tool discovery failed — MCP tools unavailable: %s", e)
 
     # Start the gateway
     success = await runner.start()


### PR DESCRIPTION
## Summary

Fixes #47509 — when MCP tool discovery fails at gateway startup, the failure is now logged at WARNING instead of silent DEBUG. Previously the gateway would start with zero MCP tools and the operator had no indication anything went wrong.

## Change

In `gateway/run.py`, the failure handler for `discover_mcp_tools`: `logger.debug(...)` → `logger.warning(...)`, with the message `MCP tool discovery failed — MCP tools unavailable: %s`.

## Impact

- The failure is now emitted at WARNING (previously DEBUG), so it surfaces in normal operation instead of being silently swallowed
- No more silent MCP failures requiring deep investigation
- Same pattern as #47616, which elevated other silent DEBUG failures to WARNING