### PR TITLE
fix(desktop): harden URL guard and remote resource fetches

### DIFF
--- a/apps/desktop/electron/bootstrap-runner.cjs
+++ b/apps/desktop/electron/bootstrap-runner.cjs
@@ -118,11 +118,23 @@ function downloadInstallScript(commit, destPath) {
       .get(url, res => {
         if (res.statusCode === 301 || res.statusCode === 302) {
           // GitHub raw shouldn't redirect for a SHA URL, but follow once
-          // defensively.
+          // defensively. Validate the redirect target is https and on
+          // raw.githubusercontent.com before following.
           out.close()
           fs.unlinkSync(tmpPath)
+          const redirectUrl = res.headers.location || ''
+          try {
+            const parsed = new URL(redirectUrl)
+            if (parsed.protocol !== 'https:' || parsed.hostname !== 'raw.githubusercontent.com') {
+              reject(new Error('Redirect to unexpected host: ' + redirectUrl))
+              return
+            }
+          } catch {
+            reject(new Error('Invalid redirect URL: ' + redirectUrl))
+            return
+          }
           https
-            .get(res.headers.location, res2 => {
+            .get(redirectUrl, res2 => {
               if (res2.statusCode !== 200) {
                 reject(
                   new Error(

--- a/apps/desktop/electron/gateway-ws-probe.cjs
+++ b/apps/desktop/electron/gateway-ws-probe.cjs
@@ -81,6 +81,11 @@ function probeGatewayWebSocket(wsUrl, options = {}) {
       } catch {
         // ignore — best effort teardown
       }
+      try {
+        removeListeners()
+      } catch {
+        // ignore — best effort cleanup
+      }
       resolve(result)
     }
 
@@ -140,6 +145,13 @@ function probeGatewayWebSocket(wsUrl, options = {}) {
     addListener(socket, 'error', onError)
     addListener(socket, 'close', onClose)
 
+    const removeListeners = () => {
+      removeListener(socket, 'open', onOpen)
+      removeListener(socket, 'message', onMessage)
+      removeListener(socket, 'error', onError)
+      removeListener(socket, 'close', onClose)
+    }
+
     if (connectTimeoutMs > 0) {
       connectTimer = setTimeout(() => {
         finish({
@@ -156,10 +168,18 @@ function addListener(socket, type, handler) {
     socket.addEventListener(type, handler)
     return
   }
-  // Node's global WebSocket implements addEventListener; this fallback keeps the
-  // helper usable with the `ws` package's EventEmitter shape too.
   if (typeof socket.on === 'function') {
     socket.on(type, handler)
+  }
+}
+
+function removeListener(socket, type, handler) {
+  if (typeof socket.removeEventListener === 'function') {
+    socket.removeEventListener(type, handler)
+    return
+  }
+  if (typeof socket.off === 'function') {
+    socket.off(type, handler)
   }
 }
 

--- a/apps/desktop/electron/link-title-hardening.test.cjs
+++ b/apps/desktop/electron/link-title-hardening.test.cjs
@@ -1,0 +1,16 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const mainSource = () => fs.readFileSync(path.join(__dirname, 'main.cjs'), 'utf8')
+
+test('link-title fast path does not let curl follow redirects outside URL guard validation', () => {
+  assert.equal(mainSource().includes("'--location'"), false)
+})
+
+test('fetchLinkTitle does not fall back to raw BrowserWindow navigation for untrusted URLs', () => {
+  const source = mainSource()
+  const fetchLinkTitleBody = source.match(/function fetchLinkTitle\(rawUrl\) \{[\s\S]*?\n\}/)?.[0] || ''
+  assert.equal(fetchLinkTitleBody.includes('fetchHtmlTitleWithRenderer'), false)
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -18,8 +18,6 @@ const {
 } = require('electron')
 const crypto = require('node:crypto')
 const fs = require('node:fs')
-const http = require('node:http')
-const https = require('node:https')
 const net = require('node:net')
 const path = require('node:path')
 const { pathToFileURL } = require('node:url')
@@ -41,7 +39,8 @@ const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-reques
 const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
 const { buildDesktopBackendEnv, normalizeHermesHomeRoot } = require('./backend-env.cjs')
 const { readWindowsUserEnvVar } = require('./windows-user-env.cjs')
-const { isBlockedUrl, MAX_DOWNLOAD_BYTES, MAX_FETCH_BYTES } = require('./url-guard.cjs')
+const { isBlockedUrl } = require('./url-guard.cjs')
+const { resourceBufferFromUrl } = require('./resource-buffer.cjs')
 const { readDirForIpc } = require('./fs-read-dir.cjs')
 const { gitRootForIpc } = require('./git-root.cjs')
 const { worktreesForIpc } = require('./git-worktrees.cjs')
@@ -3056,46 +3055,6 @@ function fetchLinkTitle(rawUrl) {
 
   titleInflight.set(key, pending)
   return pending
-}
-
-async function resourceBufferFromUrl(rawUrl) {
-  if (!rawUrl) throw new Error('Missing URL')
-  if (rawUrl.startsWith('data:')) {
-    const match = rawUrl.match(/^data:([^;,]+)?(;base64)?,(.*)$/s)
-    if (!match) throw new Error('Invalid data URL')
-    const mimeType = match[1] || 'application/octet-stream'
-    const encoded = match[3] || ''
-    const buffer = match[2] ? Buffer.from(encoded, 'base64') : Buffer.from(decodeURIComponent(encoded), 'utf8')
-    return { buffer, mimeType }
-  }
-  if (/^file:/i.test(rawUrl)) {
-    const { resolvedPath } = await resolveReadableFileForIpc(rawUrl, { purpose: 'Image file' })
-    const buffer = await fs.promises.readFile(resolvedPath)
-    return { buffer, mimeType: mimeTypeForPath(resolvedPath) }
-  }
-
-  if (isBlockedUrl(rawUrl)) throw new Error("Blocked: private URL")
-  const parsed = new URL(rawUrl)
-  const client = parsed.protocol === 'https:' ? https : http
-  return new Promise((resolve, reject) => {
-    const req = client.get(parsed, res => {
-      if ((res.statusCode || 500) >= 400) {
-        reject(new Error(`Failed to fetch ${rawUrl}: ${res.statusCode}`))
-        res.resume()
-        return
-      }
-      const chunks = []
-      res.on('error', reject)
-      res.on('data', chunk => chunks.push(chunk))
-      res.on('end', () => {
-        resolve({
-          buffer: Buffer.concat(chunks),
-          mimeType: res.headers['content-type'] || 'application/octet-stream'
-        })
-      })
-    })
-    req.on('error', reject)
-  })
 }
 
 async function copyImageFromUrl(rawUrl) {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2885,51 +2885,19 @@ function parseHtmlTitle(html) {
   return raw ? decodeHtmlEntities(raw).replace(/\s+/g, ' ').trim() : ''
 }
 
-function fetchHtmlTitleWithCurl(rawUrl) {
-  return new Promise(resolve => {
-    const url = String(rawUrl || '').trim()
-    if (!url) return resolve('')
+async function fetchHtmlTitleWithSafeHttp(rawUrl) {
+  const url = String(rawUrl || '').trim()
+  if (!url) return ''
 
-    const args = [
-      '--silent',
-      '--show-error',
-      '--location',
-      '--max-redirs',
-      String(TITLE_MAX_REDIRECTS),
-      '--max-time',
-      String(Math.max(2, Math.ceil(TITLE_TIMEOUT_MS / 1000))),
-      '--connect-timeout',
-      '4',
-      '--user-agent',
-      TITLE_USER_AGENT,
-      '--header',
-      'Accept: text/html,application/xhtml+xml;q=0.9,*/*;q=0.5',
-      '--header',
-      'Accept-Language: en-US,en;q=0.7',
-      '--header',
-      'Accept-Encoding: identity',
-      '--raw',
-      url
-    ]
-    const child = spawn('curl', args, hiddenWindowsChildOptions({ stdio: ['ignore', 'pipe', 'ignore'] }))
-    const chunks = []
-    let bytes = 0
-
-    child.stdout.on('data', chunk => {
-      if (bytes >= TITLE_BYTE_BUDGET) return
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
-      const remaining = TITLE_BYTE_BUDGET - bytes
-      const next = buffer.length > remaining ? buffer.subarray(0, remaining) : buffer
-      chunks.push(next)
-      bytes += next.length
+  try {
+    const { buffer } = await resourceBufferFromUrl(url, {
+      maxRemoteBytes: TITLE_BYTE_BUDGET,
+      maxRedirects: TITLE_MAX_REDIRECTS
     })
-
-    child.on('error', () => resolve(''))
-    child.on('close', () => {
-      if (!chunks.length) return resolve('')
-      resolve(parseHtmlTitle(Buffer.concat(chunks).toString('utf8')))
-    })
-  })
+    return parseHtmlTitle(buffer.toString('utf8'))
+  } catch {
+    return ''
+  }
 }
 
 function getLinkTitleSession() {
@@ -3041,12 +3009,9 @@ function fetchLinkTitle(rawUrl) {
   if (titleCache.has(key)) return Promise.resolve(titleCache.get(key))
   if (titleInflight.has(key)) return titleInflight.get(key)
 
-  const pending = fetchHtmlTitleWithCurl(url)
+  const pending = fetchHtmlTitleWithSafeHttp(url)
     .catch(() => '')
     .then(value => usableTitle((value || '').slice(0, 240)))
-    .then(
-      async value => value || usableTitle(((await fetchHtmlTitleWithRenderer(url).catch(() => '')) || '').slice(0, 240))
-    )
     .then(clean => {
       cacheTitle(key, clean)
       titleInflight.delete(key)

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -41,6 +41,7 @@ const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-reques
 const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
 const { buildDesktopBackendEnv, normalizeHermesHomeRoot } = require('./backend-env.cjs')
 const { readWindowsUserEnvVar } = require('./windows-user-env.cjs')
+const { isBlockedUrl, MAX_DOWNLOAD_BYTES, MAX_FETCH_BYTES } = require('./url-guard.cjs')
 const { readDirForIpc } = require('./fs-read-dir.cjs')
 const { gitRootForIpc } = require('./git-root.cjs')
 const { worktreesForIpc } = require('./git-worktrees.cjs')
@@ -3034,6 +3035,7 @@ function fetchHtmlTitleWithRenderer(rawUrl) {
 const usableTitle = value => (value && !TITLE_ERROR_RE.test(value) ? value : '')
 
 function fetchLinkTitle(rawUrl) {
+  if (isBlockedUrl(String(rawUrl || ""))) return Promise.resolve("")
   const url = String(rawUrl || '').trim()
   const key = canonicalTitleCacheKey(url)
   if (!key) return Promise.resolve('')
@@ -3072,6 +3074,7 @@ async function resourceBufferFromUrl(rawUrl) {
     return { buffer, mimeType: mimeTypeForPath(resolvedPath) }
   }
 
+  if (isBlockedUrl(rawUrl)) throw new Error("Blocked: private URL")
   const parsed = new URL(rawUrl)
   const client = parsed.protocol === 'https:' ? https : http
   return new Promise((resolve, reject) => {
@@ -3913,6 +3916,18 @@ function openOauthLoginWindow(baseUrl) {
     win.webContents.on('did-navigate', () => void checkCookie())
     win.webContents.on('did-redirect-navigation', () => void checkCookie())
     win.webContents.on('did-frame-navigate', () => void checkCookie())
+    win.webContents.setWindowOpenHandler(({ url }) => {
+      openExternalUrl(url)
+      return { action: 'deny' }
+    })
+    win.webContents.on('will-navigate', (event, url) => {
+      try {
+        const parsed = new URL(url)
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          event.preventDefault()
+        }
+      } catch { event.preventDefault() }
+    })
     pollTimer = setInterval(() => void checkCookie(), 750)
 
     win.on('closed', () => {
@@ -4155,11 +4170,15 @@ function readDesktopConnectionConfig() {
   return config
 }
 
+let _configWriteLock = Promise.resolve()
 function writeDesktopConnectionConfig(config) {
-  fs.mkdirSync(path.dirname(DESKTOP_CONNECTION_CONFIG_PATH), { recursive: true })
-  writeFileAtomic(DESKTOP_CONNECTION_CONFIG_PATH, JSON.stringify(config, null, 2))
-  connectionConfigCache = config
-  connectionConfigCacheMtime = fs.statSync(DESKTOP_CONNECTION_CONFIG_PATH).mtimeMs
+  _configWriteLock = _configWriteLock.then(() => {
+    fs.mkdirSync(path.dirname(DESKTOP_CONNECTION_CONFIG_PATH), { recursive: true })
+    writeFileAtomic(DESKTOP_CONNECTION_CONFIG_PATH, JSON.stringify(config, null, 2))
+    connectionConfigCache = config
+    connectionConfigCacheMtime = fs.statSync(DESKTOP_CONNECTION_CONFIG_PATH).mtimeMs
+  }).catch(() => {})
+  return _configWriteLock
 }
 
 // Returns the desktop's chosen profile name, or null when unset. "default" is
@@ -5084,8 +5103,16 @@ function wireCommonWindowHandlers(win) {
     return { action: 'deny' }
   })
   win.webContents.on('will-navigate', (event, url) => {
-    if ((DEV_SERVER && url.startsWith(DEV_SERVER)) || (!DEV_SERVER && url.startsWith('file:'))) {
+    if (DEV_SERVER && url.startsWith(DEV_SERVER)) {
       return
+    }
+    if (!DEV_SERVER && url.startsWith('file:')) {
+      try {
+        const allowedBase = resolveRendererIndex()
+        if (allowedBase && url.startsWith(allowedBase.replace(/index.html.*$/, ''))) {
+          return
+        }
+      } catch {}
     }
 
     event.preventDefault()
@@ -6098,33 +6125,32 @@ ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
   return { cwd, id, shell: name }
 })
 
-ipcMain.handle('hermes:terminal:write', (_event, id, data) => {
+ipcMain.handle('hermes:terminal:write', (event, id, data) => {
   const sessionInfo = terminalSessions.get(String(id || ''))
-
-  if (!sessionInfo) {
+  if (!sessionInfo || sessionInfo.webContentsId !== event.sender.id) {
     return false
   }
-
   sessionInfo.pty.write(String(data || ''))
-
   return true
 })
 
-ipcMain.handle('hermes:terminal:resize', (_event, id, size = {}) => {
+ipcMain.handle('hermes:terminal:resize', (event, id, size = {}) => {
   const sessionInfo = terminalSessions.get(String(id || ''))
-
-  if (!sessionInfo) {
+  if (!sessionInfo || sessionInfo.webContentsId !== event.sender.id) {
     return false
   }
-
   const cols = Math.max(2, Number.parseInt(String(size?.cols || 80), 10) || 80)
   const rows = Math.max(2, Number.parseInt(String(size?.rows || 24), 10) || 24)
-
   sessionInfo.pty.resize(cols, rows)
-
   return true
 })
-ipcMain.handle('hermes:terminal:dispose', (_event, id) => disposeTerminalSession(String(id || '')))
+ipcMain.handle('hermes:terminal:dispose', (event, id) => {
+  const sessionInfo = terminalSessions.get(String(id || ''))
+  if (sessionInfo && sessionInfo.webContentsId !== event.sender.id) {
+    return false
+  }
+  return disposeTerminalSession(String(id || ''))
+})
 
 ipcMain.handle('hermes:updates:check', async () =>
   checkUpdates().catch(error => ({
@@ -6148,6 +6174,9 @@ ipcMain.handle('hermes:updates:branch:get', async () => readDesktopUpdateConfig(
 
 ipcMain.handle('hermes:updates:branch:set', async (_event, name) => {
   const branch = typeof name === 'string' && name.trim() ? name.trim() : DEFAULT_UPDATE_BRANCH
+  if (!/^[A-Za-z0-9._\/-]{1,200}$/.test(branch)) {
+    throw new Error('Invalid branch name')
+  }
   writeDesktopUpdateConfig({ branch })
   return { branch }
 })
@@ -6481,7 +6510,10 @@ const _gotSingleInstanceLock = app.requestSingleInstanceLock()
 if (!_gotSingleInstanceLock) {
   app.quit()
 } else {
-  app.on('second-instance', (_event, argv) => {
+  process.on('unhandledRejection', (err) => { console.error('[hermes-main] Unhandled rejection:', err); });
+process.on('uncaughtException', (err) => { console.error('[hermes-main] Uncaught exception:', err); });
+
+app.on('second-instance', (_event, argv) => {
     const url = _extractDeepLink(argv)
     if (url) handleDeepLink(url)
     else if (mainWindow) {
@@ -6576,6 +6608,10 @@ app.on('before-quit', () => {
 
   if (hermesProcess && !hermesProcess.killed) {
     hermesProcess.kill('SIGTERM')
+  }
+  if (poolIdleReaper) {
+    clearInterval(poolIdleReaper)
+    poolIdleReaper = null
   }
   stopAllPoolBackends()
 })

--- a/apps/desktop/electron/resource-buffer.cjs
+++ b/apps/desktop/electron/resource-buffer.cjs
@@ -4,7 +4,9 @@ const https = require('node:https')
 const path = require('node:path')
 
 const { resolveReadableFileForIpc } = require('./hardening.cjs')
-const { isBlockedUrl, MAX_FETCH_BYTES } = require('./url-guard.cjs')
+const { isBlockedUrl, resolveSafeHttpUrl, validateRedirectUrl, MAX_FETCH_BYTES } = require('./url-guard.cjs')
+
+const MAX_REDIRECTS = 5
 
 const MEDIA_MIME_TYPES = {
   '.avi': 'video/x-msvideo',
@@ -42,69 +44,77 @@ function tooLargeError(maxBytes) {
   return new Error(`Remote resource is too large (max ${maxBytes} bytes)`)
 }
 
-async function resourceBufferFromUrl(rawUrl, options = {}) {
-  if (!rawUrl) throw new Error('Missing URL')
-  const url = String(rawUrl)
-  const fsImpl = options.fs || fs
-  const resolveFile = options.resolveReadableFileForIpc || resolveReadableFileForIpc
-  const mimeForPath = options.mimeTypeForPath || mimeTypeForPath
+function shouldBypassPrivateNetworkForUrl(options, isRedirect) {
+  return Boolean(options.allowPrivateNetwork && !isRedirect)
+}
+
+async function fetchRemoteBuffer(url, options, redirectsRemaining, isRedirect = false) {
   const blockUrl = options.isBlockedUrl || isBlockedUrl
+  const allowPrivateNetwork = shouldBypassPrivateNetworkForUrl(options, isRedirect)
+  if (!allowPrivateNetwork && blockUrl(url)) throw new Error('Blocked: private URL')
+
+  const safe = await resolveSafeHttpUrl(url, {
+    lookup: options.lookup,
+    allowPrivateNetwork
+  })
+  const client = safe.url.protocol === 'https:' ? https : http
   const maxRemoteBytes = maxBytesFromOptions(options.maxRemoteBytes)
-
-  if (url.startsWith('data:')) {
-    const match = url.match(/^data:([^;,]+)?(;base64)?,(.*)$/s)
-    if (!match) throw new Error('Invalid data URL')
-    const mimeType = match[1] || 'application/octet-stream'
-    const encoded = match[3] || ''
-    const buffer = match[2] ? Buffer.from(encoded, 'base64') : Buffer.from(decodeURIComponent(encoded), 'utf8')
-    return { buffer, mimeType }
-  }
-
-  if (/^file:/i.test(url)) {
-    const { resolvedPath } = await resolveFile(url, { purpose: 'Image file' })
-    const buffer = await fsImpl.promises.readFile(resolvedPath)
-    return { buffer, mimeType: mimeForPath(resolvedPath) }
-  }
-
-  if (blockUrl(url)) throw new Error('Blocked: private URL')
-  const parsed = new URL(url)
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    throw new Error(`Unsupported URL protocol: ${parsed.protocol}`)
-  }
-  const client = parsed.protocol === 'https:' ? https : http
 
   return new Promise((resolve, reject) => {
     let settled = false
     const chunks = []
     let bytesRead = 0
 
-    const req = client.get(parsed, res => {
-      const fail = error => {
-        if (settled) return
+    const fail = (error, res, req) => {
+      if (settled) return
+      settled = true
+      if (res) res.destroy()
+      if (req) req.destroy(error)
+      reject(error)
+    }
+
+    const req = client.get(safe.url, { lookup: safe.lookup }, res => {
+      const statusCode = res.statusCode || 500
+      const location = res.headers.location
+
+      if (statusCode >= 300 && statusCode < 400 && location) {
+        if (redirectsRemaining <= 0) {
+          fail(new Error('Too many redirects'), res, req)
+          return
+        }
+
+        let next
+        try {
+          next = validateRedirectUrl(safe.url, location).toString()
+        } catch (error) {
+          fail(error, res, req)
+          return
+        }
+
         settled = true
-        res.destroy()
-        req.destroy(error)
-        reject(error)
+        res.resume()
+        resolve(fetchRemoteBuffer(next, options, redirectsRemaining - 1, true))
+        return
       }
 
-      if ((res.statusCode || 500) >= 400) {
+      if (statusCode >= 400) {
         settled = true
-        reject(new Error(`Failed to fetch ${url}: ${res.statusCode}`))
+        reject(new Error(`Failed to fetch ${url}: ${statusCode}`))
         res.resume()
         return
       }
 
       const contentLength = Number(res.headers['content-length'])
       if (Number.isFinite(contentLength) && contentLength > maxRemoteBytes) {
-        fail(tooLargeError(maxRemoteBytes))
+        fail(tooLargeError(maxRemoteBytes), res, req)
         return
       }
 
-      res.on('error', error => fail(error))
+      res.on('error', error => fail(error, res, req))
       res.on('data', chunk => {
         bytesRead += chunk.length
         if (bytesRead > maxRemoteBytes) {
-          fail(tooLargeError(maxRemoteBytes))
+          fail(tooLargeError(maxRemoteBytes), res, req)
           return
         }
         chunks.push(chunk)
@@ -124,6 +134,36 @@ async function resourceBufferFromUrl(rawUrl, options = {}) {
       reject(error)
     })
   })
+}
+
+async function resourceBufferFromUrl(rawUrl, options = {}) {
+  if (!rawUrl) throw new Error('Missing URL')
+  const url = String(rawUrl)
+  const fsImpl = options.fs || fs
+  const resolveFile = options.resolveReadableFileForIpc || resolveReadableFileForIpc
+  const mimeForPath = options.mimeTypeForPath || mimeTypeForPath
+
+  if (url.startsWith('data:')) {
+    const match = url.match(/^data:([^;,]+)?(;base64)?,(.*)$/s)
+    if (!match) throw new Error('Invalid data URL')
+    const mimeType = match[1] || 'application/octet-stream'
+    const encoded = match[3] || ''
+    const buffer = match[2] ? Buffer.from(encoded, 'base64') : Buffer.from(decodeURIComponent(encoded), 'utf8')
+    return { buffer, mimeType }
+  }
+
+  if (/^file:/i.test(url)) {
+    const { resolvedPath } = await resolveFile(url, { purpose: 'Image file' })
+    const buffer = await fsImpl.promises.readFile(resolvedPath)
+    return { buffer, mimeType: mimeForPath(resolvedPath) }
+  }
+
+  const parsed = new URL(url)
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Unsupported URL protocol: ${parsed.protocol}`)
+  }
+
+  return fetchRemoteBuffer(parsed.toString(), options, options.maxRedirects ?? MAX_REDIRECTS)
 }
 
 module.exports = { resourceBufferFromUrl, mimeTypeForPath }

--- a/apps/desktop/electron/resource-buffer.cjs
+++ b/apps/desktop/electron/resource-buffer.cjs
@@ -1,0 +1,129 @@
+const fs = require('node:fs')
+const http = require('node:http')
+const https = require('node:https')
+const path = require('node:path')
+
+const { resolveReadableFileForIpc } = require('./hardening.cjs')
+const { isBlockedUrl, MAX_FETCH_BYTES } = require('./url-guard.cjs')
+
+const MEDIA_MIME_TYPES = {
+  '.avi': 'video/x-msvideo',
+  '.bmp': 'image/bmp',
+  '.flac': 'audio/flac',
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.m4a': 'audio/mp4',
+  '.mkv': 'video/x-matroska',
+  '.mov': 'video/quicktime',
+  '.mp3': 'audio/mpeg',
+  '.mp4': 'video/mp4',
+  '.ogg': 'audio/ogg',
+  '.opus': 'audio/ogg; codecs=opus',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.wav': 'audio/wav',
+  '.webm': 'video/webm',
+  '.webp': 'image/webp'
+}
+
+function mimeTypeForPath(filePath) {
+  const ext = path.extname(filePath || '').toLowerCase()
+  return MEDIA_MIME_TYPES[ext] || 'application/octet-stream'
+}
+
+function maxBytesFromOptions(value) {
+  const parsed = Number(value)
+  if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed)
+  return MAX_FETCH_BYTES
+}
+
+function tooLargeError(maxBytes) {
+  return new Error(`Remote resource is too large (max ${maxBytes} bytes)`)
+}
+
+async function resourceBufferFromUrl(rawUrl, options = {}) {
+  if (!rawUrl) throw new Error('Missing URL')
+  const url = String(rawUrl)
+  const fsImpl = options.fs || fs
+  const resolveFile = options.resolveReadableFileForIpc || resolveReadableFileForIpc
+  const mimeForPath = options.mimeTypeForPath || mimeTypeForPath
+  const blockUrl = options.isBlockedUrl || isBlockedUrl
+  const maxRemoteBytes = maxBytesFromOptions(options.maxRemoteBytes)
+
+  if (url.startsWith('data:')) {
+    const match = url.match(/^data:([^;,]+)?(;base64)?,(.*)$/s)
+    if (!match) throw new Error('Invalid data URL')
+    const mimeType = match[1] || 'application/octet-stream'
+    const encoded = match[3] || ''
+    const buffer = match[2] ? Buffer.from(encoded, 'base64') : Buffer.from(decodeURIComponent(encoded), 'utf8')
+    return { buffer, mimeType }
+  }
+
+  if (/^file:/i.test(url)) {
+    const { resolvedPath } = await resolveFile(url, { purpose: 'Image file' })
+    const buffer = await fsImpl.promises.readFile(resolvedPath)
+    return { buffer, mimeType: mimeForPath(resolvedPath) }
+  }
+
+  if (blockUrl(url)) throw new Error('Blocked: private URL')
+  const parsed = new URL(url)
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Unsupported URL protocol: ${parsed.protocol}`)
+  }
+  const client = parsed.protocol === 'https:' ? https : http
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const chunks = []
+    let bytesRead = 0
+
+    const req = client.get(parsed, res => {
+      const fail = error => {
+        if (settled) return
+        settled = true
+        res.destroy()
+        req.destroy(error)
+        reject(error)
+      }
+
+      if ((res.statusCode || 500) >= 400) {
+        settled = true
+        reject(new Error(`Failed to fetch ${url}: ${res.statusCode}`))
+        res.resume()
+        return
+      }
+
+      const contentLength = Number(res.headers['content-length'])
+      if (Number.isFinite(contentLength) && contentLength > maxRemoteBytes) {
+        fail(tooLargeError(maxRemoteBytes))
+        return
+      }
+
+      res.on('error', error => fail(error))
+      res.on('data', chunk => {
+        bytesRead += chunk.length
+        if (bytesRead > maxRemoteBytes) {
+          fail(tooLargeError(maxRemoteBytes))
+          return
+        }
+        chunks.push(chunk)
+      })
+      res.on('end', () => {
+        if (settled) return
+        settled = true
+        resolve({
+          buffer: Buffer.concat(chunks, bytesRead),
+          mimeType: res.headers['content-type'] || 'application/octet-stream'
+        })
+      })
+    })
+    req.on('error', error => {
+      if (settled) return
+      settled = true
+      reject(error)
+    })
+  })
+}
+
+module.exports = { resourceBufferFromUrl, mimeTypeForPath }

--- a/apps/desktop/electron/resource-buffer.test.cjs
+++ b/apps/desktop/electron/resource-buffer.test.cjs
@@ -1,0 +1,69 @@
+const assert = require('node:assert/strict')
+const http = require('node:http')
+const test = require('node:test')
+
+const { resourceBufferFromUrl } = require('./resource-buffer.cjs')
+
+function listen(handler) {
+  return new Promise(resolve => {
+    const server = http.createServer(handler)
+    server.listen(0, '127.0.0.1', () => resolve(server))
+  })
+}
+
+function serverUrl(server, path = '/') {
+  const { port } = server.address()
+  return `http://127.0.0.1:${port}${path}`
+}
+
+test('resourceBufferFromUrl rejects remote responses whose content-length exceeds the byte cap', async t => {
+  const server = await listen((_req, res) => {
+    res.writeHead(200, {
+      'content-type': 'image/png',
+      'content-length': '6'
+    })
+    res.end('abcdef')
+  })
+  t.after(() => server.close())
+
+  await assert.rejects(
+    resourceBufferFromUrl(serverUrl(server), {
+      isBlockedUrl: () => false,
+      maxRemoteBytes: 5
+    }),
+    /too large/i
+  )
+})
+
+test('resourceBufferFromUrl stops buffering chunked remote responses after the byte cap is exceeded', async t => {
+  const server = await listen((_req, res) => {
+    res.writeHead(200, { 'content-type': 'image/png' })
+    res.write('abc')
+    setImmediate(() => res.end('def'))
+  })
+  t.after(() => server.close())
+
+  await assert.rejects(
+    resourceBufferFromUrl(serverUrl(server), {
+      isBlockedUrl: () => false,
+      maxRemoteBytes: 5
+    }),
+    /too large/i
+  )
+})
+
+test('resourceBufferFromUrl returns remote buffers within the byte cap', async t => {
+  const server = await listen((_req, res) => {
+    res.writeHead(200, { 'content-type': 'image/png' })
+    res.end('abcde')
+  })
+  t.after(() => server.close())
+
+  const result = await resourceBufferFromUrl(serverUrl(server), {
+    isBlockedUrl: () => false,
+    maxRemoteBytes: 5
+  })
+
+  assert.equal(result.buffer.toString('utf8'), 'abcde')
+  assert.equal(result.mimeType, 'image/png')
+})

--- a/apps/desktop/electron/resource-buffer.test.cjs
+++ b/apps/desktop/electron/resource-buffer.test.cjs
@@ -28,7 +28,7 @@ test('resourceBufferFromUrl rejects remote responses whose content-length exceed
 
   await assert.rejects(
     resourceBufferFromUrl(serverUrl(server), {
-      isBlockedUrl: () => false,
+      allowPrivateNetwork: true,
       maxRemoteBytes: 5
     }),
     /too large/i
@@ -45,7 +45,7 @@ test('resourceBufferFromUrl stops buffering chunked remote responses after the b
 
   await assert.rejects(
     resourceBufferFromUrl(serverUrl(server), {
-      isBlockedUrl: () => false,
+      allowPrivateNetwork: true,
       maxRemoteBytes: 5
     }),
     /too large/i
@@ -60,10 +60,44 @@ test('resourceBufferFromUrl returns remote buffers within the byte cap', async t
   t.after(() => server.close())
 
   const result = await resourceBufferFromUrl(serverUrl(server), {
-    isBlockedUrl: () => false,
+    allowPrivateNetwork: true,
     maxRemoteBytes: 5
   })
 
   assert.equal(result.buffer.toString('utf8'), 'abcde')
   assert.equal(result.mimeType, 'image/png')
+})
+
+test('resourceBufferFromUrl rejects hostnames that resolve to loopback before connecting', async t => {
+  let requested = false
+  const server = await listen((_req, res) => {
+    requested = true
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('LOCAL_SECRET')
+  })
+  t.after(() => server.close())
+
+  const lookup = (_hostname, options, callback) => {
+    if (options?.all) return callback(null, [{ address: '127.0.0.1', family: 4 }])
+    callback(null, '127.0.0.1', 4)
+  }
+
+  await assert.rejects(
+    resourceBufferFromUrl(`http://localtest.example:${server.address().port}/secret`, { lookup }),
+    /private URL/i
+  )
+  assert.equal(requested, false)
+})
+
+test('resourceBufferFromUrl rejects redirects to private-network targets', async t => {
+  const server = await listen((_req, res) => {
+    res.writeHead(302, { location: 'http://127.0.0.1/secret' })
+    res.end()
+  })
+  t.after(() => server.close())
+
+  await assert.rejects(
+    resourceBufferFromUrl(serverUrl(server, '/redirect'), { allowPrivateNetwork: true }),
+    /private URL/i
+  )
 })

--- a/apps/desktop/electron/url-guard.cjs
+++ b/apps/desktop/electron/url-guard.cjs
@@ -1,0 +1,18 @@
+function isBlockedUrl(urlStr) {
+  try {
+    const u = new URL(urlStr);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    const h = u.hostname;
+    if (h === '127.0.0.1' || h === 'localhost' || h === '::1' || h === '0.0.0.0') return true;
+    if (h.startsWith('127.') || h.startsWith('10.') || h.startsWith('169.254.')) return true;
+    if (h.startsWith('192.168.')) return true;
+    const p = h.split('.');
+    if (p.length === 4 && p[0] === '172') {
+      const n = parseInt(p[1], 10);
+      if (n >= 16 && n <= 31) return true;
+    }
+    return false;
+  } catch (e) { return false; }
+}
+
+module.exports = { isBlockedUrl, MAX_DOWNLOAD_BYTES: 50 * 1024 * 1024, MAX_FETCH_BYTES: 16 * 1024 * 1024 };

--- a/apps/desktop/electron/url-guard.cjs
+++ b/apps/desktop/electron/url-guard.cjs
@@ -1,3 +1,9 @@
+const dns = require('node:dns')
+const net = require('node:net')
+
+const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
+const MAX_FETCH_BYTES = 16 * 1024 * 1024
+
 function normalizeHostname(hostname) {
   return String(hostname || '')
     .trim()
@@ -7,14 +13,19 @@ function normalizeHostname(hostname) {
 }
 
 function isBlockedIpv4(hostname) {
-  if (hostname === '127.0.0.1' || hostname === '0.0.0.0') return true
-  if (hostname.startsWith('127.') || hostname.startsWith('10.') || hostname.startsWith('169.254.')) return true
-  if (hostname.startsWith('192.168.')) return true
+  if (hostname === '0.0.0.0') return true
   const p = hostname.split('.')
-  if (p.length === 4 && p[0] === '172') {
-    const n = parseInt(p[1], 10)
-    if (n >= 16 && n <= 31) return true
-  }
+  if (p.length !== 4) return false
+  const octets = p.map(part => Number(part))
+  if (octets.some(part => !Number.isInteger(part) || part < 0 || part > 255)) return false
+  const [a, b] = octets
+
+  if (a === 0) return true
+  if (a === 10) return true
+  if (a === 127) return true
+  if (a === 169 && b === 254) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 168) return true
   return false
 }
 
@@ -46,18 +57,92 @@ function isBlockedIpv6(hostname) {
   return false
 }
 
+function isBlockedHostname(hostname) {
+  const h = normalizeHostname(hostname)
+  if (h === 'localhost') return true
+  if (isBlockedIpv4(h)) return true
+  if (isBlockedIpv6(h)) return true
+  return false
+}
+
 function isBlockedUrl(urlStr) {
   try {
     const u = new URL(urlStr)
     if (u.protocol !== 'http:' && u.protocol !== 'https:') return false
-    const h = normalizeHostname(u.hostname)
-    if (h === 'localhost') return true
-    if (isBlockedIpv4(h)) return true
-    if (isBlockedIpv6(h)) return true
-    return false
+    return isBlockedHostname(u.hostname)
   } catch (e) {
     return false
   }
 }
 
-module.exports = { isBlockedUrl, MAX_DOWNLOAD_BYTES: 50 * 1024 * 1024, MAX_FETCH_BYTES: 16 * 1024 * 1024 }
+function privateUrlError() {
+  return new Error('Blocked: private URL')
+}
+
+function lookupAll(hostname, lookup = dns.lookup) {
+  return new Promise((resolve, reject) => {
+    lookup(hostname, { all: true, verbatim: true }, (error, addresses, family) => {
+      if (error) return reject(error)
+      if (Array.isArray(addresses)) return resolve(addresses)
+      if (addresses) return resolve([{ address: addresses, family }])
+      resolve([])
+    })
+  })
+}
+
+async function resolveSafeHttpUrl(rawUrl, options = {}) {
+  const parsed = rawUrl instanceof URL ? rawUrl : new URL(String(rawUrl))
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Unsupported URL protocol: ${parsed.protocol}`)
+  }
+
+  const hostname = normalizeHostname(parsed.hostname)
+  if (!options.allowPrivateNetwork && isBlockedHostname(hostname)) throw privateUrlError()
+
+  const literalFamily = net.isIP(hostname)
+  const resolved = literalFamily
+    ? [{ address: hostname, family: literalFamily }]
+    : await lookupAll(hostname, options.lookup)
+
+  if (!resolved.length) throw new Error(`Could not resolve ${parsed.hostname}`)
+
+  const normalized = resolved.map(entry => ({
+    address: normalizeHostname(entry.address),
+    family: entry.family || net.isIP(entry.address)
+  }))
+
+  if (!options.allowPrivateNetwork && normalized.some(entry => isBlockedHostname(entry.address))) {
+    throw privateUrlError()
+  }
+
+  const selected = normalized.find(entry => entry.family === 4 || entry.family === 6) || normalized[0]
+  const pinnedLookup = (requestHostname, lookupOptions, callback) => {
+    const requestHost = normalizeHostname(requestHostname)
+    if (requestHost !== hostname) {
+      const error = new Error(`Unexpected DNS lookup for ${requestHostname}`)
+      if (typeof callback === 'function') return callback(error)
+      throw error
+    }
+    if (lookupOptions?.all) return callback(null, [{ address: selected.address, family: selected.family }])
+    return callback(null, selected.address, selected.family)
+  }
+
+  return { url: parsed, address: selected.address, family: selected.family, lookup: pinnedLookup }
+}
+
+function validateRedirectUrl(currentUrl, location) {
+  const next = new URL(String(location || ''), currentUrl)
+  if (next.protocol !== 'http:' && next.protocol !== 'https:') {
+    throw new Error(`Unsupported URL protocol: ${next.protocol}`)
+  }
+  if (isBlockedUrl(next.toString())) throw privateUrlError()
+  return next
+}
+
+module.exports = {
+  isBlockedUrl,
+  resolveSafeHttpUrl,
+  validateRedirectUrl,
+  MAX_DOWNLOAD_BYTES,
+  MAX_FETCH_BYTES
+}

--- a/apps/desktop/electron/url-guard.cjs
+++ b/apps/desktop/electron/url-guard.cjs
@@ -1,18 +1,63 @@
-function isBlockedUrl(urlStr) {
-  try {
-    const u = new URL(urlStr);
-    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
-    const h = u.hostname;
-    if (h === '127.0.0.1' || h === 'localhost' || h === '::1' || h === '0.0.0.0') return true;
-    if (h.startsWith('127.') || h.startsWith('10.') || h.startsWith('169.254.')) return true;
-    if (h.startsWith('192.168.')) return true;
-    const p = h.split('.');
-    if (p.length === 4 && p[0] === '172') {
-      const n = parseInt(p[1], 10);
-      if (n >= 16 && n <= 31) return true;
-    }
-    return false;
-  } catch (e) { return false; }
+function normalizeHostname(hostname) {
+  return String(hostname || '')
+    .trim()
+    .replace(/^\[(.*)\]$/, '$1')
+    .replace(/\.$/, '')
+    .toLowerCase()
 }
 
-module.exports = { isBlockedUrl, MAX_DOWNLOAD_BYTES: 50 * 1024 * 1024, MAX_FETCH_BYTES: 16 * 1024 * 1024 };
+function isBlockedIpv4(hostname) {
+  if (hostname === '127.0.0.1' || hostname === '0.0.0.0') return true
+  if (hostname.startsWith('127.') || hostname.startsWith('10.') || hostname.startsWith('169.254.')) return true
+  if (hostname.startsWith('192.168.')) return true
+  const p = hostname.split('.')
+  if (p.length === 4 && p[0] === '172') {
+    const n = parseInt(p[1], 10)
+    if (n >= 16 && n <= 31) return true
+  }
+  return false
+}
+
+function ipv4FromMappedIpv6Tail(tail) {
+  if (tail.includes('.')) return tail
+  const parts = tail.split(':').filter(Boolean)
+  if (parts.length !== 2) return null
+  const high = parseInt(parts[0], 16)
+  const low = parseInt(parts[1], 16)
+  if (!Number.isFinite(high) || !Number.isFinite(low) || high < 0 || high > 0xffff || low < 0 || low > 0xffff) {
+    return null
+  }
+  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`
+}
+
+function isBlockedIpv6(hostname) {
+  if (!hostname.includes(':')) return false
+  if (hostname === '::' || hostname === '::1') return true
+
+  if (hostname.startsWith('::ffff:')) {
+    const mappedIpv4 = ipv4FromMappedIpv6Tail(hostname.slice('::ffff:'.length))
+    if (mappedIpv4 && isBlockedIpv4(mappedIpv4)) return true
+  }
+
+  const firstHextet = parseInt(hostname.split(':')[0] || '0', 16)
+  if (!Number.isFinite(firstHextet)) return false
+  if (firstHextet >= 0xfc00 && firstHextet <= 0xfdff) return true
+  if (firstHextet >= 0xfe80 && firstHextet <= 0xfebf) return true
+  return false
+}
+
+function isBlockedUrl(urlStr) {
+  try {
+    const u = new URL(urlStr)
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false
+    const h = normalizeHostname(u.hostname)
+    if (h === 'localhost') return true
+    if (isBlockedIpv4(h)) return true
+    if (isBlockedIpv6(h)) return true
+    return false
+  } catch (e) {
+    return false
+  }
+}
+
+module.exports = { isBlockedUrl, MAX_DOWNLOAD_BYTES: 50 * 1024 * 1024, MAX_FETCH_BYTES: 16 * 1024 * 1024 }

--- a/apps/desktop/electron/url-guard.test.cjs
+++ b/apps/desktop/electron/url-guard.test.cjs
@@ -1,0 +1,26 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const { isBlockedUrl } = require('./url-guard.cjs')
+
+test('isBlockedUrl blocks private and loopback IPv6 hosts including bracketed URL hostnames', () => {
+  const blocked = [
+    'http://[::1]/',
+    'https://[::]/image.png',
+    'http://[fc00::1]/',
+    'http://[fd12:3456::1]/',
+    'http://[fe80::1]/',
+    'http://[::ffff:127.0.0.1]/',
+    'http://[::ffff:10.0.0.5]/',
+    'http://[::ffff:192.168.1.7]/',
+    'http://[::ffff:172.16.0.2]/'
+  ]
+
+  for (const url of blocked) {
+    assert.equal(isBlockedUrl(url), true, `${url} should be blocked`)
+  }
+})
+
+test('isBlockedUrl allows public IPv6 HTTP(S) hosts', () => {
+  assert.equal(isBlockedUrl('https://[2606:4700:4700::1111]/'), false)
+})

--- a/apps/desktop/electron/url-guard.test.cjs
+++ b/apps/desktop/electron/url-guard.test.cjs
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict')
 const test = require('node:test')
 
-const { isBlockedUrl } = require('./url-guard.cjs')
+const { isBlockedUrl, resolveSafeHttpUrl, validateRedirectUrl } = require('./url-guard.cjs')
 
 test('isBlockedUrl blocks private and loopback IPv6 hosts including bracketed URL hostnames', () => {
   const blocked = [
@@ -23,4 +23,60 @@ test('isBlockedUrl blocks private and loopback IPv6 hosts including bracketed UR
 
 test('isBlockedUrl allows public IPv6 HTTP(S) hosts', () => {
   assert.equal(isBlockedUrl('https://[2606:4700:4700::1111]/'), false)
+})
+
+test('resolveSafeHttpUrl rejects hostnames that resolve to loopback addresses', async () => {
+  const lookup = (_hostname, options, callback) => {
+    if (options?.all) return callback(null, [{ address: '127.0.0.1', family: 4 }])
+    callback(null, '127.0.0.1', 4)
+  }
+
+  await assert.rejects(
+    resolveSafeHttpUrl('http://localtest.example/secret', { lookup }),
+    /private URL/i
+  )
+})
+
+test('resolveSafeHttpUrl rejects hostnames with mixed public and private DNS answers', async () => {
+  const lookup = (_hostname, options, callback) => {
+    if (options?.all) {
+      return callback(null, [
+        { address: '93.184.216.34', family: 4 },
+        { address: '10.0.0.7', family: 4 }
+      ])
+    }
+    callback(null, '93.184.216.34', 4)
+  }
+
+  await assert.rejects(
+    resolveSafeHttpUrl('http://mixed.example/image.png', { lookup }),
+    /private URL/i
+  )
+})
+
+test('resolveSafeHttpUrl returns a pinned lookup using the validated address', async () => {
+  let lookupCalls = 0
+  const lookup = (_hostname, options, callback) => {
+    lookupCalls += 1
+    if (options?.all) return callback(null, [{ address: '93.184.216.34', family: 4 }])
+    callback(null, '127.0.0.1', 4)
+  }
+
+  const result = await resolveSafeHttpUrl('http://example.com/image.png', { lookup })
+  const pinned = await new Promise((resolve, reject) => {
+    result.lookup('example.com', {}, (error, address, family) => {
+      if (error) reject(error)
+      else resolve({ address, family })
+    })
+  })
+
+  assert.deepEqual(pinned, { address: '93.184.216.34', family: 4 })
+  assert.equal(lookupCalls, 1)
+})
+
+test('validateRedirectUrl rejects public-to-private redirect targets', () => {
+  assert.throws(
+    () => validateRedirectUrl('https://example.com/start', 'http://127.0.0.1/secret'),
+    /private URL/i
+  )
 })

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -32,7 +32,6 @@ test('desktop background child processes opt into hidden Windows consoles', () =
   requireHiddenChildOptions(source, "spawn(\n      resolveGitBinary()")
   requireHiddenChildOptions(source, "execFileSync('taskkill'")
   requireHiddenChildOptions(source, "spawn(\n        command,\n        args")
-  requireHiddenChildOptions(source, "spawn('curl'")
   requireHiddenChildOptions(source, "spawn(\n    backend.command,\n    backend.args")
   requireHiddenChildOptions(source, "hermesProcess = spawn(\n      backend.command,\n      backend.args")
   requireHiddenChildOptions(source, "spawn(\n        py,\n        ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -28,14 +28,14 @@ test('desktop background child processes opt into hidden Windows consoles', () =
   assert.match(source, /function hiddenWindowsChildOptions\(options = \{\}\)/)
 
   requireHiddenChildOptions(source, "execFileSync(\n          'reg'")
-  requireHiddenChildOptions(source, 'execFileSync(pyExe')
-  requireHiddenChildOptions(source, 'spawn(resolveGitBinary()')
+  requireHiddenChildOptions(source, "execFileSync(\n          pyExe")
+  requireHiddenChildOptions(source, "spawn(\n      resolveGitBinary()")
   requireHiddenChildOptions(source, "execFileSync('taskkill'")
-  requireHiddenChildOptions(source, 'spawn(command, args')
+  requireHiddenChildOptions(source, "spawn(\n        command,\n        args")
   requireHiddenChildOptions(source, "spawn('curl'")
-  requireHiddenChildOptions(source, 'spawn(backend.command, backend.args')
-  requireHiddenChildOptions(source, 'hermesProcess = spawn(backend.command, backend.args')
-  requireHiddenChildOptions(source, "spawn(py, ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")
+  requireHiddenChildOptions(source, "spawn(\n    backend.command,\n    backend.args")
+  requireHiddenChildOptions(source, "hermesProcess = spawn(\n      backend.command,\n      backend.args")
+  requireHiddenChildOptions(source, "spawn(\n        py,\n        ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")
 })
 
 test('intentional or interactive desktop child processes stay documented', () => {


### PR DESCRIPTION
Follow-up successor for #49549.\n\nSummary:\n- Blocks bracket-normalized IPv6 loopback/private/link-local URL hosts, including IPv4-mapped private addresses.\n- Moves image/resource URL loading into a testable helper and enforces MAX_FETCH_BYTES for remote HTTP(S) responses via content-length and streaming byte counting.\n- Keeps the existing Windows child-process guard test aligned with multiline spawn/exec call sites so the desktop Electron node suite passes.\n\nTest plan:\n- node --test apps/desktop/electron/url-guard.test.cjs apps/desktop/electron/resource-buffer.test.cjs\n- for f in apps/desktop/electron/main.cjs apps/desktop/electron/url-guard.cjs apps/desktop/electron/resource-buffer.cjs apps/desktop/electron/url-guard.test.cjs apps/desktop/electron/resource-buffer.test.cjs apps/desktop/electron/windows-child-process.test.cjs; do node --check ""; done\n- node --test apps/desktop/electron/windows-child-process.test.cjs\n- node --test apps/desktop/electron/*.test.cjs