### PR TITLE
fix(security): harden compaction secret redaction

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -186,6 +186,11 @@ _PATH_MENTION_RE = re.compile(r"(?:/|~/?|[A-Za-z]:\\)[^\s`'\")\]}<>]+")
 _MEDIA_DIRECTIVE_RE = re.compile(r"MEDIA:\S+")
 
 
+def _redact_compaction_text(text: Any) -> str:
+    """Redact text that may cross the compaction summary boundary."""
+    return redact_sensitive_text(text or "", force=True, redact_urls=True)
+
+
 def _dedupe_append(items: list[str], value: str, *, limit: int) -> None:
     value = value.strip()
     if value and value not in items and len(items) < limit:
@@ -1044,7 +1049,7 @@ class ContextCompressor(ContextEngine):
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
-            content = redact_sensitive_text(msg.get("content") or "")
+            content = _redact_compaction_text(msg.get("content") or "")
             content = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", content)
 
             # Tool results: keep enough content for the summarizer
@@ -1066,7 +1071,7 @@ class ContextCompressor(ContextEngine):
                         if isinstance(tc, dict):
                             fn = tc.get("function", {})
                             name = fn.get("name", "?")
-                            args = redact_sensitive_text(fn.get("arguments", ""))
+                            args = _redact_compaction_text(fn.get("arguments", ""))
                             # Truncate long arguments but keep enough for context
                             if len(args) > self._TOOL_ARGS_MAX:
                                 args = args[:self._TOOL_ARGS_HEAD] + "..."
@@ -1109,7 +1114,7 @@ class ContextCompressor(ContextEngine):
         last_dropped_turns: list[str] = []
 
         def _compact_fallback_turn(value: Any) -> str:
-            text = redact_sensitive_text(_content_text_for_contains(value))
+            text = _redact_compaction_text(_content_text_for_contains(value))
             text = re.sub(r"\bgh[pousr]_[A-Za-z0-9_]{8,}\b", "[REDACTED]", text)
             text = re.sub(r"\s+", " ", text).strip()
             if len(text) > _FALLBACK_TURN_MAX_CHARS:
@@ -1141,7 +1146,7 @@ class ContextCompressor(ContextEngine):
             if msg.get("role") == "assistant" and msg.get("tool_calls"):
                 for tc in msg.get("tool_calls") or []:
                     name, raw_args = _extract_tool_call_name_and_args(tc)
-                    args = redact_sensitive_text(raw_args)
+                    args = _redact_compaction_text(raw_args)
                     call_id = _extract_tool_call_id(tc)
                     if call_id:
                         call_id_to_tool[call_id] = (name, args)
@@ -1270,7 +1275,7 @@ Continue from the most recent unfulfilled user ask and protected tail messages. 
 
 ## Critical Context
 Summary generation was unavailable, so this is a best-effort deterministic fallback for {len(turns_to_summarize)} compacted message(s).{reason_text}"""
-        summary = self._with_summary_prefix(redact_sensitive_text(body.strip()))
+        summary = self._with_summary_prefix(_redact_compaction_text(body.strip()))
         if len(summary) > _FALLBACK_SUMMARY_MAX_CHARS:
             summary = summary[: _FALLBACK_SUMMARY_MAX_CHARS - 42].rstrip() + "\n...[fallback summary truncated]"
         return summary
@@ -1331,6 +1336,11 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
                 self._summary_failure_cooldown_until - now,
             )
             return None
+
+        if focus_topic:
+            focus_topic = _redact_compaction_text(focus_topic)
+        if self._previous_summary:
+            self._previous_summary = _redact_compaction_text(self._previous_summary)
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
         content_to_summarize = self._serialize_for_summary(turns_to_summarize)
@@ -1518,7 +1528,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                 content = str(content) if content else ""
             # Redact the summary output as well — the summarizer LLM may
             # ignore prompt instructions and echo back secrets verbatim.
-            summary = redact_sensitive_text(content.strip())
+            summary = _redact_compaction_text(content.strip())
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._summary_failure_cooldown_until = 0.0
@@ -1695,7 +1705,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             content = msg.get("content")
             if cls._is_context_summary_content(content):
                 continue
-            text = redact_sensitive_text(_content_text_for_contains(content).strip())
+            text = _redact_compaction_text(_content_text_for_contains(content).strip())
             if not text:
                 continue
             text = " ".join(text.split())

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -166,11 +166,12 @@ _URL_WITH_QUERY_RE = re.compile(
     r"(#\S*)?",                       # optional fragment
 )
 
-# URLs containing userinfo — `scheme://user:password@host` for ANY scheme
+# URLs containing userinfo — `scheme://user[:password]@host` for ANY scheme
 # (not just DB protocols already covered by _DB_CONNSTR_RE above).
-# Catches things like `https://user:token@api.example.com/v1/foo`.
+# Catches things like `https://token@api.example.com/v1/foo` and
+# `https://user:token@api.example.com/v1/foo`.
 _URL_USERINFO_RE = re.compile(
-    r"(https?|wss?|ftp)://([^/\s:@]+):([^/\s@]+)@",
+    r"(https?|wss?|ftp)://([^/\s:@]+)(?::([^/\s@]+))?@",
 )
 
 # HTTP access logs often use a relative request target rather than a full URL:
@@ -180,6 +181,10 @@ _HTTP_REQUEST_TARGET_QUERY_RE = re.compile(
     r"\b((?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|TRACE|CONNECT)\s+[^ \t\r\n\"']*?)"
     r"\?([^ \t\r\n\"']+)",
     re.IGNORECASE,
+)
+
+_RELATIVE_REQUEST_TARGET_QUERY_RE = re.compile(
+    r"(?<!\S)(/[^ \t\r\n\"']*?)\?([^ \t\r\n\"']+)",
 )
 
 # Form-urlencoded body detection: conservative — only applies when the entire
@@ -288,13 +293,13 @@ def _redact_url_query_params(text: str) -> str:
 
 
 def _redact_url_userinfo(text: str) -> str:
-    """Strip `user:password@` from HTTP/WS/FTP URLs.
+    """Strip userinfo credentials from HTTP/WS/FTP URLs.
 
     DB protocols (postgres, mysql, mongodb, redis, amqp) are handled
     separately by `_DB_CONNSTR_RE`.
     """
     return _URL_USERINFO_RE.sub(
-        lambda m: f"{m.group(1)}://{m.group(2)}:***@",
+        lambda m: f"{m.group(1)}://{m.group(2)}:***@" if m.group(3) else f"{m.group(1)}://***@",
         text,
     )
 
@@ -306,6 +311,15 @@ def _redact_http_request_target_query_params(text: str) -> str:
         query = _redact_query_string(m.group(2))
         return f"{prefix}?{query}"
     return _HTTP_REQUEST_TARGET_QUERY_RE.sub(_sub, text)
+
+
+def _redact_relative_request_target_query_params(text: str) -> str:
+    """Redact sensitive query params in bare relative request targets."""
+    def _sub(m: re.Match) -> str:
+        prefix = m.group(1)
+        query = _redact_query_string(m.group(2))
+        return f"{prefix}?{query}"
+    return _RELATIVE_REQUEST_TARGET_QUERY_RE.sub(_sub, text)
 
 
 def _redact_form_body(text: str) -> str:
@@ -324,7 +338,13 @@ def _redact_form_body(text: str) -> str:
     return _redact_query_string(text.strip())
 
 
-def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = False) -> str:
+def redact_sensitive_text(
+    text: str,
+    *,
+    force: bool = False,
+    code_file: bool = False,
+    redact_urls: bool = False,
+) -> str:
     """Apply all redaction patterns to a block of text.
 
     Safe to call on any string -- non-matching text passes through unchanged.
@@ -336,6 +356,9 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     patterns when the text is known to be source code (e.g. MAX_TOKENS=***
     constants, "apiKey": "test" fixtures). Prefix patterns, auth headers,
     private keys, DB connstrings, JWTs, and URL secrets are still redacted.
+
+    Set redact_urls=True for safety boundaries where opaque URL query tokens
+    must be removed even if that would make the URL unusable afterwards.
 
     Performance: each regex pattern is gated behind a cheap substring
     pre-check (e.g. ``"=" in text`` for ENV assignments, ``"://" in text``
@@ -411,6 +434,14 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     # Known credential shapes (sk-, ghp_, JWTs, etc.) inside URLs are still
     # caught by _PREFIX_RE and _JWT_RE above. DB connection-string passwords
     # are still caught by _DB_CONNSTR_RE.
+    if redact_urls:
+        if "://" in text and "?" in text:
+            text = _redact_url_query_params(text)
+        if "://" in text and "@" in text:
+            text = _redact_url_userinfo(text)
+        if "?" in text:
+            text = _redact_http_request_target_query_params(text)
+            text = _redact_relative_request_target_query_params(text)
 
     # Form-urlencoded bodies (only triggers on clean k=v&k=v inputs).
     if "&" in text and "=" in text:

--- a/tests/agent/test_compress_focus.py
+++ b/tests/agent/test_compress_focus.py
@@ -60,6 +60,43 @@ def test_focus_topic_injected_into_summary_prompt():
     assert "60-70%" in prompt_text
 
 
+def test_focus_topic_redacts_secrets_before_summary_prompt(monkeypatch):
+    """Manual /compress <focus> text crosses the summarizer boundary too."""
+    compressor = _make_compressor()
+    turns = [
+        {"role": "user", "content": "Summarize safely"},
+        {"role": "assistant", "content": "OK"},
+    ]
+    secret = "sk-proj-" + ("a" * 40)
+    focus_url = (
+        "https://localhost/callback?code=manual-code-123"
+        "&access_token=manual-token-456&state=keep"
+    )
+    captured_prompt = {}
+
+    def mock_call_llm(**kwargs):
+        captured_prompt["messages"] = kwargs["messages"]
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "## Goal\nSafe summary."
+        return resp
+
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    with patch("agent.context_compressor.call_llm", mock_call_llm):
+        result = compressor._generate_summary(turns, focus_topic=f"manual focus {secret} {focus_url}")
+
+    assert result is not None
+    prompt_text = captured_prompt["messages"][0]["content"]
+    assert secret not in prompt_text
+    assert "sk-proj-" not in prompt_text
+    assert "code=manual-code-123" not in prompt_text
+    assert "access_token=manual-token-456" not in prompt_text
+    assert "code=***" in prompt_text
+    assert "access_token=***" in prompt_text
+    assert "state=keep" in prompt_text
+
+
 def test_no_focus_topic_no_injection():
     """Without focus_topic, the prompt doesn't contain focus guidance."""
     compressor = _make_compressor()

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -314,6 +314,94 @@ class TestNonStringContent:
         assert "Treat the conversation turns below as source material" in prompt
         assert "structured checkpoint summary" in prompt
 
+    def test_summary_input_redaction_is_forced_and_redacts_url_tokens(self, monkeypatch):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "ok"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        secret = "sk-proj-" + ("a" * 40)
+        oauth_url = (
+            "https://localhost/callback?code=opaque-code-123"
+            "&access_token=opaque-token-456&state=keep"
+        )
+        messages = [
+            {"role": "user", "content": f"token {secret} url {oauth_url}"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call-1",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": f'{{"command":"curl {oauth_url}", "api_key":"{secret}"}}',
+                    },
+                }],
+            },
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response) as mock_call:
+            c._generate_summary(messages)
+
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        assert secret not in prompt
+        assert "sk-proj-" not in prompt
+        assert "code=opaque-code-123" not in prompt
+        assert "access_token=opaque-token-456" not in prompt
+        assert "code=***" in prompt
+        assert "access_token=***" in prompt
+        assert "state=keep" in prompt
+
+    def test_summary_output_redaction_is_forced_and_redacts_url_tokens(self, monkeypatch):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            "Leaked OPENAI_API_KEY=sk-proj-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
+            "and https://localhost/callback?code=opaque-code-123&access_token=opaque-token-456"
+        )
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            summary = c._generate_summary([{"role": "user", "content": "summarize"}])
+
+        assert "sk-proj-" not in summary
+        assert "code=opaque-code-123" not in summary
+        assert "access_token=opaque-token-456" not in summary
+        assert "OPENAI_API_KEY=***" in summary
+        assert "code=***" in summary
+        assert "access_token=***" in summary
+
+    def test_auto_focus_redaction_is_forced_and_redacts_url_tokens(self, monkeypatch):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        secret = "sk-proj-" + ("a" * 40)
+        focus_url = (
+            "https://localhost/callback?code=focus-code-123"
+            "&access_token=focus-token-456&state=keep"
+        )
+
+        focus = c._derive_auto_focus_topic([
+            {"role": "assistant", "content": "older assistant turn"},
+            {"role": "user", "content": f"recent focus has {secret} and {focus_url}"},
+        ])
+
+        assert secret not in focus
+        assert "sk-proj-" not in focus
+        assert "code=focus-code-123" not in focus
+        assert "access_token=focus-token-456" not in focus
+        assert "code=***" in focus
+        assert "access_token=***" in focus
+        assert "state=keep" in focus
+
     def test_summary_call_passes_live_main_runtime(self):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -69,6 +69,60 @@ def test_resume_rehydrates_previous_summary_from_handoff_message():
     assert f"[USER]: {SUMMARY_PREFIX}" not in prompt
 
 
+def test_previous_summary_is_redacted_before_iterative_summary_prompt(monkeypatch):
+    """Legacy persisted summaries may predate compaction redaction."""
+    compressor = _compressor()
+    secret = "sk-proj-" + ("a" * 40)
+    old_url = (
+        "https://localhost/callback?code=old-code-123"
+        "&access_token=old-token-456&state=keep"
+    )
+    compressor._previous_summary = f"Old summary leaked {secret} and {old_url}"
+
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    with patch("agent.context_compressor.call_llm", return_value=_response("updated summary")) as mock_call:
+        compressor.compress(_messages_with_handoff("safe resumed facts"))
+
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "PREVIOUS SUMMARY:" in prompt
+    assert secret not in prompt
+    assert "sk-proj-" not in prompt
+    assert "code=old-code-123" not in prompt
+    assert "access_token=old-token-456" not in prompt
+    assert "code=***" in prompt
+    assert "access_token=***" in prompt
+    assert "state=keep" in prompt
+    assert secret not in compressor._previous_summary
+    assert "access_token=old-token-456" not in compressor._previous_summary
+
+
+def test_resumed_handoff_summary_is_redacted_before_iterative_prompt(monkeypatch):
+    """Persisted handoff messages may contain pre-fix secrets after resume."""
+    compressor = _compressor()
+    secret = "sk-proj-" + ("a" * 40)
+    old_url = (
+        "https://localhost/callback?code=resumed-code-123"
+        "&access_token=resumed-token-456&state=keep"
+    )
+    old_summary = f"RESUMED-SUMMARY leaked {secret} and {old_url}"
+
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    with patch("agent.context_compressor.call_llm", return_value=_response("updated summary")) as mock_call:
+        compressor.compress(_messages_with_handoff(old_summary))
+
+    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    assert "PREVIOUS SUMMARY:" in prompt
+    assert secret not in prompt
+    assert "sk-proj-" not in prompt
+    assert "code=resumed-code-123" not in prompt
+    assert "access_token=resumed-token-456" not in prompt
+    assert "code=***" in prompt
+    assert "access_token=***" in prompt
+    assert "state=keep" in prompt
+
+
 def test_handoff_in_protected_head_populates_previous_summary_before_update():
     """A resumed protected-head handoff should restore iterative-summary state."""
     compressor = _compressor()

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -415,6 +415,27 @@ class TestWebUrlsNotRedacted:
         )
         assert redact_sensitive_text(text) == text
 
+    def test_redact_urls_option_masks_opaque_url_tokens(self):
+        text = (
+            "GET https://api.example.com/oauth/cb?code=abc123xyz789&state=csrf_ok "
+            "and wss://api.example.com/ws?token=opaqueWsToken123 "
+            "and /webhook?password=webhookSecret123&event=new-message "
+            "and https://opaqueUserinfoToken123@example.com/path"
+        )
+
+        result = redact_sensitive_text(text, redact_urls=True)
+
+        assert "code=abc123xyz789" not in result
+        assert "token=opaqueWsToken123" not in result
+        assert "password=webhookSecret123" not in result
+        assert "opaqueUserinfoToken123" not in result
+        assert "code=***" in result
+        assert "token=***" in result
+        assert "password=***" in result
+        assert "https://***@example.com/path" in result
+        assert "state=csrf_ok" in result
+        assert "event=new-message" in result
+
     def test_known_prefix_inside_url_still_redacted(self):
         """sk-/ghp_/JWT-shaped values inside a URL are still caught by
         _PREFIX_RE / _JWT_RE — the carve-out is for opaque tokens only."""


### PR DESCRIPTION
## Summary
- force secret redaction across all context compaction summary boundaries
- add opt-in strict URL redaction for safety-boundary callers without changing default URL passthrough behavior
- redact manual focus topics, auto focus hints, legacy previous summaries, summarizer input, fallback summaries, and summarizer output

## Security notes
This preserves the existing default behavior where web URLs pass through unchanged for browsing/OAuth workflows. Only compaction uses `redact_urls=True`, because compaction sends text to an auxiliary summarizer and persists the resulting summary.

## Tests
- `python -m pytest tests/agent/test_redact.py tests/agent/test_context_compressor.py tests/agent/test_compress_focus.py tests/agent/test_context_compressor_summary_continuity.py -q`
- `git diff --check`