### PR TITLE
fix: minimax-cn vision routing + auxiliary backend + API base_url

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4147,6 +4147,7 @@ def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Di
 
 _VISION_AUTO_PROVIDER_ORDER = (
     "openrouter",
+    "minimax-cn",
     "nous",
 )
 
@@ -4195,6 +4196,8 @@ def _resolve_strict_vision_backend(
         return resolve_provider_client("copilot", model, is_vision=True)
     if provider == "openrouter":
         return _try_openrouter(model=model)
+    if provider == "minimax-cn":
+        return resolve_provider_client("minimax-cn", model, is_vision=True)
     if provider == "nous":
         return _try_nous(vision=True)
     if provider == "openai-codex":

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -302,6 +302,15 @@ def _lookup_supports_vision(
         return override
     if not provider or not model:
         return None
+    # Hardcoded MiniMax override — order matters, check M3 before provider fallback
+    model_lower = model.lower()
+    provider_lower = provider.lower()
+    # M3 has native vision — check first, before provider-level fallback
+    if any(kw in model_lower for kw in ("m3",)):
+        return True   # M3 has native vision — use native pipeline
+    # All other minimax-cn models are text-only (M2.7, M2.12, etc.)
+    if any(kw in provider_lower for kw in ("minimax",)):
+        return False  # Text-only — must use vision_analyze auxiliary pipeline
     try:
         from agent.models_dev import get_model_capabilities
         caps = get_model_capabilities(provider, model)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -340,7 +340,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         id="minimax-cn",
         name="MiniMax (China)",
         auth_type="api_key",
-        inference_base_url="https://api.minimaxi.com/anthropic",
+        inference_base_url="https://api.minimaxi.com/v1",
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
     ),


### PR DESCRIPTION
Three related fixes for the minimax-cn provider (used by MiniMax-M3 and the earlier MiniMax-M2.7/M2.12 text-only models):

1. hermes_cli/auth.py - flip MiniMax CN inference base_url from /anthropic to /v1 (OpenAI-compatible protocol).

2. agent/image_routing.py - _lookup_supports_vision returns True for MiniMax-M3 (native vision) before the provider-level minimax=False fallback (text-only M2.7/M2.12).

3. agent/auxiliary_client.py - add minimax-cn to _VISION_AUTO_PROVIDER_ORDER plus matching resolver branch.

Verified end-to-end after hermes update 2026-06-20.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

