### PR TITLE
fix(mcp): confirm non-MCP GET content type with a POST before rejecting

### DIFF
--- a/tests/tools/test_mcp_preflight_content_type.py
+++ b/tests/tools/test_mcp_preflight_content_type.py
@@ -5,8 +5,15 @@ HTTP server (via httpx's ASGI/transport plumbing through a stdlib server),
 rather than reimplementing the probe inline. That distinction matters: the
 production probe must run on its own httpx client outside the MCP SDK's anyio
 task group, and a faithful test must exercise that actual method so the
-content-type allow-list, HEAD->GET fallback, and best-effort pass-through are
-all covered as shipped.
+content-type allow-list, HEAD->GET fallback, POST confirmation, and
+best-effort pass-through are all covered as shipped.
+
+Contract note (POST confirmation): MCP Streamable-HTTP is a POST protocol.
+Some real MCP servers (e.g. Attio) serve an HTML marketing page on
+``GET /mcp`` while answering ``POST /mcp`` with proper MCP JSON or an OAuth
+challenge. The probe therefore must NOT reject on a non-MCP GET content type
+alone -- it confirms with a POST first, and only rejects when the POST also
+returns a clean 2xx non-MCP response (a genuine "this is a web page" signal).
 """
 
 from __future__ import annotations
@@ -46,13 +53,28 @@ def _serve(handler_cls):
 
 def _handler(status: int = 200,
              content_type: "str | None" = "text/html; charset=utf-8",
-             body: bytes = b"<html>x</html>", head_status=None, record=None):
+             body: bytes = b"<html>x</html>", head_status=None, record=None,
+             post_status: "int | None" = None,
+             post_content_type: "str | None" = "__mirror__",
+             post_body: bytes = b"{}"):
     """Build a BaseHTTPRequestHandler that replies with the given shape.
 
     ``head_status`` lets HEAD return a different status than GET (to exercise
     the HEAD->GET fallback). ``record`` is an optional list that captures the
     HTTP methods the server actually saw.
+
+    The ``post_*`` knobs control the POST response used by the POST-confirmation
+    step. By default POST mirrors a non-MCP web page (same status/content type
+    as GET) so that a non-MCP GET is confirmed-and-rejected. Set
+    ``post_content_type`` to an MCP type (or ``post_status`` to a 4xx auth
+    challenge) to model a real MCP endpoint that only answers POST. Pass
+    ``post_content_type=None`` to send a POST response with NO content-type
+    header at all (the "mirror" sentinel is what makes ``None`` distinct from
+    the default).
     """
+
+    _post_status = post_status if post_status is not None else status
+    _post_ct = content_type if post_content_type == "__mirror__" else post_content_type
 
     class _H(http.server.BaseHTTPRequestHandler):
         def _write(self, sc, ct, payload):
@@ -75,6 +97,15 @@ def _handler(status: int = 200,
                 record.append("GET")
             self._write(status, content_type, body)
 
+        def do_POST(self):
+            if record is not None:
+                record.append("POST")
+            # Drain the request body so the client isn't left hanging.
+            length = int(self.headers.get("Content-Length", 0) or 0)
+            if length:
+                self.rfile.read(length)
+            self._write(_post_status, _post_ct, post_body)
+
         def log_message(self, format, *args):  # noqa: A002
             pass
 
@@ -82,7 +113,7 @@ def _handler(status: int = 200,
 
 
 # ---------------------------------------------------------------------------
-# Reject: non-MCP content types on a 2xx response
+# Reject: non-MCP content types confirmed by a clean 2xx non-MCP POST
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("content_type", [
@@ -93,6 +124,8 @@ def _handler(status: int = 200,
     "text/HTML",  # case-insensitivity
 ])
 def test_non_mcp_content_type_raises(content_type):
+    """GET returns non-MCP HTML AND POST also returns a clean 2xx web page ->
+    genuine wrong-URL, must raise."""
     task = _make_task("bad_srv")
     with _serve(_handler(status=200, content_type=content_type)) as base:
         with pytest.raises(NonMcpEndpointError) as exc_info:
@@ -109,6 +142,54 @@ def test_non_mcp_error_is_non_retryable_connection_error():
 
 
 # ---------------------------------------------------------------------------
+# POST confirmation: HTML on GET but a real MCP endpoint on POST must PASS
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("post_content_type", [
+    "application/json",
+    "application/json; charset=utf-8",
+    "text/event-stream",
+])
+def test_html_get_but_mcp_post_passes(post_content_type):
+    """Attio-style: GET /mcp serves an HTML landing page, POST /mcp answers
+    with an MCP content type. Must NOT raise."""
+    task = _make_task()
+    record: list[str] = []
+    with _serve(_handler(
+        status=200, content_type="text/html",
+        post_status=200, post_content_type=post_content_type,
+        record=record,
+    )) as base:
+        asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
+    assert "POST" in record  # the confirmation POST actually ran
+
+
+@pytest.mark.parametrize("post_status", [400, 401, 403, 404, 500])
+def test_html_get_but_post_challenge_passes(post_status):
+    """GET serves HTML, POST returns an auth/error challenge (non-2xx) -> the
+    URL is a real MCP endpoint that just needs credentials/a session. Pass."""
+    task = _make_task()
+    record: list[str] = []
+    with _serve(_handler(
+        status=200, content_type="text/html",
+        post_status=post_status, post_content_type="text/html",
+        record=record,
+    )) as base:
+        asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
+    assert "POST" in record
+
+
+def test_html_get_but_post_no_content_type_passes():
+    """GET HTML, POST returns 2xx with no content type -> ambiguous, pass."""
+    task = _make_task()
+    with _serve(_handler(
+        status=200, content_type="text/html",
+        post_status=200, post_content_type=None, post_body=b"",
+    )) as base:
+        asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
+
+
+# ---------------------------------------------------------------------------
 # Pass-through: valid MCP content types, ambiguous, and error responses
 # ---------------------------------------------------------------------------
 
@@ -121,7 +202,7 @@ def test_non_mcp_error_is_non_retryable_connection_error():
 def test_valid_mcp_content_types_pass(content_type):
     task = _make_task()
     with _serve(_handler(status=200, content_type=content_type, body=b"{}")) as base:
-        # Must not raise.
+        # Must not raise. GET already looks like MCP -> no POST needed.
         asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
 
 
@@ -133,7 +214,8 @@ def test_missing_content_type_passes():
 
 @pytest.mark.parametrize("status", [401, 403, 404, 500, 503])
 def test_non_2xx_responses_pass(status):
-    """4xx/5xx are auth challenges or transient errors — let the SDK handle."""
+    """4xx/5xx on the GET are auth challenges or transient errors — let the SDK
+    handle. The GET probe returns early without a POST confirmation."""
     task = _make_task()
     with _serve(_handler(status=status, content_type="text/html")) as base:
         asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
@@ -180,6 +262,7 @@ def test_cancelled_error_is_not_swallowed():
 # ---------------------------------------------------------------------------
 
 def test_head_405_falls_back_to_get_and_rejects_html():
+    """HEAD 405 -> GET HTML, and POST also a clean 2xx web page -> reject."""
     task = _make_task("fallback_srv")
     record: list[str] = []
     with _serve(_handler(
@@ -188,7 +271,8 @@ def test_head_405_falls_back_to_get_and_rejects_html():
     )) as base:
         with pytest.raises(NonMcpEndpointError):
             asyncio.run(task._preflight_content_type(f"{base}/", timeout=5.0))
-    assert record == ["HEAD", "GET"]
+    # HEAD falls back to GET, then the non-MCP GET triggers a POST confirmation.
+    assert record == ["HEAD", "GET", "POST"]
 
 
 def test_head_501_falls_back_to_get_and_passes_json():
@@ -199,6 +283,7 @@ def test_head_501_falls_back_to_get_and_passes_json():
         head_status=501, record=record,
     )) as base:
         asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
+    # GET already looks like MCP -> no POST confirmation needed.
     assert record == ["HEAD", "GET"]
 
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1934,6 +1934,47 @@ class MCPServerTask:
         if ct_base in self._MCP_CONTENT_TYPES:
             return  # Looks like a real MCP endpoint.
 
+        # HEAD/GET is NOT how MCP Streamable-HTTP works — clients POST. Some
+        # real MCP servers (e.g. Attio) serve an HTML marketing page on GET
+        # /mcp while answering POST with proper MCP JSON or an OAuth challenge.
+        # Before rejecting on the GET content type, confirm with a POST: a
+        # genuine endpoint replies with an MCP content type OR an auth/4xx
+        # challenge. Only a clean 2xx non-MCP POST is a true "wrong URL".
+        try:
+            async with _httpx.AsyncClient(**client_kwargs) as client:
+                post_headers = dict(probe_headers)
+                post_headers.setdefault(
+                    "Accept", "application/json, text/event-stream"
+                )
+                post_headers.setdefault("Content-Type", "application/json")
+                post_resp = await client.post(
+                    url,
+                    headers=post_headers,
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": LATEST_PROTOCOL_VERSION,
+                            "capabilities": {},
+                            "clientInfo": {"name": "hermes-preflight", "version": "1.0"},
+                        },
+                    },
+                )
+        except _httpx.HTTPError:
+            return  # POST transport error — let the SDK/handshake decide.
+
+        # An auth challenge or any client/server error means the URL *is* an
+        # MCP endpoint that simply needs credentials or a session — not a web
+        # page. Pass through and let the real handshake (incl. OAuth) proceed.
+        if not (200 <= post_resp.status_code < 300):
+            return
+        post_ct = (
+            post_resp.headers.get("content-type", "").split(";")[0].strip().lower()
+        )
+        if not post_ct or post_ct in self._MCP_CONTENT_TYPES:
+            return  # POST looks like real MCP — the GET HTML was a landing page.
+
         raise NonMcpEndpointError(
             f"MCP server '{self.name}' at {url} returned Content-Type "
             f"'{ct_base}', not an MCP response (expected one of: "


### PR DESCRIPTION
## Problem

The HTTP MCP preflight check (`MCPServerTask._preflight_content_type` in `tools/mcp_tool.py`) probes a server URL with HEAD/GET and rejects the endpoint when a 2xx response carries a non-MCP content type (`text/html`, etc.), raising `NonMcpEndpointError`.

But MCP Streamable-HTTP is a **POST** protocol. Some real, first-party MCP servers serve an HTML landing page on `GET /mcp` while only answering `POST /mcp` with proper MCP JSON or an OAuth challenge. The GET-only check wrongly rejects these as "not an MCP endpoint" **before the OAuth flow can even start.**

### Concrete repro: Attio's official MCP server

```
$ curl -s -o /dev/null -w '%{http_code} %{content_type}\n' https://mcp.attio.com/mcp
200 text/html; charset=utf-8        # GET -> landing page

$ curl -s -X POST https://mcp.attio.com/mcp \
    -H 'Content-Type: application/json' \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'
# -> HTTP 401 application/json with:
#    www-authenticate: Bearer resource_metadata="https://mcp.attio.com/.well-known/oauth-protected-resource", scope="openid offline_access mcp"
```

The endpoint is a perfectly valid OAuth-protected MCP server (its `.well-known/oauth-protected-resource` returns valid metadata), but `hermes mcp add/login attio --auth oauth` fails with:

> ✗ Authentication failed: MCP server 'attio' at https://mcp.attio.com/mcp returned Content-Type 'text/html', not an MCP response ...

## Fix

When the GET probe sees a non-MCP content type, **confirm with a POST `initialize` request before rejecting.** A real endpoint replies with an MCP content type or a non-2xx auth/error challenge → pass through and let the real handshake (including OAuth) proceed. Only a clean 2xx non-MCP POST is a true wrong-URL and still raises `NonMcpEndpointError`.

The change is contained to the rejection branch of `_preflight_content_type` — all existing early-return paths (MCP content type on GET, missing content type, non-2xx GET, network error, `CancelledError` propagation) are untouched.

## Tests

`tests/tools/test_mcp_preflight_content_type.py` updated to encode the new contract against the real method + a real local HTTP server:

- POST support added to the probe server harness.
- HTML-on-GET cases split into **reject** (POST also a clean 2xx web page) vs **pass** (POST returns MCP content type, or a 4xx/5xx auth challenge, or no content type).
- HEAD→GET fallback test now asserts the trailing POST confirmation (`["HEAD", "GET", "POST"]`).

```
30 passed   tests/tools/test_mcp_preflight_content_type.py
551 passed, 1 skipped   tests/tools/ -k mcp
```

Verified end-to-end: with the patch, `hermes mcp login attio` completes the OAuth browser flow and registers 37 Attio tools.