### PR TITLE
fix(gateway): detect profile tokens via secret scope for multiplexer (#49415)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -19,6 +19,24 @@ from enum import Enum
 from hermes_cli.config import get_hermes_home
 from utils import is_truthy_value
 
+
+def _get_env(name: str, default: str = "") -> str:
+    """Read an env var, falling back to the active secret scope.
+
+    When the gateway multiplexer is active, profile secrets live in a
+    ``secret_scope`` contextvar rather than ``os.environ``.  This helper
+    bridges the two so that ``load_gateway_config()`` can find tokens
+    for secondary profiles.
+    """
+    try:
+        from agent.secret_scope import get_secret
+        val = get_secret(name)
+        if val is not None:
+            return val
+    except ImportError:
+        pass
+    return os.getenv(name, default)
+
 logger = logging.getLogger(__name__)
 
 
@@ -1397,7 +1415,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         return platform_config
     
     # Telegram
-    telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
+    telegram_token = _get_env("TELEGRAM_BOT_TOKEN")
     if telegram_token:
         telegram_config = _enable_from_env(Platform.TELEGRAM)
         telegram_config.token = telegram_token
@@ -1427,7 +1445,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
     
     # Discord
-    discord_token = os.getenv("DISCORD_BOT_TOKEN")
+    discord_token = _get_env("DISCORD_BOT_TOKEN")
     if discord_token:
         discord_config = _enable_from_env(Platform.DISCORD)
         discord_config.token = discord_token
@@ -1475,7 +1493,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # outbound, public webhook inbound. Both adapters can run in parallel
     # against different phone numbers.
     whatsapp_cloud_phone_id = os.getenv("WHATSAPP_CLOUD_PHONE_NUMBER_ID")
-    whatsapp_cloud_token = os.getenv("WHATSAPP_CLOUD_ACCESS_TOKEN")
+    whatsapp_cloud_token = _get_env("WHATSAPP_CLOUD_ACCESS_TOKEN")
     if whatsapp_cloud_phone_id and whatsapp_cloud_token:
         if Platform.WHATSAPP_CLOUD not in config.platforms:
             config.platforms[Platform.WHATSAPP_CLOUD] = PlatformConfig()
@@ -1526,7 +1544,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # Slack
-    slack_token = os.getenv("SLACK_BOT_TOKEN")
+    slack_token = _get_env("SLACK_BOT_TOKEN")
     if slack_token:
         if Platform.SLACK not in config.platforms:
             # No yaml config for Slack — env-only setup, enable it
@@ -1573,7 +1591,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # Mattermost
-    mattermost_token = os.getenv("MATTERMOST_TOKEN")
+    mattermost_token = _get_env("MATTERMOST_TOKEN")
     if mattermost_token:
         mattermost_url = os.getenv("MATTERMOST_URL", "")
         if not mattermost_url:
@@ -1591,7 +1609,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # Matrix
-    matrix_token = os.getenv("MATRIX_ACCESS_TOKEN")
+    matrix_token = _get_env("MATRIX_ACCESS_TOKEN")
     matrix_homeserver = os.getenv("MATRIX_HOMESERVER", "")
     if matrix_token or os.getenv("MATRIX_PASSWORD"):
         if not matrix_homeserver:
@@ -1627,7 +1645,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # Home Assistant
-    hass_token = os.getenv("HASS_TOKEN")
+    hass_token = _get_env("HASS_TOKEN")
     if hass_token:
         if Platform.HOMEASSISTANT not in config.platforms:
             config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
@@ -1796,8 +1814,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             )
 
     # Feishu / Lark
-    feishu_app_id = os.getenv("FEISHU_APP_ID")
-    feishu_app_secret = os.getenv("FEISHU_APP_SECRET")
+    feishu_app_id = _get_env("FEISHU_APP_ID")
+    feishu_app_secret = _get_env("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
         if Platform.FEISHU not in config.platforms:
             config.platforms[Platform.FEISHU] = PlatformConfig()
@@ -1864,7 +1882,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         })
 
     # Weixin (personal WeChat via iLink Bot API)
-    weixin_token = os.getenv("WEIXIN_TOKEN")
+    weixin_token = _get_env("WEIXIN_TOKEN")
     weixin_account_id = os.getenv("WEIXIN_ACCOUNT_ID")
     if weixin_token or weixin_account_id:
         if Platform.WEIXIN not in config.platforms:


### PR DESCRIPTION
Fixes #49415. When gateway.multiplex_profiles is enabled, secondary profile adapters never start because load_gateway_config() uses os.getenv() to detect platform tokens, but the multiplexer loads profile secrets into a secret_scope contextvar rather than os.environ. Added _get_env() helper that checks get_secret() first (which reads the active scope), falling back to os.getenv(). Replaced the 10 platform token detection lines in load_gateway_config() with _get_env().