### PR TITLE
fix(agent): surface a diagnostic when ACP tool-permission requests are denied

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -9,6 +9,7 @@ back into the minimal shape Hermes expects from an OpenAI client.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import queue
 import re
@@ -29,6 +30,8 @@ from openai.types.chat.chat_completion_message_tool_call import (
 from agent.file_safety import get_read_block_error, is_write_denied
 from agent.redact import redact_sensitive_text
 from tools.environments.local import hermes_subprocess_env
+
+logger = logging.getLogger(__name__)
 
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
@@ -419,6 +422,7 @@ class CopilotACPClient:
         self.is_closed = False
         self._active_process: subprocess.Popen[str] | None = None
         self._active_process_lock = threading.Lock()
+        self._permission_denied_count = 0
 
     def close(self) -> None:
         proc: subprocess.Popen[str] | None
@@ -695,6 +699,25 @@ class CopilotACPClient:
         params = msg.get("params") or {}
 
         if method == "session/request_permission":
+            # The ACP agent (e.g. the Claude/Copilot SDK) is asking permission to
+            # run one of its OWN tools. Hermes denies these by design — it drives
+            # tools itself via the tool-call markers it injects, not the agent's
+            # native toolset. But if the agent is launched in a permission mode
+            # that ROUTES every tool through this path (e.g. Claude SDK
+            # "dontAsk"/"default", or Copilot CLI without bypass), denial here
+            # leaves the agent unable to run ANY tool — a silent, do-nothing
+            # session. Surface it once so the cause is diagnosable instead of
+            # mysterious. The fix is on the agent side: launch it in a
+            # bypass/auto-approve permission mode so it self-executes its tools.
+            self._permission_denied_count += 1
+            if self._permission_denied_count == 1:
+                logger.warning(
+                    "ACP agent requested tool permission; Hermes denies native "
+                    "ACP tool permissions by design. If this agent cannot run "
+                    "tools, launch it in a bypass/auto-approve permission mode "
+                    "(e.g. Claude Agent SDK permissionMode=bypassPermissions, or "
+                    "Copilot CLI with --allow-all-tools) so it self-executes."
+                )
             response = _permission_denied(message_id)
         elif method == "fs/read_text_file":
             try:

--- a/tests/agent/test_copilot_acp_permission_diagnostic.py
+++ b/tests/agent/test_copilot_acp_permission_diagnostic.py
@@ -1,0 +1,85 @@
+"""The ACP permission-denial path must surface a one-time diagnostic.
+
+Hermes denies the ACP agent's native tool-permission requests by design (it
+drives tools via injected markers, not the agent's own toolset). But if the
+agent is launched in a permission mode that routes EVERY tool through that path
+(Claude Agent SDK "dontAsk"/"default", Copilot CLI without bypass), the silent
+denial leaves a do-nothing agent with no diagnostic. These tests lock the
+contract: the denial still happens (security/design unchanged) AND a single
+actionable warning is emitted on the first denial, not one-per-call spam.
+"""
+
+import logging
+
+from agent.copilot_acp_client import CopilotACPClient, _permission_denied
+
+
+def _make_client() -> CopilotACPClient:
+    return CopilotACPClient(
+        api_key="copilot-acp",
+        base_url="acp://copilot",
+        command="/bin/true",
+        args=["--acp", "--stdio"],
+    )
+
+
+def test_permission_denied_payload_unchanged():
+    """The deny response shape (cancelled outcome) must not regress."""
+    resp = _permission_denied("req-1")
+    assert resp["id"] == "req-1"
+    assert resp["result"]["outcome"]["outcome"] == "cancelled"
+
+
+def test_first_denial_warns_with_actionable_cause(caplog):
+    client = _make_client()
+    msg = {"jsonrpc": "2.0", "id": 1, "method": "session/request_permission", "params": {}}
+
+    sent: list[str] = []
+
+    class _FakeStdin:
+        def write(self, data):
+            sent.append(data)
+
+        def flush(self):
+            pass
+
+    class _FakeProc:
+        stdin = _FakeStdin()
+
+    with caplog.at_level(logging.WARNING):
+        handled = client._handle_server_message(
+            msg, process=_FakeProc(), cwd="/tmp", text_parts=None, reasoning_parts=None
+        )
+
+    assert handled is True
+    # denial still sent
+    assert any("cancelled" in s for s in sent)
+    # exactly one actionable warning, naming the fix
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "bypass" in warnings[0].message.lower()
+
+
+def test_repeated_denials_warn_only_once(caplog):
+    client = _make_client()
+    msg = {"jsonrpc": "2.0", "id": 1, "method": "session/request_permission", "params": {}}
+
+    class _FakeStdin:
+        def write(self, data):
+            pass
+
+        def flush(self):
+            pass
+
+    class _FakeProc:
+        stdin = _FakeStdin()
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(5):
+            client._handle_server_message(
+                msg, process=_FakeProc(), cwd="/tmp", text_parts=None, reasoning_parts=None
+            )
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1, "denial warning must fire once, not per-call"
+    assert client._permission_denied_count == 5


### PR DESCRIPTION
## What & why

`CopilotACPClient` denies the ACP agent's native tool-permission requests by design — Hermes drives tools via the `<tool_call>` markers it injects, not the agent's own toolset (`session/request_permission` → `_permission_denied`). That denial was **silent**.

The problem surfaces when the spawned ACP agent is launched in a permission mode that routes **every** tool through `session/request_permission`:
- Claude Agent SDK with `permissionMode` `"dontAsk"` or `"default"`
- GitHub Copilot CLI without an auto-approve/bypass flag

In that mode every tool is denied, so the agent **can chat but cannot run a single tool** — a do-nothing session — and there is **no log line** explaining why. It looks like a broken model, not a permission-mode mismatch. (Hit live: an ACP fallback agent that answered prose but silently failed every Bash/Read/Write.)

## The fix

Emit a **one-time** `WARNING` on the first denial, naming the actionable cause: launch the ACP agent in a bypass/auto-approve permission mode (e.g. Claude Agent SDK `permissionMode=bypassPermissions`, or Copilot CLI with an allow-all flag) so it self-executes its tools.

- The denial response itself is **unchanged** — design and security boundary preserved. This only adds the missing diagnostic.
- Warns **once per client instance**, not per call, so a denial loop doesn't spam the log (a counter still increments for observability).

## How to test

```
pytest tests/agent/test_copilot_acp_permission_diagnostic.py -v
```
- `test_permission_denied_payload_unchanged` — deny response shape (cancelled outcome) does not regress
- `test_first_denial_warns_with_actionable_cause` — first denial logs exactly one WARNING naming the fix
- `test_repeated_denials_warn_only_once` — 5 denials → 1 warning, counter == 5

Existing `tests/agent/test_copilot_acp_client.py` / `test_copilot_acp_deprecation.py` stay green (one unrelated HOME-resolution test fails identically on clean `main` — pre-existing, not from this change).

## Platforms

Pure logging addition in `agent/copilot_acp_client.py`; no OS-specific paths. `check-windows-footguns.py` clean. Tested on Linux.