### PR TITLE
fix(dashboard): hide subagent sessions from history

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4335,10 +4335,12 @@ def _(rid, params: dict) -> dict:
         # ones not enumerated here), ACP adapter clients, webhook sessions,
         # custom `HERMES_SESSION_SOURCE` values, and older installs with
         # different source labels. We deny-list only the noisy internal
-        # sources (``tool`` sub-agent runs) rather than allow-listing a
-        # fixed set of platform names that goes stale whenever a new
-        # platform is added or a user names their own source.
-        deny = frozenset({"tool"})
+        # sources rather than allow-listing a fixed set of platform names
+        # that goes stale whenever a new platform is added or a user names
+        # their own source. The internal set mirrors
+        # tools/session_search_tool._HIDDEN_SESSION_SOURCES: ``tool``
+        # integrations and ``subagent`` delegate runs.
+        deny = frozenset({"subagent", "tool"})
 
         limit = int(params.get("limit", 200) or 200)
         # Over-fetch modestly so per-source filtering doesn't leave us
@@ -4389,7 +4391,8 @@ def _(rid, params: dict) -> dict:
     if db is None:
         return _ok(rid, {"session_id": None})
     try:
-        deny = frozenset({"tool"})
+        # Mirror session.list / _HIDDEN_SESSION_SOURCES: hide tool + subagent.
+        deny = frozenset({"subagent", "tool"})
         # Over-fetch by a generous bounded amount so heavy sub-agent
         # users (lots of recent ``tool`` rows) don't get a false
         # "no eligible session" answer.  ``session.list`` uses a


### PR DESCRIPTION
## Problem

`tools/session_search_tool.py` declares the canonical set of internal session sources that should not appear in user-facing history:

```python
_HIDDEN_SESSION_SOURCES = ("subagent", "tool")
```

CLI session search honors both. But the desktop dashboard's `session.list` and `session.most_recent` (in `tui_gateway/server.py`) deny only `{"tool"}`. As a result, **in-process `subagent` delegate runs leak into the desktop session sidebar**, cluttering the user's working sessions.

## Fix

Widen the dashboard deny-list to `{"subagent", "tool"}` at both call sites, matching `_HIDDEN_SESSION_SOURCES`. Kept as an inline literal (with a comment pointing to the canonical constant) to avoid importing the tool module into the gateway. Excluding `subagent` from `session.most_recent` is also correct — TUI auto-resume should never resume into a delegate run.

Two strings, two call sites; no behavior change beyond hiding sources Hermes already marks internal.

Follow-up to #49269 (sidecar hiding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)