### PR TITLE
fix(plugins): silence mattermost check_fn log spam for unconfigured users

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -51,20 +51,25 @@ _RECONNECT_JITTER = 0.2
 
 
 def check_mattermost_requirements() -> bool:
-    """Return True if the Mattermost adapter can be used."""
-    token = os.getenv("MATTERMOST_TOKEN", "")
-    url = os.getenv("MATTERMOST_URL", "")
-    if not token:
-        logger.debug("Mattermost: MATTERMOST_TOKEN not set")
+    """Return True if the Mattermost adapter can be used.
+
+    Intentionally silent on failure — this is a passive probe registered as
+    the platform's ``check_fn``.  It is called on every
+    ``load_gateway_config()`` (message handling, display lookups, agent
+    turns), so logging here floods the logs for every user without
+    Mattermost configured.  The caller
+    (``gateway/platform_registry.py`` ``create_adapter()``) emits its
+    own warning when requirements are not met and an adapter is actually
+    requested.
+    """
+    if not os.getenv("MATTERMOST_TOKEN", ""):
         return False
-    if not url:
-        logger.warning("Mattermost: MATTERMOST_URL not set")
+    if not os.getenv("MATTERMOST_URL", ""):
         return False
     try:
         import aiohttp  # noqa: F401
         return True
     except ImportError:
-        logger.warning("Mattermost: aiohttp not installed")
         return False
 
 

--- a/tests/plugins/test_mattermost_check_fn_silent.py
+++ b/tests/plugins/test_mattermost_check_fn_silent.py
@@ -1,0 +1,100 @@
+"""Regression tests for the Mattermost platform plugin's check_fn.
+
+The Mattermost adapter's ``check_mattermost_requirements()`` is registered as
+the platform's ``check_fn``.  This function is invoked on every
+``load_gateway_config()`` call (dozens of times during normal gateway
+operation).  It must therefore be a *silent* predicate — returning True/False
+without logging — otherwise every user without Mattermost configured gets
+their logs flooded with WARNING messages every few seconds.
+
+Sibling of the raft check_fn fix (PR #49240).
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def mm_check():
+    """Import check_mattermost_requirements."""
+    from plugins.platforms.mattermost.adapter import check_mattermost_requirements
+
+    return check_mattermost_requirements
+
+
+def test_check_returns_false_when_token_missing(mm_check, monkeypatch):
+    """check_fn returns False when MATTERMOST_TOKEN is not set."""
+    monkeypatch.delenv("MATTERMOST_TOKEN", raising=False)
+    monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+    assert mm_check() is False
+
+
+def test_check_returns_false_when_url_missing(mm_check, monkeypatch):
+    """check_fn returns False when MATTERMOST_URL is not set."""
+    monkeypatch.setenv("MATTERMOST_TOKEN", "tok-abc")
+    monkeypatch.delenv("MATTERMOST_URL", raising=False)
+    assert mm_check() is False
+
+
+def test_check_returns_false_when_aiohttp_missing(mm_check, monkeypatch):
+    """check_fn returns False when aiohttp is not installed."""
+    monkeypatch.setenv("MATTERMOST_TOKEN", "tok-abc")
+    monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+    with patch.dict("sys.modules", {"aiohttp": None}):
+        assert mm_check() is False
+
+
+def test_check_returns_true_when_all_present(mm_check, monkeypatch):
+    """check_fn returns True when token, URL, and aiohttp are available."""
+    monkeypatch.setenv("MATTERMOST_TOKEN", "tok-abc")
+    monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+    import types
+
+    fake_aiohttp = types.ModuleType("aiohttp")
+    with patch.dict("sys.modules", {"aiohttp": fake_aiohttp}):
+        assert mm_check() is True
+
+
+def test_check_silent_when_token_missing(mm_check, monkeypatch, caplog):
+    """check_fn must NOT log a WARNING when MATTERMOST_TOKEN is missing."""
+    monkeypatch.delenv("MATTERMOST_TOKEN", raising=False)
+    monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+    with caplog.at_level(logging.WARNING, logger="plugins.platforms.mattermost.adapter"):
+        mm_check()
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == [], (
+        f"check_mattermost_requirements must be silent (no WARNING logs), "
+        f"but emitted: {[r.getMessage() for r in warnings]}"
+    )
+
+
+def test_check_silent_when_url_missing(mm_check, monkeypatch, caplog):
+    """check_fn must NOT log a WARNING when MATTERMOST_URL is missing."""
+    monkeypatch.setenv("MATTERMOST_TOKEN", "tok-abc")
+    monkeypatch.delenv("MATTERMOST_URL", raising=False)
+    with caplog.at_level(logging.WARNING, logger="plugins.platforms.mattermost.adapter"):
+        mm_check()
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == [], (
+        f"check_mattermost_requirements must be silent (no WARNING logs), "
+        f"but emitted: {[r.getMessage() for r in warnings]}"
+    )
+
+
+def test_check_silent_when_aiohttp_missing(mm_check, monkeypatch, caplog):
+    """check_fn must NOT log a WARNING when aiohttp is missing."""
+    monkeypatch.setenv("MATTERMOST_TOKEN", "tok-abc")
+    monkeypatch.setenv("MATTERMOST_URL", "https://mm.example.com")
+    with patch.dict("sys.modules", {"aiohttp": None}):
+        with caplog.at_level(logging.WARNING, logger="plugins.platforms.mattermost.adapter"):
+            mm_check()
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == [], (
+        f"check_mattermost_requirements must be silent (no WARNING logs), "
+        f"but emitted: {[r.getMessage() for r in warnings]}"
+    )


### PR DESCRIPTION
## Summary

Removes `logger.warning()` calls from `check_mattermost_requirements()` so the Mattermost platform plugin's `check_fn` honors the passive-predicate contract.

This is a sibling of the raft `check_fn` fix (#49240, merged today). The Mattermost adapter has the same pattern: `check_mattermost_requirements()` is registered as the platform's `check_fn` (line 1237) and is called on every `load_gateway_config()` via the plugin-entry loop in `gateway/config.py:2072`. For every user who doesn't have `MATTERMOST_URL` set (the vast majority), the function emitted a `WARNING` on every config load — flooding logs with identical messages dozens of times during normal gateway operation.

The caller in `gateway/platform_registry.py` (`create_adapter()`, lines 221–227) already emits its own warning with the registered `install_hint` when `check_fn` returns `False` and an adapter is actually requested — so the warnings inside the probe were redundant.

## Root cause

`check_mattermost_requirements()` contained two `logger.warning()` calls (lines 61 and 67) that fired on every invocation when `MATTERMOST_URL` was unset or `aiohttp` was missing. A platform plugin's `check_fn` is contractually a passive predicate — return `True`/`False`, no side effects. This convention is documented in `plugins/platforms/teams/adapter.py` and was recently enforced for the raft adapter in #49240.

## Changes

- **`plugins/platforms/mattermost/adapter.py`** (lines 53–68): Removed `logger.warning()` and `logger.debug()` calls from `check_mattermost_requirements()`. Added a docstring documenting the silence contract (matching the raft adapter's docstring).
- **`tests/plugins/test_mattermost_check_fn_silent.py`** (new): 7 regression tests covering return values (True when all deps present, False when token/URL/aiohttp missing) and the silence contract (no WARNING logs emitted in any failure case).

## Validation

```bash
uv run --frozen python -m pytest tests/plugins/test_mattermost_check_fn_silent.py -x -q
# 7 passed
```

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Searched for existing PRs — no duplicate found
- [x] PR contains only changes related to this fix
- [x] Added regression tests
- [x] Considered cross-platform impact — N/A (env var check, no platform-specific code)