### PR TITLE
feat(telegram): make processing reaction emojis configurable

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9769,10 +9769,29 @@ class TelegramAdapter(BasePlatformAdapter):
         )
 
     # ── Message reactions (processing lifecycle) ──────────────────────────
+    #
+    # Configurable via platforms.telegram.extra in config.yaml:
+    #
+    #   reactions_on_receive: "👀"   # emoji shown when a message is received
+    #   reactions_on_success: "👍"   # emoji shown on successful completion
+    #   reactions_on_failure: "👎"   # emoji shown on failure
+    #
+    # Set any value to "clear" or "" to suppress that reaction.
+    # Master switch: env var TELEGRAM_REACTIONS=true (default false).
+
+    _REACTION_CLEAR_SENTINELS = {"clear", "none", ""}
 
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
         return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
+
+    def _reaction_emoji(self, key: str, default: str) -> str | None:
+        """Return the configured emoji for *key*, or ``None`` to suppress."""
+        raw = self.config.extra.get(key, default) if getattr(self.config, "extra", None) else default
+        val = str(raw).strip()
+        if val.lower() in self._REACTION_CLEAR_SENTINELS:
+            return None
+        return val or None
 
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Set a single emoji reaction on a Telegram message."""
@@ -9814,23 +9833,19 @@ class TelegramAdapter(BasePlatformAdapter):
         """Add an in-progress reaction when message processing begins."""
         if not self._reactions_enabled():
             return
+        emoji = self._reaction_emoji("reactions_on_receive", "\U0001f440")  # 👀
+        if not emoji:
+            return
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id:
-            await self._set_reaction(chat_id, message_id, "\U0001f440")
+            await self._set_reaction(chat_id, message_id, emoji)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Swap the in-progress reaction for a final success/failure reaction.
+        """Apply the configured reaction for the given outcome.
 
         Unlike Discord (additive reactions), Telegram's set_message_reaction
         replaces all existing reactions in one call — no remove step needed.
-
-        On CANCELLED outcomes (e.g. the user runs ``/stop``, or a session is
-        interrupted mid-flight), we explicitly clear the 👀 in-progress
-        reaction so it doesn't linger on the user's message indefinitely.
-        Without this clear, the only way to remove the 👀 was to wait for
-        another agent run to swap it to 👍/👎 — which never happens if the
-        cancellation was the last activity in the chat.
         """
         if not self._reactions_enabled():
             return
@@ -9840,12 +9855,18 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if outcome == ProcessingOutcome.CANCELLED:
             await self._clear_reactions(chat_id, message_id)
+        elif outcome == ProcessingOutcome.SUCCESS:
+            emoji = self._reaction_emoji("reactions_on_success", "\U0001f44d")  # 👍
+            if emoji:
+                await self._set_reaction(chat_id, message_id, emoji)
+            else:
+                await self._clear_reactions(chat_id, message_id)
         else:
-            await self._set_reaction(
-                chat_id,
-                message_id,
-                "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
-            )
+            emoji = self._reaction_emoji("reactions_on_failure", "\U0001f44e")  # 👎
+            if emoji:
+                await self._set_reaction(chat_id, message_id, emoji)
+            else:
+                await self._clear_reactions(chat_id, message_id)
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -53,6 +53,34 @@ def test_reactions_enabled_when_set_true(monkeypatch):
     assert adapter._reactions_enabled() is True
 
 
+def test_reactions_enabled_with_1(monkeypatch):
+    """TELEGRAM_REACTIONS=1 enables reactions."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "1")
+    adapter = _make_adapter()
+    assert adapter._reactions_enabled() is True
+
+
+def test_reactions_disabled_with_false(monkeypatch):
+    """TELEGRAM_REACTIONS=false disables reactions."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
+    adapter = _make_adapter()
+    assert adapter._reactions_enabled() is False
+
+
+def test_reactions_disabled_with_0(monkeypatch):
+    """TELEGRAM_REACTIONS=0 disables reactions."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "0")
+    adapter = _make_adapter()
+    assert adapter._reactions_enabled() is False
+
+
+def test_reactions_disabled_with_no(monkeypatch):
+    """TELEGRAM_REACTIONS=no disables reactions."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "no")
+    adapter = _make_adapter()
+    assert adapter._reactions_enabled() is False
+
+
 # ── _set_reaction ────────────────────────────────────────────────────
 
 
@@ -72,7 +100,57 @@ async def test_set_reaction_calls_bot_api(monkeypatch):
     )
 
 
+@pytest.mark.asyncio
+async def test_set_reaction_returns_false_without_bot(monkeypatch):
+    """_set_reaction should return False when bot is not available."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter._bot = None
+
+    result = await adapter._set_reaction("123", "456", "\U0001f440")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_set_reaction_handles_api_error_gracefully(monkeypatch):
+    """API errors during reaction should not propagate."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter._bot.set_message_reaction = AsyncMock(side_effect=RuntimeError("no perms"))
+
+    result = await adapter._set_reaction("123", "456", "\U0001f440")
+    assert result is False
+
+
 # ── on_processing_start ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_processing_start_adds_eyes_reaction(monkeypatch):
+    """Processing start should add eyes reaction when enabled."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+    event = _make_event()
+
+    await adapter.on_processing_start(event)
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction="\U0001f440",
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_processing_start_skipped_when_disabled(monkeypatch):
+    """Processing start should not react when reactions are disabled."""
+    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+    adapter = _make_adapter()
+    event = _make_event()
+
+    await adapter.on_processing_start(event)
+
+    adapter._bot.set_message_reaction.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -93,6 +171,50 @@ async def test_on_processing_start_handles_missing_ids(monkeypatch):
 
 
 # ── on_processing_complete ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_processing_complete_success(monkeypatch):
+    """Successful processing should set thumbs-up reaction."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+    event = _make_event()
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction="\U0001f44d",
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_processing_complete_failure(monkeypatch):
+    """Failed processing should set thumbs-down reaction."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+    event = _make_event()
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction="\U0001f44e",
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_processing_complete_skipped_when_disabled(monkeypatch):
+    """Processing complete should not react when reactions are disabled."""
+    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+    adapter = _make_adapter()
+    event = _make_event()
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    adapter._bot.set_message_reaction.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -120,6 +242,18 @@ async def test_on_processing_complete_cancelled_clears_reaction(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_on_processing_complete_cancelled_skipped_when_disabled(monkeypatch):
+    """Cancelled processing should not call the API when reactions are off."""
+    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+    adapter = _make_adapter()
+    event = _make_event()
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.CANCELLED)
+
+    adapter._bot.set_message_reaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_clear_reactions_handles_api_error_gracefully(monkeypatch):
     """API errors during clear should not propagate."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
@@ -128,6 +262,131 @@ async def test_clear_reactions_handles_api_error_gracefully(monkeypatch):
 
     result = await adapter._clear_reactions("123", "456")
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_clear_reactions_returns_false_without_bot(monkeypatch):
+    """_clear_reactions should return False when bot is not available."""
+    adapter = _make_adapter()
+    adapter._bot = None
+
+    result = await adapter._clear_reactions("123", "456")
+    assert result is False
+
+
+# ── configurable reaction emojis ───────────────────────────────────────
+
+
+def _make_adapter_with_extra(extra: dict, monkeypatch):
+    """Create an adapter with reactions enabled and the given config.extra."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter.config.extra = extra
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_on_processing_start_custom_emoji(monkeypatch):
+    """A custom reactions_on_receive emoji should be used."""
+    adapter = _make_adapter_with_extra({"reactions_on_receive": "🤔"}, monkeypatch)
+    event = _make_event()
+
+    await adapter.on_processing_start(event)
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction="🤔",
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_processing_start_suppressed_with_clear(monkeypatch):
+    """Setting reactions_on_receive to 'clear' should suppress the reaction."""
+    adapter = _make_adapter_with_extra({"reactions_on_receive": "clear"}, monkeypatch)
+    event = _make_event()
+
+    await adapter.on_processing_start(event)
+
+    adapter._bot.set_message_reaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_processing_complete_success_custom_emoji(monkeypatch):
+    """A custom reactions_on_success emoji should be used."""
+    adapter = _make_adapter_with_extra({"reactions_on_success": "✅"}, monkeypatch)
+    event = _make_event()
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction="✅",
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_processing_complete_success_clear_clears(monkeypatch):
+    """Setting reactions_on_success to 'clear' should remove the in-progress reaction."""
+    adapter = _make_adapter_with_extra({"reactions_on_success": "clear"}, monkeypatch)
+    event = _make_event()
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_processing_complete_failure_custom_emoji(monkeypatch):
+    """A custom reactions_on_failure emoji should be used."""
+    adapter = _make_adapter_with_extra({"reactions_on_failure": "❌"}, monkeypatch)
+    event = _make_event()
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction="❌",
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_processing_complete_failure_empty_clears(monkeypatch):
+    """Setting reactions_on_failure to '' should remove the in-progress reaction."""
+    adapter = _make_adapter_with_extra({"reactions_on_failure": ""}, monkeypatch)
+    event = _make_event()
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction=None,
+    )
+
+
+@pytest.mark.parametrize("sentinel", ["clear", "none", ""])
+def test_reaction_emoji_sentinel_returns_none(monkeypatch, sentinel):
+    """Sentinel values for a reaction should suppress it."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter.config.extra = {"reactions_on_receive": sentinel}
+
+    assert adapter._reaction_emoji("reactions_on_receive", "👀") is None
+
+
+def test_reaction_emoji_default_without_extra(monkeypatch):
+    """Missing config.extra should fall back to the default emoji."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+
+    assert adapter._reaction_emoji("reactions_on_receive", "👀") == "👀"
 
 
 # ── config.py bridging ───────────────────────────────────────────────
@@ -154,3 +413,20 @@ def test_config_bridges_telegram_reactions(monkeypatch, tmp_path):
     assert os.getenv("TELEGRAM_REACTIONS") == "true"
 
 
+def test_config_reactions_env_takes_precedence(monkeypatch, tmp_path):
+    """Env var should take precedence over config.yaml for reactions."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "telegram": {
+            "reactions": True,
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("TELEGRAM_REACTIONS") == "false"

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1199,8 +1199,8 @@ This covers the custom fallback transport layer that Hermes uses for Telegram co
 The bot can add emoji reactions to messages as visual processing feedback:
 
 - 👀 when the bot starts processing your message
-- ✅ when the response is delivered successfully
-- ❌ if an error occurs during processing
+- 👍 when the response is delivered successfully
+- 👎 if an error occurs during processing
 
 Reactions are **disabled by default**. Enable them in `config.yaml`:
 
@@ -1215,8 +1215,23 @@ Or via environment variable:
 TELEGRAM_REACTIONS=true
 ```
 
+You can customize the emoji for each stage or suppress a specific reaction under `platforms.telegram.extra`:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      reactions_on_receive: "👀"
+      reactions_on_success: "👍"
+      reactions_on_failure: "👎"
+```
+
+Set any of these to `"clear"`, `"none"`, or `""` to suppress that stage's reaction. For example, `reactions_on_success: "clear"` removes the 👀 reaction on success instead of replacing it with 👍.
+
+Cancelled turns always clear the in-progress reaction regardless of this configuration.
+
 :::note
-Unlike Discord (where reactions are additive), Telegram's Bot API replaces all bot reactions in a single call. The transition from 👀 to ✅/❌ happens atomically — you won't see both at once.
+Unlike Discord (where reactions are additive), Telegram's Bot API replaces all bot reactions in a single call. The transition from 👀 to 👍/👎 happens atomically — you won't see both at once.
 :::
 
 :::tip


### PR DESCRIPTION
## Summary

Make processing lifecycle reaction emojis configurable via `platforms.telegram.extra` in `config.yaml`.

## Config

```yaml
platforms:
  telegram:
    extra:
      reactions_on_receive: "👀"   # emoji when message is received
      reactions_on_success: "👍"   # emoji on successful completion
      reactions_on_failure: "👎"   # emoji on failure
```

Set any to `"clear"`, `"none"`, or `""` to suppress that reaction. CANCELLED always clears regardless of config.

## Changes

- Rebased on current `main` so the change now applies to `plugins/platforms/telegram/adapter.py`.
- Add `_reaction_emoji()` helper that reads config with `"clear"` / `"none"` / `""` as sentinel values returning `None`.
- `on_processing_start` reads `reactions_on_receive` (default 👀).
- `on_processing_complete` reads `reactions_on_success` / `reactions_on_failure` (defaults 👍 / 👎) and clears the receive reaction when a stage is suppressed.
- Add 8 tests in `tests/gateway/test_telegram_reactions.py` covering custom emojis and `clear`/`none`/empty suppression.
- Update `website/docs/user-guide/messaging/telegram.md` to document the new configuration.

## Motivation

- Users may prefer different emoji per stage
- Some want reactions on receive but not completion, or vice versa
- `"clear"` as sentinel makes config self-documenting

## Testing

```bash
venv/bin/python -m pytest tests/gateway/test_telegram_reactions.py -q
```

Result: 31 passed.

Closes #49570
