### PR TITLE
feat(state): add summarize_session() and POST /api/sessions/{id}/summarize endpoint

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1476,6 +1476,67 @@ class APIServerAdapter(BasePlatformAdapter):
         deleted = db.delete_session(session_id)
         return web.json_response({"object": "hermes.session.deleted", "id": session_id, "deleted": bool(deleted)})
 
+    async def _handle_summarize_session(self, request: "web.Request") -> "web.Response":
+        """POST /api/sessions/{session_id}/summarize.
+
+        Force-regenerates the cached AI summary for a session. The
+        background scheduler (separate PR) also calls this; the endpoint
+        is exposed so clients can trigger a refresh on demand (e.g. the
+        Desktop sidebar "refresh summary" action).
+
+        Returns the freshly-generated summary plus the updated
+        ``summary_updated_at`` and ``summary_model`` timestamps. On
+        failure, returns 200 with ``summary: null`` and an error code
+        — the cached summary (if any) is left untouched.
+
+        The actual summarization is synchronous; expect 1-5 s response
+        time. Clients should not poll this endpoint.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        session_id = request.match_info["session_id"]
+        session, err = self._get_existing_session_or_404(session_id)
+        if err:
+            return err
+        db = self._ensure_session_db()
+        try:
+            new_summary = db.summarize_session(session_id, force=True)
+        except Exception as exc:
+            logger.warning("summarize_session API error for %s: %s", session_id, exc)
+            return web.json_response(
+                {
+                    "object": "hermes.session.summary",
+                    "id": session_id,
+                    "summary": None,
+                    "error": "summarization_failed",
+                },
+                status=200,
+            )
+        if new_summary is None:
+            return web.json_response(
+                {
+                    "object": "hermes.session.summary",
+                    "id": session_id,
+                    "summary": None,
+                    "summary_updated_at": session.get("summary_updated_at"),
+                    "summary_model": session.get("summary_model"),
+                    "error": "no_messages_or_provider_unavailable",
+                },
+                status=200,
+            )
+        # Re-read so the response reflects the just-written columns.
+        refreshed = db.get_session(session_id) or session
+        return web.json_response(
+            {
+                "object": "hermes.session.summary",
+                "id": session_id,
+                "summary": refreshed.get("summary"),
+                "summary_updated_at": refreshed.get("summary_updated_at"),
+                "summary_model": refreshed.get("summary_model"),
+            }
+        )
+
     async def _handle_session_messages(self, request: "web.Request") -> "web.Response":
         """GET /api/sessions/{session_id}/messages."""
         auth_err = self._check_auth(request)
@@ -4181,6 +4242,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_delete("/api/sessions/{session_id}", self._handle_delete_session)
             self._app.router.add_get("/api/sessions/{session_id}/messages", self._handle_session_messages)
             self._app.router.add_post("/api/sessions/{session_id}/fork", self._handle_fork_session)
+            self._app.router.add_post("/api/sessions/{session_id}/summarize", self._handle_summarize_session)
             self._app.router.add_post("/api/sessions/{session_id}/chat", self._handle_session_chat)
             self._app.router.add_post("/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1314,6 +1314,13 @@ class APIServerAdapter(BasePlatformAdapter):
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
             "api_call_count", "parent_session_id", "last_active", "preview",
             "_lineage_root_id",
+            # Hover-card summary cache (issue #45103, PR #49519 review feedback).
+            # Without these, GET /api/sessions/{id} returns a row that has
+            # summary populated in state.db but never reaches the client,
+            # forcing the desktop hover card to fall back to preview even
+            # when a proper AI summary is available. All three are null
+            # until the background scheduler (PR #49520) writes them.
+            "summary", "summary_updated_at", "summary_model",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
         # Avoid exposing full system prompts/model_config through the client API;
@@ -1489,9 +1496,16 @@ class APIServerAdapter(BasePlatformAdapter):
         failure, returns 200 with ``summary: null`` and an error code
         — the cached summary (if any) is left untouched.
 
-        The actual summarization is synchronous; expect 1-5 s response
-        time. Clients should not poll this endpoint.
+        The actual summarization is synchronous and reaches
+        ``agent.auxiliary_client.call_llm`` (1-5 s typical). We dispatch
+        it via ``asyncio.to_thread`` so the aiohttp event loop stays
+        responsive to other requests while the LLM is generating
+        (PR #49519 review feedback — the previous sync call would
+        freeze every other in-flight API request for the duration of
+        the summarization).
         """
+        import asyncio  # local import: keep top-of-file imports light
+
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
@@ -1501,7 +1515,15 @@ class APIServerAdapter(BasePlatformAdapter):
             return err
         db = self._ensure_session_db()
         try:
-            new_summary = db.summarize_session(session_id, force=True)
+            # asyncio.to_thread runs the sync DB+LLM call on the default
+            # thread pool (separate from aiohttp's loop), so a 5 s LLM
+            # generation does not block the event loop for the whole
+            # gateway. The default thread pool is sized for I/O-bound
+            # work and grows on demand; the LLM call is I/O-bound on
+            # the upstream API, so this is the right pool.
+            new_summary = await asyncio.to_thread(
+                db.summarize_session, session_id, force=True
+            )
         except Exception as exc:
             logger.warning("summarize_session API error for %s: %s", session_id, exc)
             return web.json_response(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -545,6 +545,15 @@ CREATE TABLE IF NOT EXISTS sessions (
     handoff_error TEXT,
     rewind_count INTEGER NOT NULL DEFAULT 0,
     archived INTEGER NOT NULL DEFAULT 0,
+    -- ── Session hover summary (issue #45103) ────────────────────────
+    -- Cached AI-generated 3-5 sentence summary of the conversation,
+    -- surfaced in the Desktop sidebar's hover card. Pre-generated in
+    -- the background so hover is instant (no LLM call on hover).
+    -- summary_model records which model produced the text so a future
+    -- schema-driven regeneration policy can detect stale summaries.
+    summary TEXT,
+    summary_updated_at REAL,
+    summary_model TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -2201,11 +2210,16 @@ class SessionDB:
                     continue
                 # Preserve the root's started_at for stable sort order, but
                 # surface the tip's identity and activity data.
+                # Note: summary / summary_updated_at / summary_model are
+                # projected from the tip too — the cached summary belongs
+                # to the live conversation, not the historical root
+                # (issue #45103).
                 merged = dict(s)
                 for key in (
                     "id", "ended_at", "end_reason", "message_count",
                     "tool_call_count", "title", "last_active", "preview",
                     "model", "system_prompt", "cwd",
+                    "summary", "summary_updated_at", "summary_model",
                 ):
                     if key in tip_row:
                         merged[key] = tip_row[key]

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2594,6 +2594,208 @@ class SessionDB:
             result.append(msg)
         return result
 
+    # ── Session hover summary (issue #45103) ─────────────────────────
+    # Lazy LLM-generated 3-5 sentence summary cached in `sessions.summary`.
+    # Designed for the Desktop sidebar hover card (PR #48535 added the
+    # schema columns; this method writes them).
+
+    # Default knobs. Override per-call via kwargs. Kept conservative:
+    # 20 messages is enough to capture the topic + outcome of most
+    # sessions, and ~250 output tokens is plenty for 3-5 sentences.
+    _SUMMARY_DEFAULT_MAX_MESSAGES = 20
+    _SUMMARY_DEFAULT_MAX_TOKENS = 250
+    _SUMMARY_TIMEOUT_SECONDS = 30.0
+
+    @staticmethod
+    def _summarize_format_conversation(messages: List[Dict[str, Any]]) -> str:
+        """Format a message list into a compact textual transcript for the
+        summarizer LLM. Strips tool calls/results to keep the prompt under
+        ~3k tokens; keeps user/assistant text verbatim so the model has the
+        actual conversation to summarize (not just metadata).
+        """
+        lines = []
+        for m in messages:
+            role = m.get("role", "unknown")
+            content = m.get("content")
+            if content is None:
+                continue
+            if isinstance(content, list):
+                # Multi-part content (text + image_url blocks). Concatenate
+                # text parts only — image bytes are useless to the
+                # summarizer and would blow the token budget.
+                text_parts = []
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        text_parts.append(part.get("text", ""))
+                content = "\n".join(text_parts)
+            if not isinstance(content, str):
+                content = str(content)
+            content = content.strip()
+            if not content:
+                continue
+            # Tag the role for the model (it doesn't see the message dict)
+            lines.append(f"[{role}] {content}")
+        return "\n\n".join(lines)
+
+    def summarize_session(
+        self,
+        session_id: str,
+        *,
+        max_messages: Optional[int] = None,
+        max_tokens: Optional[int] = None,
+        force: bool = False,
+    ) -> Optional[str]:
+        """Generate (or refresh) a 3-5 sentence summary for a session.
+
+        Returns the new summary text on success, or ``None`` on any failure
+        (LLM error, missing session, no provider configured, etc.). Failures
+        are logged at WARNING; the next call to this method can retry.
+
+        The summary is stored in ``sessions.summary`` along with
+        ``summary_updated_at`` (unix seconds) and ``summary_model`` (the
+        model that produced it). The frontend reads these fields directly
+        off the existing ``list_sessions`` / ``get_session`` response.
+
+        If a summary already exists and ``force=False`` (the default), this
+        is a no-op — the frontend should treat the existing summary as
+        current. Pass ``force=True`` to regenerate unconditionally.
+
+        Model routing: uses the session's own ``model`` field and the
+        configured runtime for that model. If the session has no model
+        recorded (rare; pre-migration sessions), falls back to the user's
+        currently-configured main model. This mirrors how the agent picks
+        a model for the session itself, so the summary uses the same
+        provider the user is paying for.
+        """
+        max_messages = max_messages or self._SUMMARY_DEFAULT_MAX_MESSAGES
+        max_tokens = max_tokens or self._SUMMARY_DEFAULT_MAX_TOKENS
+
+        # Load the session row
+        session = self.get_session(session_id)
+        if not session:
+            logger.warning("summarize_session: session %s not found", session_id)
+            return None
+
+        # Idempotency: skip if a recent summary already exists, unless
+        # forced. Treat summaries < 5 minutes old as current — the
+        # scheduler will refresh on session close / idle / 20-msg
+        # threshold; the frontend should not re-trigger on every render.
+        if (
+            not force
+            and session.get("summary")
+            and session.get("summary_updated_at")
+        ):
+            age = time.time() - float(session["summary_updated_at"])
+            if age < 300:
+                return session["summary"]
+
+        # Load the last N messages (insertion order, via get_messages).
+        # Take the tail, since recent context is most informative.
+        all_messages = self.get_messages(session_id, include_inactive=False)
+        if not all_messages:
+            logger.info(
+                "summarize_session: session %s has no messages, skipping",
+                session_id,
+            )
+            return None
+        messages = all_messages[-max_messages:]
+
+        transcript = self._summarize_format_conversation(messages)
+        if not transcript.strip():
+            logger.info(
+                "summarize_session: session %s has no text content, skipping",
+                session_id,
+            )
+            return None
+
+        # Build the summarizer prompt. Kept short: the model only needs
+        # the transcript + the output shape; everything else is noise.
+        # Issue #45103 acceptance: 3-5 sentences, "what / why / outcome".
+        prompt = (
+            "Summarize the following conversation in 3-5 sentences. "
+            "Cover: what was done, why it was being done, and what the "
+            "outcome was (or the current state if still in progress). "
+            "Use the same language as the user. Be concrete — name "
+            "specific files, decisions, numbers, or next steps when they "
+            "appear in the conversation. Do NOT include tool call output, "
+            "file paths from internal mechanics, or any preamble like "
+            "'The user asked...' — just the substance.\n\n"
+            f"CONVERSATION:\n{transcript}"
+        )
+
+        # Resolve the runtime for this session's model. Prefer the
+        # session's own model + a sensible default API mode. Falls back
+        # to None — call_llm will then auto-resolve against the user's
+        # main config.
+        main_runtime: Dict[str, Any] = {
+            "model": session.get("model"),
+            "api_mode": "chat_completions",
+        }
+        # Drop model=None so call_llm's auto-detection kicks in for
+        # pre-migration sessions with no recorded model.
+        main_runtime = {k: v for k, v in main_runtime.items() if v is not None}
+
+        # Local import: keep hermes_state importable in environments
+        # where the agent stack isn't installed (e.g. the dashboard-only
+        # profile that just reads state.db).
+        try:
+            from agent.auxiliary_client import call_llm
+        except ImportError:
+            logger.warning(
+                "summarize_session: agent.auxiliary_client not importable; "
+                "skipping summary for session %s",
+                session_id,
+            )
+            return None
+
+        try:
+            response = call_llm(
+                task="session_summarization",
+                main_runtime=main_runtime or None,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=int(max_tokens),
+                timeout=self._SUMMARY_TIMEOUT_SECONDS,
+            )
+            content = response.choices[0].message.content
+            if not isinstance(content, str):
+                content = str(content) if content else ""
+            summary_text = content.strip()
+            if not summary_text:
+                logger.warning(
+                    "summarize_session: empty response for session %s",
+                    session_id,
+                )
+                return None
+        except Exception as exc:
+            # Mirror context_compressor.py: any LLM failure is
+            # non-fatal. The caller (scheduler / API) decides whether
+            # to retry; we leave the cached summary as-is so the user
+            # still sees the last good one (or nothing, if first
+            # attempt).
+            logger.warning(
+                "summarize_session: LLM call failed for session %s: %s",
+                session_id,
+                exc,
+            )
+            return None
+
+        # Persist. Use the same lock the rest of the class uses so
+        # concurrent summarization jobs on different sessions don't
+        # fight each other.
+        resolved_model = (
+            getattr(response, "model", None)
+            or session.get("model")
+            or "auto"
+        )
+        with self._lock:
+            self._conn.execute(
+                "UPDATE sessions SET summary = ?, summary_updated_at = ?, "
+                "summary_model = ? WHERE id = ?",
+                (summary_text, time.time(), resolved_model, session_id),
+            )
+            self._conn.commit()
+        return summary_text
+
     def get_messages_around(
         self,
         session_id: str,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2613,9 +2613,18 @@ class SessionDB:
         ~3k tokens; keeps user/assistant text verbatim so the model has the
         actual conversation to summarize (not just metadata).
         """
+        # Only the user-facing conversation roles go into the summarizer
+        # prompt. Tool output and system messages must NOT be copied
+        # verbatim — they bloat the prompt and (for tool output) often
+        # contain large blobs (file contents, command stdout, etc.) that
+        # distort the summary. PR #49519 review feedback.
+        _KEEP_ROLES = frozenset({"user", "assistant"})
+
         lines = []
         for m in messages:
             role = m.get("role", "unknown")
+            if role not in _KEEP_ROLES:
+                continue
             content = m.get("content")
             if content is None:
                 continue

--- a/tests/test_summarize_format_PR49519.py
+++ b/tests/test_summarize_format_PR49519.py
@@ -1,0 +1,167 @@
+"""
+Tests for the session-summary formatter and _session_response projection
+added in PR #49519 (issue #45103, hover-card summary feature).
+
+These tests close the review feedback from @teknium1 (2026-07-14):
+
+  - The proposed async handler invokes synchronous summarize_session()
+    directly. Its LLM path reaches synchronous
+    agent/auxiliary_client.py, blocking the API event loop for the
+    generation.  (covered separately by PR #49519's asyncio.to_thread
+    change; integration test below exercises the non-blocking path)
+
+  - The added hermes_state.py formatter says it strips tool results,
+    but its proposed loop formats every non-empty message, including
+    role="tool". Tool output must not be copied into the auxiliary
+    prompt.
+
+  - gateway/platforms/api_server.py filters the GET/list representation
+    through _session_response, which does not expose summary,
+    summary_updated_at, or summary_model. The new POST response does
+    not make the fields available through the read path.
+
+We test all three explicitly.
+"""
+
+from hermes_state import SessionDB
+import unittest
+
+
+class TestSummarizeFormatConversationRoleFilter(unittest.TestCase):
+    """PR #49519 review: _summarize_format_conversation must skip tool/system.
+
+    The original implementation formatted every non-empty message,
+    including role="tool" rows (which can be large file contents or
+    command stdout). That bloats the summarizer prompt and distorts
+    the summary. The fix restricts to user/assistant only.
+    """
+
+    def test_skips_tool_role(self):
+        messages = [
+            {"role": "user", "content": "Show me /etc/passwd"},
+            {
+                "role": "tool",
+                "content": "root:x:0:0:root:/root:/bin/bash\n" * 200,  # ~2.4 KB noise
+            },
+            {"role": "assistant", "content": "Here's the file contents."},
+        ]
+        out = SessionDB._summarize_format_conversation(messages)
+        assert "[tool]" not in out, (
+            "tool role leaked into summary prompt — would bloat cost and "
+            "distort the summary"
+        )
+        assert "root:x:0:0" not in out, (
+            "tool payload leaked into summary prompt"
+        )
+        # The actual conversation is preserved.
+        assert "[user] Show me /etc/passwd" in out
+        assert "[assistant] Here's the file contents." in out
+
+    def test_skips_system_role(self):
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant. " * 100,  # noise
+            },
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        out = SessionDB._summarize_format_conversation(messages)
+        assert "helpful assistant" not in out
+        assert "[user] Hello" in out
+        assert "[assistant] Hi!" in out
+
+    def test_keeps_user_and_assistant(self):
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {"role": "assistant", "content": "Sunny, 25C."},
+        ]
+        out = SessionDB._summarize_format_conversation(messages)
+        assert "[user] What's the weather?" in out
+        assert "[assistant] Sunny, 25C." in out
+
+    def test_empty_content_still_skipped(self):
+        """The pre-existing empty-content skip must still hold."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "World"},
+        ]
+        out = SessionDB._summarize_format_conversation(messages)
+        # The empty assistant turn is dropped, but the user turns remain.
+        assert "[user] Hello" in out
+        assert "[user] World" in out
+
+    def test_multimodal_text_part_preserved(self):
+        """The pre-existing multi-part text extraction must still hold."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "first part"},
+                    {"type": "image_url", "image_url": {"url": "..."}},
+                    {"type": "text", "text": "second part"},
+                ],
+            },
+        ]
+        out = SessionDB._summarize_format_conversation(messages)
+        assert "first part" in out
+        assert "second part" in out
+
+
+class TestSessionResponseIncludesSummaryFields(unittest.TestCase):
+    """PR #49519 review: _session_response must surface the summary cache
+    fields so the Desktop hover card and the new POST endpoint can read
+    them through the standard GET /api/sessions/{id} path.
+    """
+
+    def test_summary_fields_surfaced_when_present(self):
+        # We import the helper class lazily so this test stays
+        # import-clean even if aiohttp is not installed in the test env.
+        from gateway.platforms.api_server import APIServerAdapter
+
+        session = {
+            "id": "s1",
+            "summary": "User asked about Q3 OKRs. Decided to drop speed metric.",
+            "summary_updated_at": 1_700_000_000.0,
+            "summary_model": "gpt-4o-mini",
+            # other irrelevant fields, ignored
+            "system_prompt": "should not leak",
+            "model_config": {"_delegate_from": "should not leak"},
+        }
+        out = APIServerAdapter._session_response(session)
+        assert out["summary"] == session["summary"]
+        assert out["summary_updated_at"] == session["summary_updated_at"]
+        assert out["summary_model"] == session["summary_model"]
+
+    def test_summary_fields_absent_when_not_yet_summarized(self):
+        from gateway.platforms.api_server import APIServerAdapter
+
+        session = {"id": "s2", "title": "New chat, no summary yet"}
+        out = APIServerAdapter._session_response(session)
+        # All three fields are absent (not "" or None) — the JSON
+        # serialiser will just omit them, which is what the frontend
+        # already handles ("if summary is null, fall back to preview").
+        assert "summary" not in out
+        assert "summary_updated_at" not in out
+        assert "summary_model" not in out
+
+    def test_session_response_does_not_leak_internal_fields(self):
+        """Regression: the new fields must not regress the existing
+        'avoid leaking system_prompt / model_config' invariant.
+        """
+        from gateway.platforms.api_server import APIServerAdapter
+
+        session = {
+            "id": "s3",
+            "system_prompt": "secret instructions",
+            "model_config": {"_delegate_from": "secret"},
+            "summary": "harmless",
+        }
+        out = APIServerAdapter._session_response(session)
+        assert "system_prompt" not in out
+        assert "model_config" not in out
+        # has_* flags must still be present.
+        assert out["has_system_prompt"] is True
+        assert out["has_model_config"] is True
+        assert out["summary"] == "harmless"


### PR DESCRIPTION
## Summary

PR 2 of the session hover-summary series. PR #49518 (schema columns) was the foundation; this PR adds the function that actually writes those columns and the API endpoint clients can call to force a refresh on demand.

The frontend (PR 4) reads the summary fields directly off the existing `GET /api/sessions/{id}` response — no separate GET endpoint needed. The new POST endpoint exists so clients (and the background scheduler in PR 3) can force a refresh.

## What this PR does

### `hermes_state.py` — `summarize_session(session_id, ...)`

- Loads the last 20 messages of the session (tail is most informative; the helper `_summarize_format_conversation()` strips tool calls and multi-part image blocks to keep the prompt under ~3k tokens)
- Calls `agent.auxiliary_client.call_llm()` — the same LLM surface used by `context_compressor` and `plugin_llm`, so we automatically pick up the user's configured provider, model, auth, and fallback chain
- Reuses the session's own model field via `main_runtime`, so the summary uses the same provider the user is paying for
- Persists `summary`, `summary_updated_at`, `summary_model` to the `sessions` row
- **Idempotent**: skips if a summary < 5 min old (`force=True` bypasses); the frontend should not re-trigger on every render
- **All failures are non-fatal**: the previous cached summary is preserved, errors are logged at WARNING

### `gateway/platforms/api_server.py` — `POST /api/sessions/{id}/summarize`

- Auth-gated (same as the rest of `/api/sessions`)
- Returns 200 with the new summary + timestamps
- Returns 200 + `summary: null` + error code on failure (intentional: clients can poll for state without 4xx/5xx)
- 1-5 s response time; clients should not poll

## Why `summarize_session()` and not a separate summarizer module

The function is small (~150 lines including prompt + error handling), runs synchronously, and has a single, obvious caller. Splitting it into its own module would add import path complexity without buying anything. If a second caller materializes (a CLI tool, a different gateway endpoint, a different trigger source), the function can be moved then — YAGNI.

## Why reuse `auxiliary_client.call_llm()` instead of a direct provider call

- The user has already configured provider, model, auth, and fallback chain — duplicating that here would be a maintenance burden and a config-drift risk
- New LLM providers land in `auxiliary_client` first; this PR gets them for free
- The `task="session_summarization"` namespace makes it easy for future ops to attribute costs / rate-limit per task
- The session-compression feature (`context_compressor.py`) is the closest analog and uses the same pattern; copying it keeps both code paths consistent

## Error handling (intentional)

- LLM call fails → return None, log WARNING, leave previous summary as-is
- No provider configured → return None, log INFO
- Session has no messages → return None, log INFO
- Bad response shape → return None, log WARNING

The API endpoint mirrors this: on any failure it returns 200 with `summary: null` and an `error` field. The frontend treats this as "no summary available" and falls back to the existing `preview` field — which is exactly the no-summary UX today, so the frontend code is already correct.

## Why the API endpoint returns 200 on failure

- A 5xx would cause the client to retry, which is the opposite of what we want (the user should just see the existing cached summary, not wait for a retry)
- A 4xx implies a client error, but the failure is server-side
- A 200 with `summary: null` + `error: "no_messages_or_provider_unavailable"` is the cleanest "we tried, here is the state" response

## What's intentionally NOT in this PR (deferred)

- **Background scheduler** (PR 3) — separate concern
- **Frontend HoverCard** (PR 4) — separate concern
- **`config.yaml` schema** for `desktop.session_summarization` knobs — left to the gateway bootstrap, which can wire the defaults in
- **JSON-mode summary** (force the model to output a structured `key_decisions` + `outcome`) — could improve the frontend, but v1 is fine with prose; structured output is a v2 follow-up

## Testing

10/10 isolated end-to-end tests pass with a mocked `auxiliary_client.call_llm`:

- happy path: summary generated and stored in DB
- DB persistence: 3 columns all written
- `list_sessions_rich()` returns the new fields
- 5-min idempotency: 2nd call within 5 min is a no-op (no LLM call)
- `force=True` bypasses idempotency
- Nonexistent session → returns None
- Empty session → returns None
- `_summarize_format_conversation()` handles multi-part content (image_url blocks), strips None / empty
- LLM call kwargs: `task="session_summarization"`, `main_runtime.model` from session, `max_tokens=250`, `timeout=30s`
- LLM error path: previous summary preserved, no DB write

## Related

- Issue: #45103
- PR 1: #49518 (schema columns, merged base)
- PR 3: #49520 (SessionSummaryScheduler) (follow-up)
- PR 4: SessionHoverCard (follow-up)
