### PR TITLE
fix(tools): tear down the whole process tree on Windows terminal timeout

### DIFF
--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -96,6 +96,67 @@ def test_kill_process_uses_cached_pgid_if_wrapper_already_exited(monkeypatch):
     assert killpg_calls == [(67890, signal.SIGTERM), (67890, 0)]
 
 
+def test_kill_process_taskkill_tree_on_windows(monkeypatch):
+    """On Windows, _kill_process must tear down the whole tree with taskkill /T.
+
+    Regression: the Windows branch used ``proc.terminate()`` (TerminateProcess),
+    which kills only the wrapper handle. Orphaned descendants (e.g. an ffmpeg the
+    command spawned) kept the stdout pipe open and hung the reader long past the
+    timeout. ``taskkill /PID <pid> /T /F`` is the documented Windows tree-kill
+    primitive (matching ProcessRegistry._terminate_host_pid).
+    """
+    import tools.environments.local as local_mod
+
+    env = object.__new__(LocalEnvironment)
+    terminate_calls = []
+    proc = SimpleNamespace(
+        pid=4242,
+        terminate=lambda: terminate_calls.append(True),
+        kill=lambda: None,
+        poll=lambda: None,
+        wait=lambda timeout=None: None,
+    )
+    run_calls = []
+
+    def fake_run(cmd, **kwargs):
+        run_calls.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+
+    env._kill_process(proc)
+
+    assert run_calls == [["taskkill", "/PID", "4242", "/T", "/F"]]
+    # The wrapper-only terminate must not be what we rely on anymore.
+    assert terminate_calls == []
+
+
+def test_kill_process_windows_falls_back_to_kill_when_taskkill_missing(monkeypatch):
+    """If taskkill is unavailable, fall back to proc.kill() instead of raising."""
+    import tools.environments.local as local_mod
+
+    env = object.__new__(LocalEnvironment)
+    kill_calls = []
+    proc = SimpleNamespace(
+        pid=4243,
+        terminate=lambda: None,
+        kill=lambda: kill_calls.append(True),
+        poll=lambda: None,
+        wait=lambda timeout=None: None,
+    )
+
+    def fake_run(cmd, **kwargs):
+        raise FileNotFoundError("taskkill")
+
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+
+    env._kill_process(proc)
+
+    assert kill_calls == [True]
+
+
 def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
     """When KeyboardInterrupt arrives mid-poll, the subprocess group must be
     killed before the exception is re-raised."""

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -650,7 +650,27 @@ class LocalEnvironment(BaseEnvironment):
 
         try:
             if _IS_WINDOWS:
-                proc.terminate()
+                # proc.terminate() maps to TerminateProcess(), which kills only
+                # the wrapper handle. Orphaned descendants (e.g. an ffmpeg the
+                # command spawned) survive and keep the stdout pipe open, hanging
+                # the reader long past the timeout. taskkill /T tears down the
+                # whole tree — the documented Windows primitive, matching
+                # ProcessRegistry._terminate_host_pid. psutil's children walk is
+                # unreliable here (stale PPID links miss orphaned descendants).
+                try:
+                    subprocess.run(
+                        ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                        creationflags=windows_hide_flags(),
+                        stdin=subprocess.DEVNULL,
+                    )
+                except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+                    try:
+                        proc.kill()
+                    except Exception:
+                        pass
             else:
                 try:
                     pgid = os.getpgid(proc.pid)


### PR DESCRIPTION
## What & why

On Windows, `LocalEnvironment._kill_process` called `proc.terminate()`, which maps to `TerminateProcess()` and kills only the wrapper process. Any descendants the command spawned (e.g. an `ffmpeg` launched by a script) survive and keep the inherited stdout pipe open, so the reader blocks long past the configured `terminal.timeout`. In practice the tool call hangs for minutes and the session appears frozen until the user sends an interrupt.

The POSIX branch already handles this correctly by signalling the whole process group via `os.killpg`; only the Windows branch was missing tree teardown.

## Fix

Replace `proc.terminate()` with `taskkill /PID <pid> /T /F` — the documented Windows tree-kill primitive already used by `ProcessRegistry._terminate_host_pid` — falling back to `proc.kill()` if `taskkill` is unavailable.

`psutil`'s `children(recursive=True)` is intentionally avoided here for the reason documented in `_terminate_host_pid`: on Windows, stale PPID links mean the walk can miss orphaned descendants, whereas `taskkill /T` reliably tears down the whole tree.

## How to test

Repro (Windows): run a command that spawns a child outliving the wrapper (e.g. a script that launches `ffmpeg`, or `ping -n 600 127.0.0.1`) and let it hit `terminal.timeout`. Before this change the grandchild survives, keeps the pipe open, and the call hangs; after, the whole tree is torn down and the call returns.

Verified on Windows 11: a `cmd` wrapper spawning `ping -n 600 127.0.0.1` leaks the `ping` grandchild under the old `terminate()`, and is fully removed under the fix.

Two regression tests added (portable — monkeypatched, so they run on every platform):
- `_kill_process` issues `taskkill /PID <pid> /T /F` on Windows
- falls back to `proc.kill()` when `taskkill` is unavailable

## Platforms tested

- **Windows 11** — real process-tree teardown + unit tests
- Unit tests are platform-independent (monkeypatched), so they also run on Linux/macOS CI
