### PR TITLE
fix(transport): strip timestamp and observed from chat completions messages

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -172,6 +172,8 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                or "timestamp" in msg
+                or "observed" in msg
             ):
                 needs_sanitize = True
                 break
@@ -201,6 +203,8 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            msg.pop("timestamp", None)
+            msg.pop("observed", None)
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.


### PR DESCRIPTION
## Description

The `chat_completions` transport's `build_messages()` method sanitizes messages before sending to the API, stripping internal Hermes fields that strict OpenAI-compatible providers reject with HTTP 400. However, the detection guard and stripping block did not account for two additional internal fields:

- **`timestamp`** -- set on messages by `run_agent.py:_apply_persist_user_message_override()`, `gateway/platforms/telegram.py` for observed group chat, and restored from the session DB by `hermes_state.py`
- **`observed`** -- set by `gateway/platforms/telegram.py` for observed Telegram group chatter

When either field was the **only** non-standard field on a message, the `needs_sanitize` guard returned `False` and the raw dict (including the extra field) was sent to the provider, causing HTTP 400 errors like:

```
Extra inputs are not permitted, field: 'messages[1].timestamp', value: 1781949977
```

This affected any gateway-sourced session (particularly Telegram) against strict OpenAI-compatible providers like opencode-zen and opencode-go. Permissive providers (OpenRouter, real OpenAI) silently drop unknown message keys, which masked the bug.

## Changes

Two changes to `agent/transports/chat_completions.py::ChatCompletionsTransport.convert_messages()`:

1. Added `"timestamp" in msg` and `"observed" in msg` to the `needs_sanitize` detection guard
2. Added `msg.pop("timestamp", None)` and `msg.pop("observed", None)` to the sanitization block

Both fields are internal Hermes metadata that are not part of the OpenAI Chat Completions message schema and should always be stripped before reaching any provider, regardless of how permissive the provider is.

## Related issue

Closes #49572
