### PR TITLE
[codex] Fix plugin installers without pip

### DIFF
--- a/plugins/google_meet/cli.py
+++ b/plugins/google_meet/cli.py
@@ -249,17 +249,44 @@ def _cmd_install(*, realtime: bool, assume_yes: bool) -> int:
     # 1) pip deps — always safe, venv-scoped.
     pip_pkgs = ["playwright", "websockets"]
     print(f"\n[1/3] pip install: {' '.join(pip_pkgs)}")
+    pip_cmd = [sys.executable, "-m", "pip", "install", "--upgrade", *pip_pkgs]
     try:
-        res = _sp.run(
-            [sys.executable, "-m", "pip", "install", "--upgrade", *pip_pkgs],
-            check=False,
-        )
-        if res.returncode != 0:
-            print("  pip install failed")
-            return 1
+        res = _sp.run(pip_cmd, check=False)
+        pip_failed = res.returncode != 0
     except Exception as e:
         print(f"  pip install failed: {e}")
-        return 1
+        pip_failed = True
+
+    if pip_failed:
+        uv = _shutil.which("uv")
+        if not uv:
+            print("  pip install failed")
+            print(
+                "  no uv fallback found; manually run:\n"
+                f"    {sys.executable} -m pip install --upgrade {' '.join(pip_pkgs)}"
+            )
+            return 1
+
+        print("  pip install failed; retrying with uv")
+        uv_cmd = [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            sys.executable,
+            "--upgrade",
+            *pip_pkgs,
+        ]
+        try:
+            res = _sp.run(uv_cmd, check=False)
+            if res.returncode != 0:
+                print("  uv pip install failed")
+                print(f"  manually run: {' '.join(uv_cmd)}")
+                return 1
+        except Exception as e:
+            print(f"  uv pip install failed: {e}")
+            print(f"  manually run: {' '.join(uv_cmd)}")
+            return 1
 
     # 2) Playwright browsers — pulls chromium (~300MB first run).
     print("\n[2/3] python -m playwright install chromium")

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -515,21 +517,39 @@ def _ensure_sdk_installed() -> bool:
         print("  Skipping install. Run: pip install 'honcho-ai>=2.0.1'\n")
         return False
 
-    import subprocess
     print("  Installing honcho-ai...", flush=True)
+    pip_cmd = [sys.executable, "-m", "pip", "install", "honcho-ai>=2.0.1"]
     result = subprocess.run(
-        [sys.executable, "-m", "pip", "install", "honcho-ai>=2.0.1"],
-        capture_output=True,
-        text=True,
-        stdin=subprocess.DEVNULL,
+        pip_cmd, capture_output=True, text=True, stdin=subprocess.DEVNULL
     )
     if result.returncode == 0:
         print("  Installed.\n")
         return True
-    else:
+
+    uv = shutil.which("uv")
+    if uv:
+        uv_cmd = [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            sys.executable,
+            "honcho-ai>=2.0.1",
+        ]
+        print("  pip install failed; retrying with uv...", flush=True)
+        result = subprocess.run(
+            uv_cmd, capture_output=True, text=True, stdin=subprocess.DEVNULL
+        )
+        if result.returncode == 0:
+            print("  Installed.\n")
+            return True
         print(f"  Install failed:\n{result.stderr.strip()}")
-        print("  Run manually: pip install 'honcho-ai>=2.0.1'\n")
+        print(f"  Run manually: {' '.join(uv_cmd)}\n")
         return False
+
+    print(f"  Install failed:\n{result.stderr.strip()}")
+    print(f"  Run manually: {' '.join(pip_cmd)}\n")
+    return False
 
 
 def cmd_setup(args) -> None:

--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -62,6 +62,7 @@ import logging
 import os
 import re
 import secrets
+import shutil
 import stat
 import subprocess
 import sys
@@ -386,10 +387,28 @@ def install_deps() -> bool:
         print("Dependencies installed.")
         return True
     except subprocess.CalledProcessError as exc:
-        print(f"ERROR: Failed to install dependencies: {exc}")
-        print("Or install via the optional extra:")
-        print("  pip install 'hermes-agent[google_chat]'")
-        return False
+        pip_error = exc
+
+    uv = shutil.which("uv")
+    if uv:
+        try:
+            subprocess.check_call(
+                [uv, "pip", "install", "--python", sys.executable, "--quiet"]
+                + _REQUIRED_PACKAGES,
+                stdout=subprocess.DEVNULL,
+            )
+            print("Dependencies installed.")
+            return True
+        except subprocess.CalledProcessError as exc:
+            print(f"ERROR: Failed to install dependencies via uv: {exc}")
+            print(f"Manually: {uv} pip install --python {sys.executable} {' '.join(_REQUIRED_PACKAGES)}")
+            return False
+
+    print(f"ERROR: Failed to install dependencies: {pip_error}")
+    print("Or install via the optional extra:")
+    print("  pip install 'hermes-agent[google_chat]'")
+    print(f"Or manually: {sys.executable} -m pip install {' '.join(_REQUIRED_PACKAGES)}")
+    return False
 
 
 def check_auth(email: Optional[str] = None) -> bool:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -208,6 +208,7 @@ AUTHOR_MAP = {
     "tillfalko@gmail.com": "tillfalko",
     "hi@fesalfayed.com": "fesalfayed",
     "marek.les@seznam.cz": "maxcz79",
+    "magnus.ahmad@gmail.com": "magnusahmad",
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "kenyon1977@gmail.com": "kenyonxu",

--- a/tests/plugins/memory/test_honcho_cli_install.py
+++ b/tests/plugins/memory/test_honcho_cli_install.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import builtins
+import sys
+from types import SimpleNamespace
+
+
+def test_ensure_sdk_installed_falls_back_to_uv_when_pip_is_missing(monkeypatch):
+    from plugins.memory.honcho import cli
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "honcho":
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:3] == [sys.executable, "-m", "pip"]:
+            return SimpleNamespace(returncode=1, stderr="No module named pip")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(cli, "_prompt", lambda *args, **kwargs: "y")
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    assert cli._ensure_sdk_installed() is True
+    assert calls[0][:3] == [sys.executable, "-m", "pip"]
+    assert calls[1][:5] == ["/usr/bin/uv", "pip", "install", "--python", sys.executable]

--- a/tests/plugins/platforms/test_google_chat_oauth_install.py
+++ b/tests/plugins/platforms/test_google_chat_oauth_install.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import builtins
+import subprocess
+import sys
+
+
+def test_install_deps_falls_back_to_uv_when_pip_is_missing(monkeypatch):
+    from plugins.platforms.google_chat import oauth
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in {"googleapiclient", "google_auth_oauthlib"}:
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    calls = []
+
+    def fake_check_call(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:3] == [sys.executable, "-m", "pip"]:
+            raise subprocess.CalledProcessError(1, cmd)
+        return 0
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(oauth.subprocess, "check_call", fake_check_call)
+    monkeypatch.setattr(oauth.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    assert oauth.install_deps() is True
+    assert calls[0][:3] == [sys.executable, "-m", "pip"]
+    assert calls[1][:5] == ["/usr/bin/uv", "pip", "install", "--python", sys.executable]

--- a/tests/plugins/test_google_meet_plugin.py
+++ b/tests/plugins/test_google_meet_plugin.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -787,6 +788,52 @@ def test_cmd_install_runs_pip_and_playwright(capsys):
     pw_cmds = [c for c in calls if len(c) > 2 and c[1:4] == ["-m", "playwright", "install"]]
     assert pw_cmds, f"no playwright install run: {calls}"
     assert "chromium" in pw_cmds[0]
+
+
+def test_cmd_install_falls_back_to_uv_when_pip_is_missing(capsys):
+    """Hermes uv-managed venvs may not have pip; install into the same python."""
+    from plugins.google_meet.cli import _cmd_install
+
+    calls = []
+
+    class _FakeRes:
+        def __init__(self, rc=0):
+            self.returncode = rc
+
+    def _fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        if argv[1:4] == ["-m", "pip", "install"]:
+            return _FakeRes(1)
+        return _FakeRes(0)
+
+    def _fake_which(name):
+        if name == "uv":
+            return "/usr/bin/uv"
+        return None
+
+    with patch("platform.system", return_value="Linux"), \
+         patch("subprocess.run", side_effect=_fake_run), \
+         patch("shutil.which", side_effect=_fake_which):
+        rc = _cmd_install(realtime=False, assume_yes=True)
+    assert rc == 0
+
+    uv_cmds = [
+        c
+        for c in calls
+        if c[:6] == [
+            "/usr/bin/uv",
+            "pip",
+            "install",
+            "--python",
+            sys.executable,
+            "--upgrade",
+        ]
+    ]
+    assert uv_cmds, f"no uv pip fallback run: {calls}"
+    assert "playwright" in uv_cmds[0]
+    assert "websockets" in uv_cmds[0]
+    out = capsys.readouterr().out
+    assert "retrying with uv" in out
 
 
 def test_cmd_install_realtime_skips_when_deps_present(capsys):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -931,7 +931,6 @@ def _start_agent_build(sid: str, session: dict) -> None:
             return
 
         worker = None
-        notify_registered = False
         home_token = None
         profile_home = current.get("profile_home")
         try:
@@ -968,32 +967,60 @@ def _start_agent_build(sid: str, session: dict) -> None:
             finally:
                 _clear_session_context(tokens)
 
-            # Session DB row deferred to first run_conversation() call.
-            # pending_title applied post-first-message (see cli.exec handler).
-            current["agent"] = agent
-            # Baseline for the per-turn config sync; the profile home
-            # override is still active here.
-            current["config_model_seen"] = _config_model_target()
-
             try:
                 worker = _SlashWorker(key, getattr(agent, "model", _resolve_model()))
-                _attach_worker(sid, current, worker)
             except Exception:
-                pass
+                worker = None
 
+            register_gateway_notify = None
+            load_permanent_allowlist = None
             try:
                 from tools.approval import (
                     register_gateway_notify,
                     load_permanent_allowlist,
                 )
-
-                register_gateway_notify(
-                    key, lambda data: _emit("approval.request", sid, data)
-                )
-                notify_registered = True
-                load_permanent_allowlist()
             except Exception:
                 pass
+
+            attached = False
+            notify_registered = False
+            with _sessions_lock:
+                if _sessions.get(sid) is current:
+                    # Session DB row deferred to first run_conversation() call.
+                    # pending_title applied post-first-message (see cli.exec handler).
+                    current["agent"] = agent
+                    # Baseline for the per-turn config sync; the profile home
+                    # override is still active here.
+                    current["config_model_seen"] = _config_model_target()
+                    if worker is not None:
+                        current["slash_worker"] = worker
+                    if register_gateway_notify is not None:
+                        try:
+                            register_gateway_notify(
+                                key, lambda data: _emit("approval.request", sid, data)
+                            )
+                            notify_registered = True
+                        except Exception:
+                            pass
+                    attached = True
+            if not attached:
+                if worker is not None:
+                    try:
+                        worker.close()
+                    except Exception:
+                        pass
+                try:
+                    if hasattr(agent, "close"):
+                        agent.close()
+                except Exception:
+                    pass
+                return
+
+            if notify_registered and load_permanent_allowlist is not None:
+                try:
+                    load_permanent_allowlist()
+                except Exception:
+                    pass
 
             _wire_callbacks(sid)
             # Hydrate credits notices at session OPEN (not just on the first
@@ -1006,8 +1033,8 @@ def _start_agent_build(sid: str, session: dict) -> None:
             except Exception:
                 pass
             with _sessions_lock:
-                if sid in _sessions:
-                    _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
+                if _sessions.get(sid) is current:
+                    current["_notif_stop"] = _start_notification_poller(sid, current)
             _notify_session_boundary("on_session_reset", key)
 
             info = _session_info(agent, current)
@@ -1027,18 +1054,6 @@ def _start_agent_build(sid: str, session: dict) -> None:
         finally:
             if home_token is not None:
                 reset_hermes_home_override(home_token)
-            # _attach_worker already closed the worker if this session was
-            # reaped mid-build; only the late notify registration can still
-            # leak (session.close unregistered before _build registered it).
-            with _sessions_lock:
-                replaced = _sessions.get(sid) is not current
-            if replaced and notify_registered:
-                try:
-                    from tools.approval import unregister_gateway_notify
-
-                    unregister_gateway_notify(key)
-                except Exception:
-                    pass
             ready.set()
 
     threading.Thread(target=_build, daemon=True).start()


### PR DESCRIPTION
## Summary

- Add `uv pip install --python <current interpreter>` fallbacks for plugin install flows that previously assumed `python -m pip` was available.
- Cover Google Meet, Google Chat OAuth, and Honcho direct setup installers.
- Add regression tests for pip-less Hermes/uv-managed venvs.
- Register the PR author's git email in `scripts/release.py` for release attribution checks.
- Fix the TUI gateway session-build race so orphan cleanup is decided before installing the worker/notifier, avoiding spurious unregisters in live builds.

## Root Cause

Some Hermes-managed environments can run from a uv-managed virtualenv without `pip` bootstrapped. Plugin installers that call `sys.executable -m pip install ...` directly fail before they can install optional runtime dependencies.

The release workflow also requires every new contributor commit email to be present in `AUTHOR_MAP`, so this PR maps `magnus.ahmad@gmail.com` to `magnusahmad`.

A failing TUI gateway race test also showed that `_start_agent_build` could register notify callbacks and then rely on a late replaced-session cleanup check. The build now atomically verifies that the same session is still live before attaching the built agent, worker, and notifier; orphaned builds close their freshly-created resources without registering a late notifier.

## Validation

- `scripts/run_tests.sh tests/plugins/test_google_meet_plugin.py tests/plugins/platforms/test_google_chat_oauth_install.py tests/plugins/memory/test_honcho_cli_install.py`
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k 'session_create_close_race_does_not_orphan_worker or session_create_no_race_keeps_worker_alive or start_agent_build_passes_session_model_override'`
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k 'not browser_manage_connect_default_local_reports_launch_hint'`
- `/Users/magnus/.hermes/hermes-agent/venv/bin/python3 -c "import scripts.release as r; assert r.AUTHOR_MAP['magnus.ahmad@gmail.com'] == 'magnusahmad'; assert r.resolve_author('Magnus Ahmad', 'magnus.ahmad@gmail.com') == '@magnusahmad'"`

Note: full local `tests/test_tui_gateway_server.py` still hits the pre-existing `test_browser_manage_connect_default_local_reports_launch_hint` expectation on this Mac because a Chromium-family executable is available locally; the CI-reported gateway race tests pass.