### PR TITLE
fix(approval): detect Windows absolute sensitive paths

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -375,6 +375,12 @@ class TestTeePattern:
         assert dangerous is True
         assert key is not None
 
+    def test_tee_windows_absolute_home_bashrc(self, monkeypatch):
+        monkeypatch.setenv("HOME", r"C:\Users\alice")
+        dangerous, key, desc = detect_dangerous_command(r"echo x | tee C:\Users\alice\.bashrc")
+        assert dangerous is True
+        assert key is not None
+
     def test_tee_custom_hermes_home_env(self):
         dangerous, key, desc = detect_dangerous_command("echo x | tee $HERMES_HOME/.env")
         assert dangerous is True
@@ -443,6 +449,14 @@ class TestHermesConfigWriteProtection:
         env_path = get_hermes_home() / ".env"
         dangerous, key, desc = detect_dangerous_command(
             f"sed -i 's/API_KEY=.*/API_KEY=x/' {env_path}"
+        )
+        assert dangerous is True
+        assert "hermes config" in desc.lower() or "in-place" in desc.lower()
+
+    def test_sed_in_place_windows_absolute_hermes_home_config(self, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", r"C:\Users\alice\.hermes")
+        dangerous, key, desc = detect_dangerous_command(
+            r"sed -i 's/manual/off/' C:\Users\alice\.hermes\config.yaml"
         )
         assert dangerous is True
         assert "hermes config" in desc.lower() or "in-place" in desc.lower()
@@ -572,6 +586,14 @@ class TestSensitiveRedirectPattern:
         assert dangerous is True
         assert key is not None
 
+    def test_append_to_windows_absolute_home_ssh_authorized_keys(self, monkeypatch):
+        monkeypatch.setenv("HOME", r"C:\Users\alice")
+        dangerous, key, desc = detect_dangerous_command(
+            r"cat key >> C:\Users\alice\.ssh\authorized_keys"
+        )
+        assert dangerous is True
+        assert key is not None
+
     def test_append_to_tilde_ssh_authorized_keys(self):
         dangerous, key, desc = detect_dangerous_command("cat key >> ~/.ssh/authorized_keys")
         assert dangerous is True
@@ -594,6 +616,12 @@ class TestSensitiveRedirectPattern:
 
     def test_redirect_to_other_absolute_home_bashrc_is_not_current_user_sensitive(self):
         dangerous, key, desc = detect_dangerous_command("echo x > /tmp/not-current-home/.bashrc")
+        assert dangerous is False
+        assert key is None
+
+    def test_redirect_to_other_windows_home_bashrc_is_not_current_user_sensitive(self, monkeypatch):
+        monkeypatch.setenv("HOME", r"C:\Users\alice")
+        dangerous, key, desc = detect_dangerous_command(r"echo x > C:\Users\bob\.bashrc")
         assert dangerous is False
         assert key is None
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -570,6 +570,10 @@ def _normalize_command_for_detection(command: str) -> str:
     command = command.replace('\x00', '')
     # Normalize Unicode (fullwidth Latin, halfwidth Katakana, etc.)
     command = unicodedata.normalize('NFKC', command)
+    # Fold Windows absolute home/profile paths before stripping shell backslash
+    # escapes below. Otherwise `C:\Users\alice\.bashrc` is reduced to
+    # `C:Usersalice.bashrc` before the sensitive-path fragments can see it.
+    command = _rewrite_windows_sensitive_paths(command)
     # Strip shell backslash-escapes: r\m → rm. Prevents \-injection bypass.
     command = re.sub(r'\\([^\n])', r'\1', command)
     # Strip empty-string literals that split tokens: r''m → rm, r"\"m → rm.
@@ -587,6 +591,74 @@ def _normalize_command_for_detection(command: str) -> str:
     # pattern snapshot) so it tracks the live HERMES_HOME even when that is set
     # after this module is imported — as the hermetic test conftest does.
     command = _rewrite_resolved_hermes_home(command)
+    return command
+
+
+def _windows_absolute_path_to_slash(path: str) -> str | None:
+    """Return a slash-normalized Windows drive path, or None for non-Windows paths."""
+    candidate = (path or "").strip().strip('"\'')
+    if not re.match(r'^[a-zA-Z]:[\\/]', candidate):
+        return None
+    return candidate.replace("\\", "/").rstrip("/")
+
+
+def _replace_windows_prefix(command: str, prefix: str, replacement: str) -> str:
+    """Replace a Windows absolute path prefix with a canonical sensitive fragment.
+
+    This is intentionally prefix-scoped to the live HOME / HERMES_HOME values;
+    it does not make every arbitrary C:\\... path sensitive. Rewriting runs
+    before shell-backslash unescaping so Windows separators are not destroyed.
+    """
+    normalized_prefix = _windows_absolute_path_to_slash(prefix)
+    if not normalized_prefix:
+        return command
+
+    # First normalize drive-absolute path tokens in the command so both
+    # C:\Users\alice\.bashrc and C:/Users/alice/.bashrc compare the same way.
+    # Stop at shell separators/quotes/whitespace; quoted paths with spaces are
+    # outside the existing approval regex coverage but still no worse than before.
+    def _normalize_match(match: re.Match[str]) -> str:
+        return match.group(0).replace("\\", "/")
+
+    command = re.sub(
+        r'(?<![A-Za-z0-9_])(?:[A-Za-z]:[\\/][^\s"\'`|;&<>]*)',
+        _normalize_match,
+        command,
+    )
+
+    pattern = re.compile(re.escape(normalized_prefix) + r'(?=/|$)', re.IGNORECASE)
+    return pattern.sub(replacement.rstrip("/"), command)
+
+
+def _rewrite_windows_sensitive_paths(command: str) -> str:
+    """Fold Windows HOME/HERMES_HOME absolute paths into existing fragments.
+
+    The dangerous-command regexes are intentionally expressed in canonical
+    shell-ish forms (``~/.bashrc``, ``~/.ssh/``, ``~/.hermes/config.yaml``).
+    On Windows, commands frequently contain drive-absolute targets instead.
+    Normalize only the live user's HOME and active profile HERMES_HOME so these
+    equivalent sensitive targets hit the same patterns without broadening the
+    detector to unrelated users' files.
+    """
+    home = os.environ.get("HOME") or os.path.expanduser("~")
+    command = _replace_windows_prefix(command, home, "~")
+
+    hermes_candidates: list[str] = []
+    env_home = os.environ.get("HERMES_HOME")
+    if env_home:
+        hermes_candidates.append(env_home)
+    try:
+        from hermes_constants import get_hermes_home
+        hermes_candidates.append(str(get_hermes_home().expanduser()))
+    except Exception:
+        pass
+
+    seen: set[str] = set()
+    for candidate in hermes_candidates:
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        command = _replace_windows_prefix(command, candidate, "~/.hermes")
     return command
 
 


### PR DESCRIPTION
## Summary
- normalize live Windows `HOME` / `HERMES_HOME` absolute paths before approval regex matching strips backslashes
- catch Windows equivalents of sensitive shell rc, SSH, and Hermes config/env mutation targets
- keep matching scoped to the current `HOME` / `HERMES_HOME` so unrelated users\x27 files are not broadly treated as sensitive

Fixes #49509

## Test plan
- `.test-venv/bin/python -m pytest tests/tools/test_approval.py -q -o "addopts="`
- `.test-venv/bin/python -m ruff check tools/approval.py tests/tools/test_approval.py`
- `.test-venv/bin/python -m py_compile tools/approval.py tests/tools/test_approval.py`
