### PR TITLE
fix(langfuse): auto-install SDK via lazy_deps when plugin is enabled

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -155,15 +155,25 @@ def _get_langfuse() -> Optional[Langfuse]:
     to construct a client, and every subsequent call returns that client
     (or fast-returns ``None`` if init failed).
     """
-    global _LANGFUSE_CLIENT
+    global _LANGFUSE_CLIENT, Langfuse, propagate_attributes
     if _LANGFUSE_CLIENT is _INIT_FAILED:
         return None
     if _LANGFUSE_CLIENT is not None:
         return _LANGFUSE_CLIENT
 
     if Langfuse is None:
-        _LANGFUSE_CLIENT = _INIT_FAILED
-        return None
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+
+            _lazy_ensure("observability.langfuse", prompt=False)
+            from langfuse import Langfuse, propagate_attributes
+        except Exception:
+            logger.warning(
+                "Langfuse plugin: SDK not installed and could not be "
+                "auto-installed. Install manually: pip install langfuse",
+            )
+            _LANGFUSE_CLIENT = _INIT_FAILED
+            return None
 
     public_key = _env("HERMES_LANGFUSE_PUBLIC_KEY") or _env("LANGFUSE_PUBLIC_KEY")
     secret_key = _env("HERMES_LANGFUSE_SECRET_KEY") or _env("LANGFUSE_SECRET_KEY")

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import importlib
 import logging
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -647,26 +648,65 @@ class TestPlaceholderKeyDetection:
                     and r.name == self.LOGGER_NAME]
         assert warnings == []
 
-    def test_sdk_not_installed_still_skips_silently(self, monkeypatch, caplog):
-        """If the langfuse SDK isn't installed at all, the placeholder
-        check should never run — there's nothing the operator can do
-        about a credential mismatch when the package is missing, and
-        re-warning here would dilute the actually-actionable SDK-missing
-        signal upstream.  The ``Langfuse is None`` guard at the top of
-        ``_get_langfuse`` already handles this; this test pins that
-        behaviour."""
+    def test_sdk_not_installed_warns_after_lazy_install_fails(self, monkeypatch, caplog):
+        """If the SDK is missing and lazy_deps.ensure() cannot install it,
+        the plugin must log a warning with a manual-install hint instead of
+        silently no-op-ing — operators need to know why traces are missing."""
         self._clear_env(monkeypatch)
         monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "placeholder")
         monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "placeholder")
-        # NO monkeypatch on Langfuse here — falls back to whatever the
-        # plugin imported at module load (None if SDK absent).
         plugin = self._fresh_plugin()
         monkeypatch.setattr(plugin, "Langfuse", None, raising=False)
+
+        def _fake_ensure(*_a, **_kw):
+            raise RuntimeError("offline / allow_lazy_installs=false")
+
+        monkeypatch.setitem(
+            sys.modules,
+            "tools.lazy_deps",
+            types.SimpleNamespace(ensure=_fake_ensure),
+        )
+
         with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
             assert plugin._get_langfuse() is None
         warnings = [r for r in caplog.records if r.levelname == "WARNING"
                     and r.name == self.LOGGER_NAME]
-        assert warnings == []
+        assert len(warnings) >= 1
+        assert "pip install langfuse" in warnings[0].getMessage()
+
+    def test_sdk_lazy_install_succeeds_then_init_proceeds(self, monkeypatch, caplog):
+        """If the SDK is missing at module load but lazy_deps.ensure()
+        installs it successfully, _get_langfuse() must re-import the SDK
+        and proceed to client init — not stay stuck on the stale None."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin()
+        monkeypatch.setattr(plugin, "Langfuse", None, raising=False)
+        _FakeLangfuse.instances.clear()
+
+        # Build a fake langfuse module so the real `from langfuse import
+        # Langfuse` inside _get_langfuse() finds it after ensure() "installs".
+        fake_mod = types.SimpleNamespace(
+            Langfuse=_FakeLangfuse,
+            propagate_attributes=lambda *a, **kw: None,
+        )
+        monkeypatch.setitem(sys.modules, "langfuse", fake_mod)
+
+        def _fake_ensure(*_a, **_kw):
+            pass  # simulate successful install
+
+        monkeypatch.setitem(
+            sys.modules,
+            "tools.lazy_deps",
+            types.SimpleNamespace(ensure=_fake_ensure),
+        )
+
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            client = plugin._get_langfuse()
+        assert isinstance(client, _FakeLangfuse)
+        assert client.kwargs["public_key"] == "pk-lf-real-public-xyz"
+        assert "pip install langfuse" not in caplog.text
 
     def test_valid_prefixes_do_not_trigger_placeholder_warning(self, monkeypatch, caplog):
         """Real Langfuse keys (``pk-lf-…`` / ``sk-lf-…``) must pass the

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -120,6 +120,9 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "memory.honcho": ("honcho-ai==2.0.1",),
     "memory.hindsight": ("hindsight-client==0.6.1",),
 
+    # ─── Observability backends ─────────────────────────────────────────────
+    "observability.langfuse": ("langfuse",),
+
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
     "platform.telegram": ("python-telegram-bot[webhooks]==22.6",),
     # brotlicffi gives aiohttp a working 2-arg Decompressor.process() for


### PR DESCRIPTION
## Summary
- The langfuse plugin silently no-op'd when the `langfuse` SDK was missing — no log, no warning. After a Docker container rebuild the plugin stayed enabled in config but traces were silently dropped.
- Wire `_get_langfuse()` into the `lazy_deps` framework (same mechanism used by hindsight, honcho, discord, slack, etc.) so the SDK is auto-installed on first hook invocation.
- On install failure (offline, `allow_lazy_installs` disabled), log a warning with the manual install command instead of failing silently.

## Changes
- `tools/lazy_deps.py` — register `"observability.langfuse": ("langfuse",)` in the `LAZY_DEPS` allowlist
- `plugins/observability/langfuse/__init__.py` — call `lazy_deps.ensure()` + re-import in `_get_langfuse()` when `Langfuse is None`, with a single `except Exception` that logs a warning and falls through to `_INIT_FAILED`
- `tests/plugins/test_langfuse_plugin.py` — replace the old "silently skips" test with two tests covering the failure path (warning logged) and success path (SDK installed and client initialized)

## Test plan
- [ ] `pytest tests/plugins/test_langfuse_plugin.py` passes (new tests + all existing tests)
- [ ] Docker rebuild scenario: enable plugin in config, rebuild container, verify traces are emitted without manual `pip install`
- [ ] Offline scenario: with `security.allow_lazy_installs: false`, verify a warning is logged instead of silent no-op