### PR TITLE
fix(skills): exclude archives and preserve collision semantics

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -142,17 +142,14 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
         return None
 
     try:
-        from tools.skills_tool import SKILLS_DIR, skill_view
-        from agent.skill_utils import get_external_skills_dirs
+        from tools.skills_tool import SKILLS_DIR, _normalize_source_roots, skill_view
 
         identifier_path = Path(raw_identifier).expanduser()
         if identifier_path.is_absolute():
             normalized = None
-            trusted_roots = [SKILLS_DIR]
-            try:
-                trusted_roots.extend(get_external_skills_dirs())
-            except Exception:
-                pass
+            trusted_roots = [source["root"] for source in _normalize_source_roots()]
+            if SKILLS_DIR not in trusted_roots:
+                trusted_roots.insert(0, SKILLS_DIR)
 
             # Prefer the lexical path under a trusted skill root before
             # resolving symlinks.  Slash-command discovery can legitimately
@@ -349,67 +346,37 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     """Scan ~/.hermes/skills/ and return a mapping of /command -> skill info.
 
     Returns:
-        Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
+        Dict mapping "/skill-name" to resolved skill metadata and provenance.
     """
     global _skill_commands, _skill_commands_platform
     _skill_commands_platform = _resolve_skill_commands_platform()
     _skill_commands = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
-        disabled = _get_disabled_skill_names()
-        seen_names: set = set()
+        from tools.skills_tool import _find_all_skill_records
 
-        # Scan local dir first, then external dirs
-        dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
-        dirs_to_scan.extend(get_external_skills_dirs())
-
-        for scan_dir in dirs_to_scan:
-            for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-                if any(part in {'.git', '.github', '.hub', '.archive'} for part in skill_md.parts):
-                    continue
-                try:
-                    content = skill_md.read_text(encoding='utf-8')
-                    frontmatter, body = _parse_frontmatter(content)
-                    # Skip skills incompatible with the current OS platform
-                    if not skill_matches_platform(frontmatter):
-                        continue
-                    # Skip skills not relevant to the current runtime env
-                    # (kanban/docker/s6). Offer-time only; explicit load bypasses.
-                    if not skill_matches_environment(frontmatter):
-                        continue
-                    name = frontmatter.get('name', skill_md.parent.name)
-                    if name in seen_names:
-                        continue
-                    # Respect user's disabled skills config
-                    if name in disabled:
-                        continue
-                    description = frontmatter.get('description', '')
-                    if not description:
-                        for line in body.strip().split('\n'):
-                            line = line.strip()
-                            if line and not line.startswith('#'):
-                                description = line[:80]
-                                break
-                    seen_names.add(name)
-                    # Normalize to hyphen-separated slug, stripping
-                    # non-alnum chars (e.g. +, /) to avoid invalid
-                    # Telegram command names downstream.
-                    cmd_name = name.lower().replace(' ', '-').replace('_', '-')
-                    cmd_name = _SKILL_INVALID_CHARS.sub('', cmd_name)
-                    cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
-                    if not cmd_name:
-                        continue
-                    _skill_commands[f"/{cmd_name}"] = {
-                        "name": name,
-                        "description": description or f"Invoke the {name} skill",
-                        "skill_md_path": str(skill_md),
-                        "skill_dir": str(skill_md.parent),
-                    }
-                except Exception:
-                    continue
+        for record in _find_all_skill_records():
+            if record.get("ambiguous_sources"):
+                continue
+            name = str(record.get("name") or "")
+            if not name:
+                continue
+            # Normalize to hyphen-separated slug, stripping non-alnum chars
+            # (e.g. +, /) to avoid invalid Telegram command names downstream.
+            cmd_name = name.lower().replace(" ", "-").replace("_", "-")
+            cmd_name = _SKILL_INVALID_CHARS.sub("", cmd_name)
+            cmd_name = _SKILL_MULTI_HYPHEN.sub("-", cmd_name).strip("-")
+            if not cmd_name:
+                continue
+            _skill_commands[f"/{cmd_name}"] = {
+                "name": name,
+                "description": record.get("description") or f"Invoke the {name} skill",
+                "skill_md_path": record["skill_md_path"],
+                "skill_dir": record["skill_dir"],
+                "active_source": record["active_source"],
+                "source_type": record["source_type"],
+                "shadowed_sources": record["shadowed_sources"],
+                "resolution_reason": record["resolution_reason"],
+            }
     except Exception:
         pass
     return _skill_commands

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -65,9 +65,15 @@ def is_excluded_skill_path(path) -> bool:
     except AttributeError:
         from pathlib import PurePath
         parts = PurePath(str(path)).parts
-    return any(part in EXCLUDED_SKILL_DIRS for part in parts) or is_skill_support_path(
-        path
-    )
+    if any(part in EXCLUDED_SKILL_DIRS for part in parts):
+        return True
+    try:
+        resolved_parts = Path(path).resolve().parts
+    except (OSError, RuntimeError):
+        resolved_parts = ()
+    if any(part in EXCLUDED_SKILL_DIRS for part in resolved_parts):
+        return True
+    return is_skill_support_path(path)
 
 
 def is_skill_support_path(path) -> bool:
@@ -712,7 +718,9 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
             and not (has_skill_md and d in SKILL_SUPPORT_DIRS)
         ]
         if filename in files:
-            matches.append(Path(root) / filename)
+            candidate = Path(root) / filename
+            if not is_excluded_skill_path(candidate):
+                matches.append(candidate)
     for path in sorted(matches, key=lambda p: str(p.relative_to(skills_dir))):
         yield path
 

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -118,8 +118,8 @@ class TestExternalSkillsInFindAll:
         names = [s["name"] for s in skills]
         assert "my-external-skill" in names
 
-    def test_local_takes_precedence(self, hermes_home, external_skills_dir):
-        """If the same skill name exists locally and externally, local wins."""
+    def test_local_external_collision_is_ambiguous(self, hermes_home, external_skills_dir):
+        """Same-named local and external skills require an explicit path."""
         local_skills = hermes_home / "skills"
         local_skill = local_skills / "my-external-skill"
         local_skill.mkdir(parents=True)
@@ -133,11 +133,15 @@ class TestExternalSkillsInFindAll:
             patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
             patch("tools.skills_tool.SKILLS_DIR", local_skills),
         ):
-            from tools.skills_tool import _find_all_skills
+            from tools.skills_tool import _find_all_skills, skill_view
+
             skills = _find_all_skills()
+            viewed = json.loads(skill_view("my-external-skill"))
         matching = [s for s in skills if s["name"] == "my-external-skill"]
-        assert len(matching) == 1
-        assert matching[0]["description"] == "Local version"
+        assert matching == []
+        assert viewed["success"] is False
+        assert "Ambiguous skill name 'my-external-skill'" in viewed["error"]
+        assert len(viewed["matches"]) == 2
 
 
 class TestExternalSkillView:

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -127,6 +127,80 @@ class TestScanSkillCommands:
         assert "/knowledge-brain" in result
         assert result["/knowledge-brain"]["name"] == "knowledge-brain"
 
+    def test_excludes_archived_only_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "active-skill")
+            _make_skill(tmp_path / ".archive", "archived-only")
+
+            result = scan_skill_commands()
+
+        assert "/active-skill" in result
+        assert "/archived-only" not in result
+
+    def test_exposes_provenance_for_shadowed_bundle(self, tmp_path):
+        profile_root = tmp_path / "profile"
+        bundled_root = tmp_path / "bundled"
+        profile_root.mkdir()
+        bundled_root.mkdir()
+        _make_skill(profile_root, "shared-skill", body="PROFILE")
+        _make_skill(bundled_root, "shared-skill", body="BUNDLED")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", profile_root),
+            patch(
+                "tools.skills_tool._normalize_source_roots",
+                return_value=[
+                    {
+                        "root": profile_root,
+                        "source_type": "profile",
+                        "resolved_root": profile_root.resolve(),
+                    },
+                    {
+                        "root": bundled_root,
+                        "source_type": "bundled",
+                        "resolved_root": bundled_root.resolve(),
+                    },
+                ],
+            ),
+        ):
+            result = scan_skill_commands()
+
+        assert "/shared-skill" in result
+        command = result["/shared-skill"]
+        assert command["source_type"] == "profile"
+        assert command["active_source"].endswith("profile/shared-skill/SKILL.md")
+        assert command["shadowed_sources"][0]["source_type"] == "bundled"
+
+    def test_unresolved_profile_external_collision_is_not_command(self, tmp_path):
+        profile_root = tmp_path / "profile"
+        external_root = tmp_path / "external"
+        profile_root.mkdir()
+        external_root.mkdir()
+        _make_skill(profile_root, "shared-skill", body="PROFILE")
+        _make_skill(external_root, "shared-skill", body="EXTERNAL")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", profile_root),
+            patch(
+                "tools.skills_tool._normalize_source_roots",
+                return_value=[
+                    {
+                        "root": profile_root,
+                        "source_type": "profile",
+                        "resolved_root": profile_root.resolve(),
+                    },
+                    {
+                        "root": external_root,
+                        "source_type": "external",
+                        "resolved_root": external_root.resolve(),
+                    },
+                ],
+            ),
+        ):
+            result = scan_skill_commands()
+
+        assert "/shared-skill" not in result
+
     def test_loads_skill_invocation_from_symlinked_skill_dir(self, tmp_path):
         """Slash commands should load skills symlinked under the local skills dir."""
         external_root = tmp_path / "external"

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -13,6 +13,7 @@ from tools.skills_tool import (
     _parse_frontmatter,
     _parse_tags,
     _get_category_from_path,
+    _find_all_skill_records,
     _find_all_skills,
     skill_matches_platform,
     skills_list,
@@ -307,6 +308,153 @@ class TestFindAllSkills:
         assert [s["name"] for s in skills] == ["knowledge-brain"]
         assert skills[0]["category"] == "linked"
 
+    def test_excludes_direct_archive_directory(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "active-skill")
+            _make_skill(tmp_path / ".archive", "archived-only")
+
+            skills = _find_all_skills()
+
+        assert {skill["name"] for skill in skills} == {"active-skill"}
+
+    def test_excludes_nested_archive_directory(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "active-skill")
+            _make_skill(tmp_path / "old" / ".archive", "archived-nested")
+
+            skills = _find_all_skills()
+
+        assert {skill["name"] for skill in skills} == {"active-skill"}
+
+    def test_archive_duplicate_does_not_shadow_bundled_fallback(self, tmp_path):
+        profile_root = tmp_path / "profile"
+        bundled_root = tmp_path / "bundled"
+        profile_root.mkdir()
+        bundled_root.mkdir()
+        _make_skill(profile_root / ".archive", "shared-skill", body="ARCHIVED")
+        _make_skill(bundled_root, "shared-skill", body="BUNDLED")
+
+        with patch("tools.skills_tool.SKILLS_DIR", profile_root):
+            records = _find_all_skill_records(
+                source_roots=[
+                    {"root": profile_root, "source_type": "profile"},
+                    {"root": bundled_root, "source_type": "bundled"},
+                ]
+            )
+
+        assert [record["name"] for record in records] == ["shared-skill"]
+        assert records[0]["source_type"] == "bundled"
+        assert records[0]["shadowed_sources"] == []
+
+    def test_active_profile_duplicate_wins_over_archived_copy(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "shared-skill", body="ACTIVE")
+            _make_skill(tmp_path / ".archive", "shared-skill", body="ARCHIVED")
+
+            records = _find_all_skill_records()
+
+        assert [record["name"] for record in records] == ["shared-skill"]
+        assert records[0]["source_type"] == "profile"
+        assert records[0]["shadowed_sources"] == []
+
+    def test_profile_source_wins_over_bundled_duplicate(self, tmp_path):
+        profile_root = tmp_path / "profile"
+        bundled_root = tmp_path / "bundled"
+        profile_root.mkdir()
+        bundled_root.mkdir()
+        _make_skill(profile_root, "shared-skill", body="PROFILE")
+        _make_skill(bundled_root, "shared-skill", body="BUNDLED")
+
+        with patch("tools.skills_tool.SKILLS_DIR", profile_root):
+            records = _find_all_skill_records(
+                source_roots=[
+                    {"root": bundled_root, "source_type": "bundled"},
+                    {"root": profile_root, "source_type": "profile"},
+                ]
+            )
+
+        assert [record["name"] for record in records] == ["shared-skill"]
+        assert records[0]["source_type"] == "profile"
+        assert records[0]["shadowed_sources"][0]["source_type"] == "bundled"
+        assert "profile" in records[0]["resolution_reason"].lower()
+
+    def test_repeated_resolution_is_deterministic(self, tmp_path):
+        profile_root = tmp_path / "profile"
+        bundled_root = tmp_path / "bundled"
+        profile_root.mkdir()
+        bundled_root.mkdir()
+        _make_skill(profile_root, "shared-skill")
+        _make_skill(bundled_root, "shared-skill")
+        source_roots = [
+            {"root": bundled_root, "source_type": "bundled"},
+            {"root": profile_root, "source_type": "profile"},
+        ]
+
+        with patch("tools.skills_tool.SKILLS_DIR", profile_root):
+            first = _find_all_skill_records(source_roots=source_roots)
+            second = _find_all_skill_records(source_roots=list(reversed(source_roots)))
+
+        def _signature(records):
+            return [
+                (
+                    record["name"],
+                    record["active_source"],
+                    record["source_type"],
+                    record["shadowed_sources"],
+                )
+                for record in records
+            ]
+
+        assert _signature(first) == _signature(second)
+
+    def test_same_physical_skill_root_is_not_counted_twice(self, tmp_path):
+        real_root = tmp_path / "real"
+        real_root.mkdir()
+        _make_skill(real_root, "shared-skill")
+        symlink_root = tmp_path / "linked"
+        try:
+            symlink_root.symlink_to(real_root, target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        with patch("tools.skills_tool.SKILLS_DIR", real_root):
+            records = _find_all_skill_records(
+                source_roots=[
+                    {"root": real_root, "source_type": "profile"},
+                    {"root": symlink_root, "source_type": "external"},
+                ]
+            )
+
+        assert [record["name"] for record in records] == ["shared-skill"]
+        assert records[0]["shadowed_sources"] == []
+
+    def test_profile_external_collision_is_not_active_list_record(self, tmp_path):
+        profile_root = tmp_path / "profile"
+        external_root = tmp_path / "external"
+        profile_root.mkdir()
+        external_root.mkdir()
+        _make_skill(profile_root, "shared-skill", body="PROFILE")
+        _make_skill(external_root, "shared-skill", body="EXTERNAL")
+
+        with patch("tools.skills_tool.SKILLS_DIR", profile_root):
+            records = _find_all_skill_records(
+                source_roots=[
+                    {"root": profile_root, "source_type": "profile"},
+                    {"root": external_root, "source_type": "external"},
+                ]
+            )
+            skills = _find_all_skills(
+                source_roots=[
+                    {"root": profile_root, "source_type": "profile"},
+                    {"root": external_root, "source_type": "external"},
+                ]
+            )
+
+        assert [record["name"] for record in records] == ["shared-skill"]
+        assert "ambiguous_sources" in records[0]
+        assert len(records[0]["ambiguous_sources"]) == 2
+        assert skills == []
+
 
 # ---------------------------------------------------------------------------
 # skills_list
@@ -356,6 +504,44 @@ class TestSkillsList:
         assert result["count"] == 1
         assert result["categories"] == ["linked"]
         assert result["skills"][0]["name"] == "knowledge-brain"
+
+    def test_lists_source_provenance_for_shadowed_duplicate(self, tmp_path):
+        profile_root = tmp_path / "profile"
+        bundled_root = tmp_path / "bundled"
+        profile_root.mkdir()
+        bundled_root.mkdir()
+        _make_skill(profile_root, "shared-skill", body="PROFILE")
+        _make_skill(bundled_root, "shared-skill", body="BUNDLED")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", profile_root),
+            patch(
+                "tools.skills_tool._normalize_source_roots",
+                return_value=[
+                    {
+                        "root": profile_root,
+                        "source_type": "profile",
+                        "resolved_root": profile_root.resolve(),
+                    },
+                    {
+                        "root": bundled_root,
+                        "source_type": "bundled",
+                        "resolved_root": bundled_root.resolve(),
+                    },
+                ],
+            ),
+        ):
+            raw = skills_list()
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["count"] == 1
+        skill = result["skills"][0]
+        assert skill["name"] == "shared-skill"
+        assert skill["source_type"] == "profile"
+        assert skill["active_source"].endswith("profile/shared-skill/SKILL.md")
+        assert skill["shadowed_sources"][0]["source_type"] == "bundled"
+        assert "profile" in skill["resolution_reason"].lower()
 
 
 # ---------------------------------------------------------------------------
@@ -1125,21 +1311,7 @@ Do the legacy thing.
 
 
 class TestSkillViewCollisionDetection:
-    """Regression tests for skill_view name collision handling.
-
-    When a skill name resolves to multiple paths across the local skills
-    dir and external_dirs, skill_view must refuse to guess. Silent
-    shadowing — where ``/skills`` shows the local version but
-    ``skill_view`` loads the external one — is the bug class this guards
-    against. Reproduces with `skills.external_dirs` registered in
-    config.yaml and a same-name skill nested under a category locally.
-
-    Adapted from a regression suite originally proposed by @polkn in PR
-    #6136 (which used local-first precedence). The collision-refusal
-    behavior preserves the same protection without silently picking a
-    side, and gives the user an actionable hint (use the categorized
-    path) to recover.
-    """
+    """Regression tests for legacy skill_view ambiguity handling."""
 
     def _patch_dirs(self, local_dir, external_dirs):
         """Patch SKILLS_DIR (module-level) and get_external_skills_dirs at source."""
@@ -1152,8 +1324,7 @@ class TestSkillViewCollisionDetection:
         )
 
     def test_nested_local_collides_with_top_level_external(self, tmp_path):
-        """The original bug scenario: nested local + top-level external,
-        same name. Now refuses with both paths surfaced."""
+        """Nested profile + top-level external remains ambiguous."""
         local_dir = tmp_path / "local"
         external_dir = tmp_path / "external"
         local_dir.mkdir()
@@ -1176,14 +1347,12 @@ class TestSkillViewCollisionDetection:
         assert "Ambiguous skill name 'explore-codebase'" in result["error"]
         assert "matches" in result
         assert len(result["matches"]) == 2
-        # Both paths surfaced
         assert any("foundations/runtime" in p for p in result["matches"])
         assert any("external" in p for p in result["matches"])
         assert "hint" in result
 
     def test_top_level_local_collides_with_external(self, tmp_path):
-        """Top-level local + top-level external with the same name also
-        refuses — same-name shadowing is ambiguous regardless of nesting."""
+        """Top-level profile + external with the same name is ambiguous."""
         local_dir = tmp_path / "local"
         external_dir = tmp_path / "external"
         local_dir.mkdir()
@@ -1202,8 +1371,7 @@ class TestSkillViewCollisionDetection:
         assert len(result["matches"]) == 2
 
     def test_collision_resolvable_via_categorized_path(self, tmp_path):
-        """User can recover from a collision by passing the full
-        categorized path — the bare name is ambiguous, the path is not."""
+        """The full categorized path still resolves the same local skill."""
         local_dir = tmp_path / "local"
         external_dir = tmp_path / "external"
         local_dir.mkdir()
@@ -1326,9 +1494,8 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is True
         assert "EXTERNAL BODY" in result["content"]
 
-    def test_two_externals_same_name_also_refuse(self, tmp_path):
-        """Collision detection is symmetric — two external dirs with
-        same-name skills also trigger the refusal."""
+    def test_two_externals_same_name_refuse_ambiguity(self, tmp_path):
+        """Same-precedence external duplicates do not resolve by path order."""
         local_dir = tmp_path / "local"
         ext_a = tmp_path / "ext_a"
         ext_b = tmp_path / "ext_b"
@@ -1346,6 +1513,79 @@ class TestSkillViewCollisionDetection:
         result = json.loads(raw)
         assert result["success"] is False
         assert "Ambiguous" in result["error"]
+        assert len(result["matches"]) == 2
+
+    def test_reversing_external_root_order_keeps_ambiguity_output(self, tmp_path):
+        """External duplicate reporting is deterministic, not root-order based."""
+        local_dir = tmp_path / "local"
+        ext_a = tmp_path / "ext_a"
+        ext_b = tmp_path / "ext_b"
+        local_dir.mkdir()
+        ext_a.mkdir()
+        ext_b.mkdir()
+
+        _make_skill(ext_a, "pr", body="EXT_A VERSION")
+        _make_skill(ext_b, "pr", body="EXT_B VERSION")
+
+        p1, p2 = self._patch_dirs(local_dir, [ext_a, ext_b])
+        with p1, p2:
+            first = json.loads(skill_view("pr"))
+        p1, p2 = self._patch_dirs(local_dir, [ext_b, ext_a])
+        with p1, p2:
+            second = json.loads(skill_view("pr"))
+
+        assert first["success"] is False
+        assert second["success"] is False
+        assert first["matches"] == second["matches"]
+        assert "EXT_A VERSION" not in json.dumps(first)
+
+    def test_profile_shadows_bundled_without_ambiguity(self, tmp_path):
+        """Profile-over-bundled is the explicit safe automatic winner rule."""
+        profile_root = tmp_path / "profile"
+        bundled_root = tmp_path / "bundled"
+        profile_root.mkdir()
+        bundled_root.mkdir()
+        _make_skill(profile_root, "shared-skill", body="PROFILE VERSION")
+        _make_skill(bundled_root, "shared-skill", body="BUNDLED VERSION")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", profile_root),
+            patch(
+                "tools.skills_tool._normalize_source_roots",
+                return_value=[
+                    {
+                        "root": bundled_root,
+                        "source_type": "bundled",
+                        "resolved_root": bundled_root.resolve(),
+                    },
+                    {
+                        "root": profile_root,
+                        "source_type": "profile",
+                        "resolved_root": profile_root.resolve(),
+                    },
+                ],
+            ),
+        ):
+            result = json.loads(skill_view("shared-skill"))
+
+        assert result["success"] is True
+        assert result["source_type"] == "profile"
+        assert "PROFILE VERSION" in result["content"]
+        assert len(result["shadowed_sources"]) == 1
+        assert result["shadowed_sources"][0]["source_type"] == "bundled"
+
+    def test_two_profile_sources_same_name_refuse_ambiguity(self, tmp_path):
+        """Multiple distinct profile candidates with the same name are ambiguous."""
+        profile_root = tmp_path / "profile"
+        profile_root.mkdir()
+        _make_skill(profile_root, "shared-name", category="a", body="A VERSION")
+        _make_skill(profile_root, "shared-name", category="b", body="B VERSION")
+
+        with patch("tools.skills_tool.SKILLS_DIR", profile_root):
+            result = json.loads(skill_view("shared-name"))
+
+        assert result["success"] is False
+        assert "Ambiguous skill name 'shared-name'" in result["error"]
         assert len(result["matches"]) == 2
 
     def test_local_only_skill_loads_normally(self, tmp_path):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -69,7 +69,7 @@ Usage:
 import json
 import logging
 
-from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_constants import get_hermes_home, display_hermes_home, get_bundled_skills_dir
 import os
 import re
 from enum import Enum
@@ -80,8 +80,9 @@ from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get
 from utils import env_var_enabled
 from agent.skill_utils import (
-    EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS,
+    is_excluded_skill_path as _is_excluded_skill_path,
     is_skill_support_path as _is_skill_support_path,
+    iter_skill_index_files as _iter_skill_index_files,
 )
 
 logger = logging.getLogger(__name__)
@@ -96,6 +97,12 @@ SKILLS_DIR = HERMES_HOME / "skills"
 # Anthropic-recommended limits for progressive disclosure efficiency
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
+_SOURCE_PRIORITY = {
+    "profile": 0,
+    "external": 1,
+    "bundled": 2,
+}
+_NO_BUNDLED_SKILLS_MARKER = ".no-bundled-skills"
 
 # Platform identifiers for the 'platforms' frontmatter field.
 # Maps user-friendly names to sys.platform prefixes.
@@ -599,7 +606,384 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         return False
 
 
-def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
+def _source_priority(source_type: str) -> int:
+    return _SOURCE_PRIORITY.get(str(source_type or ""), 50)
+
+
+def _resolve_path(path: Path) -> Path:
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return path.absolute()
+
+
+def _get_bundled_skill_root() -> Path:
+    return get_bundled_skills_dir(Path(__file__).resolve().parent.parent / "skills")
+
+
+def _should_include_default_bundled_skills() -> bool:
+    """Include bundled fallback only for the real profile skills dir.
+
+    Most unit tests patch ``SKILLS_DIR`` to a temporary directory and expect a
+    hermetic discovery surface. Runtime discovery keeps bundled skills visible
+    behind profile/external sources for synced profiles unless the profile opts
+    out. A scratch ``HERMES_HOME`` without a bundled manifest has not gone
+    through bundled-skill sync, so falling back to repo skills there would make
+    tests and isolated profiles non-hermetic.
+    """
+    if (get_hermes_home() / _NO_BUNDLED_SKILLS_MARKER).exists():
+        return False
+    if not (SKILLS_DIR / ".bundled_manifest").exists():
+        return False
+    return _resolve_path(SKILLS_DIR) == _resolve_path(get_hermes_home() / "skills")
+
+
+def _normalize_source_roots(source_roots: list | None = None) -> List[Dict[str, Any]]:
+    """Return deterministic, de-duplicated skill roots with source metadata."""
+    if source_roots is None:
+        source_roots = []
+        if SKILLS_DIR.exists():
+            source_roots.append({"root": SKILLS_DIR, "source_type": "profile"})
+        try:
+            from agent.skill_utils import get_external_skills_dirs
+
+            for external_dir in get_external_skills_dirs():
+                source_roots.append({"root": external_dir, "source_type": "external"})
+        except Exception:
+            pass
+        try:
+            bundled_root = _get_bundled_skill_root()
+            if _should_include_default_bundled_skills():
+                source_roots.append({"root": bundled_root, "source_type": "bundled"})
+        except Exception:
+            pass
+
+    normalized: List[Dict[str, Any]] = []
+    for entry in source_roots:
+        if isinstance(entry, dict):
+            root_raw = entry.get("root") or entry.get("path")
+            source_type = str(entry.get("source_type") or "profile")
+        elif isinstance(entry, tuple) and len(entry) >= 2:
+            root_raw, source_type = entry[0], str(entry[1])
+        else:
+            root_raw, source_type = entry, "profile"
+        if not root_raw:
+            continue
+        root = Path(root_raw).expanduser()
+        resolved_root = _resolve_path(root)
+        if ".archive" in root.parts or ".archive" in resolved_root.parts:
+            continue
+        if not root.is_dir():
+            continue
+        normalized.append(
+            {
+                "root": root,
+                "source_type": source_type,
+                "resolved_root": resolved_root,
+            }
+        )
+
+    normalized.sort(
+        key=lambda item: (
+            _source_priority(item["source_type"]),
+            str(item["resolved_root"]),
+            str(item["root"]),
+        )
+    )
+    deduped: List[Dict[str, Any]] = []
+    seen_roots: Set[Path] = set()
+    for item in normalized:
+        if item["resolved_root"] in seen_roots:
+            continue
+        seen_roots.add(item["resolved_root"])
+        deduped.append(item)
+    return deduped
+
+
+def _read_bundled_manifest_names() -> Set[str]:
+    manifest = SKILLS_DIR / ".bundled_manifest"
+    if not manifest.exists():
+        return set()
+    names: Set[str] = set()
+    try:
+        for line in manifest.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            name, _, _hash = line.partition(":")
+            if name.strip():
+                names.add(name.strip())
+    except OSError:
+        return set()
+    return names
+
+
+def _read_curator_suppressed_names() -> Set[str]:
+    suppressed = SKILLS_DIR / ".curator_suppressed"
+    if not suppressed.exists():
+        return set()
+    names: Set[str] = set()
+    try:
+        for line in suppressed.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                names.add(line)
+    except OSError:
+        return set()
+    return names
+
+
+def _category_from_source_root(skill_md: Path, source_root: Path) -> Optional[str]:
+    try:
+        rel_path = skill_md.relative_to(source_root)
+        if len(rel_path.parts) >= 3:
+            return rel_path.parts[0]
+    except ValueError:
+        pass
+    return _get_category_from_path(skill_md)
+
+
+def _describe_source(candidate: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "source_type": candidate["source_type"],
+        "path": str(candidate["skill_md"]),
+        "skill_dir": str(candidate["skill_dir"]) if candidate.get("skill_dir") else None,
+        "source_root": str(candidate["source_root"]),
+        "canonical_path": str(candidate["canonical_path"]),
+    }
+
+
+def _candidate_sort_key(candidate: Dict[str, Any]) -> tuple:
+    return (
+        _source_priority(candidate["source_type"]),
+        str(candidate["canonical_path"]),
+        str(candidate["skill_md"]),
+    )
+
+
+def _candidate_report_sort_key(candidate: Dict[str, Any]) -> tuple:
+    return (
+        str(candidate["canonical_path"]),
+        _source_priority(candidate["source_type"]),
+        str(candidate["skill_md"]),
+    )
+
+
+def _resolution_reason(winner: Dict[str, Any], shadowed: List[Dict[str, Any]]) -> str:
+    if not shadowed:
+        return f"Only active {winner['source_type']} source matched."
+    if winner["source_type"] == "profile" and all(
+        s["source_type"] == "bundled" for s in shadowed
+    ):
+        return "Active profile source selected over bundled duplicate sources."
+    return "Resolved unique active source."
+
+
+def _filter_uninstalled_bundled_candidates(
+    name: str,
+    candidates: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    manifest_names = _read_bundled_manifest_names()
+    has_non_bundled = any(c["source_type"] != "bundled" for c in candidates)
+    filtered: List[Dict[str, Any]] = []
+    for candidate in candidates:
+        if candidate["source_type"] == "bundled" and name in manifest_names and not has_non_bundled:
+            canonical_dest = SKILLS_DIR / candidate["relative_skill_dir"]
+            if not canonical_dest.exists():
+                continue
+        filtered.append(candidate)
+    return filtered
+
+
+def _resolve_skill_candidate_group(
+    candidates: List[Dict[str, Any]],
+) -> Tuple[Optional[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Resolve only unique candidates and the safe profile-over-bundled overlay."""
+    ordered = sorted(candidates, key=_candidate_sort_key)
+    if not ordered:
+        return None, [], []
+    if len(ordered) == 1:
+        return ordered[0], [], []
+
+    profiles = [c for c in ordered if c["source_type"] == "profile"]
+    non_bundled = [c for c in ordered if c["source_type"] != "bundled"]
+    if len(profiles) == 1 and len(non_bundled) == 1:
+        winner = profiles[0]
+        shadowed = [c for c in ordered if c is not winner]
+        return winner, shadowed, []
+
+    return None, [], sorted(ordered, key=_candidate_report_sort_key)
+
+
+def _ambiguous_skill_response(name: str, candidates: List[Dict[str, Any]]) -> str:
+    ordered = sorted(candidates, key=_candidate_report_sort_key)
+    paths = [str(c["skill_md"]) for c in ordered]
+    logging.getLogger(__name__).warning(
+        "Skill name collision for '%s': %d candidates — %s",
+        name,
+        len(ordered),
+        "; ".join(paths),
+    )
+    return json.dumps(
+        {
+            "success": False,
+            "error": (
+                f"Ambiguous skill name '{name}': {len(ordered)} skills "
+                "match across your local skills dir and external_dirs. "
+                "Refusing to guess — load one explicitly by its categorized path."
+            ),
+            "matches": paths,
+            "hint": (
+                "Pass the full relative path instead of the bare name "
+                "(e.g., 'category/skill-name'), or rename one of the "
+                "colliding skills so each name is unique."
+            ),
+        },
+        ensure_ascii=False,
+    )
+
+
+def _is_ambiguous_skill_record(record: Dict[str, Any]) -> bool:
+    return bool(record.get("ambiguous_sources"))
+
+
+def _discover_skill_candidates(
+    *,
+    skip_disabled: bool = False,
+    source_roots: list | None = None,
+) -> List[Dict[str, Any]]:
+    """Collect active skill candidates before duplicate resolution."""
+    candidates: List[Dict[str, Any]] = []
+    seen_paths: Set[Path] = set()
+    disabled = _get_disabled_skill_names() if not skip_disabled else set()
+    suppressed = _read_curator_suppressed_names()
+
+    for source in _normalize_source_roots(source_roots):
+        source_root = source["root"]
+        source_type = source["source_type"]
+        for skill_md in _iter_skill_index_files(source_root, "SKILL.md"):
+            if _is_excluded_skill_path(skill_md):
+                continue
+            canonical_path = _resolve_path(skill_md)
+            if canonical_path in seen_paths:
+                continue
+            seen_paths.add(canonical_path)
+
+            skill_dir = skill_md.parent
+            try:
+                content = skill_md.read_text(encoding="utf-8")[:4000]
+                frontmatter, body = _parse_frontmatter(content)
+            except (UnicodeDecodeError, PermissionError) as e:
+                logger.debug("Failed to read skill file %s: %s", skill_md, e)
+                continue
+            except Exception as e:
+                logger.debug(
+                    "Skipping skill at %s: failed to parse: %s", skill_md, e, exc_info=True
+                )
+                continue
+
+            if not skill_matches_platform(frontmatter):
+                continue
+            if not skill_matches_environment(frontmatter):
+                continue
+
+            raw_name = str(frontmatter.get("name", skill_dir.name)).strip()
+            if not raw_name:
+                raw_name = skill_dir.name
+            if raw_name in disabled:
+                continue
+            if source_type == "bundled" and raw_name in suppressed:
+                continue
+
+            description = str(frontmatter.get("description", ""))
+            if not description:
+                for line in body.strip().split("\n"):
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        description = line
+                        break
+            if len(description) > MAX_DESCRIPTION_LENGTH:
+                description = description[:MAX_DESCRIPTION_LENGTH - 3] + "..."
+
+            try:
+                relative_skill_dir = str(skill_dir.relative_to(source_root))
+            except ValueError:
+                relative_skill_dir = skill_dir.name
+
+            candidates.append(
+                {
+                    "name": raw_name[:MAX_NAME_LENGTH],
+                    "description": description,
+                    "category": _category_from_source_root(skill_md, source_root),
+                    "skill_md": skill_md,
+                    "skill_dir": skill_dir,
+                    "source_root": source_root,
+                    "source_type": source_type,
+                    "canonical_path": canonical_path,
+                    "relative_skill_dir": relative_skill_dir,
+                }
+            )
+
+    return candidates
+
+
+def _find_all_skill_records(
+    *,
+    skip_disabled: bool = False,
+    source_roots: list | None = None,
+) -> List[Dict[str, Any]]:
+    """Return resolved skill records with deterministic source provenance."""
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for candidate in _discover_skill_candidates(
+        skip_disabled=skip_disabled,
+        source_roots=source_roots,
+    ):
+        grouped.setdefault(candidate["name"], []).append(candidate)
+
+    resolved: List[Dict[str, Any]] = []
+    for name in sorted(grouped):
+        filtered = _filter_uninstalled_bundled_candidates(name, grouped[name])
+        if not filtered:
+            continue
+
+        winner, shadowed_candidates, ambiguous = _resolve_skill_candidate_group(filtered)
+        if ambiguous:
+            resolved.append(
+                {
+                    "name": name,
+                    "description": "",
+                    "category": None,
+                    "ambiguous_sources": [_describe_source(c) for c in ambiguous],
+                }
+            )
+            continue
+        if winner is None:
+            continue
+
+        shadowed = [_describe_source(c) for c in shadowed_candidates]
+        resolved.append(
+            {
+                "name": winner["name"],
+                "description": winner["description"],
+                "category": winner["category"],
+                "active_source": str(winner["skill_md"]),
+                "source_type": winner["source_type"],
+                "shadowed_sources": shadowed,
+                "resolution_reason": _resolution_reason(winner, shadowed_candidates),
+                "skill_md_path": str(winner["skill_md"]),
+                "skill_dir": str(winner["skill_dir"]),
+                "source_root": str(winner["source_root"]),
+            }
+        )
+
+    return _sort_skills(resolved)
+
+
+def _find_all_skills(
+    *,
+    skip_disabled: bool = False,
+    source_roots: list | None = None,
+) -> List[Dict[str, Any]]:
     """Recursively find all skills in ~/.hermes/skills/ and external dirs.
 
     Args:
@@ -610,73 +994,23 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     Returns:
         List of skill metadata dicts (name, description, category).
     """
-    from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
-
-    skills = []
-    seen_names: set = set()
-
-    # Load disabled set once (not per-skill)
-    disabled = set() if skip_disabled else _get_disabled_skill_names()
-
-    # Scan local dir first, then external dirs (local takes precedence)
-    dirs_to_scan = []
-    if SKILLS_DIR.exists():
-        dirs_to_scan.append(SKILLS_DIR)
-    dirs_to_scan.extend(get_external_skills_dirs())
-
-    for scan_dir in dirs_to_scan:
-        for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-            if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
-                continue
-
-            skill_dir = skill_md.parent
-
-            try:
-                content = skill_md.read_text(encoding="utf-8")[:4000]
-                frontmatter, body = _parse_frontmatter(content)
-
-                if not skill_matches_platform(frontmatter):
-                    continue
-
-                if not skill_matches_environment(frontmatter):
-                    continue
-
-                name = frontmatter.get("name", skill_dir.name)[:MAX_NAME_LENGTH]
-                if name in seen_names:
-                    continue
-                if name in disabled:
-                    continue
-
-                description = frontmatter.get("description", "")
-                if not description:
-                    for line in body.strip().split("\n"):
-                        line = line.strip()
-                        if line and not line.startswith("#"):
-                            description = line
-                            break
-
-                if len(description) > MAX_DESCRIPTION_LENGTH:
-                    description = description[:MAX_DESCRIPTION_LENGTH - 3] + "..."
-
-                category = _get_category_from_path(skill_md)
-
-                seen_names.add(name)
-                skills.append({
-                    "name": name,
-                    "description": description,
-                    "category": category,
-                })
-
-            except (UnicodeDecodeError, PermissionError) as e:
-                logger.debug("Failed to read skill file %s: %s", skill_md, e)
-                continue
-            except Exception as e:
-                logger.debug(
-                    "Skipping skill at %s: failed to parse: %s", skill_md, e, exc_info=True
-                )
-                continue
-
-    return skills
+    records = _find_all_skill_records(
+        skip_disabled=skip_disabled,
+        source_roots=source_roots,
+    )
+    return [
+        {
+            "name": record["name"],
+            "description": record["description"],
+            "category": record["category"],
+            "active_source": record["active_source"],
+            "source_type": record["source_type"],
+            "shadowed_sources": record["shadowed_sources"],
+            "resolution_reason": record["resolution_reason"],
+        }
+        for record in records
+        if not _is_ambiguous_skill_record(record)
+    ]
 
 
 def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -964,8 +1298,6 @@ def skill_view(
             if bare:
                 local_category_name = f"{namespace}/{bare}"
 
-        from agent.skill_utils import get_external_skills_dirs
-
         # The categorized fall-through form (namespace/bare) joins onto each
         # search dir too; re-validate it since `bare` is not namespace-checked.
         if local_category_name:
@@ -980,13 +1312,9 @@ def skill_view(
                     ensure_ascii=False,
                 )
 
-        # Build list of all skill directories to search
-        all_dirs = []
-        if SKILLS_DIR.exists():
-            all_dirs.append(SKILLS_DIR)
-        all_dirs.extend(get_external_skills_dirs())
-
-        if not all_dirs:
+        source_roots = _normalize_source_roots()
+        all_dirs = [source["root"] for source in source_roots]
+        if not source_roots:
             return json.dumps(
                 {
                     "success": False,
@@ -998,68 +1326,63 @@ def skill_view(
         skill_dir = None
         skill_md = None
 
-        # Collision detection: collect ALL candidates across every dir using
-        # every lookup strategy (direct path, recursive by parent dir name,
-        # legacy flat <name>.md). If more than one matches, refuse and tell
-        # the caller — silent shadowing of a local skill by a same-named
-        # external skill is a real bug class (`/skills` shows one, agent
-        # loaded the other) so we surface it loudly instead of guessing.
-        from agent.skill_utils import iter_skill_index_files
+        candidates: List[Dict[str, Any]] = []
+        seen_md: Set[Path] = set()
 
-        candidates: List[Tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
-        seen_md: set = set()
-
-        def _record(sd: Optional[Path], smd: Path) -> None:
-            try:
-                key = smd.resolve()
-            except Exception:
-                key = smd
+        def _record(
+            sd: Optional[Path],
+            smd: Path,
+            source: Dict[str, Any],
+        ) -> None:
+            if _is_excluded_skill_path(smd):
+                return
+            key = _resolve_path(smd)
             if key in seen_md:
                 return
             seen_md.add(key)
-            candidates.append((sd, smd))
+            source_root = source["root"]
+            try:
+                relative_skill_dir = str(sd.relative_to(source_root)) if sd else smd.name
+            except ValueError:
+                relative_skill_dir = sd.name if sd else smd.name
+            candidates.append(
+                {
+                    "skill_dir": sd,
+                    "skill_md": smd,
+                    "source_root": source_root,
+                    "source_type": source["source_type"],
+                    "canonical_path": key,
+                    "relative_skill_dir": relative_skill_dir,
+                }
+            )
 
-        for search_dir in all_dirs:
-            # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
-            # at the top of the dir).
-            direct_path = search_dir / name
-            if (
-                not _is_skill_support_path(direct_path)
-                and direct_path.is_dir()
-                and (direct_path / "SKILL.md").exists()
-            ):
-                _record(direct_path, direct_path / "SKILL.md")
-            elif direct_path.with_suffix(".md").exists() and not _is_skill_support_path(
-                direct_path.with_suffix(".md")
-            ):
-                _record(None, direct_path.with_suffix(".md"))
+        def _record_lookup_path(search_dir: Path, lookup_name: str, source: Dict[str, Any]) -> None:
+            direct_path = search_dir / lookup_name
+            skill_index = direct_path / "SKILL.md"
+            if direct_path.is_dir() and skill_index.exists():
+                _record(direct_path, skill_index, source)
+                return
+            flat_md = direct_path.with_suffix(".md")
+            if flat_md.exists() and not _is_skill_support_path(flat_md):
+                _record(None, flat_md, source)
 
-            # Strategy 1b: categorized form for plugin namespace fall-through
-            # (e.g., a "myplugin:explore" name with no plugin registered also
-            # tries the on-disk path "myplugin/explore").
+        for source in source_roots:
+            search_dir = source["root"]
+            _record_lookup_path(search_dir, name, source)
+
+            # Categorized fall-through form for plugin namespace fallback
+            # (e.g., "myplugin:explore" also tries "myplugin/explore").
             if local_category_name:
-                categorized_path = search_dir / local_category_name
-                if (
-                    not _is_skill_support_path(categorized_path)
-                    and categorized_path.is_dir()
-                    and (categorized_path / "SKILL.md").exists()
-                ):
-                    _record(categorized_path, categorized_path / "SKILL.md")
-                elif categorized_path.with_suffix(
-                    ".md"
-                ).exists() and not _is_skill_support_path(
-                    categorized_path.with_suffix(".md")
-                ):
-                    _record(None, categorized_path.with_suffix(".md"))
+                _record_lookup_path(search_dir, local_category_name, source)
 
             # Strategy 2: recursive by directory name (catches nested skills
             # like "foundations/runtime/explore-codebase" called by bare name),
             # plus frontmatter `name:` lookup. `skills_list()` exposes the
             # frontmatter name, so `skill_view(name)` must accept it too even
             # when the on-disk directory is a shorter category/alias.
-            for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+            for found_skill_md in _iter_skill_index_files(search_dir, "SKILL.md"):
                 if found_skill_md.parent.name == name:
-                    _record(found_skill_md.parent, found_skill_md)
+                    _record(found_skill_md.parent, found_skill_md, source)
                     continue
                 try:
                     fm_content = found_skill_md.read_text(encoding="utf-8")
@@ -1067,7 +1390,7 @@ def skill_view(
                 except Exception:
                     fm = {}
                 if fm.get("name") == name:
-                    _record(found_skill_md.parent, found_skill_md)
+                    _record(found_skill_md.parent, found_skill_md, source)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
             # Exclude skill support docs: references/templates/assets/scripts
@@ -1077,34 +1400,24 @@ def skill_view(
                 if found_md.name != "SKILL.md" and not _is_skill_support_path(
                     found_md
                 ):
-                    _record(None, found_md)
-
-        if len(candidates) > 1:
-            paths = [str(smd) for _, smd in candidates]
-            logging.getLogger(__name__).warning(
-                "Skill name collision for '%s': %d candidates — %s",
-                name, len(candidates), "; ".join(paths),
-            )
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": (
-                        f"Ambiguous skill name '{name}': {len(candidates)} skills "
-                        "match across your local skills dir and external_dirs. "
-                        "Refusing to guess — load one explicitly by its categorized path."
-                    ),
-                    "matches": paths,
-                    "hint": (
-                        "Pass the full relative path instead of the bare name "
-                        "(e.g., 'category/skill-name'), or rename one of the "
-                        "colliding skills so each name is unique."
-                    ),
-                },
-                ensure_ascii=False,
-            )
+                    _record(None, found_md, source)
 
         if candidates:
-            skill_dir, skill_md = candidates[0]
+            candidates = _filter_uninstalled_bundled_candidates(name, candidates)
+
+        active_candidate: Optional[Dict[str, Any]] = None
+        shadowed_sources: List[Dict[str, Any]] = []
+        resolution_reason = ""
+        if candidates:
+            active_candidate, shadowed_candidates, ambiguous = _resolve_skill_candidate_group(
+                candidates
+            )
+            if ambiguous:
+                return _ambiguous_skill_response(name, ambiguous)
+            shadowed_sources = [_describe_source(c) for c in shadowed_candidates]
+            resolution_reason = _resolution_reason(active_candidate, shadowed_candidates)
+            skill_dir = active_candidate["skill_dir"]
+            skill_md = active_candidate["skill_md"]
 
         if not skill_md or not skill_md.exists():
             available = [s["name"] for s in _sort_skills(_find_all_skills())[:20]]
@@ -1133,9 +1446,10 @@ def skill_view(
         # Security: warn if skill is loaded from outside trusted directories
         # (local skills dir + configured external_dirs are all trusted)
         _outside_skills_dir = True
-        _trusted_dirs = [SKILLS_DIR.resolve()]
+        _trusted_dirs = [source["resolved_root"] for source in source_roots]
         try:
-            _trusted_dirs.extend(d.resolve() for d in all_dirs[1:])
+            if SKILLS_DIR.resolve() not in _trusted_dirs:
+                _trusted_dirs.append(SKILLS_DIR.resolve())
         except Exception:
             pass
         for _td in _trusted_dirs:
@@ -1275,6 +1589,11 @@ def skill_view(
                         "file": file_path,
                         "content": f"[Binary file: {target_file.name}, size: {target_file.stat().st_size} bytes]",
                         "is_binary": True,
+                        "skill_dir": str(skill_dir) if skill_dir else None,
+                        "active_source": str(skill_md),
+                        "source_type": active_candidate["source_type"] if active_candidate else None,
+                        "shadowed_sources": shadowed_sources,
+                        "resolution_reason": resolution_reason,
                     },
                     ensure_ascii=False,
                 )
@@ -1286,6 +1605,11 @@ def skill_view(
                     "file": file_path,
                     "content": content,
                     "file_type": target_file.suffix,
+                    "skill_dir": str(skill_dir) if skill_dir else None,
+                    "active_source": str(skill_md),
+                    "source_type": active_candidate["source_type"] if active_candidate else None,
+                    "shadowed_sources": shadowed_sources,
+                    "resolution_reason": resolution_reason,
                 },
                 ensure_ascii=False,
             )
@@ -1459,6 +1783,10 @@ def skill_view(
             "content": rendered_content,
             "path": rel_path,
             "skill_dir": str(skill_dir) if skill_dir else None,
+            "active_source": str(skill_md),
+            "source_type": active_candidate["source_type"] if active_candidate else None,
+            "shadowed_sources": shadowed_sources,
+            "resolution_reason": resolution_reason,
             "linked_files": linked_files if linked_files else None,
             "usage_hint": "To view linked files, call skill_view(name, file_path) where file_path is e.g. 'references/api.md' or 'assets/config.yaml'"
             if linked_files


### PR DESCRIPTION
## Summary

- Exclude direct and nested `.archive` directories from active skill discovery.
- Deduplicate skill sources that resolve to the same physical path.
- Allow active profile skills to shadow bundled copies.
- Preserve legacy ambiguity failures for profile/external and external/external collisions.
- Prevent slash-command discovery from silently selecting unresolved collisions.
- Add source provenance without removing existing API fields.

## Resolution contract

- Canonical duplicate: deduplicated.
- Profile versus bundled: profile wins; bundled source is recorded as shadowed.
- Bundled fallback: follows the existing `.bundled_manifest` and suppression behavior.
- Profile versus external: remains ambiguous.
- External versus external: remains ambiguous.
- Archived source: never active.

## Compatibility

`skill_view` retains the previous ambiguity failure behavior for genuine distinct collisions. Provenance fields are additive:

- `active_source`
- `source_type`
- `shadowed_sources`
- `resolution_reason`

## Verification

Focused tests:

151 passed, 0 failed

Associated tests:

```text
39 passed, 0 failed
```

Additional verification:

* Python compilation passed.
* Ruff passed.
* Wheel and source distribution builds passed.
* Live read-only inventory showed 154 visible skills.
* Active `.archive` hits: 0.
* Slash commands: 154.
* Profile-over-bundled records: 6.
* Deterministic ambiguity behavior verified.

## Scope

Changed files:

* `agent/skill_commands.py`
* `agent/skill_utils.py`
* `tools/skills_tool.py`
* `tests/agent/test_external_skills.py`
* `tests/agent/test_skill_commands.py`
* `tests/tools/test_skills_tool.py`

The complete repository test suite was not run. The focused and directly associated suites passed.
