### PR TITLE
feat: add official TickTick support (MCP catalog entry and skill)

### DIFF
--- a/optional-mcps/ticktick/manifest.yaml
+++ b/optional-mcps/ticktick/manifest.yaml
@@ -1,0 +1,40 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: ticktick
+description: Find, create, and update TickTick tasks, projects, and habits.
+source: https://help.ticktick.com/articles/7438129581631995904
+
+# TickTick ships a remote MCP server with native OAuth 2.1 (authorization
+# code + PKCE, code_challenge_method S256) and Dynamic Client Registration
+# over Streamable HTTP. Hermes's MCP client + mcp_oauth_manager handle
+# discovery, dynamic registration, PKCE, and token exchange, so there is
+# nothing to install locally. The endpoint is the bare host (POST /), which
+# answers an unauthenticated probe with a 401 + WWW-Authenticate Bearer
+# challenge pointing at its protected-resource metadata.
+transport:
+  type: http
+  url: https://mcp.ticktick.com
+
+auth:
+  type: oauth
+  # No `provider:` here. This is native MCP OAuth (case 1), not a third-party
+  # provider like Google, so the MCP client triggers the browser flow on the
+  # first probe / first connect. TickTick also accepts a Bearer token from
+  # Settings > Account > API Token. Set it on the server entry by hand if you
+  # would rather skip the browser flow.
+
+# Tool selection at install time:
+# TickTick's MCP server exposes a task-management surface (find/get/list plus
+# create/update across tasks, projects, and habits). We leave `default_enabled`
+# unset, like the linear entry, so the install-time checklist starts with
+# everything pre-checked and users prune what they don't want.
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with
+  TickTick. After auth, restart your Hermes session so the TickTick tools
+  are loaded.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure ticktick

--- a/optional-mcps/ticktick/manifest.yaml
+++ b/optional-mcps/ticktick/manifest.yaml
@@ -1,0 +1,36 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: ticktick
+description: Find, create, and update TickTick tasks, projects, and habits.
+source: https://help.ticktick.com/articles/7438129581631995904
+
+# TickTick hosts this MCP. Auth is OAuth 2.1 with PKCE and dynamic client
+# registration. Hermes opens a browser on first connect. You can skip the
+# browser and paste a Bearer token from Settings > Account > API Token.
+transport:
+  type: http
+  url: https://mcp.ticktick.com
+
+auth:
+  type: oauth
+  # No provider. This is TickTick's own login, not Google or similar.
+
+# Leave default_enabled unset so install starts with every tool on.
+# If search and fetch show up, uncheck them. They are the generic OpenAI
+# connector pair. Use search_task and get_task_by_id instead.
+
+# Desktop composer pills.
+suggest:
+  keywords:
+    - ticktick
+  hosts:
+    - ticktick.com
+
+post_install: |
+  On first connect, Hermes opens a browser so you can sign in to TickTick.
+  After that, start a new Hermes session so the tools load.
+
+  You can change which tools are on any time with:
+    hermes mcp configure ticktick

--- a/optional-skills/productivity/ticktick/SKILL.md
+++ b/optional-skills/productivity/ticktick/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: ticktick
+description: Create and manage TickTick tasks, projects, and habits.
+version: 1.0.0
+author: Adolanium
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [TickTick, Tasks, Projects, Habits, Focus, MCP, Productivity]
+    homepage: https://ticktick.com
+required_environment_variables:
+  - name: TICKTICK_API_TOKEN
+    prompt: TickTick API token (Settings > Account > API Token)
+    help: "Optional. Only for the headless or gateway Bearer path. Skip it if you use the browser OAuth flow."
+    required_for: headless Bearer authentication
+    optional: true
+---
+
+# TickTick Skill
+
+Use the official TickTick MCP server to capture, organize, and complete tasks. It can also manage projects, habits, focus records, tags, kanban columns, and comments, but it does not call the TickTick API directly. The skill expects the `ticktick` MCP from the Nous catalog to be installed and enabled.
+
+## When to Use
+
+Load this when the request is to read or change TickTick data: adding or completing tasks, planning a day from undone items, checking in a habit, logging a focus session, or reorganizing lists, tags, and boards. If the `ticktick` MCP is not installed yet, do Prerequisites first.
+
+## Prerequisites
+
+The capability comes from the official TickTick MCP server (`https://mcp.ticktick.com`, Streamable HTTP). Install the catalog entry, then authenticate one of two ways.
+
+1. Install:
+
+   ```
+   hermes mcp install ticktick
+   ```
+
+2. Authenticate. Pick the path that fits the session:
+
+   - Interactive (desktop or CLI): the default. On first connect Hermes opens a browser for TickTick OAuth (PKCE, dynamic client registration). Nothing else to set.
+   - Headless or gateway (Telegram, Discord, a server box): the browser flow needs a screen, so use a Bearer token. In the TickTick web app, open the avatar menu, then Settings > Account > API Token and create a token. Save it in the Hermes environment file:
+
+     ```
+     # ~/.hermes/.env
+     TICKTICK_API_TOKEN=tp_your_token_here
+     ```
+
+     The catalog installer adds `auth: oauth` to the TickTick server entry. Remove that line before adding the `headers` block. The finished entry should look like this:
+
+     ```yaml
+     # ~/.hermes/config.yaml, under mcp_servers:
+     mcp_servers:
+       ticktick:
+         url: https://mcp.ticktick.com
+         headers:
+           Authorization: "Bearer ${TICKTICK_API_TOKEN}"
+     ```
+
+     Do not keep `auth: oauth` alongside the Authorization header. Paste the raw token into `.env`. Hermes strips a leading `Bearer ` if you include one.
+
+3. Start a new Hermes session so the tools load. Re-run the tool checklist any time with `hermes mcp configure ticktick`.
+
+Each user brings their own account and token. Nothing here is tied to a specific account. Discover lists, tasks, and habits at runtime with the read tools below.
+
+## How to Run
+
+Once enabled, the server exposes its tools directly (47 tools as of server version 1.27.1). Call them by name. The authoritative argument schema for each tool is the definition the server advertises, so read the tool's own schema for exact field names. Most read-by-id and write operations key off two IDs: a `projectId` (a list) and a `taskId`. Resolve IDs first with a list, search, or filter tool, then act.
+
+## Quick Reference
+
+| Domain | Tools |
+|--------|-------|
+| Projects (lists) | `list_projects`, `get_project_by_id`, `get_project_with_undone_tasks`, `create_project`, `update_project` |
+| Project groups | `list_project_groups`, `create_project_group`, `update_project_group`, `delete_project_group` |
+| Tasks (read) | `get_task_by_id`, `get_task_in_project`, `search`, `search_task`, `fetch`, `filter_tasks`, `list_undone_tasks_by_date`, `list_undone_tasks_by_time_query`, `list_completed_tasks_by_date` |
+| Tasks (write) | `create_task`, `update_task`, `complete_task`, `delete_task`, `move_task`, `complete_tasks_in_project`, `batch_add_tasks`, `batch_update_tasks` |
+| Kanban columns | `list_columns`, `create_column`, `update_column` |
+| Comments | `get_comment`, `add_comment`, `delete_comment` |
+| Habits | `list_habits`, `list_habit_sections`, `get_habit`, `create_habit`, `update_habit`, `get_habit_checkins`, `upsert_habit_checkins` |
+| Focus (pomodoro) | `create_focus`, `get_focus`, `get_focuses_by_time`, `delete_focus` |
+| Tags | `list_tags`, `create_tag` |
+| Other | `list_countdowns`, `get_user_preference` |
+
+## Procedure
+
+1. Capture a task: `list_projects` to choose the list (or let it fall to the default Inbox), then `create_task` with the title plus any content, due date, or priority. For several at once, `batch_add_tasks`.
+2. Plan today: `list_undone_tasks_by_time_query` with `today` (or `list_undone_tasks_by_date` over a window of 14 days or fewer), review, then `update_task` to reschedule or `complete_task` to close items.
+3. Complete work: get the task's `projectId` and `taskId` from a list or search result, then `complete_task`. To clear several in one list, `complete_tasks_in_project` (20 tasks per call at most).
+4. Search and read: `search` or `search_task` by keyword to get IDs, then `fetch` or `get_task_by_id` for the full task.
+5. Reorganize: use `move_task` to shift tasks between lists. Use `create_project` and `create_project_group` to restructure, or `create_tag` with `update_task` to tag.
+6. Habits: run `list_habits`, then use `upsert_habit_checkins` to record a check-in. Use `get_habit_checkins` to review a date-stamp range.
+7. Focus log: call `create_focus` with `startTime`, `endTime`, and a `type`. Read the tool schema for the exact enum. Type 0 is pomodoro. Use `get_focuses_by_time` to review a bounded range.
+
+## Pitfalls
+
+- Most task operations need BOTH `projectId` and `taskId`. Get them from `list_projects`, `search`, or `filter_tasks` first. Never guess an ID.
+- "Project" in the API is the user-facing "list". A task created with no list lands in the default Inbox.
+- `list_undone_tasks_by_date` spans at most 14 days, and `get_focuses_by_time` is also range-bounded. Narrow or page the window.
+- `complete_tasks_in_project` caps at 20 tasks per call. `batch_add_tasks` and `batch_update_tasks` take arrays, so split large jobs into chunks.
+- `add_comment` content is plain text, capped at 1024 characters.
+- Writes hit the live account at once: `complete_task`, `delete_task`, `move_task`, and the batch and delete calls are real mutations. Confirm destructive actions with the user before sending them.
+- Keep the token in `~/.hermes/.env` and reference it from `config.yaml` as `${TICKTICK_API_TOKEN}`. Do not paste the raw token into `config.yaml`.
+- The server also advertises MCP prompts and resources, not just tools, for clients that want them.
+
+## Verification
+
+Ask Hermes to list your TickTick projects. That runs `list_projects` and returns your lists for the connected account. A JSON array of projects confirms the MCP is installed, authenticated, and reachable. A `401` means you should redo the OAuth flow or fix `TICKTICK_API_TOKEN`. Missing tools mean you need a fresh Hermes session after install.

--- a/optional-skills/productivity/ticktick/SKILL.md
+++ b/optional-skills/productivity/ticktick/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: ticktick
+description: Create and manage TickTick tasks, projects, and habits.
+version: 1.0.0
+author: Adolanium
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [TickTick, Tasks, Projects, Habits, Focus, MCP, Productivity]
+    homepage: https://ticktick.com
+required_environment_variables:
+  - name: TICKTICK_API_TOKEN
+    prompt: TickTick API token (Settings > Account > API Token)
+    help: "Optional. Only for headless or gateway login. Skip this if you sign in with the browser."
+    required_for: headless Bearer authentication
+    optional: true
+---
+
+# TickTick Skill
+
+Use the official TickTick MCP server to capture, organize, and complete tasks. It can also manage projects, habits, focus records, tags, kanban columns, and comments, but it does not call the TickTick API directly. The skill expects the `ticktick` MCP from the Nous catalog to be installed and enabled.
+
+## When to Use
+
+Load this when the request is to read or change TickTick data: adding or completing tasks, planning a day from undone items, checking in a habit, logging a focus session, or reorganizing lists, tags, and boards. If the `ticktick` MCP is not installed yet, do Prerequisites first.
+
+## Prerequisites
+
+The capability comes from the official TickTick MCP server (`https://mcp.ticktick.com`, Streamable HTTP). Install the catalog entry, then authenticate one of two ways.
+
+1. Install:
+
+   ```
+   hermes mcp install ticktick
+   ```
+
+2. Authenticate. Pick the path that fits the session:
+
+   - Interactive (desktop or CLI): the default. On first connect Hermes opens a browser for TickTick OAuth (PKCE, dynamic client registration). Nothing else to set.
+   - Headless or gateway (Telegram, Discord, a server box): the browser flow needs a screen, so use a Bearer token. In the TickTick web app, open the avatar menu, then Settings > Account > API Token and create a token. Save it in the Hermes environment file:
+
+     ```
+     # ${HERMES_HOME:-~/.hermes}/.env
+     TICKTICK_API_TOKEN=tp_your_token_here
+     ```
+
+     The catalog installer adds `auth: oauth` to the TickTick server entry. Remove that line before adding the `headers` block. The finished entry should look like this:
+
+     ```yaml
+     # ${HERMES_HOME:-~/.hermes}/config.yaml, under mcp_servers:
+     mcp_servers:
+       ticktick:
+         url: https://mcp.ticktick.com
+         headers:
+           Authorization: "Bearer ${TICKTICK_API_TOKEN}"
+     ```
+
+     Do not keep `auth: oauth` alongside the Authorization header. Paste the raw token into `.env`. Hermes strips a leading `Bearer ` if you include one.
+
+3. Start a new Hermes session so the tools load. Re-run the tool checklist any time with `hermes mcp configure ticktick`.
+
+Each user brings their own account and token. Nothing here is tied to a specific account. Discover lists, tasks, and habits at runtime with the read tools below.
+
+## How to Run
+
+Once enabled, the server exposes its tools directly (47 tools as of server version 1.27.1). Call them by name. Read each tool's own schema for field names. Most reads and writes need two IDs: a `projectId` (a list) and a `taskId`. Get those IDs first with a list, `search_task`, or `filter_tasks`, then act.
+
+## Quick Reference
+
+| Domain | Tools |
+|--------|-------|
+| Projects (lists) | `list_projects`, `get_project_by_id`, `get_project_with_undone_tasks`, `create_project`, `update_project` |
+| Project groups | `list_project_groups`, `create_project_group`, `update_project_group`, `delete_project_group` |
+| Tasks (read) | `get_task_by_id`, `get_task_in_project`, `search_task`, `filter_tasks`, `list_undone_tasks_by_date`, `list_undone_tasks_by_time_query`, `list_completed_tasks_by_date` |
+| Tasks (write) | `create_task`, `update_task`, `complete_task`, `delete_task`, `move_task`, `complete_tasks_in_project`, `batch_add_tasks`, `batch_update_tasks` |
+| Kanban columns | `list_columns`, `create_column`, `update_column` |
+| Comments | `get_comment`, `add_comment`, `delete_comment` |
+| Habits | `list_habits`, `list_habit_sections`, `get_habit`, `create_habit`, `update_habit`, `get_habit_checkins`, `upsert_habit_checkins` |
+| Focus (pomodoro) | `create_focus`, `get_focus`, `get_focuses_by_time`, `delete_focus` |
+| Tags | `list_tags`, `create_tag` |
+| Other | `list_countdowns`, `get_user_preference` |
+
+## Procedure
+
+1. Capture a task: `list_projects` to choose the list (or let it fall to the default Inbox), then `create_task` with the title plus any content, due date, or priority. For several at once, `batch_add_tasks`.
+2. Plan today: `list_undone_tasks_by_time_query` with `today` (or `list_undone_tasks_by_date` over a window of 14 days or fewer), review, then `update_task` to reschedule or `complete_task` to close items.
+3. Complete work: get the task's `projectId` and `taskId` from a list or search result, then `complete_task`. To clear several in one list, `complete_tasks_in_project` (20 tasks per call at most).
+4. Search and read: `search_task` by keyword to get IDs, then `get_task_by_id` for the full task. Skip `search` and `fetch`.
+5. Reorganize: use `move_task` to shift tasks between lists. Use `create_project` and `create_project_group` to restructure, or `create_tag` with `update_task` to tag.
+6. Habits: run `list_habits`, then use `upsert_habit_checkins` to record a check-in. Use `get_habit_checkins` to review a date-stamp range.
+7. Focus log: call `create_focus` with `startTime`, `endTime`, and a `type`. Read the tool schema for the exact enum. Type 0 is pomodoro. Use `get_focuses_by_time` to review a bounded range.
+
+## Pitfalls
+
+- Most task operations need BOTH `projectId` and `taskId`. Get them from `list_projects`, `search_task`, or `filter_tasks` first. Never guess an ID.
+- Skip `search` and `fetch`. Those are the generic OpenAI connector tools. Use `search_task` to find tasks and `get_task_by_id` to read one.
+- "Project" in the API is the user-facing "list". A task created with no list lands in the default Inbox.
+- `list_undone_tasks_by_date` spans at most 14 days, and `get_focuses_by_time` is also range-bounded. Narrow or page the window.
+- `complete_tasks_in_project` caps at 20 tasks per call. `batch_add_tasks` and `batch_update_tasks` take arrays, so split large jobs into chunks.
+- `add_comment` content is plain text, capped at 1024 characters.
+- Writes hit the live account at once: `complete_task`, `delete_task`, `move_task`, and the batch and delete calls are real mutations. Confirm destructive actions with the user before sending them.
+- Keep the token in `${HERMES_HOME:-~/.hermes}/.env` and reference it from `config.yaml` as `${TICKTICK_API_TOKEN}`. Do not paste the raw token into `config.yaml`.
+- The server also advertises MCP prompts and resources, not just tools, for clients that want them.
+
+## Verification
+
+Ask Hermes to list your TickTick projects. That runs `list_projects` and returns your lists for the connected account. A JSON array of projects confirms the MCP is installed, authenticated, and reachable. A `401` means you should redo the OAuth flow or fix `TICKTICK_API_TOKEN`. Missing tools mean you need a fresh Hermes session after install.

--- a/tests/skills/test_ticktick_skill.py
+++ b/tests/skills/test_ticktick_skill.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tools.skills_tool import (
+    _get_required_environment_variables,
+    _parse_frontmatter,
+)
+
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "productivity"
+    / "ticktick"
+    / "SKILL.md"
+)
+
+
+def _load_skill() -> tuple[dict, str]:
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    return _parse_frontmatter(content)
+
+
+def test_ticktick_token_is_optional() -> None:
+    frontmatter, _ = _load_skill()
+
+    variables = _get_required_environment_variables(frontmatter)
+
+    assert variables == [
+        {
+            "name": "TICKTICK_API_TOKEN",
+            "prompt": "TickTick API token (Settings > Account > API Token)",
+            "help": (
+                "Optional. Only for the headless or gateway Bearer path. "
+                "Skip it if you use the browser OAuth flow."
+            ),
+            "required_for": "headless Bearer authentication",
+            "optional": True,
+        }
+    ]
+
+
+def test_ticktick_skill_uses_modern_structure() -> None:
+    _, body = _load_skill()
+    headings = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+
+    assert body.lstrip().startswith("# TickTick Skill\n")
+    assert all(heading in body for heading in headings)
+    assert [body.index(heading) for heading in headings] == sorted(
+        body.index(heading) for heading in headings
+    )
+
+    introduction = body.split("## When to Use", 1)[0]
+    introduction = introduction.split("# TickTick Skill", 1)[1].strip()
+    sentences = re.findall(r"[^.!?]+[.!?]", introduction)
+    assert 2 <= len(sentences) <= 3
+
+
+def test_headless_setup_removes_oauth_marker() -> None:
+    _, body = _load_skill()
+
+    assert "Remove that line before adding the `headers` block" in body
+    assert "Do not keep `auth: oauth` alongside the Authorization header" in body
+    assert 'Authorization: "Bearer ${TICKTICK_API_TOKEN}"' in body

--- a/tests/skills/test_ticktick_skill.py
+++ b/tests/skills/test_ticktick_skill.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tools.skills_tool import (
+    _get_required_environment_variables,
+    _parse_frontmatter,
+)
+
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "productivity"
+    / "ticktick"
+    / "SKILL.md"
+)
+
+
+def _load_skill() -> tuple[dict, str]:
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    return _parse_frontmatter(content)
+
+
+def test_ticktick_token_is_optional() -> None:
+    frontmatter, _ = _load_skill()
+
+    variables = _get_required_environment_variables(frontmatter)
+
+    assert len(variables) == 1
+    token = variables[0]
+    assert token["name"] == "TICKTICK_API_TOKEN"
+    assert token.get("optional") is True
+
+
+def test_ticktick_skill_uses_modern_structure() -> None:
+    _, body = _load_skill()
+    headings = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+
+    assert body.lstrip().startswith("# TickTick Skill\n")
+    assert all(heading in body for heading in headings)
+    assert [body.index(heading) for heading in headings] == sorted(
+        body.index(heading) for heading in headings
+    )
+
+    introduction = body.split("## When to Use", 1)[0]
+    introduction = introduction.split("# TickTick Skill", 1)[1].strip()
+    sentences = re.findall(r"[^.!?]+[.!?]", introduction)
+    assert 2 <= len(sentences) <= 3
+
+
+def test_headless_setup_removes_oauth_marker() -> None:
+    _, body = _load_skill()
+
+    assert "Remove that line before adding the `headers` block" in body
+    assert "Do not keep `auth: oauth` alongside the Authorization header" in body
+    assert 'Authorization: "Bearer ${TICKTICK_API_TOKEN}"' in body
+
+
+def test_headless_paths_use_hermes_home() -> None:
+    _, body = _load_skill()
+
+    assert "${HERMES_HOME:-~/.hermes}/.env" in body
+    assert "${HERMES_HOME:-~/.hermes}/config.yaml" in body
+    assert "# ~/.hermes/.env" not in body
+    assert "# ~/.hermes/config.yaml" not in body
+
+
+def test_prefers_search_task_over_generic_search_fetch() -> None:
+    _, body = _load_skill()
+
+    assert "`search_task`" in body
+    assert "Skip `search` and `fetch`" in body


### PR DESCRIPTION
## What does this PR do?

Adds official TickTick support in two cohesive pieces:

1. `optional-mcps/ticktick/manifest.yaml`: a Nous-approved optional MCP catalog entry for TickTick's remote MCP server, installable with `hermes mcp install ticktick` (or via `hermes mcp picker`), modeled on the existing `linear` entry.
2. `optional-skills/productivity/ticktick/SKILL.md`: a companion optional skill that documents end-to-end use of that MCP (install, both auth paths, the full tool surface, common workflows, pitfalls, and a verification step).

TickTick ships an official remote MCP server, so the manifest follows the closest existing remote entry, `linear`: Streamable HTTP transport, native MCP OAuth (no third-party provider), and `tools.default_enabled` left unset so the install-time checklist starts with every tool pre-checked.

Every connector field is backed by a live check against the server and TickTick's docs (https://help.ticktick.com/articles/7438129581631995904):

- Endpoint `https://mcp.ticktick.com` (the bare host is the MCP endpoint). An unauthenticated `POST /` returns `401` with `www-authenticate: Bearer ... resource_metadata="https://mcp.ticktick.com/.well-known/oauth-protected-resource"`, the standard MCP OAuth challenge.
- Transport is Streamable HTTP, so `transport.type: http`.
- Auth is native OAuth 2.1. The server's `/.well-known/oauth-authorization-server` advertises `grant_types_supported: [authorization_code]`, `code_challenge_methods_supported: [plain, S256]` (PKCE), and Dynamic Client Registration (`registration_endpoint` plus `client_registration_types_supported: [dynamic]`). That is case 1 (native MCP OAuth) in the catalog's auth model, so the manifest sets `auth.type: oauth` with no `provider:`, and `tools/mcp_oauth_manager.py` handles discovery, registration, PKCE and token exchange on first connect.

The skill covers both ways to authenticate. Interactive sessions use the browser OAuth flow the catalog wires. Headless and gateway sessions (Telegram, Discord, a server box) cannot pop a browser, so the skill documents the documented Bearer-token path: a token from `Settings > Account > API Token` stored as `TICKTICK_API_TOKEN` in `~/.hermes/.env` and referenced from an `Authorization: Bearer ${TICKTICK_API_TOKEN}` header on the `mcp_servers.ticktick` entry (Hermes already supports header templates with env interpolation, see `hermes_cli/mcp_config.py`). Nothing in the skill is tied to a specific account: it lists the read tools (for example `list_projects`) used to discover each user's own lists, tasks and habits at runtime.

Both pieces ship disabled and inert until a user explicitly installs them, so nothing changes for existing users. No code, no config schema keys, no dependencies.

## Related Issue

No open issue requests this. Issue #13577 is a gateway routing bug ("Skill not found" for a hub-installed TickTick skill in a Telegram session), not a request to add a catalog entry or an in-tree skill, so it is unrelated. There is no existing TickTick catalog entry or in-tree skill, so this is not a duplicate. Not filing a `Fixes #`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-mcps/ticktick/manifest.yaml`: new catalog entry. `manifest_version: 1`, `name: ticktick`, HTTP transport to `https://mcp.ticktick.com`, `auth.type: oauth` (native OAuth, no `provider:`), `tools.default_enabled` left unset (all probed tools pre-checked at install), and a `post_install` note about the first-connect browser flow. Field-for-field parallel to `optional-mcps/linear/manifest.yaml`.
- `optional-skills/productivity/ticktick/SKILL.md`: new optional skill (description 55 chars, `platforms: [linux, macos, windows]`, `required_environment_variables: [TICKTICK_API_TOKEN]` marked optional for the headless path). Modern section order (When to Use, Prerequisites, How It Works, Quick Reference, Procedure, Pitfalls, Verification). The Quick Reference groups the server's 47 tools by domain; the Procedure and Pitfalls capture the real constraints (most task ops need both `projectId` and `taskId`, `complete_tasks_in_project` caps at 20, `list_undone_tasks_by_date` spans at most 14 days, `add_comment` is 1024 chars).

## How to Test

Run on Windows 11 (git-bash for `curl`, repo root for the Python checks).

1. Confirm the endpoint, transport and auth against the live server:

   ```
   curl -s -D - -o /dev/null -X POST https://mcp.ticktick.com \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
   ```

   returns `HTTP/1.1 401 Unauthorized` with `www-authenticate: Bearer ... resource_metadata=".../.well-known/oauth-protected-resource"`.

   ```
   curl -s https://mcp.ticktick.com/.well-known/oauth-authorization-server
   ```

   returns JSON advertising `authorization_code`, PKCE `S256`, and the dynamic `registration_endpoint` (full body under Logs below).

2. Authenticated capability probe (capabilities only, no account data read): an MCP `initialize` + `tools/list` with a Bearer token returns HTTP 200, `serverInfo` `{"name":"TickTick MCP Server","version":"1.27.1"}`, protocol `2025-06-18`, and 47 tools whose names match the skill's Quick Reference. An invalid Bearer token returns `401`. No task or project contents were fetched.

3. The catalog loader discovers the entry with no diagnostics:

   ```
   python -c "from hermes_cli.mcp_catalog import list_catalog, get_entry, catalog_diagnostics; print([e.name for e in list_catalog()]); print(catalog_diagnostics()); e=get_entry('ticktick'); print(e.transport.type, e.transport.url, e.auth.type)"
   ```

   prints `['linear', 'n8n', 'ticktick', 'unreal-engine']`, then `[]`, then `http https://mcp.ticktick.com oauth`.

4. The catalog test suite passes with the entry present:

   ```
   scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q
   ```

   I ran it in an isolated environment (no project venv on this checkout): `uv run --no-project --python 3.11 --with pytest --with pyyaml python -m pytest tests/hermes_cli/test_mcp_catalog.py -q` -> `35 passed`.

5. The skill parses through the repo's own skill loader (`skill_utils.py`): `parse_frontmatter` reads it, `extract_skill_description` returns the 55-char description, `skill_matches_platform` is true, and `_get_required_environment_variables` (in `skills_tool.py`) surfaces `TICKTICK_API_TOKEN` (same shape as the neighbor `siyuan` skill). All modern sections are present.

Not covered: completing the OAuth browser sign-in needs a TickTick account and an interactive session, so I verified the server's OAuth advertisement, the authenticated tool surface, and the catalog and skill wiring rather than a live browser token exchange.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(mcp-catalog):` for the entry, `feat(skills):` for the skill)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no TickTick catalog entry, in-tree skill, or PR exists)
- [x] My PR contains **only** changes related to this feature (two new files: the manifest and the skill)
- [ ] I've run `pytest tests/ -q` and all tests pass (data and docs only; ran the MCP catalog suite, `35 passed`, and exercised the skill through the repo loaders)
- [ ] I've added tests for my changes (the generic `test_all_shipped_manifests_parse` contract test already covers the manifest; the skill ships prose only, like `siyuan`/`shopify`, which carry no per-skill test)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) (or N/A: the skill is the documentation for the connector; catalog entries and skills are discovered by directory iteration)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys (or N/A: no new config schema; the manifest is consumed at install time and the skill reads `TICKTICK_API_TOKEN` from `.env`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows (or N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (or N/A: YAML data plus a Markdown skill, no platform code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior (or N/A)

## Screenshots / Logs

OAuth challenge on the bare endpoint (`POST /`):

```
HTTP/1.1 401 Unauthorized
content-type: application/json
www-authenticate: Bearer error="invalid_token", error_description="Authentication required", resource_metadata="https://mcp.ticktick.com/.well-known/oauth-protected-resource"
```

Authorization-server metadata (`GET /.well-known/oauth-authorization-server`):

```
{
  "issuer": "https://ticktick.com",
  "authorization_endpoint": "https://ticktick.com/oauth/authorize",
  "token_endpoint": "https://api.ticktick.com/oauth/token",
  "registration_endpoint": "https://api.ticktick.com/oauth/register",
  "client_registration_types_supported": ["dynamic"],
  "response_types_supported": ["code"],
  "grant_types_supported": ["authorization_code"],
  "token_endpoint_auth_methods_supported": ["none", "client_secret_basic"],
  "code_challenge_methods_supported": ["plain", "S256"]
}
```

Catalog discovery and tests:

```
$ python -c "from hermes_cli.mcp_catalog import list_catalog, catalog_diagnostics; print([e.name for e in list_catalog()]); print(catalog_diagnostics())"
['linear', 'n8n', 'ticktick', 'unreal-engine']
[]

$ uv run --no-project --python 3.11 --with pytest --with pyyaml python -m pytest tests/hermes_cli/test_mcp_catalog.py -q
35 passed in 3.74s
```
