### PR TITLE
fix(cli): add encoding to subprocess calls in doctor (#49499)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1459,6 +1459,8 @@ def run_doctor(args):
                     cmd,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=15
                 )
             except subprocess.TimeoutExpired:
@@ -1604,7 +1606,8 @@ def run_doctor(args):
                 audit_result = subprocess.run(
                     [_npm_bin, "audit", "--json", *audit_extra],
                     cwd=str(npm_dir),
-                    capture_output=True, text=True, timeout=30,
+                    capture_output=True, text=True, encoding="utf-8", errors="replace",
+                    timeout=30,
                 )
                 import json as _json
                 audit_data = _json.loads(audit_result.stdout) if audit_result.stdout.strip() else {}


### PR DESCRIPTION
Fixes #49499. Add encoding='utf-8' and errors='replace' to subprocess.run calls in hermes doctor that use text=True. On Windows with non-UTF-8 locale (e.g. Chinese GBK/CP936), the subprocess reader thread crashes with UnicodeDecodeError because Python defaults to the system encoding instead of UTF-8.