### PR TITLE
tests: stabilize delegate fallback mock parent

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -55,6 +55,7 @@ def _make_mock_parent(depth=0):
     parent._print_fn = None
     parent.tool_progress_callback = None
     parent.thinking_callback = None
+    parent._fallback_chain = None
     return parent
 
 


### PR DESCRIPTION
## Summary\n- make the delegate mock parent explicitly initialize \n- keep fallback inheritance tests deterministic for \n\n## Testing\n- . .venv/bin/activate && python -m unittest tests.tools.test_delegate.TestFallbackModelInheritance -q\n- . .venv/bin/activate && python -m unittest tests.tools.test_delegate -q\n