### PR TITLE
fix(desktop): guard title renderer after window teardown

### DIFF
--- a/apps/desktop/electron/link-title-renderer.test.cjs
+++ b/apps/desktop/electron/link-title-renderer.test.cjs
@@ -1,0 +1,25 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const ELECTRON_DIR = __dirname
+
+function readElectronFile(name) {
+  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8').replace(/\r\n/g, '\n')
+}
+
+test('renderer link-title timeouts tolerate destroyed BrowserWindow objects', () => {
+  const source = readElectronFile('main.cjs')
+  const readTitleIndex = source.indexOf('const readTitle = () => {')
+  assert.notEqual(readTitleIndex, -1, 'missing renderer title reader')
+
+  const snippet = source.slice(readTitleIndex, readTitleIndex + 900)
+  assert.match(snippet, /try \{/, 'title reader should guard Electron destroyed-object races')
+  assert.match(snippet, /window\.isDestroyed\(\)/, 'BrowserWindow must be checked before webContents access')
+  assert.match(snippet, /webContents\.isDestroyed\(\)/, 'WebContents must be checked before getTitle')
+  assert.match(snippet, /catch \{[\s\S]*return ''[\s\S]*\}/, 'destroyed-object TypeError should resolve to no title')
+  assert.match(snippet, /webContents\.getTitle\?\.\(\)/, 'title reader should still return the renderer title when live')
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2998,7 +2998,20 @@ function runRenderTitleJob(rawUrl) {
       return finish('')
     }
 
-    const readTitle = () => window?.webContents?.getTitle?.() || ''
+    const readTitle = () => {
+      try {
+        if (!window || window.isDestroyed()) return ''
+        const webContents = window.webContents
+        if (!webContents || webContents.isDestroyed()) return ''
+        return webContents.getTitle?.() || ''
+      } catch {
+        // The hidden title-renderer window can be destroyed by app shutdown or
+        // renderer teardown while a title timeout is still queued. Treat that
+        // race as "no title" instead of letting Electron's destroyed-object
+        // TypeError crash the main process.
+        return ''
+      }
+    }
     const scheduleGrace = () => {
       if (graceTimer) clearTimeout(graceTimer)
       graceTimer = setTimeout(() => finish(readTitle()), RENDER_TITLE_GRACE_MS)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/link-title-renderer.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary
- Guard the hidden link-title BrowserWindow/WebContents before reading the page title
- Treat teardown races as an empty title instead of throwing from Electron's destroyed-object proxy
- Add a regression test and include it in the desktop platform suite

## Test Plan
- [x] `cd apps/desktop && node --test electron/link-title-renderer.test.cjs`
- [x] `cd apps/desktop && npm run test:desktop:platforms` reached the new regression test and it passed

Note: the full local `test:desktop:platforms` run currently fails later in the pre-existing `electron/windows-child-process.test.cjs` test on macOS with `missing call site: execFileSync(pyExe`. That failure is unrelated to this patch; the new `link-title-renderer.test.cjs` test passed both standalone and within the suite.
