### PR TITLE
feat(skills): add targeted skill_view retrieval

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -590,6 +590,14 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Compact long skill_view responses into a manifest plus safety-critical
+  # sections. Disabled by default for rollback-safe rollout; agents can still
+  # request mode="brief" explicitly, and full=true/mode="full" always returns
+  # complete SKILL.md content.
+  targeted_view:
+    enabled: false
+    threshold_chars: 20000
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1998,6 +1998,14 @@ DEFAULT_CONFIG = {
         #                     never crammed into a chat bubble), apply with
         #                     /skills approve <id> or drop with /skills reject <id>.
         "write_approval": False,
+        # Compact skill_view for long skills while preserving safety-critical
+        # sections and exposing deterministic section selectors. Disabled by
+        # default for rollback-safe rollout; explicit skill_view(mode="brief")
+        # and section_slug/section_title work regardless of this flag.
+        "targeted_view": {
+            "enabled": False,
+            "threshold_chars": 20_000,
+        },
     },
 
     # Curator — background skill maintenance.

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -195,6 +195,33 @@ class TestSkillViewQualifiedName:
         assert result["name"] == "superpowers:writing-plans"
         assert "writing-plans body." in result["content"]
 
+    def test_plugin_skill_supports_targeted_section_retrieval(self, tmp_path):
+        from tools.skills_tool import skill_view
+
+        self._register_skill(
+            tmp_path,
+            content="""---
+name: writing-plans
+description: writing plans desc
+---
+
+# Plugin Skill
+
+## First
+First detail.
+
+## Second
+Second detail.
+""",
+        )
+        result = json.loads(skill_view("superpowers:writing-plans", section_slug="second"))
+
+        assert result["success"] is True
+        assert result["retrieval_mode"] == "section"
+        assert result["section"]["slug"] == "second"
+        assert "Second detail" in result["content"]
+        assert "First detail" not in result["content"]
+
     def test_invalid_namespace_returns_error(self, tmp_path):
         from tools.skills_tool import skill_view
 

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -571,6 +571,164 @@ class TestSkillView:
             skill["name"] for skill in list_result["skills"]
         ]
 
+    def test_targeted_brief_preserves_safety_sections_and_reports_savings(self, tmp_path):
+        body = """# Big Skill
+
+Opening overview that should remain visible.
+
+## Prerequisites
+Install the required CLI before acting.
+
+## Usage Catalog
+""" + ("example detail\n" * 250) + """
+## Boundaries
+Do not mutate production systems.
+
+## Verification
+Run the smoke test before reporting success.
+"""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "big-skill", body=body)
+            raw = skill_view("big-skill", mode="brief")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["retrieval_mode"] == "brief"
+        assert result["targeted_retrieval"]["full_chars"] > result["targeted_retrieval"]["returned_chars"]
+        assert result["targeted_retrieval"]["estimated_saved_chars"] > 0
+        assert "Prerequisites" in result["content"]
+        assert "Boundaries" in result["content"]
+        assert "Verification" in result["content"]
+        assert "example detail" not in result["content"]
+        assert result["sections"]
+        assert any(section["slug"] == "usage-catalog" for section in result["omitted_sections"])
+
+    def test_skill_view_section_slug_returns_exact_section(self, tmp_path):
+        body = """# Sectioned Skill
+
+Intro.
+
+## Setup
+Install tools.
+
+## Deep Dive
+Detailed implementation notes.
+
+### Nested Detail
+Nested content stays with the selected section.
+
+## Verification
+Run checks.
+"""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "sectioned", body=body)
+            raw = skill_view("sectioned", section_slug="deep-dive")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["retrieval_mode"] == "section"
+        assert result["section"]["slug"] == "deep-dive"
+        assert "Detailed implementation notes" in result["content"]
+        assert "Nested content stays" in result["content"]
+        assert "Install tools" not in result["content"]
+
+    def test_skill_view_full_escape_hatch_bypasses_brief(self, tmp_path):
+        body = "# Huge\n\n" + ("all details stay visible\n" * 300)
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "full-skill", body=body)
+            raw = skill_view("full-skill", mode="brief", full=True)
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["retrieval_mode"] == "full"
+        assert result["targeted_retrieval"]["estimated_saved_chars"] == 0
+        assert result["content"].count("all details stay visible") == 300
+
+    def test_targeted_view_feature_flag_auto_briefs_long_skills(self, tmp_path, monkeypatch):
+        body = """# Auto Brief
+
+Intro.
+
+## Reference Catalog
+""" + ("catalog detail\n" * 1800) + """
+## Safety
+Keep the safety note.
+"""
+        monkeypatch.setenv("HERMES_SKILL_VIEW_TARGETED", "1")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "auto-brief", body=body)
+            raw = skill_view("auto-brief")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["retrieval_mode"] == "brief"
+        assert "Keep the safety note" in result["content"]
+        assert "catalog detail" not in result["content"]
+
+    def test_brief_preserves_nested_and_long_safety_sections(self, tmp_path):
+        body = """# Large Skill
+
+Intro.
+
+## Safety
+""" + ("safe detail\n" * 500) + """
+### Nested Safety Detail
+Nested safety text must remain visible.
+
+## Examples
+""" + ("example\n" * 500)
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "safety-heavy", body=body)
+            raw = skill_view("safety-heavy", mode="brief")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "Nested safety text must remain visible" in result["content"]
+        assert result["content"].count("safe detail") == 500
+        assert "example\nexample" not in result["content"]
+
+    def test_safety_h1_preserves_neutral_child_sections(self, tmp_path):
+        body = """# Safety
+Do not skip safety guidance.
+
+## Neutral Detail
+This neutral child is part of the safety section.
+"""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "h1-safety", body=body)
+            raw = skill_view("h1-safety", mode="brief")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "Do not skip safety guidance" in result["content"]
+        assert "This neutral child is part of the safety section" in result["content"]
+
+    def test_duplicate_heading_slugs_are_stable_and_retrievable(self, tmp_path):
+        body = """# Duplicate Skill
+
+Intro.
+
+## Notes
+First notes.
+
+## Notes
+Second notes.
+
+## Notes 2
+Natural suffix notes.
+"""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "duplicates", body=body)
+            listing = json.loads(skill_view("duplicates", mode="brief"))
+            selected = json.loads(skill_view("duplicates", section_slug="notes-2-2"))
+
+        assert [s["slug"] for s in listing["sections"] if s["title"].startswith("Notes")] == ["notes", "notes-2", "notes-2-2"]
+        assert selected["success"] is True
+        assert selected["section"]["slug"] == "notes-2-2"
+        assert "Natural suffix notes" in selected["content"]
+        assert "First notes" not in selected["content"]
+        assert "Second notes" not in selected["content"]
+
 
 class TestSkillViewSecureSetupOnLoad:
     def test_requests_missing_required_env_and_continues(self, tmp_path, monkeypatch):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -762,6 +762,10 @@ def _serve_plugin_skill(
     *,
     preprocess: bool = True,
     session_id: str | None = None,
+    mode: str | None = None,
+    full: bool = False,
+    section_title: str | None = None,
+    section_slug: str | None = None,
 ) -> str:
     """Read a plugin-provided skill, apply guards, return JSON."""
     from hermes_cli.plugins import _get_disabled_plugins, get_plugin_manager
@@ -846,24 +850,284 @@ def _serve_plugin_skill(
                 "Could not preprocess plugin skill %s:%s", namespace, bare, exc_info=True
             )
 
-    return json.dumps(
+    plugin_content = f"{banner}{rendered_content}" if banner else rendered_content
+    normalized_mode = (mode or "").strip().lower()
+    if full or normalized_mode == "full":
+        effective_mode = "full"
+    elif section_title or section_slug:
+        effective_mode = "section"
+    elif normalized_mode == "brief":
+        effective_mode = "brief"
+    else:
+        targeted_enabled, targeted_threshold = _targeted_skill_config()
+        effective_mode = (
+            "brief" if targeted_enabled and len(plugin_content) >= targeted_threshold else "full"
+        )
+
+    sections = _split_markdown_sections(plugin_content)
+    section_listing = _section_index(sections)
+    returned_content = plugin_content
+    omitted_sections: list[dict[str, Any]] = []
+    selected_section: dict[str, Any] | None = None
+    if effective_mode == "section":
+        selected_section = _find_skill_section(
+            sections, section_title=section_title, section_slug=section_slug
+        )
+        if not selected_section:
+            selector = section_slug or section_title or ""
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Section '{selector}' not found in skill '{namespace}:{bare}'.",
+                    "sections": section_listing,
+                    "hint": "Use one of the listed section_slug values, or pass full=true for the complete skill.",
+                },
+                ensure_ascii=False,
+            )
+        returned_content = selected_section["content"].strip()
+    elif effective_mode == "brief":
+        returned_content, omitted_sections = _brief_skill_content(plugin_content, sections)
+
+    result = {
+        "success": True,
+        "name": f"{namespace}:{bare}",
+        "content": returned_content,
+        "description": description,
+        "linked_files": None,
+        "sections": section_listing,
+        "omitted_sections": omitted_sections,
+        "retrieval_mode": effective_mode,
+        "targeted_retrieval": _targeted_retrieval_metadata(
+            len(plugin_content), len(returned_content)
+        ),
+        "readiness_status": SkillReadinessStatus.AVAILABLE.value,
+    }
+    if selected_section:
+        result["section"] = {
+            "title": selected_section["title"],
+            "slug": selected_section["slug"],
+            "level": selected_section["level"],
+            "chars": len(selected_section["content"]),
+        }
+    return json.dumps(result, ensure_ascii=False)
+
+
+_TARGETED_SKILL_SAFETY_KEYWORDS = (
+    "prerequisite",
+    "setup",
+    "when to use",
+    "trigger",
+    "mandatory",
+    "must",
+    "safety",
+    "security",
+    "boundary",
+    "boundaries",
+    "pitfall",
+    "warning",
+    "verification",
+    "testing",
+    "quality gate",
+)
+_TARGETED_SKILL_DEFAULT_THRESHOLD = 20_000
+_TARGETED_SKILL_SECTION_LIMIT = 3_500
+_TARGETED_SKILL_REPEAT_CACHE: set[tuple[str, str, str]] = set()
+
+
+def _skill_section_slug(title: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", title.strip().lower()).strip("-")
+    return slug or "section"
+
+
+def _split_markdown_sections(markdown: str) -> list[dict[str, Any]]:
+    """Split Markdown into top-level retrieval sections with stable slugs."""
+    matches = list(re.finditer(r"(?m)^(#{1,6})\s+(.+?)\s*$", markdown))
+    if not matches:
+        return [
+            {
+                "title": "Document",
+                "slug": "document",
+                "level": 0,
+                "start": 0,
+                "end": len(markdown),
+                "content": markdown,
+            }
+        ]
+
+    sections: list[dict[str, Any]] = []
+    used_slugs: set[str] = set()
+    if matches[0].start() > 0:
+        prefix = markdown[: matches[0].start()]
+        if prefix.strip():
+            used_slugs.add("preamble")
+            sections.append(
+                {
+                    "title": "Preamble",
+                    "slug": "preamble",
+                    "level": 0,
+                    "start": 0,
+                    "end": matches[0].start(),
+                    "content": prefix,
+                }
+            )
+
+    for idx, match in enumerate(matches):
+        level = len(match.group(1))
+        end = len(markdown)
+        for later in matches[idx + 1 :]:
+            if len(later.group(1)) <= level:
+                end = later.start()
+                break
+        title = match.group(2).strip()
+        base_slug = _skill_section_slug(title)
+        slug = base_slug
+        suffix = 2
+        while slug in used_slugs:
+            slug = f"{base_slug}-{suffix}"
+            suffix += 1
+        used_slugs.add(slug)
+        next_heading = matches[idx + 1].start() if idx + 1 < len(matches) else len(markdown)
+        sections.append(
+            {
+                "title": title,
+                "slug": slug,
+                "level": level,
+                "start": match.start(),
+                "end": end,
+                "content": markdown[match.start() : end],
+                "intro_content": markdown[match.start() : next_heading],
+            }
+        )
+    return sections
+
+
+def _section_index(sections: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
         {
-            "success": True,
-            "name": f"{namespace}:{bare}",
-            "content": f"{banner}{rendered_content}" if banner else rendered_content,
-            "description": description,
-            "linked_files": None,
-            "readiness_status": SkillReadinessStatus.AVAILABLE.value,
-        },
-        ensure_ascii=False,
+            "title": section["title"],
+            "slug": section["slug"],
+            "level": section["level"],
+            "chars": len(section["content"]),
+        }
+        for section in sections
+    ]
+
+
+def _section_is_safety_critical(section: dict[str, Any]) -> bool:
+    text = f"{section['title']}\n{(section.get('intro_content') or section['content'])[:500]}".lower()
+    return any(keyword in text for keyword in _TARGETED_SKILL_SAFETY_KEYWORDS)
+
+
+def _truncate_skill_section(content: str) -> str:
+    if len(content) <= _TARGETED_SKILL_SECTION_LIMIT:
+        return content.rstrip()
+    return (
+        content[:_TARGETED_SKILL_SECTION_LIMIT].rstrip()
+        + "\n\n[Targeted retrieval: section truncated; request this section by section_slug for full detail.]"
     )
+
+
+def _brief_skill_content(markdown: str, sections: list[dict[str, Any]]) -> tuple[str, list[dict[str, Any]]]:
+    included: list[dict[str, Any]] = []
+    omitted: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    covered_end = -1
+    for idx, section in enumerate(sections):
+        if section["start"] < covered_end:
+            continue
+        include = idx == 0 or _section_is_safety_critical(section)
+        if include and section["slug"] not in seen:
+            included.append(section)
+            seen.add(section["slug"])
+            if _section_is_safety_critical(section):
+                covered_end = max(covered_end, section["end"])
+        else:
+            omitted.append(section)
+
+    rendered_sections: list[str] = []
+    for section in included:
+        if _section_is_safety_critical(section):
+            rendered_sections.append(section["content"].rstrip())
+            continue
+        section_content = section.get("intro_content") or section["content"]
+        rendered_sections.append(_truncate_skill_section(section_content))
+    body = "\n\n".join(rendered_sections).strip()
+    if omitted:
+        omitted_lines = "\n".join(
+            f"- {section['title']} (`{section['slug']}`, {len(section['content'])} chars)"
+            for section in omitted
+        )
+        body = (
+            f"{body}\n\n## Targeted retrieval available\n"
+            "Omitted non-safety sections can be loaded with `section_slug` or `section_title`:\n"
+            f"{omitted_lines}"
+        )
+    return body, _section_index(omitted)
+
+
+def _find_skill_section(
+    sections: list[dict[str, Any]], *, section_title: str | None, section_slug: str | None
+) -> dict[str, Any] | None:
+    if section_slug:
+        wanted = _skill_section_slug(section_slug)
+        for section in sections:
+            if section["slug"] == wanted:
+                return section
+    if section_title:
+        title_norm = section_title.strip().lower()
+        slug_norm = _skill_section_slug(section_title)
+        for section in sections:
+            if section["title"].strip().lower() == title_norm or section["slug"] == slug_norm:
+                return section
+    return None
+
+
+def _targeted_skill_config() -> tuple[bool, int]:
+    enabled = False
+    threshold = _TARGETED_SKILL_DEFAULT_THRESHOLD
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        targeted_cfg = cfg_get(cfg, "skills", "targeted_view", default={}) or {}
+        if isinstance(targeted_cfg, dict):
+            enabled = bool(targeted_cfg.get("enabled", enabled))
+            threshold = int(targeted_cfg.get("threshold_chars", threshold))
+    except Exception:
+        pass
+    env_enabled = os.getenv("HERMES_SKILL_VIEW_TARGETED", "").strip().lower()
+    if env_enabled in {"1", "true", "yes", "on"}:
+        enabled = True
+    elif env_enabled in {"0", "false", "no", "off"}:
+        enabled = False
+    return enabled, threshold
+
+
+def _targeted_retrieval_metadata(full_chars: int, returned_chars: int) -> dict[str, Any]:
+    saved = max(full_chars - returned_chars, 0)
+    return {
+        "full_chars": full_chars,
+        "returned_chars": returned_chars,
+        "estimated_saved_chars": saved,
+        "estimated_saved_percent": round((saved / full_chars) * 100, 1) if full_chars else 0.0,
+        "rollout": {
+            "explicit_modes": ["brief", "full"],
+            "escape_hatch": "Pass full=true or mode='full' to return complete SKILL.md content.",
+            "feature_flag": "Set skills.targeted_view.enabled=true or HERMES_SKILL_VIEW_TARGETED=1 to auto-brief long skills.",
+            "rollback": "Disable skills.targeted_view.enabled or unset HERMES_SKILL_VIEW_TARGETED; explicit full=true always bypasses briefing.",
+        },
+    }
 
 
 def skill_view(
     name: str,
-    file_path: str = None,
-    task_id: str = None,
+    file_path: str | None = None,
+    task_id: str | None = None,
     preprocess: bool = True,
+    mode: str | None = None,
+    full: bool = False,
+    section_title: str | None = None,
+    section_slug: str | None = None,
 ) -> str:
     """
     View the content of a skill or a specific file within a skill directory.
@@ -943,6 +1207,10 @@ def skill_view(
                     bare,
                     preprocess=preprocess,
                     session_id=task_id,
+                    mode=mode,
+                    full=full,
+                    section_title=section_title,
+                    section_slug=section_slug,
                 )
 
             # Plugin exists but this specific skill is missing?
@@ -1450,19 +1718,75 @@ def skill_view(
                     "Could not preprocess skill content for %s", skill_name, exc_info=True
                 )
 
+        normalized_mode = (mode or "").strip().lower()
+        if full or normalized_mode == "full":
+            effective_mode = "full"
+        elif section_title or section_slug:
+            effective_mode = "section"
+        elif normalized_mode == "brief":
+            effective_mode = "brief"
+        else:
+            targeted_enabled, targeted_threshold = _targeted_skill_config()
+            effective_mode = (
+                "brief"
+                if targeted_enabled and len(rendered_content) >= targeted_threshold
+                else "full"
+            )
+
+        sections = _split_markdown_sections(rendered_content)
+        section_listing = _section_index(sections)
+        returned_content = rendered_content
+        omitted_sections: list[dict[str, Any]] = []
+        selected_section: dict[str, Any] | None = None
+
+        if effective_mode == "section":
+            selected_section = _find_skill_section(
+                sections, section_title=section_title, section_slug=section_slug
+            )
+            if not selected_section:
+                selector = section_slug or section_title or ""
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": f"Section '{selector}' not found in skill '{skill_name}'.",
+                        "sections": section_listing,
+                        "hint": "Use one of the listed section_slug values, or pass full=true for the complete skill.",
+                    },
+                    ensure_ascii=False,
+                )
+            returned_content = selected_section["content"].strip()
+        elif effective_mode == "brief":
+            returned_content, omitted_sections = _brief_skill_content(
+                rendered_content, sections
+            )
+
+        retrieval_metadata = _targeted_retrieval_metadata(
+            len(rendered_content), len(returned_content)
+        )
+        if task_id:
+            cache_key = (task_id, skill_name, effective_mode)
+            retrieval_metadata["repeat_load"] = cache_key in _TARGETED_SKILL_REPEAT_CACHE
+            _TARGETED_SKILL_REPEAT_CACHE.add(cache_key)
+        else:
+            retrieval_metadata["repeat_load"] = False
+
         result = {
             "success": True,
             "name": skill_name,
             "description": frontmatter.get("description", ""),
             "tags": tags,
             "related_skills": related_skills,
-            "content": rendered_content,
+            "content": returned_content,
             "path": rel_path,
             "skill_dir": str(skill_dir) if skill_dir else None,
             "linked_files": linked_files if linked_files else None,
             "usage_hint": "To view linked files, call skill_view(name, file_path) where file_path is e.g. 'references/api.md' or 'assets/config.yaml'"
             if linked_files
             else None,
+            "sections": section_listing,
+            "omitted_sections": omitted_sections,
+            "retrieval_mode": effective_mode,
+            "targeted_retrieval": retrieval_metadata,
             "required_environment_variables": required_env_vars,
             "required_commands": [],
             "missing_required_environment_variables": remaining_missing_required_envs,
@@ -1474,6 +1798,13 @@ def skill_view(
             if setup_needed
             else SkillReadinessStatus.AVAILABLE.value,
         }
+        if selected_section:
+            result["section"] = {
+                "title": selected_section["title"],
+                "slug": selected_section["slug"],
+                "level": selected_section["level"],
+                "chars": len(selected_section["content"]),
+            }
 
         setup_help = next((e["help"] for e in required_env_vars if e.get("help")), None)
         if setup_help:
@@ -1576,7 +1907,7 @@ SKILLS_LIST_SCHEMA = {
 
 SKILL_VIEW_SCHEMA = {
     "name": "skill_view",
-    "description": "Skills allow for loading information about specific tasks and workflows, as well as scripts and templates. Load a skill's full content or access its linked files (references, templates, scripts). First call returns SKILL.md content plus a 'linked_files' dict showing available references/templates/scripts. To access those, call again with file_path parameter.",
+    "description": "Skills allow for loading information about specific tasks and workflows, as well as scripts and templates. Load a skill's full content, a compact safety brief, a deterministic section, or a linked file (references, templates, scripts). Use mode='brief' for manifest/safety briefing, section_slug/section_title for targeted retrieval, and full=true as the explicit escape hatch.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1586,7 +1917,24 @@ SKILL_VIEW_SCHEMA = {
             },
             "file_path": {
                 "type": "string",
-                "description": "OPTIONAL: Path to a linked file within the skill (e.g., 'references/api.md', 'templates/config.yaml', 'scripts/validate.py'). Omit to get the main SKILL.md content.",
+                "description": "OPTIONAL: Path to a linked file within the skill (e.g., 'references/api.md', 'templates/config.yaml', 'scripts/validate.py'). Omit to get the main SKILL.md content or targeted brief/section.",
+            },
+            "mode": {
+                "type": "string",
+                "enum": ["brief", "full"],
+                "description": "OPTIONAL: 'brief' returns manifest plus safety-critical sections and omitted-section slugs; 'full' returns complete SKILL.md content.",
+            },
+            "full": {
+                "type": "boolean",
+                "description": "OPTIONAL: Explicit escape hatch. When true, returns complete SKILL.md content even if brief mode or auto-briefing is enabled.",
+            },
+            "section_title": {
+                "type": "string",
+                "description": "OPTIONAL: Return one deterministic Markdown section by exact heading title.",
+            },
+            "section_slug": {
+                "type": "string",
+                "description": "OPTIONAL: Return one deterministic Markdown section by stable slug from a prior sections list.",
             },
         },
         "required": ["name"],
@@ -1608,7 +1956,13 @@ def _skill_view_with_bump(args, **kw):
     telemetry failure never breaks the tool call."""
     name = args.get("name", "")
     result = skill_view(
-        name, file_path=args.get("file_path"), task_id=kw.get("task_id")
+        name,
+        file_path=args.get("file_path"),
+        task_id=kw.get("task_id"),
+        mode=args.get("mode"),
+        full=bool(args.get("full", False)),
+        section_title=args.get("section_title"),
+        section_slug=args.get("section_slug"),
     )
     try:
         parsed = json.loads(result)


### PR DESCRIPTION
## What does this PR do?

Adds a production targeted retrieval path for `skill_view` so mandatory skill loading can stay safe without flooding context on large skills.

The implementation lives in the Hermes core skill tool path and supports:
- compact `mode="brief"` responses with manifest plus safety-critical sections;
- deterministic `section_slug` / `section_title` retrieval;
- explicit `full=true` / `mode="full"` escape hatch;
- existing linked-file retrieval behavior;
- savings metadata and repeat-load metadata;
- plugin-provided skill support;
- rollback-safe rollout via config/env flag.

The intended retrieval flow is progressive: request `mode="brief"` first, inspect the returned section manifest, then retrieve a specific section with `section_slug` or `section_title` only when the task needs it. This avoids loading an entire large skill solely to access one subsection, while preserving `full=true` / `mode="full"` for cases where the complete document is required.

## Related Issue

Refs revise-repeat/siva-os#187

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skills_tool.py`
  - Adds `mode`, `full`, `section_title`, and `section_slug` support to `skill_view`.
  - Adds Markdown section indexing with stable unique slugs.
  - Preserves safety-critical sections in brief mode: prerequisites, mandatory rules, boundaries, pitfalls, warnings, safety/security, testing, and verification.
  - Adds omitted-section manifests and targeted retrieval savings metadata.
  - Wires targeted retrieval through plugin skill serving.
- `hermes_cli/config.py`
  - Adds disabled-by-default `skills.targeted_view` rollout config with `enabled` and `threshold_chars`.
- `cli-config.yaml.example`
  - Documents the targeted view rollout config and rollback behavior.
- `tests/tools/test_skills_tool.py`
  - Covers brief mode, full escape hatch, section retrieval, safety preservation, duplicate slug collision behavior, and env flag auto-briefing.
- `tests/test_plugin_skills.py`
  - Covers targeted section retrieval for plugin-provided skills.

## How to Test

1. Run the scoped test suite:
   ```bash
   /Users/timbeaulac/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_skills_tool.py tests/tools/test_skill_size_limits.py tests/tools/test_skill_view_traversal.py tests/test_plugin_skills.py -q -o 'addopts='
   ```
2. Validate the config example:
   ```bash
   /Users/timbeaulac/.hermes/hermes-agent/venv/bin/python - <<'PY'
   import yaml
   from pathlib import Path
   cfg = yaml.safe_load(Path('cli-config.yaml.example').read_text())
   assert cfg['skills']['targeted_view']['enabled'] is False
   assert cfg['skills']['targeted_view']['threshold_chars'] == 20000
   print('cli-config targeted_view example OK')
   PY
   ```
3. Smoke targeted retrieval against live local skills:
   ```bash
   PYTHONPATH=. HERMES_HOME=/Users/timbeaulac/.hermes/profiles/builder python3 - <<'PY'
   import json
   from tools.skills_tool import skill_view
   for name in ['hermes-agent', 'github-issues']:
       brief = json.loads(skill_view(name, mode='brief'))
       print(name, brief['targeted_retrieval'])
   PY
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Scoped verification passed; a full-suite attempt showed broad unrelated/environment failures by ~15% and was stopped rather than conflating them with this PR.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - N/A for public docs; tool schema/config comments were updated.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A; this is tool behavior/config, not contributor workflow.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - Uses Python stdlib/string processing only; no platform-specific path or process behavior added.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Scoped verification:

```text
cli-config targeted_view example OK
148 passed, 1 warning in 3.09s
```

Live smoke savings:

```text
hermes-agent: saved 28,583 chars (62.1%)
github-issues: saved 9,528 chars (71.4%)
github-projects-v2: saved 29,349 chars (69.0%)
```

Historical state DB analyzer from the linked SIVA OS worktree:

```text
builder profile: estimated 86.9% savings
default profile: estimated 88.7% savings
```

Rollout/rollback:
- Auto-briefing is disabled by default.
- Enable with `skills.targeted_view.enabled=true` or `HERMES_SKILL_VIEW_TARGETED=1`.
- Roll back by disabling config/unsetting env.
- `full=true` or `mode="full"` always returns complete content.

