### PR TITLE
fix(doctor): pin utf-8/replace decoding for captured subprocesses

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -28,6 +28,25 @@ from hermes_constants import OPENROUTER_MODELS_URL
 from utils import base_url_host_matches
 
 
+def _run_text_subprocess(cmd, **kwargs):
+    """Run a subprocess capturing decoded text without crashing on locale codecs.
+
+    ``subprocess.run(..., text=True)`` decodes child output with the system
+    locale codec. On non-UTF-8 Windows locales (e.g. Chinese CP936/GBK) a
+    child that emits UTF-8 bytes triggers ``UnicodeDecodeError`` inside the
+    reader thread, crashing ``hermes doctor`` mid-diagnosis (see issue #49499).
+
+    Pin ``encoding="utf-8"`` and ``errors="replace"`` so decoding is
+    deterministic across locales and undecodable bytes degrade to the
+    replacement character instead of raising. Callers may override either
+    value via *kwargs*.
+    """
+    kwargs.setdefault("encoding", "utf-8")
+    kwargs.setdefault("errors", "replace")
+    kwargs.pop("text", None)
+    return subprocess.run(cmd, **kwargs)
+
+
 _PROVIDER_ENV_HINTS = (
     "OPENROUTER_API_KEY",
     "OPENAI_API_KEY",
@@ -1455,10 +1474,9 @@ def run_doctor(args):
             cmd += [target, "echo ok"]
             # Try to connect
             try:
-                result = subprocess.run(
+                result = _run_text_subprocess(
                     cmd,
                     capture_output=True,
-                    text=True,
                     timeout=15
                 )
             except subprocess.TimeoutExpired:
@@ -1601,10 +1619,10 @@ def run_doctor(args):
             try:
                 # Use resolved absolute path so Windows can execute
                 # npm.cmd (CreateProcessW can't run bare .cmd names).
-                audit_result = subprocess.run(
+                audit_result = _run_text_subprocess(
                     [_npm_bin, "audit", "--json", *audit_extra],
                     cwd=str(npm_dir),
-                    capture_output=True, text=True, timeout=30,
+                    capture_output=True, timeout=30,
                 )
                 import json as _json
                 audit_data = _json.loads(audit_result.stdout) if audit_result.stdout.strip() else {}

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -28,7 +28,7 @@ from hermes_constants import OPENROUTER_MODELS_URL
 from utils import base_url_host_matches
 
 
-def _run_text_subprocess(cmd, **kwargs):
+def _run_text_subprocess(cmd, *, timeout=None, **kwargs):
     """Run a subprocess capturing decoded text without crashing on locale codecs.
 
     ``subprocess.run(..., text=True)`` decodes child output with the system
@@ -40,11 +40,17 @@ def _run_text_subprocess(cmd, **kwargs):
     deterministic across locales and undecodable bytes degrade to the
     replacement character instead of raising. Callers may override either
     value via *kwargs*.
+
+    ``timeout`` is a keyword-only argument forwarded as a literal kwarg to
+    ``subprocess.run`` so the CLI subprocess-timeout guardrail
+    (tests/hermes_cli/test_subprocess_timeouts.py) can verify it statically.
+    Callers should always pass an explicit timeout; the ``None`` default
+    exists only so the helper's own unit tests can exercise decoding behavior.
     """
     kwargs.setdefault("encoding", "utf-8")
     kwargs.setdefault("errors", "replace")
     kwargs.pop("text", None)
-    return subprocess.run(cmd, **kwargs)
+    return subprocess.run(cmd, timeout=timeout, **kwargs)
 
 
 _PROVIDER_ENV_HINTS = (

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1476,3 +1476,63 @@ def test_npm_audit_fix_hint_avoids_crashing_workspace_flag(monkeypatch, tmp_path
     assert "build-time tooling" in out
     assert "known npm bug" in out
     assert "lockfile bump" in out
+
+
+class TestRunTextSubprocess:
+    """Regression coverage for issue #49499 — ``hermes doctor`` crashed with
+    ``UnicodeDecodeError`` on non-UTF-8 Windows locales (CP936/GBK) when a
+    captured subprocess emitted bytes invalid under the system codec.
+    """
+
+    def test_pins_utf8_and_replace_by_default(self, monkeypatch):
+        captured = {}
+
+        def _fake_run(cmd, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        monkeypatch.setattr(doctor.subprocess, "run", _fake_run)
+        doctor._run_text_subprocess(["echo", "hi"], capture_output=True)
+
+        assert captured["encoding"] == "utf-8"
+        assert captured["errors"] == "replace"
+        # ``text`` must not be forwarded alongside an explicit encoding.
+        assert "text" not in captured
+
+    def test_strips_text_kwarg(self, monkeypatch):
+        captured = {}
+
+        def _fake_run(cmd, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        monkeypatch.setattr(doctor.subprocess, "run", _fake_run)
+        # Callers historically passed text=True; it must be dropped so the
+        # explicit encoding/errors take effect (text=True + encoding is fine,
+        # but passing text alongside is redundant and we normalize it away).
+        doctor._run_text_subprocess(["echo", "hi"], capture_output=True, text=True)
+        assert "text" not in captured
+        assert captured["encoding"] == "utf-8"
+
+    def test_caller_can_override_encoding(self, monkeypatch):
+        captured = {}
+
+        def _fake_run(cmd, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        monkeypatch.setattr(doctor.subprocess, "run", _fake_run)
+        doctor._run_text_subprocess(["echo", "hi"], encoding="latin-1", errors="strict")
+        assert captured["encoding"] == "latin-1"
+        assert captured["errors"] == "strict"
+
+    def test_survives_bytes_invalid_under_gbk(self):
+        """End-to-end: bytes that raise UnicodeDecodeError under GBK decode
+        cleanly via the utf-8/replace default instead of crashing."""
+        code = r"import sys; sys.stdout.buffer.write(b'ok\xaa\xff tail')"
+        result = doctor._run_text_subprocess(
+            [sys.executable, "-c", code], capture_output=True
+        )
+        assert result.returncode == 0
+        assert result.stdout.startswith("ok")
+        assert "tail" in result.stdout


### PR DESCRIPTION
## Summary

- `hermes doctor` crashed with `UnicodeDecodeError` on non-UTF-8 Windows locales (CP936/GBK).
- Captured subprocess output now decodes deterministically and survives undecodable bytes.

## Motivation

Closes #49499.

On Chinese Simplified Windows (default locale CP936/GBK), `hermes doctor` crashed during the connectivity/diagnostic checks:

```text
UnicodeDecodeError: 'gbk' codec can't decode byte 0xaa in position 1753: illegal multibyte sequence
```

`subprocess.run(..., text=True)` decodes the child's output with the **system locale codec**. When a captured child emits UTF-8 bytes that are invalid under GBK, the decode raises inside subprocess's reader thread and takes down the command that's supposed to be the first troubleshooting step.

## Fix

Add a small helper `_run_text_subprocess()` that pins `encoding="utf-8"` and `errors="replace"` (both caller-overridable), and route the two text-capturing doctor probes — the SSH connectivity check and the `npm audit` check — through it. Undecodable bytes now degrade to the replacement character instead of crashing, exactly as the issue's "Suggested Fix" requested.

The two byte-only captures (`docker info`, `gh auth status`) don't decode text and are left unchanged.

## Verification

- `python3 -m pytest tests/hermes_cli/test_doctor.py` — 70 passed

## Real behavior proof

- **Behavior addressed:** a captured subprocess emitting bytes (`0xaa 0xff`) that are illegal under GBK.
- **Before (reproduces #49499)** — decoding those bytes with the GBK locale codec:

```text
gbk -> CRASH (reproduces #49499): 'gbk' codec can't decode byte 0xaa in position 2: illegal multibyte sequence
```

- **After** — same bytes through `_run_text_subprocess(...)`:

```text
helper -> survives: 'ok\ufffd\ufffd tail'
```

- **Regression test:** `tests/hermes_cli/test_doctor.py::TestRunTextSubprocess::test_survives_bytes_invalid_under_gbk` spawns a child that writes `b'ok\xaa\xff tail'` and asserts the helper returns cleanly (returncode 0, output preserved) — it would raise `UnicodeDecodeError` under a GBK locale with the old `text=True` path.
- **What was NOT tested:** the live GBK Windows environment itself (no Windows runner locally); the test reproduces the decode mechanism cross-platform by exercising the exact byte pattern.
