### PR TITLE
refactor(gateway): extract shared _persist_model_to_config helper (#49268)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -45,6 +45,47 @@ from utils import (
 logger = logging.getLogger("gateway.run")
 
 
+def _persist_model_to_config(config_path, *, new_model, provider, base_url):
+    """Persist a model switch to the nested ``model:`` block in ``config.yaml``.
+
+    Shared by the text ``/model <name>`` command and the inline-keyboard picker
+    callback so the read-modify-write and its scalar→dict coercion invariant
+    live in one place (#49268). The coercion guard is non-trivial: a flat
+    ``model: <name>`` (string) value would otherwise raise
+    ``TypeError: 'str' object does not support item assignment`` on the first
+    nested assignment, so callers that touch only one copy would drift.
+
+    ``provider`` controls credential hygiene: switching to a non-``custom``
+    provider clears any inline endpoint credentials left over from a previous
+    custom endpoint (matching the original per-call-site behaviour).
+    """
+    import yaml
+
+    if config_path.exists():
+        with open(config_path, encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+    else:
+        cfg = {}
+    raw_model = cfg.get("model")
+    if isinstance(raw_model, dict):
+        model_cfg = raw_model
+    elif isinstance(raw_model, str) and raw_model.strip():
+        model_cfg = {"default": raw_model.strip()}
+        cfg["model"] = model_cfg
+    else:
+        model_cfg = {}
+        cfg["model"] = model_cfg
+    model_cfg["default"] = new_model
+    model_cfg["provider"] = provider
+    if base_url:
+        model_cfg["base_url"] = base_url
+    if str(provider or "").strip().lower() != "custom":
+        clear_model_endpoint_credentials(model_cfg)
+    from hermes_cli.config import save_config
+
+    save_config(cfg)
+
+
 class GatewaySlashCommandsMixin:
     """In-session slash-command handlers for GatewayRunner."""
 
@@ -1221,28 +1262,12 @@ class GatewaySlashCommandsMixin:
                         # model survives across sessions like a typed one (#49066).
                         if persist_global:
                             try:
-                                if config_path.exists():
-                                    with open(config_path, encoding="utf-8") as f:
-                                        _persist_cfg = yaml.safe_load(f) or {}
-                                else:
-                                    _persist_cfg = {}
-                                _raw_model = _persist_cfg.get("model")
-                                if isinstance(_raw_model, dict):
-                                    _persist_model_cfg = _raw_model
-                                elif isinstance(_raw_model, str) and _raw_model.strip():
-                                    _persist_model_cfg = {"default": _raw_model.strip()}
-                                    _persist_cfg["model"] = _persist_model_cfg
-                                else:
-                                    _persist_model_cfg = {}
-                                    _persist_cfg["model"] = _persist_model_cfg
-                                _persist_model_cfg["default"] = result.new_model
-                                _persist_model_cfg["provider"] = result.target_provider
-                                if result.base_url:
-                                    _persist_model_cfg["base_url"] = result.base_url
-                                if str(result.target_provider or "").strip().lower() != "custom":
-                                    clear_model_endpoint_credentials(_persist_model_cfg)
-                                from hermes_cli.config import save_config
-                                save_config(_persist_cfg)
+                                _persist_model_to_config(
+                                    config_path,
+                                    new_model=result.new_model,
+                                    provider=result.target_provider,
+                                    base_url=result.base_url,
+                                )
                             except Exception as e:
                                 logger.warning("Failed to persist model switch: %s", e)
 
@@ -1407,34 +1432,12 @@ class GatewaySlashCommandsMixin:
             # Persist to config (default) unless --session opted out
             if persist_global:
                 try:
-                    if config_path.exists():
-                        with open(config_path, encoding="utf-8") as f:
-                            cfg = yaml.safe_load(f) or {}
-                    else:
-                        cfg = {}
-                    # Coerce scalar/None ``model:`` into a dict before mutation —
-                    # otherwise ``cfg.setdefault("model", {})`` returns the existing
-                    # scalar and the next assignment raises
-                    # ``TypeError: 'str' object does not support item assignment``.
-                    # Reproduces when ``config.yaml`` has ``model: <name>`` (flat
-                    # string) instead of the proper nested ``model: {default: ...}``.
-                    raw_model = cfg.get("model")
-                    if isinstance(raw_model, dict):
-                        model_cfg = raw_model
-                    elif isinstance(raw_model, str) and raw_model.strip():
-                        model_cfg = {"default": raw_model.strip()}
-                        cfg["model"] = model_cfg
-                    else:
-                        model_cfg = {}
-                        cfg["model"] = model_cfg
-                    model_cfg["default"] = result.new_model
-                    model_cfg["provider"] = result.target_provider
-                    if result.base_url:
-                        model_cfg["base_url"] = result.base_url
-                    if str(result.target_provider or "").strip().lower() != "custom":
-                        clear_model_endpoint_credentials(model_cfg)
-                    from hermes_cli.config import save_config
-                    save_config(cfg)
+                    _persist_model_to_config(
+                        config_path,
+                        new_model=result.new_model,
+                        provider=result.target_provider,
+                        base_url=result.base_url,
+                    )
                 except Exception as e:
                     logger.warning("Failed to persist model switch: %s", e)
 

--- a/tests/gateway/test_persist_model_to_config_helper.py
+++ b/tests/gateway/test_persist_model_to_config_helper.py
@@ -1,0 +1,111 @@
+"""Unit coverage for the shared ``_persist_model_to_config`` helper (#49268).
+
+The gateway text ``/model <name>`` command and the inline-keyboard picker
+(``_on_model_selected``) both persist a model switch through this single helper,
+so the non-trivial scalar→dict coercion invariant lives in exactly one place.
+These tests pin that invariant directly on the helper; the two end-to-end call
+paths are additionally covered by ``test_model_command_flat_string_config.py``
+and ``test_model_picker_persist.py``.
+"""
+
+import yaml
+
+from gateway.slash_commands import _persist_model_to_config
+
+_UNSET = object()
+
+
+def _run(
+    tmp_path,
+    monkeypatch,
+    *,
+    seed=_UNSET,
+    new_model="gpt-5.5",
+    provider="openrouter",
+    base_url="https://openrouter.ai/api/v1",
+):
+    """Drive the helper against an isolated ``config.yaml`` and return the
+    ``model`` block it would persist. ``save_config`` is stubbed so nothing
+    touches the real Hermes home."""
+    cfg_path = tmp_path / "config.yaml"
+    if seed is not _UNSET:
+        cfg_path.write_text(yaml.safe_dump(seed), encoding="utf-8")
+    captured = {}
+    monkeypatch.setattr(
+        "hermes_cli.config.save_config",
+        lambda cfg: captured.__setitem__("cfg", cfg),
+    )
+    _persist_model_to_config(
+        cfg_path, new_model=new_model, provider=provider, base_url=base_url
+    )
+    return captured["cfg"]["model"]
+
+
+def test_missing_config_creates_nested_model_dict(tmp_path, monkeypatch):
+    """No ``config.yaml`` on disk → a fresh nested ``model`` dict is created."""
+    model = _run(tmp_path, monkeypatch)
+    assert model == {
+        "default": "gpt-5.5",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+
+
+def test_flat_string_model_is_coerced_to_dict(tmp_path, monkeypatch):
+    """A flat ``model: <name>`` string must be coerced to a nested dict instead
+    of raising ``TypeError`` on assignment — the core invariant of #49268."""
+    model = _run(tmp_path, monkeypatch, seed={"model": "deepseek-v4-flash"})
+    assert isinstance(model, dict)
+    assert model["default"] == "gpt-5.5"
+    assert model["provider"] == "openrouter"
+
+
+def test_empty_base_url_is_not_written(tmp_path, monkeypatch):
+    """A falsy ``base_url`` is omitted so built-in providers keep resolving it
+    from their own catalog rather than a stale pinned endpoint."""
+    model = _run(tmp_path, monkeypatch, base_url="")
+    assert "base_url" not in model
+
+
+def test_switch_to_builtin_provider_clears_stale_custom_credentials(tmp_path, monkeypatch):
+    """Switching to a non-``custom`` provider strips inline endpoint credentials
+    left over from a previous custom endpoint (no secrets linger in config)."""
+    model = _run(
+        tmp_path,
+        monkeypatch,
+        seed={
+            "model": {
+                "default": "old-model",
+                "provider": "custom",
+                "base_url": "https://api.custom.example/v1",
+                "api_key": "sk-stale",
+                "api_mode": "anthropic_messages",
+            }
+        },
+    )
+    assert model["default"] == "gpt-5.5"
+    assert model["provider"] == "openrouter"
+    assert "api_key" not in model
+    assert "api_mode" not in model
+
+
+def test_switch_to_custom_provider_preserves_inline_credentials(tmp_path, monkeypatch):
+    """Switching to a ``custom`` provider keeps inline credentials — they are the
+    valid way to configure a custom endpoint."""
+    model = _run(
+        tmp_path,
+        monkeypatch,
+        provider="custom",
+        base_url="https://api.custom.example/v1",
+        seed={
+            "model": {
+                "default": "old-model",
+                "provider": "custom",
+                "api_key": "sk-live",
+                "api_mode": "anthropic_messages",
+            }
+        },
+    )
+    assert model["provider"] == "custom"
+    assert model["api_key"] == "sk-live"
+    assert model["api_mode"] == "anthropic_messages"


### PR DESCRIPTION
Closes #49268.

The gateway `/model` flow persisted the selected model to `config.yaml` through **two byte-identical** read-modify-write blocks in `gateway/slash_commands.py`:

- text `/model <name>` path
- inline-keyboard picker callback `_on_model_selected` (added in #49264)

Both ran the same scalar→dict coercion (a flat `model: <name>` string would otherwise raise `TypeError` on the nested assignment), set `default`/`provider`/`base_url`, cleared inline endpoint credentials when switching to a non-`custom` provider, and `save_config(...)` inside the same `try/except → logger.warning`. As #49268 notes, that invariant is non-trivial and drifts the moment a future change touches only one copy.

## Change
- Extract a module-level `_persist_model_to_config(config_path, *, new_model, provider, base_url)` holding the read-modify-write + coercion + credential-hygiene logic.
- Point both call sites at it; each keeps its existing `if persist_global:` + `try/except → logger.warning` wrapper, so the swallowed-exception behavior is unchanged.
- Behavior-preserving — no functional change.

## Tests
- New `tests/gateway/test_persist_model_to_config_helper.py` pins the helper's invariants directly: missing-config creation, flat-string→dict coercion, falsy-`base_url` omission, credential-clear when switching to a built-in provider, and credential-preserve when switching to `custom`.
- The two existing end-to-end suites (`test_model_picker_persist.py`, `test_model_command_flat_string_config.py`) keep asserting the persisted output for both call paths and stay green.

Left the secondary test-helper/conftest hoist that #49268 flags as lower-priority out of scope to keep this focused.
