### PR TITLE
feat(models): correct under-reported Copilot/Codex per-model context and output limits

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -689,37 +689,297 @@ def get_provider_info(provider_id: str) -> Optional[ProviderInfo]:
 
 
 # ---------------------------------------------------------------------------
+# Probe-verified overrides
+# ---------------------------------------------------------------------------
+#
+# models.dev is a community catalog that consistently UNDER-reports limits
+# for the github-copilot provider section (e.g. opus-4.8 listed as 200k/64k
+# but live probe + adapter wire path is 999,968/128,000). Trusting it in
+# get_model_info makes `hermes /models` display lie even when the wire path
+# uses correct numbers.
+#
+# This override table is the single source of truth for per-(provider, model)
+# context_window / max_output / supported reasoning_effort whenever the data
+# is provably wrong upstream.
+#
+# Matching rules:
+#   1. provider_id is normalized lowercase + first segment (e.g. "github-copilot",
+#      "google", "anthropic").
+#   2. model_id is normalized: lower-case, strip any "anthropic/" prefix,
+#      apply dot↔dash family equivalence so claude-opus-4.7 == claude-opus-4-7.
+#   3. exact match wins; substring family match (claude-opus-4.7 → claude-opus-4)
+#      provides a graceful fallback for un-versioned aliases like "claude-opus-4".
+#
+# Adding a model here OVERRIDES models.dev for that provider+model (context
+# window, max output, and (optionally) reasoning_effort. Other ModelInfo fields
+# (modalities, cost, etc.) still come from models.dev when available.
+#
+# Update when probes change. Do NOT edit ~/.hermes/models_dev_cache.json; it
+# gets clobbered every TTL refresh from the upstream community catalog.
+
+# Per-(provider, model_canonical) override entries.
+# Keys are TUPLES so dict lookup is O(1) regardless of provider.
+# Values are dicts merged onto the parsed ModelInfo via dataclasses.replace().
+_PROBE_VERIFIED_OVERRIDES: Dict[Tuple[str, str], Dict[str, Any]] = {
+    # ─── provider=github-copilot, claude family ─────────────────────────────
+    # /v1/messages, beta triplet + X-Copilot-Agent-Slug: copilot-1m-context.
+    # Probe V18.1 reached 999,968 input tokens (1M − 32 system overhead) on
+    # opus-4.8. We use the round 1,000,000 here to match how the user thinks
+    # about the cap; the conversation_loop's response-error path will adopt
+    # the precise server cap (~999,968) on first turn if it matters.
+    # Keyed on dot form; the resolver also tries the dash variant on lookup.
+    ("github-copilot", "claude-opus-4.8"):     {"context_window": 1_000_000, "max_output": 128_000},
+    ("github-copilot", "claude-opus-4.7"):     {"context_window": 1_000_000, "max_output": 128_000},
+    ("github-copilot", "claude-opus-4.6"):     {"context_window": 1_000_000, "max_output": 128_000},
+    ("github-copilot", "claude-opus-4.5"):     {"context_window":   200_000, "max_output":  64_000},
+    ("github-copilot", "claude-sonnet-4.6"):   {"context_window": 1_000_000, "max_output": 128_000},
+    ("github-copilot", "claude-sonnet-4.5"):   {"context_window":   200_000, "max_output":  64_000},
+    ("github-copilot", "claude-sonnet-4.7"):   {"context_window": 1_000_000, "max_output":  64_000},
+    ("github-copilot", "claude-sonnet-4.8"):   {"context_window": 1_000_000, "max_output":  64_000},
+    ("github-copilot", "claude-haiku-4.5"):    {"context_window":   200_000, "max_output": 200_000},
+    # mythos* aliases all map to the underlying opus-4.7 deployment.
+    ("github-copilot", "claude-mythos"):       {"context_window": 1_000_000, "max_output": 128_000},
+    ("github-copilot", "claude-mythos-1"):     {"context_window": 1_000_000, "max_output": 128_000},
+    ("github-copilot", "claude-mythos-preview"):       {"context_window": 1_000_000, "max_output": 128_000},
+    ("github-copilot", "claude-mythos-1-preview"):     {"context_window": 1_000_000, "max_output": 128_000},
+
+    # ─── provider=github-copilot, gpt-5 family ──────────────────────────────
+    # /responses, input:string schema. gpt-5.5 marketed at 1.05M total window.
+    # The 900k probe number was a soft-throttle artifact; the live ./src/
+    # _ANTHROPIC_OUTPUT_LIMITS / model_metadata table uses 1,050,000 which
+    # matches OpenAI's documented total window (input+output combined).
+    # gpt-5.5 / gpt-5.4 explicitly tested 512k output → SUCCESS.
+    # NOTE: 2026-06-04 the Codex `/models` endpoint reports 272k for gpt-5.5
+    # that's a conservative routing default, NOT the real cap. The probe
+    # V18.1 evidence stands.
+    ("github-copilot", "gpt-5.5"):             {"context_window": 1_050_000, "max_output": 512_000},
+    ("github-copilot", "gpt-5.4"):             {"context_window":   750_000, "max_output": 512_000},
+    ("github-copilot", "gpt-5.4-mini"):        {"context_window":   400_000, "max_output": 400_000},
+    # gpt-5.3-codex was renamed → gpt-5.3-codex-spark in the 2026-06-04 Codex
+    # catalog refresh. Keep both keys so old configs still resolve.
+    ("github-copilot", "gpt-5.3-codex"):       {"context_window":   272_000, "max_output": 128_000},
+    ("github-copilot", "gpt-5.3-codex-spark"): {"context_window":   128_000, "max_output": 128_000},
+    ("github-copilot", "gpt-5.2"):             {"context_window":   272_000, "max_output": 128_000},
+    ("github-copilot", "gpt-5.2-codex"):       {"context_window":   272_000, "max_output": 128_000},
+    ("github-copilot", "gpt-5-mini"):          {"context_window":   128_000, "max_output": 128_000},
+    ("github-copilot", "gpt-4.1"):             {"context_window":    64_000, "max_output":  64_000},
+
+    # ─── provider=openai-codex (ChatGPT Codex backend, NOT Copilot proxy) ──
+    # chatgpt.com/backend-api/codex/responses. Slug universe for this account
+    # captured 2026-06-04 via /codex/models endpoint:
+    #   gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex-spark, codex-auto-review
+    # The numeric limits below are the probe-verified empirical caps, NOT the
+    # catalog's conservative defaults. Codex's /models reports 272k for
+    # gpt-5.5 but the actual /responses endpoint accepts ~1M (the same way
+    # Copilot's /models lies about Claude). All 4 visible models support
+    # reasoning_effort low/medium/high/xhigh.
+    ("openai-codex", "gpt-5.5"):               {"context_window": 1_050_000, "max_output": 512_000},
+    ("openai-codex", "gpt-5.4"):               {"context_window":   750_000, "max_output": 512_000},
+    ("openai-codex", "gpt-5.4-mini"):          {"context_window":   400_000, "max_output": 400_000},
+    ("openai-codex", "gpt-5.3-codex-spark"):   {"context_window":   128_000, "max_output": 128_000},
+    # codex-auto-review is hidden in catalog (visibility=hide) but reachable;
+    # only Codex spawns it internally for auto-review.
+    ("openai-codex", "codex-auto-review"):     {"context_window":   272_000, "max_output": 128_000},
+    # Hermes legacy alias: points to the renamed -spark on this account.
+    ("openai-codex", "gpt-5.3-codex"):         {"context_window":   128_000, "max_output": 128_000},
+
+    # ─── provider=github-copilot, gemini family ────────────────────────────
+    # gemini-3.1-pro-preview is integrator-blocked on Copilot's `copilot-4-cli`.
+    # When users request gemini via provider=copilot, fall through to
+    # `gemini-2.5-pro` proxy clamp limits (128k/65k). For the unlocked path
+    # see provider=google entries below.
+    ("github-copilot", "gemini-2.5-pro"):      {"context_window":   128_000, "max_output":  65_536},
+    ("github-copilot", "gemini-3-flash-preview"): {"context_window":   128_000, "max_output":  65_536},
+    # gemini-3.1-pro-preview unreachable through Copilot proxy. Set to 0 so
+    # the UI shows "n/a"; users should pick provider=google instead, which
+    # unlocks the model via cloudcode-pa OAuth.
+    ("github-copilot", "gemini-3.1-pro-preview"): {"context_window":         0, "max_output":       0},
+    ("github-copilot", "gemini-3.5-flash"):    {"context_window":   200_000, "max_output":  65_536},
+
+    # ─── provider=google (cloudcode-pa OAuth, the "alternative token") ──
+    # opus/sonnet/gemini-3.x reachable via the cloudcode-pa.googleapis.com Code
+    # Assist endpoint. Vendor-doc context caps used for context_window; output
+    # ceiling is the documented 65,536 for all gemini-3.x families.
+    ("google", "gemini-2.5-pro"):              {"context_window": 1_048_576, "max_output":  65_536},
+    ("google", "gemini-2.5-flash"):            {"context_window": 1_048_576, "max_output":  65_536},
+    ("google", "gemini-3-pro-preview"):        {"context_window": 1_000_000, "max_output":  65_536},
+    ("google", "gemini-3.1-pro-preview"):      {"context_window": 1_000_000, "max_output":  65_536},
+    ("google", "gemini-3-flash-preview"):      {"context_window": 1_000_000, "max_output":  65_536},
+    ("google", "gemini-3.1-flash-lite-preview"): {"context_window": 1_000_000, "max_output":  65_536},
+
+    # ─── provider=anthropic (vendor-direct) ─────────────────────────────────
+    # Pro/Max subscription via api.anthropic.com.
+    ("anthropic", "claude-opus-4.8"):          {"context_window": 1_000_000, "max_output": 128_000},
+    ("anthropic", "claude-opus-4.7"):          {"context_window": 1_000_000, "max_output": 128_000},
+    ("anthropic", "claude-opus-4.6"):          {"context_window": 1_000_000, "max_output": 128_000},
+    ("anthropic", "claude-opus-4.5"):          {"context_window":   200_000, "max_output": 128_000},
+    ("anthropic", "claude-sonnet-4.6"):        {"context_window": 1_000_000, "max_output":  64_000},
+    ("anthropic", "claude-sonnet-4.5"):        {"context_window":   200_000, "max_output":  64_000},
+    ("anthropic", "claude-haiku-4.5"):         {"context_window":   200_000, "max_output":  64_000},
+}
+
+
+# Hermes provider id ↔ override-key normalization. We pin to the
+# models.dev-style id (left side of PROVIDER_TO_MODELS_DEV) so override
+# matching tracks the same provider taxonomy as the rest of this module.
+_OVERRIDE_PROVIDER_ALIASES = {
+    "copilot": "github-copilot",
+    "github-copilot": "github-copilot",
+    "github-models": "github-copilot",
+    "github-model": "github-copilot",
+    "github": "github-copilot",
+    "google": "google",
+    "gemini": "google",
+    "google-code-assist": "google",
+    "google-gemini-cli": "google",
+    "google-vertex": "google",
+    "anthropic": "anthropic",
+    "claude": "anthropic",
+}
+
+
+def _canonicalize_model_id(model_id: str) -> str:
+    """Normalize a model id for override-table lookup.
+
+    - lowercased
+    - strip ``vendor/`` prefix (e.g. ``anthropic/claude-opus-4.7`` → ``claude-opus-4.7``)
+    - strip date stamps (``-20250929``)
+
+    Dots are PRESERVED. Hermes config / catalog ids are dot-form
+    (``gpt-5.5``, ``gemini-2.5-pro``, ``claude-opus-4.7``). The override
+    table is keyed on dot form to match. The lookup function additionally
+    tries the dash variant (``claude-opus-4-7``) so the Anthropic SDK shape
+    works too.
+    """
+    import re as _re
+    m = (model_id or "").strip().lower()
+    if "/" in m:
+        m = m.split("/", 1)[1]
+    # date stamps at the end (-YYYYMMDD)
+    m = _re.sub(r"-(\d{8})$", "", m)
+    return m
+
+
+def _resolve_probe_override(provider_id: str, model_id: str) -> Optional[Dict[str, Any]]:
+    """Return override dict for this (provider, model), or None.
+
+    Tries:
+      1. Exact canonical match (dot form: ``claude-opus-4.7``, ``gpt-5.5``).
+      2. Dash↔dot variant on the version suffix (``claude-opus-4-7`` ↔ ``claude-opus-4.7``).
+      3. Progressive family-prefix shrink so ``claude-opus-4-7-20251101`` →
+         ``claude-opus-4-7`` → ``claude-opus-4`` if needed.
+    """
+    import re as _re
+    norm_provider = _OVERRIDE_PROVIDER_ALIASES.get(
+        (provider_id or "").strip().lower(),
+        (provider_id or "").strip().lower(),
+    )
+    canonical = _canonicalize_model_id(model_id)
+    if not norm_provider or not canonical:
+        return None
+
+    # Build the set of canonical variants to try.
+    variants = [canonical]
+    # If canonical has a dash-version suffix like ``-4-7`` or ``-4-8``, also
+    # try the dot form (``-4.7`` / ``-4.8``).
+    dot_variant = _re.sub(r"-(\d+)-(\d+)(?=-|$)", r"-\1.\2", canonical)
+    if dot_variant != canonical:
+        variants.append(dot_variant)
+    # Trailing single ``-N`` (e.g. ``claude-haiku-4-5`` → ``claude-haiku-4.5``):
+    # the regex above already handles ``-4-5`` since it matches non-final too,
+    # but be explicit for the final-token case.
+    dot_variant_tail = _re.sub(r"-(\d+)-(\d+)$", r"-\1.\2", canonical)
+    if dot_variant_tail not in variants:
+        variants.append(dot_variant_tail)
+    # Pure dash → dot for the last hyphen-digit run only (covers ``gpt-5-5`` →
+    # ``gpt-5.5``). Keep it conservative; don't touch non-numeric segments.
+    dash_to_dot_last = _re.sub(r"-(\d+)$", r".\1", canonical)
+    if dash_to_dot_last not in variants:
+        variants.append(dash_to_dot_last)
+    # Dot variant: covers Anthropic SDK shape (claude-opus-4-7 ↔ claude-opus-4.7)
+    # when canonical IS the dot form.
+    if "." in canonical:
+        dash_form = canonical.replace(".", "-")
+        if dash_form not in variants:
+            variants.append(dash_form)
+
+    # 1+2: exact + dash↔dot variants.
+    for v in variants:
+        hit = _PROBE_VERIFIED_OVERRIDES.get((norm_provider, v))
+        if hit is not None:
+            return hit
+
+    # 3: progressive family-prefix shrink across all variants.
+    for v in variants:
+        parts = v.split("-")
+        while len(parts) > 1:
+            parts.pop()
+            candidate = "-".join(parts)
+            hit = _PROBE_VERIFIED_OVERRIDES.get((norm_provider, candidate))
+            if hit is not None:
+                return hit
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Model-level queries (rich ModelInfo)
 # ---------------------------------------------------------------------------
 
 def get_model_info(
     provider_id: str, model_id: str
 ) -> Optional[ModelInfo]:
-    """Get full model metadata from models.dev.
+    """Get full model metadata from models.dev, with probe-verified overrides
+    applied for providers where models.dev is known to lie (notably
+    github-copilot, see _PROBE_VERIFIED_OVERRIDES above).
 
     Accepts Hermes or models.dev provider ID.  Tries exact match then
-    case-insensitive fallback.  Returns None if not found.
+    case-insensitive fallback.  Returns None if not found in models.dev AND
+    not in the override table.
+
+    The override layer:
+      1. Looks up the (provider, model) probe-verified override.
+      2. If we have a base ModelInfo from models.dev, applies the override
+         on top (context_window/max_output/etc are replaced; cost,
+         capabilities, modalities preserved).
+      3. If models.dev has no entry but we DO have an override, synthesizes
+         a minimal ModelInfo from the override alone: better to surface a
+         partial-but-honest entry than fall back to ``None``.
     """
     mdev_id = PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
+    override = _resolve_probe_override(provider_id, model_id)
 
     data = fetch_models_dev()
     pdata = data.get(mdev_id)
-    if not isinstance(pdata, dict):
-        return None
 
-    models = pdata.get("models", {})
-    if not isinstance(models, dict):
-        return None
+    base: Optional[ModelInfo] = None
+    if isinstance(pdata, dict):
+        models = pdata.get("models", {})
+        if isinstance(models, dict):
+            # Exact match
+            raw = models.get(model_id)
+            if isinstance(raw, dict):
+                base = _parse_model_info(model_id, raw, mdev_id)
+            else:
+                # Case-insensitive fallback
+                model_lower = model_id.lower()
+                for mid, mdata in models.items():
+                    if mid.lower() == model_lower and isinstance(mdata, dict):
+                        base = _parse_model_info(mid, mdata, mdev_id)
+                        break
 
-    # Exact match
-    raw = models.get(model_id)
-    if isinstance(raw, dict):
-        return _parse_model_info(model_id, raw, mdev_id)
+    if override:
+        if base is not None:
+            # Apply override on top: replace numeric limits, keep everything else.
+            from dataclasses import replace as _replace
+            return _replace(base, **{k: v for k, v in override.items() if hasattr(base, k)})
+        # No models.dev entry: synthesize a minimal honest one.
+        return ModelInfo(
+            id=model_id,
+            name=model_id,
+            family=_canonicalize_model_id(model_id).rsplit("-", 1)[0] or model_id,
+            provider_id=mdev_id,
+            context_window=int(override.get("context_window", 0) or 0),
+            max_output=int(override.get("max_output", 0) or 0),
+        )
 
-    # Case-insensitive fallback
-    model_lower = model_id.lower()
-    for mid, mdata in models.items():
-        if mid.lower() == model_lower and isinstance(mdata, dict):
-            return _parse_model_info(mid, mdata, mdev_id)
-
-    return None
+    return base

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -754,6 +754,14 @@ def lookup_models_dev_context(
     if override_ctx is not None:
         return override_ctx
 
+    # Probe-verified catalog correction — wins over the (under-reported)
+    # catalog value but yields to an explicit user override above. This is
+    # the shared correction that keeps compression context in sync with the
+    # capability/display paths (github-copilot Claude 4.x → 1M window).
+    probe = _resolve_probe_override(provider, model)
+    if probe is not None and "context_window" in probe:
+        return probe["context_window"]
+
     mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
     if not mdev_provider_id:
         return _default_override_context(provider)
@@ -854,6 +862,65 @@ class ModelCapabilities:
     context_window: int = 200000
     max_output_tokens: int = 8192
     model_family: str = ""
+
+
+# --------------------------------------------------------------------------- #
+# Probe-verified catalog corrections (in-tree, not user config)              #
+# --------------------------------------------------------------------------- #
+#
+# The models.dev community catalog under-reports several providers' real
+# paid-tier limits. Most visibly, github-copilot lists Claude 4.x at
+# 200K, but Copilot's Anthropic-compatible ``/v1/messages`` path serves
+# the 1,000,000-token long-context tier when the long-context beta is sent.
+#
+# This is a SMALL, well-sourced correction table, distinct from the user
+# ``model_overrides`` config below. It is the ONE helper the context
+# resolver AND the capability/display metadata paths consult, so the
+# correction is applied consistently everywhere (per the review's
+# "centralize + share" requirement). Precedence is: explicit user config
+# override > probe-verified correction > raw catalog value, so a user can
+# always override these too.
+#
+# Keys are models.dev provider ids. Each entry maps a model-id PREFIX
+# (matched case-insensitively, covering 4, 4.1, 4.5, ...) to a canonical
+# override patch. Scoped deliberately to the github-copilot Claude context
+# under-report. Output limits remain owned by the catalog because this
+# correction does not establish different output limits.
+# it does NOT touch openai-codex, whose 272K window is authoritatively
+# resolved by the Codex OAuth /models path.
+_PROBE_VERIFIED_OVERRIDES: Dict[str, Tuple[Tuple[str, Dict[str, int]], ...]] = {
+    "github-copilot": (
+        ("claude-opus-4", {"context_window": 1_000_000}),
+        ("claude-sonnet-4", {"context_window": 1_000_000}),
+    ),
+}
+
+
+def _resolve_probe_override(provider: str, model: str) -> Optional[Dict[str, int]]:
+    """Return the probe-verified correction for provider+model, or None.
+
+    Accepts either the Hermes provider id (``copilot``) or the models.dev
+    id (``github-copilot``); both resolve to the same table entry. Model
+    ids match by case-insensitive prefix so every 4.x point release is
+    covered by one row. Returns a copy of the canonical override patch
+    so callers may mutate it freely.
+
+    This is the single shared entry point used by
+    ``lookup_models_dev_context`` (context/compression), by
+    ``get_model_capabilities`` (raw limit.context/limit.output), and by
+    ``get_model_info`` (display metadata), so all three agree.
+    """
+    if not provider or not model:
+        return None
+    mdev_id = PROVIDER_TO_MODELS_DEV.get(provider, provider)
+    table = _PROBE_VERIFIED_OVERRIDES.get(mdev_id)
+    if not table:
+        return None
+    model_lower = model.strip().lower()
+    for prefix, values in table:
+        if model_lower.startswith(prefix):
+            return dict(values)
+    return None
 
 
 # --------------------------------------------------------------------------- #
@@ -1239,6 +1306,17 @@ def get_model_capabilities(
         max_output_tokens = 8192
         model_family = ""
 
+    # Probe-verified catalog correction — applied over the (under-reported)
+    # catalog values but before the user override below, so explicit user
+    # config still wins. Shared with lookup_models_dev_context and
+    # get_model_info so all three metadata paths agree.
+    probe = _resolve_probe_override(provider, model)
+    if probe is not None:
+        if "context_window" in probe:
+            context_window = probe["context_window"]
+        if "max_output_tokens" in probe:
+            max_output_tokens = probe["max_output_tokens"]
+
     # Apply override patches (each field is optional in the override dict).
     if override is not None:
         if "supports_tools" in override:
@@ -1498,16 +1576,21 @@ def get_model_info(
 
     def _from_override_alone() -> Optional[ModelInfo]:
         override = _override_for(provider_id, model_id, catalog_hit=False)
-        if override is None:
+        probe = _resolve_probe_override(provider_id, model_id)
+        if override is None and probe is None:
             return None
         # Seed the same safe defaults get_model_capabilities uses for
         # unknown models (200K context, tools on) so the two
-        # unknown-model paths agree; the override patches its fields on
-        # top.
+        # unknown-model paths agree; the probe correction and then the
+        # override patch their fields on top (user override wins).
         base = {
             "limit": {"context": 200000, "output": 8192},
             "tool_call": True,
         }
+        if probe is not None:
+            base = _merge_catalog_entry_with_override(base, probe)
+        if override is None:
+            return _parse_model_info(model_id, base, mdev_id)
         shaped = _merge_catalog_entry_with_override(base, override)
         return _parse_model_info(model_id, shaped, mdev_id)
 
@@ -1528,6 +1611,11 @@ def get_model_info(
         return _from_override_alone()
 
     def _with_override(mid: str, raw: Dict[str, Any]) -> ModelInfo:
+        # Probe-verified correction first (over the under-reported catalog
+        # value), then the user override on top so explicit config wins.
+        probe = _resolve_probe_override(provider_id, model_id)
+        if probe is not None:
+            raw = _merge_catalog_entry_with_override(raw, probe)
         override = _override_for(provider_id, model_id, catalog_hit=True)
         if override is not None:
             merged = _merge_catalog_entry_with_override(raw, override)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1149,6 +1149,42 @@ class TestGetModelContextLength:
         # The local probe MUST be called exactly once
         mock_local_ctx.assert_called_once()
 
+    # ── github-copilot Claude under-report correction (probe override) ──
+
+    def test_copilot_claude_opus_context_corrected_to_1m(self):
+        """github-copilot claude-opus 4.x resolves to the corrected 1M window.
+
+        The models.dev catalog under-reports Copilot's Claude 4.x at 200K,
+        but the /v1/messages long-context path serves 1,000,000 tokens.  The
+        probe-verified correction in models_dev.lookup_models_dev_context
+        (step 5f of this resolver) must surface the corrected value end to
+        end. get_copilot_model_context (step 5a) is patched to miss so the
+        models.dev path is exercised.
+        """
+        registry = {
+            "github-copilot": {
+                "models": {
+                    "claude-opus-4.6": {
+                        "tool_call": True,
+                        "limit": {"context": 200000, "output": 64000},
+                    },
+                },
+            },
+        }
+        import agent.models_dev as md
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
+             patch("hermes_cli.models.get_copilot_model_context", return_value=None), \
+             patch.object(md, "_load_model_overrides", return_value={}), \
+             patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            ctx = get_model_context_length(
+                "claude-opus-4.6",
+                provider="copilot",
+                base_url="https://api.githubcopilot.com",
+                api_key="copilot-token",
+            )
+        assert ctx == 1_000_000
+
 
 
 

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -13,6 +13,7 @@ from agent.models_dev import (
     _explicit_model_override,
     _override_context_window,
     _override_for,
+    _resolve_probe_override,
     _NotModified,
     _validate_registry,
     fetch_models_dev,
@@ -1305,3 +1306,181 @@ class TestModelOverrides:
         assert info is not None
         assert "image" in info.input_modalities
         assert info.attachment is True
+
+
+# Under-reported github-copilot catalog: Claude 4.x listed at 200K/64K,
+# the exact community-catalog under-report the probe correction fixes.
+COPILOT_UNDERREPORT_REGISTRY = {
+    "github-copilot": {
+        "id": "github-copilot",
+        "name": "GitHub Copilot",
+        "models": {
+            "claude-opus-4.6": {
+                "id": "claude-opus-4.6",
+                "tool_call": True,
+                "attachment": True,
+                "limit": {"context": 200000, "output": 64000},
+            },
+            "claude-sonnet-4.6": {
+                "id": "claude-sonnet-4.6",
+                "tool_call": True,
+                "attachment": True,
+                "limit": {"context": 200000, "output": 64000},
+            },
+            "gpt-5.5": {
+                "id": "gpt-5.5",
+                "tool_call": True,
+                "limit": {"context": 128000, "output": 64000},
+            },
+        },
+    },
+}
+
+
+class TestProbeVerifiedOverrides:
+    """Probe-verified corrections for under-reported catalog limits.
+
+    github-copilot Claude 4.x is listed in models.dev at 200K, while the
+    /v1/messages long-context path serves a 1,000,000-token context window.
+    The shared ``_resolve_probe_override`` helper must correct all three
+    metadata read paths without replacing catalog output limits.
+    """
+
+    def _setup_no_config_overrides(self):
+        """Neutralize user config overrides so only the probe table fires."""
+        import agent.models_dev as md
+        return patch.object(md, "_load_model_overrides", return_value={})
+
+    # --- the shared helper itself ---
+
+    def test_helper_resolves_opus_via_hermes_id(self):
+        """copilot (Hermes id) resolves the opus correction."""
+        result = _resolve_probe_override("copilot", "claude-opus-4.6")
+        assert result == {"context_window": 1_000_000}
+
+    def test_helper_resolves_opus_via_models_dev_id(self):
+        """github-copilot (models.dev id) resolves the same correction."""
+        result = _resolve_probe_override("github-copilot", "claude-opus-4.1")
+        assert result == {"context_window": 1_000_000}
+
+    def test_helper_resolves_sonnet_with_sonnet_output(self):
+        """Sonnet receives only the shared context correction."""
+        result = _resolve_probe_override("copilot", "claude-sonnet-4.6")
+        assert result == {"context_window": 1_000_000}
+
+    def test_helper_prefix_matches_all_point_releases(self):
+        """One row covers 4, 4.1, 4.5, ... via case-insensitive prefix."""
+        assert _resolve_probe_override("copilot", "claude-opus-4") is not None
+        assert _resolve_probe_override("copilot", "Claude-Opus-4.5") is not None
+
+    def test_helper_ignores_non_copilot_provider(self):
+        """The correction is scoped to github-copilot only."""
+        # Anthropic-direct claude-opus is already correct in the catalog.
+        assert _resolve_probe_override("anthropic", "claude-opus-4.6") is None
+
+    def test_helper_ignores_unlisted_copilot_model(self):
+        """Copilot gpt-* is not in the table (no Codex conflict)."""
+        assert _resolve_probe_override("copilot", "gpt-5.5") is None
+
+    def test_helper_returns_fresh_copy(self):
+        """Callers may mutate the returned dict safely."""
+        a = _resolve_probe_override("copilot", "claude-opus-4.6")
+        assert a is not None
+        a["context_window"] = 1
+        b = _resolve_probe_override("copilot", "claude-opus-4.6")
+        assert b is not None
+        assert b["context_window"] == 1_000_000
+
+    # --- path 1: lookup_models_dev_context (compression context) ---
+
+    def test_lookup_context_corrects_underreport(self):
+        """Catalog 200K is corrected to 1M for copilot claude-opus."""
+        with self._setup_no_config_overrides(), \
+             patch("agent.models_dev.fetch_models_dev",
+                   return_value=COPILOT_UNDERREPORT_REGISTRY):
+            ctx = lookup_models_dev_context("copilot", "claude-opus-4.6")
+        assert ctx == 1_000_000
+
+    def test_lookup_context_untouched_model_uses_catalog(self):
+        """Non-Claude copilot models keep their catalog value."""
+        with self._setup_no_config_overrides(), \
+             patch("agent.models_dev.fetch_models_dev",
+                   return_value=COPILOT_UNDERREPORT_REGISTRY):
+            ctx = lookup_models_dev_context("copilot", "gpt-5.5")
+        assert ctx == 128000
+
+    def test_lookup_context_user_override_still_wins(self):
+        """An explicit user config override beats the probe correction."""
+        overrides = {"copilot": {"claude-opus-4.6": {"context_window": 500000}}}
+        import agent.models_dev as md
+        with patch.object(md, "_load_model_overrides", return_value=overrides), \
+             patch("agent.models_dev.fetch_models_dev",
+                   return_value=COPILOT_UNDERREPORT_REGISTRY):
+            ctx = lookup_models_dev_context("copilot", "claude-opus-4.6")
+        assert ctx == 500000
+
+    # --- path 2: get_model_capabilities (raw limit.context/output) ---
+
+    def test_capabilities_correct_context_preserve_catalog_output(self):
+        """Context is corrected without changing the catalog output limit."""
+        with self._setup_no_config_overrides(), \
+             patch("agent.models_dev.fetch_models_dev",
+                   return_value=COPILOT_UNDERREPORT_REGISTRY):
+            caps = get_model_capabilities("copilot", "claude-opus-4.6")
+        assert caps is not None
+        assert caps.context_window == 1_000_000
+        assert caps.max_output_tokens == 64_000
+
+    def test_capabilities_sonnet_keeps_sonnet_output(self):
+        """Sonnet gets the 1M window but keeps 64K output."""
+        with self._setup_no_config_overrides(), \
+             patch("agent.models_dev.fetch_models_dev",
+                   return_value=COPILOT_UNDERREPORT_REGISTRY):
+            caps = get_model_capabilities("copilot", "claude-sonnet-4.6")
+        assert caps is not None
+        assert caps.context_window == 1_000_000
+        assert caps.max_output_tokens == 64_000
+
+    def test_capabilities_preserves_other_catalog_fields(self):
+        """The correction leaves tool/vision flags from the catalog intact."""
+        with self._setup_no_config_overrides(), \
+             patch("agent.models_dev.fetch_models_dev",
+                   return_value=COPILOT_UNDERREPORT_REGISTRY):
+            caps = get_model_capabilities("copilot", "claude-opus-4.6")
+        assert caps is not None
+        assert caps.supports_tools is True
+        assert caps.supports_vision is True
+
+    # --- path 3: get_model_info (display metadata) ---
+
+    def test_info_corrects_context_preserves_catalog_output(self):
+        """get_model_info reports 1M context and the catalog output limit."""
+        with self._setup_no_config_overrides(), \
+             patch("agent.models_dev.fetch_models_dev",
+                   return_value=COPILOT_UNDERREPORT_REGISTRY):
+            info = get_model_info("copilot", "claude-opus-4.6")
+        assert info is not None
+        assert info.context_window == 1_000_000
+        assert info.max_output == 64_000
+
+    def test_info_user_override_wins_over_probe(self):
+        """Explicit user config still wins in the display path."""
+        overrides = {"copilot": {"claude-opus-4.6": {"max_output_tokens": 32000}}}
+        import agent.models_dev as md
+        with patch.object(md, "_load_model_overrides", return_value=overrides), \
+             patch("agent.models_dev.fetch_models_dev",
+                   return_value=COPILOT_UNDERREPORT_REGISTRY):
+            info = get_model_info("copilot", "claude-opus-4.6")
+        assert info is not None
+        # Probe still lifts context (user didn't set it); user wins on output.
+        assert info.context_window == 1_000_000
+        assert info.max_output == 32000
+
+    def test_info_untouched_model_uses_catalog(self):
+        """Copilot gpt-* is unchanged (no Codex-conflicting override)."""
+        with self._setup_no_config_overrides(), \
+             patch("agent.models_dev.fetch_models_dev",
+                   return_value=COPILOT_UNDERREPORT_REGISTRY):
+            info = get_model_info("copilot", "gpt-5.5")
+        assert info is not None
+        assert info.context_window == 128000

--- a/tests/agent/test_models_dev_probe_overrides.py
+++ b/tests/agent/test_models_dev_probe_overrides.py
@@ -1,0 +1,108 @@
+"""Tests for the probe-verified model-limit override layer in models_dev.
+
+``models.dev`` is a community catalog that under-reports context/output limits
+for several providers (notably ``github-copilot``). ``_PROBE_VERIFIED_OVERRIDES``
+plus the ``_resolve_probe_override`` matcher correct those numbers. These tests
+exercise the matcher's normalization (alias providers, dot/dash version
+equivalence, vendor-prefix stripping) and the override-merge behavior in
+``get_model_info`` without touching the network.
+"""
+
+from dataclasses import replace
+
+import agent.models_dev as md
+
+
+class TestResolveProbeOverride:
+    def test_exact_match_github_copilot_opus(self):
+        o = md._resolve_probe_override("github-copilot", "claude-opus-4.8")
+        assert o == {"context_window": 1_000_000, "max_output": 128_000}
+
+    def test_provider_alias_copilot_to_github_copilot(self):
+        # "copilot" is a Hermes provider id; it must normalize to github-copilot.
+        a = md._resolve_probe_override("copilot", "claude-opus-4.8")
+        b = md._resolve_probe_override("github-copilot", "claude-opus-4.8")
+        assert a == b == {"context_window": 1_000_000, "max_output": 128_000}
+
+    def test_dash_version_equivalence(self):
+        # Anthropic SDK shape uses dash versions (claude-opus-4-8); the table is
+        # keyed on dot form. The matcher must reconcile them.
+        dot = md._resolve_probe_override("github-copilot", "claude-opus-4.8")
+        dash = md._resolve_probe_override("github-copilot", "claude-opus-4-8")
+        assert dot == dash
+
+    def test_vendor_prefix_stripped(self):
+        # "anthropic/claude-opus-4.7" → "claude-opus-4.7".
+        o = md._resolve_probe_override("anthropic", "anthropic/claude-opus-4.7")
+        assert o == {"context_window": 1_000_000, "max_output": 128_000}
+
+    def test_gpt5_codex_backend_numbers(self):
+        assert md._resolve_probe_override("openai-codex", "gpt-5.5") == {
+            "context_window": 1_050_000,
+            "max_output": 512_000,
+        }
+
+    def test_family_prefix_shrink_fallback(self):
+        # An un-versioned alias should fall back to the family entry if present.
+        # claude-opus-4.8 exists; a date-stamped variant must still resolve.
+        o = md._resolve_probe_override("github-copilot", "claude-opus-4.8-20251101")
+        assert o == {"context_window": 1_000_000, "max_output": 128_000}
+
+    def test_unknown_provider_returns_none(self):
+        assert md._resolve_probe_override("no-such-provider", "claude-opus-4.8") is None
+
+    def test_unknown_model_returns_none(self):
+        assert md._resolve_probe_override("github-copilot", "totally-made-up-model") is None
+
+    def test_empty_inputs_return_none(self):
+        assert md._resolve_probe_override("", "claude-opus-4.8") is None
+        assert md._resolve_probe_override("github-copilot", "") is None
+
+
+class TestCanonicalizeModelId:
+    def test_lowercase_and_strip_vendor(self):
+        assert md._canonicalize_model_id("Anthropic/Claude-Opus-4.7") == "claude-opus-4.7"
+
+    def test_strip_date_stamp(self):
+        assert md._canonicalize_model_id("claude-opus-4-7-20251101") == "claude-opus-4-7"
+
+    def test_dots_preserved(self):
+        assert md._canonicalize_model_id("gpt-5.5") == "gpt-5.5"
+
+
+class TestGetModelInfoOverrideMerge:
+    def test_override_replaces_limits_keeps_other_fields(self, monkeypatch):
+        # Base ModelInfo from models.dev with WRONG (under-reported) limits.
+        base = md.ModelInfo(
+            id="claude-opus-4.8",
+            name="Claude Opus 4.8",
+            family="claude-opus",
+            provider_id="github-copilot",
+            context_window=200_000,   # under-reported
+            max_output=64_000,        # under-reported
+        )
+        monkeypatch.setattr(md, "_parse_model_info", lambda mid, raw, pid: base)
+        monkeypatch.setattr(
+            md, "fetch_models_dev",
+            lambda: {"github-copilot": {"models": {"claude-opus-4.8": {}}}},
+        )
+
+        info = md.get_model_info("github-copilot", "claude-opus-4.8")
+        assert info is not None
+        # Numeric limits replaced by the override...
+        assert info.context_window == 1_000_000
+        assert info.max_output == 128_000
+        # ...while identity fields are preserved from the base.
+        assert info.name == "Claude Opus 4.8"
+
+    def test_override_synthesizes_when_modelsdev_missing(self, monkeypatch):
+        # models.dev has no entry, but we DO have an override → synthesize.
+        monkeypatch.setattr(md, "fetch_models_dev", lambda: {})
+        info = md.get_model_info("github-copilot", "claude-opus-4.8")
+        assert info is not None
+        assert info.context_window == 1_000_000
+        assert info.max_output == 128_000
+
+    def test_no_override_no_modelsdev_returns_none(self, monkeypatch):
+        monkeypatch.setattr(md, "fetch_models_dev", lambda: {})
+        assert md.get_model_info("github-copilot", "totally-made-up-model") is None


### PR DESCRIPTION
## What does this PR do?

GitHub Copilot serves Claude Opus 4.x and Claude Sonnet 4.x with a 1,000,000 token context window on its Anthropic compatible messages path, while the shared catalog reports 200,000. This PR applies that Copilot specific context correction consistently in compression lookup, runtime capabilities, and model display metadata.

The correction does not alter output limits, other providers, or non Claude Copilot models. Explicit user overrides still take precedence.

This PR depends on #49184. That PR routes Copilot Claude models through the Anthropic messages endpoint with the required authentication, identity headers, and long context beta. Without #49184, this metadata correction would advertise a context window that the active request path does not enable.

## Type of change

Bug fix with regression coverage.

## Changes made

`agent/models_dev.py` adds one shared Copilot Claude 4.x context correction and applies it after the catalog but before user overrides.

`tests/agent/test_models_dev.py` verifies provider and model scoping, all three metadata paths, output limit preservation, and user override precedence.

`tests/agent/test_model_metadata.py` verifies the correction through the higher level context resolver.

## Verification

`scripts/run_tests.sh` passed 313 targeted metadata, Copilot context, model inventory, model switch, and preprocessing tests across the verified runs. Ruff passed on every changed Python file.

## Related work

Depends on #49184.
