### PR TITLE
fix(security): bound VS Code Marketplace theme inflation against zip bombs

### DIFF
--- a/apps/desktop/electron/vscode-marketplace.test.ts
+++ b/apps/desktop/electron/vscode-marketplace.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert'
+import zlib from 'node:zlib'
 
 import { test } from 'vitest'
 
@@ -52,6 +53,54 @@ function makeZip(entries) {
   return Buffer.concat([...locals, centralBuf, eocd])
 }
 
+// Like makeZip, but supports deflated (method 8) entries so a test can build a
+// decompression bomb: a small compressed payload that inflates far larger.
+function makeZipWithDeflated(entries) {
+  const locals = []
+  const centrals = []
+  let offset = 0
+
+  for (const { name, data, method = 0 } of entries) {
+    const nameBuf = Buffer.from(name, 'utf8')
+    const raw = Buffer.isBuffer(data) ? data : Buffer.from(data, 'utf8')
+    const body = method === 8 ? zlib.deflateRawSync(raw) : raw
+
+    const local = Buffer.alloc(30 + nameBuf.length)
+    local.writeUInt32LE(0x04034b50, 0)
+    local.writeUInt16LE(method, 8)
+    local.writeUInt32LE(body.length, 18) // compressed size
+    local.writeUInt32LE(raw.length, 22) // uncompressed size
+    local.writeUInt16LE(nameBuf.length, 26)
+    nameBuf.copy(local, 30)
+
+    locals.push(local, body)
+
+    const central = Buffer.alloc(46 + nameBuf.length)
+    central.writeUInt32LE(0x02014b50, 0)
+    central.writeUInt16LE(method, 10)
+    central.writeUInt32LE(body.length, 20)
+    central.writeUInt32LE(raw.length, 24)
+    central.writeUInt16LE(nameBuf.length, 28)
+    central.writeUInt32LE(offset, 42) // local header offset
+    nameBuf.copy(central, 46)
+
+    centrals.push(central)
+    offset += local.length + body.length
+  }
+
+  const centralStart = offset
+  const centralBuf = Buffer.concat(centrals)
+
+  const eocd = Buffer.alloc(22)
+  eocd.writeUInt32LE(0x06054b50, 0)
+  eocd.writeUInt16LE(entries.length, 8)
+  eocd.writeUInt16LE(entries.length, 10)
+  eocd.writeUInt32LE(centralBuf.length, 12)
+  eocd.writeUInt32LE(centralStart, 16)
+
+  return Buffer.concat([...locals, centralBuf, eocd])
+}
+
 test('readCentralDirectory finds every entry', () => {
   const zip = makeZip([
     { name: 'extension/package.json', data: '{}' },
@@ -84,6 +133,29 @@ test('extractThemes reads contributed color themes (resolving ./ paths)', () => 
   assert.strictEqual(themes[0].label, 'Dracula')
   assert.strictEqual(themes[0].uiTheme, 'vs-dark')
   assert.match(themes[0].contents, /editor\.background/)
+})
+
+test('extractThemes skips a decompression-bomb theme entry instead of inflating it', () => {
+  // A tiny deflated payload that inflates to 17 MB — just over MAX_ENTRY_BYTES
+  // (16 MB). Unbounded, inflateRawSync would materialize the full 17 MB (and a
+  // real bomb would reach gigabytes). With the inflate cap, zlib throws
+  // ERR_BUFFER_TOO_LARGE, the per-theme catch skips the entry, and the bomb
+  // theme is absent from the result rather than exhausting main-process memory.
+  const bomb = Buffer.alloc(17 * 1024 * 1024, 0x41)
+
+  const pkg = JSON.stringify({
+    name: 'bomb-theme',
+    displayName: 'Bomb',
+    contributes: { themes: [{ label: 'Bomb', uiTheme: 'vs-dark', path: './themes/bomb.json' }] }
+  })
+
+  const zip = makeZipWithDeflated([
+    { name: 'extension/package.json', data: pkg, method: 0 },
+    { name: 'extension/themes/bomb.json', data: bomb, method: 8 }
+  ])
+
+  const themes = extractThemes(zip)
+  assert.strictEqual(themes.length, 0) // bomb entry skipped, not inflated
 })
 
 test('extractThemes returns empty when the extension contributes no themes', () => {

--- a/apps/desktop/electron/vscode-marketplace.test.ts
+++ b/apps/desktop/electron/vscode-marketplace.test.ts
@@ -158,6 +158,27 @@ test('extractThemes skips a decompression-bomb theme entry instead of inflating 
   assert.strictEqual(themes.length, 0) // bomb entry skipped, not inflated
 })
 
+test('extractThemes skips an oversized stored theme entry instead of decoding it', () => {
+  // A stored (uncompressed) theme entry larger than MAX_ENTRY_BYTES (16 MB)
+  // must be rejected by the length check before it is decoded to a string —
+  // the stored path has no zlib maxOutputLength to lean on.
+  const oversized = Buffer.alloc(17 * 1024 * 1024, 0x41)
+
+  const pkg = JSON.stringify({
+    name: 'big-theme',
+    displayName: 'Big',
+    contributes: { themes: [{ label: 'Big', uiTheme: 'vs-dark', path: './themes/big.json' }] }
+  })
+
+  const zip = makeZipWithDeflated([
+    { name: 'extension/package.json', data: pkg, method: 0 },
+    { name: 'extension/themes/big.json', data: oversized, method: 0 }
+  ])
+
+  const themes = extractThemes(zip)
+  assert.strictEqual(themes.length, 0) // oversized stored entry skipped, not decoded
+})
+
 test('extractThemes returns empty when the extension contributes no themes', () => {
   const zip = makeZip([{ name: 'extension/package.json', data: JSON.stringify({ name: 'x', contributes: {} }) }])
   assert.deepStrictEqual(extractThemes(zip), [])

--- a/apps/desktop/electron/vscode-marketplace.ts
+++ b/apps/desktop/electron/vscode-marketplace.ts
@@ -18,6 +18,11 @@ import zlib from 'node:zlib'
 const GALLERY_QUERY_URL = 'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery'
 const VSIX_ASSET_TYPE = 'Microsoft.VisualStudio.Services.VSIXPackage'
 const MAX_VSIX_BYTES = 40 * 1024 * 1024 // 40 MB — themes are tiny; this is paranoia.
+// Cap the *inflated* size of any single zip entry. MAX_VSIX_BYTES bounds the
+// compressed archive, but a small deflated entry can inflate to gigabytes (a
+// decompression bomb) in the Electron main process. Themes are JSON and tiny;
+// 16 MB inflated per entry is already generous.
+const MAX_ENTRY_BYTES = 16 * 1024 * 1024 // 16 MB inflated per entry.
 const MAX_REDIRECTS = 5
 const REQUEST_TIMEOUT_MS = 20_000
 
@@ -247,8 +252,8 @@ function readCentralDirectory(buf) {
   return records
 }
 
-/** Inflate a single entry to a string. */
-function extractEntry(buf, record) {
+/** Inflate a single entry to a string, bounding the inflated output. */
+function extractEntry(buf, record, maxBytes = MAX_ENTRY_BYTES) {
   // The local header's name/extra lengths can differ from the central record,
   // so re-read them here to locate the compressed payload.
   if (buf.readUInt32LE(record.localOffset) !== 0x04034b50) {
@@ -261,7 +266,19 @@ function extractEntry(buf, record) {
   const data = buf.subarray(dataStart, dataStart + record.compressedSize)
 
   // 0 = stored, 8 = deflate. Theme files are one or the other.
-  return record.method === 0 ? data.toString('utf8') : zlib.inflateRawSync(data).toString('utf8')
+  if (record.method === 0) {
+    // Stored entries are their own uncompressed size; reject an oversized one
+    // before materializing it as a string.
+    if (data.length > maxBytes) {
+      throw new Error('Zip entry exceeds the extraction size limit.')
+    }
+
+    return data.toString('utf8')
+  }
+
+  // maxOutputLength makes zlib throw ERR_BUFFER_TOO_LARGE once the inflated
+  // output would exceed the cap, instead of allocating unbounded memory.
+  return zlib.inflateRawSync(data, { maxOutputLength: maxBytes }).toString('utf8')
 }
 
 /** Normalize a package.json theme path to its zip entry name. */


### PR DESCRIPTION
> **Re-pointed onto `apps/desktop/electron/vscode-marketplace.ts`** after the desktop marketplace module was migrated to TypeScript on `main` (#57855) — the `.cjs` file this branch originally targeted no longer exists. Same defense-in-depth inflate-size cap (`MAX_ENTRY_BYTES` via zlib `maxOutputLength`), complementary to the 40 MB compressed-archive cap from #43292 (as alt-glitch confirmed), bounding a single deflated entry that would otherwise inflate to gigabytes in the Electron main process. The gap is still live on the ported `.ts` file: `extractEntry` inflates with an unbounded `zlib.inflateRawSync`. Re-applied the identical fix on the migrated file and re-verified fail-before/pass-after on it.

## This is a sibling follow-up to #43292 (commit 27a321157)

- **#43292 covered:** downloading a `.vsix` and extracting contributed color themes, with a 40 MB cap on the *downloaded* archive (`MAX_VSIX_BYTES`).
- **#43292 did NOT touch:** the *inflated* size of an individual zip entry — `extractEntry` calls `zlib.inflateRawSync` with no output bound, so a small deflated entry can inflate to gigabytes.
- **This PR adds** an inflated-size cap (`MAX_ENTRY_BYTES`, enforced via zlib `maxOutputLength` for deflate and a length check for stored entries) so a decompression-bomb `.vsix` cannot exhaust memory in the Electron main process.

## What does this PR do?

Hardens the VS Code Marketplace theme installer against a decompression-bomb (zip-bomb) `.vsix`.

`apps/desktop/electron/vscode-marketplace.ts` downloads a `.vsix` (a zip) and extracts the color-theme JSON it contributes. The download is capped at 40 MB (`MAX_VSIX_BYTES`), but `extractEntry` then inflated each deflated entry with `zlib.inflateRawSync(data)` and **no bound on the inflated output**. A deflated entry inside an under-cap (≤40 MB) archive can inflate to gigabytes — a classic decompression bomb. This runs in the **Electron main process**, so a malicious or compromised Marketplace package could exhaust memory and freeze/OOM the desktop app. The download cap does not protect against the post-inflate blowup.

The fix bounds the *inflated* output per entry: `zlib.inflateRawSync(data, { maxOutputLength: MAX_ENTRY_BYTES })` makes zlib throw `ERR_BUFFER_TOO_LARGE` once the output would exceed the cap, instead of allocating unbounded memory. Stored (uncompressed) entries are length-checked before decoding. The existing per-theme `try/catch` in `extractThemes` skips an entry that throws, so an oversized theme is dropped rather than failing the install; an oversized `package.json` manifest fails closed with a clear message.

The only inflate site is `extractEntry`; both the stored and deflated paths are now bounded, so no wider change is needed.

## Related Issue

Fixes #49456

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `apps/desktop/electron/vscode-marketplace.ts`: add `MAX_ENTRY_BYTES` (16 MB) and enforce it in `extractEntry` — `maxOutputLength` on `inflateRawSync` for deflate entries, an explicit length check for stored entries. `extractEntry` now takes an injectable `maxBytes` default param.
- `apps/desktop/electron/vscode-marketplace.test.ts`: add `makeZipWithDeflated` (builds `deflate`/method-8 entries so a test can construct a bomb) plus a regression test that a `.vsix` whose theme entry inflates past the cap is skipped by `extractThemes` (`themes.length === 0`) rather than being inflated.

## How to Test

```
node --import tsx --test apps/desktop/electron/vscode-marketplace.test.ts
```

Regression guard (verified locally on Node v22.22.1):

1. With the production change reverted, the new bomb test **fails** — the unbounded `inflateRawSync` allocates the full 17 MB and the oversized theme is returned (`themes.length === 1`).
2. With the change in place, the same `.vsix` throws `ERR_BUFFER_TOO_LARGE`, the per-theme `try/catch` drops the bomb entry, and it is absent from the result (`themes.length === 0`). All 6 tests pass.
3. The existing "reads contributed color themes" test passes both before and after, confirming the cap does not break legitimate (small) themes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused suite (`node --import tsx --test apps/desktop/electron/vscode-marketplace.test.ts`) and all tests pass (this is a Node/Electron TypeScript module run under `node:test`; `pytest` does not cover it)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Node v22.22.1)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Node `zlib`/buffer logic, platform-independent
