### PR TITLE
fix(agent): persist tool calls before turn-end flush

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3956,6 +3956,19 @@ def run_conversation(
 
                 messages.append(assistant_msg)
                 agent._emit_interim_assistant_message(assistant_msg)
+                try:
+                    # Persist the assistant tool-call turn before any tool
+                    # side effects run. If a destructive tool restarts or
+                    # terminates Hermes mid-turn, resume logic still sees the
+                    # exact tool-call block that already executed.
+                    agent._flush_messages_to_session_db(messages, conversation_history)
+                except Exception as exc:
+                    logger.warning(
+                        "Incremental tool-call persistence failed before execution "
+                        "(session=%s): %s",
+                        agent.session_id or "none",
+                        exc,
+                    )
 
                 # Close any open streaming display (response box, reasoning
                 # box) before tool execution begins.  Intermediate turns may

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -52,6 +52,25 @@ logger = logging.getLogger(__name__)
 _MAX_TOOL_WORKERS = 8
 
 
+def _flush_session_db_after_tool_progress(
+    agent,
+    messages: list,
+    *,
+    stage: str,
+) -> None:
+    """Best-effort incremental SessionDB flush for tool-call progress.
+
+    Tool execution can perform side effects that terminate or restart the
+    current Hermes process before the normal turn-end persistence path runs.
+    Flush the already-appended assistant/tool messages immediately so the
+    transcript survives destructive-but-valid tool calls.
+    """
+    try:
+        agent._flush_messages_to_session_db(messages)
+    except Exception as exc:
+        logger.warning("Incremental tool-call persistence failed after %s: %s", stage, exc)
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so patches like ``run_agent._set_interrupt`` work."""
     import run_agent
@@ -258,6 +277,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 f"[Tool execution cancelled — {tc.function.name} was skipped due to user interrupt]",
                 tc.id,
             ))
+            _flush_session_db_after_tool_progress(
+                agent,
+                messages,
+                stage=f"cancelled tool result {tc.function.name}",
+            )
         return
 
     # ── Parse args + pre-execution bookkeeping ───────────────────────
@@ -746,6 +770,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # String results pass through unchanged.
         _tool_content = agent._tool_result_content_for_active_model(name, function_result)
         messages.append(make_tool_result_message(name, _tool_content, tc.id))
+        _flush_session_db_after_tool_progress(
+            agent,
+            messages,
+            stage=f"tool result {name}",
+        )
 
         # ── Per-tool /steer drain ───────────────────────────────────
         # Same as the sequential path: drain between each collected
@@ -779,13 +808,16 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {len(remaining_calls)} tool call(s)", force=True)
             for skipped_tc in remaining_calls:
                 skipped_name = skipped_tc.function.name
-                skip_msg = {
-                    "role": "tool",
-                    "name": skipped_name,
-                    "content": f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]",
-                    "tool_call_id": skipped_tc.id,
-                }
-                messages.append(skip_msg)
+                messages.append(make_tool_result_message(
+                    skipped_name,
+                    f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]",
+                    skipped_tc.id,
+                ))
+                _flush_session_db_after_tool_progress(
+                    agent,
+                    messages,
+                    stage=f"cancelled tool result {skipped_name}",
+                )
             break
 
         function_name = tool_call.function.name
@@ -1391,6 +1423,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
         messages.append(make_tool_result_message(function_name, _tool_content, tool_call.id))
+        _flush_session_db_after_tool_progress(
+            agent,
+            messages,
+            stage=f"tool result {function_name}",
+        )
 
         # ── Per-tool /steer drain ───────────────────────────────────
         # Drain pending steer BETWEEN individual tool calls so the
@@ -1417,6 +1454,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
                     skipped_tc.id,
                 ))
+                _flush_session_db_after_tool_progress(
+                    agent,
+                    messages,
+                    stage=f"skipped tool result {skipped_name}",
+                )
             break
 
         if agent.tool_delay > 0 and i < len(assistant_message.tool_calls):

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -1,0 +1,142 @@
+from types import SimpleNamespace
+from pathlib import Path
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from agent.tool_dispatch_helpers import make_tool_result_message
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent():
+    hermes_home = Path(tempfile.mkdtemp(prefix="hermes-test-home-"))
+    (hermes_home / "logs").mkdir(parents=True, exist_ok=True)
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent._hermes_home", hermes_home),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _mock_tool_call(name="web_search", arguments="{}", call_id="call_1"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def test_run_conversation_flushes_assistant_tool_call_before_execution():
+    agent = _make_agent()
+    tool_call = _mock_tool_call(call_id="c1")
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[tool_call]),
+        _mock_response(content="done", finish_reason="stop"),
+    ]
+    flush_spy = MagicMock()
+    agent._flush_messages_to_session_db = flush_spy
+
+    def _fake_execute(assistant_message, messages, effective_task_id, api_call_count=0):
+        assert assistant_message.tool_calls[0].id == "c1"
+        assert flush_spy.call_count >= 1
+        flushed_messages = flush_spy.call_args_list[-1].args[0]
+        assert flushed_messages[-1]["role"] == "assistant"
+        assert flushed_messages[-1]["tool_calls"][0]["id"] == "c1"
+        messages.append(make_tool_result_message("web_search", "search result", "c1"))
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(agent, "_execute_tool_calls", side_effect=_fake_execute),
+    ):
+        result = agent.run_conversation("search something")
+
+    assert result["final_response"] == "done"
+
+
+def test_execute_tool_calls_sequential_flushes_tool_result_immediately():
+    agent = _make_agent()
+    tool_call = _mock_tool_call(call_id="c1")
+    flush_spy = MagicMock()
+    agent._flush_messages_to_session_db = flush_spy
+    agent._invoke_tool = MagicMock(return_value="search result")
+    messages = []
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+
+    with patch(
+        "agent.tool_executor.maybe_persist_tool_result",
+        side_effect=lambda **kwargs: kwargs["content"],
+    ):
+        agent._execute_tool_calls_sequential(assistant_message, messages, "task-1")
+
+    assert messages[-1]["role"] == "tool"
+    assert messages[-1]["tool_call_id"] == "c1"
+    assert flush_spy.call_count == 1
+    flushed_messages = flush_spy.call_args_list[0].args[0]
+    assert flushed_messages[-1]["tool_call_id"] == "c1"
+
+
+def test_execute_tool_calls_concurrent_flushes_each_tool_result_in_order():
+    agent = _make_agent()
+    tool_calls = [
+        _mock_tool_call(call_id="c1"),
+        _mock_tool_call(call_id="c2"),
+    ]
+    flushed_tool_ids = []
+
+    def _capture_flush(flush_messages):
+        flushed_tool_ids.append(flush_messages[-1]["tool_call_id"])
+
+    flush_spy = MagicMock(side_effect=_capture_flush)
+    agent._flush_messages_to_session_db = flush_spy
+    agent._invoke_tool = MagicMock(side_effect=["result one", "result two"])
+    messages = []
+    assistant_message = SimpleNamespace(content="", tool_calls=tool_calls)
+
+    with patch(
+        "agent.tool_executor.maybe_persist_tool_result",
+        side_effect=lambda **kwargs: kwargs["content"],
+    ):
+        agent._execute_tool_calls_concurrent(assistant_message, messages, "task-1")
+
+    assert [msg["tool_call_id"] for msg in messages] == ["c1", "c2"]
+    assert flushed_tool_ids == ["c1", "c2"]


### PR DESCRIPTION
Persist tool-call transcript progress to state.db before turn-end so destructive tool executions do not lose replayable history.

## What changed and why
- Persist the assistant tool-call message to `state.db` immediately before tool execution starts, so if a tool restarts or terminates Hermes mid-turn the resumed session still contains the exact `assistant(tool_calls)` block that already ran.
- Persist each appended tool-result message immediately in both sequential and concurrent execution paths, including interrupt/skip result paths, closing the data-loss window between tool side effects and the normal turn-end flush.
- Add regression tests covering the pre-execution assistant flush and the incremental sequential/concurrent tool-result flush behavior.

## How to test
- `pytest tests/run_agent/test_tool_call_incremental_persistence.py -q`
- `TMP_HERMES_HOME=$(mktemp -d); mkdir -p "$TMP_HERMES_HOME/logs"; HERMES_HOME="$TMP_HERMES_HOME" pytest tests/run_agent/test_run_agent.py tests/run_agent/test_tool_name_db_persistence.py tests/run_agent/test_tool_call_incremental_persistence.py tests/gateway/test_auto_continue.py -q -x --timeout=60`
- `ruff check agent/conversation_loop.py agent/tool_executor.py tests/run_agent/test_tool_call_incremental_persistence.py`
- `ruff format --check tests/run_agent/test_tool_call_incremental_persistence.py`
- `python scripts/check-windows-footguns.py --diff HEAD`
- `git diff --check`
- Attempted `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`; local collection stops in this environment because optional Web UI deps (`fastapi`, `uvicorn`) are not installed.

## What platforms tested on
- macOS (darwin-arm64) local

Fixes #49045

<!-- autocontrib:worker-id=issue-new-fad5db7a kind=pr-open -->