### PR TITLE
fix(dingtalk): use markdown msgtype for webhook send (#49409)

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1628,7 +1628,7 @@ async def _send_dingtalk(extra, chat_id, message):
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(
                 webhook_url,
-                json={"msgtype": "text", "text": {"content": message}},
+                json={"msgtype": "markdown", "markdown": {"title": "Hermes", "text": message}},
             )
             resp.raise_for_status()
             data = resp.json()


### PR DESCRIPTION
Fixes #49409. DingTalk webhook delivery path sent messages with msgtype text, which meant all messages delivered through this path (cron notifications, cross-platform forwards, etc.) did not get Markdown rendered. Changed to msgtype markdown which DingTalk robot webhook API fully supports.