### PR TITLE
fix(cli): prefer resolved secret cache over op refs

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -156,6 +156,69 @@ def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
     _sanitize_loaded_credentials()
 
 
+def _parse_env_assignments(path: Path, *, encoding: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    with open(path, "r", encoding=encoding) as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):].lstrip()
+            key, _, value = line.partition("=")
+            key = key.strip()
+            if not key:
+                continue
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                value = value[1:-1]
+            values[key] = value
+    return values
+
+
+def _read_env_assignments_with_fallback(path: Path) -> dict[str, str]:
+    try:
+        return _parse_env_assignments(path, encoding="utf-8")
+    except UnicodeDecodeError:
+        return _parse_env_assignments(path, encoding="latin-1")
+
+
+def _apply_resolved_secret_cache(home_path: Path) -> None:
+    """Overlay resolved cache values onto unresolved ``op://`` references.
+
+    Startup may already have a resolved secret cache from a previous 1Password
+    or runtime-secret resolution step. If ``~/.hermes/.env`` still contains the
+    raw ``op://...`` reference, python-dotenv would otherwise replace the live
+    resolved value with that unresolved literal on every gateway restart.
+
+    Only overlay when the current process env is missing the key entirely or
+    still holds an unresolved ``op://`` reference. Plaintext ``.env`` values
+    remain authoritative.
+    """
+    cache_paths: list[Path] = []
+    runtime_dir = os.getenv("XDG_RUNTIME_DIR", "").strip()
+    if runtime_dir:
+        cache_paths.append(Path(runtime_dir) / "hermes" / "resolved-secrets.env")
+    cache_paths.append(home_path / "state" / "secrets-cache" / "resolved.env")
+
+    for cache_path in cache_paths:
+        if not cache_path.exists():
+            continue
+        try:
+            cached_values = _read_env_assignments_with_fallback(cache_path)
+        except OSError:
+            continue
+        for key, cached_value in cached_values.items():
+            cached_value = cached_value.strip()
+            if not cached_value or cached_value.startswith("op://"):
+                continue
+            current = os.environ.get(key)
+            if current is None or current.startswith("op://"):
+                os.environ[key] = cached_value
+
+    _sanitize_loaded_credentials()
+
+
 def _sanitize_env_file_if_needed(path: Path) -> None:
     """Pre-sanitize a .env file before python-dotenv reads it.
 
@@ -242,6 +305,7 @@ def load_hermes_dotenv(
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
 
+    _apply_resolved_secret_cache(home_path)
     _apply_external_secret_sources(home_path)
     _apply_managed_env()
 

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -103,3 +103,131 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_resolved_secret_cache_overlays_unresolved_op_refs(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    runtime_dir = tmp_path / "runtime"
+    cache_dir = runtime_dir / "hermes"
+    cache_dir.mkdir(parents=True)
+    (home / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=op://vault/telegram/token\n",
+        encoding="utf-8",
+    )
+    (cache_dir / "resolved-secrets.env").write_text(
+        "TELEGRAM_BOT_TOKEN=123456:resolved-token\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "123456:resolved-token"
+
+
+def test_resolved_secret_cache_does_not_override_plaintext_user_env(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    cache_dir = home / "state" / "secrets-cache"
+    cache_dir.mkdir(parents=True)
+    (home / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=123456:plaintext-token\n",
+        encoding="utf-8",
+    )
+    (cache_dir / "resolved.env").write_text(
+        "TELEGRAM_BOT_TOKEN=123456:cached-token\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "123456:plaintext-token"
+
+
+def test_runtime_resolved_secret_cache_beats_persistent_cache(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    runtime_dir = tmp_path / "runtime"
+    runtime_cache_dir = runtime_dir / "hermes"
+    persistent_cache_dir = home / "state" / "secrets-cache"
+    runtime_cache_dir.mkdir(parents=True)
+    persistent_cache_dir.mkdir(parents=True)
+    (home / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=op://vault/telegram/token\n",
+        encoding="utf-8",
+    )
+    (runtime_cache_dir / "resolved-secrets.env").write_text(
+        "TELEGRAM_BOT_TOKEN=123456:runtime-token\n",
+        encoding="utf-8",
+    )
+    (persistent_cache_dir / "resolved.env").write_text(
+        "TELEGRAM_BOT_TOKEN=123456:persistent-token\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "123456:runtime-token"
+
+
+def test_resolved_secret_cache_ignores_blank_and_unresolved_values(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    cache_dir = home / "state" / "secrets-cache"
+    cache_dir.mkdir(parents=True)
+    (home / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=op://vault/telegram/token\n",
+        encoding="utf-8",
+    )
+    (cache_dir / "resolved.env").write_text(
+        "TELEGRAM_BOT_TOKEN=op://vault/telegram/cached\n"
+        "OPENAI_API_KEY=\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "op://vault/telegram/token"
+    assert os.getenv("OPENAI_API_KEY") is None
+
+
+def test_managed_env_still_wins_after_cache_overlay(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    managed_dir = tmp_path / "managed"
+    managed_dir.mkdir()
+    cache_dir = home / "state" / "secrets-cache"
+    cache_dir.mkdir(parents=True)
+    (home / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=op://vault/telegram/token\n",
+        encoding="utf-8",
+    )
+    (cache_dir / "resolved.env").write_text(
+        "TELEGRAM_BOT_TOKEN=123456:cached-token\n",
+        encoding="utf-8",
+    )
+    (managed_dir / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=123456:managed-token\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "123456:managed-token"


### PR DESCRIPTION
## What does this PR do?

Fixes the 0.17 regression where `load_hermes_dotenv()` reloads `~/.hermes/.env` with raw `op://...` secret references and clobbers already-resolved gateway secrets during startup. The loader now overlays resolved cache values from `$XDG_RUNTIME_DIR/hermes/resolved-secrets.env` and `$HERMES_HOME/state/secrets-cache/resolved.env` only when the current env var is missing or still starts with `op://`, so plaintext `.env` values keep winning.

## Related Issue

Fixes #49590

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/env_loader.py`: overlay resolved secret-cache values after dotenv loads, but before external secret sources and managed-scope overrides, so startup recovers from unresolved `op://...` refs without changing normal plaintext precedence.
- `tests/hermes_cli/test_env_loader.py`: add regression coverage for runtime-cache overlay and for preserving plaintext `.env` values over cached secrets.

## How to Test

1. Put `TELEGRAM_BOT_TOKEN=op://vault/item/credential` in `~/.hermes/.env`.
2. Put the resolved token into either `$XDG_RUNTIME_DIR/hermes/resolved-secrets.env` or `$HERMES_HOME/state/secrets-cache/resolved.env`.
3. Start the gateway and confirm the Telegram adapter receives the resolved token instead of the literal `op://...` reference.
4. Run `pytest -q tests/hermes_cli/test_env_loader.py`.
5. Run `pytest -q tests/agent/test_credential_pool.py tests/hermes_cli/test_config.py tests/hermes_cli/test_env_loader.py tests/hermes_cli/test_env_sanitize_on_load.py tests/hermes_cli/test_managed_scope_env.py tests/hermes_cli/test_managed_scope_regression.py tests/hermes_cli/test_non_ascii_credential.py tests/test_bitwarden_secrets.py tests/test_env_loader_secret_sources.py tests/test_yuanbao_integration.py tests/tools/test_credential_pool_env_fallback.py tests/tui_gateway/test_compaction_status.py tests/tui_gateway/test_protocol.py tests/tui_gateway/test_review_summary_callback.py tests/tui_gateway/test_subagent_child_mirror.py tests/tui_gateway/test_undo_command.py`.

Local note: I also attempted `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`, but this sandbox aborts collection in unrelated `tests/hermes_cli/test_cron_fire_dashboard.py` because `fastapi` is not installed here.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS on darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.

<!-- autocontrib:worker-id=issue-new-5664fc40 kind=pr-open -->