### PR TITLE
Fix UnicodeDecodeError when reading non-UTF-8 files (fix #49508)

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -633,7 +633,7 @@ class MemoryStore:
             return []
         try:
             raw = path.read_text(encoding="utf-8")
-        except (OSError, IOError):
+        except (OSError, IOError, UnicodeDecodeError):
             return []
 
         if not raw.strip():
@@ -673,7 +673,7 @@ class MemoryStore:
             return None
         try:
             raw = path.read_text(encoding="utf-8")
-        except (OSError, IOError):
+        except (OSError, IOError, UnicodeDecodeError):
             return None
         if not raw.strip():
             return None


### PR DESCRIPTION
In _read_file() and _detect_external_drift(), the code used strict UTF-8 encoding but only caught OSError/IOError, not UnicodeDecodeError. This caused the memory tool to crash when encountering non-UTF-8 encoded files (e.g., GBK, CP936, Latin-1).

Now catches UnicodeDecodeError and returns empty results instead of crashing.

**Testing:**
- All 75 existing tests pass
- Manual test with GBK-encoded file confirms no crash

Fixes #49508