### PR TITLE
[wip] feat(gateway): notify home channels on startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5682,22 +5682,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if connected_count > 0:
             await asyncio.sleep(1.0)
 
-        # Notify the chat that initiated /restart that the gateway is back.
-        planned_restart_notification_pending = _planned_restart_notification_pending()
-        await self._send_restart_notification()
-
-        # Broadcast a lightweight "gateway is back" message to configured home
-        # channels only for non-chat planned restarts (terminal/SIGUSR1/service
-        # paths). Chat-originated /restart already has a precise reply target
-        # in .restart_notify.json, so keep that lifecycle in the originating
-        # chat/topic instead of also leaking it to the configured home channel.
-        if planned_restart_notification_pending:
-            try:
-                await self._send_home_channel_startup_notifications(
-                    skip_targets=None,
-                )
-            finally:
-                _clear_planned_restart_notification()
+        # Notify the chat that initiated /restart that the gateway is back, then
+        # emit the configured home-channel startup notification. This is an
+        # event-driven lifecycle ping (sent once from the gateway startup path),
+        # not a cron/heartbeat poll. If the precise /restart target is also the
+        # home channel, skip that exact target to avoid duplicate messages.
+        await self._send_gateway_online_notifications()
 
         # Automatically continue fresh sessions that were interrupted by the
         # previous gateway restart/shutdown.  The resume_pending flag is cleared
@@ -12422,6 +12412,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 exit_code_path.unlink(missing_ok=True)
 
         return True
+
+    async def _send_gateway_online_notifications(self) -> None:
+        """Send gateway-online lifecycle notifications after startup.
+
+        Sends at most one precise /restart notification (when a chat requested
+        the restart) and one configured home-channel startup notification per
+        platform. This is intentionally tied to gateway startup/reconnect, not a
+        heartbeat poll.
+        """
+        planned_restart_notification_pending = _planned_restart_notification_pending()
+        restart_target = await self._send_restart_notification()
+        skip_targets = {restart_target} if restart_target else None
+
+        try:
+            await self._send_home_channel_startup_notifications(
+                skip_targets=skip_targets,
+            )
+        finally:
+            if planned_restart_notification_pending:
+                _clear_planned_restart_notification()
 
     async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
         """Notify the chat that initiated /restart that the gateway is back."""

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -99,6 +99,9 @@ def make_restart_runner(
     runner._send_restart_notification = GatewayRunner._send_restart_notification.__get__(
         runner, GatewayRunner
     )
+    runner._send_gateway_online_notifications = (
+        GatewayRunner._send_gateway_online_notifications.__get__(runner, GatewayRunner)
+    )
     runner._send_home_channel_startup_notifications = (
         GatewayRunner._send_home_channel_startup_notifications.__get__(runner, GatewayRunner)
     )

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -370,6 +370,77 @@ async def test_send_home_channel_startup_notification_ignores_false_send_result(
     adapter.send.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_gateway_online_notifications_send_home_on_plain_startup(tmp_path, monkeypatch):
+    """Plain gateway startup emits the configured home-channel online ping."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    await runner._send_gateway_online_notifications()
+
+    adapter.send.assert_called_once_with(
+        "home-42",
+        "♻️ Gateway online — Hermes is back and ready.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_online_notifications_skip_duplicate_restart_home_target(
+    tmp_path, monkeypatch
+):
+    """If /restart already notified the exact home target, do not double-send."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / ".restart_notify.json").write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "home-42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="restart"))
+
+    await runner._send_gateway_online_notifications()
+
+    assert adapter.send.call_count == 1
+    adapter.send.assert_called_once_with(
+        "home-42",
+        "♻ Gateway restarted successfully. Your session continues.",
+        metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_online_notifications_clears_planned_restart_marker(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    marker = tmp_path / ".restart_pending.json"
+    marker.write_text("{}")
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    await runner._send_gateway_online_notifications()
+
+    assert not marker.exists()
+
+
 # ── _send_restart_notification ───────────────────────────────────────────
 
 


### PR DESCRIPTION
[Auto generated] Going over the PR now to make sure I didn't miss anything.
## Summary
- send configured home-channel gateway-online notifications from the gateway startup path
- keep the precise /restart comeback notification, but skip duplicate home-channel pings when it targets the same chat/thread
- add tests for plain startup delivery, duplicate suppression, and planned-restart marker cleanup

## Hook mechanism notes
Hermes already has gateway event hooks via ~/.hermes/hooks/<name>/ with HOOK.yaml + handler.py. The current first-class gateway lifecycle hook is gateway:startup. I did not find an equivalent gateway:stop lifecycle event in the current hook registry; stop-time notifications are handled by gateway internals for active sessions.

## Test plan
- uv run --with pytest --with pytest-asyncio --with pyyaml python -m pytest tests/gateway/test_restart_notification.py -q -o 'addopts='
