### PR TITLE
test(delegation): cover fallback-chain inheritance under a pinned subagent base_url

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -3029,6 +3029,41 @@ class TestFallbackModelInheritance(unittest.TestCase):
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
 
+    def test_child_inherits_fallback_chain_when_base_url_pinned(self):
+        """A subagent pinned to a direct endpoint via delegation.base_url must
+        STILL inherit the parent's fallback chain (#49417).
+
+        The hard pin (override_base_url / override_provider) controls the
+        PRIMARY route — the recommended pattern for predictable, cost-controlled
+        subagent routing — but it must not silently drop the parent's fallback
+        resilience, or any outage of the pinned endpoint kills every dispatch.
+        """
+        parent = _make_mock_parent(depth=0)
+        fallback_entry = {"provider": "openrouter", "model": "gpt-4o-mini", "api_key": "sk-or-x"}
+        parent._fallback_chain = [fallback_entry]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test fallback inheritance when pinned",
+                context=None,
+                toolsets=None,
+                model="MiniMax-M3",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_provider="custom",
+                override_base_url="https://api.minimax.io/anthropic",
+                override_api_mode="anthropic_messages",
+            )
+
+        _, kwargs = MockAgent.call_args
+        # The pinned base_url controls the PRIMARY route...
+        self.assertEqual(kwargs["base_url"], "https://api.minimax.io/anthropic")
+        # ...but the parent's fallback chain must still be inherited.
+        self.assertEqual(kwargs["fallback_model"], [fallback_entry])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Context

#49417 reports that subagents pinned to a direct endpoint via `delegation.base_url` do **not** inherit the parent's `fallback_providers` chain, so an outage of the pinned endpoint kills every dispatch.

On current `main` the inheritance is already in place: `_build_child_agent` reads `parent_agent._fallback_chain` and passes it to the child as `fallback_model` **unconditionally** — independent of the `base_url`/`provider` override (`tools/delegate_tool.py`) — and `agent_init` materialises it into the child's own `_fallback_chain` (`agent/agent_init.py`). The runtime fallback path (`try_activate_fallback`) has no guard that skips a pinned/custom child.

The gap was **test coverage**, not behavior: `TestFallbackModelInheritance` only exercised the no-override inherit path. The exact scenario the issue describes — a child pinned via `delegation.base_url` — was never asserted, so a future change could silently drop it.

## Change

Add `test_child_inherits_fallback_chain_when_base_url_pinned`: it builds a child with `override_base_url` + `override_provider` set (the `delegation.base_url` hard-pin) and asserts the child still receives the parent's fallback chain, while the pinned `base_url` controls the primary route.

**Negative control:** gating `parent_fallback` on `not override_base_url` (i.e. reintroducing the bug the issue alleges) fails this test — and only this test. So it is a real regression guard, not a vacuous assertion.

```
tests/tools/test_delegate.py — 141 passed (3 in TestFallbackModelInheritance)
```

## Note on #49417

Since the inherit-when-pinned behavior already works on current `main`, the reporter's "no fallback at all" symptom is most likely either a build predating the inheritance, or the distinct, separately-tracked #24782 (subagent fallback engages but routes to the wrong `base_url`). This PR locks in the build-level inheritance; it deliberately does not claim to close #49417, which may need a runtime-routing fix tracked under #24782.

Refs #49417
