### PR TITLE
fix(desktop): harden Electron main process against crashes, SSRF, and IPC gaps

### DIFF
--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -138,11 +138,23 @@ function downloadInstallScript(commit, destPath) {
       .get(url, res => {
         if (res.statusCode === 301 || res.statusCode === 302) {
           // GitHub raw shouldn't redirect for a SHA URL, but follow once
-          // defensively.
+          // defensively. Validate the redirect target is https and on
+          // raw.githubusercontent.com before following.
           out.close()
           fs.unlinkSync(tmpPath)
+          const redirectUrl = res.headers.location || ''
+          try {
+            const parsed = new URL(redirectUrl)
+            if (parsed.protocol !== 'https:' || parsed.hostname !== 'raw.githubusercontent.com') {
+              reject(new Error('Redirect to unexpected host: ' + redirectUrl))
+              return
+            }
+          } catch {
+            reject(new Error('Invalid redirect URL: ' + redirectUrl))
+            return
+          }
           https
-            .get(res.headers.location, res2 => {
+            .get(redirectUrl, res2 => {
               if (res2.statusCode !== 200) {
                 reject(
                   new Error(

--- a/apps/desktop/electron/gateway-ws-probe.ts
+++ b/apps/desktop/electron/gateway-ws-probe.ts
@@ -88,7 +88,11 @@ function probeGatewayWebSocket<T>(
       } catch {
         // ignore — best effort teardown
       }
-
+      try {
+        removeListeners()
+      } catch {
+        // ignore — best effort cleanup
+      }
       resolve(result)
     }
 
@@ -156,6 +160,13 @@ function probeGatewayWebSocket<T>(
     addListener(socket, 'error', onError)
     addListener(socket, 'close', onClose)
 
+    const removeListeners = () => {
+      removeListener(socket, 'open', onOpen)
+      removeListener(socket, 'message', onMessage)
+      removeListener(socket, 'error', onError)
+      removeListener(socket, 'close', onClose)
+    }
+
     if (connectTimeoutMs > 0) {
       connectTimer = setTimeout(() => {
         finish({
@@ -178,6 +189,16 @@ function addListener(socket, type, handler) {
   // helper usable with the `ws` package's EventEmitter shape too.
   if (typeof socket.on === 'function') {
     socket.on(type, handler)
+  }
+}
+
+function removeListener(socket, type, handler) {
+  if (typeof socket.removeEventListener === 'function') {
+    socket.removeEventListener(type, handler)
+    return
+  }
+  if (typeof socket.off === 'function') {
+    socket.off(type, handler)
   }
 }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -67,6 +67,7 @@ import { installEmbedReferer } from './embed-referer'
 import { readDirForIpc } from './fs-read-dir'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { scanGitRepos } from './git-repo-scan'
+import { isBlockedUrl, MAX_DOWNLOAD_BYTES, MAX_FETCH_BYTES } from './url-guard'
 import {
   fileDiffVsHead,
   repoStatus,
@@ -4148,6 +4149,7 @@ function usableTitle(value: string): string {
 }
 
 function fetchLinkTitle(rawUrl) {
+  if (isBlockedUrl(String(rawUrl || ""))) return Promise.resolve("")
   const url = String(rawUrl || '').trim()
   const key = canonicalTitleCacheKey(url)
 
@@ -4206,6 +4208,7 @@ async function resourceBufferFromUrl(rawUrl) {
     return { buffer, mimeType: mimeTypeForPath(resolvedPath) }
   }
 
+  if (isBlockedUrl(rawUrl)) throw new Error("Blocked: private URL")
   const parsed = new URL(rawUrl)
   const client = parsed.protocol === 'https:' ? https : http
 
@@ -5215,6 +5218,18 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
     win.webContents.on('did-navigate', () => void checkCookie())
     win.webContents.on('did-redirect-navigation', () => void checkCookie())
     win.webContents.on('did-frame-navigate', () => void checkCookie())
+    win.webContents.setWindowOpenHandler(({ url }) => {
+      openExternalUrl(url)
+      return { action: 'deny' }
+    })
+    win.webContents.on('will-navigate', (event, url) => {
+      try {
+        const parsed = new URL(url)
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          event.preventDefault()
+        }
+      } catch { event.preventDefault() }
+    })
     pollTimer = setInterval(() => void checkCookie(), 750)
 
     // Silent-mode reveal fallback: if the cascade hasn't settled shortly, the
@@ -5842,11 +5857,15 @@ function readDesktopConnectionConfig() {
   return config
 }
 
+let _configWriteLock = Promise.resolve()
 function writeDesktopConnectionConfig(config) {
-  fs.mkdirSync(path.dirname(DESKTOP_CONNECTION_CONFIG_PATH), { recursive: true })
-  writeFileAtomic(DESKTOP_CONNECTION_CONFIG_PATH, JSON.stringify(config, null, 2))
-  connectionConfigCache = config
-  connectionConfigCacheMtime = fs.statSync(DESKTOP_CONNECTION_CONFIG_PATH).mtimeMs
+  _configWriteLock = _configWriteLock.then(() => {
+    fs.mkdirSync(path.dirname(DESKTOP_CONNECTION_CONFIG_PATH), { recursive: true })
+    writeFileAtomic(DESKTOP_CONNECTION_CONFIG_PATH, JSON.stringify(config, null, 2))
+    connectionConfigCache = config
+    connectionConfigCacheMtime = fs.statSync(DESKTOP_CONNECTION_CONFIG_PATH).mtimeMs
+  }).catch(() => {})
+  return _configWriteLock
 }
 
 // Returns the desktop's chosen profile name, or null when unset. "default" is
@@ -6985,8 +7004,16 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
     return { action: 'deny' }
   })
   win.webContents.on('will-navigate', (event, url) => {
-    if ((DEV_SERVER && url.startsWith(DEV_SERVER)) || (!DEV_SERVER && url.startsWith('file:'))) {
+    if (DEV_SERVER && url.startsWith(DEV_SERVER)) {
       return
+    }
+    if (!DEV_SERVER && url.startsWith('file:')) {
+      try {
+        const allowedBase = resolveRendererIndex()
+        if (allowedBase && url.startsWith(allowedBase.replace(/index.html.*$/, ''))) {
+          return
+        }
+      } catch {}
     }
 
     event.preventDefault()
@@ -8565,33 +8592,32 @@ ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
   return { cwd, id, shell: name }
 })
 
-ipcMain.handle('hermes:terminal:write', (_event, id, data) => {
+ipcMain.handle('hermes:terminal:write', (event, id, data) => {
   const sessionInfo = terminalSessions.get(String(id || ''))
-
-  if (!sessionInfo) {
+  if (!sessionInfo || sessionInfo.webContentsId !== event.sender.id) {
     return false
   }
-
   sessionInfo.pty.write(String(data || ''))
-
   return true
 })
 
-ipcMain.handle('hermes:terminal:resize', (_event, id, size = {}) => {
+ipcMain.handle('hermes:terminal:resize', (event, id, size = {}) => {
   const sessionInfo = terminalSessions.get(String(id || ''))
-
-  if (!sessionInfo) {
+  if (!sessionInfo || sessionInfo.webContentsId !== event.sender.id) {
     return false
   }
-
   const cols = Math.max(2, Number.parseInt(String(size?.cols || 80), 10) || 80)
   const rows = Math.max(2, Number.parseInt(String(size?.rows || 24), 10) || 24)
-
   sessionInfo.pty.resize(cols, rows)
-
   return true
 })
-ipcMain.handle('hermes:terminal:dispose', (_event, id) => disposeTerminalSession(String(id || '')))
+ipcMain.handle('hermes:terminal:dispose', (event, id) => {
+  const sessionInfo = terminalSessions.get(String(id || ''))
+  if (sessionInfo && sessionInfo.webContentsId !== event.sender.id) {
+    return false
+  }
+  return disposeTerminalSession(String(id || ''))
+})
 
 ipcMain.handle('hermes:updates:check', async () =>
   checkUpdates().catch(error => ({
@@ -8615,6 +8641,9 @@ ipcMain.handle('hermes:updates:branch:get', async () => readDesktopUpdateConfig(
 
 ipcMain.handle('hermes:updates:branch:set', async (_event, name) => {
   const branch = typeof name === 'string' && name.trim() ? name.trim() : DEFAULT_UPDATE_BRANCH
+  if (!/^[A-Za-z0-9._\/-]{1,200}$/.test(branch)) {
+    throw new Error('Invalid branch name')
+  }
   writeDesktopUpdateConfig({ branch })
 
   return { branch }
@@ -8985,7 +9014,10 @@ const _gotSingleInstanceLock = app.requestSingleInstanceLock()
 if (!_gotSingleInstanceLock) {
   app.quit()
 } else {
-  app.on('second-instance', (_event, argv) => {
+  process.on('unhandledRejection', (err) => { console.error('[hermes-main] Unhandled rejection:', err); });
+process.on('uncaughtException', (err) => { console.error('[hermes-main] Uncaught exception:', err); });
+
+app.on('second-instance', (_event, argv) => {
     const url = _extractDeepLink(argv)
 
     if (url) {
@@ -9093,6 +9125,10 @@ app.on('before-quit', () => {
   }
 
   stopBackendChild(hermesProcess)
+  if (poolIdleReaper) {
+    clearInterval(poolIdleReaper)
+    poolIdleReaper = null
+  }
   stopAllPoolBackends()
 })
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3703,9 +3703,19 @@ function fetchJson(url, token, options: any = {}) {
       },
       res => {
         const chunks = []
+        let received = 0
         res.on('error', reject)
-        res.on('data', chunk => chunks.push(chunk))
+        res.on('data', chunk => {
+          received += chunk.length
+          if (received > MAX_FETCH_BYTES) {
+            req.destroy()
+            reject(new Error(`Response from ${url} exceeded ${MAX_FETCH_BYTES} bytes`))
+            return
+          }
+          chunks.push(chunk)
+        })
         res.on('end', () => {
+          if (req.destroyed) return
           const text = Buffer.concat(chunks).toString('utf8')
 
           if ((res.statusCode || 500) >= 400) {
@@ -4222,9 +4232,19 @@ async function resourceBufferFromUrl(rawUrl) {
       }
 
       const chunks = []
+      let received = 0
       res.on('error', reject)
-      res.on('data', chunk => chunks.push(chunk))
+      res.on('data', chunk => {
+        received += chunk.length
+        if (received > MAX_DOWNLOAD_BYTES) {
+          req.destroy()
+          reject(new Error(`Download from ${rawUrl} exceeded ${MAX_DOWNLOAD_BYTES} bytes`))
+          return
+        }
+        chunks.push(chunk)
+      })
       res.on('end', () => {
+        if (req.destroyed) return
         resolve({
           buffer: Buffer.concat(chunks),
           mimeType: res.headers['content-type'] || 'application/octet-stream'
@@ -5859,13 +5879,20 @@ function readDesktopConnectionConfig() {
 
 let _configWriteLock = Promise.resolve()
 function writeDesktopConnectionConfig(config) {
-  _configWriteLock = _configWriteLock.then(() => {
+  const run = _configWriteLock.then(() => {
     fs.mkdirSync(path.dirname(DESKTOP_CONNECTION_CONFIG_PATH), { recursive: true })
     writeFileAtomic(DESKTOP_CONNECTION_CONFIG_PATH, JSON.stringify(config, null, 2))
     connectionConfigCache = config
     connectionConfigCacheMtime = fs.statSync(DESKTOP_CONNECTION_CONFIG_PATH).mtimeMs
-  }).catch(() => {})
-  return _configWriteLock
+  })
+  // Keep the serialization chain alive even when a write fails, so one failure
+  // doesn't wedge every later write. Surface the error on the returned promise
+  // (and log it) so awaiting callers don't report a phantom success.
+  _configWriteLock = run.catch(() => {})
+  return run.catch(err => {
+    console.error('[hermes-main] Failed to persist desktop connection config:', err)
+    throw err
+  })
 }
 
 // Returns the desktop's chosen profile name, or null when unset. "default" is
@@ -7009,9 +7036,17 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
     }
     if (!DEV_SERVER && url.startsWith('file:')) {
       try {
-        const allowedBase = resolveRendererIndex()
-        if (allowedBase && url.startsWith(allowedBase.replace(/index.html.*$/, ''))) {
-          return
+        // resolveRendererIndex() returns a filesystem PATH; `url` is a file://
+        // URL. Compare like-for-like by converting the renderer directory to a
+        // file: URL prefix (the previous path-vs-URL compare never matched and
+        // bounced every in-app file: navigation to the external opener).
+        const indexPath = resolveRendererIndex()
+        if (indexPath) {
+          let allowedDir = pathToFileURL(path.dirname(indexPath)).href
+          if (!allowedDir.endsWith('/')) allowedDir += '/'
+          if (url.startsWith(allowedDir)) {
+            return
+          }
         }
       } catch {}
     }
@@ -7718,13 +7753,15 @@ ipcMain.handle('hermes:cloud:agent-sign-in', async (_event, dashboardUrl) => {
 })
 ipcMain.handle('hermes:connection-config:save', async (_event, payload) => {
   const config = coerceDesktopConnectionConfig(payload)
-  writeDesktopConnectionConfig(config)
+  // Await persistence so a write failure rejects the IPC call instead of
+  // reporting a phantom success while connection.json was never written.
+  await writeDesktopConnectionConfig(config)
 
   return sanitizeDesktopConnectionConfig(config, payload?.profile)
 })
 ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
   const config = coerceDesktopConnectionConfig(payload)
-  writeDesktopConnectionConfig(config)
+  await writeDesktopConnectionConfig(config)
 
   const key = connectionScopeKey(payload?.profile)
 
@@ -8641,7 +8678,9 @@ ipcMain.handle('hermes:updates:branch:get', async () => readDesktopUpdateConfig(
 
 ipcMain.handle('hermes:updates:branch:set', async (_event, name) => {
   const branch = typeof name === 'string' && name.trim() ? name.trim() : DEFAULT_UPDATE_BRANCH
-  if (!/^[A-Za-z0-9._\/-]{1,200}$/.test(branch)) {
+  // Reject a leading '-' (would be read as a flag by a git CLI) and any '..'
+  // sequence (ref traversal) on top of the character allowlist.
+  if (!/^[A-Za-z0-9._\/-]{1,200}$/.test(branch) || branch.startsWith('-') || branch.includes('..')) {
     throw new Error('Invalid branch name')
   }
   writeDesktopUpdateConfig({ branch })

--- a/apps/desktop/electron/url-guard.ts
+++ b/apps/desktop/electron/url-guard.ts
@@ -1,0 +1,23 @@
+function isBlockedUrl(urlStr) {
+  try {
+    const u = new URL(urlStr)
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false
+    const h = u.hostname
+    if (h === '127.0.0.1' || h === 'localhost' || h === '::1' || h === '0.0.0.0') return true
+    if (h.startsWith('127.') || h.startsWith('10.') || h.startsWith('169.254.')) return true
+    if (h.startsWith('192.168.')) return true
+    const p = h.split('.')
+    if (p.length === 4 && p[0] === '172') {
+      const n = parseInt(p[1], 10)
+      if (n >= 16 && n <= 31) return true
+    }
+    return false
+  } catch {
+    return false
+  }
+}
+
+const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
+const MAX_FETCH_BYTES = 16 * 1024 * 1024
+
+export { isBlockedUrl, MAX_DOWNLOAD_BYTES, MAX_FETCH_BYTES }

--- a/apps/desktop/electron/url-guard.ts
+++ b/apps/desktop/electron/url-guard.ts
@@ -1,16 +1,90 @@
+// Parse any IPv4 representation that the platform resolver (inet_aton) would
+// accept — dotted decimal, dotted hex/octal, and the shorthand forms where a
+// trailing field fills the remaining bytes (e.g. `2130706433`, `0x7f000001`,
+// `0177.0.0.1` all mean 127.0.0.1). Returns a uint32, or null when the host is
+// not an IPv4 literal. This closes the alternate-encoding SSRF bypass that a
+// plain `startsWith('127.')` string check misses.
+function ipv4ToInt(host) {
+  const parts = host.split('.')
+  if (parts.length === 0 || parts.length > 4) return null
+  const nums = []
+  for (const part of parts) {
+    if (part === '') return null
+    let n
+    if (/^0x[0-9a-f]+$/i.test(part)) n = parseInt(part, 16)
+    else if (/^0[0-7]+$/.test(part)) n = parseInt(part, 8)
+    else if (/^[0-9]+$/.test(part)) n = parseInt(part, 10)
+    else return null
+    if (!Number.isFinite(n) || n < 0) return null
+    nums.push(n)
+  }
+  // Leading fields must fit a byte; the final field fills the remaining bytes.
+  for (let i = 0; i < nums.length - 1; i++) {
+    if (nums[i] > 0xff) return null
+  }
+  const last = nums[nums.length - 1]
+  const maxLast = Math.pow(256, 4 - (nums.length - 1))
+  if (last >= maxLast) return null
+  let value = last
+  for (let i = 0; i < nums.length - 1; i++) {
+    value += nums[i] * Math.pow(256, 3 - i)
+  }
+  if (value < 0 || value > 0xffffffff) return null
+  return value >>> 0
+}
+
+function isPrivateIPv4Int(v) {
+  const a = (v >>> 24) & 0xff
+  const b = (v >>> 16) & 0xff
+  if (a === 127) return true // 127.0.0.0/8 loopback
+  if (a === 10) return true // 10.0.0.0/8 private
+  if (a === 0) return true // 0.0.0.0/8 ("this host")
+  if (a === 169 && b === 254) return true // 169.254.0.0/16 link-local + cloud metadata
+  if (a === 192 && b === 168) return true // 192.168.0.0/16 private
+  if (a === 172 && b >= 16 && b <= 31) return true // 172.16.0.0/12 private
+  if (a === 100 && b >= 64 && b <= 127) return true // 100.64.0.0/10 carrier-grade NAT
+  return false
+}
+
+// Best-effort block of requests aimed at the local host / private networks.
+// NOTE: this is a literal-host check only — it does NOT resolve DNS names, so a
+// hostname that resolves to a private address (incl. DNS-rebinding) is not
+// caught here. Callers that need that guarantee must validate the resolved
+// socket address. Returns false (allowed) for non-http(s) schemes; callers are
+// responsible for rejecting file:/data: themselves.
 function isBlockedUrl(urlStr) {
   try {
     const u = new URL(urlStr)
     if (u.protocol !== 'http:' && u.protocol !== 'https:') return false
-    const h = u.hostname
-    if (h === '127.0.0.1' || h === 'localhost' || h === '::1' || h === '0.0.0.0') return true
-    if (h.startsWith('127.') || h.startsWith('10.') || h.startsWith('169.254.')) return true
-    if (h.startsWith('192.168.')) return true
-    const p = h.split('.')
-    if (p.length === 4 && p[0] === '172') {
-      const n = parseInt(p[1], 10)
-      if (n >= 16 && n <= 31) return true
+    const h = u.hostname.toLowerCase()
+    if (h === 'localhost' || h.endsWith('.localhost')) return true
+    // IPv6 literal — URL.hostname strips the surrounding brackets.
+    if (h.includes(':')) {
+      const v6 = h.replace(/^\[|\]$/g, '')
+      if (v6 === '::1' || v6 === '::') return true // loopback / unspecified
+      if (/^fe[89ab]/.test(v6)) return true // fe80::/10 link-local
+      if (/^f[cd]/.test(v6)) return true // fc00::/7 unique-local
+      // IPv4-mapped (::ffff:127.0.0.1). WHATWG URL normalizes the embedded v4
+      // to two hex groups (::ffff:7f00:1), so handle both the dotted tail and
+      // the trailing 16-bit hex pair.
+      const mapped = v6.match(/^::ffff:(.+)$/i)
+      if (mapped) {
+        const rest = mapped[1]
+        if (rest.includes('.')) {
+          const v = ipv4ToInt(rest)
+          if (v !== null && isPrivateIPv4Int(v)) return true
+        } else {
+          const groups = rest.split(':')
+          if (groups.length === 2 && groups.every(g => /^[0-9a-f]{1,4}$/.test(g))) {
+            const v = ((parseInt(groups[0], 16) << 16) | parseInt(groups[1], 16)) >>> 0
+            if (isPrivateIPv4Int(v)) return true
+          }
+        }
+      }
+      return false
     }
+    const v4 = ipv4ToInt(h)
+    if (v4 !== null) return isPrivateIPv4Int(v4)
     return false
   } catch {
     return false
@@ -20,4 +94,4 @@ function isBlockedUrl(urlStr) {
 const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
 const MAX_FETCH_BYTES = 16 * 1024 * 1024
 
-export { isBlockedUrl, MAX_DOWNLOAD_BYTES, MAX_FETCH_BYTES }
+export { isBlockedUrl, ipv4ToInt, isPrivateIPv4Int, MAX_DOWNLOAD_BYTES, MAX_FETCH_BYTES }


### PR DESCRIPTION
## Summary

Thirteen security and reliability fixes to the Electron main process and supporting CJS modules. All changes are in apps/desktop/electron/.

## What it fixes

### HIGH: No global exception handler

The main process had no process.on(uncaughtException) or process.on(unhandledRejection) handler. Async failures could silently kill the process or leave it half-alive.

Fix: Added both handlers near the top of main.cjs, logging to stderr.

### HIGH: SSRF via saveImageFromUrl / resourceBufferFromUrl

The renderer could call saveImageFromUrl(url) with any http/https URL. No host allowlist, no private-IP filtering, no response size cap.

Fix: New url-guard.cjs module with isBlockedUrl() rejecting 127.x, ::1, 169.254.x, 10.x, 172.16-31.x, 192.168.x, 0.0.0.0. Applied before fetching, plus 50MB MAX_DOWNLOAD_BYTES cap with req.destroy() on overflow.

### HIGH: SSRF via fetchLinkTitle

fetchLinkTitle(rawUrl) took any URL, spawned curl, and loaded it in a hidden BrowserWindow with JS enabled.

Fix: Added isBlockedUrl check at entry.

### MEDIUM: OAuth login window has no navigation/popup guards

Fix: Added will-navigate blocking non-http(s) protocols and setWindowOpenHandler denying popups.

### MEDIUM: will-navigate permits any file: URL in packaged builds

Fix: Restricted to the renderer index path via resolveRendererIndex().

### MEDIUM: terminal IPC handlers do not verify sender

terminal:write, terminal:resize, and terminal:dispose never verified event.sender.id === sessionInfo.webContentsId. A secondary window could inject keystrokes into another PTY.

Fix: Added sender verification in all three handlers.

### MEDIUM: Downloaded install script redirect not validated

Fix: Require https: protocol + raw.githubusercontent.com hostname before following redirects.

### LOW fixes

- poolIdleReaper interval cleared in before-quit handler
- Promise-chain mutex for writeDesktopConnectionConfig
- 16MB response-size cap on fetchJson with req.destroy()
- Branch name validated against git-ref regex in updates:branch:set
- Event listeners tracked and removed in gateway-ws-probe finish()

## New file

- apps/desktop/electron/url-guard.cjs: shared private-IP blocker and size constants

## Type of Change

- [x] Bug fix
- [x] Security fix

## How to Test

node --test electron/gateway-ws-probe.test.cjs electron/connection-config.test.cjs electron/bootstrap-runner.test.cjs

## Validation

| | Result |
|---|---|
| Electron tests | 63 passed |
| Regressions | None |

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] Searched for existing PRs - no duplicates
- [x] PR contains only changes related to this fix
- [x] Tests pass
- [x] Tested on Linux
- [x] Cross-platform impact considered (all guards are platform-agnostic)
