### PR TITLE
fix(telegram): extract reply_to_text from api_kwargs rich_message before store fallback

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -197,6 +197,67 @@ def _strip_mdv2(text: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+def _extract_text_from_rich_message(rich_msg: Any) -> Optional[str]:
+    """Extract plain text from a Telegram rich_message object.
+
+    Telegram Bot API 10.1 echoes ``api_kwargs['rich_message']`` back in
+    ``reply_to_message`` when a user replies to a rich-sent message.
+    The object may be a ``dict`` *or* a ``types.MappingProxyType`` --
+    duck-type via ``.get()`` instead of ``isinstance(..., dict)``.
+
+    Returns the concatenated text, or ``None`` if no usable content is
+    found.
+    """
+    if rich_msg is None:
+        return None
+    # Duck-type: MappingProxyType has .get() but fails isinstance(dict).
+    get = getattr(rich_msg, "get", None)
+    if get is None:
+        return None
+
+    # Prefer structured blocks (Telegram's parsed representation).
+    blocks = get("blocks")
+    if blocks and isinstance(blocks, (list, tuple)):
+        parts: list[str] = []
+        _collect_block_text(blocks, parts)
+        text = "\n".join(parts).strip()
+        if text:
+            return text
+
+    # Fall back to raw markdown if blocks are absent.
+    md = get("markdown")
+    if isinstance(md, str) and md.strip():
+        return md
+
+    return None
+
+
+def _collect_block_text(blocks: list, out: list[str]) -> None:
+    """Recursively collect text strings from rich_message blocks."""
+    for block in blocks:
+        if isinstance(block, str):
+            out.append(block)
+            continue
+        get = getattr(block, "get", None)
+        if get is None:
+            continue
+        # Block with a direct "text" field (paragraph, heading, pre, bold ...).
+        text_val = get("text")
+        if isinstance(text_val, str):
+            out.append(text_val)
+        elif isinstance(text_val, (list, tuple)):
+            _collect_block_text(list(text_val), out)
+        # Nested blocks (list items carry their own "blocks" array).
+        nested = get("blocks")
+        if isinstance(nested, (list, tuple)):
+            _collect_block_text(list(nested), out)
+        # List items: {"label": "...", "blocks": [...]}
+        items = get("items")
+        if isinstance(items, (list, tuple)):
+            _collect_block_text(list(items), out)
+
+
+# ---------------------------------------------------------------------------
 # Markdown table → Telegram-friendly row groups
 # ---------------------------------------------------------------------------
 # Telegram's MarkdownV2 has no table syntax — '|' is just an escaped literal,
@@ -6772,18 +6833,28 @@ class TelegramAdapter(BasePlatformAdapter):
                     or None
                 )
                 if not reply_to_text:
-                    # Rich messages (sendRichMessage — the launchd briefings and
-                    # the gateway's own rich finals) are NOT echoed with their
-                    # content in reply_to_message; Telegram sends no text,
-                    # caption, or api_kwargs for them. Recover the text we sent
-                    # from our local send-time index, keyed by message id.
+                    # Bot API 10.1 echoes rich content back in
+                    # reply_to_message.api_kwargs["rich_message"] when a user
+                    # replies to a rich-sent message.  Extract text from the
+                    # structured blocks (or raw markdown) before falling back
+                    # to the local send-time index.
                     try:
-                        from gateway import rich_sent_store
-                        reply_to_text = rich_sent_store.lookup(
-                            str(chat.id), reply_to_id
-                        )
+                        ak = getattr(message.reply_to_message, "api_kwargs", None)
+                        if ak is not None:
+                            rm = ak.get("rich_message") if hasattr(ak, "get") else None
+                            reply_to_text = _extract_text_from_rich_message(rm)
                     except Exception:
-                        reply_to_text = None
+                        pass
+                    if not reply_to_text:
+                        # Legacy fallback: recover from local send-time index
+                        # for messages sent before rich echo was available.
+                        try:
+                            from gateway import rich_sent_store
+                            reply_to_text = rich_sent_store.lookup(
+                                str(chat.id), reply_to_id
+                            )
+                        except Exception:
+                            reply_to_text = None
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt

--- a/tests/gateway/test_rich_message_text_extraction.py
+++ b/tests/gateway/test_rich_message_text_extraction.py
@@ -1,0 +1,113 @@
+"""Tests for _extract_text_from_rich_message and _collect_block_text."""
+from types import MappingProxyType
+from gateway.platforms.telegram import _extract_text_from_rich_message, _collect_block_text
+
+
+class TestExtractTextFromRichMessage:
+    """Tests for _extract_text_from_rich_message."""
+
+    def test_none_returns_none(self):
+        assert _extract_text_from_rich_message(None) is None
+
+    def test_plain_dict_with_blocks(self):
+        rich_msg = {
+            "blocks": [
+                {"type": "paragraph", "text": "Hello world"},
+                {"type": "heading", "text": "Title", "size": 2},
+            ]
+        }
+        result = _extract_text_from_rich_message(rich_msg)
+        assert result == "Hello world\nTitle"
+
+    def test_mappingproxy_with_blocks(self):
+        """MappingProxyType must NOT fail (isinstance(dict) is False)."""
+        rich_msg = MappingProxyType({
+            "blocks": [
+                {"type": "paragraph", "text": "Proxy text"},
+            ]
+        })
+        result = _extract_text_from_rich_message(rich_msg)
+        assert result == "Proxy text"
+
+    def test_blocks_with_nested_text_list(self):
+        """Blocks where text is a list of inline elements (bold, etc.)."""
+        rich_msg = {
+            "blocks": [
+                {
+                    "type": "paragraph",
+                    "text": [
+                        "Hello ",
+                        {"type": "bold", "text": "world"},
+                    ],
+                },
+            ]
+        }
+        result = _extract_text_from_rich_message(rich_msg)
+        assert result == "Hello \nworld"
+
+    def test_blocks_with_list_items(self):
+        """List items have label + nested blocks."""
+        rich_msg = {
+            "blocks": [
+                {
+                    "type": "list",
+                    "items": [
+                        {"label": "•", "blocks": [{"type": "text", "text": "Item 1"}]},
+                        {"label": "•", "blocks": [{"type": "text", "text": "Item 2"}]},
+                    ],
+                }
+            ]
+        }
+        result = _extract_text_from_rich_message(rich_msg)
+        assert result is not None
+        assert "Item 1" in result
+        assert "Item 2" in result
+
+    def test_fallback_to_markdown(self):
+        """When no blocks, fall back to markdown field."""
+        rich_msg = {"markdown": "**Bold** text with `code`"}
+        result = _extract_text_from_rich_message(rich_msg)
+        assert result == "**Bold** text with `code`"
+
+    def test_empty_blocks_falls_back_to_markdown(self):
+        rich_msg = {"blocks": [], "markdown": "fallback text"}
+        result = _extract_text_from_rich_message(rich_msg)
+        assert result == "fallback text"
+
+    def test_non_dict_returns_none(self):
+        assert _extract_text_from_rich_message("not a dict") is None
+        assert _extract_text_from_rich_message(42) is None
+
+    def test_empty_dict_returns_none(self):
+        assert _extract_text_from_rich_message({}) is None
+
+    def test_blocks_with_only_empty_text(self):
+        rich_msg = {"blocks": [{"type": "paragraph", "text": ""}]}
+        # Empty text should not produce output; falls through to markdown
+        result = _extract_text_from_rich_message(rich_msg)
+        assert result is None
+
+
+class TestCollectBlockText:
+    """Tests for _collect_block_text."""
+
+    def test_string_elements(self):
+        out = []
+        _collect_block_text(["hello", "world"], out)
+        assert out == ["hello", "world"]
+
+    def test_mixed_string_and_dict(self):
+        out = []
+        _collect_block_text(["plain", {"type": "bold", "text": "bold text"}], out)
+        assert out == ["plain", "bold text"]
+
+    def test_nested_text_list(self):
+        out = []
+        block = {"type": "paragraph", "text": ["a", {"type": "bold", "text": "b"}]}
+        _collect_block_text([block], out)
+        assert out == ["a", "b"]
+
+    def test_empty_input(self):
+        out = []
+        _collect_block_text([], out)
+        assert out == []


### PR DESCRIPTION
## What does this PR do?

Extracts `reply_to_text` from `reply_to_message.api_kwargs['rich_message']` when a user replies to a rich-sent Telegram message, before falling back to the local `rich_sent_store` index. This fixes the case where replies to messages sent via the streaming edit path arrive with empty `reply_to_text`, making the agent blind to the quoted message.

## Related Issue

Fixes #49534

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: Added `_extract_text_from_rich_message()` and `_collect_block_text()` helpers to extract plain text from Telegram's `rich_message` object (handles both `dict` and `types.MappingProxyType`). Modified the reply-to-text resolution to check `api_kwargs['rich_message']` blocks/markdown before falling back to `rich_sent_store.lookup()`.
- `tests/gateway/test_rich_message_text_extraction.py`: Added 14 tests covering dict/mappingproxy handling, nested blocks, list items, markdown fallback, and edge cases.

## How to Test

1. Send a message to the bot that triggers a streaming reply containing markdown (bold, code blocks, tables)
2. When the reply finalizes, reply to it in Telegram
3. Verify the agent receives the quoted text in `reply_to_text` (not empty)
4. Run `pytest tests/gateway/test_rich_message_text_extraction.py -v` to verify unit tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Checked: `gateway/platforms/telegram.py` — reply_to_text extraction, _try_send_rich record path, _try_edit_rich (no record), api_kwargs access pattern
- Blast radius: LOW — changes only affect the reply-to-text resolution for rich messages; legacy text/caption path unchanged
- Related patterns: `rich_sent_store.py` (local index, still used as fallback), `_try_edit_rich` (streaming edit path), `api_kwargs` access via duck typing
