### PR TITLE
feat(desktop): add configurable terminal font family (terminal.font_family in config.yaml)

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -553,7 +553,7 @@ export function DesktopController() {
     requestGateway
   })
 
-  const { refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds } = useHermesConfig({
+  const { refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds, terminalFontFamily } = useHermesConfig({
     activeSessionIdRef,
     refreshProjectBranch
   })
@@ -952,7 +952,7 @@ export function DesktopController() {
   // where it shows. Lives in main's stacking context (not the root overlay layer)
   // so pane resize handles still paint above it. Toggling never rebuilds the shell.
   const mainOverlays = (
-    <PersistentTerminal cwd={currentCwd} onAddSelectionToChat={composer.addTerminalSelectionAttachment} />
+    <PersistentTerminal cwd={currentCwd} fontFamily={terminalFontFamily} onAddSelectionToChat={composer.addTerminalSelectionAttachment} />
   )
 
   const overlays = (

--- a/apps/desktop/src/app/right-sidebar/terminal/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/index.tsx
@@ -14,14 +14,16 @@ import { useTerminalSession } from './use-terminal-session'
 
 interface TerminalTabProps {
   cwd: string
+  fontFamily: string
   onAddSelectionToChat: (text: string, label?: string) => void
 }
 
-export function TerminalTab({ cwd, onAddSelectionToChat }: TerminalTabProps) {
+export function TerminalTab({ cwd, fontFamily, onAddSelectionToChat }: TerminalTabProps) {
   const { t } = useI18n()
 
   const { addSelectionToChat, hostRef, selection, selectionStyle, shellName, status } = useTerminalSession({
     cwd,
+    fontFamily,
     onAddSelectionToChat
   })
 

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -39,6 +39,7 @@ export function TerminalSlot({ className = SLOT_CLASS }: { className?: string })
 
 interface PersistentTerminalProps {
   cwd: string
+  fontFamily: string
   onAddSelectionToChat: (text: string, label?: string) => void
 }
 
@@ -52,7 +53,7 @@ interface Rect {
 const sameRect = (a: Rect | null, b: Rect) =>
   !!a && a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height
 
-export function PersistentTerminal({ cwd, onAddSelectionToChat }: PersistentTerminalProps) {
+export function PersistentTerminal({ cwd, fontFamily, onAddSelectionToChat }: PersistentTerminalProps) {
   const slot = useStore($slot)
   const [rect, setRect] = useState<Rect | null>(null)
   const [ready, setReady] = useState(false)
@@ -116,7 +117,7 @@ export function PersistentTerminal({ cwd, onAddSelectionToChat }: PersistentTerm
   // new line. After first measurement we keep it mounted forever.
   return (
     <div aria-hidden={!visible} style={style}>
-      {ready && <TerminalTab cwd={cwd} onAddSelectionToChat={onAddSelectionToChat} />}
+      {ready && <TerminalTab cwd={cwd} fontFamily={fontFamily} onAddSelectionToChat={onAddSelectionToChat} />}
     </div>
   )
 }

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -133,6 +133,7 @@ function stripInitialPromptGap(data: string) {
 
 interface UseTerminalSessionOptions {
   cwd: string
+  fontFamily: string
   onAddSelectionToChat: (text: string, label?: string) => void
 }
 
@@ -232,7 +233,7 @@ function quotePathForShell(path: string, shellName: string): string {
   return `'${path.replace(/'/g, "'\\''")}'`
 }
 
-export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSessionOptions) {
+export function useTerminalSession({ cwd, fontFamily, onAddSelectionToChat }: UseTerminalSessionOptions) {
   // Key off renderedMode (the painted surface type), not resolvedMode (the
   // clicked switch) — a skin can keep a light surface in "dark" mode, and we
   // must match the surface or the ANSI palette inverts against it. themeName
@@ -337,7 +338,7 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
       allowTransparency: false,
       convertEol: true,
       cursorBlink: true,
-      fontFamily: "'JetBrains Mono', 'Cascadia Code', 'SF Mono', Menlo, Consolas, monospace",
+      fontFamily: fontFamily || "'JetBrains Mono', 'Cascadia Code', 'SF Mono', Menlo, Consolas, monospace",
       fontSize: 11,
       // VS Code's terminal renders 'normal'/'bold' (400/700); we were using Medium
       // (500) as the base, which reads a touch heavy at this size.

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -28,6 +28,7 @@ interface HermesConfigOptions {
 export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: HermesConfigOptions) {
   const [voiceMaxRecordingSeconds, setVoiceMaxRecordingSeconds] = useState(DEFAULT_VOICE_SECONDS)
   const [sttEnabled, setSttEnabled] = useState(true)
+  const [terminalFontFamily, setTerminalFontFamily] = useState('')
 
   const refreshHermesConfig = useCallback(async () => {
     try {
@@ -65,10 +66,11 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
 
       setVoiceMaxRecordingSeconds(recordingLimit(config.voice?.max_recording_seconds))
       setSttEnabled(config.stt?.enabled !== false)
+      setTerminalFontFamily(config.terminal?.font_family ?? '')
     } catch {
       // Config is nice-to-have; chat still works without it.
     }
   }, [activeSessionIdRef, refreshProjectBranch])
 
-  return { refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds }
+  return { refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds, terminalFontFamily }
 }

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -295,6 +295,7 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     cwd: 'Working Directory',
     backend: 'Execution Backend',
     timeout: 'Command Timeout',
+    fontFamily: 'Terminal Font',
     persistentShell: 'Persistent Shell',
     envPassthrough: 'Environment Passthrough',
     dockerImage: 'Docker Image',
@@ -442,6 +443,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   },
   terminal: {
     cwd: 'Default project folder for tool and terminal work.',
+    fontFamily: 'CSS font-family for the desktop embedded terminal (xterm.js). Set to a Nerd Font name like CaskaydiaCoveNerdFont to render icon glyphs correctly.',
     persistentShell: 'Keep shell state between commands when the backend supports it.',
     envPassthrough: 'Environment variables to pass into tool execution.',
     dockerImage: 'Container image used when the execution backend is Docker.',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -211,6 +211,7 @@ export interface HermesConfig {
   }
   terminal?: {
     cwd?: string
+    font_family?: string
   }
   stt?: {
     enabled?: boolean

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1097,6 +1097,14 @@ DEFAULT_CONFIG = {
         # When on, SETUID/SETGID caps are omitted from the container since
         # no privilege drop is needed.
         "docker_run_as_host_user": False,
+        # Terminal font family for the desktop app's embedded xterm.js terminal.
+        # When set (e.g. "'CaskaydiaCoveNerdFont', 'JetBrains Mono', monospace"),
+        # the desktop terminal uses this as the CSS font-family value, with the
+        # built-in default ("'JetBrains Mono', 'Cascadia Code', 'SF Mono', Menlo,
+        # Consolas, monospace") as fallback when the field is empty or unset.
+        # This lets users install a Nerd Font (or any custom font) and configure
+        # it here without patching the built desktop app.
+        "font_family": "",
         # Persistent shell — keep a long-lived bash shell across execute() calls
         # so cwd/env vars/shell variables survive between commands.
         # Enabled by default for non-local backends (SSH); local is always opt-in


### PR DESCRIPTION
## Summary

Adds a new config option `terminal.font_family` that lets users customize the CSS font-family for the desktop app's embedded xterm.js terminal.

## Problem

The embedded terminal font was hardcoded to:
```
JetBrains Mono, Cascadia Code, SF Mono, Menlo, Consolas, monospace
```

None of these are Nerd Fonts, so Nerd Font-only glyphs (like Starship prompt icons for the Windows logo) render as tofu/boxes. Users who have Nerd Fonts installed cannot configure the terminal to use them without patching the built desktop app JS.

## Solution

Thread a new config value `terminal.font_family` from `config.yaml` through to the xterm.js Terminal constructor:

1. Python backend (`hermes_cli/config.py`): added `"font_family": ""` to the terminal section of `DEFAULT_CONFIG`
2. TypeScript types (`types/hermes.ts`): added `font_family?: string` to `HermesConfig.terminal`
3. Config hook (`use-hermes-config.ts`): reads `config.terminal?.font_family` and exposes it as `terminalFontFamily`
4. Component chain (`desktop-controller.tsx` -> `persistent.tsx` -> `index.tsx` -> `use-terminal-session.ts`): passes the value down to the Terminal constructor
5. Fallback: when the field is empty or unset, the original hardcoded default is preserved (backward compatible)

## Usage

```yaml
# config.yaml
terminal:
  font_family: "'CaskaydiaCoveNerdFont', 'JetBrains Mono', monospace"
```

After restarting the desktop app, Nerd Font icons in the embedded terminal will render correctly.

## Files changed

- `hermes_cli/config.py` - added `font_family` default + documentation
- `apps/desktop/src/types/hermes.ts` - added type
- `apps/desktop/src/app/session/hooks/use-hermes-config.ts` - reads config value
- `apps/desktop/src/app/desktop-controller.tsx` - wires value to terminal
- `apps/desktop/src/app/right-sidebar/terminal/persistent.tsx` - passes through
- `apps/desktop/src/app/right-sidebar/terminal/index.tsx` - passes through
- `apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts` - uses config value with fallback
- `apps/desktop/src/app/settings/constants.ts` - field label + description for Settings UI

## Testing

- Verified config parsing: empty value falls back to built-in default
- Settings UI displays "Terminal Font" field with description
- The field supports arbitrary CSS font-family syntax (single font, font stacks, Nerd Font names)
- Non-empty value overrides the xterm fontFamily in the Terminal constructor
- No regressions: when `font_family` is unset or empty, behavior is identical to before
- Pre-existing TypeScript lint errors untouched (all are path-alias resolution issues in test/build context)
