### PR TITLE
fix(config): resolve platform tokens from per-profile secret scope (#49415)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -18,8 +18,24 @@ from enum import Enum
 
 from hermes_cli.config import get_hermes_home
 from utils import is_truthy_value
+from agent.secret_scope import get_secret as _scope_get_secret
 
 logger = logging.getLogger(__name__)
+
+
+def _env_or_secret(key: str, default: Optional[str] = None) -> Optional[str]:
+    """Resolve a credential, honouring the active per-profile secret scope.
+
+    During multiplexed profile loading the profile's ``.env`` is installed as
+    a contextvar-based ``SecretScope`` (via ``_profile_runtime_scope``) rather
+    than written to ``os.environ``.  ``get_secret`` reads from that scope when
+    one is active, so each secondary profile discovers its own platform tokens.
+    When no scope is active (non-multiplex deployment, or the initial
+    primary-profile load before ``set_multiplex_active`` is called) the
+    behaviour is identical to ``os.getenv``.
+    """
+    val = _scope_get_secret(key)
+    return val if val is not None else default
 
 
 def _coerce_bool(value: Any, default: bool = True) -> bool:
@@ -469,7 +485,7 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
     ),
     Platform.SIGNAL: lambda cfg: bool(cfg.extra.get("http_url")),
     Platform.EMAIL: lambda cfg: bool(cfg.extra.get("address")),
-    Platform.SMS: lambda cfg: bool(os.getenv("TWILIO_ACCOUNT_SID")),
+    Platform.SMS: lambda cfg: bool(_env_or_secret("TWILIO_ACCOUNT_SID")),
     Platform.API_SERVER: lambda cfg: True,
     Platform.WEBHOOK: lambda cfg: True,
     Platform.MSGRAPH_WEBHOOK: lambda cfg: bool(
@@ -491,7 +507,7 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
     ),
     Platform.DINGTALK: lambda cfg: bool(
         (cfg.extra.get("client_id") or os.getenv("DINGTALK_CLIENT_ID"))
-        and (cfg.extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET"))
+        and (cfg.extra.get("client_secret") or _env_or_secret("DINGTALK_CLIENT_SECRET"))
     ),
     # Relay dials OUT to a connector; it is "connected" once an endpoint URL is
     # configured (extra["relay_url"] or extra["url"]). The capability descriptor
@@ -1397,7 +1413,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         return platform_config
     
     # Telegram
-    telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
+    telegram_token = _env_or_secret("TELEGRAM_BOT_TOKEN")
     if telegram_token:
         telegram_config = _enable_from_env(Platform.TELEGRAM)
         telegram_config.token = telegram_token
@@ -1427,7 +1443,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
     
     # Discord
-    discord_token = os.getenv("DISCORD_BOT_TOKEN")
+    discord_token = _env_or_secret("DISCORD_BOT_TOKEN")
     if discord_token:
         discord_config = _enable_from_env(Platform.DISCORD)
         discord_config.token = discord_token
@@ -1475,7 +1491,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # outbound, public webhook inbound. Both adapters can run in parallel
     # against different phone numbers.
     whatsapp_cloud_phone_id = os.getenv("WHATSAPP_CLOUD_PHONE_NUMBER_ID")
-    whatsapp_cloud_token = os.getenv("WHATSAPP_CLOUD_ACCESS_TOKEN")
+    whatsapp_cloud_token = _env_or_secret("WHATSAPP_CLOUD_ACCESS_TOKEN")
     if whatsapp_cloud_phone_id and whatsapp_cloud_token:
         if Platform.WHATSAPP_CLOUD not in config.platforms:
             config.platforms[Platform.WHATSAPP_CLOUD] = PlatformConfig()
@@ -1488,7 +1504,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         wa_cloud_app_id = os.getenv("WHATSAPP_CLOUD_APP_ID")
         if wa_cloud_app_id:
             config.platforms[Platform.WHATSAPP_CLOUD].extra["app_id"] = wa_cloud_app_id
-        wa_cloud_app_secret = os.getenv("WHATSAPP_CLOUD_APP_SECRET")
+        wa_cloud_app_secret = _env_or_secret("WHATSAPP_CLOUD_APP_SECRET")
         if wa_cloud_app_secret:
             config.platforms[Platform.WHATSAPP_CLOUD].extra["app_secret"] = wa_cloud_app_secret
         # Optional: WABA id (analytics, future use)
@@ -1496,7 +1512,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if wa_cloud_waba_id:
             config.platforms[Platform.WHATSAPP_CLOUD].extra["waba_id"] = wa_cloud_waba_id
         # Webhook verify token — Meta hub.verify_token shared secret
-        wa_cloud_verify_token = os.getenv("WHATSAPP_CLOUD_VERIFY_TOKEN")
+        wa_cloud_verify_token = _env_or_secret("WHATSAPP_CLOUD_VERIFY_TOKEN")
         if wa_cloud_verify_token:
             config.platforms[Platform.WHATSAPP_CLOUD].extra["verify_token"] = wa_cloud_verify_token
         # Webhook server bind config (defaults baked into the adapter)
@@ -1526,7 +1542,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # Slack
-    slack_token = os.getenv("SLACK_BOT_TOKEN")
+    slack_token = _env_or_secret("SLACK_BOT_TOKEN")
     if slack_token:
         if Platform.SLACK not in config.platforms:
             # No yaml config for Slack — env-only setup, enable it
@@ -1573,7 +1589,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # Mattermost
-    mattermost_token = os.getenv("MATTERMOST_TOKEN")
+    mattermost_token = _env_or_secret("MATTERMOST_TOKEN")
     if mattermost_token:
         mattermost_url = os.getenv("MATTERMOST_URL", "")
         if not mattermost_url:
@@ -1591,7 +1607,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # Matrix
-    matrix_token = os.getenv("MATRIX_ACCESS_TOKEN")
+    matrix_token = _env_or_secret("MATRIX_ACCESS_TOKEN")
     matrix_homeserver = os.getenv("MATRIX_HOMESERVER", "")
     if matrix_token or os.getenv("MATRIX_PASSWORD"):
         if not matrix_homeserver:
@@ -1627,7 +1643,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # Home Assistant
-    hass_token = os.getenv("HASS_TOKEN")
+    hass_token = _env_or_secret("HASS_TOKEN")
     if hass_token:
         if Platform.HOMEASSISTANT not in config.platforms:
             config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
@@ -1661,12 +1677,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # SMS (Twilio)
-    twilio_sid = os.getenv("TWILIO_ACCOUNT_SID")
+    twilio_sid = _env_or_secret("TWILIO_ACCOUNT_SID")
     if twilio_sid:
         if Platform.SMS not in config.platforms:
             config.platforms[Platform.SMS] = PlatformConfig()
         config.platforms[Platform.SMS].enabled = True
-        config.platforms[Platform.SMS].api_key = os.getenv("TWILIO_AUTH_TOKEN", "")
+        config.platforms[Platform.SMS].api_key = _env_or_secret("TWILIO_AUTH_TOKEN", "")
     sms_home = os.getenv("SMS_HOME_CHANNEL")
     if sms_home and Platform.SMS in config.platforms:
         config.platforms[Platform.SMS].home_channel = HomeChannel(
@@ -1678,7 +1694,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
 
     # API Server
     api_server_enabled = os.getenv("API_SERVER_ENABLED", "").lower() in {"true", "1", "yes"}
-    api_server_key = os.getenv("API_SERVER_KEY", "")
+    api_server_key = _env_or_secret("API_SERVER_KEY", "")
     api_server_cors_origins = os.getenv("API_SERVER_CORS_ORIGINS", "")
     api_server_port = os.getenv("API_SERVER_PORT")
     api_server_host = os.getenv("API_SERVER_HOST")
@@ -1706,7 +1722,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Webhook platform
     webhook_enabled = os.getenv("WEBHOOK_ENABLED", "").lower() in {"true", "1", "yes"}
     webhook_port = os.getenv("WEBHOOK_PORT")
-    webhook_secret = os.getenv("WEBHOOK_SECRET", "")
+    webhook_secret = _env_or_secret("WEBHOOK_SECRET", "")
     if webhook_enabled:
         if Platform.WEBHOOK not in config.platforms:
             config.platforms[Platform.WEBHOOK] = PlatformConfig()
@@ -1777,7 +1793,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
 
     # DingTalk
     dingtalk_client_id = os.getenv("DINGTALK_CLIENT_ID")
-    dingtalk_client_secret = os.getenv("DINGTALK_CLIENT_SECRET")
+    dingtalk_client_secret = _env_or_secret("DINGTALK_CLIENT_SECRET")
     if dingtalk_client_id and dingtalk_client_secret:
         if Platform.DINGTALK not in config.platforms:
             config.platforms[Platform.DINGTALK] = PlatformConfig()
@@ -1797,7 +1813,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
 
     # Feishu / Lark
     feishu_app_id = os.getenv("FEISHU_APP_ID")
-    feishu_app_secret = os.getenv("FEISHU_APP_SECRET")
+    feishu_app_secret = _env_or_secret("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
         if Platform.FEISHU not in config.platforms:
             config.platforms[Platform.FEISHU] = PlatformConfig()
@@ -1808,10 +1824,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
             "connection_mode": os.getenv("FEISHU_CONNECTION_MODE", "websocket"),
         })
-        feishu_encrypt_key = os.getenv("FEISHU_ENCRYPT_KEY", "")
+        feishu_encrypt_key = _env_or_secret("FEISHU_ENCRYPT_KEY", "")
         if feishu_encrypt_key:
             config.platforms[Platform.FEISHU].extra["encrypt_key"] = feishu_encrypt_key
-        feishu_verification_token = os.getenv("FEISHU_VERIFICATION_TOKEN", "")
+        feishu_verification_token = _env_or_secret("FEISHU_VERIFICATION_TOKEN", "")
         if feishu_verification_token:
             config.platforms[Platform.FEISHU].extra["verification_token"] = feishu_verification_token
         feishu_home = os.getenv("FEISHU_HOME_CHANNEL")
@@ -1825,7 +1841,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
 
     # WeCom (Enterprise WeChat)
     wecom_bot_id = os.getenv("WECOM_BOT_ID")
-    wecom_secret = os.getenv("WECOM_SECRET")
+    wecom_secret = _env_or_secret("WECOM_SECRET")
     if wecom_bot_id and wecom_secret:
         if Platform.WECOM not in config.platforms:
             config.platforms[Platform.WECOM] = PlatformConfig()
@@ -1848,7 +1864,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
 
     # WeCom callback mode (self-built apps)
     wecom_callback_corp_id = os.getenv("WECOM_CALLBACK_CORP_ID")
-    wecom_callback_corp_secret = os.getenv("WECOM_CALLBACK_CORP_SECRET")
+    wecom_callback_corp_secret = _env_or_secret("WECOM_CALLBACK_CORP_SECRET")
     if wecom_callback_corp_id and wecom_callback_corp_secret:
         if Platform.WECOM_CALLBACK not in config.platforms:
             config.platforms[Platform.WECOM_CALLBACK] = PlatformConfig()
@@ -1857,14 +1873,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "corp_id": wecom_callback_corp_id,
             "corp_secret": wecom_callback_corp_secret,
             "agent_id": os.getenv("WECOM_CALLBACK_AGENT_ID", ""),
-            "token": os.getenv("WECOM_CALLBACK_TOKEN", ""),
-            "encoding_aes_key": os.getenv("WECOM_CALLBACK_ENCODING_AES_KEY", ""),
+            "token": _env_or_secret("WECOM_CALLBACK_TOKEN", ""),
+            "encoding_aes_key": _env_or_secret("WECOM_CALLBACK_ENCODING_AES_KEY", ""),
             "host": os.getenv("WECOM_CALLBACK_HOST", "0.0.0.0"),
             "port": int(os.getenv("WECOM_CALLBACK_PORT", "8645")),
         })
 
     # Weixin (personal WeChat via iLink Bot API)
-    weixin_token = os.getenv("WEIXIN_TOKEN")
+    weixin_token = _env_or_secret("WEIXIN_TOKEN")
     weixin_account_id = os.getenv("WEIXIN_ACCOUNT_ID")
     if weixin_token or weixin_account_id:
         if Platform.WEIXIN not in config.platforms:
@@ -1947,7 +1963,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
 
     # QQ (Official Bot API v2)
     qq_app_id = os.getenv("QQ_APP_ID")
-    qq_client_secret = os.getenv("QQ_CLIENT_SECRET")
+    qq_client_secret = _env_or_secret("QQ_CLIENT_SECRET")
     if qq_app_id or qq_client_secret:
         if Platform.QQBOT not in config.platforms:
             config.platforms[Platform.QQBOT] = PlatformConfig()
@@ -1988,8 +2004,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             )
 
     # Yuanbao — YUANBAO_APP_ID preferred
-    yuanbao_app_id = os.getenv("YUANBAO_APP_ID") or os.getenv("YUANBAO_APP_KEY")
-    yuanbao_app_secret = os.getenv("YUANBAO_APP_SECRET")
+    yuanbao_app_id = _env_or_secret("YUANBAO_APP_ID") or _env_or_secret("YUANBAO_APP_KEY")
+    yuanbao_app_secret = _env_or_secret("YUANBAO_APP_SECRET")
     if yuanbao_app_id and yuanbao_app_secret:
         if Platform.YUANBAO not in config.platforms:
             config.platforms[Platform.YUANBAO] = PlatformConfig()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1045,3 +1045,101 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+
+class TestSecretScopeTokenDiscovery:
+    """Platform tokens must be discoverable via the per-profile secret scope.
+
+    When ``gateway.multiplex_profiles`` is on, secondary profiles load their
+    ``.env`` into a contextvar-based ``SecretScope`` (not ``os.environ``).
+    ``_apply_env_overrides`` must honour that scope so each profile discovers
+    its own bot tokens.  See issue #49415.
+    """
+
+    def test_telegram_token_from_secret_scope(self):
+        """A token in the active scope (but absent from os.environ) must
+        enable the Telegram platform."""
+        from agent.secret_scope import set_secret_scope, reset_secret_scope
+
+        token = set_secret_scope({"TELEGRAM_BOT_TOKEN": "scope-tg-token"})
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                config = GatewayConfig()
+                _apply_env_overrides(config)
+            assert Platform.TELEGRAM in config.platforms
+            assert config.platforms[Platform.TELEGRAM].enabled is True
+            assert config.platforms[Platform.TELEGRAM].token == "scope-tg-token"
+        finally:
+            reset_secret_scope(token)
+
+    def test_discord_token_from_secret_scope(self):
+        from agent.secret_scope import set_secret_scope, reset_secret_scope
+
+        token = set_secret_scope({"DISCORD_BOT_TOKEN": "scope-dc-token"})
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                config = GatewayConfig()
+                _apply_env_overrides(config)
+            assert Platform.DISCORD in config.platforms
+            assert config.platforms[Platform.DISCORD].enabled is True
+            assert config.platforms[Platform.DISCORD].token == "scope-dc-token"
+        finally:
+            reset_secret_scope(token)
+
+    def test_slack_token_from_secret_scope(self):
+        from agent.secret_scope import set_secret_scope, reset_secret_scope
+
+        token = set_secret_scope({"SLACK_BOT_TOKEN": "scope-slack-token"})
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                config = GatewayConfig()
+                _apply_env_overrides(config)
+            assert Platform.SLACK in config.platforms
+            assert config.platforms[Platform.SLACK].enabled is True
+            assert config.platforms[Platform.SLACK].token == "scope-slack-token"
+        finally:
+            reset_secret_scope(token)
+
+    def test_multiple_tokens_from_one_scope(self):
+        """A full secondary profile .env in the scope should enable all its
+        platforms in a single ``_apply_env_overrides`` pass."""
+        from agent.secret_scope import set_secret_scope, reset_secret_scope
+
+        token = set_secret_scope({
+            "TELEGRAM_BOT_TOKEN": "tg-from-scope",
+            "DISCORD_BOT_TOKEN": "dc-from-scope",
+            "SLACK_BOT_TOKEN": "sl-from-scope",
+        })
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                config = GatewayConfig()
+                _apply_env_overrides(config)
+            assert config.platforms[Platform.TELEGRAM].token == "tg-from-scope"
+            assert config.platforms[Platform.DISCORD].token == "dc-from-scope"
+            assert config.platforms[Platform.SLACK].token == "sl-from-scope"
+        finally:
+            reset_secret_scope(token)
+
+    def test_scope_takes_precedence_over_environ(self):
+        """When a scope is active, it is authoritative — a stale token in
+        ``os.environ`` (e.g. the primary profile's) must NOT leak into a
+        secondary profile's config."""
+        from agent.secret_scope import set_secret_scope, reset_secret_scope
+
+        token = set_secret_scope({"TELEGRAM_BOT_TOKEN": "secondary-token"})
+        try:
+            # Primary's token is in os.environ; secondary's is in the scope.
+            with patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "primary-token"}):
+                config = GatewayConfig()
+                _apply_env_overrides(config)
+            assert config.platforms[Platform.TELEGRAM].token == "secondary-token"
+        finally:
+            reset_secret_scope(token)
+
+    def test_no_scope_falls_back_to_environ(self):
+        """Without an active scope, credentials resolve from os.environ
+        (backward-compatible behaviour for non-multiplex deployments)."""
+        with patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "env-token"}, clear=True):
+            config = GatewayConfig()
+            _apply_env_overrides(config)
+        assert config.platforms[Platform.TELEGRAM].token == "env-token"


### PR DESCRIPTION
## Summary

Fixes #49415.

When `gateway.multiplex_profiles` is enabled, secondary profiles load their `.env` into the context-local `SecretScope` instead of mutating process-global `os.environ`. `gateway/config.py` was still using `os.getenv()` for platform credential discovery, so secondary-profile bot tokens were invisible and adapters never started.

This change:
- adds `_env_or_secret()` to resolve credentials through `agent.secret_scope.get_secret()`;
- switches platform credential lookups in gateway config to the scoped resolver;
- preserves legacy/non-multiplex behavior because `get_secret()` falls back to `os.environ` when no secret scope is active and multiplexing is off;
- keeps non-credential deployment knobs on `os.getenv()`.

## Verification

RED proof captured in automation artifacts: 5/6 new regression tests fail on upstream/main (`TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`, multi-token scope, and scope-precedence/leak prevention).

Re-run before publishing on current `upstream/main`:

```text
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest \
  tests/gateway/test_config.py::TestSecretScopeTokenDiscovery \
  tests/agent/test_secret_scope.py \
  tests/gateway/test_multiplex_adapter_registry.py \
  -v -o "addopts=" --tb=short

28 passed in 0.73s
```

Branch relation verified after rebase:

```text
git rev-list --left-right --count upstream/main...HEAD
0 1
```

## Competitor analysis

Open competitor PR #49474 was reviewed before publishing. It is not blocking because it has no regression tests, covers fewer credential sites, and its helper falls back to `os.getenv()` after an active secret scope returns no key, which can reintroduce primary-profile token leakage. This PR includes scoped regression tests and the explicit leak-prevention case.

Auto-published by Moonsong via Path B automated pipeline.
