### PR TITLE
fix: hide TUI phantom metadata sessions

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17,6 +17,45 @@ from hermes_cli.browser_connect import ChromeDebugLaunch
 from tui_gateway import server
 
 
+@pytest.fixture(autouse=True)
+def _isolate_tui_gateway_state_db(tmp_path, monkeypatch):
+    """Keep TUI gateway tests from writing to the developer's real state.db.
+
+    ``tui_gateway.server`` is imported at module import time, before the suite's
+    autouse HERMES_HOME fixture runs.  ``hermes_state.DEFAULT_DB_PATH`` can
+    therefore already be bound to the real profile.  Rebind just the state DB
+    default and cached TUI DB handle for every test, without taking over the
+    whole Hermes home; individual tests still control config/save paths via
+    their own env or ``server._hermes_home`` monkeypatches.
+    """
+    try:
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    except Exception:
+        pass
+
+    old_db = server._db
+    if old_db is not None:
+        try:
+            old_db.close()
+        except Exception:
+            pass
+    server._db = None
+    server._db_error = None
+    try:
+        yield
+    finally:
+        current_db = server._db
+        if current_db is not None:
+            try:
+                current_db.close()
+            except Exception:
+                pass
+        server._db = None
+        server._db_error = None
+
+
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -3620,6 +3659,71 @@ def test_config_set_model_uses_live_switch_path(monkeypatch):
     assert seen["args"] == ("sid", "session-key", "new/model")
 
 
+def test_model_switch_marker_does_not_persist_empty_system_only_session():
+    """A model switch before first user message must not create an Untitled row."""
+    calls: list[tuple] = []
+
+    class _DB:
+        def get_session(self, session_id):
+            calls.append(("get_session", session_id))
+            return None
+
+        def get_messages_as_conversation(self, session_id):
+            calls.append(("history", session_id))
+            return []
+
+        def append_message(self, **kwargs):
+            calls.append(("append", kwargs))
+
+    session = _session(
+        agent=types.SimpleNamespace(_session_db=_DB()),
+        history=[],
+        session_key="k-B",
+    )
+
+    server._append_model_switch_marker(session, model="zai/glm-5.1", provider="zai")
+
+    assert [call[0] for call in calls] == ["get_session"]
+    assert session["history"] == [
+        {
+            "role": "user",
+            "content": (
+                "[System: The active model for this chat has changed to zai/glm-5.1 "
+                "via provider zai. From this point forward, use this runtime metadata "
+                "when answering questions about what model/provider is active.]"
+            ),
+        }
+    ]
+
+
+def test_model_switch_marker_persists_after_real_conversation_activity():
+    calls: list[tuple] = []
+
+    class _DB:
+        def get_session(self, session_id):
+            calls.append(("get_session", session_id))
+            return {"id": session_id}
+
+        def get_messages_as_conversation(self, session_id):
+            calls.append(("history", session_id))
+            return [{"role": "user", "content": "draw a cat"}]
+
+        def append_message(self, **kwargs):
+            calls.append(("append", kwargs))
+
+    session = _session(
+        agent=types.SimpleNamespace(_session_db=_DB()),
+        history=[{"role": "user", "content": "draw a cat"}],
+        session_key="real-session",
+    )
+
+    server._append_model_switch_marker(session, model="new/model", provider="custom")
+
+    assert calls[-1][0] == "append"
+    assert calls[-1][1]["session_id"] == "real-session"
+    assert calls[-1][1]["role"] == "user"
+
+
 def test_config_set_model_requires_confirmation_for_expensive_model(monkeypatch):
     class _Agent:
         provider = "openrouter"
@@ -5974,6 +6078,153 @@ def test_session_list_returns_clean_error_when_state_db_is_unavailable(monkeypat
     assert "state.db unavailable: locking protocol" in resp["error"]["message"]
 
 
+def test_session_list_filters_system_only_model_switch_shell(monkeypatch):
+    class _DB:
+        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
+            return [
+                {
+                    "id": "k-B",
+                    "source": "tui",
+                    "title": "Partial Answer Complete",
+                    "preview": "",
+                    "started_at": 2,
+                    "message_count": 1,
+                },
+                {
+                    "id": "real",
+                    "source": "tui",
+                    "title": "",
+                    "preview": "hello",
+                    "started_at": 1,
+                    "message_count": 2,
+                },
+            ]
+
+        def get_messages_as_conversation(self, session_id):
+            if session_id == "k-B":
+                return [
+                    {
+                        "role": "system",
+                        "content": "[System: The active model for this chat has changed]",
+                    }
+                ]
+            return [{"role": "user", "content": "hello"}]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request({"id": "1", "method": "session.list", "params": {}})
+
+    assert [s["id"] for s in resp["result"]["sessions"]] == ["real"]
+
+
+def test_session_list_keeps_projected_compression_tip_with_real_root(monkeypatch):
+    class _DB:
+        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
+            return [
+                {
+                    "id": "tip",
+                    "source": "tui",
+                    "title": "",
+                    "preview": "",
+                    "started_at": 2,
+                    "message_count": 1,
+                    "_lineage_root_id": "root",
+                },
+                {
+                    "id": "ghost",
+                    "source": "tui",
+                    "title": "",
+                    "preview": "",
+                    "started_at": 1,
+                    "message_count": 1,
+                },
+            ]
+
+        def get_messages_as_conversation(self, session_id):
+            if session_id == "root":
+                return [{"role": "user", "content": "real conversation"}]
+            return [{"role": "system", "content": "model switched"}]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request({"id": "1", "method": "session.list", "params": {}})
+    assert resp is not None
+
+    assert [s["id"] for s in resp["result"]["sessions"]] == ["tip"]
+
+
+def test_session_list_surfaces_activity_inspection_error(monkeypatch):
+    class _DB:
+        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
+            return [
+                {
+                    "id": "broken",
+                    "source": "tui",
+                    "title": "",
+                    "preview": "",
+                    "started_at": 1,
+                    "message_count": 1,
+                }
+            ]
+
+        def get_messages_as_conversation(self, session_id):
+            raise RuntimeError(f"cannot read {session_id}")
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request({"id": "1", "method": "session.list", "params": {}})
+    assert resp is not None
+
+    assert "error" in resp
+    assert resp["error"]["code"] == 5006
+    assert "cannot read broken" in resp["error"]["message"]
+
+
+def test_session_list_pages_past_filtered_metadata_shells(monkeypatch):
+    calls = []
+
+    class _DB:
+        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
+            calls.append((limit, offset))
+            if offset == 0:
+                return [
+                    {
+                        "id": f"ghost-{i}",
+                        "source": "tui",
+                        "title": "",
+                        "preview": "",
+                        "started_at": 300 - i,
+                        "message_count": 1,
+                    }
+                    for i in range(200)
+                ]
+            if offset == 200:
+                return [
+                    {
+                        "id": "real",
+                        "source": "tui",
+                        "title": "",
+                        "preview": "hello",
+                        "started_at": 1,
+                        "message_count": 1,
+                    }
+                ]
+            return []
+
+        def get_messages_as_conversation(self, session_id):
+            return [{"role": "system", "content": "model switched"}]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.list", "params": {"limit": 1}}
+    )
+    assert resp is not None
+
+    assert [s["id"] for s in resp["result"]["sessions"]] == ["real"]
+    assert calls == [(200, 0), (200, 200)]
+
+
 # --------------------------------------------------------------------------
 # session.delete — TUI resume picker `d` key
 # --------------------------------------------------------------------------
@@ -6716,7 +6967,15 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
     """Drops `tool` rows like session.list does, returns the first hit."""
 
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            offset=0,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             return [
                 {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 100},
                 {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99},
@@ -6735,7 +6994,15 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
 
 def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            offset=0,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             return [{"id": "tool-1", "source": "tool", "started_at": 1}]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
@@ -6747,13 +7014,141 @@ def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
     assert resp["result"]["session_id"] is None
 
 
+def test_session_most_recent_skips_system_only_shell(monkeypatch):
+    class _DB:
+        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
+            return [
+                {
+                    "id": "k-B",
+                    "source": "tui",
+                    "title": "Partial Answer Complete",
+                    "preview": "",
+                    "started_at": 2,
+                    "message_count": 1,
+                },
+                {
+                    "id": "real",
+                    "source": "tui",
+                    "title": "real",
+                    "started_at": 1,
+                    "message_count": 2,
+                },
+            ]
+
+        def get_messages_as_conversation(self, session_id):
+            if session_id == "k-B":
+                return [{"role": "system", "content": "model switched"}]
+            return [{"role": "user", "content": "hello"}]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.most_recent", "params": {}}
+    )
+
+    assert resp["result"]["session_id"] == "real"
+
+
+def test_session_most_recent_keeps_projected_compression_tip_with_real_root(monkeypatch):
+    class _DB:
+        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
+            return [
+                {
+                    "id": "tip",
+                    "source": "tui",
+                    "title": "",
+                    "preview": "",
+                    "started_at": 2,
+                    "message_count": 1,
+                    "_lineage_root_id": "root",
+                },
+                {
+                    "id": "real",
+                    "source": "tui",
+                    "title": "real",
+                    "started_at": 1,
+                    "message_count": 2,
+                },
+            ]
+
+        def get_messages_as_conversation(self, session_id):
+            if session_id == "root":
+                return [{"role": "user", "content": "real conversation"}]
+            if session_id == "tip":
+                return [{"role": "system", "content": "model switched"}]
+            return [{"role": "user", "content": "hello"}]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.most_recent", "params": {}}
+    )
+    assert resp is not None
+
+    assert resp["result"]["session_id"] == "tip"
+
+
+def test_session_most_recent_pages_past_filtered_metadata_shells(monkeypatch):
+    calls = []
+
+    class _DB:
+        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
+            calls.append((limit, offset))
+            if offset == 0:
+                return [
+                    {
+                        "id": f"ghost-{i}",
+                        "source": "tui",
+                        "title": "",
+                        "preview": "",
+                        "started_at": 300 - i,
+                        "message_count": 1,
+                    }
+                    for i in range(200)
+                ]
+            if offset == 200:
+                return [
+                    {
+                        "id": "real",
+                        "source": "tui",
+                        "title": "real",
+                        "started_at": 1,
+                        "message_count": 1,
+                    }
+                ]
+            return []
+
+        def get_messages_as_conversation(self, session_id):
+            if session_id == "real":
+                return [{"role": "user", "content": "hello"}]
+            return [{"role": "system", "content": "model switched"}]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.most_recent", "params": {}}
+    )
+    assert resp is not None
+
+    assert resp["result"]["session_id"] == "real"
+    assert calls == [(200, 0), (200, 200)]
+
+
 def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
     """Per contract, errors are folded into the null-result shape so
     callers don't have to special-case JSON-RPC error envelopes for
     'no answer' (Copilot review on #17130)."""
 
     class _BrokenDB:
-        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            offset=0,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             raise RuntimeError("db locked")
 
     monkeypatch.setattr(server, "_get_db", lambda: _BrokenDB())
@@ -7036,7 +7431,8 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
         == "Chromium-family browser isn't running with remote debugging — attempting to launch..."
     )
     assert any(
-        "No supported Chromium-family browser executable was found" in line
+        "Start a Chromium-family browser with remote debugging" in line
+        or "No supported Chromium-family browser executable was found" in line
         for line in resp["result"]["messages"]
     )
     assert any(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6080,7 +6080,15 @@ def test_session_list_returns_clean_error_when_state_db_is_unavailable(monkeypat
 
 def test_session_list_filters_system_only_model_switch_shell(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            offset=0,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             return [
                 {
                     "id": "k-B",
@@ -6104,8 +6112,13 @@ def test_session_list_filters_system_only_model_switch_shell(monkeypatch):
             if session_id == "k-B":
                 return [
                     {
-                        "role": "system",
-                        "content": "[System: The active model for this chat has changed]",
+                        "role": "user",
+                        "content": (
+                            "[System: The active model for this chat has changed to "
+                            "zai/glm-5.1 via provider zai. From this point forward, use "
+                            "this runtime metadata when answering questions about what "
+                            "model/provider is active.]"
+                        ),
                     }
                 ]
             return [{"role": "user", "content": "hello"}]
@@ -6119,7 +6132,15 @@ def test_session_list_filters_system_only_model_switch_shell(monkeypatch):
 
 def test_session_list_keeps_projected_compression_tip_with_real_root(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            offset=0,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             return [
                 {
                     "id": "tip",
@@ -6155,7 +6176,15 @@ def test_session_list_keeps_projected_compression_tip_with_real_root(monkeypatch
 
 def test_session_list_surfaces_activity_inspection_error(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            offset=0,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             return [
                 {
                     "id": "broken",
@@ -6184,8 +6213,16 @@ def test_session_list_pages_past_filtered_metadata_shells(monkeypatch):
     calls = []
 
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
-            calls.append((limit, offset))
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            offset=0,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
+            calls.append((limit, offset, order_by_last_active, compact_rows))
             if offset == 0:
                 return [
                     {
@@ -6222,7 +6259,7 @@ def test_session_list_pages_past_filtered_metadata_shells(monkeypatch):
     assert resp is not None
 
     assert [s["id"] for s in resp["result"]["sessions"]] == ["real"]
-    assert calls == [(200, 0), (200, 200)]
+    assert calls == [(200, 0, True, True), (200, 200, True, True)]
 
 
 # --------------------------------------------------------------------------
@@ -7016,7 +7053,15 @@ def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
 
 def test_session_most_recent_skips_system_only_shell(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            offset=0,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             return [
                 {
                     "id": "k-B",
@@ -7037,7 +7082,17 @@ def test_session_most_recent_skips_system_only_shell(monkeypatch):
 
         def get_messages_as_conversation(self, session_id):
             if session_id == "k-B":
-                return [{"role": "system", "content": "model switched"}]
+                return [
+                    {
+                        "role": "user",
+                        "content": (
+                            "[System: The active model for this chat has changed to "
+                            "zai/glm-5.1 via provider zai. From this point forward, use "
+                            "this runtime metadata when answering questions about what "
+                            "model/provider is active.]"
+                        ),
+                    }
+                ]
             return [{"role": "user", "content": "hello"}]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
@@ -7051,7 +7106,15 @@ def test_session_most_recent_skips_system_only_shell(monkeypatch):
 
 def test_session_most_recent_keeps_projected_compression_tip_with_real_root(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            offset=0,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             return [
                 {
                     "id": "tip",
@@ -7092,8 +7155,16 @@ def test_session_most_recent_pages_past_filtered_metadata_shells(monkeypatch):
     calls = []
 
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, offset=0):
-            calls.append((limit, offset))
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            offset=0,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
+            calls.append((limit, offset, order_by_last_active, compact_rows))
             if offset == 0:
                 return [
                     {
@@ -7131,7 +7202,7 @@ def test_session_most_recent_pages_past_filtered_metadata_shells(monkeypatch):
     assert resp is not None
 
     assert resp["result"]["session_id"] == "real"
-    assert calls == [(200, 0), (200, 200)]
+    assert calls == [(200, 0, True, True), (200, 200, True, True)]
 
 
 def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2434,6 +2434,80 @@ def _persist_live_session_system_prompt(session: dict | None) -> None:
         logger.debug("failed to persist live session system prompt", exc_info=True)
 
 
+def _history_has_real_activity(history: list | None) -> bool:
+    """Return True once a transcript has user-visible conversation content.
+
+    System-only entries (for example a model-switch metadata marker) must not
+    materialize an abandoned draft in state.db.  A row becomes user-facing only
+    after a user/assistant/tool turn exists.
+    """
+    for msg in history or []:
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role") or "").strip().lower()
+        if role not in {"user", "assistant", "tool"}:
+            continue
+        if msg.get("tool_calls"):
+            return True
+        content = msg.get("content")
+        if role == "tool":
+            return True
+        if isinstance(content, str):
+            if content.strip():
+                return True
+        elif content:
+            return True
+    return False
+
+
+def _db_session_exists(db, session_key: str) -> bool | None:
+    if not hasattr(db, "get_session"):
+        return None
+    try:
+        return bool(db.get_session(session_key))
+    except Exception:
+        logger.debug("failed to check session row existence", exc_info=True)
+        return None
+
+
+def _db_session_has_real_activity(db, session_key: str) -> bool:
+    if not hasattr(db, "get_messages_as_conversation"):
+        return False
+    return _history_has_real_activity(db.get_messages_as_conversation(session_key) or [])
+
+
+def _session_row_is_user_facing(db, row: dict) -> bool:
+    """Filter out system-only metadata shells from desktop session pickers."""
+    # Most rows have a first-user preview. Keep those fast-path visible.
+    if (row.get("preview") or "").strip():
+        return True
+    try:
+        message_count = int(row.get("message_count") or 0)
+    except (TypeError, ValueError):
+        return True
+    # Avoid changing legacy behavior for truly empty rows here; the bug this
+    # guards is a non-empty row whose only messages are system metadata. A title
+    # must not make such a shell user-facing: tests and failed metadata writes
+    # can stamp titles like "Partial Answer Complete" onto rows that still have
+    # no user/assistant/tool activity.
+    if message_count <= 0:
+        return True
+    session_id = str(row.get("id") or "").strip()
+    if not session_id:
+        return False
+    activity_ids: list[str] = []
+    root_id = str(row.get("_lineage_root_id") or "").strip()
+    if root_id and root_id != session_id:
+        # ``list_sessions_rich(project_compression_tips=True)`` surfaces the
+        # compression continuation tip but annotates the original root.  The tip
+        # can briefly contain only system metadata (e.g. a model switch) while
+        # the root holds the real user conversation; keep that conversation
+        # visible instead of treating the projected tip as a standalone shell.
+        activity_ids.append(root_id)
+    activity_ids.append(session_id)
+    return any(_db_session_has_real_activity(db, sid) for sid in activity_ids)
+
+
 def _append_model_switch_marker(session: dict | None, *, model: str, provider: str) -> None:
     """Record a real system-history pivot after a live model switch."""
     if not session:
@@ -2463,19 +2537,34 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
         session.setdefault("history", []).append(entry)
         session["history_version"] = int(session.get("history_version", 0)) + 1
 
+    # Do not let this system-only metadata row create an "Untitled Session" in
+    # the sidebar.  A freshly opened draft can build an agent and switch models
+    # before the user sends anything; persisting the marker there violates the
+    # lazy DB-row contract from session.create.
+    in_memory_real_activity = _history_has_real_activity(session.get("history"))
+
+    def _persist_if_user_facing(db) -> bool:
+        if db is None:
+            return False
+        exists = _db_session_exists(db, session_key)
+        if exists is False and not in_memory_real_activity:
+            return True
+        if exists is False:
+            _ensure_session_db_row(session)
+            exists = _db_session_exists(db, session_key)
+            if exists is False:
+                return True
+        db.append_message(session_id=session_key, role="user", content=marker)
+        return True
+
     try:
         agent = session.get("agent")
         db = getattr(agent, "_session_db", None) if agent is not None else None
-        if db is not None:
-            db.append_message(session_id=session_key, role="user", content=marker)
+        if _persist_if_user_facing(db):
             return
 
-        _ensure_session_db_row(session)
         with _session_db(session) as scoped_db:
-            if scoped_db is not None:
-                scoped_db.append_message(
-                    session_id=session_key, role="user", content=marker
-                )
+            _persist_if_user_facing(scoped_db)
     except Exception:
         logger.debug("failed to persist model switch marker", exc_info=True)
 
@@ -5357,15 +5446,31 @@ def _(rid, params: dict) -> dict:
         deny = frozenset({"tool"})
 
         limit = int(params.get("limit", 200) or 200)
-        # Over-fetch modestly so per-source filtering doesn't leave us
-        # short; the compression-tip projection in ``list_sessions_rich``
-        # can also merge rows.
-        fetch_limit = max(limit * 2, 200)
-        rows = [
-            s
-            for s in db.list_sessions_rich(source=None, limit=fetch_limit, order_by_last_active=True, compact_rows=True)
-            if (s.get("source") or "").strip().lower() not in deny
-        ][:limit]
+        # Keep paging until we fill the requested window or exhaust the DB. A
+        # single over-fetch can still be starved by a burst of recent phantom
+        # metadata shells, so filtering must not stop at the first page.
+        page_size = max(limit * 2, 200)
+        rows = []
+        offset = 0
+        while len(rows) < limit:
+            page = db.list_sessions_rich(
+                source=None,  # type: ignore[arg-type]
+                limit=page_size,
+                offset=offset,
+            )
+            if not page:
+                break
+            for s in page:
+                if (s.get("source") or "").strip().lower() in deny:
+                    continue
+                if not _session_row_is_user_facing(db, s):
+                    continue
+                rows.append(s)
+                if len(rows) >= limit:
+                    break
+            if len(page) < page_size:
+                break
+            offset += len(page)
         return _ok(
             rid,
             {
@@ -5406,24 +5511,32 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"session_id": None})
     try:
         deny = frozenset({"tool"})
-        # Over-fetch by a generous bounded amount so heavy sub-agent
-        # users (lots of recent ``tool`` rows) don't get a false
-        # "no eligible session" answer.  ``session.list`` uses a
-        # similar over-fetch strategy.
-        rows = db.list_sessions_rich(source=None, limit=200, order_by_last_active=True, compact_rows=True)
-        for row in rows:
-            src = (row.get("source") or "").strip().lower()
-            if src in deny:
-                continue
-            return _ok(
-                rid,
-                {
-                    "session_id": row.get("id"),
-                    "title": row.get("title") or "",
-                    "started_at": row.get("started_at") or 0,
-                    "source": row.get("source") or "",
-                },
+        page_size = 200
+        offset = 0
+        while True:
+            page = db.list_sessions_rich(
+                source=None,  # type: ignore[arg-type]
+                limit=page_size,
+                offset=offset,
             )
+            if not page:
+                break
+            for row in page:
+                src = (row.get("source") or "").strip().lower()
+                if src in deny or not _session_row_is_user_facing(db, row):
+                    continue
+                return _ok(
+                    rid,
+                    {
+                        "session_id": row.get("id"),
+                        "title": row.get("title") or "",
+                        "started_at": row.get("started_at") or 0,
+                        "source": row.get("source") or "",
+                    },
+                )
+            if len(page) < page_size:
+                break
+            offset += len(page)
         return _ok(rid, {"session_id": None})
     except Exception:
         logger.exception("session.most_recent failed")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2434,6 +2434,23 @@ def _persist_live_session_system_prompt(session: dict | None) -> None:
         logger.debug("failed to persist live session system prompt", exc_info=True)
 
 
+_MODEL_SWITCH_MARKER_PREFIX = "[System: The active model for this chat has changed to "
+_MODEL_SWITCH_MARKER_SUFFIX = (
+    ". From this point forward, use this runtime metadata when answering questions "
+    "about what model/provider is active.]"
+)
+
+
+def _is_model_switch_marker(message: dict) -> bool:
+    """Identify the synthetic model-switch marker independent of transport role."""
+    content = message.get("content")
+    return (
+        isinstance(content, str)
+        and content.startswith(_MODEL_SWITCH_MARKER_PREFIX)
+        and content.endswith(_MODEL_SWITCH_MARKER_SUFFIX)
+    )
+
+
 def _history_has_real_activity(history: list | None) -> bool:
     """Return True once a transcript has user-visible conversation content.
 
@@ -2443,6 +2460,8 @@ def _history_has_real_activity(history: list | None) -> bool:
     """
     for msg in history or []:
         if not isinstance(msg, dict):
+            continue
+        if _is_model_switch_marker(msg):
             continue
         role = str(msg.get("role") or "").strip().lower()
         if role not in {"user", "assistant", "tool"}:
@@ -2517,11 +2536,7 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
         return
 
     provider_part = f" via provider {provider}" if provider else ""
-    marker = (
-        "[System: The active model for this chat has changed to "
-        f"{model}{provider_part}. From this point forward, use this runtime "
-        "metadata when answering questions about what model/provider is active.]"
-    )
+    marker = f"{_MODEL_SWITCH_MARKER_PREFIX}{model}{provider_part}{_MODEL_SWITCH_MARKER_SUFFIX}"
     # Persist as a user message, not a system message.  The gateway appends
     # this marker after prior conversation turns, and strict OpenAI-compatible
     # providers (vLLM, Qwen) reject system messages that are not at the
@@ -5457,6 +5472,8 @@ def _(rid, params: dict) -> dict:
                 source=None,  # type: ignore[arg-type]
                 limit=page_size,
                 offset=offset,
+                order_by_last_active=True,
+                compact_rows=True,
             )
             if not page:
                 break
@@ -5518,6 +5535,8 @@ def _(rid, params: dict) -> dict:
                 source=None,  # type: ignore[arg-type]
                 limit=page_size,
                 offset=offset,
+                order_by_last_active=True,
+                compact_rows=True,
             )
             if not page:
                 break


### PR DESCRIPTION
## Summary
- avoid materializing abandoned TUI draft sessions solely for model-switch system metadata
- hide system-only metadata shells from `session.list` / `session.most_recent`, even if they have a title
- keep projected compression continuation tips visible when the lineage root has real user activity
- page past bursts of filtered metadata shells instead of only checking the first result window
- isolate `test_tui_gateway_server.py` from the developer's real `state.db`
- relax the browser remote-debug launch-hint regression test for macOS fallback output

## Test Plan
- `python3 -m pytest tests/test_tui_gateway_server.py tests/test_empty_session_hygiene.py -q -o addopts=` → `304 passed, 1 warning`
- verified a real `session-key` system-only shell is not returned by `session.list`
- verified the TUI gateway tests no longer add rows/messages to the real `~/.hermes/state.db`
