### PR TITLE
feat(webhook): support platform:chat_id format in deliver config

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -262,18 +262,26 @@ class WebhookAdapter(BasePlatformAdapter):
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
 
+        # Parse platform:chat_id format (e.g. "telegram:-1003774178835")
+        # so webhook subscriptions can target a specific channel/chat.
+        target_platform = deliver_type
+        target_chat_id = None
+        if ":" in deliver_type:
+            parts = deliver_type.split(":", 2)
+            target_platform = parts[0].lower()
+            target_chat_id = parts[1] if len(parts) > 1 else None
+
         # Cross-platform delivery — any platform with a gateway adapter.
-        # Check both built-in names and plugin-registered platforms.
-        _is_known_platform = deliver_type in _BUILTIN_DELIVER_PLATFORMS
+        _is_known_platform = target_platform in _BUILTIN_DELIVER_PLATFORMS
         if not _is_known_platform:
             try:
                 from gateway.platform_registry import platform_registry
-                _is_known_platform = platform_registry.is_registered(deliver_type)
+                _is_known_platform = platform_registry.is_registered(target_platform)
             except Exception:
                 pass
         if self.gateway_runner and _is_known_platform:
             return await self._deliver_cross_platform(
-                deliver_type, content, delivery
+                target_platform, content, delivery, target_chat_id
             )
 
         logger.warning("[webhook] Unknown deliver type: %s", deliver_type)
@@ -977,9 +985,16 @@ class WebhookAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(e))
 
     async def _deliver_cross_platform(
-        self, platform_name: str, content: str, delivery: dict
+        self, platform_name: str, content: str, delivery: dict,
+        target_chat_id: Optional[str] = None,
     ) -> SendResult:
-        """Route response to another platform (telegram, discord, etc.)."""
+        """Route response to another platform (telegram, discord, etc.).
+
+        Priority for chat_id:
+        1. target_chat_id (from platform:chat_id format in deliver config)
+        2. deliver_extra.chat_id
+        3. Home channel for the platform
+        """
         if not self.gateway_runner:
             return SendResult(
                 success=False,
@@ -1000,9 +1015,11 @@ class WebhookAdapter(BasePlatformAdapter):
                 error=f"Platform {platform_name} not connected",
             )
 
-        # Use home channel if no specific chat_id in deliver_extra
-        extra = delivery.get("deliver_extra", {})
-        chat_id = extra.get("chat_id", "")
+        # Priority: target_chat_id > deliver_extra > home channel
+        chat_id = target_chat_id or ""
+        if not chat_id:
+            extra = delivery.get("deliver_extra", {})
+            chat_id = extra.get("chat_id", "")
         if not chat_id:
             home = self.gateway_runner.config.get_home_channel(target_platform)
             if home:
@@ -1015,6 +1032,7 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Pass thread_id from deliver_extra so Telegram forum topics work
         metadata = None
+        extra = delivery.get("deliver_extra", {})
         thread_id = extra.get("message_thread_id") or extra.get("thread_id")
         if thread_id:
             metadata = {"thread_id": thread_id}

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -262,14 +262,7 @@ class WebhookAdapter(BasePlatformAdapter):
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
 
-        # Parse platform:chat_id format (e.g. "telegram:-1003774178835")
-        # so webhook subscriptions can target a specific channel/chat.
-        target_platform = deliver_type
-        target_chat_id = None
-        if ":" in deliver_type:
-            parts = deliver_type.split(":", 2)
-            target_platform = parts[0].lower()
-            target_chat_id = parts[1] if len(parts) > 1 else None
+        target_platform, target_chat_id = self._parse_deliver_target(deliver_type)
 
         # Cross-platform delivery — any platform with a gateway adapter.
         _is_known_platform = target_platform in _BUILTIN_DELIVER_PLATFORMS
@@ -902,6 +895,23 @@ class WebhookAdapter(BasePlatformAdapter):
     # Response delivery
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _parse_deliver_target(deliver_type: str) -> tuple[str, Optional[str]]:
+        """Parse a deliver config value into (platform_name, chat_id).
+
+        Supports both bare platform names (``"telegram"``) and the
+        ``platform:chat_id`` format (``"telegram:-1003774178835"``).
+
+        Returns ``(platform, None)`` when no colon is present, or
+        ``(platform, chat_id)`` when the inline chat_id format is used.
+        """
+        if ":" not in deliver_type:
+            return deliver_type, None
+        parts = deliver_type.split(":", 2)
+        platform_name = parts[0].lower()
+        chat_id = parts[1] if len(parts) > 1 and parts[1] else None
+        return platform_name, chat_id
+
     async def _direct_deliver(
         self, content: str, delivery: dict
     ) -> SendResult:
@@ -924,10 +934,12 @@ class WebhookAdapter(BasePlatformAdapter):
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
 
+        target_platform, target_chat_id = self._parse_deliver_target(deliver_type)
+
         # Fall through to the cross-platform dispatcher, which validates the
         # target name and routes via the gateway runner.
         return await self._deliver_cross_platform(
-            deliver_type, content, delivery
+            target_platform, content, delivery, target_chat_id
         )
 
     async def _deliver_github_comment(

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -469,3 +469,197 @@ class TestDirectDeliverUnit:
             )
             assert result.success is True
             mock_gh.assert_awaited_once()
+
+
+# ===================================================================
+# platform:chat_id inline format — _direct_deliver (deliver_only mode)
+# ===================================================================
+
+class TestDirectDeliverInlineChatId:
+    """Regression tests for platform:chat_id format in deliver_only mode.
+
+    Sweeper review (teknium1) found that ``_direct_deliver()`` bypassed
+    the parser added to ``send()``, so ``deliver: "telegram:-100..."``
+    still reached ``Platform(platform_name)`` and failed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_inline_chat_id_routed_correctly(self):
+        """deliver_only with telegram:<chat_id> delivers to that chat."""
+        adapter = _make_adapter({})
+        mock_target = _wire_mock_target(adapter, "telegram")
+
+        result = await adapter._direct_deliver(
+            "alert!",
+            {"deliver": "telegram:-1003774178835", "deliver_extra": {}},
+        )
+        assert result.success is True
+        mock_target.send.assert_awaited_once()
+        chat_id_arg = mock_target.send.await_args.args[0]
+        assert chat_id_arg == "-1003774178835"
+
+    @pytest.mark.asyncio
+    async def test_inline_chat_id_takes_precedence_over_deliver_extra(self):
+        """target_chat_id wins over deliver_extra.chat_id."""
+        adapter = _make_adapter({})
+        mock_target = _wire_mock_target(adapter, "telegram")
+
+        result = await adapter._direct_deliver(
+            "alert!",
+            {
+                "deliver": "telegram:-1003774178835",
+                "deliver_extra": {"chat_id": "should-be-ignored"},
+            },
+        )
+        assert result.success is True
+        chat_id_arg = mock_target.send.await_args.args[0]
+        assert chat_id_arg == "-1003774178835"
+
+    @pytest.mark.asyncio
+    async def test_bare_platform_falls_back_to_deliver_extra(self):
+        """deliver_only with bare 'telegram' still uses deliver_extra.chat_id."""
+        adapter = _make_adapter({})
+        mock_target = _wire_mock_target(adapter, "telegram")
+
+        result = await adapter._direct_deliver(
+            "hello",
+            {"deliver": "telegram", "deliver_extra": {"chat_id": "c-1"}},
+        )
+        assert result.success is True
+        chat_id_arg = mock_target.send.await_args.args[0]
+        assert chat_id_arg == "c-1"
+
+    @pytest.mark.asyncio
+    async def test_bare_platform_falls_back_to_home_channel(self):
+        """deliver_only with bare 'telegram' and no deliver_extra uses home channel."""
+        adapter = _make_adapter({})
+        mock_target = _wire_mock_target(adapter, "telegram")
+
+        # Configure mock home channel
+        mock_home = MagicMock()
+        mock_home.chat_id = "home-chat-99"
+        adapter.gateway_runner.config.get_home_channel.return_value = mock_home
+
+        result = await adapter._direct_deliver(
+            "hello",
+            {"deliver": "telegram", "deliver_extra": {}},
+        )
+        assert result.success is True
+        chat_id_arg = mock_target.send.await_args.args[0]
+        assert chat_id_arg == "home-chat-99"
+
+
+# ===================================================================
+# platform:chat_id inline format — send() (agent mode)
+# ===================================================================
+
+class TestSendInlineChatId:
+    """Regression tests for platform:chat_id format in agent-mode send()."""
+
+    @pytest.mark.asyncio
+    async def test_inline_chat_id_routed_correctly(self):
+        """Agent-mode send() with telegram:<chat_id> delivers to that chat."""
+        adapter = _make_adapter({})
+        mock_target = _wire_mock_target(adapter, "telegram")
+
+        # Populate _delivery_info as the webhook handler would
+        chat_id = "webhook:route:delivery-1"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram:-1003774178835",
+            "deliver_extra": {},
+        }
+
+        result = await adapter.send(chat_id, "agent response")
+        assert result.success is True
+        mock_target.send.assert_awaited_once()
+        target_chat_id = mock_target.send.await_args.args[0]
+        assert target_chat_id == "-1003774178835"
+
+    @pytest.mark.asyncio
+    async def test_inline_chat_id_takes_precedence_over_deliver_extra(self):
+        """In agent mode, target_chat_id wins over deliver_extra.chat_id."""
+        adapter = _make_adapter({})
+        mock_target = _wire_mock_target(adapter, "telegram")
+
+        chat_id = "webhook:route:delivery-2"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram:-1003774178835",
+            "deliver_extra": {"chat_id": "should-be-ignored"},
+        }
+
+        result = await adapter.send(chat_id, "agent response")
+        assert result.success is True
+        target_chat_id = mock_target.send.await_args.args[0]
+        assert target_chat_id == "-1003774178835"
+
+    @pytest.mark.asyncio
+    async def test_bare_platform_falls_back_to_deliver_extra(self):
+        """Agent-mode send() with bare 'telegram' uses deliver_extra.chat_id."""
+        adapter = _make_adapter({})
+        mock_target = _wire_mock_target(adapter, "telegram")
+
+        chat_id = "webhook:route:delivery-3"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram",
+            "deliver_extra": {"chat_id": "c-extra"},
+        }
+
+        result = await adapter.send(chat_id, "agent response")
+        assert result.success is True
+        target_chat_id = mock_target.send.await_args.args[0]
+        assert target_chat_id == "c-extra"
+
+    @pytest.mark.asyncio
+    async def test_bare_platform_falls_back_to_home_channel(self):
+        """Agent-mode send() with bare 'telegram' and no extra uses home channel."""
+        adapter = _make_adapter({})
+        mock_target = _wire_mock_target(adapter, "telegram")
+
+        mock_home = MagicMock()
+        mock_home.chat_id = "home-chat-42"
+        adapter.gateway_runner.config.get_home_channel.return_value = mock_home
+
+        chat_id = "webhook:route:delivery-4"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram",
+            "deliver_extra": {},
+        }
+
+        result = await adapter.send(chat_id, "agent response")
+        assert result.success is True
+        target_chat_id = mock_target.send.await_args.args[0]
+        assert target_chat_id == "home-chat-42"
+
+
+# ===================================================================
+# _parse_deliver_target unit tests
+# ===================================================================
+
+class TestParseDeliverTarget:
+    """Unit tests for the shared parser used by send() and _direct_deliver()."""
+
+    def test_bare_platform(self):
+        p, c = WebhookAdapter._parse_deliver_target("telegram")
+        assert p == "telegram"
+        assert c is None
+
+    def test_platform_with_chat_id(self):
+        p, c = WebhookAdapter._parse_deliver_target("telegram:-1003774178835")
+        assert p == "telegram"
+        assert c == "-1003774178835"
+
+    def test_platform_uppercase_normalized(self):
+        p, c = WebhookAdapter._parse_deliver_target("Telegram:-100123")
+        assert p == "telegram"
+        assert c == "-100123"
+
+    def test_platform_with_empty_chat_id(self):
+        """'telegram:' → platform='telegram', chat_id=None (falls back)."""
+        p, c = WebhookAdapter._parse_deliver_target("telegram:")
+        assert p == "telegram"
+        assert c is None
+
+    def test_discord_with_chat_id(self):
+        p, c = WebhookAdapter._parse_deliver_target("discord:123456789")
+        assert p == "discord"
+        assert c == "123456789"


### PR DESCRIPTION
## Summary

Allow webhook subscriptions to use `telegram:-1003774178835` format in the `deliver` field to target a specific channel or chat, not just the home channel.

## Problem

When configuring a webhook subscription with `--deliver "telegram:-1003774178835"`, the webhook adapter treated the entire string as a platform name and failed with `Unknown deliver type: telegram:-1003774178835`. This forced users to either:
- Deliver to the home channel only (no per-webhook targeting)
- Use `deliver_extra.chat_id` (which also didn't work for agent-mode webhooks)

## Changes

### `gateway/platforms/webhook.py`

1. **`send()` method** — Parse `platform:chat_id` format before platform lookup:
   - Split on `:` to extract platform name and optional chat_id
   - Pass `target_chat_id` to `_deliver_cross_platform`

2. **`_deliver_cross_platform()` method** — Accept optional `target_chat_id` parameter:
   - Priority: `target_chat_id` > `deliver_extra.chat_id` > home channel
   - Backward compatible — all existing callers pass `None`

## Usage

```bash
hermes webhook subscribe my-route \
  --deliver "telegram:-1003774178835" \
  --prompt "Alert: {raw}"
```

## Testing

- Existing webhook subscriptions with `deliver: telegram` continue to use home channel (no change)
- New subscriptions with `deliver: telegram:-1003774178835` deliver to the specified chat
- `deliver_extra.chat_id` still works as fallback