### PR TITLE
fix(dashboard): set headers for JWKS requests

### DIFF
--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -420,6 +420,10 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
                 self._jwks_url,
                 cache_keys=True,
                 lifespan=_JWKS_CACHE_SECONDS,
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": "HermesAgent/1.0",
+                },
             )
         return self._jwks_client
 

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -486,6 +486,10 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 disco["jwks_uri"],
                 cache_keys=True,
                 lifespan=_JWKS_CACHE_SECONDS,
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": "HermesAgent/1.0",
+                },
             )
         return self._jwks_client
 

--- a/tests/plugins/dashboard_auth/test_nous_provider.py
+++ b/tests/plugins/dashboard_auth/test_nous_provider.py
@@ -674,6 +674,23 @@ class TestVerifySession:
         _patched_jwks(p, rsa_keypair)
         return p
 
+    def test_jwks_client_sends_explicit_http_headers(self, provider):
+        """Constructor-contract regression: the JWKS fetch must send an
+        explicit Accept + User-Agent so it isn't blocked by the Portal WAF
+        (same fix as the self_hosted provider)."""
+        provider._jwks_client = None
+        with patch("jwt.PyJWKClient") as client_cls:
+            provider._get_jwks_client()
+        client_cls.assert_called_once_with(
+            provider._jwks_url,
+            cache_keys=True,
+            lifespan=nous_plugin._JWKS_CACHE_SECONDS,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "HermesAgent/1.0",
+            },
+        )
+
     def test_happy_path_returns_session(self, provider, rsa_keypair):
         token = _mint_token(rsa_keypair)
         session = provider.verify_session(access_token=token)

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -643,6 +643,26 @@ class TestVerifySession:
         with pytest.raises(ProviderError, match="JWKS"):
             provider.verify_session(access_token=token)
 
+    def test_jwks_client_sends_explicit_http_headers(self):
+        provider = oidc_plugin.SelfHostedOIDCProvider(
+            issuer=_ISSUER, client_id=_CLIENT_ID
+        )
+        provider._discovery = dict(_DISCOVERY_DOC)
+        provider._discovery_fetched_at = time.time()
+
+        with patch("jwt.PyJWKClient") as client_cls:
+            provider._get_jwks_client()
+
+        client_cls.assert_called_once_with(
+            _DISCOVERY_DOC["jwks_uri"],
+            cache_keys=True,
+            lifespan=oidc_plugin._JWKS_CACHE_SECONDS,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "HermesAgent/1.0",
+            },
+        )
+
 
 # ---------------------------------------------------------------------------
 # refresh_session + revoke_session


### PR DESCRIPTION
## What does this PR do?

Adds explicit `Accept: application/json` and `User-Agent: HermesAgent/1.0` headers when the self-hosted dashboard OIDC provider fetches JWKS through `jwt.PyJWKClient`.

Some OAuth/OIDC providers reject or mishandle JWKS requests without a normal client `User-Agent`. Passing headers at the JWKS client boundary fixes token verification without changing discovery, session storage, or provider configuration behavior.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/dashboard_auth/self_hosted/__init__.py`: passes explicit JSON accept and Hermes user-agent headers into `jwt.PyJWKClient`.
- `tests/plugins/dashboard_auth/test_self_hosted_provider.py`: adds a regression test asserting the JWKS client receives those headers.

## How to Test

1. Configure the self-hosted dashboard OIDC provider against an issuer that requires or expects a client `User-Agent` for JWKS requests.
2. Complete the dashboard sign-in flow and verify access-token session verification can fetch JWKS successfully.
3. Run `uv run pytest tests/plugins/dashboard_auth/test_self_hosted_provider.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
uv run pytest tests/plugins/dashboard_auth/test_self_hosted_provider.py -q
..................................................................       [100%]
66 passed in 4.03s
```