### PR TITLE
fix(tools): silence check_terminal_requirements log spam

### DIFF
--- a/tests/tools/test_terminal_requirements.py
+++ b/tests/tools/test_terminal_requirements.py
@@ -46,35 +46,37 @@ def test_local_terminal_requirements(monkeypatch, caplog):
     assert "Terminal requirements check failed" not in caplog.text
 
 
-def test_unknown_terminal_env_logs_error_and_returns_false(monkeypatch, caplog):
+def test_unknown_terminal_env_returns_false_silently(monkeypatch, caplog):
     _clear_terminal_env(monkeypatch)
     monkeypatch.setenv("TERMINAL_ENV", "unknown-backend")
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         ok = terminal_tool_module.check_terminal_requirements()
 
     assert ok is False
-    assert any(
-        "Unknown TERMINAL_ENV 'unknown-backend'" in record.getMessage()
-        for record in caplog.records
+    warnings_and_errors = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings_and_errors == [], (
+        f"check_terminal_requirements must be silent (no WARNING/ERROR logs), "
+        f"but emitted: {[r.getMessage() for r in warnings_and_errors]}"
     )
 
 
-def test_ssh_backend_without_host_or_user_logs_and_returns_false(monkeypatch, caplog):
+def test_ssh_backend_without_host_or_user_returns_false_silently(monkeypatch, caplog):
     _clear_terminal_env(monkeypatch)
     monkeypatch.setenv("TERMINAL_ENV", "ssh")
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         ok = terminal_tool_module.check_terminal_requirements()
 
     assert ok is False
-    assert any(
-        "SSH backend selected but TERMINAL_SSH_HOST and TERMINAL_SSH_USER" in record.getMessage()
-        for record in caplog.records
+    warnings_and_errors = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings_and_errors == [], (
+        f"check_terminal_requirements must be silent (no WARNING/ERROR logs), "
+        f"but emitted: {[r.getMessage() for r in warnings_and_errors]}"
     )
 
 
-def test_modal_backend_without_token_or_config_logs_specific_error(monkeypatch, caplog, tmp_path):
+def test_modal_backend_without_token_or_config_returns_false_silently(monkeypatch, caplog, tmp_path):
     _clear_terminal_env(monkeypatch)
     monkeypatch.setenv("TERMINAL_ENV", "modal")
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -82,13 +84,14 @@ def test_modal_backend_without_token_or_config_logs_specific_error(monkeypatch, 
     monkeypatch.setattr(terminal_tool_module, "is_managed_tool_gateway_ready", lambda _vendor: False)
     monkeypatch.setattr(terminal_tool_module.importlib.util, "find_spec", lambda _name: object())
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         ok = terminal_tool_module.check_terminal_requirements()
 
     assert ok is False
-    assert any(
-        "Modal backend selected but no direct Modal credentials/config was found" in record.getMessage()
-        for record in caplog.records
+    warnings_and_errors = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings_and_errors == [], (
+        f"check_terminal_requirements must be silent (no WARNING/ERROR logs), "
+        f"but emitted: {[r.getMessage() for r in warnings_and_errors]}"
     )
 
 
@@ -139,13 +142,14 @@ def test_modal_backend_direct_mode_does_not_fall_back_to_managed(monkeypatch, ca
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setattr(terminal_tool_module, "is_managed_tool_gateway_ready", lambda _vendor: True)
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         ok = terminal_tool_module.check_terminal_requirements()
 
     assert ok is False
-    assert any(
-        "TERMINAL_MODAL_MODE=direct" in record.getMessage()
-        for record in caplog.records
+    warnings_and_errors = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings_and_errors == [], (
+        f"check_terminal_requirements must be silent (no WARNING/ERROR logs), "
+        f"but emitted: {[r.getMessage() for r in warnings_and_errors]}"
     )
 
 
@@ -159,17 +163,18 @@ def test_modal_backend_managed_mode_does_not_fall_back_to_direct(monkeypatch, ca
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setattr(terminal_tool_module, "is_managed_tool_gateway_ready", lambda _vendor: False)
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         ok = terminal_tool_module.check_terminal_requirements()
 
     assert ok is False
-    assert any(
-        "Nous Tool Gateway access is not currently available" in record.getMessage()
-        for record in caplog.records
+    warnings_and_errors = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings_and_errors == [], (
+        f"check_terminal_requirements must be silent (no WARNING/ERROR logs), "
+        f"but emitted: {[r.getMessage() for r in warnings_and_errors]}"
     )
 
 
-def test_modal_backend_managed_mode_without_feature_flag_logs_clear_error(monkeypatch, caplog, tmp_path):
+def test_modal_backend_managed_mode_without_feature_flag_returns_false_silently(monkeypatch, caplog, tmp_path):
     _clear_terminal_env(monkeypatch)
     monkeypatch.setenv("TERMINAL_ENV", "modal")
     monkeypatch.setenv("TERMINAL_MODAL_MODE", "managed")
@@ -177,11 +182,12 @@ def test_modal_backend_managed_mode_without_feature_flag_logs_clear_error(monkey
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setattr(terminal_tool_module, "is_managed_tool_gateway_ready", lambda _vendor: False)
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         ok = terminal_tool_module.check_terminal_requirements()
 
     assert ok is False
-    assert any(
-        "Nous Tool Gateway access is not currently available" in record.getMessage()
-        for record in caplog.records
+    warnings_and_errors = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings_and_errors == [], (
+        f"check_terminal_requirements must be silent (no WARNING/ERROR logs), "
+        f"but emitted: {[r.getMessage() for r in warnings_and_errors]}"
     )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2489,7 +2489,18 @@ def terminal_tool(
 
 
 def check_terminal_requirements() -> bool:
-    """Check if all requirements for the terminal tool are met."""
+    """Check if all requirements for the terminal tool are met.
+
+    Intentionally silent — this function is registered as the terminal
+    tool's ``check_fn`` and called via ``_check_fn_cached()`` on every
+    ``get_definitions()`` pass (i.e. every LLM tool-use call, with a
+    30 s TTL cache).  Logging ERROR/WARNING here floods logs every
+    cache cycle for any user whose backend deps are missing.  The
+    caller in ``tools/registry.py`` already emits a DEBUG line when
+    the check fails, and ``hermes status`` shows the backend state.
+    This matches the convention used by every other tool check_fn
+    (browser, tts, vision, session_search, etc.).
+    """
     try:
         config = _get_env_config()
         env_type = config["env_type"]
@@ -2501,7 +2512,6 @@ def check_terminal_requirements() -> bool:
             from tools.environments.docker import find_docker
             docker = find_docker()
             if not docker:
-                logger.error("Docker executable not found in PATH or common install locations")
                 return False
             result = subprocess.run([docker, "version"], capture_output=True, timeout=5, stdin=subprocess.DEVNULL)
             return result.returncode == 0
@@ -2515,10 +2525,6 @@ def check_terminal_requirements() -> bool:
 
         elif env_type == "ssh":
             if not config.get("ssh_host") or not config.get("ssh_user"):
-                logger.error(
-                    "SSH backend selected but TERMINAL_SSH_HOST and TERMINAL_SSH_USER "
-                    "are not both set. Configure both or switch TERMINAL_ENV to 'local'."
-                )
                 return False
             return True
 
@@ -2528,56 +2534,9 @@ def check_terminal_requirements() -> bool:
                 return True
 
             if modal_state["selected_backend"] != "direct":
-                if modal_state["managed_mode_blocked"]:
-                    logger.error(
-                        "Modal backend selected with TERMINAL_MODAL_MODE=managed, but "
-                        "Nous Tool Gateway access is not currently available and no direct "
-                        "Modal credentials/config were found. %s Choose "
-                        "TERMINAL_MODAL_MODE=direct/auto to use direct Modal credentials.",
-                        nous_tool_gateway_unavailable_message(
-                            "managed Modal execution",
-                        ),
-                    )
-                    return False
-                if modal_state["mode"] == "managed":
-                    logger.error(
-                        "Modal backend selected with TERMINAL_MODAL_MODE=managed, but the managed "
-                        "tool gateway is unavailable. %s",
-                        nous_tool_gateway_unavailable_message(
-                            "managed Modal execution",
-                        ),
-                    )
-                    return False
-                elif modal_state["mode"] == "direct":
-                    if managed_nous_tools_enabled():
-                        logger.error(
-                            "Modal backend selected with TERMINAL_MODAL_MODE=direct, but no direct "
-                            "Modal credentials/config were found. Configure Modal or choose "
-                            "TERMINAL_MODAL_MODE=managed/auto."
-                        )
-                    else:
-                        logger.error(
-                            "Modal backend selected with TERMINAL_MODAL_MODE=direct, but no direct "
-                            "Modal credentials/config were found. Configure Modal or choose "
-                            "TERMINAL_MODAL_MODE=auto."
-                        )
-                    return False
-                else:
-                    if managed_nous_tools_enabled():
-                        logger.error(
-                            "Modal backend selected but no direct Modal credentials/config or managed "
-                            "tool gateway was found. Configure Modal, set up the managed gateway, "
-                            "or choose a different TERMINAL_ENV."
-                        )
-                    else:
-                        logger.error(
-                            "Modal backend selected but no direct Modal credentials/config was found. "
-                            "Configure Modal or choose a different TERMINAL_ENV."
-                        )
-                    return False
+                return False
 
             if importlib.util.find_spec("modal") is None:
-                logger.error("modal is required for direct modal terminal backend: pip install modal")
                 return False
 
             return True
@@ -2587,14 +2546,8 @@ def check_terminal_requirements() -> bool:
             return os.getenv("DAYTONA_API_KEY") is not None
 
         else:
-            logger.error(
-                "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
-                "modal, daytona, ssh.",
-                env_type,
-            )
             return False
-    except Exception as e:
-        logger.error("Terminal requirements check failed: %s", e, exc_info=True)
+    except Exception:
         return False
 
 


### PR DESCRIPTION
## Summary

Removes `logger.error()` calls from `check_terminal_requirements()` so the terminal tool's `check_fn` honors the silent-predicate convention used by every other tool `check_fn` in the codebase (browser, tts, vision, session_search, etc.).

`check_terminal_requirements()` is called via `_check_fn_cached()` on every `get_definitions()` pass — i.e. every LLM tool-use call, with a 30 s TTL cache. When backend dependencies are missing (Docker not found, SSH not configured, Modal credentials absent, unknown `TERMINAL_ENV`), the function emitted `logger.error()` messages that repeated every 30 seconds for the lifetime of the process.

The caller in `tools/registry.py` already emits a `DEBUG` line when `check_fn` returns `False`, and `hermes status` shows the full terminal backend state for user diagnosis.

## Root cause

`check_terminal_requirements()` contained 10+ `logger.error()` calls across its backend branches (docker, ssh, modal, unknown env, exception handler). Unlike platform `check_fn` callbacks (fixed for raft in #49240, mattermost in #49465, matrix in #49475), the terminal tool's `check_fn` is cached with a 30 s TTL — but still emits ERROR-level messages on every cache miss, flooding logs for any user whose backend is misconfigured.

Every other tool `check_fn` in the codebase is silent — `check_browser_requirements()`, `check_tts_requirements()`, `check_vision_requirements()`, `check_session_search_requirements()` all return `True`/`False` without logging. The terminal tool was the sole violator.

## Changes

- **`tools/terminal_tool.py`** (`check_terminal_requirements`, lines 2491–2598): Removed all `logger.error()` calls. The function now returns `True`/`False` silently. Added a docstring documenting the silence contract and its rationale. The modal backend's complex error-branching (`managed_mode_blocked`, `mode == "managed"`, `mode == "direct"`, else) was simplified to a single `if selected_backend != "direct": return False` — all branches returned `False` anyway, differing only in log messages that are now removed.
- **`tests/tools/test_terminal_requirements.py`**: Updated 6 existing tests that previously asserted specific error log messages. Tests now verify the silence contract instead — `check_fn` must not emit WARNING or ERROR logs in any failure case.

## Validation

```bash
uv run --frozen python -m pytest tests/tools/test_terminal_requirements.py tests/tools/test_terminal_tool_requirements.py -x -q
# 12 passed
```

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Searched for existing PRs — no duplicate found
- [x] PR contains only changes related to this fix
- [x] Updated existing tests to match new behavior
- [x] Considered cross-platform impact — N/A (log removal, no platform-specific code)