### PR TITLE
fix(gateway): avoid Windows console flash during PID scan

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -358,75 +358,114 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
 
     try:
         if is_windows():
-            # Prefer wmic when present (fast, stable output format).  On
-            # modern Windows 11 / Win 10 late builds, wmic has been
-            # removed as part of the WMIC deprecation — fall back to
-            # PowerShell's Get-CimInstance.  Any OSError here (FileNotFoundError
-            # on missing wmic) trips the fallback.
-            wmic_path = shutil.which("wmic")
-            used_fallback = False
-            result = None
-            if wmic_path is not None:
-                try:
-                    result = subprocess.run(
-                        [
-                            wmic_path,
-                            "process",
-                            "get",
-                            "ProcessId,CommandLine",
-                            "/FORMAT:LIST",
-                        ],
-                        capture_output=True,
-                        text=True,
-                        encoding="utf-8",
-                        errors="ignore",
-                        timeout=10,
-                    )
-                except (OSError, subprocess.TimeoutExpired):
-                    result = None
-            if result is None or result.returncode != 0 or not (result.stdout or ""):
-                # Fallback: PowerShell Get-CimInstance, emit LIST-style output
-                # so the downstream parser below doesn't need to branch.
-                powershell = shutil.which("powershell") or shutil.which("pwsh")
-                if powershell is None:
-                    return []
-                ps_cmd = (
-                    "Get-CimInstance Win32_Process | "
-                    "ForEach-Object { "
-                    "  'CommandLine=' + ($_.CommandLine -replace \"`r`n\",' ' -replace \"`n\",' '); "
-                    "  'ProcessId=' + $_.ProcessId; "
-                    "  '' "
-                    "}"
-                )
-                try:
-                    result = subprocess.run(
-                        [powershell, "-NoProfile", "-Command", ps_cmd],
-                        capture_output=True,
-                        text=True,
-                        encoding="utf-8",
-                        errors="ignore",
-                        timeout=15,
-                    )
-                except (OSError, subprocess.TimeoutExpired):
-                    return []
-                used_fallback = True
-            if result.returncode != 0 or result.stdout is None:
-                return []
-            current_cmd = ""
-            for line in result.stdout.split("\n"):
-                line = line.strip()
-                if line.startswith("CommandLine="):
-                    current_cmd = line[len("CommandLine=") :]
-                elif line.startswith("ProcessId="):
-                    pid_str = line[len("ProcessId=") :]
-                    if looks_like_gateway_command_line(current_cmd) and (
-                        all_profiles or _matches_current_profile(current_cmd)
+            psutil_scan_succeeded = False
+            try:
+                import psutil  # type: ignore
+
+                for proc in psutil.process_iter(["pid", "cmdline"]):
+                    try:
+                        info = proc.info
+                        pid = int(info.get("pid") or 0)
+                        cmdline = info.get("cmdline")
+                        if isinstance(cmdline, (list, tuple)):
+                            command = " ".join(str(part) for part in cmdline if part)
+                        elif isinstance(cmdline, str):
+                            command = cmdline
+                        else:
+                            command = ""
+                        if looks_like_gateway_command_line(command) and (
+                            all_profiles or _matches_current_profile(command)
+                        ):
+                            _append_unique_pid(pids, pid, exclude_pids)
+                    except (
+                        psutil.NoSuchProcess,
+                        psutil.AccessDenied,
+                        psutil.ZombieProcess,
+                        OSError,
+                        ValueError,
                     ):
-                        try:
-                            _append_unique_pid(pids, int(pid_str), exclude_pids)
-                        except ValueError:
-                            pass
-                    current_cmd = ""
+                        continue
+                psutil_scan_succeeded = True
+            except ImportError:
+                psutil_scan_succeeded = False
+            except Exception:
+                # If psutil itself fails unexpectedly, keep the legacy
+                # subprocess scanners as a best-effort fallback.  A successful
+                # psutil scan with zero matches is authoritative and must not
+                # spawn wmic/PowerShell, because that is the visible-flash path
+                # on hidden Windows gateway watchdog starts (#49602).
+                psutil_scan_succeeded = False
+
+            if not psutil_scan_succeeded:
+                # Last-resort scanners for unusual installs without a working
+                # psutil.  Hide the console for both helpers so the fallback
+                # does not recreate the Windows Terminal flash reported in
+                # #49602.
+                windows_no_window = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+                wmic_path = shutil.which("wmic")
+                result = None
+                if wmic_path is not None:
+                    try:
+                        result = subprocess.run(
+                            [
+                                wmic_path,
+                                "process",
+                                "get",
+                                "ProcessId,CommandLine",
+                                "/FORMAT:LIST",
+                            ],
+                            capture_output=True,
+                            text=True,
+                            encoding="utf-8",
+                            errors="ignore",
+                            timeout=10,
+                            creationflags=windows_no_window,
+                        )
+                    except (OSError, subprocess.TimeoutExpired):
+                        result = None
+                if result is None or result.returncode != 0 or not (result.stdout or ""):
+                    # Fallback: PowerShell Get-CimInstance, emit LIST-style output
+                    # so the downstream parser below doesn't need to branch.
+                    powershell = shutil.which("powershell") or shutil.which("pwsh")
+                    if powershell is None:
+                        return []
+                    ps_cmd = (
+                        "Get-CimInstance Win32_Process | "
+                        "ForEach-Object { "
+                        "  'CommandLine=' + ($_.CommandLine -replace \"`r`n\",' ' -replace \"`n\",' '); "
+                        "  'ProcessId=' + $_.ProcessId; "
+                        "  '' "
+                        "}"
+                    )
+                    try:
+                        result = subprocess.run(
+                            [powershell, "-NoProfile", "-Command", ps_cmd],
+                            capture_output=True,
+                            text=True,
+                            encoding="utf-8",
+                            errors="ignore",
+                            timeout=15,
+                            creationflags=windows_no_window,
+                        )
+                    except (OSError, subprocess.TimeoutExpired):
+                        return []
+                if result.returncode != 0 or result.stdout is None:
+                    return []
+                current_cmd = ""
+                for line in result.stdout.split("\n"):
+                    line = line.strip()
+                    if line.startswith("CommandLine="):
+                        current_cmd = line[len("CommandLine=") :]
+                    elif line.startswith("ProcessId="):
+                        pid_str = line[len("ProcessId=") :]
+                        if looks_like_gateway_command_line(current_cmd) and (
+                            all_profiles or _matches_current_profile(current_cmd)
+                        ):
+                            try:
+                                _append_unique_pid(pids, int(pid_str), exclude_pids)
+                            except ValueError:
+                                pass
+                        current_cmd = ""
         else:
             # Try /proc first (works in Docker without procps installed),
             # fall back to ps -A eww.

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -821,9 +821,132 @@ def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkey
     assert gateway.find_gateway_pids() == [321]
 
 
+def _install_fake_psutil(monkeypatch, processes=None, process_iter_error=None):
+    module = ModuleType("psutil")
+
+    class NoSuchProcess(Exception):
+        pass
+
+    class AccessDenied(Exception):
+        pass
+
+    class ZombieProcess(Exception):
+        pass
+
+    def process_iter(attrs):
+        assert attrs == ["pid", "cmdline"]
+        if process_iter_error is not None:
+            raise process_iter_error
+        return processes or []
+
+    module.NoSuchProcess = NoSuchProcess
+    module.AccessDenied = AccessDenied
+    module.ZombieProcess = ZombieProcess
+    module.process_iter = process_iter
+    monkeypatch.setitem(sys.modules, "psutil", module)
+    return module
+
+
+def test_scan_gateway_pids_windows_prefers_psutil_without_subprocess(monkeypatch):
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    _install_fake_psutil(
+        monkeypatch,
+        [
+            SimpleNamespace(info={"pid": 1111, "cmdline": ["python", "-m", "unrelated"]}),
+            SimpleNamespace(
+                info={
+                    "pid": 2468,
+                    "cmdline": ["Hermes.EXE", "gateway", "run", "--replace"],
+                }
+            ),
+        ],
+    )
+
+    def fake_run(cmd, **kwargs):
+        raise AssertionError(f"Unexpected subprocess scan on Windows: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway._scan_gateway_pids(set(), all_profiles=True) == [2468]
+
+
+def test_scan_gateway_pids_windows_psutil_no_match_does_not_spawn_wmic(monkeypatch):
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    _install_fake_psutil(
+        monkeypatch,
+        [SimpleNamespace(info={"pid": 1111, "cmdline": ["python", "-m", "unrelated"]})],
+    )
+
+    def fake_run(cmd, **kwargs):
+        raise AssertionError(f"Unexpected subprocess fallback with working psutil: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway._scan_gateway_pids(set(), all_profiles=True) == []
+
+
+def test_scan_gateway_pids_windows_wmic_fallback_hides_console(monkeypatch):
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    _install_fake_psutil(monkeypatch, process_iter_error=RuntimeError("psutil failed"))
+    monkeypatch.setattr(gateway.shutil, "which", lambda name: "wmic.exe" if name == "wmic" else None)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[:4] == ["wmic.exe", "process", "get", "ProcessId,CommandLine"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "CommandLine=C:\\Program Files\\Hermes\\Hermes.EXE gateway run --replace\n"
+                    "ProcessId=2468\n\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway._scan_gateway_pids(set(), all_profiles=True) == [2468]
+    assert calls[0][1]["creationflags"] & 0x08000000
+
+
+def test_scan_gateway_pids_windows_powershell_fallback_hides_console(monkeypatch):
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    _install_fake_psutil(monkeypatch, process_iter_error=RuntimeError("psutil failed"))
+    monkeypatch.setattr(
+        gateway.shutil,
+        "which",
+        lambda name: "powershell.exe" if name == "powershell" else None,
+    )
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[:3] == ["powershell.exe", "-NoProfile", "-Command"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "CommandLine=C:\\Program Files\\Hermes\\Hermes.EXE gateway run --replace\n"
+                    "ProcessId=2468\n\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway._scan_gateway_pids(set(), all_profiles=True) == [2468]
+    assert calls[0][1]["creationflags"] & 0x08000000
+
+
 def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch):
     monkeypatch.setattr(gateway, "is_windows", lambda: True)
     monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    _install_fake_psutil(monkeypatch, process_iter_error=RuntimeError("psutil failed"))
     monkeypatch.setattr(gateway.shutil, "which", lambda name: "wmic.exe" if name == "wmic" else None)
 
     def fake_run(cmd, **kwargs):


### PR DESCRIPTION
## Summary
- prefer psutil for Windows gateway PID scans so hidden gateway/watchdog starts do not spawn wmic or PowerShell
- keep wmic/PowerShell as best-effort fallbacks and pass CREATE_NO_WINDOW when they are needed
- add regression coverage for psutil preferred/no-match paths and hidden fallback subprocesses

Fixes #49602

## Test Plan
- python -m pytest tests/hermes_cli/test_gateway.py -q -o addopts=
- ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway.py
- python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway.py