### PR TITLE
Fix desktop memory provider built-in option

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -21,7 +21,7 @@ import { PanelEmpty } from '../overlays/panel'
 import { CONTROL_TEXT, EMPTY_SELECT_VALUE, FIELD_DESCRIPTIONS, FIELD_LABELS, SECTIONS } from './constants'
 import { FallbackModelsField } from './fallback-models-field'
 import { fieldCopyForSchemaKey } from './field-copy'
-import { enumOptionsFor, getNested, prettyName, setNested } from './helpers'
+import { enumOptionsFor, getNested, isPluginMemoryProvider, memoryProviderValue, prettyName, setNested } from './helpers'
 import { MemoryConnect } from './memory/connect'
 import { ModelSettings, ModelSettingsSkeleton } from './model-settings'
 import { EmptyState, ListRow, LoadingState, SettingsContent } from './primitives'
@@ -130,11 +130,12 @@ function ConfigField({
         <SelectContent>
           {selectOptions.map(option => (
             <SelectItem key={option || EMPTY_SELECT_VALUE} value={option || EMPTY_SELECT_VALUE}>
-              {option
-                ? (optionLabels?.[option] ?? prettyName(option))
-                : schemaKey === 'display.personality'
-                  ? c.none
-                  : c.noneParen}
+              {optionLabels?.[option] ??
+                (option
+                  ? prettyName(option)
+                  : schemaKey === 'display.personality'
+                    ? c.none
+                    : c.noneParen)}
             </SelectItem>
           ))}
         </SelectContent>
@@ -455,30 +456,41 @@ export function ConfigSettings({
         <EmptyState description={c.emptyDesc} title={c.emptyTitle} />
       ) : (
         <div className="grid gap-1">
-          {visibleFields.map(([key, field]) => (
-            <div className="scroll-mt-6 rounded-lg" id={`setting-field-${key}`} key={key}>
-              <ConfigField
-                descriptionExtra={
-                  key === 'memory.provider' && Boolean(getNested(config, key)) ? (
-                    <MemoryConnect provider={String(getNested(config, key))} />
-                  ) : undefined
-                }
-                enumOptions={
-                  key === 'tts.elevenlabs.voice_id'
-                    ? enumOptionsFor(key, getNested(config, key), config, elevenLabsVoiceOptions ?? undefined)
-                    : enumOptionsFor(key, getNested(config, key), config)
-                }
-                onChange={value => updateConfig(setNested(config, key, value))}
-                optionLabels={key === 'tts.elevenlabs.voice_id' ? elevenLabsVoiceLabels : undefined}
-                schema={field}
-                schemaKey={key}
-                value={getNested(config, key)}
-              />
-              {key === 'memory.provider' && typeof getNested(config, key) === 'string' && getNested(config, key) ? (
-                <ProviderConfigPanel provider={String(getNested(config, key))} />
-              ) : null}
-            </div>
-          ))}
+          {visibleFields.map(([key, field]) => {
+            const value =
+              key === 'memory.provider' ? memoryProviderValue(getNested(config, key)) : getNested(config, key)
+
+            return (
+              <div className="scroll-mt-6 rounded-lg" id={`setting-field-${key}`} key={key}>
+                <ConfigField
+                  descriptionExtra={
+                    key === 'memory.provider' && isPluginMemoryProvider(value) ? (
+                      <MemoryConnect provider={String(value)} />
+                    ) : undefined
+                  }
+                  enumOptions={
+                    key === 'tts.elevenlabs.voice_id'
+                      ? enumOptionsFor(key, value, config, elevenLabsVoiceOptions ?? undefined)
+                      : enumOptionsFor(key, value, config)
+                  }
+                  onChange={nextValue => updateConfig(setNested(config, key, nextValue))}
+                  optionLabels={
+                    key === 'tts.elevenlabs.voice_id'
+                      ? elevenLabsVoiceLabels
+                      : key === 'memory.provider'
+                        ? { '': c.builtIn }
+                        : undefined
+                  }
+                  schema={field}
+                  schemaKey={key}
+                  value={value}
+                />
+                {key === 'memory.provider' && isPluginMemoryProvider(value) ? (
+                  <ProviderConfigPanel provider={String(value)} />
+                ) : null}
+              </div>
+            )
+          })}
         </div>
       )}
       <input

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -238,7 +238,7 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'code_execution.mode': ['project', 'strict'],
   'context.engine': ['compressor', 'default', 'custom'],
   'delegation.reasoning_effort': ['', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
-  'memory.provider': ['', 'builtin', 'hindsight', 'honcho'],
+  'memory.provider': ['', 'hindsight', 'honcho'],
   // Terminal execution backends — kept in sync with the dispatch ladder in
   // tools/terminal_tool.py::_create_environment (local/docker/singularity/
   // modal/daytona/ssh). Remote backends need extra env (image, tokens, host).

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -3,13 +3,28 @@ import { describe, expect, it } from 'vitest'
 import type { HermesConfigRecord } from '@/types/hermes'
 
 import { defineFieldCopy, fieldCopyForSchemaKey, schemaKeyToFieldCopyKey } from './field-copy'
-import { enumOptionsFor, getNested, providerGroup, setNested, stripToolsetLabel, toolsetDisplayLabel } from './helpers'
+import {
+  enumOptionsFor,
+  getNested,
+  memoryProviderValue,
+  providerGroup,
+  setNested,
+  stripToolsetLabel,
+  toolsetDisplayLabel
+} from './helpers'
 
 describe('settings helpers', () => {
-  it('lists Hindsight as a built-in desktop memory provider option', () => {
+  it('lists plugin memory providers without exposing the built-in alias as a plugin', () => {
     const options = enumOptionsFor('memory.provider', '', {})
 
+    expect(options).toContain('')
     expect(options).toContain('hindsight')
+    expect(options).not.toContain('builtin')
+    expect(enumOptionsFor('memory.provider', 'builtin', {})).not.toContain('builtin')
+  })
+
+  it.each(['built-in', 'builtin', 'none'])('normalizes the %s memory provider alias', alias => {
+    expect(memoryProviderValue(alias)).toBe('')
   })
 
   describe('defineFieldCopy', () => {

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -7,6 +7,16 @@ import { BUILTIN_PERSONALITIES, ENUM_OPTIONS, PROVIDER_GROUPS } from './constant
 // settings/capabilities call sites keep their import path.
 export { asText, includesQuery, prettyName } from '@/lib/text'
 
+const BUILT_IN_MEMORY_PROVIDER_ALIASES = new Set(['built-in', 'builtin', 'none'])
+
+export const memoryProviderValue = (v: unknown): string => {
+  const provider = asText(v).trim()
+
+  return BUILT_IN_MEMORY_PROVIDER_ALIASES.has(provider.toLowerCase()) ? '' : provider
+}
+
+export const isPluginMemoryProvider = (v: unknown): boolean => Boolean(memoryProviderValue(v))
+
 /** Strip leading emoji from toolset titles (CLI registry prefixes labels with icons). */
 export const stripToolsetLabel = (label: string): string =>
   label.replace(/^[\p{Emoji}\p{Extended_Pictographic}\s]+/u, '').trim() || label
@@ -144,7 +154,7 @@ export function enumOptionsFor(
     return undefined
   }
 
-  const current = asText(value)
+  const current = key === 'memory.provider' ? memoryProviderValue(value) : asText(value)
 
   return current && !opts.includes(current) ? [...opts, current] : opts
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -489,6 +489,7 @@ export const en: Translations = {
     config: {
       none: 'None',
       noneParen: '(none)',
+      builtIn: 'Built-in',
       notSet: 'Not set',
       commaSeparated: 'comma-separated values',
       loading: 'Loading Hermes configuration...',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -601,6 +601,7 @@ export const ja = defineLocale({
     config: {
       none: 'なし',
       noneParen: '(なし)',
+      builtIn: '組み込み',
       notSet: '未設定',
       commaSeparated: 'カンマ区切りの値',
       loading: 'Hermes の設定を読み込み中...',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -403,6 +403,7 @@ export interface Translations {
     config: {
       none: string
       noneParen: string
+      builtIn: string
       notSet: string
       commaSeparated: string
       loading: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -590,6 +590,7 @@ export const zhHant = defineLocale({
     config: {
       none: '無',
       noneParen: '(無)',
+      builtIn: '內建',
       notSet: '未設定',
       commaSeparated: '逗號分隔的值',
       loading: '正在載入 Hermes 設定...',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -681,6 +681,7 @@ export const zh: Translations = {
     config: {
       none: '无',
       noneParen: '(无)',
+      builtIn: '内置',
       notSet: '未设置',
       commaSeparated: '逗号分隔的值',
       loading: '正在加载 Hermes 配置...',


### PR DESCRIPTION
## Summary
- Treat blank `memory.provider` as the built-in memory option in Desktop Settings.
- Remove the misleading `builtin` plugin option from the provider dropdown.
- Normalize legacy built-in aliases before rendering provider setup controls.
- Add regression coverage for the dropdown and legacy aliases.

## Why
Built-in persistent memory is the default `MEMORY.md` / `USER.md` layer. The `memory.provider` setting selects an external provider plugin that runs alongside it.

Desktop Settings exposed `builtin` as if it were a provider plugin. Selecting it could also render plugin setup controls for a provider that does not exist. The backend already normalizes `built-in`, `builtin`, and `none` to the blank built-in value; this change applies the same contract in the desktop UI.

Closes #49513

## Tests
- `npm --prefix apps/desktop run test:ui -- src/app/settings/helpers.test.ts` → **22 passed**
- `npm --prefix apps/desktop run typecheck` → passed
- ESLint on all changed desktop files with `--quiet` → passed
- `git diff --check upstream/main...HEAD` → passed

