### PR TITLE
fix(gateway): silence matrix check_fn credential-check log spam

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -664,6 +664,12 @@ def _pre_sanitize_matrix_markdown(text: str) -> str:
 def check_matrix_requirements() -> bool:
     """Return True if the Matrix adapter can be used.
 
+    Credential checks are intentionally silent — the caller
+    (``gateway/run.py`` ``_create_adapter()``) already emits a warning
+    when this function returns ``False`` and an adapter is requested.
+    Logging here duplicates that warning on every adapter-creation
+    attempt (initial connect, reconnect, profile load).
+
     Lazy-installs the full ``platform.matrix`` feature group via
     ``tools.lazy_deps.ensure_and_bind`` whenever any of the declared
     packages (mautrix, Markdown, aiosqlite, asyncpg, aiohttp-socks) is
@@ -677,10 +683,8 @@ def check_matrix_requirements() -> bool:
     homeserver = os.getenv("MATRIX_HOMESERVER", "")
 
     if not token and not password:
-        logger.debug("Matrix: neither MATRIX_ACCESS_TOKEN nor MATRIX_PASSWORD set")
         return False
     if not homeserver:
-        logger.warning("Matrix: MATRIX_HOMESERVER not set")
         return False
 
     # Check whether any package in the platform.matrix feature group is

--- a/tests/gateway/test_matrix_check_fn_silent.py
+++ b/tests/gateway/test_matrix_check_fn_silent.py
@@ -1,0 +1,72 @@
+"""Regression tests for Matrix check_matrix_requirements() silence contract.
+
+The caller in ``gateway/run.py`` ``_create_adapter()`` already emits a
+warning when ``check_matrix_requirements()`` returns ``False``.  Logging
+inside the function itself duplicates that warning on every
+adapter-creation attempt (initial connect, reconnect, profile load).
+
+Credential checks must therefore be silent — return True/False without
+emitting WARNING or higher.  This matches the convention enforced for
+platform plugin ``check_fn`` callbacks (see raft fix PR #49240 and
+mattermost fix PR #49465).
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def matrix_check():
+    from gateway.platforms.matrix import check_matrix_requirements
+
+    return check_matrix_requirements
+
+
+def test_check_returns_false_when_no_credentials(matrix_check, monkeypatch):
+    """check_fn returns False when neither token nor password is set."""
+    monkeypatch.delenv("MATRIX_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("MATRIX_PASSWORD", raising=False)
+    monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.com")
+    assert matrix_check() is False
+
+
+def test_check_returns_false_when_homeserver_missing(matrix_check, monkeypatch):
+    """check_fn returns False when MATRIX_HOMESERVER is not set."""
+    monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test_token")
+    monkeypatch.delenv("MATRIX_HOMESERVER", raising=False)
+    assert matrix_check() is False
+
+
+def test_check_silent_when_no_credentials(matrix_check, monkeypatch, caplog):
+    """check_fn must NOT log WARNING+ when credentials are missing.
+
+    The caller in gateway/run.py _create_adapter() already logs a warning
+    when check_fn returns False.  Logging here creates duplicate warnings.
+    """
+    monkeypatch.delenv("MATRIX_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("MATRIX_PASSWORD", raising=False)
+    monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.com")
+    with caplog.at_level(logging.WARNING, logger="gateway.platforms.matrix"):
+        matrix_check()
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == [], (
+        f"check_matrix_requirements credential checks must be silent "
+        f"(no WARNING logs), but emitted: {[r.getMessage() for r in warnings]}"
+    )
+
+
+def test_check_silent_when_homeserver_missing(matrix_check, monkeypatch, caplog):
+    """check_fn must NOT log WARNING+ when MATRIX_HOMESERVER is missing."""
+    monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test_token")
+    monkeypatch.delenv("MATRIX_HOMESERVER", raising=False)
+    with caplog.at_level(logging.WARNING, logger="gateway.platforms.matrix"):
+        matrix_check()
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == [], (
+        f"check_matrix_requirements credential checks must be silent "
+        f"(no WARNING logs), but emitted: {[r.getMessage() for r in warnings]}"
+    )


### PR DESCRIPTION
## Summary

Removes redundant `logger.warning()` and `logger.debug()` calls from the credential-check section of `check_matrix_requirements()` to eliminate duplicate log warnings on every adapter-creation attempt.

The caller in `gateway/run.py` `_create_adapter()` (line 7108) already emits its own warning when `check_matrix_requirements()` returns `False`:

```
Matrix: mautrix not installed or credentials not set. Run: pip install 'mautrix[encryption]'
```

The warning inside `check_matrix_requirements()` at line 683 (`"Matrix: MATRIX_HOMESERVER not set"`) fired before the caller's warning, producing duplicate log entries on every adapter-creation attempt — initial connect, reconnect (exponential backoff), and profile load.

Sibling of the raft check_fn fix (#49240) and the mattermost check_fn fix (#49465).

## Root cause

`check_matrix_requirements()` logged a `WARNING` (line 683) and a `DEBUG` (line 680) during credential checks. Unlike plugin-registered platforms (raft, mattermost) whose `check_fn` runs on every `load_gateway_config()`, Matrix is checked via the `_create_adapter()` if/elif chain — but duplicate warnings still occur on every connect, reconnect, and profile-load cycle.

## Changes

- **`gateway/platforms/matrix.py`** (lines 679–684): Removed `logger.warning("Matrix: MATRIX_HOMESERVER not set")` and `logger.debug("Matrix: neither MATRIX_ACCESS_TOKEN nor MATRIX_PASSWORD set")` from the credential-check section. Deeper diagnostic messages (package installation failure, E2EE dependency warnings) are intentionally preserved — they fire only for users who have configured Matrix credentials but have incomplete package setup, which is a different (rarer, more actionable) scenario.
- **`tests/gateway/test_matrix_check_fn_silent.py`** (new): 4 regression tests covering return values (False when credentials missing, False when homeserver missing) and the silence contract (no WARNING logs emitted in either credential-check failure case).

## Validation

```bash
uv run --frozen python -m pytest tests/gateway/test_matrix_check_fn_silent.py -x -q
# 4 passed
```

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Searched for existing PRs — no duplicate found
- [x] PR contains only changes related to this fix
- [x] Added regression tests
- [x] Considered cross-platform impact — N/A (env var check, no platform-specific code)