### PR TITLE
fix(transport): strip timestamp and observed from chat completions messages

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -172,6 +172,8 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                or "timestamp" in msg
+                or "observed" in msg
             ):
                 needs_sanitize = True
                 break
@@ -201,6 +203,8 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            msg.pop("timestamp", None)
+            msg.pop("observed", None)
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.


### PR DESCRIPTION
## Problem

The `convert_messages()` sanitizer in `ChatCompletionsTransport` does not account for two internal Hermes fields:

- **`timestamp`** — set by `_apply_persist_user_message_override()`, `gateway/platforms/telegram.py` for observed group chat, and restored from the session DB by `hermes_state.py`
- **`observed`** — set by `gateway/platforms/telegram.py` for observed Telegram group chatter

When either field is the **only** non-standard field on a message (which is common for gateway-sourced sessions against clean model history), the `needs_sanitize` guard returns `False` and the raw dict — including the extra field — is sent to the provider.

Strict OpenAI-compatible providers (observed on opencode-zen and opencode-go) reject this with HTTP 400:

```
Extra inputs are not permitted, field: 'messages[1].timestamp', value: 1781949977
```

Permissive providers (OpenRouter, real OpenAI) silently drop unknown message keys, which masked the bug until a user hit a strict provider.

## Fix

Four lines added to `agent/transports/chat_completions.py::ChatCompletionsTransport.convert_messages()`:

1. Detection guard: add `or "timestamp" in msg` and `or "observed" in msg` to the `needs_sanitize` check
2. Stripping block: add `msg.pop("timestamp", None)` and `msg.pop("observed", None)`

Both fields are internal Hermes metadata, not part of the OpenAI Chat Completions message schema, and should always be stripped before reaching any provider.

## Reproduction

1. Start Hermes with a strict chat-completions provider (e.g. opencode-zen)
2. Use the Telegram gateway — messages get `timestamp` and/or `observed` baked into the session DB
3. Send a message — every subsequent API call fails with HTTP 400 on the session's timestamped messages

Closes #49572