### PR TITLE
fix(dashboard): keep page headers visible and scope plugin CSS

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,8 +36,6 @@ import {
   Menu,
   MessageSquare,
   Package,
-  PanelLeftClose,
-  PanelLeftOpen,
   Plug,
   Puzzle,
   Radio,
@@ -344,34 +342,49 @@ function buildRoutes(
   return routes;
 }
 
-const SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
+const SIDEBAR_OPEN_KEY = "hermes-sidebar-open";
+/** @deprecated Replaced by SIDEBAR_OPEN_KEY — read once for migration. */
+const LEGACY_SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
+
+function readSidebarOpenFromStorage(): boolean {
+  try {
+    const storedOpen = localStorage.getItem(SIDEBAR_OPEN_KEY);
+    if (storedOpen !== null) return storedOpen !== "false";
+
+    const legacyCollapsed = localStorage.getItem(LEGACY_SIDEBAR_COLLAPSED_KEY);
+    if (legacyCollapsed !== null) {
+      // Old "collapsed" was a narrow icon rail; the new model is open (w-64)
+      // or fully closed — never a rail. Treat legacy collapsed=true as closed.
+      const open = legacyCollapsed !== "true";
+      localStorage.setItem(SIDEBAR_OPEN_KEY, open ? "true" : "false");
+      localStorage.removeItem(LEGACY_SIDEBAR_COLLAPSED_KEY);
+      return open;
+    }
+  } catch {
+    /* localStorage may be unavailable in private browsing */
+  }
+  return true;
+}
 
 export default function App() {
   const { t } = useI18n();
   const { pathname } = useLocation();
   const { manifests, loading: pluginsLoading } = usePlugins();
   const { theme } = useTheme();
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const closeMobile = useCallback(() => setMobileOpen(false), []);
-
-  const [collapsed, setCollapsed] = useState(() => {
+  const [sidebarOpen, setSidebarOpen] = useState(readSidebarOpenFromStorage);
+  const closeSidebar = useCallback(() => {
+    setSidebarOpen(false);
     try {
-      return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "true";
-    } catch {
-      return false;
-    }
-  });
-  const toggleCollapsed = useCallback(() => {
-    setCollapsed((prev) => {
-      const next = !prev;
-      try {
-        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
-      } catch { /* localStorage may be unavailable in private browsing */ }
-      return next;
-    });
+      localStorage.setItem(SIDEBAR_OPEN_KEY, "false");
+    } catch { /* localStorage may be unavailable in private browsing */ }
+  }, []);
+  const openSidebar = useCallback(() => {
+    setSidebarOpen(true);
+    try {
+      localStorage.setItem(SIDEBAR_OPEN_KEY, "true");
+    } catch { /* localStorage may be unavailable in private browsing */ }
   }, []);
   const isMobile = useBelowBreakpoint(1024);
-  const isDesktopCollapsed = collapsed && !isMobile;
   const tooltipWarmRef = useRef(0);
   const sidebarStatus = useSidebarStatus();
   const isDocsRoute = pathname === "/docs" || pathname === "/docs/";
@@ -457,9 +470,9 @@ export default function App() {
   const layoutVariant = theme.layoutVariant ?? "standard";
 
   useEffect(() => {
-    if (!mobileOpen) return;
+    if (!sidebarOpen || !isMobile) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setMobileOpen(false);
+      if (e.key === "Escape") closeSidebar();
     };
     document.addEventListener("keydown", onKey);
     const prevOverflow = document.body.style.overflow;
@@ -468,16 +481,7 @@ export default function App() {
       document.removeEventListener("keydown", onKey);
       document.body.style.overflow = prevOverflow;
     };
-  }, [mobileOpen]);
-
-  useEffect(() => {
-    const mql = window.matchMedia("(min-width: 1024px)");
-    const onChange = (e: MediaQueryListEvent) => {
-      if (e.matches) setMobileOpen(false);
-    };
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
+  }, [closeSidebar, isMobile, sidebarOpen]);
 
   return (
     <ProfileProvider>
@@ -510,9 +514,9 @@ export default function App() {
         <Button
           ghost
           size="icon"
-          onClick={() => setMobileOpen(true)}
+          onClick={openSidebar}
           aria-label={t.app.openNavigation}
-          aria-expanded={mobileOpen}
+          aria-expanded={sidebarOpen}
           aria-controls="app-sidebar"
           className="text-text-secondary hover:text-midground"
         >
@@ -524,11 +528,11 @@ export default function App() {
         </Typography>
       </header>
 
-      {mobileOpen && (
+      {sidebarOpen && isMobile && (
         <Button
           ghost
           aria-label={t.app.closeNavigation}
-          onClick={closeMobile}
+          onClick={closeSidebar}
           className={cn(
             "lg:hidden fixed inset-0 z-40 p-0 block",
             "bg-black/70",
@@ -541,18 +545,22 @@ export default function App() {
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-14 lg:pt-0">
         <div className="flex min-h-0 min-w-0 flex-1">
+          {(isMobile || sidebarOpen) && (
           <aside
             id="app-sidebar"
             aria-label={t.app.navigation}
+            aria-hidden={!sidebarOpen}
             className={cn(
-              "fixed top-0 left-0 z-50 flex h-dvh max-h-dvh w-64 min-h-0 flex-col font-sans",
+              "flex h-dvh max-h-dvh min-h-0 flex-col font-sans",
               "border-r border-current/20",
               "bg-background-base",
-              "transition-[transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]",
-              mobileOpen ? "translate-x-0" : "-translate-x-full",
-              "lg:sticky lg:top-0 lg:translate-x-0 lg:shrink-0 lg:overflow-hidden",
-              "lg:transition-[width] lg:duration-300 lg:ease-[cubic-bezier(0.23,1,0.32,1)]",
-              collapsed && "lg:w-14",
+              isMobile
+                ? cn(
+                    "fixed top-0 left-0 z-50 w-64",
+                    "transition-[transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]",
+                    sidebarOpen ? "translate-x-0" : "-translate-x-full",
+                  )
+                : "sticky top-0 z-50 w-64 min-w-64 max-w-64 shrink-0 overflow-hidden",
             )}
             style={{
               background: "var(--component-sidebar-background)",
@@ -564,15 +572,10 @@ export default function App() {
               className={cn(
                 "flex h-14 shrink-0 items-center gap-2",
                 "border-b border-current/20",
-                collapsed ? "lg:justify-center lg:px-0" : "px-4 justify-between",
+                "px-4 justify-between",
               )}
             >
-              <div
-                className={cn(
-                  "flex items-center gap-2",
-                  collapsed && "lg:hidden",
-                )}
-              >
+              <div className="flex items-center gap-2">
                 <PluginSlot name="header-left" />
 
                 <Typography className="font-bold text-[1.125rem] leading-[0.95] tracking-[0.0525rem] text-midground uppercase">
@@ -585,31 +588,15 @@ export default function App() {
               <Button
                 ghost
                 size="icon"
-                onClick={closeMobile}
+                onClick={closeSidebar}
                 aria-label={t.app.closeNavigation}
-                className="lg:hidden text-text-secondary hover:text-midground"
+                className="text-text-secondary hover:text-midground"
               >
                 <X />
               </Button>
-
-              <Button
-                ghost
-                size="icon"
-                onClick={toggleCollapsed}
-                aria-label={
-                  collapsed ? t.common.expand : t.common.collapse
-                }
-                className="hidden lg:flex text-text-secondary hover:text-midground"
-              >
-                {collapsed ? (
-                  <PanelLeftOpen className="h-4 w-4" />
-                ) : (
-                  <PanelLeftClose className="h-4 w-4" />
-                )}
-              </Button>
             </div>
 
-            <ProfileSwitcher collapsed={isDesktopCollapsed} />
+            <ProfileSwitcher collapsed={false} />
 
             <nav
               className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden border-t border-current/10 py-2"
@@ -618,8 +605,8 @@ export default function App() {
               <ul className="flex flex-col">
                 {sidebarNav.coreItems.map((item) => (
                   <SidebarNavLink
-                    closeMobile={closeMobile}
-                    collapsed={isDesktopCollapsed}
+                    closeMobile={isMobile ? closeSidebar : undefined}
+                    collapsed={false}
                     item={item}
                     key={item.path}
                     t={t}
@@ -638,7 +625,6 @@ export default function App() {
                     className={cn(
                       "px-5 pt-2.5 pb-1",
                       "font-sans text-display text-xs tracking-[0.12em] text-text-tertiary",
-                      isDesktopCollapsed && "lg:hidden",
                     )}
                     id="hermes-sidebar-plugin-nav-heading"
                   >
@@ -648,8 +634,8 @@ export default function App() {
                   <ul className="flex flex-col">
                     {sidebarNav.pluginItems.map((item) => (
                       <SidebarNavLink
-                        closeMobile={closeMobile}
-                        collapsed={isDesktopCollapsed}
+                        closeMobile={isMobile ? closeSidebar : undefined}
+                        collapsed={false}
                         item={item}
                         key={item.path}
                         t={t}
@@ -662,8 +648,8 @@ export default function App() {
             </nav>
 
             <SidebarSystemActions
-              collapsed={isDesktopCollapsed}
-              onNavigate={closeMobile}
+              collapsed={false}
+              onNavigate={isMobile ? closeSidebar : undefined}
               status={sidebarStatus}
               tooltipWarmRef={tooltipWarmRef}
             />
@@ -673,47 +659,57 @@ export default function App() {
                 "flex shrink-0 items-center gap-2",
                 "px-3 py-2",
                 "border-t border-current/20",
-                isDesktopCollapsed
-                  ? "lg:flex-col lg:items-start lg:gap-3 lg:py-3"
-                  : "justify-between",
+                "justify-between",
               )}
             >
-              <div
-                className={cn(
-                  "flex min-w-0 items-center gap-2",
-                  isDesktopCollapsed && "lg:flex-col lg:items-start",
-                )}
-              >
+              <div className="flex min-w-0 items-center gap-2">
                 <PluginSlot name="header-right" />
 
                 <SidebarIconWithTooltip
-                  collapsed={isDesktopCollapsed}
+                  collapsed={false}
                   label={t.theme?.switchTheme ?? "Switch theme"}
                   tooltipWarmRef={tooltipWarmRef}
                 >
-                  <ThemeSwitcher collapsed={isDesktopCollapsed} dropUp />
+                  <ThemeSwitcher collapsed={false} dropUp />
                 </SidebarIconWithTooltip>
 
                 <SidebarIconWithTooltip
-                  collapsed={isDesktopCollapsed}
+                  collapsed={false}
                   label={t.language.switchTo}
                   tooltipWarmRef={tooltipWarmRef}
                 >
-                  <LanguageSwitcher collapsed={isDesktopCollapsed} dropUp />
+                  <LanguageSwitcher collapsed={false} dropUp />
                 </SidebarIconWithTooltip>
               </div>
             </div>
 
-            <div
-              className={cn(
-                "flex shrink-0 flex-col",
-                isDesktopCollapsed && "lg:hidden",
-              )}
-            >
+            <div className="flex shrink-0 flex-col">
               <AuthWidget />
               <SidebarFooter status={sidebarStatus} />
             </div>
           </aside>
+          )}
+
+          {!isMobile && !sidebarOpen ? (
+            <div
+              className={cn(
+                "shrink-0 border-b border-current/20",
+                "bg-background-base px-3 py-2 sm:px-6",
+              )}
+              style={{ backgroundColor: "var(--background-base)" }}
+            >
+              <Button
+                ghost
+                size="icon"
+                onClick={openSidebar}
+                aria-label={t.app.openNavigation}
+                aria-controls="app-sidebar"
+                className="text-text-secondary hover:text-midground"
+              >
+                <Menu />
+              </Button>
+            </div>
+          ) : null}
 
           <PageHeaderProvider pluginTabs={pluginTabMeta}>
             <div
@@ -836,7 +832,7 @@ function SidebarNavLink({
       <NavLink
         to={path}
         end={path === "/sessions"}
-        onClick={closeMobile}
+        onClick={() => closeMobile?.()}
         aria-label={collapsed ? navLabel : undefined}
         onFocus={collapsed ? showTooltip : undefined}
         onBlur={collapsed ? hideTooltip : undefined}
@@ -975,21 +971,21 @@ function SidebarSystemActions({
     }
     void runAction(action);
     navigate("/sessions");
-    onNavigate();
+    onNavigate?.();
   };
 
   const confirmRestart = () => {
     setRestartConfirmOpen(false);
     void runAction("restart");
     navigate("/sessions");
-    onNavigate();
+    onNavigate?.();
   };
 
   const confirmUpdate = () => {
     setUpdateConfirmOpen(false);
     void runAction("update");
     navigate("/sessions");
-    onNavigate();
+    onNavigate?.();
   };
 
   return (
@@ -1317,7 +1313,7 @@ interface SidebarIconWithTooltipProps {
 }
 
 interface SidebarNavLinkProps {
-  closeMobile: () => void;
+  closeMobile?: () => void;
   collapsed: boolean;
   item: NavItem;
   t: Translations;
@@ -1326,7 +1322,7 @@ interface SidebarNavLinkProps {
 
 interface SidebarSystemActionsProps {
   collapsed: boolean;
-  onNavigate: () => void;
+  onNavigate?: () => void;
   status: StatusResponse | null;
   tooltipWarmRef: TooltipWarmRef;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -94,6 +94,7 @@ import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
 import type { Translations } from "@/i18n/types";
 import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
+import { usePluginStylesheets } from "@/plugins/usePluginStylesheets";
 import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
@@ -279,6 +280,20 @@ function partitionSidebarNav(
   return { coreItems, pluginItems };
 }
 
+/** Stable element refs so plugin-manifest refresh does not remount builtin pages. */
+const STABLE_BUILTIN_ROUTE_ELEMENTS = new Map<string, ReactNode>();
+
+function getStableRouteElement(
+  path: string,
+  Component: ComponentType,
+): ReactNode {
+  const cached = STABLE_BUILTIN_ROUTE_ELEMENTS.get(path);
+  if (cached) return cached;
+  const element = <Component key={path} />;
+  STABLE_BUILTIN_ROUTE_ELEMENTS.set(path, element);
+  return element;
+}
+
 function buildRoutes(
   builtinRoutes: Record<string, ComponentType>,
   manifests: PluginManifest[],
@@ -313,7 +328,11 @@ function buildRoutes(
         element: <PluginPage name={om.name} />,
       });
     } else {
-      routes.push({ key: `builtin:${path}`, path, element: <Component /> });
+      routes.push({
+        key: `builtin:${path}`,
+        path,
+        element: getStableRouteElement(path, Component),
+      });
     }
   }
 
@@ -370,6 +389,7 @@ export default function App() {
   const { t } = useI18n();
   const { pathname } = useLocation();
   const { manifests, loading: pluginsLoading } = usePlugins();
+  usePluginStylesheets(manifests, pathname);
   const { theme } = useTheme();
   const [sidebarOpen, setSidebarOpen] = useState(readSidebarOpenFromStorage);
   const closeSidebar = useCallback(() => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -101,6 +101,7 @@ import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
 import type { Translations } from "@/i18n/types";
 import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
+import { usePluginStylesheets } from "@/plugins/usePluginStylesheets";
 import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
@@ -304,6 +305,20 @@ function partitionSidebarNav(
   return { coreItems, pluginItems };
 }
 
+/** Stable element refs so plugin-manifest refresh does not remount builtin pages. */
+const STABLE_BUILTIN_ROUTE_ELEMENTS = new Map<string, ReactNode>();
+
+function getStableRouteElement(
+  path: string,
+  Component: ComponentType,
+): ReactNode {
+  const cached = STABLE_BUILTIN_ROUTE_ELEMENTS.get(path);
+  if (cached) return cached;
+  const element = <Component key={path} />;
+  STABLE_BUILTIN_ROUTE_ELEMENTS.set(path, element);
+  return element;
+}
+
 function buildRoutes(
   builtinRoutes: Record<string, ComponentType>,
   manifests: PluginManifest[],
@@ -338,7 +353,11 @@ function buildRoutes(
         element: <PluginPage name={om.name} />,
       });
     } else {
-      routes.push({ key: `builtin:${path}`, path, element: <Component /> });
+      routes.push({
+        key: `builtin:${path}`,
+        path,
+        element: getStableRouteElement(path, Component),
+      });
     }
   }
 
@@ -373,6 +392,7 @@ export default function App() {
   const { t } = useI18n();
   const { pathname } = useLocation();
   const { manifests, loading: pluginsLoading } = usePlugins();
+  usePluginStylesheets(manifests, pathname);
   const { theme } = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
   const closeMobile = useCallback(() => setMobileOpen(false), []);

--- a/web/src/contexts/PageHeaderProvider.tsx
+++ b/web/src/contexts/PageHeaderProvider.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useState, type ReactNode } from "react";
+import { useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useLocation } from "react-router-dom";
 import { PageHeaderContext } from "./page-header-context";
 import { resolvePageTitle } from "@/lib/resolve-page-title";
@@ -17,11 +17,15 @@ export function PageHeaderProvider({
   const [titleOverride, setTitleOverride] = useState<string | null>(null);
   const [afterTitle, setAfterTitle] = useState<ReactNode>(null);
   const [end, setEnd] = useState<ReactNode>(null);
+  const prevPathnameRef = useRef(pathname);
 
-  // Clear any per-page title / toolbar slots when the path changes. Child routes
-  // re-fill these on mount via usePageHeader.
+  // Clear per-page slots on navigation only (not the initial mount).
+  // Toolbar actions must register via useEffect so they run after this
+  // layout-phase reset — see SessionsPage / CronPage.
   /* eslint-disable react-hooks/set-state-in-effect */
   useLayoutEffect(() => {
+    if (prevPathnameRef.current === pathname) return;
+    prevPathnameRef.current = pathname;
     setTitleOverride(null);
     setAfterTitle(null);
     setEnd(null);
@@ -35,7 +39,6 @@ export function PageHeaderProvider({
   const displayTitle = titleOverride ?? defaultTitle;
 
   const isChatRoute = pathname === "/chat" || pathname === "/chat/";
-  /** Env jump-nav is wide — stack below title on small screens so KEYS stays readable. */
   const isEnvRoute =
     pathname === "/env" || pathname.startsWith("/env/");
 
@@ -50,33 +53,39 @@ export function PageHeaderProvider({
 
   return (
     <PageHeaderContext.Provider value={value}>
-      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
+      {/*
+        CSS grid: row 1 = page chrome (fixed height), row 2 = scrollable
+        outlet. Grid avoids flex min-height bugs where main content paints
+        over the header band on narrow viewports.
+      */}
+      <div className="grid min-h-0 w-full min-w-0 flex-1 grid-rows-[auto_minmax(0,1fr)] overflow-hidden">
         <header
           className={cn(
-            "z-1 w-full shrink-0",
+            "relative z-10 col-span-full w-full isolate",
             "box-border border-b border-current/20",
-            "bg-background-base",
-            // Mobile stacks title + toolbar — fixed h-14 clips content; desktop stays one row.
-            "min-h-0 overflow-x-hidden overflow-y-visible py-3 sm:h-14 sm:min-h-[3.5rem] sm:overflow-hidden sm:py-0",
+            "min-h-14 px-3 py-2 sm:px-6 sm:py-0",
           )}
+          style={{ backgroundColor: "var(--background-base)" }}
           role="banner"
         >
           <div
             className={cn(
-              "flex w-full min-w-0 flex-1 gap-3 px-3 sm:h-full sm:gap-3 sm:px-6",
+              "flex w-full min-w-0 gap-2 sm:min-h-14 sm:gap-3",
               isChatRoute
-                ? "flex-row items-center"
-                : "flex-col justify-center sm:flex-row sm:items-center",
+                ? "min-h-10 flex-row items-center"
+                : isEnvRoute
+                  ? "flex-col justify-center gap-2 sm:flex-row sm:items-center"
+                  : "min-h-10 flex-row items-center justify-between",
             )}
           >
             <div
               className={cn(
-                "flex min-w-0 flex-1 gap-2 sm:gap-3",
+                "flex min-w-0 gap-2 sm:gap-3",
                 afterTitle && isEnvRoute
-                  ? "flex-col items-start sm:flex-row sm:items-center"
+                  ? "flex-1 flex-col items-start sm:flex-row sm:items-center"
                   : afterTitle
-                    ? "flex-row flex-wrap items-center"
-                    : "flex-row items-center",
+                    ? "min-w-0 flex-1 flex-row flex-wrap items-center"
+                    : "min-w-0 shrink items-center",
               )}
             >
               <h1
@@ -88,6 +97,7 @@ export function PageHeaderProvider({
                       ? "shrink truncate"
                       : "truncate",
                 )}
+                style={{ mixBlendMode: "plus-lighter" }}
               >
                 {displayTitle}
               </h1>
@@ -108,10 +118,12 @@ export function PageHeaderProvider({
             {end ? (
               <div
                 className={cn(
-                  "flex min-w-0 sm:max-w-md sm:flex-1",
+                  "flex shrink-0 items-center",
                   isChatRoute
-                    ? "w-auto shrink-0 justify-end"
-                    : "w-full justify-start sm:justify-end",
+                    ? "justify-end"
+                    : isEnvRoute
+                      ? "w-full justify-start sm:w-auto sm:justify-end"
+                      : "justify-end",
                 )}
               >
                 {end}
@@ -122,9 +134,7 @@ export function PageHeaderProvider({
 
         <main
           className={cn(
-            "min-h-0 w-full min-w-0 flex-1 flex flex-col",
-            // Bottom inset for scrolled pages lives on the route outlet wrapper in
-            // `App.tsx` (`w-full min-w-0`) so it pads scrollable content, not flex chrome.
+            "relative z-0 col-span-full flex min-h-0 w-full min-w-0 flex-col",
             isChatRoute
               ? "overflow-hidden"
               : "overflow-y-auto overflow-x-hidden [scrollbar-gutter:stable]",

--- a/web/src/contexts/PageHeaderProvider.tsx
+++ b/web/src/contexts/PageHeaderProvider.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useState, type ReactNode } from "react";
+import { useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useLocation } from "react-router";
 import { PageHeaderContext } from "./page-header-context";
 import { resolvePageTitle } from "@/lib/resolve-page-title";
@@ -17,11 +17,15 @@ export function PageHeaderProvider({
   const [titleOverride, setTitleOverride] = useState<string | null>(null);
   const [afterTitle, setAfterTitle] = useState<ReactNode>(null);
   const [end, setEnd] = useState<ReactNode>(null);
+  const prevPathnameRef = useRef(pathname);
 
-  // Clear any per-page title / toolbar slots when the path changes. Child routes
-  // re-fill these on mount via usePageHeader.
+  // Clear per-page slots on navigation only (not the initial mount).
+  // Toolbar actions must register via useEffect so they run after this
+  // layout-phase reset — see SessionsPage / CronPage.
   /* eslint-disable react-hooks/set-state-in-effect */
   useLayoutEffect(() => {
+    if (prevPathnameRef.current === pathname) return;
+    prevPathnameRef.current = pathname;
     setTitleOverride(null);
     setAfterTitle(null);
     setEnd(null);
@@ -50,33 +54,39 @@ export function PageHeaderProvider({
 
   return (
     <PageHeaderContext.Provider value={value}>
-      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
+      {/*
+        CSS grid: row 1 = page chrome (fixed height), row 2 = scrollable
+        outlet. Grid avoids flex min-height bugs where main content paints
+        over the header band on narrow viewports.
+      */}
+      <div className="grid min-h-0 w-full min-w-0 flex-1 grid-rows-[auto_minmax(0,1fr)] overflow-hidden">
         <header
           className={cn(
-            "z-1 w-full shrink-0",
+            "relative z-10 col-span-full w-full isolate",
             "box-border border-b border-current/20",
-            "bg-background-base",
-            // Mobile stacks title + toolbar — fixed h-14 clips content; desktop stays one row.
-            "min-h-0 overflow-x-hidden overflow-y-visible py-3 sm:h-14 sm:min-h-[3.5rem] sm:overflow-hidden sm:py-0",
+            "min-h-14 px-3 py-2 sm:px-6 sm:py-0",
           )}
+          style={{ backgroundColor: "var(--background-base)" }}
           role="banner"
         >
           <div
             className={cn(
-              "flex w-full min-w-0 flex-1 gap-3 px-3 sm:h-full sm:gap-3 sm:px-6",
+              "flex w-full min-w-0 gap-2 sm:min-h-14 sm:gap-3",
               isChatRoute
-                ? "flex-row items-center"
-                : "flex-col justify-center sm:flex-row sm:items-center",
+                ? "min-h-10 flex-row items-center"
+                : isEnvRoute
+                  ? "flex-col justify-center gap-2 sm:flex-row sm:items-center"
+                  : "min-h-10 flex-row items-center justify-between",
             )}
           >
             <div
               className={cn(
-                "flex min-w-0 flex-1 gap-2 sm:gap-3",
+                "flex min-w-0 gap-2 sm:gap-3",
                 afterTitle && isEnvRoute
-                  ? "flex-col items-start sm:flex-row sm:items-center"
+                  ? "flex-1 flex-col items-start sm:flex-row sm:items-center"
                   : afterTitle
-                    ? "flex-row flex-wrap items-center"
-                    : "flex-row items-center",
+                    ? "min-w-0 flex-1 flex-row flex-wrap items-center"
+                    : "min-w-0 shrink items-center",
               )}
             >
               <h1
@@ -108,10 +118,12 @@ export function PageHeaderProvider({
             {end ? (
               <div
                 className={cn(
-                  "flex min-w-0 sm:max-w-md sm:flex-1",
+                  "flex shrink-0 items-center",
                   isChatRoute
-                    ? "w-auto shrink-0 justify-end"
-                    : "w-full justify-start sm:justify-end",
+                    ? "justify-end"
+                    : isEnvRoute
+                      ? "w-full justify-start sm:w-auto sm:justify-end"
+                      : "justify-end",
                 )}
               >
                 {end}
@@ -122,9 +134,7 @@ export function PageHeaderProvider({
 
         <main
           className={cn(
-            "min-h-0 w-full min-w-0 flex-1 flex flex-col",
-            // Bottom inset for scrolled pages lives on the route outlet wrapper in
-            // `App.tsx` (`w-full min-w-0`) so it pads scrollable content, not flex chrome.
+            "relative z-0 col-span-full flex min-h-0 w-full min-w-0 flex-col",
             isChatRoute
               ? "overflow-hidden"
               : "overflow-y-auto overflow-x-hidden [scrollbar-gutter:stable]",

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Clock, Pause, Pencil, Play, Trash2, X, Zap } from "lucide-react";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
@@ -6,20 +6,7 @@ import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { H2 } from "@nous-research/ui/ui/components/typography/h2";
 import { api } from "@/lib/api";
-import type {
-  CronJob,
-  CronDeliveryTarget,
-  ModelOptionsResponse,
-  ProfileInfo,
-  SkillInfo,
-  ToolsetInfo,
-} from "@/lib/api";
-import {
-  buildCronJobPayload,
-  cronJobHasExecutionContent,
-  cronJobFormFromJob,
-  type CronJobFormState,
-} from "@/lib/cron-job";
+import type { CronJob, CronDeliveryTarget, ProfileInfo, SkillInfo } from "@/lib/api";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import {
   DEFAULT_SCHEDULE_STATE,
@@ -29,7 +16,6 @@ import {
   buildScheduleString,
   describeSchedule,
   englishOrdinal,
-  parseScheduleString,
   type ScheduleBuilderState,
   type ScheduleDescribeStrings,
 } from "@/lib/schedule";
@@ -41,7 +27,6 @@ import { Card, CardContent } from "@nous-research/ui/ui/components/card";
 import { Input } from "@nous-research/ui/ui/components/input";
 import { Label } from "@nous-research/ui/ui/components/label";
 import { useI18n } from "@/i18n";
-import { usePageHeader } from "@/contexts/usePageHeader";
 import { PluginSlot } from "@/plugins";
 import { Segmented } from "@nous-research/ui/ui/components/segmented";
 import { AutomationBlueprints } from "@/components/AutomationBlueprints";
@@ -67,7 +52,14 @@ function getJobPrompt(job: CronJob): string {
   return asText(job.prompt);
 }
 
-function NameCheckboxPicker({
+/** Compact multi-select for attaching skills to a cron job.
+ *
+ * A checkbox list (native inputs — the `onValueChange` rule is Select-only)
+ * capped to a scrollable box. Skills already on the job but missing from the
+ * available list (e.g. removed from disk, or the job was created via CLI in
+ * another profile) are still rendered so saving doesn't silently drop them.
+ */
+function SkillsPicker({
   id,
   available,
   selected,
@@ -75,12 +67,12 @@ function NameCheckboxPicker({
   emptyLabel,
 }: {
   id: string;
-  available: Array<{ name: string; description?: string | null }>;
+  available: SkillInfo[];
   selected: string[];
-  onChange: (names: string[]) => void;
+  onChange: (skills: string[]) => void;
   emptyLabel: string;
 }) {
-  const names = available.map((item) => item.name);
+  const names = available.map((s) => s.name);
   const orphaned = selected.filter((s) => !names.includes(s));
   const all = [...orphaned.map((name) => ({ name, description: "" })), ...available];
 
@@ -98,329 +90,22 @@ function NameCheckboxPicker({
       id={id}
       className="max-h-36 overflow-y-auto border border-border bg-background/40 p-1"
     >
-      {all.map((item) => (
+      {all.map((skill) => (
         <label
-          key={item.name}
+          key={skill.name}
           className="flex cursor-pointer items-center gap-2 px-2 py-1 text-xs hover:bg-muted/40"
-          title={item.description || undefined}
+          title={skill.description || undefined}
         >
           <input
             type="checkbox"
             className="accent-foreground"
-            checked={selected.includes(item.name)}
-            onChange={(e) => toggle(item.name, e.target.checked)}
+            checked={selected.includes(skill.name)}
+            onChange={(e) => toggle(skill.name, e.target.checked)}
           />
-          <span className="font-mono-ui truncate">{item.name}</span>
+          <span className="font-mono-ui truncate">{skill.name}</span>
         </label>
       ))}
     </div>
-  );
-}
-
-interface CronJobEditorState extends CronJobFormState {
-  scheduleState: ScheduleBuilderState;
-}
-
-interface CronJobFormResources {
-  availableSkills: SkillInfo[];
-  availableToolsets: ToolsetInfo[];
-  modelOptions: ModelOptionsResponse | null;
-  deliveryTargets: CronDeliveryTarget[];
-}
-
-function emptyCronJobForm(): CronJobEditorState {
-  return {
-    name: "",
-    prompt: "",
-    schedule: "",
-    deliver: "local",
-    skills: [],
-    provider: "",
-    model: "",
-    base_url: "",
-    script: "",
-    no_agent: false,
-    context_from: "",
-    enabled_toolsets: [],
-    workdir: "",
-    scheduleState: { ...DEFAULT_SCHEDULE_STATE },
-  };
-}
-
-function editorFormFromJob(job: CronJob): CronJobEditorState {
-  const form = cronJobFormFromJob(job);
-  return { ...form, scheduleState: parseScheduleString(form.schedule) };
-}
-
-function buildCronJobPayloadFromEditor(form: CronJobEditorState) {
-  const { scheduleState, ...payloadForm } = form;
-  return buildCronJobPayload({
-    ...payloadForm,
-    schedule: buildScheduleString(scheduleState),
-  });
-}
-
-function selectOptions(
-  current: string,
-  options: Array<{ value: string; label: string }>,
-) {
-  const known = new Set(options.map((option) => option.value));
-  return [
-    ...options.map((option) => (
-      <SelectOption key={option.value} value={option.value}>
-        {option.label}
-      </SelectOption>
-    )),
-    ...(current && !known.has(current)
-      ? [
-          <SelectOption key={current} value={current}>
-            {current}
-          </SelectOption>,
-        ]
-      : []),
-  ];
-}
-
-function CronAdvancedFields({
-  idPrefix,
-  form,
-  onChange,
-  modelOptions,
-  availableToolsets,
-}: {
-  idPrefix: string;
-  form: CronJobEditorState;
-  onChange: (form: CronJobEditorState) => void;
-  modelOptions: ModelOptionsResponse | null;
-  availableToolsets: ToolsetInfo[];
-}) {
-  const update = <K extends keyof CronJobEditorState,>(
-    key: K,
-    next: CronJobEditorState[K],
-  ) => {
-    onChange({ ...form, [key]: next });
-  };
-
-  const providers = (modelOptions?.providers ?? []).filter(
-    (p) => p.authenticated !== false,
-  );
-  const selectedProvider = providers.find((p) => p.slug === form.provider);
-  const models = selectedProvider?.models ?? [];
-
-  return (
-    <details className="border border-border bg-background/30 p-3" open>
-      <summary className="cursor-pointer text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        Advanced fields
-      </summary>
-      <div className="mt-3 grid gap-3">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <div className="grid gap-1">
-            <Label htmlFor={`${idPrefix}-provider`}>Provider</Label>
-            <Select
-              id={`${idPrefix}-provider`}
-              value={form.provider}
-              onValueChange={(v) => {
-                onChange({ ...form, provider: v, model: "" });
-              }}
-            >
-              <SelectOption value="">Default</SelectOption>
-              {selectOptions(
-                form.provider,
-                providers.map((p) => ({ value: p.slug, label: p.name })),
-              )}
-            </Select>
-          </div>
-          <div className="grid gap-1">
-            <Label htmlFor={`${idPrefix}-model`}>Model</Label>
-            <Select
-              id={`${idPrefix}-model`}
-              value={form.model}
-              onValueChange={(v) => update("model", v)}
-            >
-              <SelectOption value="">Default</SelectOption>
-              {selectOptions(
-                form.model,
-                models.map((model) => ({ value: model, label: model })),
-              )}
-            </Select>
-          </div>
-        </div>
-
-        <div className="grid gap-1">
-          <Label htmlFor={`${idPrefix}-base-url`}>Base URL override</Label>
-          <Input
-            id={`${idPrefix}-base-url`}
-            placeholder="https://api.example.com/v1"
-            value={form.base_url}
-            onChange={(e) => update("base_url", e.target.value)}
-          />
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 items-end">
-          <label className="flex items-center gap-2 text-xs text-muted-foreground">
-            <input
-              type="checkbox"
-              className="accent-foreground"
-              checked={form.no_agent}
-              onChange={(e) => update("no_agent", e.target.checked)}
-            />
-            no_agent: run the script only and deliver stdout verbatim
-          </label>
-          <div className="grid gap-1">
-            <Label htmlFor={`${idPrefix}-script`}>Script</Label>
-            <Input
-              id={`${idPrefix}-script`}
-              value={form.script}
-              onChange={(e) => update("script", e.target.value)}
-              placeholder="relative/path/in/scripts"
-            />
-          </div>
-        </div>
-
-        <div className="grid gap-1">
-          <Label htmlFor={`${idPrefix}-workdir`}>Workdir</Label>
-          <Input
-            id={`${idPrefix}-workdir`}
-            value={form.workdir}
-            onChange={(e) => update("workdir", e.target.value)}
-            placeholder="/absolute/project/path"
-          />
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <div className="grid gap-1">
-            <Label htmlFor={`${idPrefix}-context-from`}>context_from job IDs</Label>
-            <textarea
-              id={`${idPrefix}-context-from`}
-              className="flex min-h-[64px] w-full border border-border bg-background/40 px-3 py-2 text-xs font-courier shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/30 focus-visible:border-foreground/25"
-              placeholder="one job id per line"
-              value={form.context_from}
-              onChange={(e) => update("context_from", e.target.value)}
-            />
-          </div>
-          <div className="grid gap-1">
-            <Label htmlFor={`${idPrefix}-toolsets`}>enabled_toolsets</Label>
-            <NameCheckboxPicker
-              id={`${idPrefix}-toolsets`}
-              available={availableToolsets}
-              selected={form.enabled_toolsets}
-              onChange={(v) => update("enabled_toolsets", v)}
-              emptyLabel="No toolsets available."
-            />
-          </div>
-        </div>
-      </div>
-    </details>
-  );
-}
-
-interface CronJobFormFieldsProps {
-  idPrefix: string;
-  autoFocus?: boolean;
-  form: CronJobEditorState;
-  resources: CronJobFormResources;
-  onChange: (form: CronJobEditorState) => void;
-}
-
-function CronJobFormFields({
-  idPrefix,
-  autoFocus,
-  form,
-  resources,
-  onChange,
-}: CronJobFormFieldsProps) {
-  const { t } = useI18n();
-  const { availableSkills, availableToolsets, deliveryTargets, modelOptions } = resources;
-  const update = <K extends keyof CronJobEditorState,>(
-    key: K,
-    next: CronJobEditorState[K],
-  ) => {
-    onChange({ ...form, [key]: next });
-  };
-  const onlyLocalAvailable =
-    deliveryTargets.filter((target) => target.id !== "local").length === 0;
-
-  const deliveryOptions = selectOptions(
-    form.deliver,
-    deliveryTargets.map((target) => {
-      const base = target.id === "local" ? t.cron.delivery.local : target.name;
-      if (target.id !== "local" && !target.home_target_set) {
-        const hint = t.cron.delivery.needsHomeChannel ?? "set a home channel first";
-        return { value: target.id, label: `${base} — ${hint}` };
-      }
-      return { value: target.id, label: base };
-    }),
-  );
-
-  return (
-    <>
-      <div className="grid gap-2">
-        <Label htmlFor={`${idPrefix}-name`}>{t.cron.nameOptional}</Label>
-        <Input
-          id={`${idPrefix}-name`}
-          autoFocus={autoFocus}
-          placeholder={t.cron.namePlaceholder}
-          value={form.name}
-          onChange={(e) => update("name", e.target.value)}
-        />
-      </div>
-
-      <div className="grid gap-2">
-        <Label htmlFor={`${idPrefix}-prompt`}>{t.cron.prompt}</Label>
-        <textarea
-          id={`${idPrefix}-prompt`}
-          className="flex min-h-[80px] w-full border border-border bg-background/40 px-3 py-2 text-sm font-courier shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/30 focus-visible:border-foreground/25"
-          placeholder={t.cron.promptPlaceholder}
-          value={form.prompt}
-          onChange={(e) => update("prompt", e.target.value)}
-        />
-      </div>
-
-      <ScheduleBuilder
-        value={form.scheduleState}
-        onChange={(state) => update("scheduleState", state)}
-      />
-
-      <div className="grid gap-2">
-        <Label htmlFor={`${idPrefix}-deliver`}>{t.cron.deliverTo}</Label>
-        <Select
-          id={`${idPrefix}-deliver`}
-          value={form.deliver}
-          onValueChange={(v) => update("deliver", v)}
-        >
-          {deliveryOptions}
-        </Select>
-        {onlyLocalAvailable && (
-          <p className="text-xs text-muted-foreground">
-            {t.cron.delivery.noneConfigured ??
-              "No messaging platforms configured. Set one up under Channels to deliver reports."}
-          </p>
-        )}
-      </div>
-
-      <div className="grid gap-2">
-        <Label htmlFor={`${idPrefix}-skills`}>Skills (optional)</Label>
-        <NameCheckboxPicker
-          id={`${idPrefix}-skills`}
-          available={availableSkills}
-          selected={form.skills}
-          onChange={(skills) => update("skills", skills)}
-          emptyLabel="No skills installed for this profile."
-        />
-        <p className="text-xs text-muted-foreground">
-          Selected skills are loaded before the prompt runs — the cron
-          sets when, the skill sets how.
-        </p>
-      </div>
-
-      <CronAdvancedFields
-        idPrefix={`${idPrefix}-advanced`}
-        form={form}
-        onChange={onChange}
-        modelOptions={modelOptions}
-        availableToolsets={availableToolsets}
-      />
-    </>
   );
 }
 
@@ -462,26 +147,6 @@ function getJobState(job: CronJob): string {
   return asText(job.state) || (job.enabled === false ? "disabled" : "scheduled");
 }
 
-function getRepeatDisplay(job: CronJob): string {
-  const repeat = job.repeat;
-  if (!repeat || repeat.times == null) return "forever";
-  const completed = repeat.completed ?? 0;
-  return completed > 0 ? `${completed}/${repeat.times}` : `${repeat.times} times`;
-}
-
-function getJobMode(job: CronJob): string {
-  if (job.no_agent) return "no_agent";
-  if (job.script) return "script+agent";
-  return "agent";
-}
-
-function getModelDisplay(job: CronJob): string {
-  const provider = asText(job.provider);
-  const model = asText(job.model);
-  if (provider && model) return `${provider}/${model}`;
-  return model || provider;
-}
-
 function getJobProfile(job: CronJob): string {
   return asText(job.profile) || asText(job.profile_name) || "default";
 }
@@ -516,8 +181,6 @@ export default function CronPage() {
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
   const { t, locale } = useI18n();
-  const { setEnd } = usePageHeader();
-
   // Translation surface for the human-readable schedule describer.
   // English ordinals are a special case ("1st", "2nd", "23rd"); every
   // other locale falls back to the plain numeric form, which avoids
@@ -535,25 +198,36 @@ export default function CronPage() {
 
   // New job modal state
   const [createModalOpen, setCreateModalOpen] = useState(false);
-  const [createProfile, setCreateProfile] = useState("default");
-  const [createForm, setCreateForm] = useState<CronJobEditorState>(
-    emptyCronJobForm,
+  const [prompt, setPrompt] = useState("");
+  // The schedule is now constructed via the ScheduleBuilder; we keep
+  // the full builder state so flipping between modes during edit
+  // doesn't erase the user's intermediate inputs. The actual string
+  // sent to the backend is derived via ``buildScheduleString`` at
+  // submit time.
+  const [scheduleState, setScheduleState] = useState<ScheduleBuilderState>(
+    DEFAULT_SCHEDULE_STATE,
   );
+  const [name, setName] = useState("");
   const closeCreateModal = useCallback(() => setCreateModalOpen(false), []);
   const createModalRef = useModalBehavior({
     open: createModalOpen,
     onClose: closeCreateModal,
   });
+  const [deliver, setDeliver] = useState("local");
+  const [jobSkills, setJobSkills] = useState<string[]>([]);
   const [deliveryTargets, setDeliveryTargets] = useState<CronDeliveryTarget[]>([
     { id: "local", name: "Local", home_target_set: true, home_env_var: null },
   ]);
   const [creating, setCreating] = useState(false);
+  const createProfile = selectedProfile === "all" ? "default" : selectedProfile;
 
   // Edit job modal state
   const [editJob, setEditJob] = useState<CronJob | null>(null);
-  const [editForm, setEditForm] = useState<CronJobEditorState>(
-    emptyCronJobForm,
-  );
+  const [editPrompt, setEditPrompt] = useState("");
+  const [editSchedule, setEditSchedule] = useState("");
+  const [editName, setEditName] = useState("");
+  const [editDeliver, setEditDeliver] = useState("local");
+  const [editSkills, setEditSkills] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
   const closeEditModal = useCallback(() => setEditJob(null), []);
   const editModalRef = useModalBehavior({
@@ -566,14 +240,16 @@ export default function CronPage() {
   // Keyed on the create-modal profile; the edit modal reuses the list —
   // a job's current skills are always shown even if not in it.
   const [availableSkills, setAvailableSkills] = useState<SkillInfo[]>([]);
-  const [availableToolsets, setAvailableToolsets] = useState<ToolsetInfo[]>([]);
-  const [modelOptions, setModelOptions] = useState<ModelOptionsResponse | null>(null);
-
-  const resourceProfile = editJob ? getJobProfile(editJob) : createProfile;
 
   const openEditModal = useCallback((job: CronJob) => {
     setEditJob(job);
-    setEditForm(editorFormFromJob(job));
+    setEditPrompt(getJobPrompt(job));
+    setEditSchedule(
+      asText(job.schedule?.expr) || asText(job.schedule_display) || "",
+    );
+    setEditName(getJobName(job));
+    setEditDeliver(asText(job.deliver) || "local");
+    setEditSkills(Array.isArray(job.skills) ? job.skills.filter(Boolean) : []);
   }, []);
 
   const loadJobs = useCallback(() => {
@@ -607,44 +283,102 @@ export default function CronPage() {
     loadJobs();
   }, [loadJobs]);
 
-  // Load resources from the profile the create/edit form actually targets.
-  // Pass "default" explicitly so the global dashboard profile switch cannot
-  // redirect a default-profile cron form to some other profile.
+  // Load installed skills for the profile new jobs will be created under.
+  // "" / "default" maps to the dashboard's own profile via the optional
+  // ?profile= scoping on /api/skills.
   useEffect(() => {
     let cancelled = false;
-    Promise.all([
-      api.getSkills(resourceProfile).catch(() => []),
-      api.getToolsets(resourceProfile).catch(() => []),
-      api.getModelOptions(resourceProfile).catch(() => null),
-    ]).then(([skills, toolsets, options]) => {
-      if (cancelled) return;
-      setAvailableSkills([...skills].sort((a, b) => a.name.localeCompare(b.name)));
-      setAvailableToolsets([...toolsets].sort((a, b) => a.name.localeCompare(b.name)));
-      setModelOptions(options);
-    });
+    api
+      .getSkills(createProfile === "default" ? undefined : createProfile)
+      .then((s) => {
+        if (!cancelled)
+          setAvailableSkills(
+            [...s].sort((a, b) => a.name.localeCompare(b.name)),
+          );
+      })
+      .catch(() => !cancelled && setAvailableSkills([]));
     return () => {
       cancelled = true;
     };
-  }, [resourceProfile]);
+  }, [createProfile]);
+
+  const scheduleString = buildScheduleString(scheduleState);
+
+  // Label for a delivery option. Configured platforms missing their cron home
+  // channel are still offered (option B), annotated so the user knows what to
+  // fix rather than wondering why delivery silently no-ops.
+  const deliverLabel = useCallback(
+    (target: CronDeliveryTarget): string => {
+      const base = target.id === "local" ? t.cron.delivery.local : target.name;
+      if (target.id !== "local" && !target.home_target_set) {
+        const hint = t.cron.delivery.needsHomeChannel ?? "set a home channel first";
+        return `${base} — ${hint}`;
+      }
+      return base;
+    },
+    [t.cron.delivery],
+  );
+
+  const renderDeliverOptions = useCallback(
+    () =>
+      deliveryTargets.map((target) => (
+        <SelectOption key={target.id} value={target.id}>
+          {deliverLabel(target)}
+        </SelectOption>
+      )),
+    [deliveryTargets, deliverLabel],
+  );
+
+  // The edit modal must always show the job's current target, even if that
+  // platform is no longer configured (e.g. job created via CLI, or the
+  // gateway was later removed) — otherwise the value would silently vanish
+  // from the dropdown and saving would drop it.
+  const renderEditDeliverOptions = useCallback(
+    (current: string) => {
+      const known = new Set(deliveryTargets.map((target) => target.id));
+      const options = deliveryTargets.map((target) => (
+        <SelectOption key={target.id} value={target.id}>
+          {deliverLabel(target)}
+        </SelectOption>
+      ));
+      if (current && !known.has(current)) {
+        options.push(
+          <SelectOption key={current} value={current}>
+            {current}
+          </SelectOption>,
+        );
+      }
+      return options;
+    },
+    [deliveryTargets, deliverLabel],
+  );
+
+  const onlyLocalAvailable =
+    deliveryTargets.filter((target) => target.id !== "local").length === 0;
 
   const handleCreate = async () => {
-    const payload = buildCronJobPayloadFromEditor(createForm);
-    if (
-      !payload.schedule ||
-      (!payload.no_agent && !cronJobHasExecutionContent(payload))
-    ) {
+    if (!prompt.trim() || !scheduleString) {
       showToast(`${t.cron.prompt} & ${t.cron.schedule} required`, "error");
-      return;
-    }
-    if (payload.no_agent && !payload.script) {
-      showToast("no_agent jobs require a script", "error");
       return;
     }
     setCreating(true);
     try {
-      await api.createCronJob(payload, createProfile);
+      await api.createCronJob(
+        {
+          prompt: prompt.trim(),
+          schedule: scheduleString,
+          name: name.trim() || undefined,
+          deliver,
+          skills: jobSkills.length > 0 ? jobSkills : undefined,
+        },
+        createProfile,
+      );
       showToast(t.common.create + " ✓", "success");
-      setCreateForm(emptyCronJobForm());
+      setPrompt("");
+      setScheduleState(DEFAULT_SCHEDULE_STATE);
+      setName("");
+      setDeliver("local");
+      setJobSkills([]);
       setCreateModalOpen(false);
       loadJobs();
     } catch (e) {
@@ -656,23 +390,21 @@ export default function CronPage() {
 
   const handleEdit = async () => {
     if (!editJob) return;
-    const payload = buildCronJobPayloadFromEditor(editForm);
-    if (
-      !payload.schedule ||
-      (!payload.no_agent && !cronJobHasExecutionContent(payload))
-    ) {
+    if (!editPrompt.trim() || !editSchedule.trim()) {
       showToast(`${t.cron.prompt} & ${t.cron.schedule} required`, "error");
-      return;
-    }
-    if (payload.no_agent && !payload.script) {
-      showToast("no_agent jobs require a script", "error");
       return;
     }
     setSaving(true);
     try {
       await api.updateCronJob(
         editJob.id,
-        payload,
+        {
+          prompt: editPrompt.trim(),
+          schedule: editSchedule.trim(),
+          name: editName.trim(),
+          deliver: editDeliver,
+          skills: editSkills,
+        },
         getJobProfile(editJob),
       );
       showToast("Saved changes ✓", "success");
@@ -742,25 +474,6 @@ export default function CronPage() {
     ),
   });
 
-  // Put "Create" button in page header
-  useLayoutEffect(() => {
-    setEnd(
-      <Button
-        className="uppercase"
-        size="sm"
-        onClick={() => {
-          setCreateProfile(selectedProfile === "all" ? "default" : selectedProfile);
-          setCreateModalOpen(true);
-        }}
-      >
-        {t.common.create}
-      </Button>,
-    );
-    return () => {
-      setEnd(null);
-    };
-  }, [setEnd, t.common.create, loading, selectedProfile]);
-
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
@@ -778,14 +491,23 @@ export default function CronPage() {
       <PluginSlot name="cron:top" />
       <Toast toast={toast} />
 
-      <Segmented
-        value={view}
-        onChange={(v) => setView(v as "jobs" | "blueprints")}
-        options={[
-          { value: "jobs", label: "Jobs" },
-          { value: "blueprints", label: "Blueprints" },
-        ]}
-      />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Segmented
+          value={view}
+          onChange={(v) => setView(v as "jobs" | "blueprints")}
+          options={[
+            { value: "jobs", label: "Jobs" },
+            { value: "blueprints", label: "Blueprints" },
+          ]}
+        />
+        <Button
+          className="uppercase sm:shrink-0"
+          size="sm"
+          onClick={() => setCreateModalOpen(true)}
+        >
+          {t.common.create}
+        </Button>
+      </div>
 
       {view === "blueprints" && (
         <AutomationBlueprints
@@ -814,13 +536,13 @@ export default function CronPage() {
       {createModalOpen && (
         <div
           ref={createModalRef}
-          className="fixed inset-0 z-[100] flex items-center justify-center bg-background/85 p-4"
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-background/85 backdrop-blur-sm p-4"
           onClick={(e) => e.target === e.currentTarget && setCreateModalOpen(false)}
           role="dialog"
           aria-modal="true"
           aria-labelledby="create-cron-title"
         >
-          <div className={cn(themedBody, "relative w-full max-w-3xl max-h-[90vh] border border-border bg-card shadow-2xl flex flex-col")}>
+          <div className={cn(themedBody, "relative w-full max-w-lg border border-border bg-card shadow-2xl flex flex-col")}>
             <Button
               ghost
               size="icon"
@@ -840,13 +562,13 @@ export default function CronPage() {
               </h2>
             </header>
 
-            <div className="min-h-0 overflow-y-auto p-5 grid gap-4">
+            <div className="p-5 grid gap-4">
               <div className="grid gap-2">
                 <Label htmlFor="cron-profile">Profile</Label>
                 <Select
                   id="cron-profile"
                   value={createProfile}
-                  onValueChange={(v) => setCreateProfile(v)}
+                  onValueChange={(v) => setSelectedProfile(v)}
                 >
                   {profiles.map((profile) => (
                     <SelectOption key={profile.name} value={profile.name}>
@@ -856,18 +578,64 @@ export default function CronPage() {
                 </Select>
               </div>
 
-              <CronJobFormFields
-                idPrefix="cron"
-                autoFocus
-                form={createForm}
-                onChange={setCreateForm}
-                resources={{
-                  availableSkills,
-                  availableToolsets,
-                  modelOptions,
-                  deliveryTargets,
-                }}
+              <div className="grid gap-2">
+                <Label htmlFor="cron-name">{t.cron.nameOptional}</Label>
+                <Input
+                  id="cron-name"
+                  autoFocus
+                  placeholder={t.cron.namePlaceholder}
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="cron-prompt">{t.cron.prompt}</Label>
+                <textarea
+                  id="cron-prompt"
+                  className="flex min-h-[80px] w-full border border-border bg-background/40 px-3 py-2 text-sm font-courier shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/30 focus-visible:border-foreground/25"
+                  placeholder={t.cron.promptPlaceholder}
+                  value={prompt}
+                  onChange={(e) => setPrompt(e.target.value)}
+                />
+              </div>
+
+              <ScheduleBuilder
+                value={scheduleState}
+                onChange={setScheduleState}
               />
+
+              <div className="grid gap-2">
+                <Label htmlFor="cron-deliver">{t.cron.deliverTo}</Label>
+                <Select
+                  id="cron-deliver"
+                  value={deliver}
+                  onValueChange={(v) => setDeliver(v)}
+                >
+                  {renderDeliverOptions()}
+                </Select>
+                {onlyLocalAvailable && (
+                  <p className="text-xs text-muted-foreground">
+                    {t.cron.delivery.noneConfigured ??
+                      "No messaging platforms configured. Set one up under Channels to deliver reports."}
+                  </p>
+                )}
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="cron-skills">Skills (optional)</Label>
+                <SkillsPicker
+                  id="cron-skills"
+                  available={availableSkills}
+                  selected={jobSkills}
+                  onChange={setJobSkills}
+                  emptyLabel="No skills installed for this profile."
+                />
+                <p className="text-xs text-muted-foreground">
+                  Selected skills are loaded before the prompt runs — the cron
+                  sets when, the skill sets how.
+                </p>
+              </div>
 
               <div className="flex justify-end">
                 <Button
@@ -889,13 +657,13 @@ export default function CronPage() {
       {editJob && (
         <div
           ref={editModalRef}
-          className="fixed inset-0 z-[100] flex items-center justify-center bg-background/85 p-4"
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-background/85 backdrop-blur-sm p-4"
           onClick={(e) => e.target === e.currentTarget && setEditJob(null)}
           role="dialog"
           aria-modal="true"
           aria-labelledby="edit-cron-title"
         >
-          <div className={cn(themedBody, "relative w-full max-w-3xl max-h-[90vh] border border-border bg-card shadow-2xl flex flex-col")}>
+          <div className={cn(themedBody, "relative w-full max-w-lg border border-border bg-card shadow-2xl flex flex-col")}>
             <Button
               ghost
               size="icon"
@@ -915,24 +683,64 @@ export default function CronPage() {
               </h2>
             </header>
 
-            <div className="min-h-0 overflow-y-auto p-5 grid gap-4">
-              <CronJobFormFields
-                idPrefix="edit-cron"
-                autoFocus
-                form={editForm}
-                onChange={setEditForm}
-                resources={{
-                  availableSkills,
-                  availableToolsets,
-                  modelOptions,
-                  deliveryTargets,
-                }}
-              />
+            <div className="p-5 grid gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="edit-cron-name">{t.cron.nameOptional}</Label>
+                <Input
+                  id="edit-cron-name"
+                  autoFocus
+                  placeholder={t.cron.namePlaceholder}
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                />
+              </div>
 
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-muted-foreground font-mono-ui truncate pr-4">
-                  {editJob.id}
-                </span>
+              <div className="grid gap-2">
+                <Label htmlFor="edit-cron-prompt">{t.cron.prompt}</Label>
+                <textarea
+                  id="edit-cron-prompt"
+                  className="flex min-h-[80px] w-full border border-border bg-background/40 px-3 py-2 text-sm font-courier shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/30 focus-visible:border-foreground/25"
+                  placeholder={t.cron.promptPlaceholder}
+                  value={editPrompt}
+                  onChange={(e) => setEditPrompt(e.target.value)}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="grid gap-2">
+                  <Label htmlFor="edit-cron-schedule">{t.cron.schedule}</Label>
+                  <Input
+                    id="edit-cron-schedule"
+                    placeholder={t.cron.schedulePlaceholder}
+                    value={editSchedule}
+                    onChange={(e) => setEditSchedule(e.target.value)}
+                  />
+                </div>
+
+                <div className="grid gap-2">
+                  <Label htmlFor="edit-cron-deliver">{t.cron.deliverTo}</Label>
+                  <Select
+                    id="edit-cron-deliver"
+                    value={editDeliver}
+                    onValueChange={(v) => setEditDeliver(v)}
+                  >
+                    {renderEditDeliverOptions(editDeliver)}
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="edit-cron-skills">Skills</Label>
+                <SkillsPicker
+                  id="edit-cron-skills"
+                  available={availableSkills}
+                  selected={editSkills}
+                  onChange={setEditSkills}
+                  emptyLabel="No skills installed for this profile."
+                />
+              </div>
+
+              <div className="flex justify-end">
                 <Button
                   className="uppercase"
                   size="sm"
@@ -992,11 +800,6 @@ export default function CronPage() {
           const deliver = asText(job.deliver);
           const profile = getJobProfile(job);
           const jobKey = getJobKey(job);
-          const mode = getJobMode(job);
-          const modelDisplay = getModelDisplay(job);
-          const toolsets = Array.isArray(job.enabled_toolsets)
-            ? job.enabled_toolsets.filter(Boolean)
-            : [];
 
           return (
             <Card key={jobKey}>
@@ -1020,19 +823,6 @@ export default function CronPage() {
                           : `${job.skills.length} skills`}
                       </Badge>
                     )}
-                    {mode !== "agent" && (
-                      <Badge tone="outline">{mode}</Badge>
-                    )}
-                    {modelDisplay && (
-                      <Badge tone="outline" title={modelDisplay}>
-                        model
-                      </Badge>
-                    )}
-                    {toolsets.length > 0 && (
-                      <Badge tone="outline" title={toolsets.join(", ")}>
-                        {toolsets.length} toolsets
-                      </Badge>
-                    )}
                   </div>
                   {hasName && promptText && (
                     <p className="text-xs text-muted-foreground truncate mb-1">
@@ -1043,7 +833,6 @@ export default function CronPage() {
                     <span className="font-mono-ui">
                       {getJobScheduleDisplay(job, scheduleDescribeStrings)}
                     </span>
-                    <span>repeat: {getRepeatDisplay(job)}</span>
                     <span>
                       {t.cron.last}: {formatTime(job.last_run_at)}
                     </span>
@@ -1051,11 +840,6 @@ export default function CronPage() {
                       {t.cron.next}: {formatTime(job.next_run_at)}
                     </span>
                   </div>
-                  {job.last_delivery_error && (
-                    <p className="text-xs text-destructive mt-1">
-                      delivery: {job.last_delivery_error}
-                    </p>
-                  )}
                   {job.last_error && (
                     <p className="text-xs text-destructive mt-1">
                       {job.last_error}

--- a/web/src/plugins/plugin-path.test.ts
+++ b/web/src/plugins/plugin-path.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { isPluginTabActive, normalizeDashboardPath } from "./plugin-path";
+
+describe("normalizeDashboardPath", () => {
+  it("strips trailing slashes", () => {
+    expect(normalizeDashboardPath("/cron/")).toBe("/cron");
+    expect(normalizeDashboardPath("/")).toBe("/");
+  });
+});
+
+describe("isPluginTabActive", () => {
+  it("matches exact tab paths", () => {
+    expect(isPluginTabActive("/livingcolor", "/livingcolor")).toBe(true);
+    expect(isPluginTabActive("/sessions", "/livingcolor")).toBe(false);
+  });
+
+  it("matches sub-routes under the tab", () => {
+    expect(isPluginTabActive("/livingcolor/projects/foo", "/livingcolor")).toBe(
+      true,
+    );
+  });
+});

--- a/web/src/plugins/plugin-path.test.ts
+++ b/web/src/plugins/plugin-path.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPluginTabActive,
+  normalizeDashboardPath,
+  pluginTabRoutePath,
+} from "./plugin-path";
+
+describe("normalizeDashboardPath", () => {
+  it("strips trailing slashes", () => {
+    expect(normalizeDashboardPath("/cron/")).toBe("/cron");
+    expect(normalizeDashboardPath("/")).toBe("/");
+  });
+});
+
+describe("pluginTabRoutePath", () => {
+  it("uses tab.path when the plugin is a new route", () => {
+    expect(pluginTabRoutePath({ path: "/livingcolor" })).toBe("/livingcolor");
+  });
+
+  it("uses tab.override when the plugin replaces a builtin route", () => {
+    expect(
+      pluginTabRoutePath({ path: "/livingcolor", override: "/cron" }),
+    ).toBe("/cron");
+  });
+});
+
+describe("isPluginTabActive", () => {
+  it("matches exact tab paths", () => {
+    expect(isPluginTabActive("/livingcolor", "/livingcolor")).toBe(true);
+    expect(isPluginTabActive("/sessions", "/livingcolor")).toBe(false);
+  });
+
+  it("matches sub-routes under the tab", () => {
+    expect(isPluginTabActive("/livingcolor/projects/foo", "/livingcolor")).toBe(
+      true,
+    );
+  });
+
+  it("activates an override plugin on the replaced route, not tab.path", () => {
+    const tab = { path: "/livingcolor", override: "/cron" };
+    const route = pluginTabRoutePath(tab);
+    expect(isPluginTabActive("/cron", route)).toBe(true);
+    expect(isPluginTabActive("/cron/jobs/1", route)).toBe(true);
+    expect(isPluginTabActive("/livingcolor", route)).toBe(false);
+  });
+});

--- a/web/src/plugins/plugin-path.ts
+++ b/web/src/plugins/plugin-path.ts
@@ -1,0 +1,12 @@
+/** Normalize dashboard paths for route matching (no trailing slash). */
+export function normalizeDashboardPath(path: string): string {
+  return path.replace(/\/$/, "") || "/";
+}
+
+/** True when `pathname` is the plugin tab or a sub-route of it. */
+export function isPluginTabActive(pathname: string, tabPath: string): boolean {
+  const current = normalizeDashboardPath(pathname);
+  const base = normalizeDashboardPath(tabPath);
+  if (base === "/") return current === "/";
+  return current === base || current.startsWith(`${base}/`);
+}

--- a/web/src/plugins/plugin-path.ts
+++ b/web/src/plugins/plugin-path.ts
@@ -1,0 +1,23 @@
+/** Normalize dashboard paths for route matching (no trailing slash). */
+export function normalizeDashboardPath(path: string): string {
+  return path.replace(/\/$/, "") || "/";
+}
+
+/**
+ * Path the plugin actually renders on. Override plugins replace a built-in
+ * route (`tab.override`) and never activate at `tab.path`.
+ */
+export function pluginTabRoutePath(tab: {
+  path: string;
+  override?: string;
+}): string {
+  return tab.override ?? tab.path;
+}
+
+/** True when `pathname` is the plugin tab or a sub-route of it. */
+export function isPluginTabActive(pathname: string, tabPath: string): boolean {
+  const current = normalizeDashboardPath(pathname);
+  const base = normalizeDashboardPath(tabPath);
+  if (base === "/") return current === "/";
+  return current === base || current.startsWith(`${base}/`);
+}

--- a/web/src/plugins/usePluginStylesheets.ts
+++ b/web/src/plugins/usePluginStylesheets.ts
@@ -1,0 +1,63 @@
+/**
+ * Route-scoped plugin CSS injection.
+ *
+ * Plugin bundles often ship a full Tailwind build (preflight resets on `*`,
+ * `html`, `body`). Loading that globally breaks the Hermes shell on every
+ * page once manifests arrive — only enable a plugin's stylesheet while its
+ * tab route (or a sub-route) is active.
+ */
+
+import { useEffect } from "react";
+import { HERMES_BASE_PATH } from "@/lib/api";
+import type { PluginManifest } from "./types";
+import { isPluginTabActive } from "./plugin-path";
+
+function stylesheetId(name: string): string {
+  return `hermes-plugin-css-${name}`;
+}
+
+export function usePluginStylesheets(
+  manifests: PluginManifest[],
+  pathname: string,
+): void {
+  useEffect(() => {
+    const activeNames = new Set(
+      manifests
+        .filter(
+          (m) => m.css && isPluginTabActive(pathname, m.tab.path),
+        )
+        .map((m) => m.name),
+    );
+
+    for (const manifest of manifests) {
+      if (!manifest.css) continue;
+      const id = stylesheetId(manifest.name);
+      const cssUrl = `${HERMES_BASE_PATH}/dashboard-plugins/${manifest.name}/${manifest.css}`;
+
+      // Drop legacy global <link> tags from the old loader (no id attribute).
+      for (const legacy of document.querySelectorAll<HTMLLinkElement>(
+        `link[rel="stylesheet"][href^="${cssUrl}"]`,
+      )) {
+        if (legacy.id !== id) legacy.remove();
+      }
+
+      const existing = document.getElementById(id) as HTMLLinkElement | null;
+
+      if (!activeNames.has(manifest.name)) {
+        existing?.remove();
+        continue;
+      }
+
+      if (existing) continue;
+
+      const link = document.createElement("link");
+      link.id = id;
+      link.rel = "stylesheet";
+      link.href = import.meta.env.DEV
+        ? `${cssUrl}?hermes_dv=${Date.now()}`
+        : cssUrl;
+      link.setAttribute("data-hermes-plugin-css", manifest.name);
+      document.head.appendChild(link);
+    }
+  }, [manifests, pathname]);
+}

--- a/web/src/plugins/usePluginStylesheets.ts
+++ b/web/src/plugins/usePluginStylesheets.ts
@@ -1,0 +1,64 @@
+/**
+ * Route-scoped plugin CSS injection.
+ *
+ * Plugin bundles often ship a full Tailwind build (preflight resets on `*`,
+ * `html`, `body`). Loading that globally breaks the Hermes shell on every
+ * page once manifests arrive — only enable a plugin's stylesheet while its
+ * rendered route (tab.override ?? tab.path, or a sub-route) is active.
+ */
+
+import { useEffect } from "react";
+import { HERMES_BASE_PATH } from "@/lib/api";
+import type { PluginManifest } from "./types";
+import { isPluginTabActive, pluginTabRoutePath } from "./plugin-path";
+
+function stylesheetId(name: string): string {
+  return `hermes-plugin-css-${name}`;
+}
+
+export function usePluginStylesheets(
+  manifests: PluginManifest[],
+  pathname: string,
+): void {
+  useEffect(() => {
+    const activeNames = new Set(
+      manifests
+        .filter(
+          (m) =>
+            m.css && isPluginTabActive(pathname, pluginTabRoutePath(m.tab)),
+        )
+        .map((m) => m.name),
+    );
+
+    for (const manifest of manifests) {
+      if (!manifest.css) continue;
+      const id = stylesheetId(manifest.name);
+      const cssUrl = `${HERMES_BASE_PATH}/dashboard-plugins/${manifest.name}/${manifest.css}`;
+
+      // Drop legacy global <link> tags from the old loader (no id attribute).
+      for (const legacy of document.querySelectorAll<HTMLLinkElement>(
+        `link[rel="stylesheet"][href^="${cssUrl}"]`,
+      )) {
+        if (legacy.id !== id) legacy.remove();
+      }
+
+      const existing = document.getElementById(id) as HTMLLinkElement | null;
+
+      if (!activeNames.has(manifest.name)) {
+        existing?.remove();
+        continue;
+      }
+
+      if (existing) continue;
+
+      const link = document.createElement("link");
+      link.id = id;
+      link.rel = "stylesheet";
+      link.href = import.meta.env.DEV
+        ? `${cssUrl}?hermes_dv=${Date.now()}`
+        : cssUrl;
+      link.setAttribute("data-hermes-plugin-css", manifest.name);
+      document.head.appendChild(link);
+    }
+  }, [manifests, pathname]);
+}

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -2,9 +2,9 @@
  * usePlugins hook — discovers and loads dashboard plugins.
  *
  * 1. Fetches plugin manifests from GET /api/dashboard/plugins
- * 2. Injects CSS <link> tags for plugins that declare css
- * 3. Loads plugin JS bundles via <script> tags
- * 4. Waits for plugins to call register() and resolves them
+ * 2. Loads plugin JS bundles via <script> tags
+ *    (CSS is injected route-scoped — see usePluginStylesheets)
+ * 3. Waits for plugins to call register() and resolves them
  */
 
 import { useState, useEffect, useRef } from "react";
@@ -41,17 +41,6 @@ export function usePlugins() {
     const injectedScripts: HTMLScriptElement[] = [];
 
     for (const manifest of manifests) {
-      // Inject CSS if specified.
-      if (manifest.css) {
-        const cssUrl = `${HERMES_BASE_PATH}/dashboard-plugins/${manifest.name}/${manifest.css}`;
-        if (!document.querySelector(`link[href="${cssUrl}"]`)) {
-          const link = document.createElement("link");
-          link.rel = "stylesheet";
-          link.href = cssUrl;
-          document.head.appendChild(link);
-        }
-      }
-
       // Load JS bundle. In dev, cache-bust so Vite HMR can clear the
       // in-memory registry while the browser would otherwise never
       // re-execute a previously cached <script> URL.

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -2,9 +2,9 @@
  * usePlugins hook — discovers and loads dashboard plugins.
  *
  * 1. Fetches plugin manifests from GET /api/dashboard/plugins
- * 2. Injects CSS <link> tags for plugins that declare css
- * 3. Loads plugin JS bundles via <script> tags
- * 4. Waits for plugins to call register() and resolves them
+ * 2. Loads plugin JS bundles via <script> tags
+ *    (CSS is injected route-scoped — see usePluginStylesheets)
+ * 3. Waits for plugins to call register() and resolves them
  */
 
 import { useState, useEffect, useRef } from "react";
@@ -100,17 +100,6 @@ export function usePlugins() {
     const injectedScripts: HTMLScriptElement[] = [];
 
     for (const manifest of manifests) {
-      // Inject CSS if specified.
-      if (manifest.css) {
-        const cssUrl = `${HERMES_BASE_PATH}/dashboard-plugins/${manifest.name}/${manifest.css}`;
-        if (!document.querySelector(`link[href="${cssUrl}"]`)) {
-          const link = document.createElement("link");
-          link.rel = "stylesheet";
-          link.href = cssUrl;
-          document.head.appendChild(link);
-        }
-      }
-
       // Load JS bundle. In dev, cache-bust so Vite HMR can clear the
       // in-memory registry while the browser would otherwise never
       // re-execute a previously cached <script> URL.


### PR DESCRIPTION
## Summary

- Scope plugin dashboard CSS to the active plugin route (including `tab.override`) so Tailwind preflight from plugins cannot reset global shell styles.
- Keep page headers (`/cron`, `/sessions`, etc.) on an opaque grid row so titles and actions stay visible.
- Stabilize builtin route elements so plugin manifest refresh does not remount pages.

## Unstacked from #49112

This PR no longer includes sidebar commits. It is based on current `main` and can merge independently of #49112.

## Sweeper feedback

- **`tab.override`:** `usePluginStylesheets` matches `tab.override ?? tab.path` via `pluginTabRoutePath`. Covered in `plugin-path.test.ts`.
- **CronPage form:** left untouched. The previous rewrite of Create-form state is dropped.

## Test plan

- [ ] `plugin-path.test.ts` — exact path, sub-route, and override cases
- [ ] Visit `/cron` — title stays visible after plugins load
- [ ] Visit `/sessions` — header does not overlap list content
- [ ] Open a plugin tab with bundled CSS — styles apply on that route only; `/sessions` shell unchanged after navigating away
- [ ] Plugin with `tab.override` — its CSS loads on the overridden route