### PR TITLE
fix(tools): remove phantom empty last line from read_file (#49451)

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -842,6 +842,12 @@ class ShellFileOperations(FileOperations):
         from tools.tool_output_limits import get_max_line_length
         max_line_length = get_max_line_length()
         lines = content.split('\n')
+        # Drop the phantom trailing empty line that split() produces when the
+        # content ends with '\n' (the normal well-formed case).  Matches
+        # cat -n behaviour: a trailing newline terminates the last line, it
+        # does not start a new empty one.
+        if lines and lines[-1] == '':
+            lines.pop()
         numbered = []
         for i, line in enumerate(lines, start=start_line):
             # Truncate long lines


### PR DESCRIPTION
Fixes #49451. read_file adds a phantom empty last line because content.split('\n') produces a trailing empty string for files ending in a newline. Strip the trailing empty element before numbering, matching cat -n behavior.