### PR TITLE
docs(delegate): clarify subagent model is config-level, not per-call

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2885,6 +2885,7 @@ def _build_top_level_description() -> str:
         f"Orchestrators are bounded by max_spawn_depth={max_depth} for this "
         f"user and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
+        "- Subagent model is NOT selectable per call: children inherit the parent model (plus its fallback chain) unless you pin all subagents to a model via delegation.provider / delegation.model in config.yaml.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
         "- Results are always returned as an array, one entry per task."
     )


### PR DESCRIPTION
## What

One-line addition to the `delegate_task` tool description: subagent model is **not** selectable per call. Children inherit the parent model (plus its fallback chain) unless all subagents are pinned via `delegation.provider` / `delegation.model` in `config.yaml`.

## Why

A recurring stream of issues (#49332, #23467, #17685, #11999, plus five open PRs) reports the `delegate_task` `model` parameter as "silently dropped." The premise is wrong: there is no per-call `model` parameter — it was removed intentionally in `fb0f579b1` (*refactor: remove model parameter from delegate_task function*) to enforce consistent delegation behavior. The schema and function signature have carried no `model` field since.

What the tool description never said is **how** subagent model is actually controlled, so users kept expecting a `model` arg and reporting its absence as a bug. This adds that one missing sentence.

## Scope

- Pure docs/description change to the dynamically-built tool description in `tools/delegate_tool.py`. **No behavior change.**
- Does NOT re-add the per-call `model` param (that would revert `fb0f579b1`). The five open PRs proposing that remain a maintainer won't-implement call.

## Verification

- `ast.parse` clean; description still builds at `get_definitions()` time.
- 1 insertion, 0 deletions.