### PR TITLE
fix(desktop): mute hidden link-title window so historical links don't autoplay audio

### DIFF
--- a/apps/desktop/electron/link-title-window.cjs
+++ b/apps/desktop/electron/link-title-window.cjs
@@ -1,0 +1,42 @@
+'use strict'
+
+// Hidden BrowserWindow used by tier-2 link-title resolution: when curl can't
+// read a page <title> (bot walls, JS-rendered pages), we briefly load the URL
+// in an offscreen window and read its title. That window loads arbitrary
+// user-linked pages — including YouTube/`watch` URLs that autoplay — so it must
+// never be allowed to emit sound.
+
+function linkTitleWindowOptions(partitionSession) {
+  return {
+    show: false,
+    width: 1280,
+    height: 800,
+    webPreferences: {
+      backgroundThrottling: false,
+      contextIsolation: true,
+      javascript: true,
+      nodeIntegration: false,
+      sandbox: true,
+      session: partitionSession,
+      webSecurity: true
+    }
+  }
+}
+
+// Create the offscreen title-fetch window and immediately mute it. Without the
+// mute, autoplaying media on the loaded page (e.g. a YouTube link) leaks ~2s of
+// audio every time a session containing such links is re-rendered. See #49505.
+function createLinkTitleWindow(BrowserWindow, partitionSession) {
+  const window = new BrowserWindow(linkTitleWindowOptions(partitionSession))
+
+  try {
+    window.webContents.setAudioMuted(true)
+  } catch {
+    // webContents may be unavailable in degraded/headless environments; muting
+    // is best-effort and the window is destroyed within a few seconds anyway.
+  }
+
+  return window
+}
+
+module.exports = { createLinkTitleWindow, linkTitleWindowOptions }

--- a/apps/desktop/electron/link-title-window.test.cjs
+++ b/apps/desktop/electron/link-title-window.test.cjs
@@ -1,0 +1,56 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const { createLinkTitleWindow, linkTitleWindowOptions } = require('./link-title-window.cjs')
+
+function makeFakeBrowserWindow() {
+  const calls = { audioMuted: [] }
+  const FakeBrowserWindow = function (options) {
+    this.options = options
+    this.webContents = {
+      setAudioMuted(value) {
+        calls.audioMuted.push(value)
+      }
+    }
+  }
+
+  return { FakeBrowserWindow, calls }
+}
+
+test('linkTitleWindowOptions keeps the offscreen, hardened defaults', () => {
+  const session = { id: 'link-titles' }
+  const options = linkTitleWindowOptions(session)
+
+  assert.equal(options.show, false)
+  assert.equal(options.webPreferences.session, session)
+  assert.equal(options.webPreferences.contextIsolation, true)
+  assert.equal(options.webPreferences.sandbox, true)
+  assert.equal(options.webPreferences.nodeIntegration, false)
+})
+
+test('createLinkTitleWindow mutes audio so historical links never autoplay sound', () => {
+  // Regression for #49505: the hidden title-fetch window loaded YouTube/watch
+  // URLs (to read their <title>) without muting, leaking ~2s of audio on every
+  // history re-render.
+  const { FakeBrowserWindow, calls } = makeFakeBrowserWindow()
+
+  const window = createLinkTitleWindow(FakeBrowserWindow, { id: 'link-titles' })
+
+  assert.ok(window instanceof FakeBrowserWindow)
+  assert.deepEqual(calls.audioMuted, [true])
+})
+
+test('createLinkTitleWindow still returns the window if muting throws', () => {
+  const ThrowingBrowserWindow = function (options) {
+    this.options = options
+    this.webContents = {
+      setAudioMuted() {
+        throw new Error('webContents unavailable')
+      }
+    }
+  }
+
+  const window = createLinkTitleWindow(ThrowingBrowserWindow, { id: 'link-titles' })
+
+  assert.ok(window instanceof ThrowingBrowserWindow)
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -34,6 +34,7 @@ const {
   SESSION_WINDOW_MIN_WIDTH
 } = require('./session-windows.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
+const { createLinkTitleWindow } = require('./link-title-window.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
 const { adoptServedDashboardToken } = require('./dashboard-token.cjs')
 const { waitForDashboardPort } = require('./backend-ready.cjs')
@@ -2980,20 +2981,7 @@ function runRenderTitleJob(rawUrl) {
     }
 
     try {
-      window = new BrowserWindow({
-        show: false,
-        width: 1280,
-        height: 800,
-        webPreferences: {
-          backgroundThrottling: false,
-          contextIsolation: true,
-          javascript: true,
-          nodeIntegration: false,
-          sandbox: true,
-          session: partitionSession,
-          webSecurity: true
-        }
-      })
+      window = createLinkTitleWindow(BrowserWindow, partitionSession)
     } catch {
       return finish('')
     }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/link-title-window.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary

Fixes #49505 — reopening a desktop session that contains YouTube (or other autoplaying) links re-renders history and leaks ~2s of audio per link, on every fresh app open.

**Root cause:** link-title resolution has a tier-2 fallback (`runRenderTitleJob` in `apps/desktop/electron/main.cjs`) that loads the URL in a hidden offscreen `BrowserWindow` to read its `<title>` when curl can't. That window was never muted, so any page that autoplays media (e.g. a YouTube `watch` URL) plays sound until the grace/hard timer fires and the window is destroyed (~2s). It fires automatically because `useLinkTitle` requests the title for every link on mount, and the main-process title cache is empty on a fresh launch — so it repeats every open.

**Fix:** extract the offscreen window creation into `link-title-window.cjs` and call `webContents.setAudioMuted(true)` immediately after construction, so the title probe can never emit sound. Title fetching itself is unchanged; the user-initiated preview webview (which legitimately plays media on click) is untouched.

## Changes
- `apps/desktop/electron/link-title-window.cjs` (new) — `createLinkTitleWindow()` / `linkTitleWindowOptions()`; mutes audio on creation.
- `apps/desktop/electron/main.cjs` — use the helper in `runRenderTitleJob` instead of inline `new BrowserWindow(...)`.
- `apps/desktop/electron/link-title-window.test.cjs` (new) — regression tests for muting + hardened defaults.
- `apps/desktop/package.json` — register the new test in `test:desktop:platforms`.

## Test plan
- [x] `node --test electron/link-title-window.test.cjs` (3/3 pass)
- [x] `node --test` across `link-title-window` + `session-windows` + `hardening` (29/29 pass)
- [ ] Manual: open a session containing a YouTube link in the desktop app, reopen the app, click the session — confirm no audio plays on re-render.