### PR TITLE
feat(skill): memory-enhanced-retrieval — entity-indexed two-stage retrieval

### DIFF
--- a/optional-skills/research/hermes-memory-ab-test/SKILL.md
+++ b/optional-skills/research/hermes-memory-ab-test/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: memory-enhanced-retrieval
+description: >-
+  Entity-indexed two-stage retrieval for Hermes. Uses jieba + SQLite as a
+  sidecar to build an entity index from conversation history, then performs
+  two-stage keyword expansion across retrieval passes. Zero changes to Hermes
+  core; removes cleanly.
+version: 1.0.0
+author: luxuguang-leo
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [memory, retrieval, entity-index, search, mragent]
+    related_skills: []
+---
+
+# Memory Enhanced Retrieval
+
+Improves `session_search` for multi-hop and cross-session queries using entity
+indexing + two-stage retrieval. Based on A/B testing against MRAgent (ICML 2026)
+on 10 real-world conversation scenarios.
+
+**Key result**: 100% correct+partial (vs MRAgent 30%), 12s avg (vs 33s), zero
+failures (vs MRAgent 50%).
+
+Full report: https://github.com/luxuguang-leo/hermes-memory-ab-test
+
+## How It Works
+
+```
+Write: conversation → jieba → extract entities → SQLite sidecar
+                                                    ↓
+Read:  question → jieba → index lookup → first pass → new entities → second pass → LLM answer
+```
+
+1. **Entity Index (sidecar)**: When storing conversations, jieba extracts named
+   entities (persons, places, organizations, concepts) and writes them to an
+   independent SQLite database.
+2. **Stage 1**: On query, entity extraction from the question narrows the search
+   scope via the index. Falls back to keyword matching when entity extraction
+   yields no results.
+3. **Stage 2**: New entities are extracted from stage 1's results and used for
+   a second search pass over uncovered turns.
+4. **Merge**: Results from both passes are merged with even sampling for
+   coverage, then sent to the LLM for a single answer call.
+
+## When to Use
+
+- The user asks a question that requires connecting facts across multiple
+  conversation turns
+- The user asks a question spanning multiple past sessions
+- `session_search` returns sparse or ambiguous results
+- The user reports that the agent "couldn't find something they said earlier"
+
+## Prerequisites
+
+```bash
+pip install jieba
+```
+
+## Installation
+
+```bash
+hermes skills install memory-enhanced-retrieval
+```
+
+## Rollback
+
+```bash
+hermes skills remove memory-enhanced-retrieval
+rm -rf ~/.hermes/entity_index/
+```
+
+## A/B Test Results
+
+Tested on 10 scenarios (multi-hop, temporal, cross-session) with Gemma4 12B:
+
+| Metric | Proposed | MRAgent | Flat RAG |
+|--------|---------|---------|----------|
+| Correct | 70% | 20% | 30% |
+| Correct+Partial | 100% | 30% | 40% |
+| Avg time | 12s | 33s | 4s |
+| LLM calls | 1 | 3 | 2 |
+| Stable | 10/10 | 5/10 | 5/10 |
+
+## References
+
+- MRAgent: "Memory is Reconstructed, Not Retrieved" — ICML 2026, arXiv:2606.06036
+- Hermes Agent: https://hermes-agent.nousresearch.com/
+- A/B test repo: https://github.com/luxuguang-leo/hermes-memory-ab-test

--- a/optional-skills/research/hermes-memory-ab-test/scripts/build_index.py
+++ b/optional-skills/research/hermes-memory-ab-test/scripts/build_index.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+Entity index builder. Run once after storing memory to update the sidecar index.
+"""
+import argparse, json, re, sqlite3
+from pathlib import Path
+import jieba.posseg as pseg
+
+STOPWORDS = set("的了在是我有和就不人都一个上也很到说要去你会着没看好自己这".strip())
+EN_SW = {"the","a","an","is","are","was","were","do","does","did","has","have",
+         "had","will","would","could","should","may","might","can","what","why",
+         "how","when","where","who","which"}
+
+def extract(text):
+    seen = set()
+    results = []
+    for word, flag in pseg.cut(text):
+        w = word.strip()
+        if len(w) < 2 or w.lower() in EN_SW or w in STOPWORDS:
+            continue
+        key = w.lower()
+        if key in seen:
+            continue
+        if flag == 'eng' and w[0].isupper():
+            seen.add(key); results.append((w, 'proper_noun'))
+        elif flag.startswith(('nr','ns','nt','nz')):
+            seen.add(key); results.append((w, {'nr':'person','ns':'place','nt':'org','nz':'proper_noun'}.get(flag[:2],'entity')))
+        elif flag.startswith(('n','v','a','l')):
+            seen.add(key); results.append((w, 'concept'))
+    return results
+
+def build_index(conversation, db_path):
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE IF NOT EXISTS entities (entity TEXT, turn_idx INT, content TEXT, tag TEXT)")
+    conn.execute("DELETE FROM entities")
+    for idx, turn in enumerate(conversation):
+        for entity, tag in extract(turn):
+            conn.execute("INSERT INTO entities VALUES (?, ?, ?, ?)",
+                         (entity.lower(), idx, turn[:200], tag))
+    conn.commit(); conn.close()
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--db", default=str(Path.home()/".hermes/entity_index/index.db"))
+    p.add_argument("--add", help="conversation turn text to index")
+    args = p.parse_args()
+    if args.add:
+        build_index([args.add], args.db)


### PR DESCRIPTION
## Summary

Adds `memory-enhanced-retrieval` as an optional skill under `research/`. This skill implements entity-indexed two-stage retrieval to improve multi-hop and cross-session recall in Hermes' session search.

## Background

Based on A/B testing against MRAgent (ICML 2026, "Memory is Reconstructed, Not Retrieved") on 10 real-world conversation scenarios:

| Metric | Proposed | MRAgent | Flat RAG |
|--------|---------|---------|----------|
| Correct+Partial | 100% | 30% | 40% |
| Avg time | 12s | 33s | 4s |
| LLM calls | 1 | 3 | 2 |
| Stable | 10/10 | 5/10 | 5/10 |

## Design

- **Sidecar architecture**: jieba + SQLite, completely independent from Hermes' state.db
- **Two-stage retrieval**: first pass via entity index, second pass expands with newly discovered entities
- **Zero core changes**: skill-only, `hermes skills remove` for full rollback
- **~150 lines total**, MIT licensed

Full report: https://github.com/luxuguang-leo/hermes-memory-ab-test