### PR TITLE
fix(desktop): improve chat readability

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -290,7 +290,7 @@ const AssistantMessage: FC<{
 
   return (
     <MessagePrimitive.Root
-      className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden"
+      className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden border-l-2 border-(--ui-stroke-tertiary) pl-3"
       data-role="assistant"
       data-slot="aui_assistant-message-root"
       data-streaming={isRunning ? 'true' : undefined}
@@ -827,7 +827,7 @@ function StickyHumanMessageContainer({ attachments, children }: { attachments?: 
 // so without the carve-out, clicking a stuck bubble drags the window instead of
 // opening the edit composer.
 const USER_BUBBLE_BASE_CLASS =
-  'composer-human-message standalone-glass relative flex w-full min-w-0 max-w-full flex-col gap-1.5 overflow-hidden rounded-xl border bg-(--dt-user-bubble) px-3 py-2 text-left [-webkit-app-region:no-drag]'
+  'composer-human-message standalone-glass relative flex w-full min-w-0 max-w-full flex-col gap-1.5 overflow-hidden rounded-xl border bg-[color-mix(in_srgb,var(--dt-primary)_16%,var(--ui-chat-bubble-background))] px-3 py-2 text-left ring-1 ring-[color-mix(in_srgb,var(--dt-primary)_22%,transparent)] [-webkit-app-region:no-drag]'
 
 const USER_ACTION_ICON_BUTTON_CLASS =
   'grid place-items-center rounded-md bg-transparent text-(--ui-text-secondary) transition-colors hover:bg-(--ui-control-active-background) hover:text-foreground disabled:cursor-default disabled:text-(--ui-text-quaternary) disabled:opacity-70'

--- a/apps/desktop/src/components/assistant-ui/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/user-message-edit.test.tsx
@@ -138,4 +138,16 @@ describe('click-to-edit user message', () => {
       expect(container.querySelector('[data-slot="aui_edit-composer-root"]')).toBeTruthy()
     })
   })
+
+  it('visually separates human prompts from assistant responses', async () => {
+    const { container } = render(<StockHarness onEdit={async () => {}} />)
+
+    const userBubble = await screen.findByRole('button', { name: 'Edit message' })
+    const assistantRoot = container.querySelector('[data-slot="aui_assistant-message-root"]')
+
+    expect(userBubble.className).toContain('bg-[color-mix(in_srgb,var(--dt-primary)_16%')
+    expect(userBubble.className).toContain('ring-1')
+    expect(assistantRoot?.className).toContain('border-l-2')
+    expect(assistantRoot?.className).toContain('pl-3')
+  })
 })

--- a/apps/desktop/src/lib/markdown-code.test.ts
+++ b/apps/desktop/src/lib/markdown-code.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { isLikelyProseCodeBlock } from './markdown-code'
+import { isLikelyProseCodeBlock } from '@/lib/markdown-code'
 
 describe('isLikelyProseCodeBlock', () => {
   it('detects prose that Streamdown mislabels as an unknown language', () => {
@@ -15,6 +15,20 @@ describe('isLikelyProseCodeBlock', () => {
         ].join('\n')
       )
     ).toBe(true)
+  })
+
+  it('treats Japanese plaintext flow fences as prose instead of code cards', () => {
+    const flow = `社長・担当者
+  ↓
+Discord #施工事例 に写真と数行メモを投稿
+  ↓
+Hermes Agent / ライ君 が内容を整理
+  ↓
+HPの施工事例ページにそのまま載せられる下書きを作成
+  ↓
+必要なら Googleドキュメント / Markdown / PDF / WordPress担当会社へ送る文章まで生成`
+
+    expect(isLikelyProseCodeBlock('text', flow)).toBe(true)
   })
 
   it('keeps real code blocks', () => {

--- a/apps/desktop/src/lib/markdown-code.ts
+++ b/apps/desktop/src/lib/markdown-code.ts
@@ -163,6 +163,15 @@ export function isLikelyProseFence(info: string, body: string): boolean {
 
   if (
     hasInfoTail &&
+    NON_CODE_FENCE_LANGUAGES.has(language) &&
+    signals.codeSignals <= 2 &&
+    (signals.proseLines >= 1 || signals.bulletLines >= 1 || signals.urlLines >= 1)
+  ) {
+    return true
+  }
+
+  if (
+    hasInfoTail &&
     signals.codeSignals <= 2 &&
     (signals.proseLines >= 2 || signals.bulletLines >= 1 || signals.urlLines >= 1)
   ) {

--- a/apps/desktop/src/lib/markdown-code.ts
+++ b/apps/desktop/src/lib/markdown-code.ts
@@ -112,7 +112,11 @@ function proseLineCount(body: string): number {
   return body.split('\n').filter(line => {
     const trimmed = line.trim()
 
-    return Boolean(trimmed) && /^[A-Za-z0-9"'`*-]/.test(trimmed)
+    // Count non-ASCII prose too. Plaintext fences are often used for
+    // customer-facing Japanese/Chinese/Korean workflows and diagrams; if we
+    // only count Latin starters, those get rendered as code cards with a
+    // confusing "Code · text" header.
+    return Boolean(trimmed) && /^(?:[\p{L}\p{N}"'`*-]|[^\x00-\x7F])/u.test(trimmed)
   }).length
 }
 

--- a/apps/desktop/src/lib/markdown-preprocess.test.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { preprocessMarkdown } from '@/lib/markdown-preprocess'
+
+describe('preprocessMarkdown prose fences', () => {
+  it('strips plaintext language labels while keeping prose fence titles', () => {
+    const input = ['```text 【詳細ページ用】', 'タイトル：四街道市', '```'].join('\n')
+
+    expect(preprocessMarkdown(input)).toBe('【詳細ページ用】\nタイトル：四街道市')
+  })
+
+  it('preserves line breaks inside Japanese plaintext prose fences', () => {
+    const input = [
+      '```text',
+      '基本情報：',
+      '工事内容：外壁塗装・付帯部塗装',
+      '建物種別：戸建て',
+      '築年数：未確認',
+      '```'
+    ].join('\n')
+
+    expect(preprocessMarkdown(input)).toBe(
+      ['基本情報：\\', '工事内容：外壁塗装・付帯部塗装\\', '建物種別：戸建て\\', '築年数：未確認'].join('\n')
+    )
+  })
+
+  it('keeps real code fences intact', () => {
+    const input = ['```ts', 'const value = 1', '```'].join('\n')
+
+    expect(preprocessMarkdown(input)).toBe(input)
+  })
+})

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -157,12 +157,37 @@ function extend(out: string[], lines: string[]) {
   }
 }
 
+function proseFenceLabel(info: string): string {
+  const trimmed = info.trim()
+  const token = trimmed.split(/\s+/, 1)[0] || ''
+  const language = sanitizeLanguageTag(token)
+
+  // Prose fences often use an info string such as ```text 【詳細ページ用】.
+  // Once we've decided the fence is prose, the language token is renderer
+  // metadata, not user-facing content. Keep the human title tail only.
+  return language ? trimmed.slice(token.length).trim() : trimmed
+}
+
+function proseFenceHardBreakLines(lines: string[]): string[] {
+  return lines.map((line, index) => {
+    if (!line.trim()) {
+      return line
+    }
+
+    const next = lines[index + 1]
+
+    return next && next.trim() ? `${line}\\` : line
+  })
+}
+
 function pushProseFence(out: string[], indent: string, info: string, lines: string[]) {
-  if (info) {
-    out.push(`${indent}${info}`.trimEnd())
+  const label = proseFenceLabel(info)
+
+  if (label) {
+    out.push(`${indent}${label}`.trimEnd())
   }
 
-  extend(out, lines)
+  extend(out, proseFenceHardBreakLines(lines))
 }
 
 function findClosingFence(lines: string[], start: number, marker: string): number {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -317,10 +317,10 @@
 
     --composer-shell-pad-block-end: 0.625rem;
     --message-text-indent: 0.75rem;
-    --conversation-text-font-size: 0.8125rem;
-    --conversation-tool-font-size: 0.6875rem;
-    --conversation-caption-font-size: 0.75rem;
-    --conversation-line-height: 1.125rem;
+    --conversation-text-font-size: 0.9375rem;
+    --conversation-tool-font-size: 0.8125rem;
+    --conversation-caption-font-size: 0.8125rem;
+    --conversation-line-height: 1.35rem;
     --conversation-caption-line-height: 1rem;
     --conversation-turn-gap: 0.375rem;
     /* Gap between top-level turn blocks (prose ↔ tools ↔ thinking) — enough air


### PR DESCRIPTION
## Summary
- Increase the desktop conversation font size for easier scanning.
- Tint human/user message bubbles and add a subtle ring so prompts stand out from assistant responses.
- Add a subtle left border and indent to assistant messages so long conversation history is easier to skim.
- Render prose-like plaintext fences, including Japanese business workflows, as normal chat text instead of code cards with a confusing "Code · text" header.
- Strip renderer-only plaintext language labels (for example, `text`) from prose fences while preserving human titles such as `【詳細ページ用】`.
- Preserve line breaks inside prose plaintext fences so Japanese key/value sections such as 基本情報 do not collapse into one hard-to-read paragraph.
- Add regression tests for message separation, prose-fence detection, label stripping, line-break preservation, and real code fences.

## Motivation
Long Hermes Desktop chat histories can be difficult to scan because user prompts and assistant responses appear visually similar, especially when scrolling through previous turns.

Plaintext fenced blocks are also often used for non-code explanations and workflows. In Japanese business-use cases, a flow or detail section rendered as "text ..." made users wonder what "text" meant and collapsed structured lines such as 基本情報 into a dense paragraph. This PR keeps real code blocks as code, but renders prose-like plaintext fences as readable chat text.

## Test plan
- `npm run test:ui -- src/components/assistant-ui/user-message-edit.test.tsx`
- `npm run test:ui -- src/lib/markdown-code.test.ts`
- `npm run test:ui -- src/lib/markdown-preprocess.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run pack`