### PR TITLE
feat(image-gen): support Codex image editing

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -19,14 +19,17 @@ Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
+import os
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
     error_response,
+    normalize_reference_images,
     resolve_aspect_ratio,
     save_b64_image,
     success_response,
@@ -69,6 +72,7 @@ _SIZES = {
     "square": "1024x1024",
     "portrait": "1024x1536",
 }
+MAX_REFERENCE_IMAGES = 16
 
 # Codex Responses surface used for the request. The chat model itself is only
 # the host that calls the ``image_generation`` tool; the actual image work is
@@ -77,7 +81,8 @@ _CODEX_CHAT_MODEL = "gpt-5.5"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation requests by "
-    "using the image_generation tool when provided."
+    "using the image_generation tool when provided. Use provided images as "
+    "visual references when present."
 )
 
 
@@ -143,8 +148,42 @@ def _read_codex_access_token() -> Optional[str]:
         return None
 
 
-def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[str, Any]:
+def _codex_input_image_part(source: str) -> Dict[str, str]:
+    """Return a Responses ``input_image`` part for a URL, data URI, or local file.
+
+    The ChatGPT/Codex Responses endpoint accepts the same image part shape as
+    the public OpenAI Responses API. Public URLs and existing data URIs can be
+    forwarded directly; local files need to be inlined as data URLs because the
+    private Codex endpoint cannot read this machine's filesystem.
+    """
+    source = source.strip()
+    lower = source.lower()
+    if lower.startswith(("http://", "https://", "data:")):
+        return {"type": "input_image", "image_url": source}
+
+    ext = os.path.splitext(source)[1].lstrip(".").lower() or "png"
+    if ext == "jpg":
+        ext = "jpeg"
+    if ext not in {"png", "jpeg", "webp", "gif"}:
+        ext = "png"
+
+    with open(source, "rb") as fh:
+        encoded = base64.b64encode(fh.read()).decode("utf-8")
+    return {"type": "input_image", "image_url": f"data:image/{ext};base64,{encoded}"}
+
+
+def _build_responses_payload(
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    image_sources: Optional[List[str]] = None,
+) -> Dict[str, Any]:
     """Build the Codex Responses request body for an image_generation call."""
+    content = [{"type": "input_text", "text": prompt}]
+    for source in image_sources or []:
+        content.append(_codex_input_image_part(source))
+
     return {
         "model": _CODEX_CHAT_MODEL,
         "store": False,
@@ -152,7 +191,7 @@ def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[st
         "input": [{
             "type": "message",
             "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
+            "content": content,
         }],
         "tools": [{
             "type": "image_generation",
@@ -242,7 +281,14 @@ def _iter_sse_json(response: Any):
         yield payload
 
 
-def _collect_image_b64(token: str, *, prompt: str, size: str, quality: str) -> Optional[str]:
+def _collect_image_b64(
+    token: str,
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    image_sources: Optional[List[str]] = None,
+) -> Optional[str]:
     """Stream a Codex Responses image_generation call and return the b64 image."""
     import httpx
     from agent.auxiliary_client import _codex_cloudflare_headers
@@ -253,7 +299,12 @@ def _collect_image_b64(token: str, *, prompt: str, size: str, quality: str) -> O
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     })
-    payload = _build_responses_payload(prompt=prompt, size=size, quality=quality)
+    payload = _build_responses_payload(
+        prompt=prompt,
+        size=size,
+        quality=quality,
+        image_sources=image_sources,
+    )
     timeout = httpx.Timeout(300.0, connect=30.0, read=300.0, write=30.0, pool=30.0)
 
     image_b64: Optional[str] = None
@@ -319,7 +370,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         return {
             "name": "OpenAI (Codex auth)",
             "badge": "free",
-            "tag": "gpt-image-2 via ChatGPT/Codex OAuth — no API key required (text-to-image only)",
+            "tag": "gpt-image-2 via ChatGPT/Codex OAuth — no API key required; text-to-image & image editing",
             "env_vars": [],
             "post_setup_hint": (
                 "Sign in with `hermes auth codex` (or `hermes setup` → Codex) "
@@ -328,12 +379,14 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         }
 
     def capabilities(self) -> Dict[str, Any]:
-        # The Codex Responses image_generation tool path is text-to-image
-        # only here. Image-to-image / editing via Codex OAuth is not wired —
-        # users who need editing should use the `openai` (API key), `fal`, or
-        # `xai` backends. Declaring text-only keeps the dynamic tool schema
-        # honest so the model doesn't attempt an unsupported edit.
-        return {"modalities": ["text"], "max_reference_images": 0}
+        # The Codex Responses image_generation tool accepts input_image parts
+        # alongside the prompt, matching the public OpenAI Responses API image
+        # editing workflow. Keep the cap aligned with the API-key OpenAI
+        # backend's gpt-image-2 edit path.
+        return {
+            "modalities": ["text", "image"],
+            "max_reference_images": MAX_REFERENCE_IMAGES,
+        }
 
     def generate(
         self,
@@ -346,21 +399,6 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
     ) -> Dict[str, Any]:
         prompt = (prompt or "").strip()
         aspect = resolve_aspect_ratio(aspect_ratio)
-
-        # Image-to-image / editing is not supported on the Codex OAuth path.
-        # Surface a clear, actionable error instead of silently ignoring the
-        # source image and producing an unrelated picture.
-        if (isinstance(image_url, str) and image_url.strip()) or reference_image_urls:
-            return error_response(
-                error=(
-                    "This model is not capable of image-to-image / editing. "
-                    "Please provide a text-only prompt (drop image_url and "
-                    "reference_image_urls)."
-                ),
-                error_type="modality_unsupported",
-                provider="openai-codex",
-                aspect_ratio=aspect,
-            )
 
         if not prompt:
             return error_response(
@@ -394,6 +432,14 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         tier_id, meta = _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
 
+        sources: List[str] = []
+        if isinstance(image_url, str) and image_url.strip():
+            sources.append(image_url.strip())
+        for ref in (normalize_reference_images(reference_image_urls) or []):
+            sources.append(ref)
+        sources = sources[:MAX_REFERENCE_IMAGES]
+        modality = "image" if sources else "text"
+
         token = _read_codex_access_token()
         if not token:
             return error_response(
@@ -409,12 +455,21 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             )
 
         try:
-            b64 = _collect_image_b64(
-                token,
-                prompt=prompt,
-                size=size,
-                quality=meta["quality"],
-            )
+            if sources:
+                b64 = _collect_image_b64(
+                    token,
+                    prompt=prompt,
+                    size=size,
+                    quality=meta["quality"],
+                    image_sources=sources,
+                )
+            else:
+                b64 = _collect_image_b64(
+                    token,
+                    prompt=prompt,
+                    size=size,
+                    quality=meta["quality"],
+                )
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)
             return error_response(
@@ -454,6 +509,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             prompt=prompt,
             aspect_ratio=aspect,
             provider="openai-codex",
+            modality=modality,
             extra={"size": size, "quality": meta["quality"]},
         )
 

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -67,6 +67,11 @@ class TestMetadata:
         assert schema["env_vars"] == []
         assert schema["badge"] == "free"
 
+    def test_capabilities_advertise_image_editing(self, provider):
+        caps = provider.capabilities()
+        assert caps["modalities"] == ["text", "image"]
+        assert caps["max_reference_images"] == 16
+
 
 # ── Availability ────────────────────────────────────────────────────────────
 
@@ -159,6 +164,71 @@ class TestGenerate:
         assert tool["output_format"] == "png"
         assert tool["background"] == "opaque"
         assert tool["partial_images"] == 1
+
+    def test_codex_stream_request_includes_image_inputs(self, tmp_path):
+        source = tmp_path / "source.png"
+        source.write_bytes(bytes.fromhex(_PNG_HEX))
+
+        payload = codex_plugin._build_responses_payload(
+            prompt="turn the blue circle green",
+            size="1024x1024",
+            quality="medium",
+            image_sources=[str(source), "https://example.com/ref.png"],
+        )
+
+        content = payload["input"][0]["content"]
+        assert content[0] == {"type": "input_text", "text": "turn the blue circle green"}
+        assert content[1]["type"] == "input_image"
+        assert content[1]["image_url"].startswith("data:image/png;base64,")
+        assert content[2] == {"type": "input_image", "image_url": "https://example.com/ref.png"}
+
+    def test_generate_forwards_image_sources_to_codex_stream(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        captured = {}
+
+        def _collect(token, *, prompt, size, quality, image_sources=None):
+            captured.update({
+                "token": token,
+                "prompt": prompt,
+                "size": size,
+                "quality": quality,
+                "image_sources": image_sources,
+            })
+            return _b64_png()
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate(
+            "turn the blue circle green",
+            aspect_ratio="square",
+            image_url="https://example.com/source.png",
+            reference_image_urls=["https://example.com/ref.png"],
+        )
+
+        assert result["success"] is True
+        assert result["modality"] == "image"
+        assert captured["image_sources"] == [
+            "https://example.com/source.png",
+            "https://example.com/ref.png",
+        ]
+
+    def test_generate_clamps_codex_reference_images_to_cap(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        captured = {}
+
+        def _collect(token, *, prompt, size, quality, image_sources=None):
+            captured["image_sources"] = image_sources
+            return _b64_png()
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        refs = [f"https://example.com/ref-{idx}.png" for idx in range(20)]
+        result = provider.generate("combine the references", reference_image_urls=refs)
+
+        assert result["success"] is True
+        assert captured["image_sources"] == refs[:16]
 
     def test_partial_image_event_used_when_done_missing(self):
         """If output_item.done is missing, partial_image_b64 is accepted."""

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -114,7 +114,7 @@ Two inputs drive the edit:
 | **OpenAI** (`gpt-image-2`) | ✓ | up to 16 | `images.edit()` |
 | **xAI** (Grok Imagine) | ✓ | 1 | `/v1/images/edits` (`grok-imagine-image-quality`) |
 | **Krea** (`Krea 2`) | ✓ | up to 10 | reference-guided generation (`image_style_references`) |
-| **OpenAI (Codex auth)** | ✗ | — | text-to-image only |
+| **OpenAI (Codex auth)** (`gpt-image-2`) | ✓ | up to 16 | Codex Responses `image_generation` with `input_image` parts |
 
 FAL models with an editing endpoint: `flux-2/klein/9b`, `flux-2-pro`,
 `nano-banana-pro`, `gpt-image-1.5`, `gpt-image-2`, `ideogram/v3`, and


### PR DESCRIPTION
## What does this PR do?

Adds image-to-image / editing support to the OpenAI Codex-authenticated image backend.

Hermes already accepts `image_url` and `reference_image_urls` at the image-generation provider boundary, but the `openai-codex` provider advertised text-only capability and rejected image inputs. This PR keeps the existing Codex Responses `image_generation` tool path and attaches source/reference images as Responses `input_image` content parts. Public URLs and existing data URLs pass through directly; local file paths are inlined as `data:image/...;base64,...` URLs so the Codex backend can read them.

This makes the Codex-auth backend match the regular OpenAI `gpt-image-2` provider's editing capability while preserving the existing text-to-image behavior when no image inputs are supplied.

## Related Issue

Closes #42850

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/image_gen/openai-codex/__init__.py`
  - Advertises `modalities: ["text", "image"]` with `max_reference_images: 16`.
  - Accepts `image_url` and `reference_image_urls` instead of returning `modality_unsupported`.
  - Normalizes and clamps image sources to the provider cap.
  - Builds Codex Responses payloads with `input_text` plus one `input_image` part per source/reference.
  - Converts local image paths to data URLs; forwards HTTP(S) URLs and existing data URLs unchanged.
  - Marks successful edit/image-to-image calls with `modality: "image"`.
- `tests/plugins/image_gen/test_openai_codex_provider.py`
  - Adds coverage for capability reporting, image-input payload shape, source forwarding, and reference-image clamping.
- `website/docs/user-guide/features/image-generation.md`
  - Updates the backend support table to document Codex-auth image editing support.

## How to Test

1. Run the provider tests:
   ```bash
   scripts/run_tests.sh tests/plugins/image_gen/test_openai_codex_provider.py
   python -m pytest tests/plugins/image_gen/test_openai_codex_provider.py -q
   ```
2. Run the affected image-generation suites:
   ```bash
   scripts/run_tests.sh      tests/plugins/image_gen      tests/tools/test_image_generation.py      tests/tools/test_image_generation_artifacts.py      tests/tools/test_image_generation_image_to_image.py      tests/tools/test_image_generation_plugin_dispatch.py      tests/agent/test_image_gen_registry.py      tests/agent/test_image_routing.py
   ```
3. Run the direct pytest suite used for the branch smoke gate:
   ```bash
   python -m pytest      tests/plugins/image_gen      tests/tools/test_image_generation.py      tests/tools/test_image_generation_image_to_image.py      tests/tools/test_image_generation_plugin_dispatch.py      -q
   ```
4. Run syntax and whitespace checks:
   ```bash
   python -m py_compile      plugins/image_gen/openai-codex/__init__.py      tests/plugins/image_gen/test_openai_codex_provider.py
   git diff --check
   ```
5. Optional live smoke test with Codex auth configured:
   - Call `OpenAICodexImageGenProvider.generate(...)` with a local `image_url` path.
   - Confirm the response has `success: true`, `provider: "openai-codex"`, and `modality: "image"`.
   - Confirm the output file is a real PNG and reflects the requested edit.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — not checked because this branch was validated with the canonical affected-suite runs below; current `main` is already green and this branch only touches the Codex image-provider path
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 5.14 / Python 3.13.5, focused test suites plus live Codex OAuth smoke test

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `website/docs/user-guide/features/image-generation.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture/workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — image path handling uses Python file APIs; no shell/path assumptions added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — dynamic provider capabilities now expose image support for `openai-codex`

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Branch state after rebasing onto current `main`:

```text
branch=feat/openai-codex-image-editing
HEAD=0b500ddd0c5a474120d18399183c0bcdac1a12f0
origin/main=b88d0007c9d0037a1ec3daa2477bd4f79eaf566b
merge-base=b88d0007c9d0037a1ec3daa2477bd4f79eaf566b
status_short=<>
```

Changed files:

```text
M plugins/image_gen/openai-codex/__init__.py
M tests/plugins/image_gen/test_openai_codex_provider.py
M website/docs/user-guide/features/image-generation.md
```

Validation performed after rebase:

```text
$ scripts/run_tests.sh tests/plugins/image_gen/test_openai_codex_provider.py
=== Summary: 1 files, 22 tests passed, 0 failed (100% complete) in 5.7s ===

$ python -m pytest tests/plugins/image_gen/test_openai_codex_provider.py -q
22 passed in 2.26s

$ scripts/run_tests.sh tests/plugins/image_gen tests/tools/test_image_generation.py tests/tools/test_image_generation_artifacts.py tests/tools/test_image_generation_image_to_image.py tests/tools/test_image_generation_plugin_dispatch.py tests/agent/test_image_gen_registry.py tests/agent/test_image_routing.py
=== Summary: 11 files, 284 tests passed, 0 failed (100% complete) in 16.3s ===

$ python -m pytest tests/plugins/image_gen tests/tools/test_image_generation.py tests/tools/test_image_generation_image_to_image.py tests/tools/test_image_generation_plugin_dispatch.py -q
193 passed in 13.06s

$ python -m py_compile plugins/image_gen/openai-codex/__init__.py tests/plugins/image_gen/test_openai_codex_provider.py
# passed

$ git diff --check
# passed
```

Live Codex OAuth smoke test against the modified provider:

```json
{
  "success": true,
  "provider": "openai-codex",
  "model": "gpt-image-2-medium",
  "modality": "image",
  "aspect_ratio": "square",
  "size": "1024x1024",
  "quality": "medium"
}
```

The live output was a real PNG generated from a local input image; visual inspection confirmed the edit preserved the simple bordered composition and changed the target circle from blue to green.