### PR TITLE
feat(dingtalk): enable file delivery via OAPI media upload

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -29,6 +29,7 @@ Configuration in config.yaml:
 import asyncio
 import json
 import logging
+import mimetypes
 import os
 import re
 import traceback
@@ -874,6 +875,23 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         # Try AI Card first (using alibabacloud_dingtalk.card_1_0 SDK).
         if self._card_template_id and current_message and self._card_sdk:
+            # Extract and deliver MEDIA: files separately before card content,
+            # because the card template's content variable may truncate long
+            # file paths (e.g. /home/xinlei.kang/.hermes/...mp3), causing
+            # the media delivery pipeline to fail with "file not found".
+            _media_files, _cleaned_for_card = self.extract_media(content)
+            if _media_files:
+                for _media_path, _ in _media_files:
+                    try:
+                        await self._send_file_via_webhook(
+                            chat_id, _media_path,
+                        )
+                    except Exception as _e:
+                        logger.warning(
+                            "[%s] Failed to send pre-card media %s: %s",
+                            self.name, _media_path, _e,
+                        )
+                content = _cleaned_for_card
             # Close any previously-open streaming cards for this chat
             # before creating a new one (handles tool-progress → final-
             # response handoff; also cleans up lingering commentary cards).
@@ -937,6 +955,101 @@ class DingTalkAdapter(BasePlatformAdapter):
         """DingTalk does not support typing indicators."""
         pass
 
+    async def _send_file_via_webhook(
+        self,
+        chat_id: str,
+        file_path: str,
+    ) -> SendResult:
+        """Upload a file to DingTalk OAPI and send as file attachment via session webhook.
+
+        DingTalk's session webhook only supports text/markdown payloads natively.
+        To deliver files (PDFs, images, videos, archives, etc.) we:
+          1. Upload the file to OAPI media endpoint to get a ``media_id``
+          2. Send a ``msgtype=file`` payload through the active session webhook
+
+        The OAPI media upload has a **20 MB** size limit. Files exceeding this
+        are rejected with a clear error rather than failing silently.
+        """
+        if not os.path.isfile(file_path):
+            return SendResult(success=False, error=f"File not found: {file_path}")
+        if not self._http_client:
+            return SendResult(success=False, error="HTTP client not initialized")
+
+        file_size = os.path.getsize(file_path)
+        max_size = 20 * 1024 * 1024  # 20 MB — DingTalk OAPI media upload limit
+        if file_size > max_size:
+            return SendResult(
+                success=False,
+                error=(
+                    f"File too large ({file_size / 1024 / 1024:.1f} MB). "
+                    f"DingTalk media upload limit is 20 MB."
+                ),
+            )
+
+        token = await self._get_access_token()
+        if not token:
+            return SendResult(success=False, error="Failed to get access token")
+
+        # Upload to OAPI media endpoint
+        filename = os.path.basename(file_path)
+        content_type = mimetypes.guess_type(file_path)[0] or "application/octet-stream"
+        try:
+            with open(file_path, "rb") as f:
+                file_data = f.read()
+
+            upload_url = f"https://oapi.dingtalk.com/media/upload?access_token={token}"
+            upload_resp = await self._http_client.post(
+                upload_url,
+                data={"type": "file"},
+                files={"media": (filename, file_data, content_type)},
+                timeout=60.0,
+            )
+            if upload_resp.status_code != 200:
+                return SendResult(
+                    success=False,
+                    error=f"Media upload failed HTTP {upload_resp.status_code}: {upload_resp.text[:200]}",
+                )
+            upload_data = upload_resp.json()
+            if upload_data.get("errcode", 0) != 0:
+                return SendResult(
+                    success=False,
+                    error=f"Media upload error: {upload_data.get('errmsg', upload_resp.text[:200])}",
+                )
+            media_id = upload_data.get("media_id", "")
+            if not media_id:
+                return SendResult(
+                    success=False,
+                    error=f"Media upload returned no media_id: {upload_resp.text[:200]}",
+                )
+        except Exception as e:
+            logger.error("[%s] File upload error: %s", self.name, e)
+            return SendResult(success=False, error=f"File upload error: {e}")
+
+        # Send via session webhook
+        webhook_info = self._get_valid_webhook(chat_id)
+        if not webhook_info:
+            return SendResult(
+                success=False,
+                error="No valid session_webhook for file delivery",
+            )
+        session_webhook, _ = webhook_info
+
+        try:
+            resp = await self._http_client.post(
+                session_webhook,
+                json={"msgtype": "file", "file": {"media_id": media_id}},
+                timeout=15.0,
+            )
+            if resp.status_code < 300:
+                return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
+            return SendResult(
+                success=False,
+                error=f"File send failed HTTP {resp.status_code}: {resp.text[:200]}",
+            )
+        except Exception as e:
+            logger.error("[%s] File send error: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_image(
         self,
         chat_id: str,
@@ -970,14 +1083,8 @@ class DingTalkAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """DingTalk webhook replies cannot send local image files directly."""
-        return SendResult(
-            success=False,
-            error=(
-                "DingTalk session webhook replies do not support local image uploads. "
-                "Only markdown/text replies are supported without OpenAPI media upload."
-            ),
-        )
+        """Send a local image file via OAPI media upload + session webhook."""
+        return await self._send_file_via_webhook(chat_id, image_path)
 
     async def send_document(
         self,
@@ -989,14 +1096,8 @@ class DingTalkAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """DingTalk webhook replies cannot send local file attachments directly."""
-        return SendResult(
-            success=False,
-            error=(
-                "DingTalk session webhook replies do not support local file attachments. "
-                "Only markdown/text replies are supported without OpenAPI message send."
-            ),
-        )
+        """Send a local file (PDF, ZIP, etc.) via OAPI media upload + session webhook."""
+        return await self._send_file_via_webhook(chat_id, file_path)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about a DingTalk conversation."""

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -323,24 +323,231 @@ class TestSend:
         assert payload["markdown"]["text"] == "Screenshot\n\n![image](https://example.com/demo.png)"
 
     @pytest.mark.asyncio
-    async def test_send_image_file_returns_explicit_unsupported_error(self):
+    async def test_send_image_file_routes_to_file_webhook(self, tmp_path):
         from plugins.platforms.dingtalk.adapter import DingTalkAdapter
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
 
-        result = await adapter.send_image_file("chat-123", "/tmp/demo.png")
+        img = tmp_path / "photo.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
 
-        assert result.success is False
-        assert result.error and "do not support local image uploads" in result.error
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"errcode": 0, "media_id": "@media_abc"}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        adapter._http_client = mock_client
+        adapter._session_webhooks["chat-123"] = (
+            "https://oapi.dingtalk.com/robot/send?access_token=x",
+            9999999999999,
+        )
+        adapter._stream_client = MagicMock()
+        adapter._stream_client.get_access_token = MagicMock(return_value="tok")
+
+        result = await adapter.send_image_file("chat-123", str(img))
+        assert result.success is True
+        assert mock_client.post.call_count == 2  # upload + webhook send
 
     @pytest.mark.asyncio
-    async def test_send_document_returns_explicit_unsupported_error(self):
+    async def test_send_document_routes_to_file_webhook(self, tmp_path):
         from plugins.platforms.dingtalk.adapter import DingTalkAdapter
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
 
-        result = await adapter.send_document("chat-123", "/tmp/demo.pdf")
+        pdf = tmp_path / "report.pdf"
+        pdf.write_bytes(b"%PDF-1.4" + b"\x00" * 100)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"errcode": 0, "media_id": "@media_def"}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        adapter._http_client = mock_client
+        adapter._session_webhooks["chat-123"] = (
+            "https://oapi.dingtalk.com/robot/send?access_token=x",
+            9999999999999,
+        )
+        adapter._stream_client = MagicMock()
+        adapter._stream_client.get_access_token = MagicMock(return_value="tok")
+
+        result = await adapter.send_document("chat-123", str(pdf))
+        assert result.success is True
+        assert mock_client.post.call_count == 2  # upload + webhook send
+
+
+# ---------------------------------------------------------------------------
+# File delivery via OAPI media upload + session webhook
+# ---------------------------------------------------------------------------
+
+
+class TestSendFileViaWebhook:
+
+    def _make_adapter(self, tmp_path, file_name="test.pdf", file_size=1024):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+
+        fpath = tmp_path / file_name
+        fpath.write_bytes(b"\x00" * file_size)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"errcode": 0, "media_id": "@media_123"}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        adapter._http_client = mock_client
+        adapter._session_webhooks["chat-1"] = (
+            "https://oapi.dingtalk.com/robot/send?access_token=x",
+            9999999999999,
+        )
+        adapter._stream_client = MagicMock()
+        adapter._stream_client.get_access_token = MagicMock(return_value="tok")
+
+        return adapter, fpath, mock_client
+
+    @pytest.mark.asyncio
+    async def test_success_uploads_and_sends(self, tmp_path):
+        adapter, fpath, mock_client = self._make_adapter(tmp_path, "report.pdf")
+
+        result = await adapter._send_file_via_webhook("chat-1", str(fpath))
+
+        assert result.success is True
+        assert result.message_id
+        assert mock_client.post.call_count == 2
+
+        # Verify upload call
+        upload_call = mock_client.post.call_args_list[0]
+        assert "oapi.dingtalk.com/media/upload" in upload_call.args[0]
+        assert upload_call.kwargs["data"] == {"type": "file"}
+        files_arg = upload_call.kwargs["files"]
+        assert files_arg["media"][0] == "report.pdf"  # original filename
+        assert "pdf" in files_arg["media"][2]  # content type detected
+
+        # Verify webhook send call
+        send_call = mock_client.post.call_args_list[1]
+        payload = send_call.kwargs["json"]
+        assert payload["msgtype"] == "file"
+        assert payload["file"]["media_id"] == "@media_123"
+
+    @pytest.mark.asyncio
+    async def test_file_not_found(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+
+        result = await adapter._send_file_via_webhook("chat-1", "/nonexistent/file.pdf")
 
         assert result.success is False
-        assert result.error and "do not support local file attachments" in result.error
+        assert result.error and "File not found" in result.error
+
+    @pytest.mark.asyncio
+    async def test_no_http_client(self, tmp_path):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        fpath = tmp_path / "test.pdf"
+        fpath.write_bytes(b"\x00" * 10)
+
+        result = await adapter._send_file_via_webhook("chat-1", str(fpath))
+
+        assert result.success is False
+        assert result.error and "HTTP client not initialized" in result.error
+
+    @pytest.mark.asyncio
+    async def test_file_too_large(self, tmp_path):
+        adapter, fpath, _ = self._make_adapter(
+            tmp_path, "huge.zip", file_size=21 * 1024 * 1024,
+        )
+
+        result = await adapter._send_file_via_webhook("chat-1", str(fpath))
+
+        assert result.success is False
+        assert result.error and "too large" in result.error
+        assert result.error and "20 MB" in result.error
+
+    @pytest.mark.asyncio
+    async def test_no_access_token(self, tmp_path):
+        adapter, fpath, _ = self._make_adapter(tmp_path)
+        adapter._stream_client.get_access_token = MagicMock(return_value=None)
+
+        result = await adapter._send_file_via_webhook("chat-1", str(fpath))
+
+        assert result.success is False
+        assert result.error and "access token" in result.error
+
+    @pytest.mark.asyncio
+    async def test_upload_http_error(self, tmp_path):
+        adapter, fpath, mock_client = self._make_adapter(tmp_path)
+        err_resp = MagicMock()
+        err_resp.status_code = 500
+        err_resp.text = "Internal Server Error"
+        mock_client.post = AsyncMock(return_value=err_resp)
+
+        result = await adapter._send_file_via_webhook("chat-1", str(fpath))
+
+        assert result.success is False
+        assert result.error and "500" in result.error
+
+    @pytest.mark.asyncio
+    async def test_upload_api_error(self, tmp_path):
+        adapter, fpath, mock_client = self._make_adapter(tmp_path)
+        err_resp = MagicMock()
+        err_resp.status_code = 200
+        err_resp.json.return_value = {"errcode": 40001, "errmsg": "invalid token"}
+        mock_client.post = AsyncMock(return_value=err_resp)
+
+        result = await adapter._send_file_via_webhook("chat-1", str(fpath))
+
+        assert result.success is False
+        assert result.error and "invalid token" in result.error
+
+    @pytest.mark.asyncio
+    async def test_upload_no_media_id(self, tmp_path):
+        adapter, fpath, mock_client = self._make_adapter(tmp_path)
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"errcode": 0}  # no media_id
+        resp.text = '{"errcode": 0}'
+        mock_client.post = AsyncMock(return_value=resp)
+
+        result = await adapter._send_file_via_webhook("chat-1", str(fpath))
+
+        assert result.success is False
+        assert result.error and "no media_id" in result.error
+
+    @pytest.mark.asyncio
+    async def test_no_valid_webhook(self, tmp_path):
+        adapter, fpath, _ = self._make_adapter(tmp_path)
+        adapter._session_webhooks.clear()  # no webhook cached
+
+        result = await adapter._send_file_via_webhook("chat-1", str(fpath))
+
+        assert result.success is False
+        assert result.error and "session_webhook" in result.error
+
+    @pytest.mark.asyncio
+    async def test_webhook_send_failure(self, tmp_path):
+        adapter, fpath, mock_client = self._make_adapter(tmp_path)
+        # First call (upload) succeeds, second call (webhook send) fails
+        upload_resp = MagicMock()
+        upload_resp.status_code = 200
+        upload_resp.json.return_value = {"errcode": 0, "media_id": "@media_123"}
+
+        webhook_resp = MagicMock()
+        webhook_resp.status_code = 403
+        webhook_resp.text = "Forbidden"
+
+        mock_client.post = AsyncMock(side_effect=[upload_resp, webhook_resp])
+
+        result = await adapter._send_file_via_webhook("chat-1", str(fpath))
+
+        assert result.success is False
+        assert result.error and "403" in result.error
+
+    @pytest.mark.asyncio
+    async def test_content_type_detection(self, tmp_path):
+        adapter, fpath, mock_client = self._make_adapter(tmp_path, "video.mp4")
+
+        await adapter._send_file_via_webhook("chat-1", str(fpath))
+
+        upload_call = mock_client.post.call_args_list[0]
+        files_arg = upload_call.kwargs["files"]
+        assert "video/mp4" in files_arg["media"][2]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

DingTalk session webhooks only support text/markdown payloads natively. File attachments (PDFs, images, videos, archives) could not be delivered — `send_document()` and `send_image_file()` both returned "unsupported" errors.

This PR enables file delivery through DingTalk OAPI media upload + session webhook:
1. Uploads the file to `oapi.dingtalk.com/media/upload` to get a `media_id`
2. Sends a `msgtype=file` payload through the active session webhook

## Related Issue

No related issue

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### `gateway/platforms/dingtalk.py`

- **`_send_file_via_webhook(chat_id, file_path)`** — new internal method that:
  1. Uploads the file to `oapi.dingtalk.com/media/upload` to get a `media_id`
  2. Sends a `msgtype=file` payload through the active session webhook

- **`send_document()`** and **`send_image_file()`** — now route to `_send_file_via_webhook` instead of returning "unsupported" errors

- **`send()` MEDIA extraction** — extracts `MEDIA:<path>` tags from response content and delivers files before AI Card rendering, avoiding path truncation issues with long file paths

### Quality improvements
- Preserves original filenames via `os.path.basename` (previously hardcoded `file{ext}`)
- Detects MIME content type via `mimetypes` module (previously `application/octet-stream` for everything)
- Enforces 20 MB DingTalk OAPI upload limit with a clear error message
- Upload timeout increased from 30s to 60s for larger files
- Removed unused `reply_to` parameter from internal method

### `tests/gateway/test_dingtalk.py`

13 new tests in `TestSendFileViaWebhook` class:

| Test | Coverage |
|------|----------|
| `test_success_uploads_and_sends` | Happy path: upload → webhook send, verifies filename + media_id |
| `test_file_not_found` | Missing file |
| `test_no_http_client` | Uninitialized HTTP client |
| `test_file_too_large` | 21 MB file rejected with clear error |
| `test_no_access_token` | Token retrieval failure |
| `test_upload_http_error` | OAPI returns HTTP 500 |
| `test_upload_api_error` | OAPI returns errcode != 0 |
| `test_upload_no_media_id` | OAPI response missing media_id |
| `test_no_valid_webhook` | Expired/missing session webhook |
| `test_webhook_send_failure` | Upload succeeds, webhook send fails |
| `test_content_type_detection` | MIME type auto-detection (video/mp4) |
| `test_send_image_file_routes_to_file_webhook` | Public API routing |
| `test_send_document_routes_to_file_webhook` | Public API routing |

All 79 dingtalk tests pass.

### No extra configuration required

Uses existing adapter infrastructure:
- `self._http_client` (already initialized)
- Access token from Stream client (already cached)
- Session webhook URL from inbound messages (already available)
- OAPI media upload is a public API — no additional permissions needed

## How to Test

1. Configure a DingTalk bot with a Stream client
2. Ask Hermes to generate a file (e.g., `hermes -q "Create a PDF report"`)
3. Verify the file is delivered through the DingTalk session webhook
4. Test with different file types: PDF, image, video, archive
5. Test edge cases: file > 20 MB (should fail with clear error), missing file, upload failure

Automated: 13 new tests cover success path, all error paths (file not found, HTTP errors, API errors, missing media_id, webhook failures), and content type detection. All 79 dingtalk tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
