### PR TITLE
fix(memory): handle non-UTF-8 files gracefully instead of crashing

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -650,3 +650,37 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+    def test_read_file_handles_non_utf8_bytes(self, tmp_path, monkeypatch):
+        """A memory file containing non-UTF-8 bytes (e.g. GBK on non-English
+        Windows systems) must not crash _read_file with an uncaught
+        UnicodeDecodeError (issue #49508). It should decode with replacement
+        and return a usable (if partially lossy) result instead.
+        """
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        bad_file = tmp_path / "MEMORY.md"
+        bad_file.write_bytes("中文测试".encode("gbk"))
+
+        result = MemoryStore._read_file(bad_file)
+        assert isinstance(result, list)
+        # Should not raise, and should produce some (possibly lossy) content
+        # rather than silently returning an empty list.
+        assert len(result) >= 1
+
+    def test_load_from_disk_survives_non_utf8_memory_file(self, tmp_path, monkeypatch):
+        """End-to-end: a non-UTF-8 MEMORY.md must not crash load_from_disk()."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        (tmp_path / "MEMORY.md").write_bytes("legacy GBK content 中文".encode("gbk"))
+        s = MemoryStore()
+        # Must not raise UnicodeDecodeError.
+        s.load_from_disk()
+
+    def test_detect_external_drift_handles_non_utf8_bytes(self, tmp_path, monkeypatch):
+        """_detect_external_drift must not crash on non-UTF-8 file content."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        s = MemoryStore()
+        target = "memory"
+        path = s._path_for(target)
+        path.write_bytes("legacy GBK content 中文".encode("gbk"))
+        # Must not raise UnicodeDecodeError.
+        s._detect_external_drift(target)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -510,6 +510,21 @@ class MemoryStore:
             raw = path.read_text(encoding="utf-8")
         except (OSError, IOError):
             return []
+        except UnicodeDecodeError:
+            # Non-UTF-8 bytes (e.g. GBK/CP936/Latin-1 on non-English Windows
+            # systems) must not crash the memory tool (issue #49508).
+            # Decode with replacement so ingestion degrades gracefully
+            # instead of raising, and log so the corruption is visible
+            # rather than silently swallowed.
+            logger.warning(
+                "[memory] %s is not valid UTF-8; reading with errors='replace'. "
+                "Some characters may be lost.",
+                path,
+            )
+            try:
+                raw = path.read_text(encoding="utf-8", errors="replace")
+            except (OSError, IOError):
+                return []
 
         if not raw.strip():
             return []
@@ -550,6 +565,16 @@ class MemoryStore:
             raw = path.read_text(encoding="utf-8")
         except (OSError, IOError):
             return None
+        except UnicodeDecodeError:
+            logger.warning(
+                "[memory] %s is not valid UTF-8 during drift check; "
+                "reading with errors='replace'.",
+                path,
+            )
+            try:
+                raw = path.read_text(encoding="utf-8", errors="replace")
+            except (OSError, IOError):
+                return None
         if not raw.strip():
             return None
 


### PR DESCRIPTION
## Problem

_read_file() and _detect_external_drift() used path.read_text(encoding=utf-8) with only (OSError, IOError) caught. UnicodeDecodeError (raised for GBK/CP936/Latin-1 files common on non-English Windows systems) was not caught and crashed the memory tool (issue #49508).

## Fix

Catch UnicodeDecodeError explicitly, log a warning naming the file, retry with errors=replace. Stronger than the issues suggested replace-only approach -- data loss stays visible instead of silently swallowed.

Added 3 regression tests (GBK-encoded input) covering _read_file, end-to-end load_from_disk(), and _detect_external_drift(). Full suite: 72 passed.

Fixes #49508