### PR TITLE
fix(security): require loopback capability token for WhatsApp bridge sends

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -20,6 +20,7 @@ import logging
 import os
 import platform
 import re
+import secrets
 import signal
 import subprocess
 
@@ -415,6 +416,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._bridge_log: Optional[Path] = None
         self._poll_task: Optional[asyncio.Task] = None
         self._http_session: Optional["aiohttp.ClientSession"] = None
+        # Per-spawn loopback capability token for the bridge's state-changing
+        # endpoints. Generated/loaded in _load_or_create_bridge_token() and
+        # passed to the bridge via WHATSAPP_BRIDGE_TOKEN; the adapter echoes it
+        # back in the X-Hermes-Bridge-Token header on every send. Persisted
+        # 0600 in the session dir so a bridge reused across gateway restarts
+        # (the scriptHash handshake) keeps the same token.
+        self._bridge_token: Optional[str] = None
         # Set to True by disconnect() before we SIGTERM our child bridge so
         # _check_managed_bridge_exit() can distinguish an intentional
         # shutdown-time exit (returncode -15 / -2 / 0) from a real crash.
@@ -459,6 +467,55 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not math.isfinite(parsed) or parsed < 0:
             return float(default)
         return parsed
+
+    def _load_or_create_bridge_token(self) -> str:
+        """Return the loopback capability token for the bridge, creating and
+        persisting one if needed.
+
+        Persisted 0600 in the session dir as ``bridge-token`` so a bridge that
+        survives a gateway restart (reused via the scriptHash handshake) keeps
+        the same token the new adapter will present.  Regenerated only if the
+        file is missing/empty/unreadable.
+        """
+        cached = getattr(self, "_bridge_token", None)
+        if cached:
+            return cached
+        token_path = self._session_path / "bridge-token"
+        try:
+            existing = token_path.read_text(encoding="utf-8").strip()
+            if existing:
+                self._bridge_token = existing
+                return existing
+        except (OSError, ValueError):
+            pass
+        token = secrets.token_urlsafe(32)
+        try:
+            self._session_path.mkdir(parents=True, exist_ok=True)
+            # Write 0600 BEFORE content so the secret is never briefly world-readable.
+            fd = os.open(str(token_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            try:
+                os.write(fd, token.encode("utf-8"))
+            finally:
+                os.close(fd)
+        except OSError as e:
+            # Non-fatal: fall back to an in-memory token. A bridge reused across
+            # a restart would then 401 until it is recycled (scriptHash/tokenAuth
+            # handshake), which is the safe direction (fail closed, then heal).
+            logger.warning("[%s] Could not persist bridge token: %s", self.name, e)
+        self._bridge_token = token
+        return token
+
+    def _bridge_auth_headers(self) -> Dict[str, str]:
+        """Header dict carrying the capability token, or empty if none."""
+        token = self._bridge_token or self._load_or_create_bridge_token()
+        return {"X-Hermes-Bridge-Token": token} if token else {}
+
+    def _new_bridge_http_session(self) -> "aiohttp.ClientSession":
+        """Create the adapter->bridge aiohttp session with the capability
+        token pre-set as a default header, so EVERY send/edit/media/typing
+        call is authenticated without per-call-site changes."""
+        import aiohttp
+        return aiohttp.ClientSession(headers=self._bridge_auth_headers())
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """
@@ -589,11 +646,23 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 # treated as stale by definition.
                                 running_hash = data.get("scriptHash", "")
                                 disk_hash = _file_content_hash(bridge_path)
-                                if running_hash and disk_hash and running_hash == disk_hash:
+                                # Reuse only if the running bridge ALSO enforces
+                                # token auth (tokenAuth:true). A pre-token bridge
+                                # is treated as stale so it gets recycled with a
+                                # fresh token instead of serving unauthenticated
+                                # forever — this is what makes enforce-from-start
+                                # safe with zero send outage.
+                                running_token_auth = bool(data.get("tokenAuth"))
+                                if (running_hash and disk_hash and running_hash == disk_hash
+                                        and running_token_auth):
                                     print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
+                                    # Load the token THIS bridge was started with
+                                    # (persisted 0600 in the session dir) so our
+                                    # send headers match what it will accept.
+                                    self._load_or_create_bridge_token()
                                     self._mark_connected()
                                     self._bridge_process = None  # Not managed by us
-                                    self._http_session = aiohttp.ClientSession()
+                                    self._http_session = self._new_bridge_http_session()
                                     self._poll_task = asyncio.create_task(self._poll_messages())
                                     return True
                                 print(
@@ -625,6 +694,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env = with_hermes_node_path()
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
+            # Loopback capability token: the bridge requires it on every
+            # state-changing endpoint (X-Hermes-Bridge-Token). Generated/loaded
+            # 0600 in the session dir; passed via env here. The terminal /
+            # execute_code subprocess sanitizer blocklists WHATSAPP_BRIDGE_TOKEN
+            # so the agent's own shell can't read it and hand-roll an
+            # unauthenticated bridge POST (the cross-recipient leak vector).
+            bridge_env["WHATSAPP_BRIDGE_TOKEN"] = self._load_or_create_bridge_token()
             # Pass the profile-aware cache directories so the bridge writes
             # media where the Python side reads it.  Without these the bridge
             # hardcodes ~/.hermes/{image,audio,document}_cache, which diverges
@@ -718,8 +794,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     print(f"[{self.name}]   Bridge log: {self._bridge_log}")
                     print(f"[{self.name}]   If session expired, re-pair: hermes whatsapp")
             
-            # Create a persistent HTTP session for all bridge communication
-            self._http_session = aiohttp.ClientSession()
+            # Create a persistent HTTP session for all bridge communication.
+            # Pre-set the capability token as a default header so every send
+            # path is authenticated without per-call-site changes.
+            self._http_session = self._new_bridge_http_session()
 
             # Start message polling task
             self._poll_task = asyncio.create_task(self._poll_messages())

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1638,6 +1638,32 @@ def _bridge_media_type(file_path: str, is_voice: bool, force_document: bool) -> 
     return "document"
 
 
+def _load_standalone_bridge_token(extra: Dict[str, Any]) -> Optional[str]:
+    """Read the persisted bridge capability token for standalone sends.
+
+    Mirrors ``WhatsAppAdapter._load_or_create_bridge_token``'s session_path
+    resolution, but only READS the file — never creates it. The live adapter
+    is the sole writer/rotator: it generates the token, persists it 0600 in
+    the session dir, and launches the bridge process with it in
+    ``WHATSAPP_BRIDGE_TOKEN`` env. A standalone caller (cron running detached
+    from the gateway) just needs to present that same already-persisted
+    secret back to the bridge's ``X-Hermes-Bridge-Token`` gate. If the file
+    isn't there yet (bridge never started by a live adapter), there is no
+    token to send — the bridge will 401 the request, which is correct
+    fail-closed behavior rather than fabricating a token that won't match.
+    """
+    session_path = Path(extra.get(
+        "session_path",
+        get_hermes_dir("platforms/whatsapp/session", "whatsapp/session"),
+    ))
+    token_path = session_path / "bridge-token"
+    try:
+        token = token_path.read_text(encoding="utf-8").strip()
+        return token or None
+    except OSError:
+        return None
+
+
 async def _standalone_send(
     pconfig,
     chat_id,
@@ -1664,7 +1690,18 @@ async def _standalone_send(
         media = media_files or []
         text = message or ""
         last_message_id = None
-        async with aiohttp.ClientSession() as session:
+        # The bridge's state-changing endpoints (/send, /send-media) are
+        # gated behind the X-Hermes-Bridge-Token capability token when the
+        # live adapter started it with tokenAuth enabled (the default since
+        # the bridge's capability-token hardening). Without this header every
+        # standalone (cron-detached) delivery 401s — this was firing silently
+        # on any cron job whose delivery took this fallback path instead of
+        # the live-adapter path in _deliver_result (#jellyfin-cron-401).
+        headers = {}
+        bridge_token = _load_standalone_bridge_token(extra)
+        if bridge_token:
+            headers["X-Hermes-Bridge-Token"] = bridge_token
+        async with aiohttp.ClientSession(headers=headers) as session:
             # 1) Text first (skip the /send call when this chunk is media-only).
             if text.strip():
                 async with session.post(

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -26,7 +26,7 @@ import pino from 'pino';
 import path from 'path';
 import { mkdirSync, readFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
 import { fileURLToPath } from 'url';
-import { randomBytes, createHash } from 'crypto';
+import { randomBytes, createHash, timingSafeEqual } from 'crypto';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
@@ -100,6 +100,42 @@ try {
     .slice(0, 16);
 } catch {}
 const PAIR_ONLY = args.includes('--pair-only');
+
+// Loopback capability token for state-changing endpoints.
+//
+// The bridge already binds loopback-only and validates the Host header
+// (DNS-rebind defense, GHSA-ppp5-vxwm-4cf7).  That stops a remote/browser
+// attacker, but every *local* process still shares the loopback interface,
+// so any co-resident process could POST an arbitrary `chatId` to /send,
+// /send-media, /edit or /react and drive the user's WhatsApp account
+// (impersonation / cross-recipient leak).  This brings the bridge to the
+// same caller-auth posture the rest of the project's loopback HTTP surfaces
+// already enforce (X-Hermes-Session-Token in hermes_cli/web_server.py,
+// X-Hermes-Sidecar-Token in the photon sidecar, hmac bearer in api_server).
+//
+// The gateway generates a per-spawn random token and passes it via
+// WHATSAPP_BRIDGE_TOKEN.  When set, callers must echo it back in the
+// X-Hermes-Bridge-Token header on every state-changing endpoint.  When
+// UNSET (e.g. a bridge launched by hand outside the gateway) auth is
+// disabled so existing manual/dev workflows are unaffected — opt-in by
+// presence, exactly like WHATSAPP_ALLOWED_USERS gating inbound.
+const BRIDGE_TOKEN = (process.env.WHATSAPP_BRIDGE_TOKEN || '').trim();
+const BRIDGE_TOKEN_BUF = BRIDGE_TOKEN ? Buffer.from(BRIDGE_TOKEN) : null;
+
+// Timing-safe comparison of the presented token against the configured one.
+// Length-prefix guards timingSafeEqual's equal-length requirement without
+// leaking length via an early return path that differs from a mismatch.
+function bridgeTokenOk(presented) {
+  if (!BRIDGE_TOKEN_BUF) return true; // auth disabled (no token configured)
+  const got = Buffer.from(String(presented || ''));
+  if (got.length !== BRIDGE_TOKEN_BUF.length) return false;
+  try {
+    return timingSafeEqual(got, BRIDGE_TOKEN_BUF);
+  } catch {
+    return false;
+  }
+}
+
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
@@ -720,6 +756,24 @@ app.use((req, res, next) => {
   next();
 });
 
+// Capability-token gate for state-changing endpoints (default-deny).
+//
+// Read-only endpoints are explicitly allowlisted; everything else requires
+// the per-spawn token in X-Hermes-Bridge-Token.  Default-deny means any
+// future route that can act as the user is protected automatically without
+// having to remember to add it here.  /health is allowlisted because the
+// gateway's reuse handshake reads it BEFORE it knows the token; the other
+// read paths expose no ability to act as the user.  No-op when no token is
+// configured (manual/dev bridges), matching the opt-in-by-presence model.
+const TOKEN_OPEN_PREFIXES = ['/health', '/messages', '/chat', '/groups'];
+app.use((req, res, next) => {
+  if (!BRIDGE_TOKEN_BUF) return next(); // auth disabled
+  const isOpen = TOKEN_OPEN_PREFIXES.some((p) => req.path === p || req.path.startsWith(p + '/'));
+  if (isOpen) return next();
+  if (bridgeTokenOk(req.headers['x-hermes-bridge-token'])) return next();
+  return res.status(401).json({ error: 'Unauthorized: missing or invalid bridge token' });
+});
+
 // Poll for new messages (long-poll style)
 app.get('/messages', (req, res) => {
   const msgs = messageQueue.splice(0, messageQueue.length);
@@ -993,6 +1047,7 @@ app.get('/health', (req, res) => {
     queueLength: messageQueue.length,
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
+    tokenAuth: !!BRIDGE_TOKEN_BUF,
   });
 });
 

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -757,3 +757,60 @@ class TestNoCredsPreflight:
         # but the fatal-error code is NOT the "not paired" one.
         assert result is False
         assert adapter._fatal_error_code != "whatsapp_not_paired"
+
+
+# ---------------------------------------------------------------------------
+# Bridge capability-token (loopback auth for state-changing endpoints)
+# ---------------------------------------------------------------------------
+
+class TestBridgeCapabilityToken:
+    """The bridge requires X-Hermes-Bridge-Token on send/edit/media/react so a
+    co-resident local process (incl. the agent's own shell) cannot POST an
+    arbitrary chatId and impersonate the user. These tests exercise the real
+    token generation / persistence / header-injection path on the adapter.
+    """
+
+    def _adapter_with_session(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+        adapter.platform = Platform.WHATSAPP
+        adapter._session_path = Path(tmp_path) / "session"
+        adapter._bridge_token = None
+        return adapter
+
+    def test_generates_and_persists_token_0600(self, tmp_path):
+        adapter = self._adapter_with_session(tmp_path)
+        token = adapter._load_or_create_bridge_token()
+        assert token, "token must be non-empty"
+        token_file = adapter._session_path / "bridge-token"
+        assert token_file.exists()
+        assert token_file.read_text(encoding="utf-8").strip() == token
+        mode = token_file.stat().st_mode & 0o777
+        assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+    def test_token_is_stable_across_calls_and_reloads(self, tmp_path):
+        adapter = self._adapter_with_session(tmp_path)
+        first = adapter._load_or_create_bridge_token()
+        assert adapter._load_or_create_bridge_token() == first
+        adapter2 = self._adapter_with_session(tmp_path)
+        assert adapter2._load_or_create_bridge_token() == first
+
+    def test_auth_headers_carry_token(self, tmp_path):
+        adapter = self._adapter_with_session(tmp_path)
+        token = adapter._load_or_create_bridge_token()
+        headers = adapter._bridge_auth_headers()
+        assert headers.get("X-Hermes-Bridge-Token") == token
+
+    def test_token_blocklisted_from_agent_shell(self):
+        from tools.environments.local import (
+            _HERMES_PROVIDER_ENV_BLOCKLIST,
+            _sanitize_subprocess_env,
+        )
+
+        assert "WHATSAPP_BRIDGE_TOKEN" in _HERMES_PROVIDER_ENV_BLOCKLIST
+        out = _sanitize_subprocess_env(
+            {"WHATSAPP_BRIDGE_TOKEN": "secret", "PATH": "/usr/bin"}
+        )
+        assert "WHATSAPP_BRIDGE_TOKEN" not in out
+        assert out.get("PATH") == "/usr/bin"

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -151,7 +151,10 @@ class TestStaleBridgeHandshake:
             session_path=tmp_path / "session",
         )
         disk_hash = _file_content_hash(bridge_dir / "bridge.js")
-        mock_client = _mock_health({"status": "connected", "scriptHash": disk_hash})
+        # tokenAuth:true is now required for reuse — a bridge that predates the
+        # capability-token feature is recycled (see test below) so it can't keep
+        # serving unauthenticated.
+        mock_client = _mock_health({"status": "connected", "scriptHash": disk_hash, "tokenAuth": True})
 
         with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
              patch("aiohttp.ClientSession", mock_client), \
@@ -164,6 +167,38 @@ class TestStaleBridgeHandshake:
         assert result is True
         mock_popen.assert_not_called()  # reused, never spawned
         mock_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_recycles_bridge_without_token_auth(self, tmp_path):
+        """A running bridge whose hash matches but that does NOT enforce token
+        auth (tokenAuth missing/false — i.e. predates the capability-token
+        feature) must be treated as stale and recycled, so it never keeps
+        serving unauthenticated state-changing endpoints."""
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        # Hash matches, but no tokenAuth → must recycle, not reuse.
+        mock_client = _mock_health({"status": "connected", "scriptHash": disk_hash})
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_popen.assert_called_once()  # tokenless bridge replaced, not reused
 
     @pytest.mark.asyncio
     async def test_restarts_bridge_on_hash_mismatch(self, tmp_path):

--- a/tests/tools/test_whatsapp_send_message_media.py
+++ b/tests/tools/test_whatsapp_send_message_media.py
@@ -219,3 +219,60 @@ def test_text_only_unchanged_behavior():
         "message_id": "t1",
     }
     assert len(calls) == 1 and calls[0][0].endswith("/send")
+
+
+# ---------------------------------------------------------------------------
+# Bridge capability-token auth on standalone (cron-detached) sends.
+#
+# The bridge gates every state-changing endpoint (/send, /send-media) behind
+# X-Hermes-Bridge-Token when the live adapter started it with tokenAuth
+# enabled. _standalone_send runs OUTSIDE the live adapter (a detached cron
+# tick), so it must independently load and present that same token — it must
+# NOT mint its own (the bridge would reject a mismatched token anyway).
+# Regression for the "WhatsApp bridge error (401): missing or invalid bridge
+# token" cron delivery failure.
+# ---------------------------------------------------------------------------
+
+
+def test_standalone_send_attaches_persisted_bridge_token(tmp_path):
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    (session_dir / "bridge-token").write_text("s3cr3t-token", encoding="utf-8")
+    pconfig = SimpleNamespace(
+        token="", extra={"bridge_port": 3000, "session_path": str(session_dir)}
+    )
+
+    session_ctx, calls = _session_with([_resp(200, {"messageId": "t1"})])
+    captured_session_kwargs = {}
+
+    def _client_session(*args, **kwargs):
+        captured_session_kwargs.update(kwargs)
+        return session_ctx
+
+    with patch("aiohttp.ClientSession", side_effect=_client_session):
+        res = asyncio.run(_standalone_send(pconfig, "12345", "hi"))
+
+    assert res["success"] is True
+    assert captured_session_kwargs.get("headers") == {
+        "X-Hermes-Bridge-Token": "s3cr3t-token"
+    }
+
+
+def test_standalone_send_sends_no_auth_header_when_token_file_absent(tmp_path):
+    session_dir = tmp_path / "session-never-started"
+    pconfig = SimpleNamespace(
+        token="", extra={"bridge_port": 3000, "session_path": str(session_dir)}
+    )
+
+    session_ctx, _ = _session_with([_resp(200, {"messageId": "t1"})])
+    captured_session_kwargs = {}
+
+    def _client_session(*args, **kwargs):
+        captured_session_kwargs.update(kwargs)
+        return session_ctx
+
+    with patch("aiohttp.ClientSession", side_effect=_client_session):
+        res = asyncio.run(_standalone_send(pconfig, "12345", "hi"))
+
+    assert res["success"] is True
+    assert captured_session_kwargs.get("headers") == {}

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -199,6 +199,17 @@ def _build_provider_env_blocklist() -> frozenset:
         "EMAIL_HOME_ADDRESS",
         "EMAIL_HOME_ADDRESS_NAME",
         "HERMES_DASHBOARD_SESSION_TOKEN",
+        # Loopback capability token for the WhatsApp bridge's state-changing
+        # endpoints. Blocklisted so the agent's own terminal / execute_code
+        # subprocess CANNOT read it and hand-roll an authenticated bridge POST
+        # with an arbitrary chatId — the exact bypass that let a session's
+        # media be delivered to the wrong recipient. With the token withheld
+        # from the shell, the only working send paths are the adapter (routes
+        # by the active session's chat_id) and the in-process whatsapp_action
+        # tool, making cross-recipient leakage via raw POST structurally
+        # impossible. Mirrors HERMES_DASHBOARD_SESSION_TOKEN above; also
+        # unregisterable as skill passthrough per GHSA-rhgp-j443-p4rf.
+        "WHATSAPP_BRIDGE_TOKEN",
         "GATEWAY_ALLOWED_USERS",
         "GH_TOKEN",
         "GITHUB_APP_ID",


### PR DESCRIPTION
**Rebased onto current `main` (re-homed for #41112).** The WhatsApp adapter moved from `gateway/platforms/whatsapp.py` to the bundled plugin at `plugins/platforms/whatsapp/adapter.py` in #41112. This branch is rebased so the per-spawn token logic now lives in the plugin adapter; the bridge.js / `tools/environments/local.py` / test changes are unchanged in substance. 43 WhatsApp connect + stale-bridge tests pass.

---

## Summary

The WhatsApp bridge's state-changing HTTP endpoints (`/send`, `/send-media`, `/edit`, `/react`, `/typing`) have no caller authentication. The loopback bind + Host-header guard (GHSA-ppp5-vxwm-4cf7) stop a remote/browser attacker, but **every co-resident local process shares the loopback interface**, so any local process can POST an arbitrary `chatId` and drive the user's WhatsApp account (impersonation / cross-recipient leak).

This is weaker caller-auth than the other loopback HTTP surfaces in the project already enforce:
- `X-Hermes-Session-Token` in `hermes_cli/web_server.py`
- `X-Hermes-Sidecar-Token` in the photon sidecar
- hmac bearer in `api_server`

This PR brings the bridge to parity with a **per-spawn capability token**.

## Relationship to #7073

#7073 (OrbisAI, automated) targets the same vulnerability. This PR is a **complement / superset** — it converges on the same token-middleware design and additionally closes three gaps #7073 does not address. Happy to fold into #7073's branch if maintainers prefer a single PR; opening here because the extra coverage is substantial. Full credit to #7073 for independently flagging the same surface.

| Concern | #7073 | This PR |
|---|---|---|
| Token middleware on state-changing endpoints | ✅ | ✅ |
| **Bridge-reuse across gateway restart** | ❌ fresh key the running bridge never received → every send 401s until manual restart | ✅ `/health` advertises `tokenAuth`; a pre-token bridge is **recycled** rather than reused — enforce-from-start, zero send outage |
| **Agent's own shell as the attack vector** | ❌ only defends external callers | ✅ `WHATSAPP_BRIDGE_TOKEN` blocklisted from the terminal/execute_code subprocess sanitizer so the agent shell cannot read the token and hand-roll an authenticated raw POST (the actual incident vector) |
| Timing-safe compare | `!==` | `timingSafeEqual` |
| Tests | none | token gen/persist/0600/stability/header-injection, shell-deny, tokenless-bridge-recycled, reuse-requires-`tokenAuth` |

## Changes

- **`plugins/platforms/whatsapp/adapter.py`**: generate a per-spawn token (`secrets.token_urlsafe`), persist it `0600` in the session dir so a bridge reused across a gateway restart keeps the same token, pass it via `WHATSAPP_BRIDGE_TOKEN`, and pre-set it as a default header on the adapter's aiohttp session so every send path is authenticated without per-call-site changes. Bridge reuse now also requires `tokenAuth:true`, so a pre-token bridge is recycled rather than reused.
- **`scripts/whatsapp-bridge/bridge.js`**: default-deny token middleware. Read-only endpoints (`/health`, `/messages`, `/chat`, `/groups`) are allowlisted; every other endpoint requires `X-Hermes-Bridge-Token` (timing-safe compare). No-op when no token is configured. `/health` advertises `tokenAuth` so the gateway can detect a pre-token bridge.
- **`tools/environments/local.py`**: blocklist `WHATSAPP_BRIDGE_TOKEN` from the terminal/execute_code subprocess sanitizer so the agent's own shell cannot read the token and hand-roll an authenticated raw bridge POST. Mirrors the existing `HERMES_DASHBOARD_SESSION_TOKEN` entry.

## Verification

- `tests/gateway/test_whatsapp_connect.py` + `tests/gateway/test_whatsapp_stale_bridge.py` — **43 passed**.
- No-op for a hand-launched bridge (no token configured) — read-only endpoints stay open; existing manual workflows unaffected.
- Backward-compatible bridge-reuse handshake: a running pre-token bridge is recycled with zero send outage rather than left in a 401 state.
