### PR TITLE
fix(plugins/langfuse): langfuse absent from hermes tools and tracing never reaches langfuse

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -79,6 +79,7 @@ CONFIGURABLE_TOOLSETS = [
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
     ("computer_use",     "🖱️  Computer Use (macOS)",     "background desktop control via cua-driver"),
+    ("langfuse",         "📊 Langfuse Observability",   "LLM call tracing & observability"),
 ]
 
 
@@ -111,7 +112,7 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "langfuse"}
 
 
 def _xai_credentials_present() -> bool:

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -779,22 +779,21 @@ def on_pre_llm_call(*, task_id: str = "", session_id: str = "", platform: str = 
                     api_call_count: int = 0, messages: Any = None, turn_type: str = "user",
                     conversation_history: Any = None, user_message: Any = None,
                     turn_id: str = "", api_request_id: str = "", **_: Any) -> None:
-    # Older Hermes branches used pre_llm_call for request-scoped tracing and
-    # passed the actual API messages. Current Hermes also has a turn-scoped
-    # pre_llm_call used for context injection; tracing that hook creates an
-    # extra orphan/root trace before the real request trace. Only trace the
-    # legacy request-shaped call here.
-    if not isinstance(messages, list):
-        return
-
     client = _get_langfuse()
     if client is None:
         return
 
-    # messages is a list only for legacy Hermes branches that fired
-    # pre_llm_call with API messages directly. Current Hermes fires
-    # pre_llm_call for context injection (conversation_history/user_message,
-    # no messages list) — tracing that would create orphan traces.
+    # Normalize the various message-argument shapes into the standard list.
+    # Current Hermes fires pre_llm_call for turn-scoped context injection and
+    # passes conversation_history / user_message (no raw messages list). Older
+    # Hermes branches passed the actual API messages directly. The helper
+    # handles both shapes — see _coerce_request_messages.
+    input_messages = _coerce_request_messages(
+        messages=messages,
+        conversation_history=conversation_history,
+        user_message=user_message,
+    )
+
     task_key = _trace_key(
         task_id,
         session_id,
@@ -813,7 +812,7 @@ def on_pre_llm_call(*, task_id: str = "", session_id: str = "", platform: str = 
                 provider=provider,
                 model=model,
                 api_mode=api_mode,
-                messages=messages,
+                messages=input_messages,
                 client=client,
                 turn_id=turn_id,
                 api_request_id=api_request_id,
@@ -928,7 +927,23 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
     with _STATE_LOCK:
         state = _TRACE_STATE.get(task_key)
         generation = state.generations.pop(req_key, None) if state else None
-    if state is None or generation is None:
+    if state is None:
+        return
+
+    # Turn-scoped post_llm_call (from turn_finalizer): the pre_llm_call
+    # created the root trace but no api_request-scoped generation exists.
+    # Finish the root trace directly.
+    if generation is None:
+        if assistant_response is not None:
+            output = {"content": _safe_value(assistant_response), "reasoning": None, "tool_calls": []}
+        elif assistant_message is not None:
+            output = _serialize_assistant_message(assistant_message)
+        else:
+            output = {}
+        has_tools = _assistant_has_tool_calls(assistant_message) if assistant_message else False
+        has_content = bool(output.get("content"))
+        if not has_tools and has_content:
+            _finish_trace(task_key, output=output)
         return
 
     # Handle both call patterns:


### PR DESCRIPTION
…

Two independent bugs made the langfuse observability plugin inert:

1. Appearance. The plugin uses hooks-only registration (no ctx.register_tool()), so it was absent from the "hermes tools" TUI checklist. The config dialog existed but was unreachable. Fixed by adding a static entry to CONFIGURABLE_TOOLSETS and listing langfuse in _DEFAULT_OFF_TOOLSETS.

2. Tracing. on_pre_llm_call had a guard: `if not isinstance(messages, list): return`. The agent core invokes pre_llm_call with conversation_history/user_message kwargs (not a messages list), so messages defaulted to None, the guard fired, and no root trace was ever started. pre_api_request/post_api_request were expected to handle real LLM tracing but are never invoked anywhere in the agent core.

   Fix: replace the isinstance guard with _coerce_request_messages() (the existing helper that normalizes the various message-argument shapes), and add a turn-scoped fallback in on_post_llm_call so the root trace gets finished with assistant_response when no api_request-scoped generation exists.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #42033

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `hermes tools`
2. Any subsequent option
3. LangFuse options now appear
4. LangFuse configuration dialogs also accessible through `Reconfigure an existing tool's provider or API key`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04 (W10 WSL2)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
