### PR TITLE
fix(whatsapp): install bridge into a writable dir on read-only installs (fix #49561)

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -181,7 +181,10 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+from gateway.platforms.whatsapp_common import (
+    WhatsAppBehaviorMixin,
+    resolve_whatsapp_bridge_dir,
+)
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -261,7 +264,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     share it. Only transport-specific code lives here.
     """
 
-    # Default bridge location relative to the hermes-agent install
+    # Default bridge location relative to the hermes-agent install. The actual
+    # directory used for npm install / spawning is resolved per-instance via
+    # ``resolve_whatsapp_bridge_dir()`` so read-only install trees (Docker
+    # ``/opt/hermes``) fall back to a writable HERMES_HOME copy — see #49561.
     _DEFAULT_BRIDGE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "whatsapp-bridge"
 
     def __init__(self, config: PlatformConfig):
@@ -270,7 +276,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._bridge_port: int = config.extra.get("bridge_port", 3000)
         self._bridge_script: Optional[str] = config.extra.get(
             "bridge_script",
-            str(self._DEFAULT_BRIDGE_DIR / "bridge.js"),
+            str(resolve_whatsapp_bridge_dir() / "bridge.js"),
         )
         self._session_path: Path = Path(config.extra.get(
             "session_path",

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -35,10 +35,85 @@ import json
 import logging
 import os
 import re
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 
 logger = logging.getLogger(__name__)
+
+
+# Files that make up the Baileys bridge source (everything except the installed
+# ``node_modules`` and the install stamp). Used to mirror the bridge into a
+# writable location when the install tree is read-only.
+_BRIDGE_SOURCE_GLOBS = ("*.js", "*.mjs", "*.json")
+
+
+def bridge_source_dir() -> Path:
+    """Directory where the Baileys WhatsApp bridge source ships in the install."""
+    return Path(__file__).resolve().parents[2] / "scripts" / "whatsapp-bridge"
+
+
+def _dir_is_writable(path: Path) -> bool:
+    """True when ``npm install`` could create ``node_modules`` inside ``path``.
+
+    Checks ``path`` itself when it exists, otherwise the nearest existing parent
+    (npm would create the leaf dir). Used to detect read-only install trees such
+    as ``/opt/hermes`` in container images.
+    """
+    try:
+        probe = path
+        while not probe.exists() and probe != probe.parent:
+            probe = probe.parent
+        return os.access(probe, os.W_OK)
+    except OSError:
+        return False
+
+
+def _sync_bridge_source(source_dir: Path, target_dir: Path) -> None:
+    """Mirror bridge source files into ``target_dir`` when missing or changed.
+
+    Leaves an existing ``node_modules`` in ``target_dir`` untouched; only source
+    files are refreshed so an updated ``package.json`` (e.g. after ``hermes
+    update``) propagates and the adapter's dependency-refresh stamp reinstalls.
+    """
+    import shutil
+
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.warning("Could not create WhatsApp bridge dir %s: %s", target_dir, exc)
+        return
+
+    for pattern in _BRIDGE_SOURCE_GLOBS:
+        for src in source_dir.glob(pattern):
+            dst = target_dir / src.name
+            try:
+                if not dst.exists() or src.read_bytes() != dst.read_bytes():
+                    shutil.copy2(src, dst)
+            except OSError as exc:
+                logger.warning("Could not copy bridge file %s -> %s: %s", src, dst, exc)
+                continue
+
+
+def resolve_whatsapp_bridge_dir() -> Path:
+    """Return a writable WhatsApp bridge directory, mirroring source if needed.
+
+    The bridge source ships under ``<install>/scripts/whatsapp-bridge`` and npm
+    must create ``node_modules`` inside the bridge dir. In container images the
+    install tree (e.g. ``/opt/hermes``) is read-only for the runtime user, so
+    ``npm install`` fails with ``EACCES`` (issue #49561). When the install dir
+    is not writable, mirror the bridge source into a writable ``HERMES_HOME``
+    location and use that instead. Writable installs are unaffected.
+    """
+    from hermes_constants import get_hermes_home
+
+    source_dir = bridge_source_dir()
+    if _dir_is_writable(source_dir):
+        return source_dir
+
+    target_dir = get_hermes_home() / "scripts" / "whatsapp-bridge"
+    _sync_bridge_source(source_dir, target_dir)
+    return target_dir
 
 
 class WhatsAppBehaviorMixin:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2466,8 +2466,10 @@ def cmd_whatsapp(args):
             print("  ⚠ No allowlist — the agent will respond to ALL incoming messages")
 
     # ── Step 4: Install bridge dependencies ──────────────────────────────
-    project_root = Path(__file__).resolve().parents[1]
-    bridge_dir = project_root / "scripts" / "whatsapp-bridge"
+    # Resolve a writable bridge dir: in Docker the install tree (/opt/hermes)
+    # is read-only, so npm install must run from a HERMES_HOME copy — see #49561.
+    from gateway.platforms.whatsapp_common import resolve_whatsapp_bridge_dir
+    bridge_dir = resolve_whatsapp_bridge_dir()
     bridge_script = bridge_dir / "bridge.js"
 
     if not bridge_script.exists():

--- a/tests/gateway/test_whatsapp_bridge_dir.py
+++ b/tests/gateway/test_whatsapp_bridge_dir.py
@@ -1,0 +1,99 @@
+"""Tests for writable WhatsApp bridge directory resolution (issue #49561).
+
+In Docker the install tree (e.g. ``/opt/hermes``) is read-only for the runtime
+user, so ``npm install`` inside ``<install>/scripts/whatsapp-bridge`` fails with
+``EACCES``. ``resolve_whatsapp_bridge_dir()`` must fall back to a writable
+``HERMES_HOME`` copy in that case, while leaving writable installs untouched.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from gateway.platforms import whatsapp_common as wc
+
+
+def _make_source(tmp: Path) -> Path:
+    src = tmp / "install" / "scripts" / "whatsapp-bridge"
+    src.mkdir(parents=True)
+    (src / "bridge.js").write_text("// bridge v1\n")
+    (src / "package.json").write_text('{"name":"bridge","version":"1"}\n')
+    (src / "package-lock.json").write_text("{}\n")
+    (src / "allowlist.js").write_text("// allow\n")
+    return src
+
+
+def test_resolve_uses_install_dir_when_writable(tmp_path, monkeypatch):
+    src = _make_source(tmp_path)
+    monkeypatch.setattr(wc, "bridge_source_dir", lambda: src)
+
+    # A real writable source dir: resolve returns it unchanged, no copy made.
+    result = wc.resolve_whatsapp_bridge_dir()
+
+    assert result == src
+
+
+def test_resolve_falls_back_to_hermes_home_when_readonly(tmp_path, monkeypatch):
+    src = _make_source(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(wc, "bridge_source_dir", lambda: src)
+    monkeypatch.setattr(wc, "_dir_is_writable", lambda path: path != src)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = wc.resolve_whatsapp_bridge_dir()
+
+    expected = home / "scripts" / "whatsapp-bridge"
+    assert result == expected
+    # Source files are mirrored so connect()/pairing find bridge.js + deps.
+    assert (expected / "bridge.js").read_text() == "// bridge v1\n"
+    assert (expected / "package.json").exists()
+    assert (expected / "package-lock.json").exists()
+    assert (expected / "allowlist.js").exists()
+
+
+def test_sync_preserves_existing_node_modules(tmp_path):
+    src = _make_source(tmp_path)
+    target = tmp_path / "home" / "scripts" / "whatsapp-bridge"
+    (target / "node_modules" / "baileys").mkdir(parents=True)
+    (target / "node_modules" / "baileys" / "index.js").write_text("module\n")
+
+    wc._sync_bridge_source(src, target)
+
+    # node_modules is left intact; source files are copied in alongside it.
+    assert (target / "node_modules" / "baileys" / "index.js").read_text() == "module\n"
+    assert (target / "bridge.js").read_text() == "// bridge v1\n"
+
+
+def test_sync_refreshes_changed_source(tmp_path):
+    src = _make_source(tmp_path)
+    target = tmp_path / "home" / "scripts" / "whatsapp-bridge"
+    target.mkdir(parents=True)
+    (target / "bridge.js").write_text("// bridge OLD\n")
+
+    wc._sync_bridge_source(src, target)
+
+    assert (target / "bridge.js").read_text() == "// bridge v1\n"
+
+
+def test_dir_is_writable(tmp_path):
+    writable = tmp_path / "w"
+    writable.mkdir()
+    assert wc._dir_is_writable(writable) is True
+
+    # Non-existent leaf under a writable parent is treated as writable
+    # (npm would create the leaf dir).
+    assert wc._dir_is_writable(writable / "scripts" / "whatsapp-bridge") is True
+
+
+@pytest.mark.skipif(os.geteuid() == 0 if hasattr(os, "geteuid") else True,
+                    reason="root bypasses POSIX write permission bits")
+def test_dir_is_writable_false_on_readonly(tmp_path):
+    ro = tmp_path / "ro"
+    ro.mkdir()
+    os.chmod(ro, 0o500)
+    try:
+        assert wc._dir_is_writable(ro) is False
+    finally:
+        os.chmod(ro, 0o700)


### PR DESCRIPTION
## Summary

Fixes #49561 — on Docker/read-only installs, both `hermes whatsapp` setup and the gateway adapter fail to install the bridge with `npm error EACCES: permission denied, mkdir /opt/hermes/scripts/whatsapp-bridge/node_modules`.

**Root cause:** the Baileys bridge ships under `<install>/scripts/whatsapp-bridge` and `npm install` must create `node_modules` *inside* that dir. In container images the install tree (`/opt/hermes`) is read-only for the runtime user, so the install fails. There are two affected call sites: the CLI setup (`cmd_whatsapp` in `hermes_cli/main.py`) and the gateway adapter (`WhatsAppAdapter` in `gateway/platforms/whatsapp.py`).

**Fix:** add `resolve_whatsapp_bridge_dir()` in `gateway/platforms/whatsapp_common.py`:
- If the install bridge dir is writable, return it unchanged (normal installs — no behavior change).
- Otherwise, mirror the bridge source files into a writable `HERMES_HOME/scripts/whatsapp-bridge` copy (preserving any existing `node_modules`, refreshing source when `package.json`/`bridge.js` change) and return that. `npm install` and the spawned bridge then agree on one writable location.

Both call sites are routed through the helper.

## Why not #49584
[#49584](https://github.com/NousResearch/hermes-agent/pull/49584) does not fix the reported flow:
- It only edits `WhatsAppAdapter.__init__`, leaving the CLI `cmd_whatsapp` path (the exact repro: "run the hermes whatsapp command and install the bridge dependency") still pinned to the read-only `/opt/hermes` dir.
- Its adapter logic (`if hermes_home_bridge.exists() or not install_bridge.exists()`) selects the **install dir** whenever the shipped source exists (it always does), so it still installs into the read-only path; and it never copies `bridge.js`/`package.json` into `HERMES_HOME`, so if it ever picked that branch `connect()` would fail with "bridge script not found".
- It also bundles two unrelated changes (#49508 memory `UnicodeDecodeError`, #49535 `HERMES_WRITE_SAFE_ROOT` multi-dir) into the same PR.

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_whatsapp_bridge_dir.py` (6 new tests)
- [x] `scripts/run_tests.sh tests/gateway/test_whatsapp_stale_bridge.py tests/gateway/test_whatsapp_connect.py` (38 pass — no regression)
- [x] `scripts/run_tests.sh tests/hermes_cli/test_whatsapp_setup_ordering.py`
- [ ] Manual: in a Docker image with read-only `/opt/hermes`, run `hermes whatsapp` and `hermes gateway` — bridge installs into `$HERMES_HOME/scripts/whatsapp-bridge` and pairs/connects.