### PR TITLE
fix(web): clear stale `api`-alias credential on provider switch in main-model assignment

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -903,7 +903,12 @@ def _apply_main_model_assignment(
     if api_key.strip():
         model_cfg["api_key"] = api_key.strip()
         model_cfg.pop("api", None)
-    elif model_cfg.get("api_key") and new_provider != prev_provider:
+    elif (model_cfg.get("api_key") or model_cfg.get("api")) and new_provider != prev_provider:
+        # A stale endpoint secret can live under the legacy ``api`` alias with
+        # no ``api_key`` (the resolver still reads ``model.api`` as a key), so
+        # the switch-clears-the-key path must trigger on either field — else the
+        # old endpoint's secret survives in config.yaml and contaminates a later
+        # custom resolution. clear_model_endpoint_credentials scrubs both.
         clear_model_endpoint_credentials(model_cfg, clear_api_mode=False)
     if new_provider != prev_provider:
         clear_model_endpoint_credentials(model_cfg, clear_api_key=False)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2350,6 +2350,18 @@ class TestWebServerEndpoints:
         assert "api_key" not in out
         assert "api_mode" not in out
 
+        # switching providers when the stale secret lives under the legacy
+        # ``api`` alias only (no api_key) → it must be cleared too. The resolver
+        # reads ``model.api`` as a key, so leaving it behind keeps a secret in
+        # config.yaml that contaminates the next custom resolution.
+        out = _apply_main_model_assignment(
+            {"provider": "custom", "api": "sk-legacy-stale", "base_url": "http://endpoint-a/v1"},
+            "openrouter",
+            "m",
+        )
+        assert "api" not in out
+        assert "api_key" not in out
+
     def test_parse_model_ids_handles_openai_and_bare_shapes(self):
         """Model discovery must tolerate the common /v1/models shapes and
         never raise (so a slightly non-standard local endpoint still works)."""


### PR DESCRIPTION
## Summary

Follow-up to `c253b0738` ("clear stale endpoint credentials across switches").

That commit added `clear_model_endpoint_credentials()` to scrub an old endpoint's inline secret — `api_key`, the **legacy `api` alias**, and `api_mode` — when the web UI switches the main model to a different provider. But `_apply_main_model_assignment` (`hermes_cli/web_server.py`) gates the key-scrub path on `model_cfg["api_key"]` being truthy:

```python
if api_key.strip():
    model_cfg["api_key"] = api_key.strip()
    model_cfg.pop("api", None)
elif model_cfg.get("api_key") and new_provider != prev_provider:   # ← api_key only
    clear_model_endpoint_credentials(model_cfg, clear_api_mode=False)
if new_provider != prev_provider:
    clear_model_endpoint_credentials(model_cfg, clear_api_key=False)  # clears api_mode only
```

So when the stale secret lives **only under the legacy `api` alias** (no `api_key`), a provider switch fails that `elif`, and the second call uses `clear_api_key=False` — the secret under `api` is never cleared and **survives in `config.yaml`**.

This matters because `model.api` is a live credential read path — `_resolve_openrouter_runtime()` reads `for k in ("api_key", "api")` and feeds it as the api_key candidate on the custom/auto branch. So endpoint A's plaintext secret persists and becomes the active credential the next time resolution flows through a custom endpoint — the exact "secrets in config.yaml… contaminate later custom resolution" harm `clear_model_endpoint_credentials`'s own docstring names.

It's also an **inconsistency**: the sibling persistence sites (the two gateway model-picker paths and the aux-slot path) call the helper *unconditionally* on a non-custom switch and already scrub `api`; only this caller had the `api_key`-only gate.

Reproduced:
```python
_apply_main_model_assignment(
    {"provider": "custom", "api": "sk-secret-A", "base_url": "https://endpoint-A/v1"},
    "openrouter", "m",
)
# before: {"provider": "openrouter", "api": "sk-secret-A", "base_url": "", "default": "m"}  ← stale secret survives
# after:  {"provider": "openrouter", "base_url": "", "default": "m"}
```

## Fix

Widen the guard to fire on either field:

```python
elif (model_cfg.get("api_key") or model_cfg.get("api")) and new_provider != prev_provider:
```

The same-provider re-pick (preserves the key) and explicit-new-key paths are unchanged.

## Tests

Added the legacy-`api`-alias case to `test_apply_main_model_assignment_base_url_and_context_reconcile` in `tests/hermes_cli/test_web_server.py` (asserts both `api` and `api_key` are absent after a provider switch). **Fails without the fix** (the `api` alias survives); passes with it.