### PR TITLE
fix(platforms): guard email/telegram port and delay env vars against malformed values

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -309,10 +309,14 @@ class EmailAdapter(BasePlatformAdapter):
         self._address = os.getenv("EMAIL_ADDRESS", "")
         self._password = os.getenv("EMAIL_PASSWORD", "")
         self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
-        self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
-        self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
-        self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
-        self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        try:
+            self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
+            self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
+            self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        except (TypeError, ValueError):
+            self._imap_port = 993
+            self._smtp_port = 587
+            self._poll_interval = 15
 
         # Skip attachments — configured via config.yaml:
         #   platforms:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -433,7 +433,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self._rich_draft_disabled: bool = False
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
-        self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
+        try:
+            self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
+        except (TypeError, ValueError):
+            self._media_batch_delay_seconds = 0.8
         self._pending_photo_batches: Dict[str, MessageEvent] = {}
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}


### PR DESCRIPTION
## Summary

`EMAIL_IMAP_PORT`, `EMAIL_SMTP_PORT`, `EMAIL_POLL_INTERVAL`, and `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` use bare `int()`/`float()` on `os.getenv()` which raises `ValueError` on malformed input.

### Fix

Wrap in `try/except (TypeError, ValueError)` to fall back to defaults.

### Changes
- `gateway/platforms/email.py`: guard 3 port/interval casts
- `gateway/platforms/telegram.py`: guard media batch delay cast
