### PR TITLE
fix(desktop): reconcile blueprint deep-link sanitization

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -313,15 +313,19 @@ export function DesktopController() {
         return
       }
 
+      const sanitizedName = (payload.name || "").replace(/[^A-Za-z0-9_-]/g, "").slice(0, 64)
+      if (!sanitizedName) return
+
       const slots = Object.entries(payload.params || {})
         .map(([k, v]) => {
-          const sval = /\s/.test(v) ? `"${v.replace(/"/g, '\\"')}"` : v
+          const cleanVal = String(v || "").replace(/[\r\n\x00-\x1f]/g, "")
+          const sval = /\s/.test(String(v || "") ? `"${v.replace(/"/g, '\\"')}"` : v
 
           return `${k}=${sval}`
         })
         .join(' ')
 
-      const command = `/blueprint ${payload.name}${slots ? ' ' + slots : ''}`
+      const command = `/blueprint ${sanitizedName}${slots ? ' ' + slots : ''}`
       requestComposerInsert(command, { mode: 'block', target: 'main' })
       requestComposerFocus('main')
     })

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -14,8 +14,8 @@ import { useSkinCommand } from '@/themes/use-skin-command'
 
 import { formatRefValue } from '../components/assistant-ui/directive-text'
 import { getCronJobs, getSessionMessages, listAllProfileSessions, type SessionInfo, triggerCronJob } from '../hermes'
-import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '../lib/chat-messages'
 import { buildBlueprintDeepLinkCommand } from '../lib/blueprint-deep-link'
+import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '../lib/chat-messages'
 import { storedSessionIdForNotification } from '../lib/session-ids'
 import {
   isMessagingSource,
@@ -57,8 +57,8 @@ import {
   $gatewayState,
   $messages,
   $messagingSessions,
-  $resumeFailedSessionId,
   $resumeExhaustedSessionId,
+  $resumeFailedSessionId,
   $selectedStoredSessionId,
   $sessions,
   $workingSessionIds,

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -15,6 +15,7 @@ import { useSkinCommand } from '@/themes/use-skin-command'
 import { formatRefValue } from '../components/assistant-ui/directive-text'
 import { getCronJobs, getSessionMessages, listAllProfileSessions, type SessionInfo, triggerCronJob } from '../hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '../lib/chat-messages'
+import { buildBlueprintDeepLinkCommand } from '../lib/blueprint-deep-link'
 import { storedSessionIdForNotification } from '../lib/session-ids'
 import {
   isMessagingSource,
@@ -309,28 +310,10 @@ export function DesktopController() {
   // that arrived during boot is flushed exactly once.
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onDeepLink?.(payload => {
-      if (!payload || payload.kind !== 'blueprint' || !payload.name) {
+      const command = buildBlueprintDeepLinkCommand(payload)
+      if (!command) {
         return
       }
-
-      const sanitizedName = (payload.name || "").replace(/[^A-Za-z0-9_-]/g, "").slice(0, 64)
-      if (!sanitizedName) return
-
-      const slots = Object.entries(payload.params || {})
-        .map(([k, v]) => {
-          // Sanitize key (allowlist) and value (strip control chars) before
-          // building the slash command — both reach the composer verbatim.
-          const cleanKey = String(k || "").replace(/[^A-Za-z0-9_-]/g, "").slice(0, 64)
-          if (!cleanKey) return ""
-          const cleanVal = String(v || "").replace(/[\r\n\x00-\x1f]/g, "")
-          const sval = /\s/.test(cleanVal) ? `"${cleanVal.replace(/"/g, '\\"')}"` : cleanVal
-
-          return `${cleanKey}=${sval}`
-        })
-        .filter(Boolean)
-        .join(' ')
-
-      const command = `/blueprint ${sanitizedName}${slots ? ' ' + slots : ''}`
       requestComposerInsert(command, { mode: 'block', target: 'main' })
       requestComposerFocus('main')
     })

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -318,11 +318,16 @@ export function DesktopController() {
 
       const slots = Object.entries(payload.params || {})
         .map(([k, v]) => {
+          // Sanitize key (allowlist) and value (strip control chars) before
+          // building the slash command — both reach the composer verbatim.
+          const cleanKey = String(k || "").replace(/[^A-Za-z0-9_-]/g, "").slice(0, 64)
+          if (!cleanKey) return ""
           const cleanVal = String(v || "").replace(/[\r\n\x00-\x1f]/g, "")
-          const sval = /\s/.test(String(v || "") ? `"${v.replace(/"/g, '\\"')}"` : v
+          const sval = /\s/.test(cleanVal) ? `"${cleanVal.replace(/"/g, '\\"')}"` : cleanVal
 
-          return `${k}=${sval}`
+          return `${cleanKey}=${sval}`
         })
+        .filter(Boolean)
         .join(' ')
 
       const command = `/blueprint ${sanitizedName}${slots ? ' ' + slots : ''}`

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -120,6 +120,12 @@ export function useSessionStateCache({
     }
 
     const created = createClientSessionState(storedSessionId ?? null)
+    // LRU eviction: cap cached sessions to prevent unbounded memory growth
+    const MAX_CACHED = 12
+    if (sessionStateByRuntimeIdRef.current.size >= MAX_CACHED) {
+      const oldestKey = sessionStateByRuntimeIdRef.current.keys().next().value
+      if (oldestKey) sessionStateByRuntimeIdRef.current.delete(oldestKey)
+    }
     sessionStateByRuntimeIdRef.current.set(sessionId, created)
 
     if (storedSessionId) {

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef, useEffect } from 'react'
 
 import { BrandMark } from '@/components/brand-mark'
 import { Button } from '@/components/ui/button'
@@ -255,11 +255,19 @@ function ManualView({ command, onDone }: { command: string; onDone: () => void }
   const { t } = useI18n()
   const u = t.updates
   const [copied, setCopied] = useState(false)
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+    }
+  }, [])
 
   const handleCopy = () => {
     void writeClipboardText(command).then(() => {
       setCopied(true)
-      window.setTimeout(() => setCopied(false), 1800)
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+      copyTimerRef.current = setTimeout(() => setCopied(false), 1800)
     })
   }
 

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { BrandMark } from '@/components/brand-mark'
 import { Button } from '@/components/ui/button'

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useState, useRef, useEffect } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 import { BrandMark } from '@/components/brand-mark'
 import { Button } from '@/components/ui/button'

--- a/apps/desktop/src/components/chat/terminal-output.tsx
+++ b/apps/desktop/src/components/chat/terminal-output.tsx
@@ -46,7 +46,7 @@ export function TerminalOutput({ className, text }: TerminalOutputProps) {
       data-selectable-text="true"
       ref={ref}
     >
-      <pre className="w-max min-w-full font-mono text-[0.5625rem] leading-[0.85rem] whitespace-pre text-muted-foreground/70">
+      <pre role="log" aria-live="polite" aria-label="Terminal output" className="w-max min-w-full font-mono text-[0.5625rem] leading-[0.85rem] whitespace-pre text-muted-foreground/70">
         {text}
       </pre>
     </div>

--- a/apps/desktop/src/components/ui/log-view.tsx
+++ b/apps/desktop/src/components/ui/log-view.tsx
@@ -8,6 +8,8 @@ import { cn } from '@/lib/utils'
 export function LogView({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
+      role="log"
+      aria-label="Log output"
       className={cn(
         'overflow-auto rounded-lg border border-(--ui-stroke-tertiary) px-2.5 py-1.5 font-mono text-[0.6875rem] leading-[1.5] whitespace-pre-wrap break-words text-(--ui-text-tertiary) [scrollbar-width:thin]',
         className

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -147,7 +147,7 @@ export async function listSessions(
 
   return {
     ...result,
-    sessions: result.sessions.slice(0, limit),
+    sessions: Array.isArray(result?.sessions) ? result.sessions.slice(0, limit) : [],
     offset: 0
   }
 }
@@ -188,7 +188,7 @@ export async function listAllProfileSessions(
 
   return {
     ...result,
-    sessions: result.sessions.slice(0, limit),
+    sessions: Array.isArray(result?.sessions) ? result.sessions.slice(0, limit) : [],
     offset: 0
   }
 }

--- a/apps/desktop/src/lib/blueprint-deep-link.test.ts
+++ b/apps/desktop/src/lib/blueprint-deep-link.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildBlueprintDeepLinkCommand } from './blueprint-deep-link'
+
+describe('buildBlueprintDeepLinkCommand', () => {
+  it('formats valid blueprint deep links for composer insertion', () => {
+    expect(
+      buildBlueprintDeepLinkCommand({
+        kind: 'blueprint',
+        name: 'morning-brief',
+        params: {
+          time: '08:00',
+          label: 'daily brief'
+        }
+      })
+    ).toBe('/blueprint morning-brief time=08:00 label="daily brief"')
+  })
+
+  it('drops unsafe names and rejects empty names after sanitization', () => {
+    expect(buildBlueprintDeepLinkCommand({ kind: 'blueprint', name: '../bad name', params: {} })).toBe(
+      '/blueprint badname'
+    )
+    expect(buildBlueprintDeepLinkCommand({ kind: 'blueprint', name: '💥', params: {} })).toBeNull()
+  })
+
+  it('skips unsafe parameter keys and strips control characters from values', () => {
+    expect(
+      buildBlueprintDeepLinkCommand({
+        kind: 'blueprint',
+        name: 'daily',
+        params: {
+          ok_key: 'hello\n/evil "quoted"',
+          'bad key': 'should-not-appear',
+          'bad=key': 'should-not-appear',
+          good2: 'plain\u0000value'
+        }
+      })
+    ).toBe('/blueprint daily ok_key="hello/evil \\"quoted\\"" good2=plainvalue')
+  })
+
+  it('ignores non-blueprint payloads', () => {
+    expect(buildBlueprintDeepLinkCommand(null)).toBeNull()
+    expect(buildBlueprintDeepLinkCommand({ kind: 'other', name: 'daily', params: {} })).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/blueprint-deep-link.ts
+++ b/apps/desktop/src/lib/blueprint-deep-link.ts
@@ -1,6 +1,5 @@
 const SAFE_IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/
 const UNSAFE_BLUEPRINT_NAME_RE = /[^A-Za-z0-9_-]/g
-const CONTROL_CHAR_RE = /[\u0000-\u001f\u007f]/g
 const MAX_BLUEPRINT_NAME_LENGTH = 64
 const MAX_PARAM_VALUE_LENGTH = 512
 
@@ -18,8 +17,18 @@ function sanitizeBlueprintName(value: unknown): string {
   return String(value ?? '').replace(UNSAFE_BLUEPRINT_NAME_RE, '').slice(0, MAX_BLUEPRINT_NAME_LENGTH)
 }
 
+function stripControlCharacters(value: string): string {
+  return Array.from(value)
+    .filter((char) => {
+      const codePoint = char.codePointAt(0) ?? 0
+
+      return codePoint > 0x1f && codePoint !== 0x7f
+    })
+    .join('')
+}
+
 function formatParamValue(value: unknown): string {
-  const cleanValue = String(value ?? '').replace(CONTROL_CHAR_RE, '').slice(0, MAX_PARAM_VALUE_LENGTH)
+  const cleanValue = stripControlCharacters(String(value ?? '')).slice(0, MAX_PARAM_VALUE_LENGTH)
 
   if (!/[\s"]/.test(cleanValue)) {
     return cleanValue
@@ -34,19 +43,23 @@ export function buildBlueprintDeepLinkCommand(rawPayload: unknown): string | nul
   }
 
   const payload = rawPayload as BlueprintDeepLinkPayload
+
   if (payload.kind !== 'blueprint') {
     return null
   }
 
   const sanitizedName = sanitizeBlueprintName(payload.name)
+
   if (!sanitizedName) {
     return null
   }
 
   const params = isRecord(payload.params) ? payload.params : {}
+
   const slots = Object.entries(params)
     .flatMap(([rawKey, rawValue]) => {
       const key = String(rawKey ?? '')
+
       if (!SAFE_IDENTIFIER_RE.test(key)) {
         return []
       }

--- a/apps/desktop/src/lib/blueprint-deep-link.ts
+++ b/apps/desktop/src/lib/blueprint-deep-link.ts
@@ -1,0 +1,59 @@
+const SAFE_IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/
+const UNSAFE_BLUEPRINT_NAME_RE = /[^A-Za-z0-9_-]/g
+const CONTROL_CHAR_RE = /[\u0000-\u001f\u007f]/g
+const MAX_BLUEPRINT_NAME_LENGTH = 64
+const MAX_PARAM_VALUE_LENGTH = 512
+
+type BlueprintDeepLinkPayload = {
+  kind?: unknown
+  name?: unknown
+  params?: unknown
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function sanitizeBlueprintName(value: unknown): string {
+  return String(value ?? '').replace(UNSAFE_BLUEPRINT_NAME_RE, '').slice(0, MAX_BLUEPRINT_NAME_LENGTH)
+}
+
+function formatParamValue(value: unknown): string {
+  const cleanValue = String(value ?? '').replace(CONTROL_CHAR_RE, '').slice(0, MAX_PARAM_VALUE_LENGTH)
+
+  if (!/[\s"]/.test(cleanValue)) {
+    return cleanValue
+  }
+
+  return `"${cleanValue.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
+
+export function buildBlueprintDeepLinkCommand(rawPayload: unknown): string | null {
+  if (!isRecord(rawPayload)) {
+    return null
+  }
+
+  const payload = rawPayload as BlueprintDeepLinkPayload
+  if (payload.kind !== 'blueprint') {
+    return null
+  }
+
+  const sanitizedName = sanitizeBlueprintName(payload.name)
+  if (!sanitizedName) {
+    return null
+  }
+
+  const params = isRecord(payload.params) ? payload.params : {}
+  const slots = Object.entries(params)
+    .flatMap(([rawKey, rawValue]) => {
+      const key = String(rawKey ?? '')
+      if (!SAFE_IDENTIFIER_RE.test(key)) {
+        return []
+      }
+
+      return [`${key}=${formatParamValue(rawValue)}`]
+    })
+    .join(' ')
+
+  return `/blueprint ${sanitizedName}${slots ? ' ' + slots : ''}`
+}

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -194,8 +194,12 @@ export function useLinkTitle(url?: null | string): string {
   return title
 }
 
+export function isSafeExternalUrl(url: string): boolean {
+  return /^(https?:|file:|hermes-media:)/i.test(url)
+}
+
 export function openExternalLink(href: string): void {
-  if (href) {
+  if (href && isSafeExternalUrl(href)) {
     void window.hermesDesktop?.openExternal?.(href)
   }
 }

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -121,7 +121,7 @@ export function isRemoteGateway(): boolean {
 export async function gatewayMediaDataUrl(path: string): Promise<string> {
   const file = filePathFromMediaPath(path)
 
-  const result = await window.hermesDesktop!.api<{ data_url: string }>({
+  const result = await window.hermesDesktop?.api<{ data_url: string }>({
     path: `/api/media?path=${encodeURIComponent(file)}`
   })
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -479,7 +479,7 @@ export function startUpdatePoller(): void {
   void checkUpdates()
   void checkBackendUpdates()
   void refreshDesktopVersion()
-  bridge.onProgress(ingestProgress)
+  progressUnsub = bridge.onProgress(ingestProgress)
 
   // The poller starts at mount, before the gateway connects — so the first
   // backend check above sees mode≠remote and no-ops. Re-check once the
@@ -501,12 +501,16 @@ export function startUpdatePoller(): void {
   }, 30 * 60 * 1000)
 }
 
+let progressUnsub: (() => void) | null = null
+
 export function stopUpdatePoller(): void {
   if (backgroundTimer !== null) {
     clearInterval(backgroundTimer)
     backgroundTimer = null
   }
 
+  progressUnsub?.()
+  progressUnsub = null
   connectionUnsub?.()
   connectionUnsub = null
   lastConnectionMode = undefined

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -376,6 +376,7 @@ export interface SessionResumeResponse {
   messages: SessionMessage[]
   resumed: string
   session_id: string
+  running?: boolean
 }
 
 export interface SessionRuntimeInfo {


### PR DESCRIPTION
## Summary
- Supersedes PR #49553 head `68c8f8b69b424d2f1fe5e924ec328cc3b3ac70fe` with the previously approved blueprint deep-link helper/test commits.
- Keeps the contributor's current repair commit in history, then cherry-picks the approved local remediation commits (`a518dbc5d`, `cd1d8c036`) on top.
- Fixes the current PR head's remaining focused eslint blockers (`no-control-regex`, import ordering, `curly`) in the desktop-controller deep-link path by moving the sanitization into a tested helper.

## Verification
Current PR head (`68c8f8b69`) evidence:
- `cd apps/desktop && npm run typecheck` -> PASS after linking the existing desktop dependency install into the temporary worktree.
- `cd apps/desktop && npx eslint src/app/desktop-controller.tsx src/app/updates-overlay.tsx` -> FAIL: 8 errors, including `no-control-regex`, import ordering, and `curly` violations.
- `src/lib/blueprint-deep-link.test.ts` was absent on current PR head, so the focused helper test could not run there.

Successor branch evidence (`operator/reconcile-pr-49553-approved-current`, head `a6956387a`):
- `cd apps/desktop && npm run test:ui -- src/lib/blueprint-deep-link.test.ts` -> PASS, 1 file / 4 tests.
- `cd apps/desktop && npm run typecheck` -> PASS.
- `cd apps/desktop && npx eslint src/lib/blueprint-deep-link.ts src/lib/blueprint-deep-link.test.ts src/app/desktop-controller.tsx` -> PASS with 0 errors and 2 padding warnings.
- Including `src/app/updates-overlay.tsx` in the eslint scope still reports only pre-existing/out-of-scope updates-overlay lint errors; the duplicate `useEffect` import is gone.
- `git diff --check origin/pr-49553..HEAD` -> PASS.

## Notes
- This PR intentionally does not merge or release anything.
- The branch is a reconciliation artifact for blocked PR #49553 / Kanban closeout.
