### PR TITLE
fix(tools): stop read_file rendering a phantom empty line for newline-terminated files

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -354,6 +354,34 @@ class TestShellFileOpsHelpers:
         assert result.error is None
         assert result.content == "alpha\n"
 
+    def test_newline_terminated_content_has_no_phantom_line(self, file_ops):
+        # A file ending in a newline (the normal, well-formed case) has its
+        # last line terminated, NOT followed by an empty line. The gutter must
+        # match `cat -n`: three lines in, three numbered lines out.
+        result = file_ops._add_line_numbers("line1\nline2\nline3\n")
+        assert result == "1|line1\n2|line2\n3|line3"
+        assert "4|" not in result
+        assert len(result.split("\n")) == 3
+
+    def test_non_terminated_content_still_numbered_correctly(self, file_ops):
+        # Content with no trailing newline was already correct; guard it.
+        result = file_ops._add_line_numbers("line1\nline2\nline3")
+        assert result == "1|line1\n2|line2\n3|line3"
+
+    def test_trailing_blank_line_is_kept(self, file_ops):
+        # "a" then a genuine blank line, then the terminating newline: that is
+        # two lines (a, blank), so only the single terminator is dropped.
+        result = file_ops._add_line_numbers("a\n\n")
+        assert result == "1|a\n2|"
+        assert "3|" not in result
+
+    def test_newline_terminated_with_offset_has_no_phantom_line(self, file_ops):
+        # A truncated page (offset>1) that ends on a newline must not append a
+        # phantom numbered line at the page boundary.
+        result = file_ops._add_line_numbers("def f():\n    return 1\n", start_line=10)
+        assert result == "10|def f():\n11|    return 1"
+        assert "12|" not in result
+
 
 class TestSearchPathValidation:
     """Test that search() returns an error for non-existent paths."""

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -912,6 +912,14 @@ class ShellFileOperations(FileOperations):
         """
         from tools.tool_output_limits import get_max_line_length
         max_line_length = get_max_line_length()
+        # A trailing newline terminates the final line; it does not start a
+        # new, empty line. Splitting on '\n' without accounting for that gives
+        # a spurious empty element, so every newline-terminated file (the
+        # common, well-formed case) would render a phantom "<N+1>|" line that
+        # is not in the file. Drop the single terminating newline first, the
+        # way `cat -n` and editor gutters do.
+        if content.endswith('\n'):
+            content = content[:-1]
         lines = content.split('\n')
         numbered = []
         for i, line in enumerate(lines, start=start_line):


### PR DESCRIPTION
## What does this PR do?

`read_file` adds a `N|content` gutter to its output. For any file that ends in a newline, which is the normal well formed case, it rendered one extra numbered line at the end with no content. A 3 line file came back as 4 lines, the last one empty. That phantom line is what the model sees, and it is not in the file.

The cause is in `_add_line_numbers` (`tools/file_operations.py`). It splits on `\n`, and a trailing newline makes `str.split` return a trailing empty string, which then gets its own line number:

```python
"line1\nline2\nline3\n".split("\n")
# ['line1', 'line2', 'line3', '']  -> the '' becomes a numbered line
```

`read_file` reads each page with `sed -n 'offset,end p'`, which keeps the last line's trailing newline, so this fired on essentially every read. It is in the shared `ShellFileOperations`, so every terminal backend (local, docker, modal, ssh) was affected. On a truncated multi page read it was a little worse: the page ending on a newline showed a phantom `N+1|` empty line, and the next page showed real content at that same number.

`cat -n` and editor gutters do not do this. A trailing newline terminates the last line, it does not begin a new empty one.

## Related Issue

Fixes #49451

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/file_operations.py`: `_add_line_numbers` now drops a single terminating newline before splitting, so the trailing newline does not render as a phantom extra line. Files with no trailing newline are unchanged, and a genuine trailing blank line (`"a\n\n"`) is preserved as a real empty line.
- `tests/tools/test_file_operations.py`: regression tests for newline terminated content, the no trailing newline case, a kept trailing blank line, and the offset (paged) case.

## How to Test

Quick reproduction:

```python
from tools.environments.local import LocalEnvironment
from tools.file_operations import ShellFileOperations

with open("/tmp/demo.txt", "w") as f:
    f.write("line1\nline2\nline3\n")

ops = ShellFileOperations(LocalEnvironment(cwd="/tmp"), cwd="/tmp")
print(repr(ops.read_file("/tmp/demo.txt").content))
# before: '1|line1\n2|line2\n3|line3\n4|'   (phantom 4| line)
# after:  '1|line1\n2|line2\n3|line3'
```

Test suite:

```
pytest tests/tools/test_file_operations.py -q
```

Verified on Python 3.11.9 (x86_64) and Python 3.13.13 (arm64): the four new tests fail on current main and pass with this change, and the full `test_file_operations.py` (94 tests) stays green. `ruff check` is clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and the affected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, on two interpreters and architectures (Python 3.11.9 x86_64 and Python 3.13.13 arm64)

### Documentation & Housekeeping

- [x] N/A, no config keys, architecture changes, or tool behavior changes beyond the bug fix

Max Freedom Pollard
