### PR TITLE
fix(plugins): correct sys.path depth in discord/raft platform adapters

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -98,7 +98,7 @@ except ImportError:
 
 import sys
 from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 

--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -36,7 +36,7 @@ except ImportError:
 
 import sys
 from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (


### PR DESCRIPTION
## Problem

`plugins/platforms/discord/adapter.py` and `plugins/platforms/raft/adapter.py`
both insert the repo root onto `sys.path` via:

    sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))

This is correct for adapters at `gateway/platforms/<name>.py` (3 levels
deep, where `parents[2]` is the repo root), but discord/raft live one
level deeper at `plugins/platforms/<name>/adapter.py`, so `parents[2]`
resolves to the `plugins/` directory instead of the repo root.

Since `discord-platform` and `raft-platform` are `kind: platform` and
auto-load unconditionally on every `PluginManager.discover_and_load()`
call (no opt-in required), this silently inserts `plugins/` at
`sys.path[0]` on every process that runs plugin discovery — which is
effectively every hermes-agent / hermes-webui startup.

From that point on, any `import cron` in the same process resolves to
`plugins/cron/__init__.py` (the bundled cron-provider discovery shim,
which has no `jobs.py`/`scheduler.py`) instead of the real top-level
`cron/` scheduler package — causing
`ModuleNotFoundError: No module named 'cron.jobs'` anywhere downstream
that does `from cron.jobs import ...` afterward (e.g.
`tools/cronjob_tools.py`, hermes-webui's `/api/crons` endpoint).

## Fix

Change `parents[2]` to `parents[3]` in both files, matching the actual
nesting depth (`plugins/platforms/<name>/adapter.py` is 4 levels below
the repo root). Verified both files immediately follow with
`from gateway.config import ...` / `from gateway.platforms.base import ...`,
confirming the intent was always the repo root.

## Verification

Reproduced and fixed in isolation:

    # before fix
    >>> sys.path[0]
    ''
    >>> PluginManager().discover_and_load()
    >>> sys.path[0]
    '/repo/plugins'        # wrong
    >>> import cron.jobs
    ModuleNotFoundError: No module named 'cron.jobs'

    # after fix
    >>> PluginManager().discover_and_load()
    >>> sys.path[0]
    '/repo'                # correct
    >>> import cron.jobs   # succeeds