### PR TITLE
fix(desktop): preserve profile when opening session routes

### DIFF
--- a/apps/desktop/electron/event-dedupe.test.ts
+++ b/apps/desktop/electron/event-dedupe.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { createEventDeduper } from './event-dedupe'
+import { createEventDeduper, notificationDedupeKey } from './event-dedupe'
 
 test('collapses the same key inside the window (two windows, one event)', () => {
   const isDup = createEventDeduper(1000)
@@ -17,6 +17,17 @@ test('distinct keys are independent', () => {
   assert.equal(isDup('input:s1', 0), false)
   assert.equal(isDup('approval:s1', 0), false, 'different kind')
   assert.equal(isDup('input:s2', 0), false, 'different session')
+})
+
+test('notification keys partition colliding session ids by normalized profile', () => {
+  assert.notEqual(
+    notificationDedupeKey({ kind: 'turnDone', profile: 'alpha', sessionId: 'shared' }),
+    notificationDedupeKey({ kind: 'turnDone', profile: 'beta', sessionId: 'shared' })
+  )
+  assert.equal(
+    notificationDedupeKey({ kind: 'turnDone', profile: ' default ', sessionId: 'shared' }),
+    notificationDedupeKey({ kind: 'turnDone', profile: null, sessionId: 'shared' })
+  )
 })
 
 test('re-fires once the window elapses', () => {

--- a/apps/desktop/electron/event-dedupe.ts
+++ b/apps/desktop/electron/event-dedupe.ts
@@ -8,6 +8,18 @@
 
 const DEDUPE_INTERVAL_MS = 1000
 
+interface NotificationIdentity {
+  kind?: null | string
+  profile?: null | string
+  sessionId?: null | string
+}
+
+export function notificationDedupeKey(payload: NotificationIdentity): string {
+  const profile = payload.profile?.trim() || 'default'
+
+  return `${payload.kind ?? ''}:${profile}:${payload.sessionId ?? ''}`
+}
+
 // Returns true when `key` was already claimed within the interval (caller drops
 // this one). Self-evicting: stale keys are pruned on every call, so the map
 // can't grow unbounded.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -83,7 +83,7 @@ import {
 } from './desktop-uninstall'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
 import { installEmbedReferer } from './embed-referer'
-import { createEventDeduper } from './event-dedupe'
+import { createEventDeduper, notificationDedupeKey } from './event-dedupe'
 import { findGitBash as _findGitBash } from './find-git-bash'
 import { installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
 import { createFirstRunSetupGate } from './first-run-setup-gate'
@@ -8473,7 +8473,9 @@ function focusWindow(win) {
   win.focus()
 }
 
-function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?: boolean } = {}) {
+function spawnSecondaryWindow(
+  { sessionId, watch, profile }: { profile?: null | string; sessionId?: string; watch?: boolean } = {}
+) {
   const icon = getAppIconPath()
 
   const win = new BrowserWindow({
@@ -8519,6 +8521,7 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     buildSessionWindowUrl(sessionId, {
       devServer: DEV_SERVER,
       rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex(),
+      profile,
       watch
     }),
     'Session window'
@@ -8528,8 +8531,8 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
 }
 
 // Open (or focus) a standalone window for a single chat session.
-function createSessionWindow(sessionId, { watch = false } = {}) {
-  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ sessionId, watch }))
+function createSessionWindow(sessionId, { profile = null, watch = false } = {}) {
+  return sessionWindows.openOrFocus(sessionId, profile, () => spawnSecondaryWindow({ profile, sessionId, watch }))
 }
 
 // Additional full "instance" windows — peers of the primary that render the
@@ -9255,7 +9258,10 @@ ipcMain.handle('hermes:window:openSession', async (_event, sessionId, opts) => {
     return { ok: false, error: 'invalid-session-id' }
   }
 
-  createSessionWindow(sessionId.trim(), { watch: opts?.watch === true })
+  createSessionWindow(sessionId, {
+    profile: typeof opts?.profile === 'string' ? opts.profile.trim() || null : null,
+    watch: opts?.watch === true
+  })
 
   return { ok: true }
 })
@@ -10010,7 +10016,7 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
   // kind+session can arrive here twice. Collapse it at this single choke point.
   // Return true (not false): a notification for the event IS being shown by the
   // first caller, so the settings "send test" success probe stays honest.
-  if (isDuplicateNotification(`${payload?.kind ?? ''}:${payload?.sessionId ?? ''}`)) {
+  if (isDuplicateNotification(notificationDedupeKey(payload ?? {}))) {
     return true
   }
 
@@ -10033,7 +10039,10 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
     focusWindow(mainWindow)
 
     if (payload?.sessionId) {
-      mainWindow.webContents.send('hermes:focus-session', payload.sessionId)
+      mainWindow.webContents.send('hermes:focus-session', {
+        profile: typeof payload?.profile === 'string' ? payload.profile : null,
+        sessionId: payload.sessionId
+      })
     }
   })
   notification.on('action', (_actionEvent, index) => {
@@ -10044,7 +10053,11 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
     const action = actions[index]
 
     if (action?.id) {
-      mainWindow.webContents.send('hermes:notification-action', { sessionId: payload?.sessionId, actionId: action.id })
+      mainWindow.webContents.send('hermes:notification-action', {
+        actionId: action.id,
+        profile: typeof payload?.profile === 'string' ? payload.profile : null,
+        sessionId: payload?.runtimeSessionId ?? payload?.sessionId
+      })
     }
   })
   notification.show()
@@ -10316,7 +10329,9 @@ ipcMain.on('hermes:quick-entry:submit', (_event, payload) => {
   // Deliberately does NOT raise/focus the main window — the user asked to fire
   // a prompt from wherever they were, not to be yanked into the app.
   mainWindow.webContents.send('hermes:quick-entry:submit', {
-    target: typeof payload?.target === 'string' && payload.target ? payload.target : 'current',
+    // Renderer-side validation accepts only the discriminated object. Forward
+    // old/invalid shapes unchanged so they are rejected rather than redirected.
+    target: payload?.target,
     text
   })
 })

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -224,7 +224,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     return () => ipcRenderer.removeListener('hermes:window-state-changed', listener)
   },
   onFocusSession: callback => {
-    const listener = (_event, sessionId) => callback(sessionId)
+    const listener = (_event, payload) => callback(payload)
     ipcRenderer.on('hermes:focus-session', listener)
 
     return () => ipcRenderer.removeListener('hermes:focus-session', listener)

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -76,6 +76,15 @@ test('buildSessionWindowUrl encodes the session id in the hash route', () => {
   assert.ok(url.indexOf('?win=secondary') < url.indexOf('#'))
 })
 
+test('buildSessionWindowUrl carries the owning profile in the hash route', () => {
+  const url = buildSessionWindowUrl('abc123', {
+    devServer: 'http://localhost:5173',
+    profile: 'ubuntu server'
+  })
+
+  assert.equal(url, 'http://localhost:5173/?win=secondary#/abc123?profile=ubuntu%20server')
+})
+
 test('buildSessionWindowUrl builds a packaged file URL with the flag before the hash', () => {
   const url = buildSessionWindowUrl('abc', { rendererIndexPath: '/opt/app/index.html' })
 
@@ -100,6 +109,16 @@ test('instanceWindowBounds falls back to the persisted geometry with no source w
   assert.equal(instanceWindowBounds(null, fallback), fallback)
 })
 
+test('buildSessionWindowUrl carries the active profile into a new-session draft', () => {
+  const url = buildSessionWindowUrl(null, {
+    devServer: 'http://localhost:5173',
+    newSession: true,
+    profile: 'alpha profile'
+  })
+
+  assert.equal(url, 'http://localhost:5173/?win=secondary&new=1#/?profile=alpha%20profile')
+})
+
 test('registry opens one window per session and focuses on re-open', () => {
   const registry = createSessionWindowRegistry()
   let built = 0
@@ -118,6 +137,19 @@ test('registry opens one window per session and focuses on re-open', () => {
   assert.equal(first, second)
   assert.equal(registry.size, 1)
   assert.equal(win.calls.focus, 1, 'second open focuses the existing window')
+})
+
+test('registry treats equal session ids in different profiles as distinct windows', () => {
+  const registry = createSessionWindowRegistry()
+  const alpha = makeFakeWindow()
+  const beta = makeFakeWindow()
+
+  const alphaResult = registry.openOrFocus('shared-id', 'alpha', () => alpha)
+  const betaResult = registry.openOrFocus('shared-id', 'beta', () => beta)
+
+  assert.equal(alphaResult, alpha)
+  assert.equal(betaResult, beta)
+  assert.equal(registry.size, 2)
 })
 
 test('registry restores + shows a minimized/hidden window on re-open', () => {
@@ -183,12 +215,17 @@ test('registry ignores empty / non-string session ids', () => {
   assert.equal(registry.size, 0)
 })
 
-test('registry trims the session id before keying', () => {
+test('registry preserves opaque session-id bytes when keying', () => {
   const registry = createSessionWindowRegistry()
-  const win = makeFakeWindow()
-  registry.openOrFocus('  s1  ', () => win)
+  const spaced = makeFakeWindow()
+  const plain = makeFakeWindow()
 
+  registry.openOrFocus('  s1  ', () => spaced)
+  registry.openOrFocus('s1', () => plain)
+
+  assert.equal(registry.has('  s1  '), true)
   assert.equal(registry.has('s1'), true)
+  assert.equal(registry.size, 2)
 })
 
 test('chatWindowWebPreferences disables background throttling so streaming paints while blurred', () => {

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -41,9 +41,14 @@ function chatWindowWebPreferences(preloadPath: string) {
 // onboarding overlays and the global session sidebar. `watch=1` marks a
 // spectator window (e.g. a running subagent's session): the renderer resumes it
 // lazily so the gateway never builds an agent just to stream into it.
-function buildSessionWindowUrl(sessionId: string, { devServer, rendererIndexPath, watch }: any = {}) {
-  const query = `?win=secondary${watch ? '&watch=1' : ''}`
-  const route = `#/${encodeURIComponent(sessionId)}`
+function buildSessionWindowUrl(
+  sessionId: null | string,
+  { devServer, newSession, rendererIndexPath, watch, profile }: any = {}
+) {
+  const query = `?win=secondary${watch ? '&watch=1' : ''}${newSession ? '&new=1' : ''}`
+  const profileKey = typeof profile === 'string' ? profile.trim() : ''
+  const profileQuery = profileKey ? `?profile=${encodeURIComponent(profileKey)}` : ''
+  const route = newSession ? `#/${profileQuery}` : `#/${encodeURIComponent(sessionId ?? '')}${profileQuery}`
 
   if (devServer) {
     const base = devServer.endsWith('/') ? devServer.slice(0, -1) : devServer
@@ -76,7 +81,8 @@ function instanceWindowBounds(base: { x: number; y: number; width: number; heigh
   }
 }
 
-// A small registry keyed by sessionId that guarantees one window per chat:
+// A small registry keyed by owning profile + sessionId that guarantees one
+// window per chat identity:
 // opening a session that already has a live window focuses it instead of
 // spawning a duplicate, and a window removes itself from the registry when it
 // closes. The actual BrowserWindow construction is injected (the `factory`) so
@@ -84,12 +90,22 @@ function instanceWindowBounds(base: { x: number; y: number; width: number; heigh
 function createSessionWindowRegistry() {
   const windows = new Map()
 
-  function openOrFocus(sessionId, factory) {
-    const key = typeof sessionId === 'string' ? sessionId.trim() : ''
+  const registryKey = (sessionId, profile) => {
+    const profileKey = typeof profile === 'string' ? profile.trim() || 'default' : 'default'
 
-    if (!key) {
+    return `${profileKey}\u0000${sessionId}`
+  }
+
+  function openOrFocus(sessionId, profileOrFactory, maybeFactory = undefined) {
+    const id = typeof sessionId === 'string' ? sessionId : ''
+    const profile = typeof profileOrFactory === 'function' ? undefined : profileOrFactory
+    const factory = typeof profileOrFactory === 'function' ? profileOrFactory : maybeFactory
+
+    if (!id.trim() || typeof factory !== 'function') {
       return null
     }
+
+    const key = registryKey(id, profile)
 
     const existing = windows.get(key)
 
@@ -108,7 +124,7 @@ function createSessionWindowRegistry() {
       return existing
     }
 
-    const win = factory(key)
+    const win = factory(id)
 
     if (!win) {
       return null
@@ -128,8 +144,8 @@ function createSessionWindowRegistry() {
 
   return {
     openOrFocus,
-    get: key => windows.get(key),
-    has: key => windows.has(key),
+    get: (sessionId, profile = null) => windows.get(registryKey(sessionId, profile)),
+    has: (sessionId, profile = null) => windows.has(registryKey(sessionId, profile)),
     get size() {
       return windows.size
     }

--- a/apps/desktop/src/app/artifacts/artifact-utils.test.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo, SessionMessage } from '@/types/hermes'
+
+import { collectArtifactsForSession } from './artifact-utils'
+
+const session = (profile: string): SessionInfo => ({
+  archived: false,
+  cwd: null,
+  ended_at: null,
+  id: 'shared-id',
+  input_tokens: 0,
+  is_active: false,
+  last_active: 0,
+  message_count: 1,
+  model: null,
+  output_tokens: 0,
+  preview: null,
+  profile,
+  source: null,
+  started_at: 1,
+  title: `${profile} chat`,
+  tool_call_count: 0
+})
+
+const messages: SessionMessage[] = [
+  {
+    content: '[report](https://example.com/report.pdf)',
+    role: 'assistant',
+    timestamp: 123
+  }
+]
+
+describe('collectArtifactsForSession profile identity', () => {
+  it('retains the owning profile and includes it in the artifact id', () => {
+    const alpha = collectArtifactsForSession(session('alpha'), messages)[0]
+    const beta = collectArtifactsForSession(session('beta'), messages)[0]
+
+    expect(alpha).toMatchObject({ profile: 'alpha', sessionId: 'shared-id' })
+    expect(beta).toMatchObject({ profile: 'beta', sessionId: 'shared-id' })
+    expect(alpha.id).not.toBe(beta.id)
+  })
+})

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -1,5 +1,6 @@
 import { readDesktopFileDataUrl } from '@/lib/desktop-fs'
 import { filePathFromMediaPath, isRemoteGateway, mediaExternalUrl } from '@/lib/media'
+import { normalizeProfileKey, sessionIdentityKey } from '@/lib/session-identity'
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
 export type ArtifactKind = 'image' | 'file' | 'link'
@@ -12,6 +13,7 @@ export interface ArtifactRecord {
   value: string
   href: string
   label: string
+  profile: string
   sessionId: string
   sessionTitle: string
   timestamp: number
@@ -246,6 +248,7 @@ function collectArtifactsFromMessage(message: SessionMessage, pushValue: (value:
 export function collectArtifactsForSession(session: SessionInfo, messages: SessionMessage[]): ArtifactRecord[] {
   const found = new Map<string, ArtifactRecord>()
   const title = artifactSessionTitle(session)
+  const profile = normalizeProfileKey(session.profile)
 
   for (const message of messages) {
     if (message.role !== 'assistant' && message.role !== 'tool') {
@@ -259,7 +262,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         return
       }
 
-      const key = `${session.id}:${value}`
+      const key = `${sessionIdentityKey(session.id, profile)}:${value}`
 
       if (found.has(key)) {
         return
@@ -271,6 +274,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         value,
         href: artifactHref(value),
         label: artifactLabel(value),
+        profile,
         sessionId: session.id,
         sessionTitle: title,
         timestamp: message.timestamp || session.last_active || session.started_at || Date.now()

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -92,7 +92,7 @@ function paginationItems(page: number, pageCount: number): Array<number | 'ellip
 
 type CellCtx = {
   onOpen: (href: string) => void | Promise<void>
-  onOpenChat: (sessionId: string) => void
+  onOpenChat: (sessionId: string, profile: string) => void
 }
 
 interface ArtifactColumn {
@@ -280,7 +280,7 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
   const cellCtx: CellCtx = {
     onOpen: openArtifact,
-    onOpenChat: sessionId => openSession(sessionId, navigate)
+    onOpenChat: (sessionId, profile) => openSession(sessionId, navigate, 'in-place', profile)
   }
 
   return (
@@ -345,7 +345,7 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
                       failedImage={failedImageIds.has(artifact.id)}
                       key={artifact.id}
                       onImageError={markImageFailed}
-                      onOpenChat={sessionId => openSession(sessionId, navigate)}
+                      onOpenChat={(sessionId, profile) => openSession(sessionId, navigate, 'in-place', profile)}
                     />
                   ))}
                 </div>
@@ -433,7 +433,7 @@ interface ArtifactImageCardProps {
   artifact: ArtifactRecord
   failedImage: boolean
   onImageError: (id: string) => void
-  onOpenChat: (sessionId: string) => void
+  onOpenChat: (sessionId: string, profile: string) => void
 }
 
 function ArtifactImageCard({ artifact, failedImage, onImageError, onOpenChat }: ArtifactImageCardProps) {
@@ -502,7 +502,12 @@ function ArtifactImageCard({ artifact, failedImage, onImageError, onOpenChat }: 
         </div>
 
         <div className="flex flex-wrap gap-1.5">
-          <Button onClick={() => onOpenChat(artifact.sessionId)} size="xs" type="button" variant="textStrong">
+          <Button
+            onClick={() => onOpenChat(artifact.sessionId, artifact.profile)}
+            size="xs"
+            type="button"
+            variant="textStrong"
+          >
             <FolderOpen className="size-3" />
             {a.chat}
           </Button>
@@ -606,7 +611,10 @@ function LocationCell({ artifact }: { artifact: ArtifactRecord; ctx: CellCtx }) 
 
 function SessionCell({ artifact, ctx }: { artifact: ArtifactRecord; ctx: CellCtx }) {
   return (
-    <ArtifactCellAction onClick={() => ctx.onOpenChat(artifact.sessionId)} title={artifact.sessionTitle}>
+    <ArtifactCellAction
+      onClick={() => ctx.onOpenChat(artifact.sessionId, artifact.profile)}
+      title={artifact.sessionTitle}
+    >
       <span className="flex min-w-0 flex-col">
         <span className="truncate">{artifact.sessionTitle}</span>
         <span className="truncate text-[0.6875rem] font-normal text-(--ui-text-tertiary)">

--- a/apps/desktop/src/app/chat/composer/model-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.test.tsx
@@ -95,6 +95,7 @@ describe('ModelPill per-surface model label', () => {
       $messages: atom([]),
       $messagesEmpty: atom(true),
       $model: atom('tile/claude-sonnet'),
+      $profile: atom('default'),
       $provider: atom('anthropic'),
       $reasoningEffort: atom('high'),
       $runtimeId: atom('tile-runtime'),

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -126,7 +126,9 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   const openAgents = () => navigate(AGENTS_ROUTE)
 
   const openSubagent = (item: ComposerStatusItem) =>
-    item.sessionId ? void openSessionInNewWindow(item.sessionId, { watch: true }) : openAgents()
+    item.sessionId
+      ? void openSessionInNewWindow(item.sessionId, { profile: item.sessionProfile, watch: true })
+      : openAgents()
 
   // Preview links live as child rows of the background group — a localhost dev
   // server and its preview are the same thing — so they no longer float as an

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -22,6 +22,7 @@ import type { ChatMessage } from '@/lib/chat-messages'
 import { quickModelOptions, sessionTitle } from '@/lib/chat-runtime'
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { sessionIdentityKey, sessionMatchesIdentity } from '@/lib/session-identity'
 import { cn } from '@/lib/utils'
 import { migrateSessionDraft } from '@/store/composer'
 import { migrateQueuedPrompts, parkQueuedPrompts } from '@/store/composer-queue'
@@ -36,15 +37,16 @@ import {
   $introPersonality,
   $introSeed,
   $resumeExhaustedSessionId,
+  $selectedSessionIdentityKey,
   $sessions,
+  resolveComposerMigrationKeys,
   resolveComposerSessionKey,
-  sessionMatchesStoredId,
   sessionPinId
 } from '@/store/session'
 import { isSecondaryWindow, isWatchWindow } from '@/store/windows'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
-import { primaryRouteSelectedSessionId, routeSessionId } from '../routes'
+import { primaryRouteSelectedSessionId, routeSessionId, routeSessionIdentityKey, routeSessionProfile } from '../routes'
 import { titlebarHeaderBaseClass, titlebarHeaderShadowClass, titlebarHeaderTitleClass } from '../shell/titlebar'
 
 import { ChatDropOverlay } from './chat-drop-overlay'
@@ -86,7 +88,7 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   onEdit: (message: AppendMessage) => Promise<void>
   onReload: (parentId: string | null) => Promise<void>
   onRestoreToMessage?: (messageId: string, target?: { text?: string; userOrdinal?: number | null }) => Promise<void>
-  onRetryResume: (sessionId: string) => void
+  onRetryResume: (sessionId: string, profile?: null | string) => void
   onTranscribeAudio?: (audio: Blob) => Promise<string>
   onDismissError?: (messageId: string) => void
 }
@@ -107,11 +109,16 @@ function ChatHeader({
   selectedSessionId
 }: ChatHeaderProps) {
   const sessions = useStore($sessions)
+  const selectedSessionIdentityKey = useStore($selectedSessionIdentityKey)
   const pinnedSessionIds = useStore($pinnedSessionIds)
   const profiles = useStore($profiles)
 
+  const activeGatewayProfile = useStore($activeGatewayProfile)
+
   const activeStoredSession =
-    (selectedSessionId && sessions.find(session => sessionMatchesStoredId(session, selectedSessionId))) || null
+    (selectedSessionId &&
+      sessions.find(session => sessionMatchesIdentity(session, selectedSessionId, activeGatewayProfile))) ||
+    null
 
   const title = activeStoredSession ? sessionTitle(activeStoredSession) : 'New session'
 
@@ -125,9 +132,11 @@ function ChatHeader({
   // state after auto-compression rotates the id.
   const selectedIsPinned = activeStoredSession
     ? pinnedSessionIds.includes(sessionPinId(activeStoredSession))
-    : selectedSessionId
-      ? pinnedSessionIds.includes(selectedSessionId)
-      : false
+    : selectedSessionIdentityKey
+      ? pinnedSessionIds.includes(selectedSessionIdentityKey)
+      : selectedSessionId
+        ? pinnedSessionIds.includes(sessionIdentityKey(selectedSessionId, activeGatewayProfile))
+        : false
 
   // Secondary windows (new-session scratch, subagent watch, cmd-click pop-out)
   // are compact side panels — they drop the session-actions header + border
@@ -307,6 +316,7 @@ export function ChatView({
   const messagesEmpty = useStore(view.$messagesEmpty)
   const lastVisibleIsUser = useStore(view.$lastVisibleIsUser)
   const selectedSessionId = useStore(view.$storedId)
+  const selectedSessionIdentityKey = useStore($selectedSessionIdentityKey)
   const sessions = useStore($sessions)
   const resumeExhaustedSessionId = useStore($resumeExhaustedSessionId)
 
@@ -316,13 +326,16 @@ export function ChatView({
   // latter can be momentarily null/stale mid-switch, which used to leak into
   // the composer's scope key (#59305). A tile has no route, so it always uses
   // its own selection directly.
-  const queueSessionKey = useMemo(() => {
-    const effectiveSelectedSessionId = isPrimary
-      ? primaryRouteSelectedSessionId(location.pathname, selectedSessionId)
-      : selectedSessionId
+  const effectiveSelectedSessionId = isPrimary
+    ? primaryRouteSelectedSessionId(location.pathname, selectedSessionId)
+    : selectedSessionId
 
-    return resolveComposerSessionKey(effectiveSelectedSessionId, sessions)
-  }, [isPrimary, location.pathname, selectedSessionId, sessions])
+  const composerProfile = isPrimary ? (routeSessionProfile(location.search) ?? activeGatewayProfile) : activeGatewayProfile
+
+  const queueSessionKey = useMemo(
+    () => resolveComposerSessionKey(effectiveSelectedSessionId, sessions, composerProfile),
+    [composerProfile, effectiveSelectedSessionId, sessions]
+  )
 
   // When the tip row arrives after compression, migrate any tip-keyed stash onto
   // the durable lineage key before the composer remounts onto that key.
@@ -331,9 +344,27 @@ export function ChatView({
       return
     }
 
-    migrateSessionDraft(selectedSessionId, queueSessionKey)
-    migrateQueuedPrompts(selectedSessionId, queueSessionKey)
-  }, [queueSessionKey, selectedSessionId])
+    const { legacyLineageKey, selectedIdentity } = resolveComposerMigrationKeys(
+      selectedSessionId,
+      sessions,
+      composerProfile
+    )
+
+    // Raw pre-profile draft keys have no owner. Only the default profile may
+    // claim them; queue storage migrates its legacy record to canonical default
+    // identities at decode time, so queue migration never guesses from bytes.
+    if (composerProfile === 'default') {
+      migrateSessionDraft(selectedSessionId, queueSessionKey)
+      migrateSessionDraft(legacyLineageKey, queueSessionKey)
+      migrateQueuedPrompts(
+        legacyLineageKey ? sessionIdentityKey(legacyLineageKey, 'default') : null,
+        queueSessionKey
+      )
+    }
+
+    migrateSessionDraft(selectedIdentity, queueSessionKey)
+    migrateQueuedPrompts(selectedIdentity, queueSessionKey)
+  }, [composerProfile, queueSessionKey, selectedSessionId, sessions])
 
   // Transcript-side stops (the streaming message's hover Stop, the runtime's
   // cancel) are explicit halts, same as the composer's Stop button: park any
@@ -348,13 +379,21 @@ export function ChatView({
 
   // A tile IS its session — no route involved, never "mismatched".
   const routedSessionId = isPrimary ? routeSessionId(location.pathname) : selectedSessionId
+  const routedSessionProfile = isPrimary ? routeSessionProfile(location.search) ?? activeGatewayProfile : null
   const isRoutedSessionView = Boolean(routedSessionId)
+
+  const routedSessionIdentity = isPrimary
+    ? routeSessionIdentityKey(location.pathname, location.search, activeGatewayProfile)
+    : routedSessionId && routedSessionProfile
+      ? sessionIdentityKey(routedSessionId, routedSessionProfile)
+      : null
 
   // The URL points at a session the store hasn't loaded yet (sidebar / cmd-K /
   // direct nav). Derived in render so the swap reads instantly: the same frame
   // the id changes we drop the old transcript and show the loader, instead of
   // waiting for the resume effect (which paints a frame later) to clear them.
-  const routeSessionMismatch = isRoutedSessionView && routedSessionId !== selectedSessionId
+  const routeSessionMismatch =
+    isPrimary && isRoutedSessionView && routedSessionIdentity !== selectedSessionIdentityKey
 
   // The compact new-session pop-out skips the wordmark/tagline intro — it's a
   // scratch window, not the full-height empty state.
@@ -378,7 +417,11 @@ export function ChatView({
   // Suppress the loader and show an explicit error + manual Retry instead of
   // spinning forever. Gated on the route matching so a stale latch from another
   // session can't blank the current one.
-  const resumeExhausted = isPrimary && isRoutedSessionView && resumeExhaustedSessionId === routedSessionId
+  const resumeExhausted =
+    isPrimary &&
+    isRoutedSessionView &&
+    Boolean(resumeExhaustedSessionId) &&
+    resumeExhaustedSessionId === routedSessionIdentity
 
   const loadingSession =
     !resumeExhausted && isRoutedSessionView && (routeSessionMismatch || (messagesEmpty && !activeSessionId))
@@ -388,7 +431,11 @@ export function ChatView({
   // to send to until a retry rebinds one. Watch windows are pure spectators of a
   // subagent run driven elsewhere — no composer, transcript is read-only.
   const showChatBar = !loadingSession && !resumeExhausted && !isWatchWindow()
-  const threadKey = selectedSessionId || activeSessionId || (isRoutedSessionView ? location.pathname : 'new')
+
+  const threadKey =
+    (isPrimary ? selectedSessionIdentityKey : queueSessionKey) ||
+    activeSessionId ||
+    (isRoutedSessionView ? routedSessionIdentity || location.pathname : 'new')
 
   const modelOptionsQuery = useQuery<ModelOptionsResponse>({
     queryKey: modelOptionsQueryKey(activeGatewayProfile, activeSessionId),
@@ -526,7 +573,11 @@ export function ChatView({
                 title={t.desktop.resumeStrandedTitle}
               >
                 <div className="grid justify-items-center">
-                  <Button onClick={() => onRetryResume(routedSessionId)} size="sm" variant="outline">
+                  <Button
+                    onClick={() => onRetryResume(routedSessionId, routedSessionProfile)}
+                    size="sm"
+                    variant="outline"
+                  >
                     {t.desktop.resumeRetry}
                   </Button>
                 </div>

--- a/apps/desktop/src/app/chat/right-rail/preview-artifact.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-artifact.test.tsx
@@ -1,7 +1,13 @@
 import { act, cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { $artifactRegistry, $artifactVersionSelection, artifactPreviewTarget, upsertArtifact } from '@/store/artifacts'
+import {
+  $artifactRegistry,
+  $artifactVersionSelection,
+  artifactPreviewTarget,
+  artifactsForSession,
+  upsertArtifact
+} from '@/store/artifacts'
 
 import { ArtifactPreview } from './preview-artifact'
 
@@ -16,7 +22,7 @@ function register(title: string, kind: 'code' | 'html' | 'svg', content: string)
 }
 
 async function renderArtifact(artifactId: string) {
-  const record = $artifactRegistry.get()['session-1']!.find(item => item.id === artifactId)!
+  const record = artifactsForSession('session-1').find(item => item.id === artifactId)!
 
   await act(async () => {
     render(<ArtifactPreview target={artifactPreviewTarget(record)} />)
@@ -98,7 +104,7 @@ describe('ArtifactPreview', () => {
 
   it('falls back to an empty state when the registry no longer has the artifact', async () => {
     const { artifactId } = register('Dashboard', 'html', '<h1>gone</h1>')
-    const record = $artifactRegistry.get()['session-1']!.find(item => item.id === artifactId)!
+    const record = artifactsForSession('session-1').find(item => item.id === artifactId)!
     const target = artifactPreviewTarget(record)
 
     $artifactRegistry.set({})

--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -15,7 +15,7 @@ import { startSessionDrag } from './session-drag'
  * the drop has to land on the tab the user can actually see.
  */
 
-vi.mock('@/store/session-states', () => ({ openSessionTile: vi.fn() }))
+vi.mock('@/store/session-states', () => ({ openSessionTile: vi.fn(async () => undefined) }))
 vi.mock('./composer/focus', () => ({ requestComposerInsertRefs: vi.fn() }))
 
 const ZONE = { left: 0, top: 0, right: 1000, bottom: 800 }
@@ -97,7 +97,7 @@ describe('session drop targeting across stacked tabs', () => {
 
     dragTo(row, 980, 400)
 
-    expect(openSessionTile).toHaveBeenCalledWith('dragged', 'right', 'session-tile:visible', undefined)
+    expect(openSessionTile).toHaveBeenCalledWith('dragged', 'right', 'session-tile:visible', undefined, 'default')
     expect(requestComposerInsertRefs).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -184,11 +184,12 @@ export function startSessionDrag(
 
     onCommit() {
       if (split) {
-        openSessionTile(payload.id, split.pos, split.anchor, split.before)
-        // A tile for this session may already exist (openSessionTile is
-        // idempotent — e.g. persisted from an earlier run): a drop must never
-        // feel dead, so front/unhide/un-dismiss it either way.
-        revealTreePane(`session-tile:${payload.id}`)
+        void openSessionTile(payload.id, split.pos, split.anchor, split.before, payload.profile).then(() => {
+          // A tile for this session may already exist (openSessionTile is
+          // idempotent — e.g. persisted from an earlier run): a drop must never
+          // feel dead, so front/unhide/un-dismiss it either way.
+          revealTreePane(`session-tile:${payload.id}`)
+        })
       } else if (link) {
         // The "link to chat" drop: an @session chip in that surface's composer.
         requestComposerInsertRefs([sessionInlineRef(payload)], { target: link })

--- a/apps/desktop/src/app/chat/session-status-dot.tsx
+++ b/apps/desktop/src/app/chat/session-status-dot.tsx
@@ -1,6 +1,7 @@
 import { useStore } from '@nanostores/react'
 
 import { type Translations, useI18n } from '@/i18n'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { cn } from '@/lib/utils'
 import { $backgroundRunningSessionIds } from '@/store/composer-status'
 import { $unreadFinishedSessionIds } from '@/store/session'
@@ -80,6 +81,9 @@ export interface SessionStatusDotProps {
    *  the sidebar row's `session.id` and a pane tile's `storedSessionId` are the
    *  same stored id (`$workingSessionIds` et al. map `storedSessionId`). */
   storedSessionId: string
+  /** Owning profile when the stored row is not loaded yet (tiles/routes can
+   * render before the paginated session list contains their row). */
+  profile?: null | string
   /** The session row for color resolution — recents OR the project tree. Both
    *  call sites already hold it; passing it lets the idle dot inherit the
    *  project color even for a session older than the paginated recents page
@@ -102,7 +106,7 @@ export interface SessionStatusDotProps {
  * project color; the active states own the dot with their semantic color so an
  * attention cue is never masked by the inherited tint.
  */
-export function SessionStatusDot({ storedSessionId, session, branchStem, className }: SessionStatusDotProps) {
+export function SessionStatusDot({ storedSessionId, session, branchStem, className, profile }: SessionStatusDotProps) {
   const { t } = useI18n()
   const r = t.sidebar.row
 
@@ -110,12 +114,13 @@ export function SessionStatusDot({ storedSessionId, session, branchStem, classNa
   // back to the resolver for a session outside the recents page.
   useStore($sessionColorById)
   const color = sessionColorFor(session) ?? null
+  const identityKey = sessionIdentityKey(storedSessionId, session?.profile ?? profile)
 
-  const needsInput = useStore($attentionSessionIds).includes(storedSessionId)
-  const isWorking = useStore($workingSessionIds).includes(storedSessionId)
-  const isStalled = useStore($stalledSessionIds).includes(storedSessionId)
-  const isUnread = useStore($unreadFinishedSessionIds).includes(storedSessionId)
-  const hasBackground = useStore($backgroundRunningSessionIds).includes(storedSessionId)
+  const needsInput = useStore($attentionSessionIds).includes(identityKey)
+  const isWorking = useStore($workingSessionIds).includes(identityKey)
+  const isStalled = useStore($stalledSessionIds).includes(identityKey)
+  const isUnread = useStore($unreadFinishedSessionIds).includes(identityKey)
+  const hasBackground = useStore($backgroundRunningSessionIds).includes(identityKey)
 
   const dotState = sessionDotState({ hasBackground, isStalled, isUnread, isWorking, needsInput })
 

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -18,13 +18,14 @@ import { useI18n } from '@/i18n'
 import { textPart } from '@/lib/chat-messages'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
+import { sessionMatchesIdentity } from '@/lib/session-identity'
 import { clearClarifyRequest } from '@/store/clarify'
 import type { ComposerAttachment } from '@/store/composer'
 import { resetSessionBackground } from '@/store/composer-status'
 import { notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
-import { $connection, $sessions, sessionMatchesStoredId } from '@/store/session'
+import { $connection, $sessions } from '@/store/session'
 import { $sessionStates, sessionTileDelegate } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { clearSessionSubagents } from '@/store/subagents'
@@ -71,10 +72,14 @@ export function listTileSessionRow(deps: {
   runtimeId: string
   sessions: readonly SessionInfo[]
   storedSessionId: string
+  storedSessionProfile?: null | string
 }): boolean {
   const preview = deps.preview.trim()
 
-  if (!preview || deps.sessions.some(session => sessionMatchesStoredId(session, deps.storedSessionId))) {
+  if (
+    !preview ||
+    deps.sessions.some(session => sessionMatchesIdentity(session, deps.storedSessionId, deps.storedSessionProfile))
+  ) {
     return false
   }
 
@@ -82,7 +87,10 @@ export function listTileSessionRow(deps: {
     { info: { cwd: deps.cwd, model: deps.model }, session_id: deps.runtimeId, stored_session_id: deps.storedSessionId },
     deps.storedSessionId,
     null,
-    preview
+    preview,
+    null,
+    undefined,
+    deps.storedSessionProfile
   )
   broadcastSessionsChanged()
 
@@ -90,15 +98,22 @@ export function listTileSessionRow(deps: {
 }
 
 interface SessionTileActionsArgs {
+  profile: string
   runtimeId: string
   scope: ComposerScope
   storedSessionId: string
 }
 
-export function useSessionTileActions({ runtimeId, scope, storedSessionId }: SessionTileActionsArgs) {
+export function useSessionTileActions({ profile, runtimeId, scope, storedSessionId }: SessionTileActionsArgs) {
   const { t } = useI18n()
   const copy = t.desktop
-  const { requestGateway } = useGatewayRequest()
+  const { requestGatewayForProfile } = useGatewayRequest()
+
+  const requestGateway = useCallback(
+    <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number) =>
+      requestGatewayForProfile<T>(profile, method, params, timeoutMs),
+    [profile, requestGatewayForProfile]
+  )
 
   const runtimeIdRef = useRef(runtimeId)
   runtimeIdRef.current = runtimeId
@@ -146,9 +161,10 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       preview,
       runtimeId,
       sessions: $sessions.get(),
-      storedSessionId: storedIdRef.current
+      storedSessionId: storedIdRef.current,
+      storedSessionProfile: profile
     })
-  }, [])
+  }, [profile])
 
   // Tile-side attachment staging: same upload rules as the primary submit
   // (skip synced/pathless, byte-upload files+images), against the tile scope.
@@ -156,9 +172,10 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
     async (
       sessionId: string,
       attachments: ComposerAttachment[],
-      options: { updateComposerAttachments?: boolean } = {}
+      options: { requestGateway?: typeof requestGateway; updateComposerAttachments?: boolean } = {}
     ): Promise<ComposerAttachment[]> => {
       const remote = $connection.get()?.mode === 'remote'
+      const submitGateway = options.requestGateway ?? requestGateway
       const synced: ComposerAttachment[] = []
 
       for (const attachment of attachments) {
@@ -169,7 +186,11 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
         }
 
         if (attachment.kind === 'image' || attachment.kind === 'file') {
-          const next = await uploadComposerAttachment(attachment, { remote, requestGateway, sessionId })
+          const next = await uploadComposerAttachment(attachment, {
+            remote,
+            requestGateway: submitGateway,
+            sessionId
+          })
 
           if (options.updateComposerAttachments ?? true) {
             scope.attachments.update(next)
@@ -196,6 +217,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
     copy,
     createBackendSessionForSend: async () => runtimeIdRef.current,
     getRoutedStoredSessionId: () => storedIdRef.current,
+    getRoutedStoredSessionProfile: () => profile,
     getRuntimeIdForStoredSession: storedId => (storedId === storedIdRef.current ? runtimeIdRef.current : null),
     // A tile IS its session — no route to abandon, so the create-abort guard's
     // token is a stable constant (the guard never trips for a tile).
@@ -227,14 +249,19 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
 
       if (!attachments.length && SLASH_COMMAND_RE.test(visibleText)) {
         triggerHaptic('selection')
-        await sessionTileDelegate()?.executeSlash(visibleText, runtimeIdRef.current)
+        await sessionTileDelegate()?.executeSlash(visibleText, runtimeIdRef.current, profile, storedIdRef.current)
 
         return true
       }
 
-      return await submitPromptText(rawText, options)
+      return await submitPromptText(rawText, {
+        ...options,
+        profile,
+        sessionId: runtimeIdRef.current,
+        storedSessionId: storedIdRef.current
+      })
     },
-    [listTileSession, scope.attachments.$attachments, submitPromptText]
+    [listTileSession, profile, scope.attachments.$attachments, submitPromptText]
   )
 
   const cancelRun = useCallback(async () => {
@@ -255,7 +282,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
     clearSessionSubagents(sessionId)
     resetSessionBackground(sessionId)
     setSessionDraftingTool(sessionId, '')
-    clearAllPrompts(sessionId)
+    clearAllPrompts(sessionId, profile)
     clearClarifyRequest(undefined, sessionId)
 
     try {
@@ -263,7 +290,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
     } catch (err) {
       notifyError(err, copy.stopFailed)
     }
-  }, [copy.stopFailed, requestGateway, update])
+  }, [copy.stopFailed, profile, requestGateway, update])
 
   const steerPrompt = useCallback(
     async (rawText: string): Promise<boolean> => {

--- a/apps/desktop/src/app/chat/session-tile-row.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-row.test.ts
@@ -29,14 +29,15 @@ function row(overrides: Partial<SessionInfo> = {}): SessionInfo {
   }
 }
 
-function seed(preview: string, sessions: SessionInfo[] = $sessions.get()) {
+function seed(preview: string, sessions: SessionInfo[] = $sessions.get(), profile?: string) {
   return listTileSessionRow({
     cwd: '/work/repo',
     model: 'claude-opus-5',
     preview,
     runtimeId: RUNTIME,
     sessions,
-    storedSessionId: STORED
+    storedSessionId: STORED,
+    storedSessionProfile: profile
   })
 }
 
@@ -66,6 +67,15 @@ describe('listTileSessionRow', () => {
     const rotated = row({ _lineage_root_id: STORED, id: 'stored-tab-compressed-2' })
 
     expect(seed('after compression', [rotated])).toBe(false)
+  })
+
+  it('does not let a colliding session from another profile suppress the tile row', () => {
+    const alpha = row({ profile: 'alpha', title: 'Alpha' })
+
+    expect(seed('beta prompt', [alpha], 'beta')).toBe(true)
+    expect($sessions.get()).toEqual([
+      expect.objectContaining({ id: STORED, preview: 'beta prompt', profile: 'beta' })
+    ])
   })
 
   it('does not list a session on an empty or whitespace-only send', () => {

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -34,6 +34,7 @@ import { transcribeAudio } from '@/hermes'
 import { useI18n } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { sessionTitle } from '@/lib/chat-runtime'
+import { sessionMatchesIdentity } from '@/lib/session-identity'
 import { createComposerAttachmentScope } from '@/store/composer'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
 import { $activeGatewayProfile } from '@/store/profile'
@@ -43,8 +44,7 @@ import {
   $gatewayState,
   $selectedStoredSessionId,
   $sessions,
-  sessionMatchesStoredId,
-  sessionPinId
+  resolveSessionPinId
 } from '@/store/session'
 import {
   $sessionStates,
@@ -74,7 +74,7 @@ const NO_MESSAGES: ChatMessage[] = []
 
 /** The tile's SessionView: the same atom shape the primary chat renders
  *  from, computed from this session's slice of `$sessionStates`. */
-function buildTileView(storedSessionId: string): SessionView {
+function buildTileView(storedSessionId: string, profile: string): SessionView {
   const $runtimeId = computed(
     $sessionTiles,
     tiles => tiles.find(t => t.storedSessionId === storedSessionId)?.runtimeId ?? null
@@ -96,6 +96,7 @@ function buildTileView(storedSessionId: string): SessionView {
     $messages,
     $messagesEmpty: computed($messages, messages => messages.length === 0),
     $model: computed($state, state => state?.model ?? ''),
+    $profile: atom(profile),
     $provider: computed($state, state => state?.provider ?? ''),
     $reasoningEffort: computed($state, state => state?.reasoningEffort ?? ''),
     $runtimeId,
@@ -125,15 +126,15 @@ function TileChat({
 
   const scope = useMemo<ComposerScope>(
     () => ({
-      $awaitingInput: sessionAwaitingInput(runtimeId),
+      $awaitingInput: sessionAwaitingInput(runtimeId, activeGatewayProfile),
       $messages: view.$messages,
       attachments,
       target: `tile:${storedSessionId}`
     }),
-    [attachments, runtimeId, storedSessionId, view.$messages]
+    [activeGatewayProfile, attachments, runtimeId, storedSessionId, view.$messages]
   )
 
-  const actions = useSessionTileActions({ runtimeId, scope, storedSessionId })
+  const actions = useSessionTileActions({ profile: activeGatewayProfile, runtimeId, scope, storedSessionId })
 
   // The same attach/pick/paste/drop pipeline the primary composer uses,
   // pointed at this tile's chips + session.
@@ -196,9 +197,10 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const tiles = useStore($sessionTiles)
   const tile = tiles.find(t => t.storedSessionId === storedSessionId)
   const runtimeId = tile?.runtimeId ?? null
+  const activeGatewayProfile = useStore($activeGatewayProfile)
   const gatewayOpen = useStore($gatewayState) === 'open'
   const resumingRef = useRef(false)
-  const view = useMemo(() => buildTileView(storedSessionId), [storedSessionId])
+  const view = useMemo(() => buildTileView(storedSessionId, activeGatewayProfile), [activeGatewayProfile, storedSessionId])
 
   // A tab-strip "+"/⌘T tab is created UNLISTED — its session stays out of
   // $sessions (no sidebar clutter) until it's actually used, so the tab shows
@@ -211,7 +213,8 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const hasMessages = useStore(view.$messagesEmpty) === false
 
   useEffect(() => {
-    const alreadyListed = () => $sessions.get().some(s => sessionMatchesStoredId(s, storedSessionId))
+    const alreadyListed = () =>
+      $sessions.get().some(s => sessionMatchesIdentity(s, storedSessionId, activeGatewayProfile))
 
     if (!runtimeId || !hasMessages || alreadyListed()) {
       return
@@ -225,7 +228,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
         return
       }
 
-      void resolveStoredSession(storedSessionId)
+      void resolveStoredSession(storedSessionId, activeGatewayProfile)
         .then(resolved => {
           if (cancelled || resolved || remaining <= 0) {
             return
@@ -245,7 +248,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
         window.clearTimeout(timer)
       }
     }
-  }, [hasMessages, runtimeId, storedSessionId])
+  }, [activeGatewayProfile, hasMessages, runtimeId, storedSessionId])
 
   // Same gating as the primary's route resume (use-route-resume): never fire
   // session.resume before the gateway is OPEN. Persisted tiles mount at boot
@@ -266,7 +269,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
     resumingRef.current = true
 
     delegate
-      .resumeTile(storedSessionId)
+      .resumeTile(storedSessionId, activeGatewayProfile)
       .then(id => patchSessionTile(storedSessionId, { error: undefined, runtimeId: id }))
       .catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err)
@@ -283,7 +286,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
       .finally(() => {
         resumingRef.current = false
       })
-  }, [gatewayOpen, runtimeId, storedSessionId, tile?.error])
+  }, [activeGatewayProfile, gatewayOpen, runtimeId, storedSessionId, tile?.error])
 
   // The gateway (re)opening invalidates any latched error — it likely came
   // from a not-yet-open gateway or the previous connection. Clearing it
@@ -332,8 +335,11 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
  *  the paginated recents page, so it has no `$sessions` row at all until new
  *  activity lands it there — resolving through the tree keeps its tab titled
  *  and tinted instead of a grey "Session" placeholder. */
-export function tileStoredRow(storedSessionId: string): SessionInfo | undefined {
-  const match = (s: SessionInfo) => sessionMatchesStoredId(s, storedSessionId)
+export function tileStoredRow(
+  storedSessionId: string,
+  profile: null | string | undefined = $activeGatewayProfile.get()
+): SessionInfo | undefined {
+  const match = (s: SessionInfo) => sessionMatchesIdentity(s, storedSessionId, profile)
 
   return (
     $sessions.get().find(match) ??
@@ -443,9 +449,9 @@ function useTileMenuRow(storedSessionId: string): { pinId: string; profile?: str
 
   return useSyncExternalStore(subscribe, () => {
     const stored = tileStoredRow(storedSessionId)
-    const pinId = stored ? sessionPinId(stored) : storedSessionId
+    const profile = stored?.profile ?? $activeGatewayProfile.get()
+    const pinId = resolveSessionPinId(stored, storedSessionId, profile)
     const title = tileTitle(storedSessionId)
-    const profile = stored?.profile
     const key = `${pinId}\u0000${title}\u0000${profile ?? ''}`
 
     if (cache.current?.key !== key) {
@@ -484,10 +490,10 @@ export function SessionTabMenu({
   return (
     <span className="contents" onContextMenu={event => event.stopPropagation()}>
       <SessionContextMenu
-        onArchive={() => void sessionTileDelegate()?.archiveSession(storedSessionId)}
-        onBranch={() => void sessionTileDelegate()?.branchSession(storedSessionId)}
+        onArchive={() => void sessionTileDelegate()?.archiveSession(storedSessionId, profile)}
+        onBranch={() => void sessionTileDelegate()?.branchSession(storedSessionId, profile)}
         onClose={onClose}
-        onDelete={() => void sessionTileDelegate()?.deleteSession(storedSessionId)}
+        onDelete={() => void sessionTileDelegate()?.deleteSession(storedSessionId, profile)}
         onHideTabBar={onHideTabBar}
         onPin={() => (pinned ? unpinSession(pinId) : pinSession(pinId))}
         pinned={pinned}
@@ -550,7 +556,11 @@ export const watchSessionTiles = paneMirror<SessionTile>({
   // two surfaces. Self-subscribing (live state + resolved color), so the strip
   // needn't re-sync when it changes.
   tabLead: storedSessionId => (
-    <SessionStatusDot session={tileStoredRow(storedSessionId)} storedSessionId={storedSessionId} />
+    <SessionStatusDot
+      profile={$activeGatewayProfile.get()}
+      session={tileStoredRow(storedSessionId)}
+      storedSessionId={storedSessionId}
+    />
   ),
   render: storedSessionId => <SessionTilePane storedSessionId={storedSessionId} />,
   tabWrap: (storedSessionId, tab) => (

--- a/apps/desktop/src/app/chat/session-view.tsx
+++ b/apps/desktop/src/app/chat/session-view.tsx
@@ -3,6 +3,8 @@ import { createContext, useContext } from 'react'
 
 import type { ClientSessionState } from '@/app/types'
 import type { ChatMessage } from '@/lib/chat-messages'
+import { parseSessionIdentityKey } from '@/lib/session-identity'
+import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
   $awaitingResponse,
@@ -13,6 +15,7 @@ import {
   $currentProvider,
   $currentReasoningEffort,
   $messages,
+  $selectedSessionIdentityKey,
   $selectedStoredSessionId
 } from '@/store/session'
 import { $sessionStates } from '@/store/session-states'
@@ -50,6 +53,7 @@ export interface SessionView {
   $lastVisibleIsUser: ReadableAtom<boolean>
   $cwd: ReadableAtom<string>
   $model: ReadableAtom<string>
+  $profile: ReadableAtom<string>
   $provider: ReadableAtom<string>
   $fast: ReadableAtom<boolean>
   $reasoningEffort: ReadableAtom<string>
@@ -86,6 +90,9 @@ export const PRIMARY_SESSION_VIEW: SessionView = {
   $messages: $primaryMessages,
   $messagesEmpty: computed($primaryMessages, messages => messages.length === 0),
   $model: primaryField<string>(state => state.model, $currentModel),
+  $profile: computed([$selectedSessionIdentityKey, $activeGatewayProfile], (identity, activeProfile) =>
+    identity ? parseSessionIdentityKey(identity).profile : activeProfile
+  ),
   $provider: primaryField<string>(state => state.provider, $currentProvider),
   $reasoningEffort: primaryField<string>(state => state.reasoningEffort, $currentReasoningEffort),
   $runtimeId: $activeSessionId,

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -64,7 +64,7 @@ interface SidebarCronJobsSectionProps {
   label: string
   max?: number
   // Open a run session's chat (1 click to output).
-  onOpenRun: (sessionId: string) => void
+  onOpenRun: (sessionId: string, profile?: null | string) => void
   // Open the full Cron page focused on this job (manage / full history).
   onManageJob: (jobId: string) => void
   // Fire the job now.
@@ -182,7 +182,7 @@ function CronJobSidebarRow({
   job: CronJob
   nowMs: number
   onManage: () => void
-  onOpenRun: (sessionId: string) => void
+  onOpenRun: (sessionId: string, profile?: null | string) => void
   onTogglePeek: () => void
   onTrigger: () => void
 }) {
@@ -318,7 +318,13 @@ function CronJobSidebarRow({
   )
 }
 
-function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (sessionId: string) => void }) {
+function CronJobSidebarRuns({
+  jobId,
+  onOpenRun
+}: {
+  jobId: string
+  onOpenRun: (sessionId: string, profile?: null | string) => void
+}) {
   const { t } = useI18n()
   const c = t.cron
   const selectedSessionId = useStore($selectedStoredSessionId)
@@ -373,7 +379,7 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
                   : 'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-foreground'
               )}
               key={run.id}
-              onClick={() => onOpenRun(run.id)}
+              onClick={() => onOpenRun(run.id, run.profile)}
               type="button"
             >
               {formatRunTime(run.last_active || run.started_at)}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -27,6 +27,7 @@ import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/he
 import { useI18n } from '@/i18n'
 import { comboTokens } from '@/lib/keybinds/combo'
 import { profileColor } from '@/lib/profile-color'
+import { parseSessionIdentityKey, sessionIdentityKey } from '@/lib/session-identity'
 import { sessionMatchesSearch } from '@/lib/session-search'
 import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
@@ -62,7 +63,14 @@ import {
   toggleSidebarMessagingOpen,
   unpinSession
 } from '@/store/layout'
-import { $newChatProfile, $profiles, $profileScope, ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $newChatProfile,
+  $profiles,
+  $profileScope,
+  ALL_PROFILES,
+  normalizeProfileKey
+} from '@/store/profile'
 import {
   $activeProjectId,
   $projects,
@@ -91,11 +99,12 @@ import {
   $messagingTruncated,
   $sessionProfilesTruncated,
   $sessions,
+  $sessionsHydratedProfileScope,
   $sessionsLoading,
   sessionPinId,
   setCurrentCwd
 } from '@/store/session'
-import { $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/store/session-states'
+import { $focusedSessionIdentityKey, $workingSessionIds, type SplitDir } from '@/store/session-states'
 
 import {
   type AppView,
@@ -109,7 +118,13 @@ import type { SidebarNavItem } from '../../types'
 
 import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarLoadMoreRow } from './load-more-row'
-import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
+import {
+  mergeScopedSessionOrderIds,
+  orderByIds,
+  reconcileOrderIds,
+  resolveManualSessionOrderIds,
+  sameIds
+} from './order'
 import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
 import {
@@ -129,6 +144,7 @@ import {
   StartWorkButton,
   useRepoWorktreeMap
 } from './projects'
+import { mergeSidebarSearchResults } from './search-results'
 import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
@@ -195,42 +211,16 @@ const HEADER_ACTION_BTN =
 const HEADER_NAV_BTN =
   'text-(--ui-text-tertiary) opacity-70 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100 focus-visible:opacity-100'
 
-// FTS results cover sessions that aren't in the loaded page; synthesize a
-// minimal SessionInfo so they render in the same row component (resume works
-// by id; the snippet stands in for the preview).
-function searchResultToSession(result: SessionSearchResult): SessionInfo {
-  const ts = result.session_started ?? Date.now() / 1000
-
-  return {
-    archived: false,
-    cwd: null,
-    ended_at: null,
-    id: result.session_id,
-    _lineage_root_id: result.lineage_root ?? null,
-    input_tokens: 0,
-    is_active: false,
-    last_active: ts,
-    message_count: 0,
-    model: result.model ?? null,
-    output_tokens: 0,
-    preview: result.snippet?.trim() || null,
-    source: result.source ?? null,
-    started_at: ts,
-    title: null,
-    tool_call_count: 0
-  }
-}
-
 interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   currentView: AppView
   onNavigate: (item: SidebarNavItem) => void
   onLoadMoreSessions: () => Promise<void> | void
   onLoadMoreProfileSessions?: (profile: string) => Promise<void> | void
   onLoadMoreMessaging?: (platform: string) => Promise<void> | void
-  onResumeSession: (sessionId: string) => void
-  onDeleteSession: (sessionId: string) => void
-  onArchiveSession: (sessionId: string) => void
-  onBranchSession: (sessionId: string) => void
+  onResumeSession: (sessionId: string, profile?: null | string) => void
+  onDeleteSession: (sessionId: string, profile?: null | string) => void
+  onArchiveSession: (sessionId: string, profile?: null | string) => void
+  onBranchSession: (sessionId: string, profile?: null | string) => void
   onNewSessionInWorkspace: (path: null | string) => void
   /** Create a brand-new session and open it as a tile on `dir`. */
   onNewSessionSplit: (dir: SplitDir) => void
@@ -291,7 +281,7 @@ export function ChatSidebar({
   const cronOpen = useStore($sidebarCronOpen)
   // The sidebar highlight tracks the FOCUSED session — the interacted tile's
   // tab, else the main selection — so it stays 1:1 with whatever tab is active.
-  const selectedSessionId = useStore($focusedStoredSessionId)
+  const selectedSessionIdentity = useStore($focusedSessionIdentityKey)
   const sessions = useStore($sessions)
   const cronSessions = useStore($cronSessions)
   const cronJobs = useStore($cronJobs)
@@ -299,8 +289,10 @@ export function ChatSidebar({
   const messagingPlatformTotals = useStore($messagingPlatformTotals)
   const messagingTruncated = useStore($messagingTruncated)
   const sessionsLoading = useStore($sessionsLoading)
+  const sessionsHydratedProfileScope = useStore($sessionsHydratedProfileScope)
   const sessionProfilesTruncated = useStore($sessionProfilesTruncated)
   const workingSessionIds = useStore($workingSessionIds)
+  const activeGatewayProfile = useStore($activeGatewayProfile)
   const profiles = useStore($profiles)
   const profileScope = useStore($profileScope)
   // Only surface the profile switcher when more than one profile exists, so
@@ -368,7 +360,7 @@ export function ChatSidebar({
     }
   }, [])
 
-  const activeSidebarSessionId = currentView === 'chat' ? selectedSessionId : null
+  const activeSidebarSessionId = currentView === 'chat' ? selectedSessionIdentity : null
 
   const dndSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
@@ -403,10 +395,12 @@ export function ChatSidebar({
     // them too — otherwise a pinned cron job can't resolve into the Pinned
     // section. Recents take precedence on id collisions (set last).
     for (const s of [...cronSessions, ...visibleSessions]) {
-      map.set(s.id, s)
+      map.set(sessionIdentityKey(s.id, s.profile), s)
 
-      if (s._lineage_root_id && !map.has(s._lineage_root_id)) {
-        map.set(s._lineage_root_id, s)
+      const lineageKey = s._lineage_root_id ? sessionIdentityKey(s._lineage_root_id, s.profile) : null
+
+      if (lineageKey && !map.has(lineageKey)) {
+        map.set(lineageKey, s)
       }
     }
 
@@ -418,10 +412,12 @@ export function ChatSidebar({
     const out: SessionInfo[] = []
 
     for (const pinId of pinnedSessionIds) {
-      const session = sessionByAnyId.get(pinId)
+      const parsedPin = parseSessionIdentityKey(pinId)
+      const pinIdentity = sessionIdentityKey(parsedPin.storedSessionId, parsedPin.profile)
+      const session = sessionByAnyId.get(pinIdentity)
 
-      if (session && !seen.has(session.id)) {
-        seen.add(session.id)
+      if (session && !seen.has(sessionPinId(session))) {
+        seen.add(sessionPinId(session))
         out.push(session)
       }
     }
@@ -429,16 +425,10 @@ export function ChatSidebar({
     return out
   }, [pinnedSessionIds, sessionByAnyId])
 
-  const pinnedRealIdSet = useMemo(() => new Set(pinnedSessions.map(s => s.id)), [pinnedSessions])
-  const pinnedIdSet = useMemo(() => new Set(pinnedSessionIds), [pinnedSessionIds])
-
-  // A pinned session belongs to the Pinned section and nowhere else, so every
-  // other list filters it out (the flat recents already did). Match on the live
-  // id AND the durable pin id — a backend snapshot can surface either side of a
-  // compression tip rotation.
+  const pinnedRealIdSet = useMemo(() => new Set(pinnedSessions.map(sessionPinId)), [pinnedSessions])
   const isPinnedSession = useCallback(
-    (session: SessionInfo) => pinnedRealIdSet.has(session.id) || pinnedIdSet.has(sessionPinId(session)),
-    [pinnedRealIdSet, pinnedIdSet]
+    (session: SessionInfo) => pinnedRealIdSet.has(sessionPinId(session)),
+    [pinnedRealIdSet]
   )
 
   // Full-text search across *all* sessions (not just the loaded page) so 699
@@ -457,7 +447,7 @@ export function ChatSidebar({
     setSearchPending(true)
 
     const id = window.setTimeout(() => {
-      void searchSessions(trimmedQuery)
+      void searchSessions(trimmedQuery, activeGatewayProfile)
         .then(res => {
           if (!cancelled) {
             setServerMatches(res.results)
@@ -475,32 +465,17 @@ export function ChatSidebar({
       cancelled = true
       window.clearTimeout(id)
     }
-  }, [trimmedQuery])
+  }, [activeGatewayProfile, trimmedQuery])
 
   const searchResults = useMemo(() => {
     if (!trimmedQuery) {
       return []
     }
 
-    const out = new Map<string, SessionInfo>()
+    const clientMatches = sortedSessions.filter(session => sessionMatchesSearch(session, trimmedQuery))
 
-    for (const s of sortedSessions) {
-      if (sessionMatchesSearch(s, trimmedQuery)) {
-        out.set(s.id, s)
-      }
-    }
-
-    for (const match of serverMatches) {
-      if (out.has(match.session_id)) {
-        continue
-      }
-
-      const loaded = sessionByAnyId.get(match.session_id)
-      out.set(match.session_id, loaded ?? searchResultToSession(match))
-    }
-
-    return [...out.values()]
-  }, [trimmedQuery, sortedSessions, serverMatches, sessionByAnyId])
+    return mergeSidebarSearchResults(clientMatches, serverMatches, sessionByAnyId, activeGatewayProfile)
+  }, [activeGatewayProfile, trimmedQuery, sortedSessions, serverMatches, sessionByAnyId])
 
   const unpinnedAgentSessions = useMemo(
     () => sortedSessions.filter(s => !isPinnedSession(s)),
@@ -508,10 +483,14 @@ export function ChatSidebar({
   )
 
   useEffect(() => {
+    const requestedScope = profileScope === ALL_PROFILES ? ALL_PROFILES : normalizeProfileKey(profileScope)
+
     const next = resolveManualSessionOrderIds(
-      unpinnedAgentSessions.map(s => s.id),
+      unpinnedAgentSessions.map(s => sessionIdentityKey(s.id, s.profile)),
       agentOrderIds,
-      agentOrderManual
+      agentOrderManual,
+      sessionsLoading || sessionsHydratedProfileScope !== requestedScope,
+      showAllProfiles ? profiles.map(profile => normalizeProfileKey(profile.name)) : [normalizeProfileKey(profileScope)]
     )
 
     if (!next.length && agentOrderManual) {
@@ -527,10 +506,22 @@ export function ChatSidebar({
     if (next.length && !sameIds(next, agentOrderIds)) {
       setSidebarSessionOrderIds(next)
     }
-  }, [agentOrderIds, agentOrderManual, unpinnedAgentSessions])
+  }, [
+    agentOrderIds,
+    agentOrderManual,
+    profileScope,
+    profiles,
+    sessionsHydratedProfileScope,
+    sessionsLoading,
+    showAllProfiles,
+    unpinnedAgentSessions
+  ])
 
   const agentSessions = useMemo(
-    () => (agentOrderManual ? orderByIds(unpinnedAgentSessions, s => s.id, agentOrderIds) : unpinnedAgentSessions),
+    () =>
+      agentOrderManual
+        ? orderByIds(unpinnedAgentSessions, s => sessionIdentityKey(s.id, s.profile), agentOrderIds)
+        : unpinnedAgentSessions,
     [unpinnedAgentSessions, agentOrderIds, agentOrderManual]
   )
 
@@ -1108,15 +1099,15 @@ export function ChatSidebar({
   // typed write — no id-prefix sniffing to figure out which level moved.
   const reorderSessions = (ids: string[]) => {
     setSidebarSessionOrderManual(true)
-    setSidebarSessionOrderIds(ids)
+    setSidebarSessionOrderIds(mergeScopedSessionOrderIds(agentOrderIds, ids))
   }
 
   // Persist the new project overview order (drag-to-reorder); orderByIds applies
   // it over the default sort, so stale/new ids reconcile on the next render.
   const reorderProjects = (ids: string[]) => setSidebarProjectOrderIds(ids)
 
-  // Sortable rows carry live session ids; the pinned store is keyed by durable
-  // (lineage-root) ids, so translate before persisting the new order.
+  // Sortable rows carry compound live identities; the pinned store is keyed by
+  // compound durable (lineage-root) identities, so translate before persisting.
   const reorderPinned = (ids: string[]) =>
     setPinnedSessionOrder(
       ids.map(id => {

--- a/apps/desktop/src/app/chat/sidebar/order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.test.ts
@@ -1,8 +1,29 @@
 import { describe, expect, it } from 'vitest'
 
-import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
+import { sessionIdentityKey, sessionIdentityKeysFromLegacyIds } from '@/lib/session-identity'
+
+import {
+  mergeScopedSessionOrderIds,
+  orderByIds,
+  reconcileOrderIds,
+  resolveManualSessionOrderIds,
+  sameIds
+} from './order'
 
 describe('resolveManualSessionOrderIds', () => {
+  it('preserves persisted order while an empty session list is still hydrating', () => {
+    const persisted = [sessionIdentityKey('other', 'default'), sessionIdentityKey('shared', 'default')]
+
+    expect(resolveManualSessionOrderIds([], persisted, true, true)).toEqual(persisted)
+    expect(resolveManualSessionOrderIds([], persisted, true, false)).toEqual([])
+  })
+
+  it('does not prune persisted ids from a partially hydrated session list', () => {
+    const persisted = [sessionIdentityKey('other', 'default'), sessionIdentityKey('shared', 'default')]
+
+    expect(resolveManualSessionOrderIds([persisted[0]], persisted, true, true)).toEqual(persisted)
+  })
+
   it('clears legacy auto-seeded order until the user manually reorders sessions', () => {
     expect(resolveManualSessionOrderIds(['newest', 'older'], ['older', 'newest'], false)).toEqual([])
   })
@@ -17,6 +38,66 @@ describe('resolveManualSessionOrderIds', () => {
 
   it('clears manual order when none of the saved ids still exist', () => {
     expect(resolveManualSessionOrderIds(['newest'], ['gone'], true)).toEqual([])
+  })
+
+  it('preserves a legacy default-profile manual order after identity migration', () => {
+    const current = [sessionIdentityKey('shared', 'default'), sessionIdentityKey('other', 'default')]
+    const persisted = sessionIdentityKeysFromLegacyIds(['other', 'shared'])
+
+    expect(resolveManualSessionOrderIds(current, persisted, true)).toEqual([
+      sessionIdentityKey('other', 'default'),
+      sessionIdentityKey('shared', 'default')
+    ])
+  })
+
+  it('does not erase another profile order while its rows are unloaded', () => {
+    const savedDefaultOrder = sessionIdentityKeysFromLegacyIds(['other', 'shared'])
+
+    expect(resolveManualSessionOrderIds([sessionIdentityKey('shared', 'beta')], savedDefaultOrder, true)).toBe(
+      savedDefaultOrder
+    )
+  })
+
+  it('preserves hidden-profile order after reconciling a visible profile drag', () => {
+    const alphaA = sessionIdentityKey('a1', 'alpha')
+    const alphaB = sessionIdentityKey('a2', 'alpha')
+    const betaA = sessionIdentityKey('b1', 'beta')
+    const betaB = sessionIdentityKey('b2', 'beta')
+    const afterDrag = [alphaB, alphaA, betaA, betaB]
+
+    expect(resolveManualSessionOrderIds([alphaB, alphaA], afterDrag, true, false, ['alpha'])).toEqual(afterDrag)
+  })
+
+  it('drops an empty visible profile without erasing hidden-profile order', () => {
+    const alphaA = sessionIdentityKey('a1', 'alpha')
+    const betaA = sessionIdentityKey('b1', 'beta')
+
+    expect(resolveManualSessionOrderIds([], [alphaA, betaA], true, false, ['alpha'])).toEqual([betaA])
+  })
+
+  it('drops stale rows for an empty profile explicitly included in a wider scope', () => {
+    const alphaA = sessionIdentityKey('a1', 'alpha')
+    const betaGone = sessionIdentityKey('gone', 'beta')
+
+    expect(resolveManualSessionOrderIds([alphaA], [alphaA, betaGone], true, false, ['alpha', 'beta'])).toEqual([
+      alphaA
+    ])
+  })
+})
+
+describe('mergeScopedSessionOrderIds', () => {
+  it("reorders one profile without erasing another profile's persisted order", () => {
+    const alphaA = sessionIdentityKey('a', 'alpha')
+    const alphaB = sessionIdentityKey('b', 'alpha')
+    const betaA = sessionIdentityKey('a', 'beta')
+    const betaB = sessionIdentityKey('b', 'beta')
+
+    expect(mergeScopedSessionOrderIds([alphaA, alphaB, betaA, betaB], [alphaB, alphaA])).toEqual([
+      alphaB,
+      alphaA,
+      betaA,
+      betaB
+    ])
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/order.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.ts
@@ -1,3 +1,5 @@
+import { parseSessionIdentityKey } from '@/lib/session-identity'
+
 /** New ids first, then ids still present in the persisted order. */
 export function reconcileFreshFirst(currentIds: string[], orderIds: string[]): string[] {
   const current = new Set(currentIds)
@@ -7,19 +9,86 @@ export function reconcileFreshFirst(currentIds: string[], orderIds: string[]): s
   return [...currentIds.filter(id => !retainedSet.has(id)), ...retained]
 }
 
-export function resolveManualSessionOrderIds(currentIds: string[], orderIds: string[], manual: boolean): string[] {
-  if (!manual || !currentIds.length || !orderIds.length) {
+export function resolveManualSessionOrderIds(
+  currentIds: string[],
+  orderIds: string[],
+  manual: boolean,
+  hydrating = false,
+  scopedProfiles?: readonly string[]
+): string[] {
+  if (!manual || !orderIds.length) {
     return []
+  }
+
+  if (hydrating) {
+    return orderIds
+  }
+
+  const profilesInScope = new Set(
+    scopedProfiles ?? currentIds.map(id => parseSessionIdentityKey(id).profile)
+  )
+
+  const isInScope = (id: string) => profilesInScope.has(parseSessionIdentityKey(id).profile)
+  const scopedOrderIds = orderIds.filter(isInScope)
+  const hiddenOrderIds = orderIds.filter(id => !isInScope(id))
+
+  if (!currentIds.length) {
+    return scopedProfiles ? hiddenOrderIds : []
   }
 
   const current = new Set(currentIds)
-  const retained = orderIds.filter(id => current.has(id))
+  const retained = scopedOrderIds.filter(id => current.has(id))
 
   if (!retained.length) {
-    return []
+    if (!scopedOrderIds.length) {
+      return orderIds
+    }
+
+    return hiddenOrderIds
   }
 
-  return reconcileFreshFirst(currentIds, orderIds)
+  return mergeScopedSessionOrderIds(orderIds, reconcileFreshFirst(currentIds, scopedOrderIds), [...profilesInScope])
+}
+
+/** Merge a drag order for the profiles represented by `scopedIds` without
+ * erasing persisted order for profiles whose rows are not currently visible. */
+export function mergeScopedSessionOrderIds(
+  orderIds: string[],
+  scopedIds: string[],
+  scopedProfiles?: readonly string[]
+): string[] {
+  if (!scopedIds.length && !scopedProfiles?.length) {
+    return orderIds
+  }
+
+  const nextScopedIds = [...new Set(scopedIds)]
+
+  const profilesInScope = new Set([
+    ...(scopedProfiles ?? []),
+    ...nextScopedIds.map(id => parseSessionIdentityKey(id).profile)
+  ])
+
+  const merged: string[] = []
+  let inserted = false
+
+  for (const id of orderIds) {
+    if (profilesInScope.has(parseSessionIdentityKey(id).profile)) {
+      if (!inserted) {
+        merged.push(...nextScopedIds)
+        inserted = true
+      }
+
+      continue
+    }
+
+    merged.push(id)
+  }
+
+  if (!inserted) {
+    merged.push(...nextScopedIds)
+  }
+
+  return merged
 }
 
 /** Reorder `items` by `orderIds`; items missing from the order surface first. */

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { HermesGitWorktree } from '@/global'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import type { ProjectInfo, SessionInfo } from '@/types/hermes'
 
 import {
@@ -415,6 +416,37 @@ describe('mergeRepoWorktreeGroups (visual enhancer)', () => {
     expect(home?.sessions.map(s => s.id).sort()).toEqual(['a', 'b'])
   })
 
+  it('keeps same-id sessions from different profiles when folding the home lane', () => {
+    const repo = {
+      id: '/repo',
+      path: '/repo',
+      groups: [
+        lane({
+          id: '/repo::branch::main',
+          label: 'main',
+          isMain: true,
+          path: '/repo',
+          sessions: [makeSession('/repo', { id: 'shared', profile: 'alpha' })]
+        }),
+        lane({
+          id: '/repo::branch::old',
+          label: 'old-feature',
+          isMain: true,
+          path: '/repo',
+          sessions: [makeSession('/repo', { id: 'shared', profile: 'beta' })]
+        })
+      ]
+    }
+
+    const discovered: HermesGitWorktree[] = [
+      { branch: 'main', detached: false, isMain: true, locked: false, path: '/repo' }
+    ]
+
+    const home = mergeRepoWorktreeGroups(repo, discovered).find(group => group.isHome)
+
+    expect(home?.sessions.map(session => session.profile).sort()).toEqual(['alpha', 'beta'])
+  })
+
   it('leaves main lanes untouched on a remote backend (no git probe)', () => {
     const repo = {
       id: '/repo',
@@ -697,6 +729,25 @@ describe('overlayLiveLanes', () => {
     expect(overlaid.repos[0].groups.flatMap(g => g.sessions.map(s => s.id))).toEqual(['dup'])
   })
 
+  it('keeps colliding live session ids from different profiles in the same lane', () => {
+    const project = projectNode({
+      id: '/www/app',
+      isAuto: true,
+      repos: [{ id: '/www/app', label: 'app', path: '/www/app', sessionCount: 0, groups: [] }]
+    })
+
+    const live = [
+      makeSession('/www/app', { id: 'shared', profile: 'alpha', title: 'Alpha' }),
+      makeSession('/www/app', { id: 'shared', profile: 'beta', title: 'Beta' })
+    ]
+
+    const overlaid = overlayLiveLanes(project, live)
+    const main = overlaid.repos[0].groups.find(group => group.label === 'main')
+
+    expect(main?.sessions.map(session => session.profile).sort()).toEqual(['alpha', 'beta'])
+    expect(overlaid.sessionCount).toBe(2)
+  })
+
   it('adds a new session to an existing worktree lane keyed by a divergent id (matches by path)', () => {
     // Backend keyed the worktree lane off a branch-style id (no live git probe),
     // but the lane PATH is the worktree dir. A new session under that worktree
@@ -804,7 +855,7 @@ describe('overlayLiveLanes', () => {
     })
 
     // No live rows (both deleted from $sessions); only 'gone' is tombstoned.
-    const overlaid = overlayLiveLanes(project, [a], new Set(['gone']))
+    const overlaid = overlayLiveLanes(project, [a], new Set([sessionIdentityKey('gone', 'default')]))
 
     expect(overlaid.repos[0].groups.map(g => g.id)).toEqual(['/www/app::branch::main'])
     expect(overlaid.repos[0].groups[0].sessions.map(s => s.id)).toEqual(['keep'])
@@ -855,7 +906,7 @@ describe('overlayLivePreviews', () => {
       ]
     })
 
-    const previews = overlayLivePreviews([project], [], [], 3, new Set(['gone']))
+    const previews = overlayLivePreviews([project], [], [], 3, new Set([sessionIdentityKey('gone', 'default')]))
 
     expect(previews['/www/app'].map(s => s.id)).toEqual(['old'])
   })
@@ -864,6 +915,22 @@ describe('overlayLivePreviews', () => {
     const previews = overlayLivePreviews([homeNode([])], [makeSession(null, { id: 'fresh' })], [], 3)
 
     expect(previews[NO_PROJECT_ID].map(s => s.id)).toEqual(['fresh'])
+  })
+
+  it('evicts only the matching profile when session ids collide', () => {
+    const project = projectNode({ id: '/www/app' })
+    const alpha = makeSession('/www/app', { id: 'shared-id', profile: 'alpha' })
+    const beta = makeSession('/www/app', { id: 'shared-id', profile: 'beta' })
+
+    const previews = overlayLivePreviews(
+      [project],
+      [alpha, beta],
+      [],
+      3,
+      new Set([sessionIdentityKey('shared-id', 'alpha')])
+    )
+
+    expect(previews['/www/app']).toEqual([beta])
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -1,5 +1,6 @@
 import type { HermesGitWorktree } from '@/global'
 import type { ProjectInfo, SessionInfo } from '@/hermes'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { normalize } from '@/lib/text'
 
 // Session grouping is now computed authoritatively on the backend
@@ -243,7 +244,9 @@ export function mergeRepoWorktreeGroups(
     const byId = new Map<string, SessionInfo>()
 
     for (const session of sessions) {
-      byId.set(session.id, byId.get(session.id) ?? session)
+      const identityKey = sessionIdentityKey(session.id, session.profile)
+
+      byId.set(identityKey, byId.get(identityKey) ?? session)
     }
 
     return [...byId.values()]
@@ -449,7 +452,12 @@ export function sessionProjectColor(session: SessionInfo, projects: ProjectInfo[
 }
 
 const upsertSession = (rows: SessionInfo[], session: SessionInfo): SessionInfo[] =>
-  [session, ...rows.filter(row => row.id !== session.id)].sort((a, b) => b.started_at - a.started_at)
+  [
+    session,
+    ...rows.filter(
+      row => sessionIdentityKey(row.id, row.profile) !== sessionIdentityKey(session.id, session.profile)
+    )
+  ].sort((a, b) => b.started_at - a.started_at)
 
 /**
  * The lane a live session belongs to WITHIN a known repo root, by path — the
@@ -508,7 +516,7 @@ export function overlayRepoLanes(
       return { ...g, sessions: [...g.sessions] }
     }
 
-    const kept = g.sessions.filter(s => !removed.has(s.id))
+    const kept = g.sessions.filter(s => !removed.has(sessionIdentityKey(s.id, s.profile)))
 
     changed ||= kept.length !== g.sessions.length
 
@@ -518,7 +526,7 @@ export function overlayRepoLanes(
   for (const session of live) {
     const cwd = (session.cwd || '').trim()
 
-    if (removed.has(session.id) || !cwd) {
+    if (removed.has(sessionIdentityKey(session.id, session.profile)) || !cwd) {
       continue
     }
 
@@ -711,7 +719,7 @@ export function overlayLivePreviews(
   const byProject = new Map<string, SessionInfo[]>()
 
   for (const session of live) {
-    if (removed.has(session.id)) {
+    if (removed.has(sessionIdentityKey(session.id, session.profile))) {
       continue
     }
 
@@ -731,7 +739,10 @@ export function overlayLivePreviews(
 
   for (const node of projects) {
     const liveRows = byProject.get(node.id) ?? []
-    const base = (node.previewSessions ?? []).filter(session => !removed.has(session.id))
+
+    const base = (node.previewSessions ?? []).filter(
+      session => !removed.has(sessionIdentityKey(session.id, session.profile))
+    )
 
     if (!liveRows.length && !base.length) {
       continue
@@ -741,8 +752,10 @@ export function overlayLivePreviews(
     const map = new Map<string, SessionInfo>()
 
     for (const session of [...liveRows, ...base]) {
-      if (!map.has(session.id)) {
-        map.set(session.id, session)
+      const key = sessionIdentityKey(session.id, session.profile)
+
+      if (!map.has(key)) {
+        map.set(key, session)
       }
     }
 

--- a/apps/desktop/src/app/chat/sidebar/search-results.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/search-results.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo, SessionSearchResult } from '@/hermes'
+import { sessionIdentityKey } from '@/lib/session-identity'
+
+import { mergeSidebarSearchResults } from './search-results'
+
+const session = (id: string, profile: string, title: string): SessionInfo => ({
+  archived: false,
+  cwd: null,
+  ended_at: null,
+  id,
+  input_tokens: 0,
+  is_active: false,
+  last_active: 1,
+  message_count: 1,
+  model: null,
+  output_tokens: 0,
+  preview: null,
+  profile,
+  source: null,
+  started_at: 1,
+  title,
+  tool_call_count: 0
+})
+
+const match = (sessionId: string): SessionSearchResult => ({
+  lineage_root: sessionId,
+  model: null,
+  role: 'user',
+  session_id: sessionId,
+  session_started: 1,
+  snippet: 'matched',
+  source: null
+})
+
+describe('mergeSidebarSearchResults', () => {
+  it('keeps colliding client and server ids under their owning profiles', () => {
+    const personal = session('shared-id', 'default', 'Personal')
+    const work = session('shared-id', 'work', 'Work')
+
+    const loaded = new Map([
+      [sessionIdentityKey(personal.id, personal.profile), personal],
+      [sessionIdentityKey(work.id, work.profile), work]
+    ])
+
+    const result = mergeSidebarSearchResults([personal], [match('shared-id')], loaded, 'work')
+
+    expect(result).toEqual([personal, work])
+  })
+
+  it('assigns the searched profile to an unloaded result', () => {
+    const [result] = mergeSidebarSearchResults([], [match('unloaded')], new Map(), 'work')
+
+    expect(result).toMatchObject({ id: 'unloaded', profile: 'work' })
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/search-results.ts
+++ b/apps/desktop/src/app/chat/sidebar/search-results.ts
@@ -1,0 +1,52 @@
+import type { SessionInfo, SessionSearchResult } from '@/hermes'
+import { sessionIdentityKey } from '@/lib/session-identity'
+
+// FTS results cover sessions that are not in the loaded page. The search
+// endpoint is profile-scoped, so its bare ids inherit the explicitly requested
+// profile before they are merged into an all-profile sidebar.
+export function searchResultToSession(result: SessionSearchResult, profile: null | string): SessionInfo {
+  const ts = result.session_started ?? Date.now() / 1000
+
+  return {
+    archived: false,
+    cwd: null,
+    ended_at: null,
+    id: result.session_id,
+    _lineage_root_id: result.lineage_root ?? null,
+    input_tokens: 0,
+    is_active: false,
+    last_active: ts,
+    message_count: 0,
+    model: result.model ?? null,
+    output_tokens: 0,
+    preview: result.snippet?.trim() || null,
+    profile: profile ?? undefined,
+    source: result.source ?? null,
+    started_at: ts,
+    title: null,
+    tool_call_count: 0
+  }
+}
+
+export function mergeSidebarSearchResults(
+  clientMatches: SessionInfo[],
+  serverMatches: SessionSearchResult[],
+  loadedByIdentity: ReadonlyMap<string, SessionInfo>,
+  profile: null | string
+): SessionInfo[] {
+  const merged = new Map<string, SessionInfo>()
+
+  for (const session of clientMatches) {
+    merged.set(sessionIdentityKey(session.id, session.profile), session)
+  }
+
+  for (const match of serverMatches) {
+    const identityKey = sessionIdentityKey(match.session_id, profile)
+
+    if (!merged.has(identityKey)) {
+      merged.set(identityKey, loadedByIdentity.get(identityKey) ?? searchResultToSession(match, profile))
+    }
+  }
+
+  return [...merged.values()]
+}

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.ts
@@ -1,9 +1,10 @@
 import { atom } from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { $activeGatewayProfile } from '@/store/profile'
 import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
 
-import { renameSessionPreferringRpc } from './session-actions-menu'
+import { renameSessionPreferringRpc, updateRenamedSessionTitle } from './session-actions-menu'
 
 // The branched-session rename bug: a freshly branched session lives only in the
 // gateway's runtime _sessions map (no state.db row yet), so REST PATCH
@@ -51,6 +52,7 @@ afterEach(() => {
   request.mockClear()
   activeGateway.mockReset()
   activeGateway.mockReturnValue({ request })
+  $activeGatewayProfile.set('default')
   $activeSessionId.set(null)
   $selectedStoredSessionId.set(null)
 })
@@ -70,6 +72,7 @@ describe('renameSessionPreferringRpc', () => {
   it('falls back to REST when the RPC fails (e.g. socket mid-reconnect)', async () => {
     $selectedStoredSessionId.set(STORED_ID)
     $activeSessionId.set(RUNTIME_ID)
+    $activeGatewayProfile.set('work')
     request.mockRejectedValueOnce(new Error('not connected'))
 
     const result = await renameSessionPreferringRpc(STORED_ID, 'My branch', 'work')
@@ -77,6 +80,16 @@ describe('renameSessionPreferringRpc', () => {
     expect(request).toHaveBeenCalledOnce()
     expect(renameSession).toHaveBeenCalledWith(STORED_ID, 'My branch', 'work')
     expect(result.title).toBe('rest-title')
+  })
+
+  it('uses REST when another profile owns the same stored session id', async () => {
+    $selectedStoredSessionId.set(STORED_ID)
+    $activeSessionId.set(RUNTIME_ID)
+
+    await renameSessionPreferringRpc(STORED_ID, 'Other profile', 'work')
+
+    expect(request).not.toHaveBeenCalled()
+    expect(renameSession).toHaveBeenCalledWith(STORED_ID, 'Other profile', 'work')
   })
 
   it('uses REST for a non-active row (background/persisted session)', async () => {
@@ -108,5 +121,19 @@ describe('renameSessionPreferringRpc', () => {
 
     expect(request).not.toHaveBeenCalled()
     expect(renameSession).toHaveBeenCalledWith(STORED_ID, 'My branch', undefined)
+  })
+})
+
+describe('updateRenamedSessionTitle', () => {
+  it('updates only the owning profile when stored session ids collide', () => {
+    const sessions = [
+      { id: 'shared', profile: 'alpha', title: 'Alpha title' },
+      { id: 'shared', profile: 'beta', title: 'Beta title' }
+    ]
+
+    expect(updateRenamedSessionTitle(sessions, 'shared', 'alpha', 'Renamed alpha')).toEqual([
+      { id: 'shared', profile: 'alpha', title: 'Renamed alpha' },
+      { id: 'shared', profile: 'beta', title: 'Beta title' }
+    ])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -16,7 +16,7 @@ vi.mock('@/components/pane-shell/tree/store', () => ({
   closeTreeTabsToRight: vi.fn(),
   treeTabCloseTargets: vi.fn(() => null)
 }))
-vi.mock('@/hermes', () => ({ renameSession: vi.fn() }))
+vi.mock('@/hermes', () => ({ renameSession: vi.fn(), setApiRequestProfile: vi.fn() }))
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
     t: {

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -27,13 +27,14 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { PROFILE_SWATCHES } from '@/lib/profile-color'
 import { exportSession } from '@/lib/session-export'
+import { sessionIdentityKey, sessionMatchesIdentity } from '@/lib/session-identity'
 import { activeGateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import {
   $activeSessionId,
   $selectedStoredSessionId,
   $sessions,
-  sessionMatchesStoredId,
   sessionPinId,
   setSessions
 } from '@/store/session'
@@ -64,7 +65,10 @@ export async function renameSessionPreferringRpc(
   title: string,
   profile?: string
 ): Promise<{ title?: string }> {
-  const isActiveRow = storedSessionId === $selectedStoredSessionId.get()
+  const isActiveRow =
+    storedSessionId === $selectedStoredSessionId.get() &&
+    normalizeProfileKey(profile) === normalizeProfileKey($activeGatewayProfile.get())
+
   const runtimeId = isActiveRow ? $activeSessionId.get() : null
   const gateway = activeGateway()
 
@@ -86,6 +90,16 @@ export async function renameSessionPreferringRpc(
   }
 
   return renameSession(storedSessionId, title, profile)
+}
+
+export function updateRenamedSessionTitle<
+  T extends { id: string; profile?: null | string; title?: null | string }
+>(sessions: T[], storedSessionId: string, profile: null | string | undefined, title: null | string): T[] {
+  const targetIdentity = sessionIdentityKey(storedSessionId, profile)
+
+  return sessions.map(session =>
+    sessionIdentityKey(session.id, session.profile) === targetIdentity ? { ...session, title } : session
+  )
 }
 
 interface SessionActions {
@@ -115,11 +129,11 @@ interface SessionActions {
 // component so only an OPEN submenu subscribes to the stores (not every row's
 // menu). Reads/writes the override keyed by the DURABLE id so a color survives
 // compression; clearing falls back to the inherited project color.
-function SessionColorSwatches({ sessionId }: { sessionId: string }) {
+function SessionColorSwatches({ profile, sessionId }: { profile?: string; sessionId: string }) {
   const { t } = useI18n()
   const overrides = useStore($sessionColorOverrides)
-  const session = useStore($sessions).find(s => sessionMatchesStoredId(s, sessionId))
-  const durableId = session ? sessionPinId(session) : sessionId
+  const session = useStore($sessions).find(s => sessionMatchesIdentity(s, sessionId, profile))
+  const durableId = session ? sessionPinId(session) : sessionIdentityKey(sessionId, profile)
 
   return (
     <ColorSwatches
@@ -151,10 +165,15 @@ function useSessionActions({
   const [renameOpen, setRenameOpen] = useState(false)
   const tiles = useStore($sessionTiles)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const activeGatewayProfile = useStore($activeGatewayProfile)
 
   // Already showing as a tab somewhere (a tile, or loaded in main — main IS
   // a tab): offering "Open in new tab" again is noise.
-  const alreadyTabbed = sessionId === selectedStoredSessionId || tiles.some(tile => tile.storedSessionId === sessionId)
+  const belongsToActiveProfile = normalizeProfileKey(profile) === normalizeProfileKey(activeGatewayProfile)
+
+  const alreadyTabbed =
+    belongsToActiveProfile &&
+    (sessionId === selectedStoredSessionId || tiles.some(tile => tile.storedSessionId === sessionId))
 
   const spec = (partial: Omit<ActionItemSpec, 'onSelect'> & { onSelect: () => void }): ActionItemSpec => partial
 
@@ -172,7 +191,7 @@ function useSessionActions({
               // Stack into the MAIN zone as a tab (center dock; the strip
               // sticky-shows on gain) — the door to the tab bar. Focuses first
               // if the session is already on screen.
-              openSession(sessionId, () => undefined, 'tab')
+              openSession(sessionId, () => undefined, 'tab', profile)
             }
           })
         ]
@@ -185,7 +204,7 @@ function useSessionActions({
             label: r.newWindow,
             onSelect: () => {
               triggerHaptic('selection')
-              openSession(sessionId, () => undefined, 'window')
+              openSession(sessionId, () => undefined, 'window', profile)
             }
           })
         ]
@@ -327,7 +346,7 @@ function useSessionActions({
           <span>{t.sidebar.projects.menuAppearance}</span>
         </kit.SubTrigger>
         <kit.SubContent className="p-2">
-          <SessionColorSwatches sessionId={sessionId} />
+          <SessionColorSwatches profile={profile} sessionId={sessionId} />
         </kit.SubContent>
       </kit.Sub>
       <CopyButton
@@ -463,7 +482,7 @@ function RenameSessionDialog({ open, onOpenChange, sessionId, currentTitle, prof
     try {
       const result = await renameSessionPreferringRpc(sessionId, next, profile)
       const finalTitle = result.title || next || ''
-      setSessions(prev => prev.map(s => (s.id === sessionId ? { ...s, title: finalTitle || null } : s)))
+      setSessions(prev => updateRenamedSessionTitle(prev, sessionId, profile, finalTitle || null))
       notify({ durationMs: 2_000, kind: 'success', message: r.renamed })
       onOpenChange(false)
     } catch (err) {

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -12,6 +12,7 @@ import type { SessionInfo } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { coarseElapsed } from '@/lib/time'
 import { cn } from '@/lib/utils'
@@ -86,7 +87,7 @@ export function SidebarSessionRow({
   const handoffSource = handoffOriginSource(session.handoff_state, session.handoff_platform)
   const handoffLabel = handoffSource ? (sessionSourceLabel(handoffSource) ?? handoffSource) : null
   // True when a clarify prompt in this session is waiting on the user.
-  const needsInput = useStore($attentionSessionIds).includes(session.id)
+  const needsInput = useStore($attentionSessionIds).includes(sessionIdentityKey(session.id, session.profile))
 
   return (
     <SessionContextMenu
@@ -128,6 +129,7 @@ export function SidebarSessionRow({
             </SessionActionsMenu>
           </div>
         }
+        aria-current={isSelected ? 'page' : undefined}
         className={cn(
           'group row-hover relative',
           isSelected && 'bg-(--ui-row-active-background)',
@@ -174,7 +176,7 @@ export function SidebarSessionRow({
               event.preventDefault()
               event.stopPropagation()
               triggerHaptic('selection')
-              openSession(session.id, () => undefined, 'tab')
+              openSession(session.id, () => undefined, 'tab', session.profile)
             }
           }}
           onClick={event => {
@@ -185,7 +187,7 @@ export function SidebarSessionRow({
               event.preventDefault()
               event.stopPropagation()
               triggerHaptic('selection')
-              openSession(session.id, () => undefined, 'window')
+              openSession(session.id, () => undefined, 'window', session.profile)
 
               return
             }
@@ -195,7 +197,7 @@ export function SidebarSessionRow({
               event.preventDefault()
               event.stopPropagation()
               triggerHaptic('selection')
-              openSession(session.id, () => undefined, 'tab')
+              openSession(session.id, () => undefined, 'tab', session.profile)
 
               return
             }

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -1,0 +1,180 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+import { sessionIdentityKey } from '@/lib/session-identity'
+
+const sortableMocks = vi.hoisted(() => ({
+  listIds: [] as string[][],
+  rowIds: [] as string[],
+  virtualRowIds: [] as string[]
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: ({ id }: { id: string }) => {
+    sortableMocks.virtualRowIds.push(id)
+
+    return {
+      attributes: {},
+      isDragging: false,
+      listeners: {},
+      setNodeRef: vi.fn(),
+      transform: null,
+      transition: undefined
+    }
+  }
+}))
+
+vi.mock('./reorderable-list', () => ({
+  ReorderableList: ({ children, ids }: { children: React.ReactNode; ids: string[] }) => {
+    sortableMocks.listIds.push(ids)
+
+    return <div data-testid="sortable-session-list">{children}</div>
+  },
+  useSortableBindings: (id: string) => {
+    sortableMocks.rowIds.push(id)
+
+    return {}
+  }
+}))
+
+import { SidebarSessionsSection } from './sessions-section'
+
+const crossProfileSession: SessionInfo = {
+  ended_at: null,
+  id: 'telegram-session',
+  input_tokens: 0,
+  is_active: false,
+  last_active: 1,
+  message_count: 2,
+  model: null,
+  output_tokens: 0,
+  preview: 'remote thread',
+  profile: 'ubuntu-server',
+  source: 'telegram',
+  started_at: 1,
+  title: 'Cross Profile Chat',
+  tool_call_count: 0
+}
+
+describe('SidebarSessionsSection profile routing', () => {
+  beforeEach(() => {
+    sortableMocks.listIds.length = 0
+    sortableMocks.rowIds.length = 0
+    sortableMocks.virtualRowIds.length = 0
+  })
+
+  it('passes the session owner when a row is resumed', () => {
+    const onResumeSession = vi.fn()
+
+    render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={null}
+        label="Sessions"
+        onArchiveSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onResumeSession={onResumeSession}
+        onToggle={vi.fn()}
+        onTogglePin={vi.fn()}
+        open
+        pinned={false}
+        sessions={[crossProfileSession]}
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Cross Profile Chat'))
+
+    expect(onResumeSession).toHaveBeenCalledWith('telegram-session', 'ubuntu-server')
+  })
+
+  it('isolates selected and working state for colliding stored ids', () => {
+    const alpha = { ...crossProfileSession, id: 'shared', profile: 'alpha', title: 'Alpha Chat' }
+    const beta = { ...crossProfileSession, id: 'shared', profile: 'beta', title: 'Beta Chat' }
+
+    render(
+      <SidebarSessionsSection
+        activeSessionId={sessionIdentityKey('shared', 'beta')}
+        emptyState={null}
+        label="Sessions"
+        onArchiveSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onResumeSession={vi.fn()}
+        onToggle={vi.fn()}
+        onTogglePin={vi.fn()}
+        open
+        pinned={false}
+        sessions={[alpha, beta]}
+        workingSessionIdSet={new Set([sessionIdentityKey('shared', 'alpha')])}
+      />
+    )
+
+    expect(screen.getByText('Alpha Chat').closest('[data-working]')?.getAttribute('data-working')).toBe('true')
+    expect(screen.getByText('Alpha Chat').closest('[aria-current]')).toBeNull()
+    expect(screen.getByText('Beta Chat').closest('[data-working]')).toBeNull()
+    expect(screen.getByText('Beta Chat').closest('[aria-current]')?.getAttribute('aria-current')).toBe('page')
+  })
+
+  it('uses compound identities for drag-and-drop rows with colliding stored ids', () => {
+    const alpha = { ...crossProfileSession, id: 'shared', profile: 'alpha', title: 'Alpha Chat' }
+    const beta = { ...crossProfileSession, id: 'shared', profile: 'beta', title: 'Beta Chat' }
+    const identities = [sessionIdentityKey('shared', 'alpha'), sessionIdentityKey('shared', 'beta')]
+
+    render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={null}
+        label="Sessions"
+        onArchiveSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onReorderSessions={vi.fn()}
+        onResumeSession={vi.fn()}
+        onToggle={vi.fn()}
+        onTogglePin={vi.fn()}
+        open
+        pinned={false}
+        sessions={[alpha, beta]}
+        sortable
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    expect(sortableMocks.listIds).toEqual([identities])
+    expect(sortableMocks.rowIds).toEqual(identities)
+  })
+
+  it('uses compound identities for virtualized drag-and-drop rows', () => {
+    const sessions = Array.from({ length: 25 }, (_, index) => ({
+      ...crossProfileSession,
+      id: index < 2 ? 'shared' : `session-${index}`,
+      profile: index === 1 ? 'beta' : 'alpha',
+      title: `Session ${index}`
+    }))
+
+    const identities = sessions.map(session => sessionIdentityKey(session.id, session.profile))
+
+    render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={null}
+        label="Sessions"
+        onArchiveSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onReorderSessions={vi.fn()}
+        onResumeSession={vi.fn()}
+        onToggle={vi.fn()}
+        onTogglePin={vi.fn()}
+        open
+        pinned={false}
+        sessions={sessions}
+        sortable
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    expect(sortableMocks.listIds).toEqual([identities])
+    expect(sortableMocks.virtualRowIds).toContain(sessionIdentityKey('shared', 'alpha'))
+    expect(sortableMocks.virtualRowIds).toContain(sessionIdentityKey('shared', 'beta'))
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -10,6 +10,7 @@ import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { flattenSessionsWithBranches } from '@/lib/session-branch-tree'
 import { groupEntriesByRecency, type SidebarListRow, toSessionRows } from '@/lib/session-date-groups'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
@@ -89,9 +90,9 @@ interface SidebarSessionsSectionProps {
   sessions: SessionInfo[]
   activeSessionId: null | string
   workingSessionIdSet: Set<string>
-  onResumeSession: (sessionId: string) => void
-  onDeleteSession: (sessionId: string) => void
-  onArchiveSession: (sessionId: string) => void
+  onResumeSession: (sessionId: string, profile?: null | string) => void
+  onDeleteSession: (sessionId: string, profile?: null | string) => void
+  onArchiveSession: (sessionId: string, profile?: null | string) => void
   onBranchSession?: (sessionId: string, profile?: string) => void
   onTogglePin: (sessionId: string) => void
   onNewSessionInWorkspace?: (path: null | string) => void
@@ -224,25 +225,26 @@ export function SidebarSessionsSection({
   )
 
   const renderRow = (session: SessionInfo, draggable: boolean, branchStem?: string) => {
+    const identityKey = sessionIdentityKey(session.id, session.profile)
     const rowProps = {
       branchStem,
       isPinned: pinned,
-      isSelected: session.id === activeSessionId,
-      isWorking: workingSessionIdSet.has(session.id),
-      onArchive: () => onArchiveSession(session.id),
+      isSelected: identityKey === activeSessionId,
+      isWorking: workingSessionIdSet.has(identityKey),
+      onArchive: () => onArchiveSession(session.id, session.profile),
       onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
-      onDelete: () => onDeleteSession(session.id),
+      onDelete: () => onDeleteSession(session.id, session.profile),
       onPin: () => onTogglePin(sessionPinId(session)),
-      onResume: () => onResumeSession(session.id),
+      onResume: () => onResumeSession(session.id, session.profile),
       reorderable: draggable && !branchStem,
       session,
       showProfile: showProfileTags
     }
 
     return draggable && !branchStem ? (
-      <SortableSidebarSessionRow key={session.id} {...rowProps} />
+      <SortableSidebarSessionRow key={identityKey} {...rowProps} />
     ) : (
-      <SidebarSessionRow key={session.id} {...rowProps} />
+      <SidebarSessionRow key={identityKey} {...rowProps} />
     )
   }
 
@@ -381,7 +383,11 @@ export function SidebarSessionsSection({
 
     inner =
       sessionsDraggable && onReorderSessions ? (
-        <ReorderableList ids={sessions.map(s => s.id)} onReorder={onReorderSessions} sensors={dndSensors}>
+        <ReorderableList
+          ids={sessions.map(session => sessionIdentityKey(session.id, session.profile))}
+          onReorder={onReorderSessions}
+          sensors={dndSensors}
+        >
           {virtual}
         </ReorderableList>
       ) : (
@@ -389,7 +395,11 @@ export function SidebarSessionsSection({
       )
   } else if (sessionsDraggable && onReorderSessions) {
     inner = (
-      <ReorderableList ids={sessions.map(s => s.id)} onReorder={onReorderSessions} sensors={dndSensors}>
+      <ReorderableList
+        ids={sessions.map(session => sessionIdentityKey(session.id, session.profile))}
+        onReorder={onReorderSessions}
+        sensors={dndSensors}
+      >
         {flatRows.map(row => renderListRow(row, true))}
       </ReorderableList>
     )
@@ -434,7 +444,12 @@ interface SortableSessionRowProps {
 }
 
 function SortableSidebarSessionRow(props: SortableSessionRowProps) {
-  return <SidebarSessionRow {...props} {...useSortableBindings(props.session.id)} />
+  return (
+    <SidebarSessionRow
+      {...props}
+      {...useSortableBindings(sessionIdentityKey(props.session.id, props.session.profile))}
+    />
+  )
 }
 
 function SortableProjectOverviewRow(props: React.ComponentProps<typeof ProjectOverviewRow>) {

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -6,6 +6,7 @@ import { type FC, useCallback, useRef } from 'react'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type SidebarListRow } from '@/lib/session-date-groups'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
@@ -31,10 +32,10 @@ interface VirtualSessionListProps {
   activeSessionId: null | string
   className?: string
   rows: SidebarListRow[]
-  onArchiveSession: (sessionId: string) => void
+  onArchiveSession: (sessionId: string, profile?: null | string) => void
   onBranchSession?: (sessionId: string, profile?: string) => void
-  onDeleteSession: (sessionId: string) => void
-  onResumeSession: (sessionId: string) => void
+  onDeleteSession: (sessionId: string, profile?: null | string) => void
+  onResumeSession: (sessionId: string, profile?: null | string) => void
   onTogglePin: (sessionId: string) => void
   pinned: boolean
   showProfileTags?: boolean
@@ -69,7 +70,11 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     getItemKey: index => {
       const row = listRows[index]
 
-      return row ? (row.kind === 'divider' ? row.key : row.entry.session.id) : index
+      return row
+        ? row.kind === 'divider'
+          ? row.key
+          : sessionIdentityKey(row.entry.session.id, row.entry.session.profile)
+        : index
     },
     getScrollElement: () => scrollerRef.current,
     // jsdom-friendly default; the real rect takes over on first observe.
@@ -102,18 +107,19 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     }
 
     const { branchStem, session } = row.entry
+    const identityKey = sessionIdentityKey(session.id, session.profile)
     const reorderable = sortable && !branchStem
 
     const commonProps: SessionRowCommonProps = {
       branchStem,
       isPinned: pinned,
-      isSelected: session.id === activeSessionId,
-      isWorking: workingSessionIdSet.has(session.id),
-      onArchive: () => onArchiveSession(session.id),
+      isSelected: identityKey === activeSessionId,
+      isWorking: workingSessionIdSet.has(identityKey),
+      onArchive: () => onArchiveSession(session.id, session.profile),
       onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
-      onDelete: () => onDeleteSession(session.id),
+      onDelete: () => onDeleteSession(session.id, session.profile),
       onPin: () => onTogglePin(sessionPinId(session)),
-      onResume: () => onResumeSession(session.id),
+      onResume: () => onResumeSession(session.id, session.profile),
       reorderable,
       showProfile: showProfileTags
     }
@@ -121,7 +127,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     return reorderable ? (
       <VirtualSortableRow
         index={virtualItem.index}
-        key={session.id}
+        key={identityKey}
         measureRef={virtualizer.measureElement}
         rowProps={commonProps}
         session={session}
@@ -130,7 +136,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       <SidebarSessionRow
         {...commonProps}
         data-index={virtualItem.index}
-        key={session.id}
+        key={identityKey}
         ref={virtualizer.measureElement}
         session={session}
       />
@@ -160,7 +166,9 @@ interface VirtualSortableRowProps {
 }
 
 function VirtualSortableRow({ index, measureRef, rowProps, session }: VirtualSortableRowProps) {
-  const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({ id: session.id })
+  const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
+    id: sessionIdentityKey(session.id, session.profile)
+  })
 
   // Merge dnd-kit's setNodeRef with the virtualizer's measureElement so
   // the row participates in both DnD hit-testing and TanStack height

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -25,6 +25,7 @@ import {
   Wrench
 } from '@/lib/icons'
 import { exportSession } from '@/lib/session-export'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { fmtDateTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
@@ -51,10 +52,10 @@ type UsagePeriod = (typeof USAGE_PERIODS)[number]
 interface CommandCenterViewProps {
   initialSection?: CommandCenterSection
   onClose: () => void
-  onDeleteSession: (sessionId: string) => Promise<void>
+  onDeleteSession: (sessionId: string, profile?: null | string) => Promise<void>
   // Accepted for call-site parity; navigation lives in the global Cmd+K palette.
   onNavigateRoute?: (path: string) => void
-  onOpenSession: (sessionId: string) => void
+  onOpenSession: (sessionId: string, profile?: null | string) => void
 }
 
 function formatTimestamp(value?: number | null): string {
@@ -355,10 +356,13 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                     const pinned = pinnedSessionIds.includes(pinId)
 
                     return (
-                      <li className="group flex items-center gap-2 py-2" key={session.id}>
+                      <li
+                        className="group flex items-center gap-2 py-2"
+                        key={sessionIdentityKey(session.id, session.profile)}
+                      >
                         <button
                           className="min-w-0 flex-1 text-left"
-                          onClick={() => onOpenSession(session.id)}
+                          onClick={() => onOpenSession(session.id, session.profile)}
                           type="button"
                         >
                           <div className="truncate text-[length:var(--conversation-text-font-size)] font-medium text-foreground">
@@ -383,7 +387,7 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                           </RowIconButton>
                           <RowIconButton
                             className="hover:text-destructive"
-                            onClick={() => void onDeleteSession(session.id)}
+                            onClick={() => void onDeleteSession(session.id, session.profile)}
                             title={cc.deleteSession}
                           >
                             <Trash2 className="size-3.5" />

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -58,6 +58,7 @@ import {
 } from '@/store/command-palette'
 import { $bindings } from '@/store/keybinds'
 import { openPetGenerate } from '@/store/pet-generate'
+import { $activeGatewayProfile } from '@/store/profile'
 import { requestStartWorkSession } from '@/store/projects'
 import { runGatewayRestart } from '@/store/system-actions'
 import { applyBackendUpdate } from '@/store/updates'
@@ -87,6 +88,7 @@ import { prettyName } from '../settings/helpers'
 import { usePaletteContributions } from './contrib'
 import { MarketplaceThemePage } from './marketplace-theme-page'
 import { PetInlineToggle, PetPalettePage } from './pet-palette-page'
+import { archivedSessionTarget, sessionPaletteItemId } from './session-items'
 
 interface PaletteItem {
   /** Keybind action id — its live combo renders as a hotkey hint. */
@@ -133,6 +135,7 @@ interface SessionEntry {
   git_branch?: null | string
   id: string
   preview?: string
+  profile?: null | string
   title: string
 }
 
@@ -228,6 +231,7 @@ const toSessionEntry = (session: SessionRow): SessionEntry => ({
   git_branch: session.git_branch ?? null,
   id: session.id,
   preview: session.preview ?? undefined,
+  profile: session.profile,
   title: sessionTitle(session)
 })
 
@@ -382,9 +386,10 @@ export function CommandPalette() {
   // Sessions: plain select = open in-place (focus existing tile/main, else main);
   // ⌘/⌃-select / ⌘-Enter = new tab; ⇧⌘ = own window. Same door as the sidebar.
   const goSession = useCallback(
-    (sessionId: string) => (event?: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean }) => {
-      openSession(sessionId, navigate, openSessionIntentFromModifiers(event))
-    },
+    (sessionId: string, profile?: null | string) =>
+      (event?: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean }) => {
+        openSession(sessionId, navigate, openSessionIntentFromModifiers(event), profile)
+      },
     [navigate]
   )
 
@@ -656,7 +661,7 @@ export function CommandPalette() {
             id: `goto-${directId}`,
             keywords: ['session', 'id', 'go to', directId],
             label: `${t.commandCenter.goToSession} ${directId}`,
-            runWithEvent: goSession(directId)
+            runWithEvent: goSession(directId, $activeGatewayProfile.get())
           }
         ]
       })
@@ -736,7 +741,7 @@ export function CommandPalette() {
         heading: t.commandCenter.sections.sessions,
         items: sessions.map(session => ({
           icon: MessageCircle,
-          id: `session-${session.id}`,
+          id: sessionPaletteItemId('session', session),
           keywords: [
             'chat',
             'session',
@@ -744,7 +749,7 @@ export function CommandPalette() {
             ...(session.git_branch ? [session.git_branch] : [])
           ],
           label: session.title,
-          runWithEvent: goSession(session.id)
+          runWithEvent: goSession(session.id, session.profile)
         }))
       })
     }
@@ -779,7 +784,7 @@ export function CommandPalette() {
         heading: t.commandCenter.archivedChats,
         items: archivedSessions.map(session => ({
           icon: Archive,
-          id: `archived-${session.id}`,
+          id: sessionPaletteItemId('archived', session),
           keywords: [
             'archived',
             'chat',
@@ -788,7 +793,7 @@ export function CommandPalette() {
             ...(session.git_branch ? [session.git_branch] : [])
           ],
           label: session.title,
-          run: go(`${SETTINGS_ROUTE}?tab=sessions&session=${encodeURIComponent(session.id)}`)
+          run: go(archivedSessionTarget(session))
         }))
       })
     }

--- a/apps/desktop/src/app/command-palette/session-items.test.ts
+++ b/apps/desktop/src/app/command-palette/session-items.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { sessionIdentityKey } from '@/lib/session-identity'
+
+import { archivedSessionElementId, archivedSessionTarget, sessionPaletteItemId } from './session-items'
+
+describe('command-palette session identity', () => {
+  it('distinguishes colliding stored ids by profile and keeps ids opaque', () => {
+    expect(sessionPaletteItemId('session', { id: 'shared', profile: 'alpha' })).not.toBe(
+      sessionPaletteItemId('session', { id: 'shared', profile: 'beta' })
+    )
+    expect(sessionPaletteItemId('session', { id: ' shared ', profile: 'alpha' })).toContain(
+      encodeURIComponent(sessionIdentityKey(' shared ', 'alpha'))
+    )
+  })
+
+  it('deep-links archived rows by compound identity', () => {
+    const identity = sessionIdentityKey('shared', 'alpha')
+
+    expect(archivedSessionTarget({ id: 'shared', profile: 'alpha' })).toContain(encodeURIComponent(identity))
+    expect(archivedSessionElementId(identity)).toBe(`archived-session-${encodeURIComponent(identity)}`)
+  })
+})

--- a/apps/desktop/src/app/command-palette/session-items.ts
+++ b/apps/desktop/src/app/command-palette/session-items.ts
@@ -1,0 +1,18 @@
+import { sessionIdentityKey } from '@/lib/session-identity'
+
+interface SessionIdentity {
+  id: string
+  profile?: null | string
+}
+
+export function sessionPaletteItemId(prefix: 'archived' | 'session', session: SessionIdentity): string {
+  return `${prefix}-${encodeURIComponent(sessionIdentityKey(session.id, session.profile))}`
+}
+
+export function archivedSessionTarget(session: SessionIdentity): string {
+  return `/settings?tab=sessions&session=${encodeURIComponent(sessionIdentityKey(session.id, session.profile))}`
+}
+
+export function archivedSessionElementId(identityKey: string): string {
+  return `archived-session-${encodeURIComponent(identityKey)}`
+}

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -41,6 +41,7 @@ import { sessionTitle as storedSessionTitle } from '@/lib/chat-runtime'
 import { LayoutDashboard, PanelBottom } from '@/lib/icons'
 import { type KeybindContribution, KEYBINDS_AREA } from '@/lib/keybinds/actions'
 import { Codecs, persistentAtom } from '@/lib/persisted'
+import { parseSessionIdentityKey, sessionMatchesIdentity } from '@/lib/session-identity'
 import { pruneComposerPopoutZones } from '@/store/composer-popout'
 import {
   $fileBrowserOpen,
@@ -56,7 +57,11 @@ import {
 } from '@/store/layout'
 import { $previewOpenRequest, $previewTabs, closeRightRail } from '@/store/preview'
 import { $reviewOpen, closeReview, REVIEW_PANE_ID } from '@/store/review'
-import { $currentCwd, $selectedStoredSessionId, $sessions, sessionMatchesStoredId } from '@/store/session'
+import {
+  $currentCwd,
+  $selectedSessionIdentityKey,
+  $sessions
+} from '@/store/session'
 import { watchSessionPins } from '@/store/session-pin-sync'
 import { $statusbarVisible, toggleStatusbarVisible } from '@/store/statusbar-prefs'
 
@@ -108,15 +113,16 @@ const wrapWorkspaceTab = (tab: ReactElement) => <WorkspaceTabMenu>{tab}</Workspa
 /** The `@session` payload for the workspace tab — the loaded primary session,
  *  or null on a fresh draft / full-page view (nothing to link). */
 const workspaceDragPayload = (): SessionDragPayload | null => {
-  const selected = $selectedStoredSessionId.get()
+  const identityKey = $selectedSessionIdentityKey.get()
 
-  if (!selected || $workspaceIsPage.get()) {
+  if (!identityKey || $workspaceIsPage.get()) {
     return null
   }
 
-  const stored = $sessions.get().find(s => sessionMatchesStoredId(s, selected))
+  const { profile, storedSessionId } = parseSessionIdentityKey(identityKey)
+  const stored = $sessions.get().find(s => sessionMatchesIdentity(s, storedSessionId, profile))
 
-  return { id: selected, profile: stored?.profile ?? '', title: stored ? storedSessionTitle(stored) : '' }
+  return { id: storedSessionId, profile, title: stored ? storedSessionTitle(stored) : '' }
 }
 
 // The main tab drags like a session tile — drop it on a composer to link the
@@ -434,8 +440,14 @@ watchSessionPins()
 // register() replaces same-id in place; the render fn is the shared constant
 // above, so the pane content never remounts.
 const syncWorkspaceTitle = () => {
-  const selected = $selectedStoredSessionId.get()
-  const stored = selected ? $sessions.get().find(s => sessionMatchesStoredId(s, selected)) : null
+  const identityKey = $selectedSessionIdentityKey.get()
+  const identity = identityKey ? parseSessionIdentityKey(identityKey) : null
+
+  const stored = identity
+    ? $sessions
+        .get()
+        .find(s => sessionMatchesIdentity(s, identity.storedSessionId, identity.profile))
+    : null
 
   registry.register({
     id: 'workspace',
@@ -445,7 +457,15 @@ const syncWorkspaceTitle = () => {
       // The tab's status dot — the SAME primitive the sidebar row and session
       // tiles render, so the main tab never disagrees with its sidebar row. No
       // dot on a fresh draft (no session yet).
-      tabLead: selected ? () => <SessionStatusDot session={stored} storedSessionId={selected} /> : undefined,
+      tabLead: identity
+        ? () => (
+            <SessionStatusDot
+              profile={identity.profile}
+              session={stored}
+              storedSessionId={identity.storedSessionId}
+            />
+          )
+        : undefined,
       // Pages aren't tab-able: the main zone's bar stands down while one shows.
       headerVeto: $workspaceIsPage.get(),
       placement: 'main',
@@ -458,7 +478,7 @@ const syncWorkspaceTitle = () => {
   })
 }
 
-$selectedStoredSessionId.listen(syncWorkspaceTitle)
+$selectedSessionIdentityKey.listen(syncWorkspaceTitle)
 $sessions.listen(syncWorkspaceTitle)
 $workspaceIsPage.listen(syncWorkspaceTitle)
 

--- a/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { $selectedStoredSessionId, $unreadFinishedSessionIds } from '@/store/session'
 import { $attentionSessionIds, $workingSessionIds, clearAllSessionStates } from '@/store/session-states'
 
@@ -32,7 +33,7 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
       sessions: [{ id: 'runtime-a', session_key: 'stored-a', status: 'working' }]
     })
 
-    expect($workingSessionIds.get()).toEqual(['stored-a'])
+    expect($workingSessionIds.get()).toEqual([sessionIdentityKey('stored-a', 'default')])
 
     // The turn finished and the gateway reaped the session between polls.
     rehydrateLiveSessionStatuses({ sessions: [] })
@@ -47,7 +48,7 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
 
     rehydrateLiveSessionStatuses({ sessions: [] })
 
-    expect($unreadFinishedSessionIds.get()).toEqual(['stored-b'])
+    expect($unreadFinishedSessionIds.get()).toEqual([sessionIdentityKey('stored-b', 'default')])
   })
 
   it('clears a blocked session that disappears from the live snapshot', () => {
@@ -55,7 +56,7 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
       sessions: [{ id: 'runtime-c', session_key: 'stored-c', status: 'waiting' }]
     })
 
-    expect($attentionSessionIds.get()).toEqual(['stored-c'])
+    expect($attentionSessionIds.get()).toEqual([sessionIdentityKey('stored-c', 'default')])
 
     rehydrateLiveSessionStatuses({ sessions: [] })
 
@@ -74,6 +75,6 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
 
     rehydrateLiveSessionStatuses({ sessions: [] }, Date.now(), 'default')
 
-    expect($workingSessionIds.get()).toEqual(['stored-other'])
+    expect($workingSessionIds.get()).toEqual([sessionIdentityKey('stored-other', 'other')])
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/live-status-spinner.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/live-status-spinner.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { $selectedStoredSessionId, $unreadFinishedSessionIds } from '@/store/session'
 import { $workingSessionIds, clearAllSessionStates } from '@/store/session-states'
 
@@ -34,7 +35,7 @@ describe('rehydrateLiveSessionStatuses — seeding a turn the renderer never saw
       sessions: [{ id: 'runtime-cold', session_key: 'stored-cold', status: 'working' }]
     })
 
-    expect($workingSessionIds.get()).toContain('stored-cold')
+    expect($workingSessionIds.get()).toContain(sessionIdentityKey('stored-cold', 'default'))
   })
 
   it('keeps the spinner across polls while the turn is still running', () => {
@@ -45,7 +46,7 @@ describe('rehydrateLiveSessionStatuses — seeding a turn the renderer never saw
       sessions: [{ id: 'runtime-cold', session_key: 'stored-cold', status: 'working' }]
     })
 
-    expect($workingSessionIds.get()).toContain('stored-cold')
+    expect($workingSessionIds.get()).toContain(sessionIdentityKey('stored-cold', 'default'))
   })
 
   it('shows the spinner when a runtime id is recycled onto a new stored session', () => {
@@ -59,8 +60,8 @@ describe('rehydrateLiveSessionStatuses — seeding a turn the renderer never saw
       sessions: [{ id: 'runtime-1', session_key: 'stored-new', status: 'working' }]
     })
 
-    expect($workingSessionIds.get()).toContain('stored-new')
-    expect($workingSessionIds.get()).not.toContain('stored-old')
+    expect($workingSessionIds.get()).toContain(sessionIdentityKey('stored-new', 'default'))
+    expect($workingSessionIds.get()).not.toContain(sessionIdentityKey('stored-old', 'default'))
   })
 
   it('leaves a starting session idle — the agent build is not proof of a turn', () => {
@@ -72,6 +73,6 @@ describe('rehydrateLiveSessionStatuses — seeding a turn the renderer never saw
       sessions: [{ id: 'runtime-boot', session_key: 'stored-boot', status: 'starting' }]
     })
 
-    expect($workingSessionIds.get()).not.toContain('stored-boot')
+    expect($workingSessionIds.get()).not.toContain(sessionIdentityKey('stored-boot', 'default'))
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { sessionIdentityKey } from '@/lib/session-identity'
 import {
   $attentionSessionIds,
   $stalledSessionIds,
@@ -44,8 +45,11 @@ describe('rehydrateLiveSessionStatuses', () => {
       now
     )
 
-    expect($workingSessionIds.get()).toEqual(['overnight-exam-learning', 'temporary-file-cleanup'])
-    expect($stalledSessionIds.get()).toEqual(['overnight-exam-learning'])
+    expect($workingSessionIds.get()).toEqual([
+      sessionIdentityKey('overnight-exam-learning', 'default'),
+      sessionIdentityKey('temporary-file-cleanup', 'default')
+    ])
+    expect($stalledSessionIds.get()).toEqual([sessionIdentityKey('overnight-exam-learning', 'default')])
     expect($attentionSessionIds.get()).toEqual([])
   })
 
@@ -54,8 +58,8 @@ describe('rehydrateLiveSessionStatuses', () => {
       sessions: [{ id: 'runtime-needs-user', session_key: 'needs-user', status: 'waiting' }]
     })
 
-    expect($workingSessionIds.get()).toEqual(['needs-user'])
-    expect($attentionSessionIds.get()).toEqual(['needs-user'])
+    expect($workingSessionIds.get()).toEqual([sessionIdentityKey('needs-user', 'default')])
+    expect($attentionSessionIds.get()).toEqual([sessionIdentityKey('needs-user', 'default')])
     expect($stalledSessionIds.get()).toEqual([])
   })
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -63,7 +63,7 @@ export function rehydrateLiveSessionStatuses(
 
   for (const session of response.sessions ?? []) {
     const runtimeSessionId = session.id?.trim()
-    const storedSessionId = session.session_key?.trim()
+    const storedSessionId = session.session_key
     const needsInput = session.status === 'waiting'
     const working = session.status === 'working' || needsInput
 
@@ -85,15 +85,16 @@ export function rehydrateLiveSessionStatuses(
       existing.needsInput !== needsInput
     ) {
       publishSessionState(runtimeSessionId, {
-        ...(existing ?? createClientSessionState(storedSessionId)),
+        ...(existing ?? createClientSessionState(storedSessionId, [], profileKey)),
         busy: working,
         needsInput,
-        storedSessionId
+        storedSessionId,
+        storedSessionProfile: profileKey
       })
     }
 
     if (!working) {
-      setSessionStalled(storedSessionId, false)
+      setSessionStalled(storedSessionId, false, profileKey)
 
       continue
     }
@@ -106,7 +107,7 @@ export function rehydrateLiveSessionStatuses(
       lastActiveMs > 0 &&
       nowMs - lastActiveMs >= SESSION_WATCHDOG_TIMEOUT_MS
 
-    setSessionStalled(storedSessionId, isQuiet)
+    setSessionStalled(storedSessionId, isQuiet, profileKey)
   }
 
   // A runtime this profile's snapshot reported live LAST poll but not this one

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { openSession } from '@/app/open-session'
-import { storedSessionIdForNotification } from '@/lib/session-ids'
+import { sessionIdentityForNotification } from '@/lib/session-ids'
 import { respondToApprovalAction } from '@/store/native-notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
@@ -24,10 +24,12 @@ interface DesktopIntegrationsParams {
   chatOpen: boolean
   hasPreview: boolean
   locationPathname: string
+  locationSearch: string
   navigate: (to: string, options?: { replace?: boolean }) => void
   refreshSessions: () => Promise<unknown> | unknown
   resumeExhaustedSessionId: null | string
   routedSessionId: null | string
+  routedSessionProfile: null | string
   runtimeIdByStoredSessionId: { readonly current: Map<string, string> }
 }
 
@@ -40,10 +42,12 @@ interface DesktopIntegrationsParams {
  */
 export function useDesktopIntegrations({
   locationPathname,
+  locationSearch,
   navigate,
   refreshSessions,
   resumeExhaustedSessionId,
   routedSessionId,
+  routedSessionProfile,
   runtimeIdByStoredSessionId
 }: DesktopIntegrationsParams): void {
   // Update polling — populates $desktopVersion/$updateStatus, which feed the
@@ -74,14 +78,18 @@ export function useDesktopIntegrations({
     if (routedSessionId) {
       setRememberedSessionId(
         routedSessionId,
-        rememberedSessionProfile($sessions.get(), routedSessionId, $activeGatewayProfile.get())
+        rememberedSessionProfile(
+          $sessions.get(),
+          routedSessionId,
+          routedSessionProfile ?? $activeGatewayProfile.get()
+        )
       )
     }
 
     if (!isOverlayView(appViewForPath(locationPathname))) {
-      setRememberedRoute(locationPathname)
+      setRememberedRoute(`${locationPathname}${locationSearch}`)
     }
-  }, [locationPathname, routedSessionId])
+  }, [locationPathname, locationSearch, routedSessionId, routedSessionProfile])
 
   const restoredRef = useRef(false)
 
@@ -108,7 +116,7 @@ export function useDesktopIntegrations({
     const last = getRememberedSessionId($activeGatewayProfile.get())
 
     if (last) {
-      navigate(sessionRoute(last), { replace: true })
+      navigate(sessionRoute(last, $activeGatewayProfile.get()), { replace: true })
     }
   }, [locationPathname, navigate])
 
@@ -128,9 +136,13 @@ export function useDesktopIntegrations({
   // tile / main) instead of forcing main. Runtime id is translated to the
   // stored id the chat route is keyed by; action buttons resolve in place.
   useEffect(() => {
-    const unsubscribe = window.hermesDesktop?.onFocusSession?.(sessionId => {
-      if (sessionId) {
-        openSession(storedSessionIdForNotification(sessionId, runtimeIdByStoredSessionId.current), navigate)
+    const unsubscribe = window.hermesDesktop?.onFocusSession?.(target => {
+      if (target?.sessionId) {
+        const identity = target.profile
+          ? target
+          : sessionIdentityForNotification(target.sessionId, runtimeIdByStoredSessionId.current)
+
+        openSession(identity.sessionId, navigate, 'in-place', identity.profile)
       }
     })
 
@@ -138,8 +150,8 @@ export function useDesktopIntegrations({
   }, [navigate, runtimeIdByStoredSessionId])
 
   useEffect(() => {
-    const unsubscribe = window.hermesDesktop?.onNotificationAction?.(({ actionId, sessionId }) => {
-      void respondToApprovalAction(sessionId ?? null, actionId)
+    const unsubscribe = window.hermesDesktop?.onNotificationAction?.(({ actionId, profile, sessionId }) => {
+      void respondToApprovalAction(sessionId ?? null, actionId, profile)
     })
 
     return () => unsubscribe?.()
@@ -176,7 +188,7 @@ export function useDesktopIntegrations({
   // path is the `view.closeTab` keybind (use-keybinds), sharing closeActiveTab.
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onClosePreviewRequested?.(
-      () => void closeActiveTab(id => navigate(sessionRoute(id)))
+      () => void closeActiveTab(id => navigate(sessionRoute(id, $activeGatewayProfile.get())))
     )
 
     return () => unsubscribe?.()

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.tsx
@@ -1,0 +1,243 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { sessionIdentityKey } from '@/lib/session-identity'
+import { $notifications, clearNotifications } from '@/store/notifications'
+import type { QuickEntryStatePush, QuickEntrySubmitPayload } from '@/store/quick-entry'
+import { setSessions } from '@/store/session'
+import { setSessionTileDelegate } from '@/store/session-states'
+import type { SessionInfo } from '@/types/hermes'
+
+import { useQuickEntryBridge } from './use-quick-entry-bridge'
+
+const row = (profile: string, title: string, id = 'shared'): SessionInfo =>
+  ({
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 0,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    profile,
+    source: null,
+    started_at: 0,
+    title
+  }) as SessionInfo
+
+describe('useQuickEntryBridge session ownership', () => {
+  let submitFromQuickWindow: ((payload: QuickEntrySubmitPayload) => void) | null
+  const pushState = vi.fn<(payload: QuickEntryStatePush) => void>()
+
+  beforeEach(() => {
+    submitFromQuickWindow = null
+    pushState.mockClear()
+    setSessions([row('alpha', 'Alpha'), row('beta', 'Beta')])
+    clearNotifications()
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        quickEntry: {
+          onSubmit: vi.fn((callback: (payload: QuickEntrySubmitPayload) => void) => {
+            submitFromQuickWindow = callback
+
+            return () => {
+              submitFromQuickWindow = null
+            }
+          }),
+          pushState
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    setSessions([])
+    clearNotifications()
+  })
+
+  it('publishes collision-safe targets and resumes the selected exact owner', async () => {
+    const resumeTile = vi.fn(async () => 'runtime-alpha')
+    const submitToSession = vi.fn(async () => undefined)
+
+    setSessionTileDelegate({
+      archiveSession: vi.fn(async () => undefined),
+      branchSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      executeSlash: vi.fn(async () => undefined),
+      interruptSession: vi.fn(async () => undefined),
+      resumeTile,
+      submitToSession,
+      updateSession: vi.fn()
+    })
+
+    const { unmount } = renderHook(() =>
+      useQuickEntryBridge({ startFreshSessionDraft: vi.fn(), submitText: vi.fn() })
+    )
+
+    expect(pushState).toHaveBeenCalledWith({
+      connected: false,
+      sessions: [
+        {
+          id: sessionIdentityKey('shared', 'alpha'),
+          target: { kind: 'session', profile: 'alpha', storedSessionId: 'shared' },
+          title: 'Alpha'
+        },
+        {
+          id: sessionIdentityKey('shared', 'beta'),
+          target: { kind: 'session', profile: 'beta', storedSessionId: 'shared' },
+          title: 'Beta'
+        }
+      ]
+    })
+
+    submitFromQuickWindow?.({
+      target: { kind: 'session', profile: 'alpha', storedSessionId: 'shared' },
+      text: 'owned prompt'
+    })
+
+    await waitFor(() => expect(resumeTile).toHaveBeenCalledWith('shared', 'alpha'))
+    expect(submitToSession).toHaveBeenCalledWith('runtime-alpha', 'owned prompt', 'alpha')
+
+    unmount()
+  })
+
+  it('preserves an exact opaque target containing the identity separator', async () => {
+    const opaqueId = 'left\0right'
+    const resumeTile = vi.fn(async () => 'runtime-alpha')
+
+    setSessions([row('alpha', 'Alpha', opaqueId)])
+    setSessionTileDelegate({
+      archiveSession: vi.fn(async () => undefined),
+      branchSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      executeSlash: vi.fn(async () => undefined),
+      interruptSession: vi.fn(async () => undefined),
+      resumeTile,
+      submitToSession: vi.fn(async () => undefined),
+      updateSession: vi.fn()
+    })
+
+    const { unmount } = renderHook(() =>
+      useQuickEntryBridge({ startFreshSessionDraft: vi.fn(), submitText: vi.fn() })
+    )
+
+    submitFromQuickWindow?.({
+      target: { kind: 'session', profile: 'alpha', storedSessionId: opaqueId },
+      text: 'opaque prompt'
+    })
+
+    await waitFor(() => expect(resumeTile).toHaveBeenCalledWith(opaqueId, 'alpha'))
+    unmount()
+  })
+
+  it('does not confuse opaque IDs with control names or another compound picker id', async () => {
+    const compoundCollision = sessionIdentityKey('shared', 'alpha')
+    const resumeTile = vi.fn(async () => 'runtime-exact')
+    const submitToSession = vi.fn(async () => undefined)
+
+    setSessions([
+      row('alpha', 'Alpha', 'shared'),
+      row('beta', 'Beta', compoundCollision),
+      row('gamma', 'Gamma', 'current')
+    ])
+    setSessionTileDelegate({
+      archiveSession: vi.fn(async () => undefined),
+      branchSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      executeSlash: vi.fn(async () => undefined),
+      interruptSession: vi.fn(async () => undefined),
+      resumeTile,
+      submitToSession,
+      updateSession: vi.fn()
+    })
+
+    const { unmount } = renderHook(() =>
+      useQuickEntryBridge({ startFreshSessionDraft: vi.fn(), submitText: vi.fn() })
+    )
+
+    submitFromQuickWindow?.({
+      target: { kind: 'session', profile: 'beta', storedSessionId: compoundCollision },
+      text: 'compound collision'
+    })
+    submitFromQuickWindow?.({
+      target: { kind: 'session', profile: 'gamma', storedSessionId: 'current' },
+      text: 'control collision'
+    })
+
+    await waitFor(() => expect(resumeTile).toHaveBeenCalledTimes(2))
+    expect(resumeTile).toHaveBeenNthCalledWith(1, compoundCollision, 'beta')
+    expect(resumeTile).toHaveBeenNthCalledWith(2, 'current', 'gamma')
+    expect(submitToSession).toHaveBeenNthCalledWith(1, 'runtime-exact', 'compound collision', 'beta')
+    expect(submitToSession).toHaveBeenNthCalledWith(2, 'runtime-exact', 'control collision', 'gamma')
+
+    unmount()
+  })
+
+  it('fails closed when a selected session target is stale', async () => {
+    const resumeTile = vi.fn(async () => 'runtime-stale')
+    const submitText = vi.fn()
+
+    setSessionTileDelegate({
+      archiveSession: vi.fn(async () => undefined),
+      branchSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      executeSlash: vi.fn(async () => undefined),
+      interruptSession: vi.fn(async () => undefined),
+      resumeTile,
+      submitToSession: vi.fn(async () => undefined),
+      updateSession: vi.fn()
+    })
+
+    const { unmount } = renderHook(() =>
+      useQuickEntryBridge({ startFreshSessionDraft: vi.fn(), submitText })
+    )
+
+    setSessions([])
+    submitFromQuickWindow?.({
+      target: { kind: 'session', profile: 'alpha', storedSessionId: 'shared' },
+      text: 'do not redirect'
+    })
+    await Promise.resolve()
+
+    expect(resumeTile).not.toHaveBeenCalled()
+    expect(submitText).not.toHaveBeenCalled()
+    expect($notifications.get()[0]?.kind).toBe('error')
+    unmount()
+  })
+
+  it('does not redirect into the visible chat when an owned-session resume rejects', async () => {
+    const resumeTile = vi.fn(async () => Promise.reject(new Error('resume failed')))
+    const submitToSession = vi.fn(async () => undefined)
+    const submitText = vi.fn()
+
+    setSessionTileDelegate({
+      archiveSession: vi.fn(async () => undefined),
+      branchSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      executeSlash: vi.fn(async () => undefined),
+      interruptSession: vi.fn(async () => undefined),
+      resumeTile,
+      submitToSession,
+      updateSession: vi.fn()
+    })
+
+    const { unmount } = renderHook(() => useQuickEntryBridge({ startFreshSessionDraft: vi.fn(), submitText }))
+
+    submitFromQuickWindow?.({
+      target: { kind: 'session', profile: 'alpha', storedSessionId: 'shared' },
+      text: 'do not redirect'
+    })
+
+    await waitFor(() => expect(resumeTile).toHaveBeenCalledWith('shared', 'alpha'))
+    await Promise.resolve()
+
+    expect(submitToSession).not.toHaveBeenCalled()
+    expect(submitText).not.toHaveBeenCalled()
+    expect($notifications.get()[0]?.kind).toBe('error')
+    unmount()
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -1,9 +1,10 @@
 import { useEffect, useRef } from 'react'
 
+import { useI18n } from '@/i18n'
+import { normalizeProfileKey, sessionIdentityKey } from '@/lib/session-identity'
+import { notifyError } from '@/store/notifications'
 import {
   initQuickEntryBridge,
-  QUICK_TARGET_CURRENT,
-  QUICK_TARGET_NEW,
   type QuickEntrySessionOption,
   setQuickEntrySubmitHandler
 } from '@/store/quick-entry'
@@ -26,7 +27,12 @@ function sessionOptions(): QuickEntrySessionOption[] {
     .filter(session => !session.archived)
     .slice(0, QUICK_ENTRY_SESSION_OPTIONS)
     .map(session => ({
-      id: session.id,
+      id: sessionIdentityKey(session.id, session.profile),
+      target: {
+        kind: 'session' as const,
+        profile: normalizeProfileKey(session.profile),
+        storedSessionId: session.id
+      },
       title: session.title?.trim() || session.preview?.trim() || session.id
     }))
 }
@@ -51,6 +57,9 @@ function sessionOptions(): QuickEntrySessionOption[] {
  * one keystroke would send N prompts.
  */
 export function useQuickEntryBridge({ startFreshSessionDraft, submitText }: QuickEntryBridgeParams): void {
+  const { t } = useI18n()
+  const copyRef = useRef(t.desktop)
+  copyRef.current = t.desktop
   const submitTextRef = useRef(submitText)
   submitTextRef.current = submitText
   const startFreshRef = useRef(startFreshSessionDraft)
@@ -62,7 +71,7 @@ export function useQuickEntryBridge({ startFreshSessionDraft, submitText }: Quic
     }
 
     setQuickEntrySubmitHandler(({ target, text }) => {
-      if (target === QUICK_TARGET_NEW) {
+      if (target.kind === 'new') {
         // Same as the user clicking New Chat and typing: fresh draft, then the
         // normal submit creates the backend session.
         startFreshRef.current()
@@ -71,20 +80,31 @@ export function useQuickEntryBridge({ startFreshSessionDraft, submitText }: Quic
         return
       }
 
-      if (target !== QUICK_TARGET_CURRENT) {
+      if (target.kind === 'session') {
         // A picked stored session: resume + submit in the background through
         // the session-tile delegate so the primary view stays where it is.
         const delegate = sessionTileDelegate()
 
-        if (delegate) {
-          void delegate
-            .resumeTile(target)
-            .then(runtimeId => delegate.submitToSession(runtimeId, text))
-            // A dead/undeliverable target must not swallow the prompt.
-            .catch(() => void submitTextRef.current(text))
+        const targetExists = $sessions
+          .get()
+          .some(
+            session =>
+              session.id === target.storedSessionId && normalizeProfileKey(session.profile) === target.profile
+          )
+
+        if (!delegate || !targetExists) {
+          notifyError(new Error(copyRef.current.sessionUnavailable), copyRef.current.promptFailed)
 
           return
         }
+
+        void delegate
+          .resumeTile(target.storedSessionId, target.profile)
+          .then(runtimeId => delegate.submitToSession(runtimeId, text, target.profile))
+          // Never redirect a failed owned-session send into the visible chat.
+          .catch(error => notifyError(error, copyRef.current.promptFailed))
+
+        return
       }
 
       void submitTextRef.current(text)

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -33,20 +33,46 @@ const row = (over: Partial<SessionInfo>): SessionInfo =>
     ...over
   }) as SessionInfo
 
-function renderTile(requestGateway: ReturnType<typeof vi.fn>) {
+function renderTile(
+  requestGateway: ReturnType<typeof vi.fn>,
+  actions: {
+    archiveSession?: (storedSessionId: string, profile?: null | string) => Promise<unknown>
+    branchStoredSession?: (storedSessionId: string, profile?: null | string) => Promise<unknown>
+    removeSession?: (storedSessionId: string, profile?: null | string) => Promise<unknown>
+  } = {},
+  requestGatewayForProfile?: ReturnType<typeof vi.fn>
+) {
   renderHook(() =>
     useSessionTileDelegate({
-      archiveSession: vi.fn(async () => undefined),
-      branchStoredSession: vi.fn(async () => undefined),
+      archiveSession: actions.archiveSession ?? vi.fn(async () => undefined),
+      branchStoredSession: actions.branchStoredSession ?? vi.fn(async () => undefined),
       executeSlashCommand: vi.fn(async () => undefined) as never,
-      removeSession: vi.fn(async () => undefined),
+      removeSession: actions.removeSession ?? vi.fn(async () => undefined),
       requestGateway: requestGateway as never,
+      requestGatewayForProfile: requestGatewayForProfile as never,
       runtimeIdByStoredSessionIdRef: { current: new Map() },
       sessionStateByRuntimeIdRef: { current: new Map() },
       updateSessionState: vi.fn()
     })
   )
 }
+
+describe('useSessionTileDelegate owned actions', () => {
+  it('forwards the tab owner instead of substituting the active profile', async () => {
+    const archiveSession = vi.fn(async () => undefined)
+    const branchStoredSession = vi.fn(async () => undefined)
+    const removeSession = vi.fn(async () => undefined)
+
+    renderTile(vi.fn(), { archiveSession, branchStoredSession, removeSession })
+    await sessionTileDelegate()!.archiveSession('shared', 'alpha')
+    await sessionTileDelegate()!.branchSession('shared', 'alpha')
+    await sessionTileDelegate()!.deleteSession('shared', 'alpha')
+
+    expect(archiveSession).toHaveBeenCalledWith('shared', 'alpha')
+    expect(branchStoredSession).toHaveBeenCalledWith('shared', 'alpha')
+    expect(removeSession).toHaveBeenCalledWith('shared', 'alpha')
+  })
+})
 
 describe('useSessionTileDelegate resumeTile', () => {
   beforeEach(() => {
@@ -70,7 +96,7 @@ describe('useSessionTileDelegate resumeTile', () => {
     )
 
     renderTile(requestGateway)
-    const runtimeId = await sessionTileDelegate()!.resumeTile('stored-x')
+    const runtimeId = await sessionTileDelegate()!.resumeTile('stored-x', 'ai-engineer')
 
     expect(runtimeId).toBe('runtime-1')
     expect(getSessionMessages).toHaveBeenCalledWith('stored-x', 'ai-engineer')
@@ -89,12 +115,57 @@ describe('useSessionTileDelegate resumeTile', () => {
     )
 
     renderTile(requestGateway)
-    await sessionTileDelegate()!.resumeTile('stored-y')
+    await sessionTileDelegate()!.resumeTile('stored-y', 'default')
 
     expect(requestGateway).toHaveBeenCalledWith('session.resume', {
       session_id: 'stored-y',
       cols: 96,
       profile: 'default'
     })
+  })
+
+  it('uses the tile bucket owner instead of a sole colliding cache row', async () => {
+    setSessions([row({ id: 'shared', profile: 'alpha' })])
+
+    const requestGateway = vi.fn(async (method: string) =>
+      method === 'session.resume' ? ({ session_id: 'runtime-beta' } as never) : ({} as never)
+    )
+
+    renderTile(requestGateway)
+    await sessionTileDelegate()!.resumeTile('shared', 'beta')
+
+    expect(getSessionMessages).toHaveBeenCalledWith('shared', 'beta')
+    expect(requestGateway).toHaveBeenCalledWith('session.resume', {
+      session_id: 'shared',
+      cols: 96,
+      profile: 'beta'
+    })
+  })
+
+  it('resumes and submits through the captured owner gateway', async () => {
+    const requestGateway = vi.fn(async () => ({} as never))
+
+    const requestGatewayForProfile = vi.fn(async (_profile: string, method: string) =>
+      (method === 'session.resume' ? { session_id: 'runtime-alpha' } : {}) as never
+    )
+
+    renderTile(requestGateway, {}, requestGatewayForProfile)
+
+    const runtimeId = await sessionTileDelegate()!.resumeTile('shared', 'alpha')
+    await sessionTileDelegate()!.submitToSession(runtimeId, 'owned prompt', 'alpha')
+
+    expect(requestGatewayForProfile).toHaveBeenNthCalledWith(1, 'alpha', 'session.resume', {
+      session_id: 'shared',
+      cols: 96,
+      profile: 'alpha'
+    })
+    expect(requestGatewayForProfile).toHaveBeenNthCalledWith(
+      2,
+      'alpha',
+      'prompt.submit',
+      { session_id: 'runtime-alpha', text: 'owned prompt' },
+      1_800_000
+    )
+    expect(requestGateway).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -2,22 +2,25 @@ import { useEffect } from 'react'
 
 import { getSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { toChatMessages } from '@/lib/chat-messages'
+import { sessionIdentityKey } from '@/lib/session-identity'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { publishSessionState, setSessionTileDelegate } from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
 
 import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
 import { resolveSessionProfile } from '../../session/hooks/use-session-actions/utils'
 import type { useSessionStateCache } from '../../session/hooks/use-session-state-cache'
-import type { GatewayRequester } from '../types'
+import type { GatewayRequester, ProfileGatewayRequester } from '../types'
 
 type SessionStateCache = ReturnType<typeof useSessionStateCache>
 
 interface SessionTileDelegateParams {
-  archiveSession: (storedSessionId: string) => Promise<unknown>
-  branchStoredSession: (storedSessionId: string) => Promise<unknown>
+  archiveSession: (storedSessionId: string, profile?: null | string) => Promise<unknown>
+  branchStoredSession: (storedSessionId: string, profile?: null | string) => Promise<unknown>
   executeSlashCommand: ReturnType<typeof usePromptActions>['executeSlashCommand']
-  removeSession: (storedSessionId: string) => Promise<unknown>
+  removeSession: (storedSessionId: string, profile?: null | string) => Promise<unknown>
   requestGateway: GatewayRequester
+  requestGatewayForProfile?: ProfileGatewayRequester
   runtimeIdByStoredSessionIdRef: SessionStateCache['runtimeIdByStoredSessionIdRef']
   sessionStateByRuntimeIdRef: SessionStateCache['sessionStateByRuntimeIdRef']
   updateSessionState: SessionStateCache['updateSessionState']
@@ -36,50 +39,61 @@ export function useSessionTileDelegate({
   executeSlashCommand,
   removeSession,
   requestGateway,
+  requestGatewayForProfile,
   runtimeIdByStoredSessionIdRef,
   sessionStateByRuntimeIdRef,
   updateSessionState
 }: SessionTileDelegateParams): void {
   useEffect(() => {
+    const requestOwnedGateway: ProfileGatewayRequester = requestGatewayForProfile
+      ? requestGatewayForProfile
+      : (_profile, method, params, timeoutMs) =>
+          timeoutMs === undefined ? requestGateway(method, params) : requestGateway(method, params, timeoutMs)
+
     setSessionTileDelegate({
-      archiveSession: async storedSessionId => {
-        await archiveSession(storedSessionId)
+      archiveSession: async (storedSessionId, ownerProfile) => {
+        const profile = normalizeProfileKey(ownerProfile ?? $activeGatewayProfile.get())
+        await archiveSession(storedSessionId, profile)
       },
-      branchSession: async storedSessionId => {
-        await branchStoredSession(storedSessionId)
+      branchSession: async (storedSessionId, ownerProfile) => {
+        const profile = normalizeProfileKey(ownerProfile ?? $activeGatewayProfile.get())
+        await branchStoredSession(storedSessionId, profile)
       },
-      deleteSession: async storedSessionId => {
-        await removeSession(storedSessionId)
+      deleteSession: async (storedSessionId, ownerProfile) => {
+        const profile = normalizeProfileKey(ownerProfile ?? $activeGatewayProfile.get())
+        await removeSession(storedSessionId, profile)
       },
-      executeSlash: async (rawCommand, sessionId) => {
-        await executeSlashCommand(rawCommand, { sessionId })
+      executeSlash: async (rawCommand, sessionId, profile, storedSessionId) => {
+        await executeSlashCommand(rawCommand, { profile, sessionId, storedSessionId })
       },
-      interruptSession: async runtimeId => {
-        await requestGateway('session.interrupt', { session_id: runtimeId })
+      interruptSession: async (runtimeId, ownerProfile) => {
+        const profile = normalizeProfileKey(ownerProfile)
+        await requestOwnedGateway(profile, 'session.interrupt', { session_id: runtimeId })
       },
-      resumeTile: async storedSessionId => {
-        const existing = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
+      resumeTile: async (storedSessionId, ownerProfile) => {
+        const profile = normalizeProfileKey(
+          ownerProfile ?? (await resolveSessionProfile(storedSessionId)) ?? $activeGatewayProfile.get()
+        )
+
+        const existing = runtimeIdByStoredSessionIdRef.current.get(sessionIdentityKey(storedSessionId, profile))
         const cached = existing ? sessionStateByRuntimeIdRef.current.get(existing) : undefined
 
-        if (existing && cached?.storedSessionId === storedSessionId) {
+        if (
+          existing &&
+          cached?.storedSessionId === storedSessionId &&
+          normalizeProfileKey(cached.storedSessionProfile) === profile
+        ) {
           publishSessionState(existing, cached)
 
           return existing
         }
 
-        // Resolve the owning profile before binding a runtime. A tile can open a
-        // session from any profile, not just the active one; resuming (or
-        // reading messages) without a profile lets the gateway fall back to the
-        // launch-profile DB and fork the conversation into the wrong profile —
-        // the same cross-profile bleed the recovery resumes had (#67603).
-        const profile = await resolveSessionProfile(storedSessionId)
-
         const [prefetch, resumed] = await Promise.all([
           getSessionMessages(storedSessionId, profile).catch(() => null),
-          requestGateway<SessionResumeResponse>('session.resume', {
+          requestOwnedGateway<SessionResumeResponse>(profile, 'session.resume', {
             session_id: storedSessionId,
             cols: 96,
-            ...(profile ? { profile } : {})
+            profile
           })
         ])
 
@@ -97,13 +111,20 @@ export function useSessionTileDelegate({
             messages:
               state.messages.length > 0 ? state.messages : toChatMessages(prefetch?.messages ?? resumed?.messages ?? [])
           }),
-          storedSessionId
+          storedSessionId,
+          profile
         )
 
         return runtimeId
       },
-      submitToSession: async (runtimeId, text) => {
-        await requestGateway('prompt.submit', { session_id: runtimeId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+      submitToSession: async (runtimeId, text, ownerProfile) => {
+        const profile = normalizeProfileKey(ownerProfile)
+        await requestOwnedGateway(
+          profile,
+          'prompt.submit',
+          { session_id: runtimeId, text },
+          PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+        )
       },
       updateSession: (runtimeId, updater) => updateSessionState(runtimeId, updater)
     })
@@ -113,6 +134,7 @@ export function useSessionTileDelegate({
     executeSlashCommand,
     removeSession,
     requestGateway,
+    requestGatewayForProfile,
     runtimeIdByStoredSessionIdRef,
     sessionStateByRuntimeIdRef,
     updateSessionState

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -9,7 +9,7 @@
 
 import { useStore } from '@nanostores/react'
 import { type ComponentProps, lazy, memo, type ReactNode, Suspense, useMemo } from 'react'
-import { Navigate, Route, Routes, useParams } from 'react-router-dom'
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom'
 
 import { ContribBoundary } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
@@ -19,7 +19,7 @@ import { $freshDraftReady, $gatewayState } from '@/store/session'
 import { ChatView } from '../chat'
 import { ChatSidebar } from '../chat/sidebar'
 import { TerminalPaneChrome } from '../right-sidebar/terminal/chrome'
-import { contributedRoutes, NEW_CHAT_ROUTE, ROUTES_AREA, sessionRoute } from '../routes'
+import { contributedRoutes, NEW_CHAT_ROUTE, ROUTES_AREA, routeSessionProfile, sessionRoute } from '../routes'
 import { useStatusSnapshot } from '../shell/hooks/use-status-snapshot'
 import { useStatusbarItems } from '../shell/hooks/use-statusbar-items'
 import { ModelMenuPanel } from '../shell/model-menu-panel'
@@ -38,8 +38,15 @@ const SkillsView = lazy(async () => ({ default: (await import('../skills')).Skil
 
 export function LegacySessionRedirect() {
   const { sessionId } = useParams()
+  const { search } = useLocation()
+  const activeProfile = useStore($activeGatewayProfile)
 
-  return <Navigate replace to={sessionId ? sessionRoute(sessionId) : NEW_CHAT_ROUTE} />
+  return (
+    <Navigate
+      replace
+      to={sessionId ? sessionRoute(sessionId, routeSessionProfile(search) ?? activeProfile) : NEW_CHAT_ROUTE}
+    />
+  )
 }
 
 export const SidebarSurface = memo(function SidebarSurface({

--- a/apps/desktop/src/app/contrib/types.ts
+++ b/apps/desktop/src/app/contrib/types.ts
@@ -7,6 +7,7 @@ import type { useGatewayRequest } from '../gateway/hooks/use-gateway-request'
 import type { ModelMenuPanel } from '../shell/model-menu-panel'
 
 export type GatewayRequester = ReturnType<typeof useGatewayRequest>['requestGateway']
+export type ProfileGatewayRequester = ReturnType<typeof useGatewayRequest>['requestGatewayForProfile']
 
 /** The ChatSidebar handlers the controller owns — forwarded verbatim. */
 export type SidebarActions = Pick<

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -26,6 +26,7 @@ import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { emitGatewayEvent } from '@/contrib/events'
 import { getSessionMessages, triggerCronJob } from '@/hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { normalizeProfileKey, parseSessionIdentityKey, sessionMatchesIdentity } from '@/lib/session-identity'
 import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
@@ -45,10 +46,10 @@ import {
   $messagingSessions,
   $resumeExhaustedSessionId,
   $resumeFailedSessionId,
+  $selectedSessionIdentityKey,
   $selectedStoredSessionId,
   $sessions,
-  sessionMatchesStoredId,
-  sessionPinId,
+  resolveSessionPinId,
   setAwaitingResponse,
   setBusy,
   setMessages
@@ -72,7 +73,14 @@ import { RemoteFolderPicker } from '../right-sidebar/files/remote-picker'
 import { resetProjectTreeState } from '../right-sidebar/files/use-project-tree'
 import { PersistentTerminal } from '../right-sidebar/terminal/persistent'
 import { closeAllTerminals } from '../right-sidebar/terminal/terminals'
-import { CRON_ROUTE, navigateToWorkspacePage, routeSessionId, SETTINGS_ROUTE, syncWorkspaceRoute } from '../routes'
+import {
+  CRON_ROUTE,
+  navigateToWorkspacePage,
+  routeSessionId,
+  routeSessionProfile,
+  SETTINGS_ROUTE,
+  syncWorkspaceRoute
+} from '../routes'
 import { SessionPickerOverlay } from '../session-picker-overlay'
 import { SessionSwitcher } from '../session-switcher'
 import { useBackgroundQueueDrain } from '../session/hooks/use-background-queue-drain'
@@ -156,24 +164,30 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const freshDraftReady = useStore($freshDraftReady)
   const resumeFailedSessionId = useStore($resumeFailedSessionId)
   const resumeExhaustedSessionId = useStore($resumeExhaustedSessionId)
+  const selectedSessionIdentityKey = useStore($selectedSessionIdentityKey)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const messagingSessions = useStore($messagingSessions)
   const activeGatewayProfile = useStore($activeGatewayProfile)
   const profileScope = useStore($profileScope)
 
   const routedSessionId = routeSessionId(location.pathname)
+  const routedSessionProfile = routeSessionProfile(location.search)
   const routedSessionIdRef = useRef(routedSessionId)
+  const routedSessionProfileRef = useRef(routedSessionProfile)
 
   routedSessionIdRef.current = routedSessionId
+  routedSessionProfileRef.current = routedSessionProfile
   const routeToken = `${location.pathname}:${location.search}:${location.hash}`
   const routeTokenRef = useRef(routeToken)
   routeTokenRef.current = routeToken
   const getRouteToken = useCallback(() => routeTokenRef.current, [])
 
   const getRoutedStoredSessionId = useCallback(() => routedSessionIdRef.current, [])
+  const getRoutedStoredSessionProfile = useCallback(() => routedSessionProfileRef.current, [])
 
   const clearRoutedSessionIntent = useCallback(() => {
     routedSessionIdRef.current = null
+    routedSessionProfileRef.current = null
   }, [])
 
   // Point the workspace at the route: the pane contribution re-registers
@@ -222,7 +236,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     setMessages
   })
 
-  const { connectionRef, gateway, gatewayRef, requestGateway } = useGatewayRequest()
+  const { connectionRef, gateway, gatewayRef, requestGateway, requestGatewayForProfile } = useGatewayRequest()
 
   const {
     loadMoreMessagingForPlatform,
@@ -303,7 +317,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         return
       }
 
-      const storedProfile = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))?.profile
+      const selectedIdentity = parseSessionIdentityKey($selectedSessionIdentityKey.get() ?? '')
+
+      const storedProfile =
+        (selectedIdentity.storedSessionId === storedSessionId ? selectedIdentity.profile : null) ??
+        sessionStateByRuntimeIdRef.current.get(runtimeSessionId)?.storedSessionProfile ??
+        activeGatewayProfile
 
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {
@@ -333,7 +352,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         }
       }
     },
-    [activeSessionIdRef, selectedStoredSessionIdRef, updateSessionState]
+    [activeGatewayProfile, activeSessionIdRef, selectedStoredSessionIdRef, sessionStateByRuntimeIdRef, updateSessionState]
   )
 
   // Refresh the open messaging transcript (inbound platform turns arrive via
@@ -347,7 +366,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       return
     }
 
-    const stored = $messagingSessions.get().find(s => sessionMatchesStoredId(s, storedSessionId))
+    const selectedIdentity = parseSessionIdentityKey($selectedSessionIdentityKey.get() ?? '')
+
+    const stored = $messagingSessions
+      .get()
+      .find(s => sessionMatchesIdentity(s, storedSessionId, selectedIdentity.profile || activeGatewayProfile))
 
     if (!stored || !isMessagingSource(stored.source)) {
       return
@@ -373,7 +396,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     } catch {
       // Non-fatal: next poll or manual refresh can hydrate.
     }
-  }, [activeSessionIdRef, busyRef, selectedStoredSessionIdRef, updateSessionState])
+  }, [activeGatewayProfile, activeSessionIdRef, busyRef, selectedStoredSessionIdRef, updateSessionState])
 
   const { handleGatewayEvent } = useMessageStream({
     activeGatewayProfile,
@@ -558,13 +581,15 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     busyRef,
     createBackendSessionForSend,
     getRoutedStoredSessionId,
+    getRoutedStoredSessionProfile,
     getRuntimeIdForStoredSession,
     getRouteToken,
     handleSkinCommand,
     openMemoryGraph: openStarmap,
     refreshSessions,
     requestGateway,
-    resumeStoredSession: resumeSession,
+    requestGatewayForProfile,
+    resumeStoredSession: (sessionId, profile) => resumeSession(sessionId, false, profile),
     selectedStoredSessionIdRef,
     startFreshSessionDraft,
     sttEnabled,
@@ -576,7 +601,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   useBackgroundQueueDrain({
     enabled: gatewayState === 'open',
     runtimeIdByStoredSessionIdRef,
-    selectedStoredSessionId,
+    selectedSessionIdentityKey,
     submitText
   })
 
@@ -588,6 +613,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     executeSlashCommand,
     removeSession,
     requestGateway,
+    requestGatewayForProfile,
     runtimeIdByStoredSessionIdRef,
     sessionStateByRuntimeIdRef,
     updateSessionState
@@ -640,6 +666,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   )
 
   useRouteResume({
+    activeGatewayProfile,
     activeSessionId,
     activeSessionIdRef,
     creatingSessionRef,
@@ -651,6 +678,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     resumeFailedSessionId,
     resumeExhaustedSessionId,
     routedSessionId,
+    routedSessionProfile,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef,
@@ -689,7 +717,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // live over the websocket already.
   const activeIsMessaging =
     !!selectedStoredSessionId &&
-    isMessagingSource(messagingSessions.find(s => sessionMatchesStoredId(s, selectedStoredSessionId))?.source)
+    isMessagingSource(
+      messagingSessions.find(s => sessionMatchesIdentity(s, selectedStoredSessionId, activeGatewayProfile))?.source
+    )
 
   // Keep app data live while the gateway is open (on-connect reseed + the
   // cron / messaging / transcript visibility polls + fresh-draft reseed).
@@ -717,10 +747,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     chatOpen,
     hasPreview: Boolean(previewTarget),
     locationPathname: location.pathname,
+    locationSearch: location.search,
     navigate,
     refreshSessions,
     resumeExhaustedSessionId,
     routedSessionId,
+    routedSessionProfile,
     runtimeIdByStoredSessionId: runtimeIdByStoredSessionIdRef
   })
 
@@ -733,8 +765,16 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       return
     }
 
-    const session = $sessions.get().find(s => sessionMatchesStoredId(s, sessionId))
-    const pinId = session ? sessionPinId(session) : sessionId
+    const selectedIdentityKey = $selectedSessionIdentityKey.get()
+    const selectedIdentity = selectedIdentityKey ? parseSessionIdentityKey(selectedIdentityKey) : null
+
+    const session = selectedIdentity
+      ? $sessions
+          .get()
+          .find(s => sessionMatchesIdentity(s, selectedIdentity.storedSessionId, selectedIdentity.profile))
+      : undefined
+
+    const pinId = resolveSessionPinId(session, sessionId, selectedIdentity?.profile ?? $activeGatewayProfile.get())
 
     if ($pinnedSessionIds.get().includes(pinId)) {
       unpinSession(pinId)
@@ -778,20 +818,21 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const nextActions: WiringActions = {
     onAddContextRef: composer.addContextRefAttachment,
     onAddUrl: url => composer.addContextRefAttachment(`@url:${formatRefValue(url)}`, url),
-    onArchiveSession: sessionId => void archiveSession(sessionId),
+    onArchiveSession: (sessionId, profile) => void archiveSession(sessionId, profile),
     onAttachDroppedItems: composer.attachDroppedItems,
     onAttachImageBlob: composer.attachImageBlob,
     onBranchInNewChat: messageId => void branchInNewChat(messageId),
-    onBranchSession: sessionId => void branchStoredSession(sessionId),
+    onBranchSession: (sessionId, profile) => void branchStoredSession(sessionId, profile),
     onCancel: cancelRun,
     onDeleteSelectedSession: () => {
-      const id = $selectedStoredSessionId.get()
+      const identityKey = $selectedSessionIdentityKey.get()
 
-      if (id) {
-        void removeSession(id)
+      if (identityKey) {
+        const { profile, storedSessionId } = parseSessionIdentityKey(identityKey)
+        void removeSession(storedSessionId, profile)
       }
     },
-    onDeleteSession: sessionId => void removeSession(sessionId),
+    onDeleteSession: (sessionId, profile) => void removeSession(sessionId, profile),
     onDismissError: dismissError,
     onEdit: editMessage,
     onLoadMoreMessaging: loadMoreMessagingForPlatform,
@@ -813,8 +854,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onRestoreToMessage: restoreToMessage,
     // Already on screen (open tile, or the main session)? Jump to its tab;
     // otherwise load it into main. Same door every other session link uses.
-    onResumeSession: sessionId => openSession(sessionId, navigate),
-    onRetryResume: sessionId => void resumeSession(sessionId, true),
+    onResumeSession: (sessionId, profile) => openSession(sessionId, navigate, 'in-place', profile),
+    onRetryResume: (sessionId, profile) => void resumeSession(sessionId, true, profile),
     onSteer: steerPrompt,
     onSubmit: submitText,
     onThreadMessagesChange: handleThreadMessagesChange,
@@ -950,7 +991,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         />
       )}
       <ModelPickerOverlay gateway={gateway || undefined} onSelect={selectModel} profile={activeGatewayProfile} />
-      <SessionPickerOverlay onResume={sessionId => openSession(sessionId, navigate)} />
+      <SessionPickerOverlay onResume={(sessionId, profile) => openSession(sessionId, navigate, 'in-place', profile)} />
       <ModelVisibilityOverlay
         gateway={gateway || undefined}
         onOpenProviders={openProviderSettings}
@@ -992,7 +1033,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
             onClose={closeOverlayToPreviousRoute}
             onDeleteSession={removeSession}
             onNavigateRoute={path => navigateToWorkspacePage(navigate, path)}
-            onOpenSession={sessionId => openSession(sessionId, navigate)}
+            onOpenSession={(sessionId, profile) => openSession(sessionId, navigate, 'in-place', profile)}
           />
         </Suspense>
       )}
@@ -1007,7 +1048,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         <Suspense fallback={null}>
           <CronView
             onClose={closeOverlayToPreviousRoute}
-            onOpenSession={sessionId => openSession(sessionId, navigate)}
+            onOpenSession={(sessionId, profile) => openSession(sessionId, navigate, 'in-place', profile)}
           />
         </Suspense>
       )}

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -278,7 +278,7 @@ function matchesQuery(job: CronJob, q: string): boolean {
 
 interface CronViewProps extends React.ComponentProps<'section'> {
   onClose: () => void
-  onOpenSession?: (sessionId: string) => void
+  onOpenSession?: (sessionId: string, profile?: null | string) => void
   setStatusbarItemGroup?: SetStatusbarItemGroup
 }
 
@@ -604,7 +604,7 @@ function CronJobDetail({
   busy: boolean
   c: Translations['cron']
   job: CronJob
-  onOpenSession?: (sessionId: string) => void
+  onOpenSession?: (sessionId: string, profile?: null | string) => void
   onPauseResume: () => void
   onTrigger: () => void
 }) {
@@ -684,7 +684,7 @@ function CronJobRuns({
 }: {
   c: Translations['cron']
   jobId: string
-  onOpenSession?: (sessionId: string) => void
+  onOpenSession?: (sessionId: string, profile?: null | string) => void
 }) {
   const [runs, setRuns] = useState<null | SessionInfo[]>(null)
 
@@ -745,7 +745,7 @@ function CronJobRuns({
             <button
               className="row-hover flex items-center justify-between gap-3 rounded-md px-2 py-1 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               key={run.id}
-              onClick={() => onOpenSession?.(run.id)}
+              onClick={() => onOpenSession?.(run.id, run.profile)}
               type="button"
             >
               <span className="truncate text-foreground/85">{run.title?.trim() || run.preview?.trim() || run.id}</span>

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -5,6 +5,7 @@ import type { HermesConnection } from '@/global'
 import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import {
   $desktopBoot,
   applyDesktopBootProgress,
@@ -38,7 +39,7 @@ import {
   setSessionsLoading
 } from '@/store/session'
 import { $attentionSessionIds, $workingSessionIds, resetTileRuntimeBindings } from '@/store/session-states'
-import type { RpcEvent } from '@/types/hermes'
+import type { RpcEvent, SessionInfo } from '@/types/hermes'
 
 import { stashGatewaySurvivor, survivorIsStale, takeGatewaySurvivor } from './gateway-hmr-survivor'
 
@@ -58,6 +59,21 @@ interface GatewayBootOptions {
   onGatewayReady: (gateway: HermesGateway | null) => void
   refreshHermesConfig: () => Promise<void>
   refreshSessions: () => Promise<void>
+}
+
+export function profilesWithLiveSessions(
+  sessions: Pick<SessionInfo, 'id' | 'profile'>[],
+  liveSessionIds: ReadonlySet<string>
+): Set<string> {
+  const profiles = new Set<string>()
+
+  for (const session of sessions) {
+    if (liveSessionIds.has(sessionIdentityKey(session.id, session.profile))) {
+      profiles.add(normalizeProfileKey(session.profile))
+    }
+  }
+
+  return profiles
 }
 
 export function useGatewayBoot({
@@ -425,15 +441,8 @@ export function useGatewayBoot({
     // to idle-reap. The active profile is always spared.
     const recomputeKeptGateways = () => {
       const live = new Set([...$workingSessionIds.get(), ...$attentionSessionIds.get()])
-      const keep = new Set<string>()
 
-      for (const session of $sessions.get()) {
-        if (live.has(session.id)) {
-          keep.add(normalizeProfileKey(session.profile))
-        }
-      }
-
-      pruneSecondaryGateways(keep)
+      pruneSecondaryGateways(profilesWithLiveSessions($sessions.get(), live))
     }
 
     const offWorking = $workingSessionIds.subscribe(() => recomputeKeptGateways())

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -3,7 +3,7 @@ import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useRef } from 'react'
 
 import type { HermesGateway } from '@/hermes'
-import { $gateway, ensureActiveGatewayOpen, isActivePrimary } from '@/store/gateway'
+import { $gateway, ensureActiveGatewayOpen, gatewayForProfile, isActivePrimary } from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $gatewayState, setConnection } from '@/store/session'
 
@@ -144,5 +144,43 @@ export function useGatewayRequest() {
     [ensureGatewayOpen]
   )
 
-  return { connectionRef, gateway, gatewayRef, requestGateway }
+  // Resolve the socket by immutable owner instead of whichever profile happens
+  // to be active when a delayed callback finally sends. Unlike switching the
+  // active gateway, this never changes the window's visible profile.
+  const requestGatewayForProfile = useCallback(
+    async <T>(
+      profile: string,
+      method: string,
+      params: Record<string, unknown> = {},
+      timeoutMs?: number,
+      signal?: AbortSignal
+    ) => {
+      const gateway = await gatewayForProfile(profile)
+
+      if (!gateway) {
+        throw new Error(`Hermes gateway unavailable for profile ${profile}`)
+      }
+
+      try {
+        return await gateway.request<T>(method, params, timeoutMs, signal)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+
+        if (!/not connected|connection closed/i.test(message)) {
+          throw error
+        }
+
+        const recovered = await gatewayForProfile(profile)
+
+        if (!recovered) {
+          throw error
+        }
+
+        return recovered.request<T>(method, params, timeoutMs, signal)
+      }
+    },
+    []
+  )
+
+  return { connectionRef, gateway, gatewayRef, requestGateway, requestGatewayForProfile }
 }

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -26,6 +26,7 @@ import {
   toggleSidebarOpen
 } from '@/store/layout'
 import {
+  $activeGatewayProfile,
   $newChatProfile,
   cycleProfile,
   requestProfileCreate,
@@ -44,6 +45,7 @@ import {
   onSwitcherTabDown,
   onSwitcherTabUp,
   openOrAdvanceSwitcher,
+  type SessionSwitcherTarget,
   slotSessionId,
   switcherActive,
   switcherJustClosed
@@ -102,9 +104,9 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     }
   }
 
-  const goToSession = (sessionId: null | string) => {
-    if (sessionId) {
-      openSession(sessionId, navigate)
+  const goToSession = (target: null | SessionSwitcherTarget) => {
+    if (target) {
+      openSession(target.sessionId, navigate, 'in-place', target.profile)
     }
   }
 
@@ -197,7 +199,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     // macOS the menu accelerator owns ⌘W and routes through the same
     // closeActiveTab via IPC (see use-desktop-integrations); this binding is
     // the Win/Linux path where ⌘W reaches the renderer directly.
-    'view.closeTab': () => void closeActiveTab(id => navigate(sessionRoute(id))),
+    'view.closeTab': () => void closeActiveTab(id => navigate(sessionRoute(id, $activeGatewayProfile.get()))),
     'view.reopenTab': reopenLastClosedTile,
     'view.findInPage': openFindBar,
     // ⌘G / ⌘⇧G are handled by the find bar's own capture-phase listener while

--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -5,6 +5,13 @@ const openSessionTile = vi.fn()
 const openSessionInNewWindow = vi.fn()
 const canOpenSessionWindow = vi.fn(() => true)
 const workspaceIsPageGet = vi.fn(() => false)
+const activeGatewayProfileGet = vi.fn(() => 'default')
+const sessionRoute = vi.fn((id: string, _profile?: null | string) => `/c/${encodeURIComponent(id)}`)
+
+vi.mock('@/store/profile', () => ({
+  $activeGatewayProfile: { get: () => activeGatewayProfileGet() },
+  normalizeProfileKey: (profile?: null | string) => profile?.trim() || 'default'
+}))
 
 vi.mock('@/store/session-states', () => ({
   focusedSessionNeedsRoute: (focused: 'main' | 'tile' | null, workspaceIsPage: boolean) =>
@@ -20,7 +27,7 @@ vi.mock('@/store/windows', () => ({
 
 vi.mock('./routes', () => ({
   $workspaceIsPage: { get: () => workspaceIsPageGet() },
-  sessionRoute: (id: string) => `/c/${encodeURIComponent(id)}`
+  sessionRoute: (id: string, profile?: null | string) => sessionRoute(id, profile)
 }))
 
 import { openSession, openSessionIntentFromModifiers } from './open-session'
@@ -50,12 +57,14 @@ describe('openSession', () => {
     openSessionInNewWindow.mockReset()
     canOpenSessionWindow.mockReturnValue(true)
     workspaceIsPageGet.mockReturnValue(false)
+    activeGatewayProfileGet.mockReturnValue('default')
+    sessionRoute.mockClear()
   })
 
   it('in-place focuses an existing tile and does not navigate', () => {
     focusOpenSession.mockReturnValue('tile')
     openSession('s1', navigate)
-    expect(focusOpenSession).toHaveBeenCalledWith('s1')
+    expect(focusOpenSession).toHaveBeenCalledWith('s1', 'default')
     expect(navigate).not.toHaveBeenCalled()
     expect(openSessionTile).not.toHaveBeenCalled()
   })
@@ -79,10 +88,18 @@ describe('openSession', () => {
     expect(navigate).toHaveBeenCalledWith('/c/s1')
   })
 
+  it('routes a different-profile session without focusing a colliding active-profile surface', () => {
+    focusOpenSession.mockReturnValue('tile')
+    openSession('s1', navigate, 'in-place', 'work')
+    expect(focusOpenSession).not.toHaveBeenCalled()
+    expect(sessionRoute).toHaveBeenCalledWith('s1', 'work')
+    expect(navigate).toHaveBeenCalledWith('/c/s1')
+  })
+
   it('tab focuses an existing open session instead of stacking another', () => {
     focusOpenSession.mockReturnValue('tile')
     openSession('s1', navigate, 'tab')
-    expect(focusOpenSession).toHaveBeenCalledWith('s1')
+    expect(focusOpenSession).toHaveBeenCalledWith('s1', 'default')
     expect(openSessionTile).not.toHaveBeenCalled()
     expect(navigate).not.toHaveBeenCalled()
   })
@@ -90,13 +107,13 @@ describe('openSession', () => {
   it('tab opens a stacked session tile when not on screen', () => {
     focusOpenSession.mockReturnValue(null)
     openSession('s1', navigate, 'tab')
-    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
+    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center', undefined, undefined, 'default')
     expect(navigate).not.toHaveBeenCalled()
   })
 
   it('window pops out when the bridge supports it', () => {
     openSession('s1', navigate, 'window')
-    expect(openSessionInNewWindow).toHaveBeenCalledWith('s1')
+    expect(openSessionInNewWindow).toHaveBeenCalledWith('s1', { profile: 'default' })
     expect(openSessionTile).not.toHaveBeenCalled()
   })
 
@@ -105,7 +122,7 @@ describe('openSession', () => {
     focusOpenSession.mockReturnValue(null)
     openSession('s1', navigate, 'window')
     expect(openSessionInNewWindow).not.toHaveBeenCalled()
-    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
+    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center', undefined, undefined, 'default')
   })
 
   it('no-ops on an empty id', () => {

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -11,6 +11,7 @@
  *   - `window` (⇧⌘-click) — pop into its own window; falls back to `tab` when
  *     the bridge has no session-window support.
  */
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { focusedSessionNeedsRoute, focusOpenSession, openSessionTile } from '@/store/session-states'
 import { canOpenSessionWindow, openSessionInNewWindow } from '@/store/windows'
 
@@ -48,17 +49,20 @@ export function openSessionIntentFromModifiers(
 export function openSession(
   storedSessionId: string,
   navigate: OpenSessionNavigate,
-  intent: OpenSessionIntent = 'in-place'
+  intent: OpenSessionIntent = 'in-place',
+  profile?: null | string
 ): void {
   if (!storedSessionId) {
     return
   }
 
+  const activeProfile = normalizeProfileKey($activeGatewayProfile.get())
+  const targetProfile = normalizeProfileKey(profile ?? activeProfile)
   let resolved: OpenSessionIntent = intent
 
   if (resolved === 'window') {
     if (canOpenSessionWindow()) {
-      void openSessionInNewWindow(storedSessionId)
+      void openSessionInNewWindow(storedSessionId, { profile: targetProfile })
 
       return
     }
@@ -71,11 +75,11 @@ export function openSession(
     // Already on screen? Front it. openSessionTile would no-op on main without
     // focusing, or try to relocate an existing tile — neither is right for a
     // soft "open beside" link.
-    if (focusOpenSession(storedSessionId)) {
+    if (targetProfile === activeProfile && focusOpenSession(storedSessionId, targetProfile)) {
       return
     }
 
-    openSessionTile(storedSessionId, 'center')
+    void openSessionTile(storedSessionId, 'center', undefined, undefined, targetProfile)
 
     return
   }
@@ -84,7 +88,10 @@ export function openSession(
   // otherwise load it into main. From a full page (artifacts, skills, …) a
   // `'main'` hit still has to route back: fronting the workspace tab alone
   // leaves the page showing.
-  if (focusedSessionNeedsRoute(focusOpenSession(storedSessionId), $workspaceIsPage.get())) {
-    navigate(sessionRoute(storedSessionId))
+  if (
+    targetProfile !== activeProfile ||
+    focusedSessionNeedsRoute(focusOpenSession(storedSessionId, targetProfile), $workspaceIsPage.get())
+  ) {
+    navigate(sessionRoute(storedSessionId, targetProfile))
   }
 }

--- a/apps/desktop/src/app/routes.test.ts
+++ b/apps/desktop/src/app/routes.test.ts
@@ -1,9 +1,37 @@
 import { describe, expect, it } from 'vitest'
 
-import { NEW_CHAT_ROUTE, primaryRouteSelectedSessionId, sessionRoute, SETTINGS_ROUTE } from './routes'
+import { sessionIdentityKey } from '@/lib/session-identity'
+
+import {
+  NEW_CHAT_ROUTE,
+  primaryRouteSelectedSessionId,
+  routeSessionIdentityKey,
+  routeSessionProfile,
+  sessionRoute,
+  SETTINGS_ROUTE
+} from './routes'
 
 const SESS_A = 'sess-a'
 const SESS_B = 'sess-b'
+
+describe('profile-routed session paths', () => {
+  it('retains the owning profile when building a session route', () => {
+    expect(sessionRoute('telegram/session', 'ubuntu server')).toBe('/telegram%2Fsession?profile=ubuntu%20server')
+  })
+
+  it('recovers and normalizes the owning profile from the route query', () => {
+    expect(routeSessionProfile('?profile=%20ubuntu%20server%20')).toBe('ubuntu server')
+    expect(routeSessionProfile('?profile=%20%20')).toBeNull()
+    expect(routeSessionProfile('')).toBeNull()
+  })
+
+  it('distinguishes colliding stored ids by the route owner profile', () => {
+    expect(routeSessionIdentityKey('/shared', '?profile=alpha', 'default')).toBe(
+      sessionIdentityKey('shared', 'alpha')
+    )
+    expect(routeSessionIdentityKey('/shared', '?profile=beta', 'default')).toBe(sessionIdentityKey('shared', 'beta'))
+  })
+})
 
 describe('primaryRouteSelectedSessionId', () => {
   it('prefers the routed session id over a stale/different store selection (#59305)', () => {

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
 import { registry } from '@/contrib/registry'
+import { sessionIdentityKey } from '@/lib/session-identity'
 
 type NavigateLike = (to: string, options?: { replace?: boolean }) => void
 
@@ -181,8 +182,24 @@ export function primaryRouteSelectedSessionId(pathname: string, storeSelectedSes
   return routeSessionId(pathname) ?? storeSelectedSessionId
 }
 
-export function sessionRoute(sessionId: string): string {
-  return `${SESSION_ROUTE_PREFIX}${encodeURIComponent(sessionId)}`
+export function routeSessionProfile(search: string): string | null {
+  const profile = new URLSearchParams(search).get('profile')?.trim()
+
+  return profile || null
+}
+
+/** Compound durable identity represented by a session route, if any. */
+export function routeSessionIdentityKey(pathname: string, search: string, fallbackProfile: string): string | null {
+  const storedSessionId = routeSessionId(pathname)
+
+  return storedSessionId ? sessionIdentityKey(storedSessionId, routeSessionProfile(search) ?? fallbackProfile) : null
+}
+
+export function sessionRoute(sessionId: string, profile?: null | string): string {
+  const path = `${SESSION_ROUTE_PREFIX}${encodeURIComponent(sessionId)}`
+  const profileKey = profile?.trim()
+
+  return profileKey ? `${path}?profile=${encodeURIComponent(profileKey)}` : path
 }
 
 export function appViewForPath(pathname: string): AppView {

--- a/apps/desktop/src/app/session-picker-overlay.tsx
+++ b/apps/desktop/src/app/session-picker-overlay.tsx
@@ -1,10 +1,10 @@
 import { useStore } from '@nanostores/react'
 
 import { SessionPickerDialog } from '@/components/session-picker'
-import { $gatewayState, $selectedStoredSessionId, $sessionPickerOpen, setSessionPickerOpen } from '@/store/session'
+import { $gatewayState, $selectedSessionIdentityKey, $sessionPickerOpen, setSessionPickerOpen } from '@/store/session'
 
 interface SessionPickerOverlayProps {
-  onResume: (storedSessionId: string) => void
+  onResume: (storedSessionId: string, profile?: null | string) => void
 }
 
 /**
@@ -15,7 +15,7 @@ interface SessionPickerOverlayProps {
 export function SessionPickerOverlay({ onResume }: SessionPickerOverlayProps) {
   const open = useStore($sessionPickerOpen)
   const gatewayOpen = useStore($gatewayState) === 'open'
-  const activeStoredSessionId = useStore($selectedStoredSessionId)
+  const activeSessionIdentityKey = useStore($selectedSessionIdentityKey)
 
   if (!gatewayOpen) {
     return null
@@ -23,7 +23,7 @@ export function SessionPickerOverlay({ onResume }: SessionPickerOverlayProps) {
 
   return (
     <SessionPickerDialog
-      activeStoredSessionId={activeStoredSessionId}
+      activeSessionIdentityKey={activeSessionIdentityKey}
       onOpenChange={setSessionPickerOpen}
       onResume={onResume}
       open={open}

--- a/apps/desktop/src/app/session-switcher.test.ts
+++ b/apps/desktop/src/app/session-switcher.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { sessionIdentityKey } from '@/lib/session-identity'
+
+import { sessionSwitcherStatus } from './session-switcher'
+
+describe('sessionSwitcherStatus', () => {
+  it('reads status from the owning profile when stored session ids collide', () => {
+    const statusIds = {
+      attention: new Set([sessionIdentityKey('shared', 'alpha')]),
+      unread: new Set([sessionIdentityKey('shared', 'beta')]),
+      working: new Set([sessionIdentityKey('shared', 'beta')])
+    }
+
+    expect(sessionSwitcherStatus({ id: 'shared', profile: 'alpha' }, statusIds)).toEqual({
+      attention: true,
+      unread: false,
+      working: false
+    })
+    expect(sessionSwitcherStatus({ id: 'shared', profile: 'beta' }, statusIds)).toEqual({
+      attention: false,
+      unread: true,
+      working: true
+    })
+  })
+})

--- a/apps/desktop/src/app/session-switcher.tsx
+++ b/apps/desktop/src/app/session-switcher.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
 
 import { sessionTitle } from '@/lib/chat-runtime'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { cn } from '@/lib/utils'
 import { $unreadFinishedSessionIds } from '@/store/session'
 import { $attentionSessionIds, $workingSessionIds } from '@/store/session-states'
@@ -11,6 +12,19 @@ import { $switcherIndex, $switcherOpen, $switcherSessions, closeSwitcher } from 
 
 import { HUD_ITEM, HUD_POSITION, HUD_SURFACE, HUD_TEXT } from './floating-hud'
 import { openSession } from './open-session'
+
+export function sessionSwitcherStatus(
+  session: { id: string; profile?: null | string },
+  statusIds: { attention: ReadonlySet<string>; unread: ReadonlySet<string>; working: ReadonlySet<string> }
+): { attention: boolean; unread: boolean; working: boolean } {
+  const identityKey = sessionIdentityKey(session.id, session.profile)
+
+  return {
+    attention: statusIds.attention.has(identityKey),
+    unread: statusIds.unread.has(identityKey),
+    working: statusIds.working.has(identityKey)
+  }
+}
 
 // Compact session-switcher HUD — keyboard-driven from `use-keybinds`, rows
 // clickable via mousedown (Ctrl+click on macOS). No Dialog: Tab stays global.
@@ -37,9 +51,9 @@ export function SessionSwitcher() {
   const attentionIds = new Set(attention)
   const unreadIds = new Set(unread)
 
-  const pick = (sessionId: string) => {
+  const pick = (sessionId: string, profile?: null | string) => {
     closeSwitcher()
-    openSession(sessionId, navigate)
+    openSession(sessionId, navigate, 'in-place', profile)
   }
 
   return createPortal(
@@ -61,6 +75,13 @@ export function SessionSwitcher() {
       >
         {sessions.map((session, i) => {
           const selected = i === index
+          const identityKey = sessionIdentityKey(session.id, session.profile)
+
+          const status = sessionSwitcherStatus(session, {
+            attention: attentionIds,
+            unread: unreadIds,
+            working: workingIds
+          })
 
           return (
             <div
@@ -70,18 +91,14 @@ export function SessionSwitcher() {
                 HUD_TEXT,
                 selected ? 'bg-accent text-accent-foreground' : 'text-(--ui-text-secondary)'
               )}
-              key={session.id}
+              key={identityKey}
               onMouseDown={e => {
                 e.preventDefault()
-                pick(session.id)
+                pick(session.id, session.profile)
               }}
               ref={selected ? activeRef : undefined}
             >
-              <SwitcherDot
-                attention={attentionIds.has(session.id)}
-                unread={unreadIds.has(session.id)}
-                working={workingIds.has(session.id)}
-              />
+              <SwitcherDot {...status} />
               <span className="min-w-0 flex-1 truncate">{sessionTitle(session)}</span>
               {i < 9 && (
                 <span

--- a/apps/desktop/src/app/session/hooks/preview-open.test.tsx
+++ b/apps/desktop/src/app/session/hooks/preview-open.test.tsx
@@ -2,9 +2,13 @@ import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { HermesPreviewTarget } from '@/global'
 import { assistantTextPart, type ChatMessage } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { $previewTabs, $previewTarget, closeRightRail, type PreviewTarget } from '@/store/preview'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $activeSessionId, $currentCwd, $messages, $selectedStoredSessionId } from '@/store/session'
+import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type { RpcEvent } from '@/types/hermes'
 
 import { usePreviewRouting } from './use-preview-routing'
@@ -15,7 +19,7 @@ function assistantMessage(id: string, text: string): ChatMessage {
   return { id, parts: [assistantTextPart(text)], role: 'assistant' }
 }
 
-function fileTarget(path: string): PreviewTarget {
+function fileTarget(path: string): HermesPreviewTarget & PreviewTarget {
   return { kind: 'file', label: path, path, previewKind: 'html', source: path, url: `file://${path}` }
 }
 
@@ -39,6 +43,7 @@ async function emitPreviewOpen(url = '/tmp/artifact-test.html') {
   await act(async () => {
     handleEvent({
       payload: { label: 'hi bestie', url },
+      profile: 'default',
       session_id: RUNTIME_SESSION_ID,
       type: 'preview.open'
     } as unknown as RpcEvent)
@@ -49,8 +54,10 @@ describe('open_preview', () => {
   beforeEach(() => {
     // A live session always has a runtime id; only the STORED id lags.
     $activeSessionId.set(RUNTIME_SESSION_ID)
+    $activeGatewayProfile.set('default')
     $currentCwd.set('/work')
     $messages.set([])
+    clearAllSessionStates()
     closeRightRail()
     window.localStorage.clear()
 
@@ -65,7 +72,9 @@ describe('open_preview', () => {
     $messages.set([])
     closeRightRail()
     $activeSessionId.set(null)
+    $activeGatewayProfile.set('default')
     $selectedStoredSessionId.set(null)
+    clearAllSessionStates()
     window.localStorage.clear()
     vi.restoreAllMocks()
   })
@@ -107,6 +116,145 @@ describe('open_preview', () => {
         session_id: 'some-other-session',
         type: 'preview.open'
       } as unknown as RpcEvent)
+    })
+
+    expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  it('ignores a pooled preview event from another profile when runtime ids collide', async () => {
+    $selectedStoredSessionId.set('shared')
+    $activeGatewayProfile.set('beta')
+    render(<Harness />)
+
+    await act(async () => {
+      handleEvent({
+        payload: { url: '/tmp/alpha.html' },
+        profile: 'alpha',
+        session_id: RUNTIME_SESSION_ID,
+        type: 'preview.open'
+      } as unknown as RpcEvent)
+    })
+
+    expect(window.hermesDesktop.normalizePreviewTarget).not.toHaveBeenCalled()
+    expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  it('ignores a pooled preview event from another profile before the stored id exists', async () => {
+    $selectedStoredSessionId.set(null)
+    $activeGatewayProfile.set('beta')
+    render(<Harness />)
+
+    await act(async () => {
+      handleEvent({
+        payload: { url: '/tmp/alpha.html' },
+        profile: 'alpha',
+        session_id: RUNTIME_SESSION_ID,
+        type: 'preview.open'
+      } as unknown as RpcEvent)
+    })
+
+    expect(window.hermesDesktop.normalizePreviewTarget).not.toHaveBeenCalled()
+    expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  it('ignores stale colliding runtime state when the focused draft has no stored id yet', async () => {
+    publishSessionState(RUNTIME_SESSION_ID, {
+      ...createClientSessionState('shared'),
+      storedSessionProfile: 'alpha'
+    })
+    $selectedStoredSessionId.set(null)
+    $activeGatewayProfile.set('beta')
+    render(<Harness />)
+
+    await act(async () => {
+      handleEvent({
+        payload: { url: '/tmp/alpha.html' },
+        profile: 'alpha',
+        session_id: RUNTIME_SESSION_ID,
+        type: 'preview.open'
+      } as unknown as RpcEvent)
+    })
+
+    expect(window.hermesDesktop.normalizePreviewTarget).not.toHaveBeenCalled()
+    expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  it('fails closed on a profileless preview event that only matches a pooled runtime id', async () => {
+    $selectedStoredSessionId.set(null)
+    $activeGatewayProfile.set('beta')
+    render(<Harness />)
+
+    await act(async () => {
+      handleEvent({
+        payload: { url: '/tmp/owner-unknown.html' },
+        session_id: RUNTIME_SESSION_ID,
+        type: 'preview.open'
+      } as unknown as RpcEvent)
+    })
+
+    expect(window.hermesDesktop.normalizePreviewTarget).not.toHaveBeenCalled()
+    expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  it('drops an async open when focus moves to the same stored id in another profile', async () => {
+    let resolveTarget!: (target: HermesPreviewTarget) => void
+
+    const pendingTarget = new Promise<HermesPreviewTarget>(resolve => {
+      resolveTarget = resolve
+    })
+
+    $selectedStoredSessionId.set('shared')
+    $activeGatewayProfile.set('alpha')
+    vi.mocked(window.hermesDesktop.normalizePreviewTarget).mockReturnValue(pendingTarget)
+    render(<Harness />)
+
+    await act(async () => {
+      handleEvent({
+        payload: { url: '/tmp/owned.html' },
+        profile: 'alpha',
+        session_id: RUNTIME_SESSION_ID,
+        type: 'preview.open'
+      } as unknown as RpcEvent)
+    })
+
+    await waitFor(() => expect(window.hermesDesktop.normalizePreviewTarget).toHaveBeenCalled())
+
+    await act(async () => {
+      $activeGatewayProfile.set('beta')
+      resolveTarget(fileTarget('/tmp/owned.html'))
+      await pendingTarget
+    })
+
+    expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  it('drops an async open when the profile changes before the stored id exists', async () => {
+    let resolveTarget!: (target: HermesPreviewTarget) => void
+
+    const pendingTarget = new Promise<HermesPreviewTarget>(resolve => {
+      resolveTarget = resolve
+    })
+
+    $selectedStoredSessionId.set(null)
+    $activeGatewayProfile.set('alpha')
+    vi.mocked(window.hermesDesktop.normalizePreviewTarget).mockReturnValue(pendingTarget)
+    render(<Harness />)
+
+    await act(async () => {
+      handleEvent({
+        payload: { url: '/tmp/owned.html' },
+        profile: 'alpha',
+        session_id: RUNTIME_SESSION_ID,
+        type: 'preview.open'
+      } as unknown as RpcEvent)
+    })
+
+    await waitFor(() => expect(window.hermesDesktop.normalizePreviewTarget).toHaveBeenCalled())
+
+    await act(async () => {
+      $activeGatewayProfile.set('beta')
+      resolveTarget(fileTarget('/tmp/owned.html'))
+      await pendingTarget
     })
 
     expect($previewTabs.get()).toHaveLength(0)

--- a/apps/desktop/src/app/session/hooks/session-context-drift.test.ts
+++ b/apps/desktop/src/app/session/hooks/session-context-drift.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { sessionIdentityKey } from '@/lib/session-identity'
+
 import { NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../routes'
 
 import { routeTargetFromToken, sessionContextDrift } from './session-context-drift'
@@ -73,6 +75,36 @@ describe('sessionContextDrift', () => {
     })
 
     expect(reason).toBe('route:sess-a->sess-b')
+  })
+
+  it('drifts when only the routed profile changes for a colliding stored id', () => {
+    const reason = sessionContextDrift({
+      startRouteToken: routeToken(sessionRoute('shared'), '?profile=alpha'),
+      nowRouteToken: routeToken(sessionRoute('shared'), '?profile=beta'),
+      startSelectedStoredId: 'shared',
+      nowSelectedStoredId: 'shared',
+      startSelectedProfile: 'alpha',
+      nowSelectedProfile: 'beta',
+      submitTargetStoredId: 'shared',
+      submitTargetProfile: 'alpha'
+    })
+
+    expect(reason).toBe('route:alpha/shared->beta/shared')
+  })
+
+  it('drifts when selection moves between profiles that share the stored id', () => {
+    const reason = sessionContextDrift({
+      startRouteToken: routeToken(sessionRoute('shared'), '?profile=alpha'),
+      nowRouteToken: routeToken(sessionRoute('shared'), '?profile=alpha'),
+      startSelectedStoredId: 'shared',
+      nowSelectedStoredId: 'shared',
+      startSelectedProfile: 'alpha',
+      nowSelectedProfile: 'beta',
+      submitTargetStoredId: 'shared',
+      submitTargetProfile: 'alpha'
+    })
+
+    expect(reason).toBe('selection:alpha/shared->beta/shared')
   })
 
   it('drifts when the route moves to the new-chat route mid-submit', () => {
@@ -161,6 +193,23 @@ describe('sessionContextDrift', () => {
     })
 
     expect(reason).toBe('composer:sess-b->sess-a')
+  })
+
+  it('drifts when compound composer scopes have the same raw id under different profiles', () => {
+    const reason = sessionContextDrift({
+      startRouteToken: routeToken(sessionRoute('shared'), '?profile=beta'),
+      nowRouteToken: routeToken(sessionRoute('shared'), '?profile=beta'),
+      startSelectedStoredId: 'shared',
+      nowSelectedStoredId: 'shared',
+      startSelectedProfile: 'beta',
+      nowSelectedProfile: 'beta',
+      submitTargetStoredId: 'shared',
+      submitTargetProfile: 'beta',
+      composerScope: sessionIdentityKey('shared', 'alpha'),
+      submitTargetComposerScope: sessionIdentityKey('shared', 'beta')
+    })
+
+    expect(reason).toBe('composer:alpha/shared->beta/shared')
   })
 
   it('checks the composer prong before the route/selection prongs', () => {

--- a/apps/desktop/src/app/session/hooks/session-context-drift.ts
+++ b/apps/desktop/src/app/session/hooks/session-context-drift.ts
@@ -1,4 +1,6 @@
-import { isNewChatRoute, routeSessionId } from '../../routes'
+import { parseSessionIdentityKey, sessionIdentityKey } from '@/lib/session-identity'
+
+import { isNewChatRoute, routeSessionId, routeSessionProfile } from '../../routes'
 
 /**
  * The chat a route token points at: the stored/routed session id, `'__new__'`
@@ -7,6 +9,21 @@ import { isNewChatRoute, routeSessionId } from '../../routes'
  * rather than their raw string.
  */
 export type RouteTarget = string | null
+
+function routeTokenParts(token: string): { pathname: string; search: string } {
+  const firstSeparator = token.indexOf(':')
+
+  if (firstSeparator === -1) {
+    return { pathname: token, search: '' }
+  }
+
+  const secondSeparator = token.indexOf(':', firstSeparator + 1)
+
+  return {
+    pathname: token.slice(0, firstSeparator),
+    search: secondSeparator === -1 ? token.slice(firstSeparator + 1) : token.slice(firstSeparator + 1, secondSeparator)
+  }
+}
 
 /**
  * Reduce a route token to the chat it targets. The token is
@@ -18,10 +35,34 @@ export type RouteTarget = string | null
  * id arrives as %3A, and the app's other routes are literal colon-free paths).
  */
 export function routeTargetFromToken(token: string): RouteTarget {
-  const separator = token.indexOf(':')
-  const pathname = separator === -1 ? token : token.slice(0, separator)
+  const { pathname } = routeTokenParts(token)
 
   return routeSessionId(pathname) ?? (isNewChatRoute(pathname) ? '__new__' : null)
+}
+
+function routeIdentityFromToken(token: string, fallbackProfile?: null | string): RouteTarget {
+  const { pathname, search } = routeTokenParts(token)
+  const storedSessionId = routeSessionId(pathname)
+
+  if (storedSessionId) {
+    return sessionIdentityKey(storedSessionId, routeSessionProfile(search) ?? fallbackProfile)
+  }
+
+  return isNewChatRoute(pathname) ? '__new__' : null
+}
+
+function selectionIdentity(storedSessionId: string | null, profile?: null | string): string | null {
+  return storedSessionId === null ? null : sessionIdentityKey(storedSessionId, profile)
+}
+
+function describeTarget(target: RouteTarget): string {
+  if (!target || target === '__new__') {
+    return String(target)
+  }
+
+  const { profile, storedSessionId } = parseSessionIdentityKey(target)
+
+  return profile === 'default' ? storedSessionId : `${profile}/${storedSessionId}`
 }
 
 interface SessionContextDriftArgs {
@@ -29,6 +70,8 @@ interface SessionContextDriftArgs {
   nowRouteToken: string
   startSelectedStoredId: string | null
   nowSelectedStoredId: string | null
+  startSelectedProfile?: null | string
+  nowSelectedProfile?: null | string
   /**
    * The stored session this submit is bound to, when known. Drift ignores a
    * move *to* this id: the submit pipeline itself re-homes selection and route
@@ -37,18 +80,19 @@ interface SessionContextDriftArgs {
    * a real chat as drift.
    */
   submitTargetStoredId?: string | null
+  submitTargetProfile?: null | string
   /**
-   * The composer scope that was actually loaded when the text was submitted
-   * (SubmitTextOptions.composerScope). The composer and the session-side refs
-   * live in separate React subtrees and can each be internally consistent yet
-   * still disagree with each other at the instant of send — this prong catches
-   * that cross-component drift (#59305). Omit for non-composer submits.
+   * The compound durable identity that the composer had loaded when the text
+   * was submitted (SubmitTextOptions.composerScope). The composer and the
+   * session-side refs live in separate React subtrees and can each be internally
+   * consistent yet still disagree at send time — this catches that drift
+   * (#59305). Omit for non-composer submits.
    */
   composerScope?: string | null
   /**
-   * resolveComposerSessionKey(submitTargetStoredId, sessions) — the durable
-   * lineage-root form of the submit target, in the SAME domain as
-   * composerScope. Compared against composerScope instead of the raw
+   * resolveComposerSessionKey(submitTargetStoredId, sessions, profile) — the
+   * compound durable lineage-root identity of the submit target, in the SAME
+   * domain as composerScope. Compared against composerScope instead of the raw
    * submitTargetStoredId: the composer keys drafts/attachments on the lineage
    * root (stable across auto-compression tip rotation) while
    * submitTargetStoredId tracks the live tip — comparing composerScope
@@ -75,7 +119,10 @@ export function sessionContextDrift({
   nowRouteToken,
   startSelectedStoredId,
   nowSelectedStoredId,
+  startSelectedProfile,
+  nowSelectedProfile,
   submitTargetStoredId,
+  submitTargetProfile,
   composerScope,
   submitTargetComposerScope
 }: SessionContextDriftArgs): string | null {
@@ -87,29 +134,29 @@ export function sessionContextDrift({
   // submitTargetStoredId (live tip) — see the field doc on
   // SessionContextDriftArgs for why those two must not be conflated.
   if (composerScope !== undefined && composerScope !== null && composerScope !== submitTargetComposerScope) {
-    return `composer:${composerScope}->${submitTargetComposerScope}`
+    return `composer:${describeTarget(composerScope)}->${describeTarget(submitTargetComposerScope ?? null)}`
   }
 
-  const targetStart = routeTargetFromToken(startRouteToken)
-  const targetNow = routeTargetFromToken(nowRouteToken)
+  const targetStart = routeIdentityFromToken(startRouteToken, startSelectedProfile)
+  const targetNow = routeIdentityFromToken(nowRouteToken, nowSelectedProfile)
+  const submitTarget = selectionIdentity(submitTargetStoredId ?? null, submitTargetProfile)
 
   // Route prong: the routed chat moved to a different, real chat. A null target
   // (navigated to settings / a non-chat overlay route) or a search/hash-only
   // change (same target) is not drift, and neither is landing on the submit's
   // own target.
-  if (targetNow !== targetStart && targetNow !== null && targetNow !== submitTargetStoredId) {
-    return `route:${targetStart}->${targetNow}`
+  if (targetNow !== targetStart && targetNow !== null && targetNow !== submitTarget) {
+    return `route:${describeTarget(targetStart)}->${describeTarget(targetNow)}`
   }
 
   // Selection prong: selection moved to a different, real stored session. A
   // null-reset (nowSelectedStoredId === null) or a move onto the submit's own
   // target is not drift.
-  if (
-    nowSelectedStoredId !== null &&
-    nowSelectedStoredId !== startSelectedStoredId &&
-    nowSelectedStoredId !== submitTargetStoredId
-  ) {
-    return `selection:${startSelectedStoredId}->${nowSelectedStoredId}`
+  const selectedStart = selectionIdentity(startSelectedStoredId, startSelectedProfile)
+  const selectedNow = selectionIdentity(nowSelectedStoredId, nowSelectedProfile)
+
+  if (selectedNow !== null && selectedNow !== selectedStart && selectedNow !== submitTarget) {
+    return `selection:${describeTarget(selectedStart)}->${describeTarget(selectedNow)}`
   }
 
   return null

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -3,6 +3,7 @@ import type { MutableRefObject } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
@@ -10,26 +11,29 @@ import {
   getQueuedPrompts,
   parkQueuedPrompts
 } from '@/store/composer-queue'
+import { $activeGatewayProfile } from '@/store/profile'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 
 import { useBackgroundQueueDrain } from './use-background-queue-drain'
 import type { SubmitTextOptions } from './use-prompt-actions/utils'
 
+const DEFAULT_BACKGROUND_IDENTITY = sessionIdentityKey('stored-session-a', 'default')
+
 function Harness({
   enabled = true,
   runtimeMap,
-  selectedStoredSessionId = 'stored-session-b',
+  selectedSessionIdentityKey = sessionIdentityKey('stored-session-b', 'default'),
   submitText
 }: {
   enabled?: boolean
   runtimeMap: MutableRefObject<Map<string, string>>
-  selectedStoredSessionId?: string | null
+  selectedSessionIdentityKey?: string | null
   submitText: (text: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
 }) {
   useBackgroundQueueDrain({
     enabled,
     runtimeIdByStoredSessionIdRef: runtimeMap,
-    selectedStoredSessionId,
+    selectedSessionIdentityKey,
     submitText
   })
 
@@ -40,6 +44,7 @@ describe('useBackgroundQueueDrain', () => {
   beforeEach(() => {
     vi.useRealTimers()
     clearAllSessionStates()
+    $activeGatewayProfile.set('default')
   })
 
   afterEach(() => {
@@ -52,10 +57,10 @@ describe('useBackgroundQueueDrain', () => {
   })
 
   it('drains an idle queued prompt for a non-selected background session', async () => {
-    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const runtimeMap = { current: new Map([[sessionIdentityKey('stored-session-a', 'default'), 'rt-session-a']]) }
     const submitText = vi.fn(async () => true)
 
-    enqueueQueuedPrompt('stored-session-a', { text: 'continue in the background', attachments: [] })
+    enqueueQueuedPrompt(DEFAULT_BACKGROUND_IDENTITY, { text: 'continue in the background', attachments: [] })
     clearAllSessionStates()
 
     render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
@@ -64,34 +69,41 @@ describe('useBackgroundQueueDrain', () => {
       expect(submitText).toHaveBeenCalledWith('continue in the background', {
         attachments: [],
         fromQueue: true,
+        profile: 'default',
         sessionId: 'rt-session-a',
         storedSessionId: 'stored-session-a'
       })
     })
 
-    await waitFor(() => expect(getQueuedPrompts('stored-session-a')).toHaveLength(0))
+    await waitFor(() => expect(getQueuedPrompts(DEFAULT_BACKGROUND_IDENTITY)).toHaveLength(0))
   })
 
   it('leaves the selected session queue to the mounted ChatBar drainer', async () => {
-    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const runtimeMap = { current: new Map([[sessionIdentityKey('stored-session-a', 'default'), 'rt-session-a']]) }
     const submitText = vi.fn(async () => true)
 
-    enqueueQueuedPrompt('stored-session-a', { text: 'visible queue entry', attachments: [] })
+    enqueueQueuedPrompt(DEFAULT_BACKGROUND_IDENTITY, { text: 'visible queue entry', attachments: [] })
     clearAllSessionStates()
 
-    render(<Harness runtimeMap={runtimeMap} selectedStoredSessionId="stored-session-a" submitText={submitText} />)
+    render(
+      <Harness
+        runtimeMap={runtimeMap}
+        selectedSessionIdentityKey={sessionIdentityKey('stored-session-a', 'default')}
+        submitText={submitText}
+      />
+    )
 
     await new Promise(resolve => window.setTimeout(resolve, 0))
 
     expect(submitText).not.toHaveBeenCalled()
-    expect(getQueuedPrompts('stored-session-a')).toHaveLength(1)
+    expect(getQueuedPrompts(DEFAULT_BACKGROUND_IDENTITY)).toHaveLength(1)
   })
 
   it('does not drain a background session that is still marked working', async () => {
-    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const runtimeMap = { current: new Map([[sessionIdentityKey('stored-session-a', 'default'), 'rt-session-a']]) }
     const submitText = vi.fn(async () => true)
 
-    enqueueQueuedPrompt('stored-session-a', { text: 'wait for current turn', attachments: [] })
+    enqueueQueuedPrompt(DEFAULT_BACKGROUND_IDENTITY, { text: 'wait for current turn', attachments: [] })
     // Mark the session as working (busy) so the drain should skip it
     publishSessionState('rt-session-a', { ...createClientSessionState('stored-session-a'), busy: true })
 
@@ -100,18 +112,18 @@ describe('useBackgroundQueueDrain', () => {
     await new Promise(resolve => window.setTimeout(resolve, 0))
 
     expect(submitText).not.toHaveBeenCalled()
-    expect(getQueuedPrompts('stored-session-a')).toHaveLength(1)
+    expect(getQueuedPrompts(DEFAULT_BACKGROUND_IDENTITY)).toHaveLength(1)
   })
 
   it('does not drain a parked background session, even when idle', async () => {
     // A Stop in a tile parks that session's queue; when the user then focuses
     // another chat, THIS drainer takes over the tile's queue — it must honor
     // the park just like the mounted ChatBar drainer does.
-    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const runtimeMap = { current: new Map([[sessionIdentityKey('stored-session-a', 'default'), 'rt-session-a']]) }
     const submitText = vi.fn(async () => true)
 
-    enqueueQueuedPrompt('stored-session-a', { text: 'halted by stop', attachments: [] })
-    parkQueuedPrompts('stored-session-a')
+    enqueueQueuedPrompt(DEFAULT_BACKGROUND_IDENTITY, { text: 'halted by stop', attachments: [] })
+    parkQueuedPrompts(DEFAULT_BACKGROUND_IDENTITY)
     clearAllSessionStates()
 
     render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
@@ -119,14 +131,14 @@ describe('useBackgroundQueueDrain', () => {
     await new Promise(resolve => window.setTimeout(resolve, 0))
 
     expect(submitText).not.toHaveBeenCalled()
-    expect(getQueuedPrompts('stored-session-a')).toHaveLength(1)
+    expect(getQueuedPrompts(DEFAULT_BACKGROUND_IDENTITY)).toHaveLength(1)
   })
 
   it('passes a null runtime id so submitText can resume stale background sessions by stored id', async () => {
     const runtimeMap = { current: new Map<string, string>() }
     const submitText = vi.fn(async () => true)
 
-    enqueueQueuedPrompt('stored-session-a', { text: 'resume then send', attachments: [] })
+    enqueueQueuedPrompt(DEFAULT_BACKGROUND_IDENTITY, { text: 'resume then send', attachments: [] })
 
     render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
 
@@ -134,6 +146,7 @@ describe('useBackgroundQueueDrain', () => {
       expect(submitText).toHaveBeenCalledWith('resume then send', {
         attachments: [],
         fromQueue: true,
+        profile: 'default',
         sessionId: null,
         storedSessionId: 'stored-session-a'
       })
@@ -143,10 +156,10 @@ describe('useBackgroundQueueDrain', () => {
   it('retries a rejected background drain without waiting for another queue or busy-state change', async () => {
     vi.useFakeTimers()
 
-    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const runtimeMap = { current: new Map([[sessionIdentityKey('stored-session-a', 'default'), 'rt-session-a']]) }
     const submitText = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
 
-    enqueueQueuedPrompt('stored-session-a', { text: 'retry me', attachments: [] })
+    enqueueQueuedPrompt(DEFAULT_BACKGROUND_IDENTITY, { text: 'retry me', attachments: [] })
 
     render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
 
@@ -155,7 +168,7 @@ describe('useBackgroundQueueDrain', () => {
     })
 
     expect(submitText).toHaveBeenCalledTimes(1)
-    expect(getQueuedPrompts('stored-session-a')).toHaveLength(1)
+    expect(getQueuedPrompts(DEFAULT_BACKGROUND_IDENTITY)).toHaveLength(1)
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(750)
@@ -163,6 +176,33 @@ describe('useBackgroundQueueDrain', () => {
     })
 
     expect(submitText).toHaveBeenCalledTimes(2)
-    expect(getQueuedPrompts('stored-session-a')).toHaveLength(0)
+    expect(getQueuedPrompts(DEFAULT_BACKGROUND_IDENTITY)).toHaveLength(0)
+  })
+
+  it('does not drain a colliding stored id owned by another profile', async () => {
+    const alphaKey = sessionIdentityKey('shared', 'alpha')
+    const runtimeMap = { current: new Map([[alphaKey, 'rt-alpha']]) }
+    const submitText = vi.fn(async () => true)
+
+    enqueueQueuedPrompt(alphaKey, { text: 'alpha only', attachments: [] })
+
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+
+    expect(submitText).not.toHaveBeenCalled()
+    expect(getQueuedPrompts(alphaKey)).toHaveLength(1)
+  })
+
+  it('does not reinterpret a legacy raw queue key as the active non-default profile', async () => {
+    $activeGatewayProfile.set('beta')
+    const runtimeMap = { current: new Map([[sessionIdentityKey('shared', 'beta'), 'rt-beta']]) }
+    const submitText = vi.fn(async () => true)
+
+    enqueueQueuedPrompt('shared', { text: 'legacy owner unknown', attachments: [] })
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+
+    expect(submitText).not.toHaveBeenCalled()
+    expect(getQueuedPrompts('shared')).toHaveLength(1)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
+import { normalizeProfileKey, parseSessionIdentityKey } from '@/lib/session-identity'
 import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $parkedQueueSessions,
@@ -13,6 +14,7 @@ import {
   shouldAutoDrain
 } from '@/store/composer-queue'
 import { notify } from '@/store/notifications'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $workingSessionIds } from '@/store/session-states'
 
 import type { SubmitTextOptions } from './use-prompt-actions/utils'
@@ -22,7 +24,7 @@ type SubmitQueuedPrompt = (text: string, options?: SubmitTextOptions) => Promise
 interface BackgroundQueueDrainOptions {
   enabled: boolean
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
-  selectedStoredSessionId: string | null
+  selectedSessionIdentityKey: string | null
   submitText: SubmitQueuedPrompt
 }
 
@@ -39,7 +41,7 @@ const BACKGROUND_DRAIN_RETRY_MS = 750
 export function useBackgroundQueueDrain({
   enabled,
   runtimeIdByStoredSessionIdRef,
-  selectedStoredSessionId,
+  selectedSessionIdentityKey,
   submitText
 }: BackgroundQueueDrainOptions) {
   const { t } = useI18n()
@@ -82,7 +84,7 @@ export function useBackgroundQueueDrain({
   )
 
   const drainSessionQueue = useCallback(
-    (sessionKey: string, entry: QueuedPromptEntry) => {
+    (sessionKey: string, identityKey: string, storedSessionId: string, profile: string, entry: QueuedPromptEntry) => {
       if (drainingSessionIdsRef.current.has(sessionKey)) {
         return
       }
@@ -115,14 +117,15 @@ export function useBackgroundQueueDrain({
             return true
           }
 
-          const runtimeSessionId = runtimeIdByStoredSessionIdRef.current.get(sessionKey) ?? null
+          const runtimeSessionId = runtimeIdByStoredSessionIdRef.current.get(identityKey) ?? null
 
           const accepted = await Promise.resolve(
             submitTextRef.current(liveEntry.text, {
               attachments: liveEntry.attachments,
               fromQueue: true,
+              profile,
               sessionId: runtimeSessionId,
-              storedSessionId: sessionKey
+              storedSessionId
             })
           )
 
@@ -155,13 +158,21 @@ export function useBackgroundQueueDrain({
     }
 
     const working = new Set(workingSessionIds)
+    const profile = $activeGatewayProfile.get()
 
     for (const [sessionKey, entries] of Object.entries(queuedPromptsBySession)) {
+      // Persisted v1 keys are migrated at the storage boundary. A raw live key
+      // still parses as default, so a non-default profile fails closed rather
+      // than claiming ownerless queue state.
+      const identityKey = sessionKey
+      const identity = parseSessionIdentityKey(identityKey)
+
       if (
-        sessionKey === selectedStoredSessionId ||
+        normalizeProfileKey(identity.profile) !== normalizeProfileKey(profile) ||
+        identityKey === selectedSessionIdentityKey ||
         drainingSessionIdsRef.current.has(sessionKey) ||
         !shouldAutoDrain({
-          isBusy: working.has(sessionKey),
+          isBusy: working.has(identityKey),
           parked: Boolean(parkedQueueSessions[sessionKey]),
           queueLength: entries.length
         })
@@ -175,7 +186,7 @@ export function useBackgroundQueueDrain({
         continue
       }
 
-      drainSessionQueue(sessionKey, entry)
+      drainSessionQueue(sessionKey, identityKey, identity.storedSessionId, identity.profile, entry)
     }
   }, [
     drainSessionQueue,
@@ -183,7 +194,7 @@ export function useBackgroundQueueDrain({
     parkedQueueSessions,
     queuedPromptsBySession,
     retryTick,
-    selectedStoredSessionId,
+    selectedSessionIdentityKey,
     workingSessionIds
   ])
 }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -16,6 +16,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { invalidateSlashCompletions } from '@/lib/slash-completion-cache'
+import { sessionMatchesIdentity } from '@/lib/session-identity'
 import { type AgentNoticePayload, clearAgentNotice, nativeNoticeInput, showAgentNotice } from '@/store/agent-notices'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { billingCtaLabel, clearBillingBlock, runBillingRecovery, setBillingBlock } from '@/store/billing-block'
@@ -36,7 +37,6 @@ import {
   $currentCwd,
   $currentModel,
   $currentProvider,
-  sessionMatchesStoredId,
   setCurrentBranch,
   setCurrentCwd,
   setCurrentFastMode,
@@ -258,6 +258,16 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
       const sessionId = route.sessionId
       const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
+
+      const notificationSession = () => {
+        const state = sessionId ? updateSessionState(sessionId, current => current) : undefined
+
+        return {
+          profile: state?.storedSessionProfile ?? event.profile ?? $activeGatewayProfile.get(),
+          sessionId,
+          storedSessionId: state?.storedSessionId
+        }
+      }
 
       // Mid-turn compaction does not emit another message.start. The first
       // model output or tool event proves summarization has finished and the
@@ -630,9 +640,9 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
         // Turn ended — drop any blocking prompt still open for THIS session
         // (e.g. interrupted, or the approval already resolved). Scoped to the
-        // session so a background turn finishing can't wipe the active chat's
-        // prompt, and vice versa.
-        clearAllPrompts(sessionId)
+        // exact profile/session owner so colliding pooled runtime ids cannot
+        // clear one another's prompts.
+        clearAllPrompts(sessionId, notificationSession().profile)
         clearClarifyRequest(undefined, sessionId)
         // Turn ended without a final `todo` update — drop a still-unfinished
         // list so "Tasks N/M" doesn't stay pinned above the composer with the
@@ -703,7 +713,11 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         const nextTitle = typeof payload?.title === 'string' ? payload.title.trim() : ''
 
         if (storedId && nextTitle) {
-          setSessions(prev => prev.map(s => (sessionMatchesStoredId(s, storedId) ? { ...s, title: nextTitle } : s)))
+          setSessions(prev =>
+            prev.map(s =>
+              sessionMatchesIdentity(s, storedId, activeGatewayProfile) ? { ...s, title: nextTitle } : s
+            )
+          )
         }
       } else if (event.type === 'tool.generating') {
         // Announced while the model is still emitting the call's JSON, so it
@@ -835,9 +849,9 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           }
 
           dispatchNativeNotification({
+            ...notificationSession(),
             body: question,
             kind: 'input',
-            sessionId,
             title: translateNow('notifications.native.inputTitle')
           })
         }
@@ -859,6 +873,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             : undefined,
           command,
           description,
+          profile: notificationSession().profile,
           sessionId: sessionId ?? null,
           smartDenied: payload?.smart_denied === true
         })
@@ -868,13 +883,13 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         }
 
         dispatchNativeNotification({
+          ...notificationSession(),
           actions: [
             { id: 'approve', text: translateNow('notifications.native.approveAction') },
             { id: 'reject', text: translateNow('notifications.native.rejectAction') }
           ],
           body: command || description,
           kind: 'approval',
-          sessionId,
           title: translateNow('notifications.native.approvalTitle')
         })
       } else if (event.type === 'sudo.request') {
@@ -883,16 +898,16 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
         if (requestId) {
-          setSudoRequest({ requestId, sessionId: sessionId ?? null })
+          setSudoRequest({ profile: notificationSession().profile, requestId, sessionId: sessionId ?? null })
 
           if (sessionId) {
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
           }
 
           dispatchNativeNotification({
+            ...notificationSession(),
             body: translateNow('notifications.native.inputBody'),
             kind: 'input',
-            sessionId,
             title: translateNow('notifications.native.inputTitle')
           })
         }
@@ -908,6 +923,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           setSecretRequest({
             requestId,
             envVar,
+            profile: notificationSession().profile,
             prompt: promptText,
             sessionId: sessionId ?? null
           })
@@ -917,9 +933,9 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           }
 
           dispatchNativeNotification({
+            ...notificationSession(),
             body: promptText || envVar || translateNow('notifications.native.inputBody'),
             kind: 'input',
-            sessionId,
             title: translateNow('notifications.native.inputTitle')
           })
         }
@@ -1032,7 +1048,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // for this session so an approval/sudo/secret overlay can't linger past
         // the failed turn (same intent as the message.complete clear).
         if (sessionId) {
-          clearAllPrompts(sessionId)
+          clearAllPrompts(sessionId, notificationSession().profile)
           clearClarifyRequest(undefined, sessionId)
           clearActiveSessionTodos(sessionId)
           setSessionCompacting(sessionId, false)
@@ -1045,9 +1061,9 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         }
 
         dispatchNativeNotification({
+          ...notificationSession(),
           body: errorMessage,
           kind: 'turnError',
-          sessionId,
           title: translateNow('notifications.native.turnErrorTitle')
         })
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -37,7 +37,8 @@ interface MessageStreamOptions {
   hydrateFromStoredSession: (
     attempts?: number,
     storedSessionId?: string | null,
-    runtimeSessionId?: string | null
+    runtimeSessionId?: string | null,
+    profile?: string | null
   ) => Promise<void>
   queryClient: QueryClient
   refreshHermesConfig: () => Promise<void>
@@ -604,13 +605,15 @@ export function useMessageStream({
       }
 
       if (shouldHydrate) {
-        void hydrateFromStoredSession(3, completedState.storedSessionId, sessionId)
+        void hydrateFromStoredSession(3, completedState.storedSessionId, sessionId, completedState.storedSessionProfile)
       }
 
       dispatchNativeNotification({
         body: text.slice(0, 140) || translateNow('notifications.native.turnDoneBody'),
         kind: 'turnDone',
+        profile: completedState.storedSessionProfile,
         sessionId,
+        storedSessionId: completedState.storedSessionId,
         title: translateNow('notifications.native.turnDoneTitle')
       })
     },

--- a/apps/desktop/src/app/session/hooks/use-preview-routing.ts
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 
 import { gatewayEventCompletedFileDiff } from '@/lib/gateway-events'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
+import { normalizeProfileKey } from '@/lib/session-identity'
 import {
   $previewTabs,
   beginPreviewServerRestart,
@@ -10,8 +11,9 @@ import {
   progressPreviewServerRestart,
   requestPreviewReload
 } from '@/store/preview'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $currentCwd } from '@/store/session'
-import { $focusedRuntimeId } from '@/store/session-states'
+import { $focusedRuntimeId, $focusedSessionIdentityKey } from '@/store/session-states'
 import type { RpcEvent } from '@/types/hermes'
 
 type EventHandler = (event: RpcEvent) => void
@@ -24,6 +26,52 @@ interface PreviewRoutingOptions {
 
 function asRecord(payload: unknown): Record<string, unknown> {
   return payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {}
+}
+
+interface PreviewOwner {
+  identity: null | string
+  profile: string
+  runtimeId: string
+}
+
+function focusedPreviewOwner(): PreviewOwner | null {
+  const runtimeId = $focusedRuntimeId.get()
+
+  if (!runtimeId) {
+    return null
+  }
+
+  // Durable focused identity + active profile are authoritative. Runtime ids
+  // are pooled per backend, so joining through $sessionStates[runtimeId] can
+  // inherit a stale owner left by another profile before this draft publishes
+  // its own stored id/state.
+  const profile = normalizeProfileKey($activeGatewayProfile.get())
+  const identity = $focusedSessionIdentityKey.get()
+
+  return { identity, profile, runtimeId }
+}
+
+function eventBelongsToOwner(event: RpcEvent, owner: PreviewOwner): boolean {
+  // Gateway boot/registry stamps every real socket event with its source
+  // profile. A profileless event has only a pooled runtime id and therefore
+  // cannot establish ownership safely.
+  if (event.session_id !== owner.runtimeId || !event.profile) {
+    return false
+  }
+
+  if (normalizeProfileKey(event.profile) !== owner.profile) {
+    return false
+  }
+
+  return true
+}
+
+function ownerStillFocused(owner: PreviewOwner): boolean {
+  const current = focusedPreviewOwner()
+
+  return owner.identity
+    ? current?.identity === owner.identity
+    : current?.runtimeId === owner.runtimeId && current.profile === owner.profile
 }
 
 export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestGateway }: PreviewRoutingOptions) {
@@ -60,6 +108,7 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
   const handleDesktopGatewayEvent = useCallback<EventHandler>(
     event => {
       baseHandleGatewayEvent(event)
+      const owner = focusedPreviewOwner()
 
       if (event.type === 'preview.open') {
         // Agent-driven open in response to an explicit user request ("show
@@ -72,9 +121,9 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
         const { url, label } = asRecord(event.payload)
         const target = typeof url === 'string' ? url.trim() : ''
 
-        if (target && (!event.session_id || event.session_id === $focusedRuntimeId.get())) {
+        if (target && owner && eventBelongsToOwner(event, owner)) {
           void normalizeOrLocalPreviewTarget(target, $currentCwd.get() || currentCwd || undefined).then(resolved => {
-            if (resolved) {
+            if (resolved && ownerStillFocused(owner)) {
               const trimmedLabel = typeof label === 'string' ? label.trim() : ''
               openPreview(trimmedLabel ? { ...resolved, label: trimmedLabel } : resolved, 'tool-result')
             }
@@ -98,7 +147,7 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
         }
       }
 
-      if (event.session_id && event.session_id !== $focusedRuntimeId.get()) {
+      if (!owner || !eventBelongsToOwner(event, owner)) {
         return
       }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -6,9 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getSession } from '@/hermes'
 import { textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
 import { $notifications, clearNotifications } from '@/store/notifications'
+import { $activeGatewayProfile } from '@/store/profile'
 import {
   $busy,
   $connection,
@@ -18,9 +20,10 @@ import {
   $turnStartedAt,
   setCurrentUsage,
   setMessages,
+  setSelectedStoredSessionId,
   setSessions
 } from '@/store/session'
-import { dropSessionState, publishSessionState } from '@/store/session-states'
+import { clearAllSessionStates, dropSessionState, publishSessionState } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
 import type { SubmitTextOptions } from './utils'
@@ -90,6 +93,7 @@ function Harness({
   activeSessionIdRef: activeSessionIdRefProp,
   busyRef,
   getRoutedStoredSessionId,
+  getRoutedStoredSessionProfile,
   getRuntimeIdForStoredSession,
   getRouteToken,
   onUpdateState,
@@ -98,6 +102,7 @@ function Harness({
   openMemoryGraph,
   refreshSessions,
   requestGateway,
+  requestGatewayForProfile,
   resumeStoredSession,
   seedMessages,
   selectedStoredSessionIdRef: selectedStoredSessionIdRefProp,
@@ -108,19 +113,27 @@ function Harness({
   activeSessionIdRef?: MutableRefObject<string | null>
   busyRef?: MutableRefObject<boolean>
   getRoutedStoredSessionId?: () => null | string
+  getRoutedStoredSessionProfile?: () => null | string
   getRuntimeIdForStoredSession?: (storedSessionId: string) => null | string
   getRouteToken?: () => string
   onUpdateState?: (
     sessionId: string,
     storedSessionId: null | string | undefined,
-    state: Record<string, unknown>
+    state: Record<string, unknown>,
+    storedSessionProfile?: null | string
   ) => void
   onReady: (handle: HarnessHandle) => void
   onSeedState?: (state: Record<string, unknown>) => void
   openMemoryGraph?: () => void
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
-  resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
+  requestGatewayForProfile?: <T>(
+    profile: string,
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number
+  ) => Promise<T>
+  resumeStoredSession?: (storedSessionId: string, profile?: null | string) => Promise<void> | void
   seedMessages?: unknown[]
   selectedStoredSessionIdRef?: MutableRefObject<string | null>
   storedSessionId?: null | string
@@ -153,22 +166,24 @@ function Harness({
     busyRef: localBusyRef,
     createBackendSessionForSend: createBackendSessionForSend ?? (async () => RUNTIME_SESSION_ID),
     getRoutedStoredSessionId: getRoutedStoredSessionId ?? (() => null),
+    getRoutedStoredSessionProfile: getRoutedStoredSessionProfile ?? (() => null),
     getRuntimeIdForStoredSession: getRuntimeIdForStoredSession ?? (() => null),
     getRouteToken: getRouteToken ?? (() => 'token'),
     handleSkinCommand: () => '',
     openMemoryGraph: openMemoryGraph ?? (() => undefined),
     refreshSessions,
     requestGateway,
+    requestGatewayForProfile,
     resumeStoredSession: resumeStoredSession ?? (() => undefined),
     selectedStoredSessionIdRef,
     startFreshSessionDraft: () => undefined,
     sttEnabled: false,
-    updateSessionState: (sessionId, updater, storedSessionId) => {
+    updateSessionState: (sessionId, updater, storedSessionId, storedSessionProfile) => {
       // Seed with interrupted:true so we can prove a fresh submit clears it.
       const next = updater(stateRef.current) as unknown as Record<string, unknown>
       stateRef.current = next as never
       onSeedState?.(next)
-      onUpdateState?.(sessionId, storedSessionId, next)
+      onUpdateState?.(sessionId, storedSessionId, next, storedSessionProfile)
 
       return next as never
     }
@@ -215,6 +230,8 @@ describe('usePromptActions /title', () => {
 
   afterEach(() => {
     cleanup()
+    clearAllSessionStates()
+    $activeGatewayProfile.set('default')
     vi.restoreAllMocks()
   })
 
@@ -265,6 +282,62 @@ describe('usePromptActions /title', () => {
     // Even when queued, the sidebar reflects the chosen title optimistically.
     expect(refreshSessions).toHaveBeenCalledTimes(1)
     expect($sessions.get()[0]?.title).toBe('Fresh chat')
+  })
+
+  it('updates only alpha/shared when the profile changes before a title RPC resolves', async () => {
+    const sharedStoredId = 'shared'
+
+    setSessions(() => [
+      sessionInfo({ id: sharedStoredId, profile: 'alpha', title: 'Alpha old' }),
+      sessionInfo({ id: sharedStoredId, profile: 'beta', title: 'Beta old' })
+    ])
+    $activeGatewayProfile.set('alpha')
+    publishSessionState(
+      sharedStoredId,
+      createClientSessionState(sharedStoredId, [], 'alpha')
+    )
+
+    let resolveTitle: (value: { pending: boolean; title: string }) => void = () => undefined
+
+    const titleResult = new Promise<{ pending: boolean; title: string }>(resolve => {
+      resolveTitle = resolve
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.title') {
+        return (await titleResult) as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId={sharedStoredId}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={sharedStoredId}
+      />
+    )
+
+    let submitted: Promise<boolean>
+    act(() => {
+      submitted = handle!.submitTextRaw('/title Alpha new')
+    })
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.title', expect.anything()))
+
+    $activeGatewayProfile.set('beta')
+    resolveTitle({ pending: false, title: 'Alpha new' })
+    await act(async () => {
+      await submitted
+    })
+
+    expect($sessions.get().map(session => [session.profile, session.title])).toEqual([
+      ['alpha', 'Alpha new'],
+      ['beta', 'Beta old']
+    ])
   })
 
   it('falls through to the slash worker for a bare /title (show current title)', async () => {
@@ -433,7 +506,9 @@ describe('usePromptActions /compress', () => {
 
   afterEach(() => {
     cleanup()
+    clearAllSessionStates()
     clearNotifications()
+    $activeGatewayProfile.set('default')
     setCurrentUsage({ calls: 0, input: 0, output: 0, total: 0 })
     setMessages([])
     vi.restoreAllMocks()
@@ -479,6 +554,50 @@ describe('usePromptActions /compress', () => {
     )
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
     expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+  })
+
+  it('applies a compression title only to alpha/shared when profile ids collide', async () => {
+    const sharedStoredId = 'shared'
+
+    setSessions(() => [
+      sessionInfo({ id: sharedStoredId, profile: 'alpha', title: 'Alpha old' }),
+      sessionInfo({ id: sharedStoredId, profile: 'beta', title: 'Beta old' })
+    ])
+    $activeGatewayProfile.set('alpha')
+    publishSessionState(
+      sharedStoredId,
+      createClientSessionState(sharedStoredId, [], 'alpha')
+    )
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.compress') {
+        return {
+          info: { title: 'Alpha compressed' },
+          removed: 1,
+          summary: { headline: 'Compressed alpha/shared' }
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId={sharedStoredId}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={sharedStoredId}
+      />
+    )
+
+    await handle!.submitText('/compress')
+
+    expect($sessions.get().map(session => [session.profile, session.title])).toEqual([
+      ['alpha', 'Alpha compressed'],
+      ['beta', 'Beta old']
+    ])
   })
 
   it('replaces the transcript from the response messages', async () => {
@@ -675,7 +794,12 @@ describe('usePromptActions /compress', () => {
   it('does not clobber the foreground transcript when compression resolves after a session switch', async () => {
     const RUNTIME_SESSION_B = 'rt-session-b'
     const storedSessionIdRef: MutableRefObject<string | null> = { current: 'stored-a' }
-    const updates: Array<{ sessionId: string; storedSessionId: null | string | undefined }> = []
+
+    const updates: Array<{
+      profile: null | string | undefined
+      sessionId: string
+      storedSessionId: null | string | undefined
+    }> = []
 
     let resolveCompress: (value: unknown) => void = () => undefined
 
@@ -695,13 +819,16 @@ describe('usePromptActions /compress', () => {
 
     setMessages([{ id: 'foreground-b', parts: [textPart('session B transcript')], role: 'user', timestamp: 0 }])
     setCurrentUsage({ calls: 7, input: 70, output: 30, total: 100 })
+    $activeGatewayProfile.set('alpha')
 
     let handle: HarnessHandle | null = null
     await actRender(
       <Harness
         activeSessionIdRef={activeSessionIdRef}
         onReady={h => (handle = h)}
-        onUpdateState={(sessionId, storedSessionId) => updates.push({ sessionId, storedSessionId })}
+        onUpdateState={(sessionId, storedSessionId, _state, profile) =>
+          updates.push({ profile, sessionId, storedSessionId })
+        }
         refreshSessions={async () => undefined}
         requestGateway={requestGateway}
         selectedStoredSessionIdRef={storedSessionIdRef}
@@ -720,6 +847,7 @@ describe('usePromptActions /compress', () => {
 
     // Switch to session B before compression resolves.
     activeSessionIdRef.current = RUNTIME_SESSION_B
+    $activeGatewayProfile.set('beta')
     resolveCompress({
       info: { usage: { context_used: 4_000, total: 12_000 } },
       messages: [{ content: 'compressed session A transcript', role: 'system' }],
@@ -735,7 +863,7 @@ describe('usePromptActions /compress', () => {
       { id: 'foreground-b', parts: [textPart('session B transcript')], role: 'user', timestamp: 0 }
     ])
     expect($currentUsage.get()).toEqual(expect.objectContaining({ calls: 7, input: 70, output: 30, total: 100 }))
-    expect(updates).toContainEqual({ sessionId: RUNTIME_SESSION_ID, storedSessionId: 'stored-a' })
+    expect(updates).toContainEqual({ profile: 'alpha', sessionId: RUNTIME_SESSION_ID, storedSessionId: 'stored-a' })
   })
 
   it('keeps a late compression error bound to its invocation-time stored session', async () => {
@@ -926,6 +1054,8 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
   afterEach(() => {
     cleanup()
     $busy.set(false)
+    $queuedPromptsBySession.set({})
+    clearAllSessionStates()
     vi.restoreAllMocks()
   })
 
@@ -1069,7 +1199,7 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
     // The kickoff must NOT submit mid-turn — and must NOT vanish either.
     expect(calls.map(c => c.method)).toEqual(['slash.exec'])
 
-    const queued = getQueuedPrompts(RUNTIME_SESSION_ID)
+    const queued = getQueuedPrompts(sessionIdentityKey(RUNTIME_SESSION_ID, 'default'))
     expect(queued.map(entry => entry.text)).toEqual(['ship the release notes'])
 
     const renderedText = states
@@ -1161,7 +1291,9 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
     await handle!.submitText('/audit-only audit the session states')
 
     expect(calls).toEqual(['slash.exec'])
-    expect(getQueuedPrompts(RUNTIME_SESSION_ID).map(entry => entry.text)).toEqual(['audit the session states'])
+    expect(getQueuedPrompts(sessionIdentityKey(RUNTIME_SESSION_ID, 'default')).map(entry => entry.text)).toEqual([
+      'audit the session states'
+    ])
 
     dropSessionState(RUNTIME_SESSION_ID)
     $queuedPromptsBySession.set({})
@@ -1205,8 +1337,10 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
     expect(boundStoredIds).not.toHaveLength(0)
     expect(new Set(boundStoredIds)).toEqual(new Set([tileStoredId]))
     // …and the kickoff queues against the tile, never the foreground chat.
-    expect(getQueuedPrompts(tileStoredId).map(entry => entry.text)).toEqual(['run it in the tab'])
-    expect(getQueuedPrompts('primary-stored')).toEqual([])
+    expect(getQueuedPrompts(sessionIdentityKey(tileStoredId, 'default')).map(entry => entry.text)).toEqual([
+      'run it in the tab'
+    ])
+    expect(getQueuedPrompts(sessionIdentityKey('primary-stored', 'default'))).toEqual([])
 
     dropSessionState(tileRuntimeId)
     $queuedPromptsBySession.set({})
@@ -1516,6 +1650,9 @@ describe('usePromptActions submit / queue drain semantics', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    $activeGatewayProfile.set('default')
+    setSelectedStoredSessionId(null)
+    clearAllSessionStates()
   })
 
   it('clears a leftover interrupted flag on a fresh submit (so the new turn streams)', async () => {
@@ -1691,6 +1828,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
     expect(accepted).toBe(true)
     // Must resume the correct stored session to get the right runtime id.
     expect(requestGateway).toHaveBeenCalledWith('session.resume', {
+      profile: 'default',
       session_id: 'stored-session-a',
       source: 'desktop'
     })
@@ -1710,6 +1848,142 @@ describe('usePromptActions submit / queue drain semantics', () => {
         ([method, params]) => method !== 'prompt.submit' || params?.session_id !== 'rt-foreground'
       )
     ).toBe(true)
+  })
+
+  it('treats alpha/shared as background while beta/shared is selected', async () => {
+    const requestGateway = vi.fn(async (method: string) =>
+      (method === 'session.resume' ? { session_id: 'rt-alpha-rebound' } : {}) as never
+    )
+
+    $activeGatewayProfile.set('beta')
+    setSelectedStoredSessionId('shared', 'beta')
+    publishSessionState('rt-beta-foreground', {
+      ...createClientSessionState('shared'),
+      storedSessionProfile: 'beta'
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId="rt-beta-foreground"
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId="shared"
+      />
+    )
+
+    expect(
+      await handle!.submitText('queued for alpha/shared', {
+        fromQueue: true,
+        profile: 'alpha',
+        sessionId: null,
+        storedSessionId: 'shared'
+      })
+    ).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith('session.resume', {
+      profile: 'alpha',
+      session_id: 'shared',
+      source: 'desktop'
+    })
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      { session_id: 'rt-alpha-rebound', text: 'queued for alpha/shared' },
+      1_800_000
+    )
+    expect(requestGateway).not.toHaveBeenCalledWith(
+      'prompt.submit',
+      expect.objectContaining({ session_id: 'rt-beta-foreground' }),
+      expect.anything()
+    )
+  })
+
+  it('uses the captured profile gateway for a colliding background runtime id', async () => {
+    const requestGateway = vi.fn(async () => ({}) as never)
+    const requestGatewayForProfile = vi.fn(async () => ({}) as never)
+
+    $activeGatewayProfile.set('beta')
+    setSelectedStoredSessionId('shared', 'beta')
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId="rt-collision"
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        requestGatewayForProfile={requestGatewayForProfile}
+        storedSessionId="shared"
+      />
+    )
+
+    expect(
+      await handle!.submitText('alpha-owned prompt', {
+        fromQueue: true,
+        profile: 'alpha',
+        sessionId: 'rt-collision',
+        storedSessionId: 'shared'
+      })
+    ).toBe(true)
+    expect(requestGatewayForProfile).toHaveBeenCalledWith(
+      'alpha',
+      'prompt.submit',
+      { session_id: 'rt-collision', text: 'alpha-owned prompt' },
+      1_800_000
+    )
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
+  })
+
+  it('recovers a failed new-session submit with the durable id captured at create settle', async () => {
+    const activeSessionIdRef = { current: null } as MutableRefObject<null | string>
+    const selectedStoredSessionIdRef = { current: null } as MutableRefObject<null | string>
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = 'rt-created'
+      selectedStoredSessionIdRef.current = 'stored-created'
+      setSelectedStoredSessionId('stored-created', 'default')
+
+      return 'rt-created'
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        selectedStoredSessionIdRef.current = 'stored-selected-later'
+        setSelectedStoredSessionId('stored-selected-later', 'default')
+        throw new Error('request timed out: prompt.submit')
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: 'rt-recovered' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    await handle!.submitText('first prompt')
+
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.resume',
+      expect.objectContaining({ session_id: 'stored-created' })
+    )
+    expect(requestGateway).not.toHaveBeenCalledWith(
+      'session.resume',
+      expect.objectContaining({ session_id: 'stored-selected-later' })
+    )
   })
 
   it('a rejected fromQueue drain returns false (entry stays queued) and a later retry sends it', async () => {
@@ -1818,6 +2092,8 @@ describe('usePromptActions submit / queue drain semantics', () => {
 describe('usePromptActions redirectPrompt', () => {
   afterEach(() => {
     cleanup()
+    $activeGatewayProfile.set('default')
+    setSelectedStoredSessionId(null)
     vi.restoreAllMocks()
   })
 
@@ -1919,6 +2195,9 @@ describe('usePromptActions redirectPrompt', () => {
     const calls: { method: string; params?: Record<string, unknown> }[] = []
     let redirectAttempts = 0
 
+    $activeGatewayProfile.set('alpha')
+    setSelectedStoredSessionId(STORED_SESSION_ID, 'alpha')
+
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
 
@@ -1926,6 +2205,8 @@ describe('usePromptActions redirectPrompt', () => {
         redirectAttempts += 1
 
         if (redirectAttempts === 1) {
+          $activeGatewayProfile.set('beta')
+          setSelectedStoredSessionId(STORED_SESSION_ID, 'beta')
           throw new Error('session not found')
         }
 
@@ -1953,7 +2234,7 @@ describe('usePromptActions redirectPrompt', () => {
     expect(await handle!.redirectPrompt('reconnect nudge')).toBe(true)
     expect(calls.map(c => c.method)).toEqual(['session.redirect', 'session.resume', 'session.redirect'])
     expect(calls[0]?.params).toEqual({ session_id: RUNTIME_SESSION_ID, text: 'reconnect nudge' })
-    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
+    expect(calls[1]?.params).toEqual({ profile: 'alpha', session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'reconnect nudge' })
     expect(handle!.activeSessionIdRef.current).toBe(RECOVERED_SESSION_ID)
   })
@@ -2340,6 +2621,10 @@ describe('usePromptActions sleep/wake session recovery', () => {
   afterEach(() => {
     cleanup()
     $turnStartedAt.set(null)
+    $activeGatewayProfile.set('default')
+    setSelectedStoredSessionId(null)
+    clearAllSessionStates()
+    setSessions(() => [])
     vi.restoreAllMocks()
   })
 
@@ -2386,7 +2671,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(ok).toBe(true)
     // First submit (stale id) → session.resume (stored id) → retry submit (fresh id).
     expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
-    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
+    expect(calls[1]?.params).toEqual({ profile: 'default', session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'message after wake' })
   })
 
@@ -2395,6 +2680,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
   // into the wrong profile's DB — the session then appears under both profiles.
   it('carries the owning profile from the cache into the recovery resume', async () => {
     setSessions(() => [sessionInfo({ id: STORED_SESSION_ID, profile: 'work' })])
+    setSelectedStoredSessionId(STORED_SESSION_ID, 'work')
 
     const calls: { method: string; params?: Record<string, unknown> }[] = []
     let submitAttempts = 0
@@ -2531,7 +2817,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
       session_id: 'rt-background-stale',
       text: 'queued background message after wake'
     })
-    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
+    expect(calls[1]?.params).toEqual({ profile: 'default', session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({
       queued: true,
       session_id: RECOVERED_SESSION_ID,
@@ -2579,7 +2865,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
     expect(calls.map(c => c.method)).toEqual(['session.interrupt', 'session.resume', 'session.interrupt'])
     expect(calls[0]?.params).toEqual({ session_id: RUNTIME_SESSION_ID })
-    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
+    expect(calls[1]?.params).toEqual({ profile: 'default', session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID })
   })
 
@@ -2711,7 +2997,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
     expect(ok).toBe(true)
     expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
-    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
+    expect(calls[1]?.params).toEqual({ profile: 'default', session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({
       session_id: RECOVERED_SESSION_ID,
       text: 'message during starved loop'
@@ -2754,7 +3040,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(ok).toBe(true)
     expect(createBackendSessionForSend).not.toHaveBeenCalled()
     expect(calls.map(c => c.method)).toEqual(['session.resume', 'prompt.submit'])
-    expect(calls[0]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
+    expect(calls[0]?.params).toEqual({ profile: 'default', session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[1]?.params).toMatchObject({ session_id: RECOVERED_SESSION_ID })
   })
 
@@ -2827,7 +3113,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     )
 
     expect(await handle!.submitText('follow-up while the profile route is rebinding')).toBe(true)
-    expect(resumeStoredSession).toHaveBeenCalledWith(STORED_SESSION_ID)
+    expect(resumeStoredSession).toHaveBeenCalledWith(STORED_SESSION_ID, 'default')
     expect(createBackendSessionForSend).not.toHaveBeenCalled()
     expect(requestGateway).toHaveBeenCalledWith(
       'prompt.submit',
@@ -2865,10 +3151,54 @@ describe('usePromptActions sleep/wake session recovery', () => {
     )
 
     expect(await handle!.submitText('stay in the routed profile session')).toBe(true)
-    expect(resumeStoredSession).toHaveBeenCalledWith(STORED_SESSION_ID)
+    expect(resumeStoredSession).toHaveBeenCalledWith(STORED_SESSION_ID, 'default')
     expect(requestGateway).toHaveBeenCalledWith(
       'prompt.submit',
       { session_id: RECOVERED_SESSION_ID, text: 'stay in the routed profile session' },
+      1_800_000
+    )
+  })
+
+  it('uses the explicit routed profile when selected alpha/shared collides with routed beta/shared', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'rt-alpha-stale' }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'shared' }
+    let boundRuntimeId: null | string = null
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    $activeGatewayProfile.set('alpha')
+    setSelectedStoredSessionId('shared', 'alpha')
+
+    const resumeStoredSession = vi.fn(async (_storedSessionId: string, profile?: null | string) => {
+      expect(profile).toBe('beta')
+      $activeGatewayProfile.set('beta')
+      setSelectedStoredSessionId('shared', 'beta')
+      selectedStoredSessionIdRef.current = 'shared'
+      activeSessionIdRef.current = 'rt-beta-recovered'
+      boundRuntimeId = 'rt-beta-recovered'
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId="rt-alpha-stale"
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => 'shared'}
+        getRoutedStoredSessionProfile={() => 'beta'}
+        getRuntimeIdForStoredSession={() => boundRuntimeId}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        resumeStoredSession={resumeStoredSession}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId="shared"
+      />
+    )
+
+    expect(await handle!.submitText('beta route prompt')).toBe(true)
+    expect(resumeStoredSession).toHaveBeenCalledWith('shared', 'beta')
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      { session_id: 'rt-beta-recovered', text: 'beta route prompt' },
       1_800_000
     )
   })
@@ -2946,7 +3276,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(await handle!.submitText('do not fork me')).toBe(false)
     expect(busyRef.current).toBe(false)
     expect($messages.get()).toEqual([])
-    expect(resumeStoredSession).toHaveBeenCalledWith(STORED_SESSION_ID)
+    expect(resumeStoredSession).toHaveBeenCalledWith(STORED_SESSION_ID, 'default')
     expect(createBackendSessionForSend).not.toHaveBeenCalled()
     expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything(), expect.anything())
 
@@ -3011,6 +3341,9 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    $activeGatewayProfile.set('default')
+    setSelectedStoredSessionId(null)
+    clearAllSessionStates()
     setSessions(() => [])
   })
 
@@ -3064,7 +3397,64 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
     expect(await submitting).toBe(false)
     expect(calls.some(c => c.method === 'prompt.submit')).toBe(false)
     expect(calls.find(c => c.method === 'session.resume')?.params).toEqual({
+      profile: 'default',
       session_id: STORED_SESSION_A,
+      source: 'desktop'
+    })
+  })
+
+  it('keeps recovery on alpha/shared and aborts when the route switches to beta/shared', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'alpha-runtime' }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'shared' }
+    let routeToken = '/shared:?profile=alpha:'
+    let submitAttempts = 0
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    $activeGatewayProfile.set('alpha')
+    setSelectedStoredSessionId('shared', 'alpha')
+    publishSessionState('alpha-runtime', {
+      ...createClientSessionState('shared'),
+      storedSessionProfile: 'alpha'
+    })
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'prompt.submit') {
+        submitAttempts += 1
+        $activeGatewayProfile.set('beta')
+        setSelectedStoredSessionId('shared', 'beta')
+        selectedStoredSessionIdRef.current = 'shared'
+        routeToken = '/shared:?profile=beta:'
+        throw new Error('4007 session not found')
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: 'alpha-recovered' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId="alpha-runtime"
+        activeSessionIdRef={activeSessionIdRef}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId="shared"
+      />
+    )
+
+    expect(await handle!.submitText('alpha-only prompt')).toBe(false)
+    expect(submitAttempts).toBe(1)
+    expect(calls.find(c => c.method === 'session.resume')?.params).toEqual({
+      profile: 'alpha',
+      session_id: 'shared',
       source: 'desktop'
     })
   })
@@ -3101,7 +3491,9 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
 
     // The composer's scope is the lineage root (what resolveComposerSessionKey
     // actually returns for this session) — a legitimate, non-drifted submit.
-    const ok = await handle!.submitText('message into the rotated session', { composerScope: ROOT_ID })
+    const ok = await handle!.submitText('message into the rotated session', {
+      composerScope: sessionIdentityKey(ROOT_ID, 'default')
+    })
 
     expect(ok).toBe(true)
     expect(calls.some(c => c.method === 'prompt.submit')).toBe(true)
@@ -3132,7 +3524,9 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
       />
     )
 
-    const ok = await handle!.submitText('typed while B was on screen', { composerScope: STORED_SESSION_B })
+    const ok = await handle!.submitText('typed while B was on screen', {
+      composerScope: sessionIdentityKey(STORED_SESSION_B, 'default')
+    })
 
     expect(ok).toBe(false)
     expect(calls.some(c => c.method === 'prompt.submit')).toBe(false)
@@ -3157,7 +3551,9 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
       />
     )
 
-    const ok = await handle!.submitText('typed while A was on screen', { composerScope: STORED_SESSION_A })
+    const ok = await handle!.submitText('typed while A was on screen', {
+      composerScope: sessionIdentityKey(STORED_SESSION_A, 'default')
+    })
 
     expect(ok).toBe(true)
     expect(calls.some(c => c.method === 'prompt.submit')).toBe(true)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -10,6 +10,7 @@ import { pathLabel, SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
 import { triggerHaptic } from '@/lib/haptics'
 import { setMutableRef } from '@/lib/mutable-ref'
+import { parseSessionIdentityKey } from '@/lib/session-identity'
 import { normalize } from '@/lib/text'
 import { clearClarifyRequest } from '@/store/clarify'
 import {
@@ -21,16 +22,19 @@ import {
 import { resetSessionBackground } from '@/store/composer-status'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { clearAllPrompts } from '@/store/prompts'
 import {
   $busy,
   $connection,
   $messages,
+  $selectedSessionIdentityKey,
   setAwaitingResponse,
   setBusy,
   setMessages,
   setTurnStartedAt
 } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
 import { clearSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
@@ -44,7 +48,6 @@ import type {
   ImageAttachResponse,
   SessionRedirectResponse
 } from '../../../types'
-import { resolveSessionProfile } from '../use-session-actions/utils'
 
 import {
   applyBranchVisibility,
@@ -66,6 +69,7 @@ import {
   type GatewayRequest,
   inlineErrorMessage,
   isSessionNotFoundError,
+  type ProfileGatewayRequest,
   readFileDataUrlForAttach,
   readImageForRemoteAttach,
   type SubmitTextOptions
@@ -176,20 +180,23 @@ interface PromptActionsOptions {
   branchCurrentSession: () => Promise<boolean>
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
   getRoutedStoredSessionId: () => null | string
+  getRoutedStoredSessionProfile: () => null | string
   getRuntimeIdForStoredSession: (storedSessionId: string) => null | string
   getRouteToken: () => string
   handleSkinCommand: (arg: string) => string
   openMemoryGraph: () => void
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
-  resumeStoredSession: (storedSessionId: string) => Promise<void> | void
+  requestGatewayForProfile?: ProfileGatewayRequest
+  resumeStoredSession: (storedSessionId: string, profile?: null | string) => Promise<void> | void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   startFreshSessionDraft: () => void
   sttEnabled: boolean
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
-    storedSessionId?: string | null
+    storedSessionId?: string | null,
+    storedSessionProfile?: null | string
   ) => ClientSessionState
 }
 
@@ -207,12 +214,14 @@ export function usePromptActions({
   branchCurrentSession,
   createBackendSessionForSend,
   getRoutedStoredSessionId,
+  getRoutedStoredSessionProfile,
   getRuntimeIdForStoredSession,
   getRouteToken,
   handleSkinCommand,
   openMemoryGraph,
   refreshSessions,
   requestGateway,
+  requestGatewayForProfile,
   resumeStoredSession,
   selectedStoredSessionIdRef,
   startFreshSessionDraft,
@@ -228,7 +237,7 @@ export function usePromptActions({
       role: ChatMessage['role'],
       text: string,
       storedSessionId?: string | null,
-      options: { insertBeforeActiveReply?: boolean } = {}
+      options: { insertBeforeActiveReply?: boolean; storedSessionProfile?: null | string } = {}
     ) => {
       // Strip ANSI: slash-command output from the backend worker carries SGR
       // color codes (e.g. "Unknown command" in red). The ESC byte is invisible
@@ -269,12 +278,33 @@ export function usePromptActions({
 
           return { ...state, messages }
         },
-        storedSessionId ?? selectedStoredSessionIdRef.current
+        storedSessionId ?? selectedStoredSessionIdRef.current,
+        options.storedSessionProfile
       )
 
       return messageId
     },
     [selectedStoredSessionIdRef, updateSessionState]
+  )
+
+  const captureSessionTarget = useCallback(
+    (sessionId: string) => {
+      const runtimeState = $sessionStates.get()[sessionId]
+      const selectedIdentityKey = $selectedSessionIdentityKey.get()
+      const selectedIdentity = selectedIdentityKey ? parseSessionIdentityKey(selectedIdentityKey) : null
+      const storedSessionId = runtimeState?.storedSessionId ?? selectedStoredSessionIdRef.current
+
+      const selectedProfile =
+        storedSessionId && selectedIdentity?.storedSessionId === storedSessionId ? selectedIdentity.profile : null
+
+      return {
+        profile: normalizeProfileKey(
+          runtimeState?.storedSessionProfile ?? selectedProfile ?? $activeGatewayProfile.get()
+        ),
+        storedSessionId
+      }
+    },
+    [selectedStoredSessionIdRef]
   )
 
   // In-flight drop-time eager uploads, keyed by attachment id. Submit joins
@@ -286,9 +316,10 @@ export function usePromptActions({
     async (
       sessionId: string,
       attachments: ComposerAttachment[],
-      options: { updateComposerAttachments?: boolean } = {}
+      options: { requestGateway?: GatewayRequest; updateComposerAttachments?: boolean } = {}
     ): Promise<ComposerAttachment[]> => {
       const updateComposerAttachments = options.updateComposerAttachments ?? true
+      const submitGateway = options.requestGateway ?? requestGateway
       const remote = $connection.get()?.mode === 'remote'
       const synced: ComposerAttachment[] = []
 
@@ -317,7 +348,11 @@ export function usePromptActions({
         }
 
         if (attachment.kind === 'image' || attachment.kind === 'file') {
-          const nextAttachment = await uploadComposerAttachment(attachment, { remote, requestGateway, sessionId })
+          const nextAttachment = await uploadComposerAttachment(attachment, {
+            remote,
+            requestGateway: submitGateway,
+            sessionId
+          })
 
           // Update-only: never resurrect a chip the user removed mid-upload.
           if (updateComposerAttachments) {
@@ -401,9 +436,11 @@ export function usePromptActions({
     copy,
     createBackendSessionForSend,
     getRoutedStoredSessionId,
+    getRoutedStoredSessionProfile,
     getRuntimeIdForStoredSession,
     getRouteToken,
     requestGateway,
+    requestGatewayForProfile,
     resumeStoredSession,
     selectedStoredSessionIdRef,
     syncAttachmentsForSubmit,
@@ -500,12 +537,14 @@ export function usePromptActions({
     copy,
     createBackendSessionForSend,
     getRoutedStoredSessionId,
+    getRoutedStoredSessionProfile,
     getRuntimeIdForStoredSession,
     handleSkinCommand,
     handoffSession,
     openMemoryGraph,
     refreshSessions,
     requestGateway,
+    requestGatewayForProfile,
     resumeStoredSession,
     selectedStoredSessionIdRef,
     startFreshSessionDraft,
@@ -522,7 +561,16 @@ export function usePromptActions({
         triggerHaptic('selection')
         // Forward the explicit target (background queue drain, tile) — dropping
         // it ran the command against whatever chat happened to be in front.
-        await executeSlashCommand(visibleText, options?.sessionId ? { sessionId: options.sessionId } : undefined)
+        await executeSlashCommand(
+          visibleText,
+          options
+            ? {
+                profile: options.profile,
+                sessionId: options.sessionId,
+                storedSessionId: options.storedSessionId
+              }
+            : undefined
+        )
 
         return true
       }
@@ -557,6 +605,7 @@ export function usePromptActions({
     // The ref is updated via useEffect on every activeSessionId change, so it
     // always reflects the current session — same pattern submitText uses.
     const sessionId = activeSessionIdRef.current
+    const target = sessionId ? captureSessionTarget(sessionId) : null
 
     const releaseBusy = () => {
       setMutableRef(busyRef, false)
@@ -573,22 +622,27 @@ export function usePromptActions({
       return
     }
 
-    updateSessionState(sessionId, state => {
-      const streamId = state.streamId
-      const messages = finalizeInterruptedMessages(state.messages, streamId)
+    updateSessionState(
+      sessionId,
+      state => {
+        const streamId = state.streamId
+        const messages = finalizeInterruptedMessages(state.messages, streamId)
 
-      return {
-        ...state,
-        messages,
-        busy: false,
-        awaitingResponse: false,
-        streamId: null,
-        pendingBranchGroup: null,
-        needsInput: false,
-        interrupted: true,
-        turnStartedAt: null
-      }
-    })
+        return {
+          ...state,
+          messages,
+          busy: false,
+          awaitingResponse: false,
+          streamId: null,
+          pendingBranchGroup: null,
+          needsInput: false,
+          interrupted: true,
+          turnStartedAt: null
+        }
+      },
+      target?.storedSessionId,
+      target?.profile
+    )
 
     clearSessionTodos(sessionId)
     clearSessionSubagents(sessionId)
@@ -598,7 +652,7 @@ export function usePromptActions({
     // raised. Drop this session's pending clarify / approval / sudo / secret so
     // a dead panel (and the sidebar "needs input" dot) can't linger and accept
     // an answer the backend will reject.
-    clearAllPrompts(sessionId)
+    clearAllPrompts(sessionId, target?.profile)
     clearClarifyRequest(undefined, sessionId)
 
     try {
@@ -607,14 +661,12 @@ export function usePromptActions({
     } catch (err) {
       let stopError = err
 
-      if (isSessionNotFoundError(err) && selectedStoredSessionIdRef.current) {
+      if (isSessionNotFoundError(err) && target?.storedSessionId) {
         try {
-          const resumeProfile = await resolveSessionProfile(selectedStoredSessionIdRef.current)
-
           const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-            session_id: selectedStoredSessionIdRef.current,
+            session_id: target.storedSessionId,
             source: 'desktop',
-            ...(resumeProfile ? { profile: resumeProfile } : {})
+            profile: target.profile
           })
 
           const recoveredId = resumed?.session_id
@@ -634,7 +686,7 @@ export function usePromptActions({
       releaseBusy()
       notifyError(stopError, copy.stopFailed)
     }
-  }, [activeSessionIdRef, busyRef, copy.stopFailed, requestGateway, selectedStoredSessionIdRef, updateSessionState])
+  }, [activeSessionIdRef, busyRef, captureSessionTarget, copy.stopFailed, requestGateway, updateSessionState])
 
   // The desktop steering action is an immediate correction: the core cancels
   // model generation and rebuilds the live turn with displayed reasoning and
@@ -647,6 +699,7 @@ export function usePromptActions({
       // reaches the live model mid-turn, so a stale target delivers the user's
       // correction into a conversation they are no longer looking at.
       const sessionId = activeSessionIdRef.current
+      const target = sessionId ? captureSessionTarget(sessionId) : null
 
       if (!text || !sessionId) {
         return false
@@ -662,22 +715,35 @@ export function usePromptActions({
         // its RPC response. Insert before the live reply *before* awaiting the
         // gateway; appending after the response leaves the correction below a
         // reply that the redirect has already replaced.
-        const messageId = appendSessionTextMessage(id, 'user', text, undefined, { insertBeforeActiveReply: true })
+        const messageId = appendSessionTextMessage(id, 'user', text, target?.storedSessionId, {
+          insertBeforeActiveReply: true,
+          storedSessionProfile: target?.profile
+        })
 
         const discardOptimisticMessage = () =>
-          updateSessionState(id, state => ({
-            ...state,
-            messages: state.messages.filter(message => message.id !== messageId)
-          }))
+          updateSessionState(
+            id,
+            state => ({
+              ...state,
+              messages: state.messages.filter(message => message.id !== messageId)
+            }),
+            target?.storedSessionId,
+            target?.profile
+          )
 
         const moveOptimisticMessageToEnd = () =>
-          updateSessionState(id, state => {
-            const message = state.messages.find(candidate => candidate.id === messageId)
+          updateSessionState(
+            id,
+            state => {
+              const message = state.messages.find(candidate => candidate.id === messageId)
 
-            return message
-              ? { ...state, messages: [...state.messages.filter(candidate => candidate.id !== messageId), message] }
-              : state
-          })
+              return message
+                ? { ...state, messages: [...state.messages.filter(candidate => candidate.id !== messageId), message] }
+                : state
+            },
+            target?.storedSessionId,
+            target?.profile
+          )
 
         try {
           const result = await requestGateway<SessionRedirectResponse>('session.redirect', { session_id: id, text })
@@ -712,14 +778,12 @@ export function usePromptActions({
         // A stale runtime id after reconnect 404s ("session not found"): resume
         // the stored session and retry once, mirroring stopPrompt so a
         // correction right after a reconnect isn't lost to the race.
-        if (isSessionNotFoundError(err) && selectedStoredSessionIdRef.current) {
+        if (isSessionNotFoundError(err) && target?.storedSessionId) {
           try {
-            const resumeProfile = await resolveSessionProfile(selectedStoredSessionIdRef.current)
-
             const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-              session_id: selectedStoredSessionIdRef.current,
+              session_id: target.storedSessionId,
               source: 'desktop',
-              ...(resumeProfile ? { profile: resumeProfile } : {})
+              profile: target.profile
             })
 
             const recoveredId = resumed?.session_id
@@ -738,7 +802,7 @@ export function usePromptActions({
 
       return false
     },
-    [activeSessionIdRef, appendSessionTextMessage, requestGateway, selectedStoredSessionIdRef, updateSessionState]
+    [activeSessionIdRef, appendSessionTextMessage, captureSessionTarget, requestGateway, updateSessionState]
   )
 
   const reloadFromMessage = useCallback(

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/resolve-target-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/resolve-target-session.test.ts
@@ -42,6 +42,25 @@ describe('resolveTargetSessionId', () => {
     })
   })
 
+  it('uses the captured owner profile instead of resolving against a later active profile', async () => {
+    const requestGateway = vi.fn(async () => ({ session_id: RECOVERED }))
+
+    await resolveTargetSessionId(
+      deps({
+        requestGateway: requestGateway as never,
+        routedStoredSessionId: 'shared',
+        selectedStoredSessionId: 'shared',
+        targetProfile: 'alpha'
+      })
+    )
+
+    expect(requestGateway).toHaveBeenCalledWith('session.resume', {
+      session_id: 'shared',
+      source: 'desktop',
+      profile: 'alpha'
+    })
+  })
+
   it('reuses the live runtime id when the cache confirms it owns the targeted stored session', async () => {
     const createSession = vi.fn(async () => 'rt-brand-new-WRONG')
     const requestGateway = vi.fn(async () => ({ session_id: 'rt-resume-WRONG' }))

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/resolve-target-session.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/resolve-target-session.ts
@@ -49,6 +49,7 @@ export interface ResolveTargetSessionDeps {
   requestGateway: GatewayRequest
   routedStoredSessionId: null | string
   selectedStoredSessionId: null | string
+  targetProfile?: null | string
 }
 
 export async function resolveTargetSessionId(deps: ResolveTargetSessionDeps): Promise<null | string> {
@@ -59,7 +60,8 @@ export async function resolveTargetSessionId(deps: ResolveTargetSessionDeps): Pr
     getRuntimeIdForStoredSession,
     requestGateway,
     routedStoredSessionId,
-    selectedStoredSessionId
+    selectedStoredSessionId,
+    targetProfile
   } = deps
 
   // 1. An explicit target always wins — the caller knows which session it means.
@@ -89,7 +91,7 @@ export async function resolveTargetSessionId(deps: ResolveTargetSessionDeps): Pr
 
   if (storedTarget) {
     try {
-      const profile = await resolveSessionProfile(storedTarget)
+      const profile = targetProfile ?? (await resolveSessionProfile(storedTarget))
 
       const resumed = await requestGateway<{ session_id?: string }>('session.resume', {
         session_id: storedTarget,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -15,6 +15,7 @@ import {
   resolveDesktopCommand
 } from '@/lib/desktop-slash-commands'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
+import { parseSessionIdentityKey, sessionIdentityKey } from '@/lib/session-identity'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { openCommandPalettePage } from '@/store/command-palette'
 import { setComposerDraft } from '@/store/composer'
@@ -26,6 +27,7 @@ import { $petGenInput, openPetGenerate } from '@/store/pet-generate'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import {
   $connection,
+  $selectedSessionIdentityKey,
   $sessions,
   $yoloActive,
   resolveComposerSessionKey,
@@ -44,12 +46,14 @@ import type {
   SessionTitleResponse,
   SlashExecResponse
 } from '../../../types'
+import { resolveSessionProfile } from '../use-session-actions/utils'
 
 import { resolveTargetSessionId } from './resolve-target-session'
 import {
   type GatewayRequest,
   isSessionIdCandidate,
   isTargetSessionBusy,
+  type ProfileGatewayRequest,
   renderCommandsCatalog,
   renderRpcResult,
   slashStatusText,
@@ -76,13 +80,15 @@ interface SlashCommandDeps {
     sessionId: string,
     role: ChatMessage['role'],
     text: string,
-    storedSessionId?: string | null
+    storedSessionId?: string | null,
+    options?: { insertBeforeActiveReply?: boolean; storedSessionProfile?: null | string }
   ) => void
   branchCurrentSession: () => Promise<boolean>
   busyRef: MutableRefObject<boolean>
   copy: Translations['desktop']
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
   getRoutedStoredSessionId: () => null | string
+  getRoutedStoredSessionProfile: () => null | string
   getRuntimeIdForStoredSession: (storedSessionId: string) => null | string
   handleSkinCommand: (arg: string) => string
   handoffSession: (
@@ -92,14 +98,16 @@ interface SlashCommandDeps {
   openMemoryGraph: () => void
   refreshSessions: () => Promise<void>
   requestGateway: GatewayRequest
-  resumeStoredSession: (storedSessionId: string) => Promise<void> | void
+  requestGatewayForProfile?: ProfileGatewayRequest
+  resumeStoredSession: (storedSessionId: string, profile?: null | string) => Promise<void> | void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   startFreshSessionDraft: () => void
   submitPromptText: (rawText: string, options?: SubmitTextOptions) => Promise<boolean>
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
-    storedSessionId?: string | null
+    storedSessionId?: string | null,
+    storedSessionProfile?: null | string
   ) => ClientSessionState
 }
 
@@ -113,12 +121,14 @@ export function useSlashCommand(deps: SlashCommandDeps) {
     copy,
     createBackendSessionForSend,
     getRoutedStoredSessionId,
+    getRoutedStoredSessionProfile,
     getRuntimeIdForStoredSession,
     handleSkinCommand,
     handoffSession,
     openMemoryGraph,
     refreshSessions,
     requestGateway,
+    requestGatewayForProfile,
     resumeStoredSession,
     selectedStoredSessionIdRef,
     startFreshSessionDraft,
@@ -129,7 +139,48 @@ export function useSlashCommand(deps: SlashCommandDeps) {
   const compressInFlightRef = useRef(new Set<string>())
 
   return useCallback(
-    async (rawCommand: string, options?: { sessionId?: string; recordInput?: boolean }) => {
+    async (
+      rawCommand: string,
+      options?: {
+        profile?: null | string
+        recordInput?: boolean
+        sessionId?: null | string
+        storedSessionId?: null | string
+      }
+    ) => {
+      const routedStoredSessionId = options?.storedSessionId ?? getRoutedStoredSessionId()
+      const routedStoredSessionProfile = options?.storedSessionId ? options.profile : getRoutedStoredSessionProfile()
+      const selectedStoredSessionId = options?.storedSessionId ?? selectedStoredSessionIdRef.current
+      const selectedIdentityKey = $selectedSessionIdentityKey.get()
+      const selectedIdentity = selectedIdentityKey ? parseSessionIdentityKey(selectedIdentityKey) : null
+
+      const selectedOwnerProfile =
+        selectedStoredSessionId && selectedIdentity?.storedSessionId === selectedStoredSessionId
+          ? selectedIdentity.profile
+          : null
+
+      const fallbackProfile = $activeGatewayProfile.get()
+
+      const resolvedOwnerProfile =
+        options?.profile ||
+        routedStoredSessionProfile ||
+        $sessionStates.get()[options?.sessionId ?? '']?.storedSessionProfile ||
+        selectedOwnerProfile ||
+        (routedStoredSessionId || selectedStoredSessionId
+          ? await resolveSessionProfile(routedStoredSessionId ?? selectedStoredSessionId)
+          : undefined)
+
+      // Capture the target owner before any create/resume/command await. A
+      // profile switch while a slash command is resolving must not re-home it.
+      const targetProfile = normalizeProfileKey(resolvedOwnerProfile ?? fallbackProfile)
+
+      const requestTargetGateway: GatewayRequest = (method, params, timeoutMs) =>
+        requestGatewayForProfile
+          ? requestGatewayForProfile(targetProfile, method, params, timeoutMs)
+          : timeoutMs === undefined
+            ? requestGateway(method, params)
+            : requestGateway(method, params, timeoutMs)
+
       // Resolve the session this command targets through the SHARED ladder that
       // submit.ts uses. A slash command runs backend commands against a runtime
       // session, and per-session state (`/goal`, `/usage`, `/status`) is keyed by
@@ -145,9 +196,10 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           createSession: () => createBackendSessionForSend(preview),
           explicitRuntimeId: sessionHint,
           getRuntimeIdForStoredSession,
-          requestGateway,
-          routedStoredSessionId: getRoutedStoredSessionId(),
-          selectedStoredSessionId: selectedStoredSessionIdRef.current
+          requestGateway: requestTargetGateway,
+          routedStoredSessionId,
+          selectedStoredSessionId,
+          targetProfile
         })
 
       // Resolve the target session plus a writer for inline slash output, or
@@ -155,7 +207,17 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       // build-renderSlashOutput boilerplate every exec-style handler repeats.
       const withSlashOutput = async (
         ctx: SlashActionCtx
-      ): Promise<{ render: (text: string) => void; sessionId: string; storedSessionId: string | null } | null> => {
+      ): Promise<{
+        render: (text: string) => void
+        sessionId: string
+        storedSessionId: string | null
+        storedSessionProfile: string
+      } | null> => {
+        // A draft may not have published runtime state yet. Snapshot its owner
+        // before session creation/resume awaits so a profile switch cannot
+        // re-home the command after it starts.
+        const fallbackSessionProfile = targetProfile
+
         // A slash on a fresh draft creates the backend session; seed the
         // sidebar preview with the typed command so the row doesn't sit as
         // "Untitled session" (auto-title only fires after a full exchange,
@@ -176,7 +238,14 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         // to updateSessionState re-keyed the tile's cache entry onto the
         // primary's stored session. Fall back to the selection only for a
         // session with no published state yet (a draft this call just created).
-        const storedSessionId = $sessionStates.get()[sessionId]?.storedSessionId ?? selectedStoredSessionIdRef.current
+        const publishedState = $sessionStates.get()[sessionId]
+
+        const storedSessionId =
+          publishedState?.storedSessionId ?? options?.storedSessionId ?? selectedStoredSessionIdRef.current
+
+        const storedSessionProfile = normalizeProfileKey(
+          publishedState?.storedSessionProfile ?? fallbackSessionProfile
+        )
 
         // Header carries the command token only. The full invocation would
         // duplicate long args — `/goal <prose>` echoed the whole goal in the
@@ -186,10 +255,29 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             sessionId,
             'system',
             ctx.recordInput ? slashStatusText(`/${ctx.name}`, text) : text,
-            storedSessionId
+            storedSessionId,
+            { storedSessionProfile }
           )
 
-        return { render, sessionId, storedSessionId }
+        return { render, sessionId, storedSessionId, storedSessionProfile }
+      }
+
+      const updateStoredSessionTitle = (
+        storedSessionId: string | null,
+        storedSessionProfile: string,
+        title: string | null
+      ) => {
+        if (!storedSessionId) {
+          return
+        }
+
+        const targetIdentity = sessionIdentityKey(storedSessionId, storedSessionProfile)
+
+        setSessions(prev =>
+          prev.map(session =>
+            sessionIdentityKey(session.id, session.profile) === targetIdentity ? { ...session, title } : session
+          )
+        )
       }
 
       // `exec` commands (and unknown skill / quick commands the backend owns)
@@ -288,7 +376,12 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             // rather than re-reading the globals here — a session switch between
             // dispatch and this branch would otherwise queue the kickoff on
             // whichever chat is now in front.
-            const queueKey = resolveComposerSessionKey(storedSessionId, $sessions.get()) || storedSessionId || sessionId
+            const targetProfile =
+              $sessionStates.get()[sessionId]?.storedSessionProfile ?? $activeGatewayProfile.get()
+
+            const queueKey =
+              resolveComposerSessionKey(storedSessionId, $sessions.get(), targetProfile) ||
+              sessionIdentityKey(storedSessionId || sessionId, targetProfile)
 
             if (enqueueQueuedPrompt(queueKey, { attachments: [], text: message, displayText })) {
               renderSlashOutput('session busy — message queued to send when the current turn finishes')
@@ -303,15 +396,21 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           // same pair the output writer and the busy gate above already use.
           // Bare `submitPromptText(message)` let submit re-resolve from
           // `activeSessionIdRef`, which names the FOREGROUND chat: a `/work`
-          // typed into a fresh ⌘T tab loaded the skill in that tab, then fired
-          // its kickoff as a user message into whatever conversation was on
-          // screen. Every other target the dispatcher serves (tile, background
-          // queue drain, a session created by this very call) had the same leak.
-          await submitPromptText(message, { sessionId, storedSessionId, displayText })
+          // typed into a fresh ⌘T tab loaded the skill in that tab, printed
+          // "⚡ loading skill" there, then fired its kickoff as a user message
+          // into whatever conversation was on screen. Every other target the
+          // dispatcher serves (tile, background queue drain, a session created
+          // by this very call) had the same leak.
+          await submitPromptText(message, {
+            profile: $sessionStates.get()[sessionId]?.storedSessionProfile ?? $activeGatewayProfile.get(),
+            sessionId,
+            storedSessionId,
+            displayText
+          })
         }
 
         try {
-          const result = await requestGateway<unknown>('slash.exec', {
+          const result = await requestTargetGateway<unknown>('slash.exec', {
             session_id: sessionId,
             command: command.replace(/^\/+/, '')
           })
@@ -347,7 +446,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
         try {
           const dispatch = parseCommandDispatch(
-            await requestGateway<unknown>('command.dispatch', { session_id: sessionId, name, arg })
+            await requestTargetGateway<unknown>('command.dispatch', { session_id: sessionId, name, arg })
           )
 
           if (!dispatch) {
@@ -403,7 +502,10 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           // Forward the surface's declared timeout when present; the default
           // requestGateway layer keeps (30s) is too tight for RPCs that do
           // real work.
-          const result = await requestGateway<unknown>(surface.rpc, params, surface.timeoutMs)
+          const result = await (requestGatewayForProfile
+            ? requestTargetGateway<unknown>(surface.rpc, params, surface.timeoutMs)
+            : requestGateway<unknown>(surface.rpc, params, surface.timeoutMs))
+
           const body = renderRpcResult(result, ctx.name)
 
           renderSlashOutput(body || `/${ctx.name}: no output`)
@@ -453,17 +555,18 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             return
           }
 
-          const { render: renderSlashOutput, sessionId, storedSessionId } = resolved
+          const { render: renderSlashOutput, sessionId, storedSessionId, storedSessionProfile } = resolved
           const focusTopic = ctx.arg.trim()
-          const noticeId = `session-compress:${sessionId}`
+          const operationKey = sessionIdentityKey(sessionId, storedSessionProfile)
+          const noticeId = `session-compress:${operationKey}`
 
           // Coalesce concurrent compress requests for the same session so a
           // double-enter doesn't fire two LLM summarise calls.
-          if (compressInFlightRef.current.has(sessionId)) {
+          if (compressInFlightRef.current.has(operationKey)) {
             return
           }
 
-          compressInFlightRef.current.add(sessionId)
+          compressInFlightRef.current.add(operationKey)
           notify({
             durationMs: 0,
             id: noticeId,
@@ -472,7 +575,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           })
 
           try {
-            const result = await requestGateway<SessionCompressResponse>(
+            const result = await requestTargetGateway<SessionCompressResponse>(
               'session.compress',
               {
                 session_id: sessionId,
@@ -491,7 +594,8 @@ export function useSlashCommand(deps: SlashCommandDeps) {
               updateSessionState(
                 sessionId,
                 state => ({ ...state, messages: toChatMessages(result.messages!) }),
-                storedSessionId
+                storedSessionId,
+                storedSessionProfile
               )
             }
 
@@ -502,11 +606,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             }
 
             if (result?.info?.title !== undefined) {
-              setSessions(prev =>
-                prev.map(session =>
-                  session.id === sessionId ? { ...session, title: result.info!.title || null } : session
-                )
-              )
+              updateStoredSessionTitle(storedSessionId, storedSessionProfile, result.info.title || null)
             }
 
             if (result?.summary?.headline) {
@@ -568,7 +668,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
             renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
           } finally {
-            compressInFlightRef.current.delete(sessionId)
+            compressInFlightRef.current.delete(operationKey)
           }
         },
         // /yolo maps to the status-bar YOLO control — a per-session approval
@@ -586,7 +686,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           }
 
           try {
-            const active = await setSessionYolo(requestGateway, sid, next)
+            const active = await setSessionYolo(requestTargetGateway, sid, next)
             appendSessionTextMessage(sid, 'system', copy.yoloSystem(active))
           } catch {
             notify({ kind: 'error', title: copy.yoloTitle, message: copy.yoloToggleFailed })
@@ -687,11 +787,11 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             return
           }
 
-          const { render: renderSlashOutput, sessionId } = resolved
+          const { render: renderSlashOutput, sessionId, storedSessionId, storedSessionProfile } = resolved
           const { arg } = ctx
 
           try {
-            const result = await requestGateway<SessionTitleResponse>('session.title', {
+            const result = await requestTargetGateway<SessionTitleResponse>('session.title', {
               session_id: sessionId,
               title: arg
             })
@@ -699,7 +799,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             const finalTitle = (result?.title || arg).trim()
             const queued = result?.pending === true
 
-            setSessions(prev => prev.map(s => (s.id === sessionId ? { ...s, title: finalTitle || null } : s)))
+            updateStoredSessionTitle(storedSessionId, storedSessionProfile, finalTitle || null)
             await refreshSessions().catch(() => undefined)
             renderSlashOutput(
               finalTitle
@@ -720,7 +820,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           const { render: renderSlashOutput, sessionId } = resolved
 
           try {
-            const catalog = await requestGateway<CommandsCatalogLike>('commands.catalog', { session_id: sessionId })
+            const catalog = await requestTargetGateway<CommandsCatalogLike>('commands.catalog', { session_id: sessionId })
 
             renderSlashOutput(renderCommandsCatalog(catalog, copy))
           } catch (err) {
@@ -768,7 +868,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
               return
             }
 
-            setPetScale(requestGateway, value)
+            setPetScale(requestTargetGateway, value)
 
             return
           }
@@ -815,7 +915,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           }
 
           try {
-            const result = await requestGateway<BrowserManageResponse>('browser.manage', {
+            const result = await requestTargetGateway<BrowserManageResponse>('browser.manage', {
               action: cmdAction,
               session_id: sessionId,
               ...(url && { url })
@@ -877,7 +977,12 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           return
         }
 
-        const sessions = $sessions.get()
+        const activeProfile = normalizeProfileKey($activeGatewayProfile.get())
+
+        const sessions = $sessions
+          .get()
+          .filter(session => normalizeProfileKey(session.profile) === activeProfile)
+
         const lower = query.toLowerCase()
 
         const match =
@@ -950,7 +1055,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         }
       }
 
-      await runSlash(rawCommand, options?.sessionId, options?.recordInput ?? true)
+      await runSlash(rawCommand, options?.sessionId ?? undefined, options?.recordInput ?? true)
     },
     [
       activeSessionIdRef,
@@ -960,12 +1065,14 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       copy,
       createBackendSessionForSend,
       getRoutedStoredSessionId,
+      getRoutedStoredSessionProfile,
       getRuntimeIdForStoredSession,
       handleSkinCommand,
       handoffSession,
       openMemoryGraph,
       refreshSessions,
       requestGateway,
+      requestGatewayForProfile,
       resumeStoredSession,
       selectedStoredSessionIdRef,
       startFreshSessionDraft,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -6,6 +6,7 @@ import { type ChatMessage, textPart } from '@/lib/chat-messages'
 import { optimisticAttachmentRef } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
 import { setMutableRef } from '@/lib/mutable-ref'
+import { parseSessionIdentityKey, sessionIdentityKey } from '@/lib/session-identity'
 import {
   isVoicePlaybackActive,
   markVoicePlaybackInterrupted,
@@ -20,7 +21,15 @@ import {
 } from '@/store/composer'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
-import { $sessions, resolveComposerSessionKey, setAwaitingResponse, setBusy, setMessages } from '@/store/session'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import {
+  $selectedSessionIdentityKey,
+  $sessions,
+  resolveComposerSessionKey,
+  setAwaitingResponse,
+  setBusy,
+  setMessages
+} from '@/store/session'
 import { $sessionStates } from '@/store/session-states'
 
 import type { ClientSessionState } from '../../../types'
@@ -36,6 +45,7 @@ import {
   isSessionBusyError,
   isSessionNotFoundError,
   isTargetSessionBusy,
+  type ProfileGatewayRequest,
   type SubmitTextOptions,
   withSessionBusyRetry
 } from './utils'
@@ -46,20 +56,23 @@ interface SubmitPromptDeps {
   copy: Translations['desktop']
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
   getRoutedStoredSessionId: () => null | string
+  getRoutedStoredSessionProfile: () => null | string
   getRuntimeIdForStoredSession: (storedSessionId: string) => null | string
   getRouteToken: () => string
   requestGateway: GatewayRequest
-  resumeStoredSession: (storedSessionId: string) => Promise<void> | void
+  requestGatewayForProfile?: ProfileGatewayRequest
+  resumeStoredSession: (storedSessionId: string, profile?: null | string) => Promise<void> | void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   syncAttachmentsForSubmit: (
     sessionId: string,
     attachments: ComposerAttachment[],
-    options?: { updateComposerAttachments?: boolean }
+    options?: { requestGateway?: GatewayRequest; updateComposerAttachments?: boolean }
   ) => Promise<ComposerAttachment[]>
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
-    storedSessionId?: string | null
+    storedSessionId?: string | null,
+    storedSessionProfile?: null | string
   ) => ClientSessionState
   /** Composer-scope seams: the main chat runs on the module-level globals
    *  (defaults); a session tile injects its own so a tile submit never writes
@@ -91,9 +104,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
     copy,
     createBackendSessionForSend,
     getRoutedStoredSessionId,
+    getRoutedStoredSessionProfile,
     getRuntimeIdForStoredSession,
     getRouteToken,
     requestGateway,
+    requestGatewayForProfile,
     resumeStoredSession,
     selectedStoredSessionIdRef,
     syncAttachmentsForSubmit,
@@ -171,26 +186,6 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // so the backend notes the interruption to the model.
       const interrupted = takeVoicePlaybackInterrupted()
 
-      // Queue drains carry their source session explicitly. A background drain
-      // must never inherit the currently selected session after the user moves
-      // to another chat.
-      const targetStoredSessionId = options?.storedSessionId ?? selectedStoredSessionIdRef.current
-
-      const targetStartedInCurrentView =
-        !targetStoredSessionId || targetStoredSessionId === selectedStoredSessionIdRef.current
-
-      // A queued/background drain whose runtime binding was reaped must NOT
-      // inherit the foreground runtime id when its storedSessionId targets a
-      // different session — that would land the queued prompt in whichever
-      // session the user happens to be viewing (cross-session leak). When the
-      // drain is for the current view (no storedSessionId, or it matches the
-      // foreground), the foreground runtime is correct and must be kept.
-      const isBackgroundQueueDrain = Boolean(
-        options?.fromQueue && options?.storedSessionId && options.storedSessionId !== selectedStoredSessionIdRef.current
-      )
-
-      let sessionId: null | string = options?.sessionId ?? (isBackgroundQueueDrain ? null : activeSessionIdRef.current)
-
       // Pin the foreground session context for the whole async submit pipeline.
       // Without this, a fast session switch during session.resume / file.attach
       // can redirect the user's text into a different chat (#54527). Mutable —
@@ -199,6 +194,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       const startingActiveSessionId = activeSessionIdRef.current
       const selectedStoredSessionId = selectedStoredSessionIdRef.current
       const routedStoredSessionId = getRoutedStoredSessionId()
+      const routedStoredSessionProfile = getRoutedStoredSessionProfile()
 
       const routedRuntimeId = routedStoredSessionId ? getRuntimeIdForStoredSession(routedStoredSessionId) : null
 
@@ -215,6 +211,74 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       let startingRouteToken = getRouteToken()
 
+      // Queue drains carry their source session explicitly. Otherwise the route
+      // wins over a stale selection when its runtime binding needs recovery.
+      const targetStoredSessionId = options?.storedSessionId ?? startingStoredSessionId
+      let recoveryStoredSessionId = targetStoredSessionId
+      const selectedIdentityKey = $selectedSessionIdentityKey.get()
+      const selectedIdentity = selectedIdentityKey ? parseSessionIdentityKey(selectedIdentityKey) : null
+      const targetRuntimeState = $sessionStates.get()[guardSessionId ?? '']
+
+      const selectedOwnerProfile =
+        targetStoredSessionId && selectedIdentity?.storedSessionId === targetStoredSessionId
+          ? selectedIdentity.profile
+          : null
+
+      const runtimeOwnerProfile =
+        targetStoredSessionId && targetRuntimeState?.storedSessionId === targetStoredSessionId
+          ? targetRuntimeState.storedSessionProfile
+          : null
+
+      const routedOwnerProfile =
+        targetStoredSessionId && targetStoredSessionId === routedStoredSessionId
+          ? routedStoredSessionProfile
+          : null
+
+      // Resolve an uncached durable target before the rest of the submit can
+      // await attachments or gateway work. resolveStoredSession snapshots the
+      // active profile at invocation, so a later profile switch cannot change
+      // the owner selected here.
+      const fallbackProfile = $activeGatewayProfile.get()
+
+      const resolvedOwnerProfile =
+        options?.profile ||
+        routedOwnerProfile ||
+        runtimeOwnerProfile ||
+        selectedOwnerProfile ||
+        (targetStoredSessionId ? await resolveSessionProfile(targetStoredSessionId) : undefined)
+
+      const targetProfile = normalizeProfileKey(resolvedOwnerProfile ?? fallbackProfile)
+
+      const requestTargetGateway: GatewayRequest = (method, params, timeoutMs) =>
+        requestGatewayForProfile
+          ? requestGatewayForProfile(targetProfile, method, params, timeoutMs)
+          : timeoutMs === undefined
+            ? requestGateway(method, params)
+            : requestGateway(method, params, timeoutMs)
+
+      const targetIdentityKey = targetStoredSessionId
+        ? sessionIdentityKey(targetStoredSessionId, targetProfile)
+        : null
+
+      const targetStartedInCurrentView = Boolean(
+        !targetStoredSessionId ||
+        selectedIdentityKey === targetIdentityKey ||
+        (routedStoredSessionId === targetStoredSessionId &&
+          sessionIdentityKey(routedStoredSessionId, routedStoredSessionProfile ?? fallbackProfile) === targetIdentityKey) ||
+        (!selectedIdentityKey &&
+          targetStoredSessionId === selectedStoredSessionId &&
+          normalizeProfileKey(fallbackProfile) === targetProfile)
+      )
+
+      // A queued/background drain whose runtime binding was reaped must NOT
+      // inherit the foreground runtime id. Compare the full durable identity:
+      // alpha/shared is background while beta/shared is selected.
+      const isBackgroundQueueDrain = Boolean(
+        options?.fromQueue && options?.storedSessionId && !targetStartedInCurrentView
+      )
+
+      let sessionId: null | string = options?.sessionId ?? (isBackgroundQueueDrain ? null : startingActiveSessionId)
+
       // Reason string (or null) for why the session context genuinely drifted
       // under this in-flight submit. sessionContextDrift ignores the churn a
       // busy gateway produces (selection null-resets on a gateway/profile
@@ -227,12 +291,19 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // pipeline's own re-home) is never counted as drift.
       const sessionDriftReason = (): string | null =>
         targetStartedInCurrentView
-          ? sessionContextDrift({
+          ? (() => {
+              const nowIdentityKey = $selectedSessionIdentityKey.get()
+              const nowIdentity = nowIdentityKey ? parseSessionIdentityKey(nowIdentityKey) : null
+
+              return sessionContextDrift({
               startRouteToken: startingRouteToken,
               nowRouteToken: getRouteToken(),
               startSelectedStoredId: startingStoredSessionId,
               nowSelectedStoredId: selectedStoredSessionIdRef.current,
+              startSelectedProfile: targetProfile,
+              nowSelectedProfile: nowIdentity?.profile ?? $activeGatewayProfile.get(),
               submitTargetStoredId: startingStoredSessionId,
+              submitTargetProfile: targetProfile,
               composerScope: options?.composerScope,
               // The composer keys drafts/attachments on the durable lineage
               // root (survives auto-compression tip rotation), while
@@ -240,8 +311,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
               // into the same lineage-root domain before comparing, or every
               // submit into a session that has ever compressed would
               // false-positive-abort.
-              submitTargetComposerScope: resolveComposerSessionKey(startingStoredSessionId, $sessions.get())
-            })
+              submitTargetComposerScope: resolveComposerSessionKey(
+                startingStoredSessionId,
+                $sessions.get(),
+                targetProfile
+              )
+              })
+            })()
           : null
 
       const targetIsCurrentView = (): boolean => targetStartedInCurrentView && !sessionDriftReason()
@@ -250,7 +326,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // stalled turn can't stack the same prompt into multiple real turns. The
       // foreground ChatBar and background drainers can briefly overlap during a
       // session switch; this per-session lock makes that safe.
-      const submitLockKey = targetStoredSessionId || sessionId || startingActiveSessionId || '__pending_new__'
+      const submitLockKey = `${targetProfile}\u0000${targetStoredSessionId || sessionId || startingActiveSessionId || '__pending_new__'}`
 
       if (_submitInFlight.has(submitLockKey)) {
         return false
@@ -310,7 +386,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // (what made drained-after-interrupt sends go silent).
             interrupted: false
           }),
-          targetStoredSessionId
+          targetStoredSessionId,
+          targetProfile
         )
 
       // After sync rewrites refs, refresh the optimistic message in place so the
@@ -322,7 +399,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             ...state,
             messages: state.messages.map(message => (message.id === optimisticId ? buildUserMessage() : message))
           }),
-          targetStoredSessionId
+          targetStoredSessionId,
+          targetProfile
         )
 
       const dropOptimistic = (sid: null | string) => {
@@ -343,7 +421,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             awaitingResponse: false,
             pendingBranchGroup: null
           }),
-          targetStoredSessionId
+          targetStoredSessionId,
+          targetProfile
         )
       }
 
@@ -383,7 +462,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // cross-wired. Run the full profile-aware resume path. Creating here
         // would fork a contextless chat against whichever profile is active.
         try {
-          await resumeStoredSession(routedStoredSessionId)
+          await resumeStoredSession(routedStoredSessionId, targetProfile)
         } catch {
           return abortForSessionSwitch(null)
         }
@@ -423,12 +502,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         try {
           // Re-register on the session's OWNING profile — resuming on whichever
           // profile is live would fork the conversation into the wrong DB (#67603).
-          const resumeProfile = await resolveSessionProfile(targetStoredSessionId)
-
-          const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+          const resumed = await requestTargetGateway<{ session_id: string }>('session.resume', {
             session_id: targetStoredSessionId,
             source: 'desktop',
-            ...(resumeProfile ? { profile: resumeProfile } : {})
+            profile: targetProfile
           })
 
           const resumeDrift = sessionDriftReason()
@@ -521,6 +598,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // Re-pin the baseline to the created chat for the rest of the
         // pipeline; the closures (seedOptimistic et al) see the new value.
         startingStoredSessionId = selectedStoredSessionIdRef.current
+        recoveryStoredSessionId = startingStoredSessionId
         startingRouteToken = getRouteToken()
 
         seedOptimistic(sessionId)
@@ -528,6 +606,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       try {
         const syncedAttachments = await syncAttachmentsForSubmit(sessionId, attachments, {
+          requestGateway: requestTargetGateway,
           updateComposerAttachments: usingComposerAttachments
         })
 
@@ -565,10 +644,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         try {
           await withSessionBusyRetry(() =>
-            requestGateway('prompt.submit', submitParams(sessionId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+            requestTargetGateway('prompt.submit', submitParams(sessionId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
           )
         } catch (firstErr) {
-          const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
+          const recoverStoredSessionId = recoveryStoredSessionId
 
           if ((isSessionNotFoundError(firstErr) || isGatewayTimeoutError(firstErr)) && recoverStoredSessionId) {
             // Re-register the session in the gateway and get a fresh live ID.
@@ -576,12 +655,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // backend loop (#55578 symptom d) rejects the submit even though
             // the stored session is fine — resume + retry instead of erroring
             // out and losing the session binding.
-            const resumeProfile = await resolveSessionProfile(recoverStoredSessionId)
-
-            const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+            const resumed = await requestTargetGateway<{ session_id: string }>('session.resume', {
               session_id: recoverStoredSessionId,
               source: 'desktop',
-              ...(resumeProfile ? { profile: resumeProfile } : {})
+              profile: targetProfile
             })
 
             const resumeRetryDrift = sessionDriftReason()
@@ -600,7 +677,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
               }
 
               await withSessionBusyRetry(() =>
-                requestGateway('prompt.submit', submitParams(recoveredId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+                requestTargetGateway('prompt.submit', submitParams(recoveredId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
               )
             } else {
               submitErr = firstErr
@@ -654,7 +731,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             pendingBranchGroup: null,
             sawAssistantPayload: true
           }),
-          targetStoredSessionId
+          targetStoredSessionId,
+          targetProfile
         )
 
         if (targetIsCurrentView() && isProviderSetupError(err)) {
@@ -676,9 +754,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       copy,
       createBackendSessionForSend,
       getRoutedStoredSessionId,
+      getRoutedStoredSessionProfile,
       getRuntimeIdForStoredSession,
       getRouteToken,
       requestGateway,
+      requestGatewayForProfile,
       resumeStoredSession,
       scope,
       selectedStoredSessionIdRef,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -7,6 +7,12 @@ import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import type { ComposerAttachment } from '@/store/composer'
 
 export type GatewayRequest = <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
+export type ProfileGatewayRequest = <T>(
+  profile: string,
+  method: string,
+  params?: Record<string, unknown>,
+  timeoutMs?: number
+) => Promise<T>
 
 export function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -399,6 +405,9 @@ export interface SubmitTextOptions {
    *  dispatcher passes the invocation (`/work fix the leak`) here. */
   displayText?: string
   fromQueue?: boolean
+  /** Owning profile for a stored-session target. Required by background drains
+   *  so two profiles may safely queue the same raw stored id. */
+  profile?: null | string
   /** Runtime session id to submit into. Queue drains pass this so a
    *  backgrounded/source session cannot be replaced by the current foreground
    *  session between enqueue and drain. */

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -2,11 +2,16 @@ import { cleanup, render } from '@testing-library/react'
 import type { MutableRefObject } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { $resumeExhaustedSessionId, setResumeExhaustedSessionId } from '@/store/session'
 
 import { useRouteResume } from './use-route-resume'
 
+const DEFAULT_SESSION_IDENTITY = sessionIdentityKey('session-1', 'default')
+const OTHER_DEFAULT_SESSION_IDENTITY = sessionIdentityKey('other-session', 'default')
+
 interface HarnessProps {
+  activeGatewayProfile?: string
   activeSessionId: null | string
   activeSessionIdRef: MutableRefObject<null | string>
   creatingSessionRef: MutableRefObject<boolean>
@@ -14,18 +19,31 @@ interface HarnessProps {
   freshDraftReady: boolean
   gatewayState: string
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
+  resumeSession: (sessionId: string, focus: boolean, profile?: null | string) => Promise<unknown>
   resumeFailedSessionId?: null | string
   resumeExhaustedSessionId?: null | string
   routedSessionId: null | string
+  routedSessionProfile?: null | string
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: null | string
   selectedStoredSessionIdRef: MutableRefObject<null | string>
   startFreshSessionDraft: (focus: boolean) => unknown
 }
 
-function RouteResumeHarness({ resumeFailedSessionId = null, resumeExhaustedSessionId = null, ...props }: HarnessProps) {
-  useRouteResume({ ...props, resumeExhaustedSessionId, resumeFailedSessionId })
+function RouteResumeHarness({
+  activeGatewayProfile = 'default',
+  resumeFailedSessionId = null,
+  resumeExhaustedSessionId = null,
+  routedSessionProfile = null,
+  ...props
+}: HarnessProps) {
+  useRouteResume({
+    activeGatewayProfile,
+    ...props,
+    resumeExhaustedSessionId,
+    resumeFailedSessionId,
+    routedSessionProfile
+  })
 
   return null
 }
@@ -41,7 +59,11 @@ describe('useRouteResume', () => {
     const startFreshSessionDraft = vi.fn()
     const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-1' }
     const creatingSessionRef = { current: false }
-    const runtimeIdByStoredSessionIdRef = { current: new Map([['session-1', 'runtime-1']]) }
+
+    const runtimeIdByStoredSessionIdRef = {
+      current: new Map([[sessionIdentityKey('session-1', 'default'), 'runtime-1']])
+    }
+
     const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'session-1' }
 
     const { rerender } = render(
@@ -93,7 +115,11 @@ describe('useRouteResume', () => {
     const startFreshSessionDraft = vi.fn()
     const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-1' }
     const creatingSessionRef = { current: false }
-    const runtimeIdByStoredSessionIdRef = { current: new Map([['session-1', 'runtime-1']]) }
+
+    const runtimeIdByStoredSessionIdRef = {
+      current: new Map([[sessionIdentityKey('session-1', 'default'), 'runtime-1']])
+    }
+
     const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'session-1' }
 
     const { rerender } = render(
@@ -140,6 +166,99 @@ describe('useRouteResume', () => {
 
     expect(resumeSession).toHaveBeenCalledTimes(1)
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+  })
+
+  it('passes the routed profile through to resumeSession', () => {
+    const resumeSession = vi.fn(async () => undefined)
+
+    render(
+      <RouteResumeHarness
+        activeSessionId={null}
+        activeSessionIdRef={{ current: null }}
+        creatingSessionRef={{ current: false }}
+        currentView="chat"
+        freshDraftReady={false}
+        gatewayState="open"
+        locationPathname="/telegram-session"
+        resumeSession={resumeSession}
+        routedSessionId="telegram-session"
+        routedSessionProfile="ubuntu-server"
+        runtimeIdByStoredSessionIdRef={{ current: new Map() }}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={{ current: null }}
+        startFreshSessionDraft={vi.fn()}
+      />
+    )
+
+    expect(resumeSession).toHaveBeenCalledWith('telegram-session', true, 'ubuntu-server')
+  })
+
+  it('resumes again when only the routed profile changes for the same stored id', () => {
+    const resumeSession = vi.fn(async () => undefined)
+
+    const sharedProps = {
+      activeGatewayProfile: 'alpha',
+      activeSessionId: 'runtime-alpha',
+      activeSessionIdRef: { current: 'runtime-alpha' } as MutableRefObject<null | string>,
+      creatingSessionRef: { current: false },
+      currentView: 'chat',
+      freshDraftReady: false,
+      gatewayState: 'open',
+      locationPathname: '/shared-session',
+      resumeSession,
+      routedSessionId: 'shared-session',
+      runtimeIdByStoredSessionIdRef: {
+        current: new Map([[sessionIdentityKey('shared-session', 'alpha'), 'runtime-alpha']])
+      },
+      selectedStoredSessionId: 'shared-session',
+      selectedStoredSessionIdRef: { current: 'shared-session' } as MutableRefObject<null | string>,
+      startFreshSessionDraft: vi.fn()
+    }
+
+    const { rerender } = render(<RouteResumeHarness {...sharedProps} routedSessionProfile="alpha" />)
+
+    expect(resumeSession).not.toHaveBeenCalled()
+
+    rerender(<RouteResumeHarness {...sharedProps} routedSessionProfile="beta" />)
+
+    expect(resumeSession).toHaveBeenCalledTimes(1)
+    expect(resumeSession).toHaveBeenLastCalledWith('shared-session', true, 'beta')
+  })
+
+  it('re-resumes a profileless route when the active profile owner changes', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const activeSessionIdRef = { current: 'runtime-alpha' } as MutableRefObject<null | string>
+    const selectedStoredSessionIdRef = { current: 'shared' } as MutableRefObject<null | string>
+
+    const runtimeIdByStoredSessionIdRef = {
+      current: new Map([[sessionIdentityKey('shared', 'alpha'), 'runtime-alpha']])
+    }
+
+    const sharedProps = {
+      activeSessionId: 'runtime-alpha',
+      activeSessionIdRef,
+      creatingSessionRef: { current: false },
+      currentView: 'chat',
+      freshDraftReady: false,
+      gatewayState: 'open',
+      locationPathname: '/shared',
+      resumeSession,
+      routedSessionId: 'shared',
+      routedSessionProfile: null,
+      runtimeIdByStoredSessionIdRef,
+      selectedStoredSessionId: 'shared',
+      selectedStoredSessionIdRef,
+      startFreshSessionDraft: vi.fn()
+    }
+
+    const { rerender } = render(<RouteResumeHarness {...sharedProps} activeGatewayProfile="alpha" />)
+
+    expect(resumeSession).not.toHaveBeenCalled()
+
+    rerender(<RouteResumeHarness {...sharedProps} activeGatewayProfile="beta" />)
+
+    expect(resumeSession).toHaveBeenCalledTimes(1)
+    expect(resumeSession).toHaveBeenCalledWith('shared', true, 'beta')
   })
 
   it('resumes when pathname changes to a routed session', () => {
@@ -197,7 +316,11 @@ describe('useRouteResume', () => {
     const startFreshSessionDraft = vi.fn()
     const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-1' }
     const creatingSessionRef = { current: false }
-    const runtimeIdByStoredSessionIdRef = { current: new Map([['session-1', 'runtime-1']]) }
+
+    const runtimeIdByStoredSessionIdRef = {
+      current: new Map([[sessionIdentityKey('session-1', 'default'), 'runtime-1']])
+    }
+
     const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'session-1' }
 
     const { rerender } = render(
@@ -291,11 +414,49 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     }
   }
 
+  it('partitions failure recovery by profile when routed stored ids collide', () => {
+    vi.useFakeTimers()
+    const resumeSession = vi.fn(async () => undefined)
+    const props = strandedProps(resumeSession)
+    const alphaFailure = sessionIdentityKey('session-1', 'alpha')
+
+    const { rerender } = render(
+      <RouteResumeHarness
+        {...props}
+        activeGatewayProfile="alpha"
+        resumeFailedSessionId={alphaFailure}
+        routedSessionProfile="alpha"
+      />
+    )
+
+    resumeSession.mockClear()
+
+    vi.advanceTimersByTime(1_000)
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, 'alpha')
+
+    resumeSession.mockClear()
+    rerender(
+      <RouteResumeHarness
+        {...props}
+        activeGatewayProfile="beta"
+        resumeFailedSessionId={alphaFailure}
+        routedSessionProfile="beta"
+      />
+    )
+    // The main route effect legitimately resumes beta because the route owner
+    // changed. Isolate the bounded-retry effect: alpha's failure must not
+    // schedule an additional beta resume after its backoff window.
+    resumeSession.mockClear()
+    vi.advanceTimersByTime(8_000)
+
+    expect(resumeSession).not.toHaveBeenCalled()
+  })
+
   it('retries the resume on backoff when the routed session is flagged as failed', () => {
     vi.useFakeTimers()
     const resumeSession = vi.fn(async () => undefined)
 
-    render(<RouteResumeHarness {...strandedProps(resumeSession)} resumeFailedSessionId="session-1" />)
+    render(<RouteResumeHarness {...strandedProps(resumeSession)} resumeFailedSessionId={DEFAULT_SESSION_IDENTITY} />)
 
     // The main effect fires one resume on mount (pathname-changed). Clear it so
     // we assert purely the bounded-retry effect's scheduled retry below.
@@ -315,7 +476,12 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     const resumeSession = vi.fn(async () => undefined)
 
     // The failure flag points at a different session than the route.
-    render(<RouteResumeHarness {...strandedProps(resumeSession)} resumeFailedSessionId="other-session" />)
+    render(
+      <RouteResumeHarness
+        {...strandedProps(resumeSession)}
+        resumeFailedSessionId={OTHER_DEFAULT_SESSION_IDENTITY}
+      />
+    )
     resumeSession.mockClear() // drop the mount resume
 
     vi.advanceTimersByTime(10_000)
@@ -327,7 +493,7 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     const resumeSession = vi.fn(async () => undefined)
     const props = strandedProps(resumeSession)
 
-    render(<RouteResumeHarness {...props} resumeFailedSessionId="session-1" />)
+    render(<RouteResumeHarness {...props} resumeFailedSessionId={DEFAULT_SESSION_IDENTITY} />)
     resumeSession.mockClear() // drop the mount resume
 
     // A resume landed while we waited: runtime is now bound.
@@ -346,13 +512,16 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     // entry (null) and a repeat failure re-sets it ('session-1'). That null->id
     // toggle is what re-runs the effect and advances the bounded counter. The
     // routed session never changes, so the counter is NOT reset between cycles.
-    const { rerender } = render(<RouteResumeHarness {...props} resumeFailedSessionId="session-1" />)
+    const { rerender } = render(
+      <RouteResumeHarness {...props} resumeFailedSessionId={DEFAULT_SESSION_IDENTITY} />
+    )
+
     resumeSession.mockClear() // drop the mount resume; count only the retries
 
     for (let i = 0; i < 8; i += 1) {
       vi.advanceTimersByTime(8_000) // fire the scheduled retry (if any)
       rerender(<RouteResumeHarness {...props} resumeFailedSessionId={null} />) // cleared at entry
-      rerender(<RouteResumeHarness {...props} resumeFailedSessionId="session-1" />) // re-armed on failure
+      rerender(<RouteResumeHarness {...props} resumeFailedSessionId={DEFAULT_SESSION_IDENTITY} />) // re-armed on failure
     }
 
     // Capped at MAX_RESUME_RETRIES (4): a persistently dead backend can't
@@ -362,7 +531,7 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     // Once auto-retry gives up, the exhausted latch is armed for the routed
     // session so the chat view can swap the perpetual loader for an explicit
     // error + manual Retry instead of spinning forever.
-    expect($resumeExhaustedSessionId.get()).toBe('session-1')
+    expect($resumeExhaustedSessionId.get()).toBe(sessionIdentityKey('session-1', 'default'))
   })
 
   it('does not arm the exhausted latch while retries remain', () => {
@@ -370,7 +539,10 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     const resumeSession = vi.fn(async () => undefined)
     const props = strandedProps(resumeSession)
 
-    const { rerender } = render(<RouteResumeHarness {...props} resumeFailedSessionId="session-1" />)
+    const { rerender } = render(
+      <RouteResumeHarness {...props} resumeFailedSessionId={DEFAULT_SESSION_IDENTITY} />
+    )
+
     resumeSession.mockClear()
 
     // Two failure cycles — still under the 4-retry cap, so the latch must stay
@@ -378,7 +550,7 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     for (let i = 0; i < 2; i += 1) {
       vi.advanceTimersByTime(8_000)
       rerender(<RouteResumeHarness {...props} resumeFailedSessionId={null} />)
-      rerender(<RouteResumeHarness {...props} resumeFailedSessionId="session-1" />)
+      rerender(<RouteResumeHarness {...props} resumeFailedSessionId={DEFAULT_SESSION_IDENTITY} />)
     }
 
     expect($resumeExhaustedSessionId.get()).toBeNull()
@@ -390,7 +562,7 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     const props = strandedProps(resumeSession)
 
     // Pre-arm the latch as if this session had exhausted its retries.
-    setResumeExhaustedSessionId('session-1')
+    setResumeExhaustedSessionId(DEFAULT_SESSION_IDENTITY)
 
     // Route is now on a different, healthy session that is not flagged as
     // failed — the retry effect's "route moved off" branch clears the latch.
@@ -418,17 +590,20 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     // Phase A — exhaust the bounded auto-retry (counter → MAX) like a dead
     // backend. The resumeExhaustedSessionId prop stays null here: the hook sets
     // the store, which doesn't feed back into the prop in this harness.
-    const { rerender } = render(<RouteResumeHarness {...props} resumeFailedSessionId="session-1" />)
+    const { rerender } = render(
+      <RouteResumeHarness {...props} resumeFailedSessionId={DEFAULT_SESSION_IDENTITY} />
+    )
+
     resumeSession.mockClear()
 
     for (let i = 0; i < 8; i += 1) {
       vi.advanceTimersByTime(8_000)
       rerender(<RouteResumeHarness {...props} resumeFailedSessionId={null} />)
-      rerender(<RouteResumeHarness {...props} resumeFailedSessionId="session-1" />)
+      rerender(<RouteResumeHarness {...props} resumeFailedSessionId={DEFAULT_SESSION_IDENTITY} />)
     }
 
     expect(resumeSession.mock.calls.length).toBe(4) // capped
-    expect($resumeExhaustedSessionId.get()).toBe('session-1')
+    expect($resumeExhaustedSessionId.get()).toBe(sessionIdentityKey('session-1', 'default'))
 
     // Phase B — user clicks Retry on the SAME stranded session. resumeSession
     // clears both latches at entry; the exhausted latch's armed->cleared edge
@@ -437,9 +612,17 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     // transitions: reflect the armed latch, then clear it (retry), then re-arm
     // the failure latch on the fresh failure.
     resumeSession.mockClear()
-    rerender(<RouteResumeHarness {...props} resumeExhaustedSessionId="session-1" resumeFailedSessionId="session-1" />)
+    rerender(
+      <RouteResumeHarness
+        {...props}
+        resumeExhaustedSessionId={DEFAULT_SESSION_IDENTITY}
+        resumeFailedSessionId={DEFAULT_SESSION_IDENTITY}
+      />
+    )
     rerender(<RouteResumeHarness {...props} resumeExhaustedSessionId={null} resumeFailedSessionId={null} />)
-    rerender(<RouteResumeHarness {...props} resumeExhaustedSessionId={null} resumeFailedSessionId="session-1" />)
+    rerender(
+      <RouteResumeHarness {...props} resumeExhaustedSessionId={null} resumeFailedSessionId={DEFAULT_SESSION_IDENTITY} />
+    )
 
     // A real retry fires again instead of staying pinned at MAX (which would
     // dispatch nothing). Without the reset the counter stays >= MAX and this
@@ -460,12 +643,20 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     // only advances the counter when a timer truly fires, so the latch stays
     // clear no matter how many spurious re-renders happen mid-backoff.
     const { rerender } = render(
-      <RouteResumeHarness {...props} resumeFailedSessionId="session-1" resumeSession={vi.fn(async () => undefined)} />
+      <RouteResumeHarness
+        {...props}
+        resumeFailedSessionId={DEFAULT_SESSION_IDENTITY}
+        resumeSession={vi.fn(async () => undefined)}
+      />
     )
 
     for (let j = 0; j < 8; j += 1) {
       rerender(
-        <RouteResumeHarness {...props} resumeFailedSessionId="session-1" resumeSession={vi.fn(async () => undefined)} />
+        <RouteResumeHarness
+          {...props}
+          resumeFailedSessionId={DEFAULT_SESSION_IDENTITY}
+          resumeSession={vi.fn(async () => undefined)}
+        />
       )
     }
 

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -1,9 +1,12 @@
 import { type MutableRefObject, useEffect, useRef } from 'react'
 
 import { isNewChatRoute } from '@/app/routes'
+import { sessionIdentityKey } from '@/lib/session-identity'
+import { normalizeProfileKey } from '@/store/profile'
 import { setResumeExhaustedSessionId } from '@/store/session'
 
 interface RouteResumeOptions {
+  activeGatewayProfile: string
   activeSessionId: string | null
   activeSessionIdRef: MutableRefObject<string | null>
   creatingSessionRef: MutableRefObject<boolean>
@@ -11,7 +14,7 @@ interface RouteResumeOptions {
   freshDraftReady: boolean
   gatewayState: string | undefined
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
+  resumeSession: (sessionId: string, focus: boolean, profile?: null | string) => Promise<unknown>
   // Stored-session id whose most recent resume failed terminally (set by
   // useSessionActions, mirrored from $resumeFailedSessionId). While this equals
   // routedSessionId the window would otherwise latch on the loader forever, so
@@ -24,6 +27,7 @@ interface RouteResumeOptions {
   // signal the effect below uses to reset the attempt counter.
   resumeExhaustedSessionId: string | null
   routedSessionId: string | null
+  routedSessionProfile: string | null
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: string | null
   selectedStoredSessionIdRef: MutableRefObject<string | null>
@@ -66,6 +70,7 @@ function rawHashLooksLikeSession(): boolean {
 }
 
 export function useRouteResume({
+  activeGatewayProfile,
   activeSessionId,
   activeSessionIdRef,
   creatingSessionRef,
@@ -77,17 +82,19 @@ export function useRouteResume({
   resumeFailedSessionId,
   resumeExhaustedSessionId,
   routedSessionId,
+  routedSessionProfile,
   runtimeIdByStoredSessionIdRef,
   selectedStoredSessionId,
   selectedStoredSessionIdRef,
   startFreshSessionDraft
 }: RouteResumeOptions) {
-  const lastPathnameRef = useRef<string | null>(null)
+  const lastRouteIdentityRef = useRef<string | null>(null)
   const seenGatewayStateRef = useRef(false)
   const wasGatewayOpenRef = useRef(false)
   // Per-session retry bookkeeping for the bounded auto-retry effect below. Keyed
-  // by the session id we're retrying so switching chats resets the counter.
-  const retrySessionIdRef = useRef<string | null>(null)
+  // by compound durable identity so alpha/shared and beta/shared never inherit
+  // one another's retry budget.
+  const retrySessionIdentityRef = useRef<string | null>(null)
   const retryAttemptRef = useRef(0)
   // Tracks the previous exhausted-latch value so we can detect its armed->cleared
   // edge. resumeSession clears $resumeExhaustedSessionId on a manual Retry /
@@ -96,16 +103,23 @@ export function useRouteResume({
   // never touches this latch, so it can't spuriously trigger the reset).
   const prevResumeExhaustedRef = useRef<string | null>(null)
 
+  const routedOwnerProfile = normalizeProfileKey(routedSessionProfile ?? activeGatewayProfile)
+  const routedSessionIdentity = routedSessionId ? sessionIdentityKey(routedSessionId, routedOwnerProfile) : null
+
+  const failedSessionIdentity = resumeFailedSessionId
+  const exhaustedSessionIdentity = resumeExhaustedSessionId
+
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
     const gatewayOpen = gatewayState === 'open'
-    const pathnameChanged = lastPathnameRef.current !== locationPathname
+    const routeIdentity = `${locationPathname}\u0000${routedOwnerProfile}`
+    const routeChanged = lastRouteIdentityRef.current !== routeIdentity
     // Fire only on a genuine closed->open transition (a reconnect). seenGatewayStateRef
     // stays false until the first effect run, so a session that mounts with the gateway
     // already open is not mistaken for "became open" and does not double-resume with the
     // pathname-driven initial resume below.
     const gatewayBecameOpen = seenGatewayStateRef.current && !wasGatewayOpenRef.current && gatewayOpen
-    lastPathnameRef.current = locationPathname
+    lastRouteIdentityRef.current = routeIdentity
     seenGatewayStateRef.current = true
     wasGatewayOpenRef.current = gatewayOpen
 
@@ -114,10 +128,13 @@ export function useRouteResume({
     }
 
     if (routedSessionId) {
-      const cachedRuntime = runtimeIdByStoredSessionIdRef.current.get(routedSessionId)
+      const cachedRuntime = runtimeIdByStoredSessionIdRef.current.get(
+        sessionIdentityKey(routedSessionId, routedOwnerProfile)
+      )
 
       const alreadyActive =
         routedSessionId === selectedStoredSessionIdRef.current &&
+        normalizeProfileKey(activeGatewayProfile) === routedOwnerProfile &&
         Boolean(cachedRuntime) &&
         cachedRuntime === activeSessionIdRef.current
 
@@ -141,14 +158,18 @@ export function useRouteResume({
       // we're stranded on a routed session that never loaded. The first two
       // guard against a transient /:sid re-resume during "new chat" state clears
       // before the pathname updates from /:sid -> /.
-      const shouldResume = pathnameChanged || gatewayBecameOpen || stuckOnRoutedSession
+      const shouldResume = routeChanged || gatewayBecameOpen || stuckOnRoutedSession
 
       // On a reconnect (gatewayBecameOpen) re-resume even when the route looks
       // `alreadyActive`: the cached runtime id can be stale once the gateway
       // rebinds/reaps the session on its side, and trusting it strands Desktop on
       // a dead id ("session not found"). Otherwise keep skipping when already active.
       if ((gatewayBecameOpen || !alreadyActive) && shouldResume && !creatingSessionRef.current) {
-        void resumeSession(routedSessionId, true)
+        if (routedSessionProfile || routedOwnerProfile !== 'default') {
+          void resumeSession(routedSessionId, true, routedOwnerProfile)
+        } else {
+          void resumeSession(routedSessionId, true)
+        }
       }
 
       return
@@ -163,6 +184,7 @@ export function useRouteResume({
       startFreshSessionDraft(true)
     }
   }, [
+    activeGatewayProfile,
     activeSessionId,
     activeSessionIdRef,
     creatingSessionRef,
@@ -172,6 +194,8 @@ export function useRouteResume({
     locationPathname,
     resumeSession,
     routedSessionId,
+    routedOwnerProfile,
+    routedSessionProfile,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef,
@@ -201,10 +225,14 @@ export function useRouteResume({
     // immediately re-arm the exhausted error — never the renewed backoff cycle
     // the store/session.ts + use-session-actions.ts comments promise. (Point 2)
     const wasExhausted = prevResumeExhaustedRef.current
-    prevResumeExhaustedRef.current = resumeExhaustedSessionId
+    prevResumeExhaustedRef.current = exhaustedSessionIdentity
 
-    if (wasExhausted && wasExhausted === routedSessionId && resumeExhaustedSessionId !== wasExhausted) {
-      retrySessionIdRef.current = routedSessionId
+    if (
+      wasExhausted &&
+      wasExhausted === routedSessionIdentity &&
+      exhaustedSessionIdentity !== wasExhausted
+    ) {
+      retrySessionIdentityRef.current = routedSessionIdentity
       retryAttemptRef.current = 0
     }
 
@@ -213,7 +241,9 @@ export function useRouteResume({
     }
 
     const stranded =
-      Boolean(routedSessionId) && resumeFailedSessionId === routedSessionId && !creatingSessionRef.current
+      Boolean(routedSessionIdentity) &&
+      failedSessionIdentity === routedSessionIdentity &&
+      !creatingSessionRef.current
 
     if (!stranded) {
       // Route moved off the stranded session (or it recovered) — reset the
@@ -222,18 +252,18 @@ export function useRouteResume({
       // the current route: that's the error state we want to keep showing).
       // resumeSession also clears it on a fresh attempt; this covers a plain
       // route-change away from the stranded window.
-      if (retrySessionIdRef.current !== routedSessionId) {
-        retrySessionIdRef.current = null
+      if (retrySessionIdentityRef.current !== routedSessionIdentity) {
+        retrySessionIdentityRef.current = null
         retryAttemptRef.current = 0
-        setResumeExhaustedSessionId(current => (current && current !== routedSessionId ? null : current))
+        setResumeExhaustedSessionId(current => (current && current !== routedSessionIdentity ? null : current))
       }
 
       return
     }
 
     // New stranded session id → reset the attempt counter.
-    if (retrySessionIdRef.current !== routedSessionId) {
-      retrySessionIdRef.current = routedSessionId
+    if (retrySessionIdentityRef.current !== routedSessionIdentity) {
+      retrySessionIdentityRef.current = routedSessionIdentity
       retryAttemptRef.current = 0
     }
 
@@ -243,7 +273,7 @@ export function useRouteResume({
       // Surface an explicit error + manual Retry in the chat view instead of
       // spinning the loader forever — resumeSession (manual Retry / reconnect /
       // reselect) clears this latch and resets the counter for a fresh cycle.
-      setResumeExhaustedSessionId(routedSessionId)
+      setResumeExhaustedSessionId(routedSessionIdentity)
 
       return
     }
@@ -269,7 +299,12 @@ export function useRouteResume({
       // having fired. A flapping backend could then hit MAX in a couple of
       // re-renders with far fewer than MAX real attempts. (Point 3)
       retryAttemptRef.current += 1
-      void resumeSession(sessionId, true)
+
+      if (routedSessionProfile || routedOwnerProfile !== 'default') {
+        void resumeSession(sessionId, true, routedOwnerProfile)
+      } else {
+        void resumeSession(sessionId, true)
+      }
     }, resumeRetryDelayMs(attempt))
 
     return () => clearTimeout(timer)
@@ -277,11 +312,16 @@ export function useRouteResume({
     activeSessionIdRef,
     creatingSessionRef,
     currentView,
+    exhaustedSessionIdentity,
+    failedSessionIdentity,
     gatewayState,
     resumeSession,
     resumeFailedSessionId,
     resumeExhaustedSessionId,
     routedSessionId,
+    routedSessionIdentity,
+    routedOwnerProfile,
+    routedSessionProfile,
     selectedStoredSessionIdRef
   ])
 }

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4,9 +4,11 @@ import { useEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
-import { getSession, getSessionMessages, type SessionInfo } from '@/hermes'
+import { deleteSession, getSession, getSessionMessages, type SessionInfo, setSessionArchived } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
+import { clearQueuedPrompts, enqueueQueuedPrompt, getQueuedPrompts } from '@/store/composer-queue'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile } from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
@@ -21,6 +23,7 @@ import {
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
   $selectedStoredSessionId,
+  $sessions,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
   setCurrentCwd,
@@ -76,7 +79,7 @@ function deferred<T>() {
 
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
-  'createBackendSessionForSend' | 'selectSidebarItem' | 'startFreshSessionDraft'
+  'archiveSession' | 'createBackendSessionForSend' | 'removeSession' | 'selectSidebarItem' | 'startFreshSessionDraft'
 >
 
 function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
@@ -139,12 +142,14 @@ function StoredIdRotationHarness({
   activeSessionIdRef,
   getRoutedStoredSessionId,
   navigate,
-  selectedStoredSessionIdRef
+  selectedStoredSessionIdRef,
+  sessionStateByRuntimeIdRef = { current: new Map<string, ClientSessionState>() }
 }: {
   activeSessionIdRef: MutableRefObject<string | null>
   getRoutedStoredSessionId: () => null | string
   navigate: (to: string, options?: { replace?: boolean }) => void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
+  sessionStateByRuntimeIdRef?: MutableRefObject<Map<string, ClientSessionState>>
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
 
@@ -162,7 +167,7 @@ function StoredIdRotationHarness({
     runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
     selectedStoredSessionId: selectedStoredSessionIdRef.current,
     selectedStoredSessionIdRef,
-    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    sessionStateByRuntimeIdRef,
     syncSessionStateToView: vi.fn(),
     updateSessionState: () => ({}) as ClientSessionState
   })
@@ -204,8 +209,133 @@ describe('active stored-session id rotation routing', () => {
 
     await waitFor(() => expect(selectedStoredSessionIdRef.current).toBe('stored-A-next'))
     expect($selectedStoredSessionId.get()).toBe('stored-A-next')
-    expect(navigate).toHaveBeenCalledWith(sessionRoute('stored-A-next'), { replace: true })
+    expect(navigate).toHaveBeenCalledWith(sessionRoute('stored-A-next', 'default'), { replace: true })
     expect($activeSessionStoredIdRotation.get()).toBeNull()
+  })
+
+  it('preserves the runtime owner when a stored id rotates after the active profile changed', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'runtime-A' }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'shared' }
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([
+        ['runtime-A', { ...createClientSessionState('shared'), storedSessionProfile: 'alpha' }]
+      ])
+    }
+
+    const navigate = vi.fn()
+
+    $activeGatewayProfile.set('beta')
+    setSelectedStoredSessionId('shared', 'alpha')
+    render(
+      <StoredIdRotationHarness
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => 'shared'}
+        navigate={navigate}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+
+    act(() => {
+      setActiveSessionStoredIdRotation({
+        nextStoredSessionId: 'shared-next',
+        previousStoredSessionId: 'shared',
+        runtimeSessionId: 'runtime-A'
+      })
+    })
+
+    await waitFor(() => expect(selectedStoredSessionIdRef.current).toBe('shared-next'))
+    expect(navigate).toHaveBeenCalledWith(sessionRoute('shared-next', 'alpha'), { replace: true })
+  })
+
+  it('does not let a non-default rotation claim legacy draft or decoded default queue state', async () => {
+    const runtimeSessionId = 'runtime-beta'
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'shared' }
+    const defaultQueueIdentity = sessionIdentityKey('shared', 'default')
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([[runtimeSessionId, { ...createClientSessionState('shared'), storedSessionProfile: 'beta' }]])
+    }
+
+    stashSessionDraft('shared', 'legacy default draft', [])
+    enqueueQueuedPrompt(defaultQueueIdentity, { attachments: [], text: 'legacy default queue' })
+    setSelectedStoredSessionId('shared', 'beta')
+
+    render(
+      <StoredIdRotationHarness
+        activeSessionIdRef={{ current: runtimeSessionId }}
+        getRoutedStoredSessionId={() => 'shared'}
+        navigate={vi.fn()}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+
+    act(() => {
+      setActiveSessionStoredIdRotation({
+        nextStoredSessionId: 'shared-next',
+        previousStoredSessionId: 'shared',
+        runtimeSessionId
+      })
+    })
+
+    await waitFor(() => expect(selectedStoredSessionIdRef.current).toBe('shared-next'))
+    expect(takeSessionDraft('shared').text).toBe('legacy default draft')
+    expect(takeSessionDraft(sessionIdentityKey('shared', 'beta')).text).toBe('')
+    expect(getQueuedPrompts(defaultQueueIdentity).map(prompt => prompt.text)).toEqual(['legacy default queue'])
+    expect(getQueuedPrompts(sessionIdentityKey('shared', 'beta'))).toEqual([])
+
+    clearSessionDraft('shared')
+    clearSessionDraft(sessionIdentityKey('shared', 'beta'))
+    clearQueuedPrompts(defaultQueueIdentity)
+    clearQueuedPrompts(sessionIdentityKey('shared', 'beta'))
+  })
+
+  it('resolves the durable lineage only within the rotation owner profile', async () => {
+    const runtimeSessionId = 'runtime-alpha'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: runtimeSessionId }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'alpha-root' }
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([
+        [runtimeSessionId, { ...createClientSessionState('alpha-root'), storedSessionProfile: 'alpha' }]
+      ])
+    }
+
+    setSessions([
+      storedSession({ id: 'shared', profile: 'beta', _lineage_root_id: 'beta-root' }),
+      storedSession({ id: 'shared', profile: 'alpha', _lineage_root_id: 'alpha-root' })
+    ])
+    stashSessionDraft(sessionIdentityKey('alpha-root', 'alpha'), 'alpha draft', [])
+    setSelectedStoredSessionId('alpha-root', 'alpha')
+    setActiveSessionId(runtimeSessionId)
+
+    render(
+      <StoredIdRotationHarness
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => 'alpha-root'}
+        navigate={vi.fn()}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+
+    act(() => {
+      setActiveSessionStoredIdRotation({
+        nextStoredSessionId: 'shared',
+        previousStoredSessionId: 'alpha-root',
+        runtimeSessionId
+      })
+    })
+
+    await waitFor(() => expect($selectedStoredSessionId.get()).toBe('shared'))
+    expect(takeSessionDraft(sessionIdentityKey('alpha-root', 'alpha')).text).toBe('alpha draft')
+    expect(takeSessionDraft(sessionIdentityKey('beta-root', 'alpha')).text).toBe('')
+
+    clearSessionDraft(sessionIdentityKey('alpha-root', 'alpha'))
+    clearSessionDraft(sessionIdentityKey('beta-root', 'alpha'))
+    setSessions([])
   })
 
   it('keeps draft on the previous tip when the new tip row is not loaded yet', async () => {
@@ -239,10 +369,11 @@ describe('active stored-session id rotation routing', () => {
     })
 
     await waitFor(() => expect($selectedStoredSessionId.get()).toBe(tipAfter))
-    expect(takeSessionDraft(tipBefore).text).toBe('typed during gap')
+    expect(takeSessionDraft(sessionIdentityKey(tipBefore, 'default')).text).toBe('typed during gap')
+    expect(takeSessionDraft(tipBefore).text).toBe('')
     expect(takeSessionDraft(tipAfter).text).toBe('')
 
-    clearSessionDraft(tipBefore)
+    clearSessionDraft(sessionIdentityKey(tipBefore, 'default'))
     clearSessionDraft(tipAfter)
     setActiveSessionId(null)
   })
@@ -282,10 +413,11 @@ describe('active stored-session id rotation routing', () => {
 
     await waitFor(() => expect($selectedStoredSessionId.get()).toBe(tipAfter))
     // Durable key remains the lineage root — same scope ChatBar will keep using.
-    expect(takeSessionDraft(tipBefore).text).toBe(typedWhileThinking)
+    expect(takeSessionDraft(sessionIdentityKey(tipBefore, 'default')).text).toBe(typedWhileThinking)
+    expect(takeSessionDraft(tipBefore).text).toBe('')
     expect(takeSessionDraft(tipAfter).text).toBe('')
 
-    clearSessionDraft(tipBefore)
+    clearSessionDraft(sessionIdentityKey(tipBefore, 'default'))
     clearSessionDraft(tipAfter)
     setActiveSessionId(null)
     setSessions([])
@@ -571,6 +703,7 @@ describe('createBackendSessionForSend profile routing', () => {
 // (b) arm $resumeFailedSessionId so use-route-resume can retry. A resume that
 // succeeds must NOT leave the flag armed.
 function ResumeHarness({
+  navigate = vi.fn(),
   onStateUpdate,
   onReady,
   requestGateway,
@@ -578,8 +711,14 @@ function ResumeHarness({
   selectedStoredSessionId = null,
   sessionStateByRuntimeIdRef
 }: {
-  onStateUpdate?: (sessionId: string, state: ClientSessionState) => void
-  onReady: (resume: (storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) => void
+  navigate?: (path: string, options?: { replace?: boolean }) => void
+  onStateUpdate?: (
+    sessionId: string,
+    state: ClientSessionState,
+    storedSessionId?: null | string,
+    storedSessionProfile?: null | string
+  ) => void
+  onReady: (resume: (storedSessionId: string, replaceRoute?: boolean, profile?: null | string) => Promise<unknown>) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
   selectedStoredSessionId?: string | null
@@ -595,7 +734,7 @@ function ResumeHarness({
     ensureSessionState: () => ({}) as ClientSessionState,
     getRouteToken: () => 'token',
     getRoutedStoredSessionId: () => null,
-    navigate: vi.fn() as never,
+    navigate: navigate as never,
     requestGateway,
     resetViewSync: vi.fn(),
     runtimeIdByStoredSessionIdRef: runtimeIdByStoredSessionIdRef ?? ref(new Map<string, string>()),
@@ -603,9 +742,9 @@ function ResumeHarness({
     selectedStoredSessionIdRef: ref<string | null>(selectedStoredSessionId),
     sessionStateByRuntimeIdRef: sessionStateByRuntimeIdRef ?? ref(new Map<string, ClientSessionState>()),
     syncSessionStateToView: vi.fn(),
-    updateSessionState: (sessionId, updater) => {
+    updateSessionState: (sessionId, updater, storedSessionId, storedSessionProfile) => {
       const next = updater({} as ClientSessionState)
-      onStateUpdate?.(sessionId, next)
+      onStateUpdate?.(sessionId, next, storedSessionId, storedSessionProfile)
 
       return next
     }
@@ -621,6 +760,7 @@ function ResumeHarness({
 describe('resumeSession failure recovery', () => {
   afterEach(() => {
     cleanup()
+    $activeGatewayProfile.set('default')
     setActiveSessionId(null)
     setResumeFailedSessionId(null)
     setMessages([])
@@ -631,6 +771,7 @@ describe('resumeSession failure recovery', () => {
   async function runResume(
     requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>,
     options: {
+      navigate?: (path: string, options?: { replace?: boolean }) => void
       runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
       sessionStateByRuntimeIdRef?: MutableRefObject<Map<string, ClientSessionState>>
     } = {}
@@ -640,6 +781,31 @@ describe('resumeSession failure recovery', () => {
     await waitFor(() => expect(resume).not.toBeNull())
     await resume!('stored-1', true)
   }
+
+  it('pins a cold resume state write to the captured owner profile', async () => {
+    const ownerWrites: Array<null | string | undefined> = []
+    const requestGateway = vi.fn(async (method: string) =>
+      method === 'session.resume'
+        ? ({ session_id: 'runtime-alpha', resumed: 'shared', messages: [], info: {} } as never)
+        : ({} as never)
+    )
+    vi.mocked(getSessionMessages).mockResolvedValue({ messages: [], session_id: 'shared' } as never)
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean, profile?: null | string) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        onStateUpdate={(_runtimeId, _state, _storedId, profile) => ownerWrites.push(profile)}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    $activeGatewayProfile.set('beta')
+    await resume!('shared', false, 'alpha')
+
+    expect(ownerWrites.at(-1)).toBe('alpha')
+  })
 
   it('arms $resumeFailedSessionId when resume RPC and REST fallback both fail', async () => {
     // session.resume rejects (e.g. timeout against a wedged backend)...
@@ -658,7 +824,28 @@ describe('resumeSession failure recovery', () => {
 
     // The window is no longer silently stranded: the failure latch is armed for
     // the stored session, which use-route-resume consumes to retry.
-    expect($resumeFailedSessionId.get()).toBe('stored-1')
+    expect($resumeFailedSessionId.get()).toBe(sessionIdentityKey('stored-1', 'default'))
+  })
+
+  it('fails closed when an explicit session is missing from both resume endpoints', async () => {
+    const navigate = vi.fn()
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        throw new Error('404 Session not found')
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(getSessionMessages).mockRejectedValue(new Error('404 Session not found'))
+
+    await runResume(requestGateway, { navigate })
+
+    expect(navigate).not.toHaveBeenCalled()
+    expect($resumeFailedSessionId.get()).toBe(sessionIdentityKey('stored-1', 'default'))
+    expect($activeSessionId.get()).toBeNull()
+    expect($messages.get()).toEqual([])
   })
 
   it('does NOT arm the failure latch when the resume RPC fails but the REST fallback paints history', async () => {
@@ -856,7 +1043,7 @@ describe('resumeSession failure recovery', () => {
 
   it('leaves the failure latch clear when resume succeeds', async () => {
     // Pre-arm to prove a successful resume clears it (entry-clear path).
-    setResumeFailedSessionId('stored-1')
+    setResumeFailedSessionId(sessionIdentityKey('stored-1', 'default'))
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       if (method === 'session.resume') {
@@ -914,14 +1101,14 @@ describe('resumeSession failure recovery', () => {
 
     await runResume(requestGateway)
 
-    expect($resumeFailedSessionId.get()).toBe('stored-1')
+    expect($resumeFailedSessionId.get()).toBe(sessionIdentityKey('stored-1', 'default'))
     expect($activeSessionId.get()).toBeNull()
     expect($messages.get()).toEqual([])
   })
 
   it('does not reuse an empty cached runtime view for a stored session with history', async () => {
     const runtimeIdByStoredSessionIdRef = {
-      current: new Map([['stored-1', 'runtime-stale']])
+      current: new Map([[sessionIdentityKey('stored-1', 'default'), 'runtime-stale']])
     } satisfies MutableRefObject<Map<string, string>>
 
     const sessionStateByRuntimeIdRef = {
@@ -946,6 +1133,7 @@ describe('resumeSession failure recovery', () => {
             sawAssistantPayload: false,
             serviceTier: '',
             storedSessionId: 'stored-1',
+            storedSessionProfile: 'default',
             streamId: null,
             turnStartedAt: null,
             usage: null,
@@ -976,7 +1164,7 @@ describe('resumeSession failure recovery', () => {
     })
 
     expect(requestGateway).not.toHaveBeenCalledWith('session.usage', { session_id: 'runtime-stale' })
-    expect(runtimeIdByStoredSessionIdRef.current.has('stored-1')).toBe(false)
+    expect(runtimeIdByStoredSessionIdRef.current.has(sessionIdentityKey('stored-1', 'default'))).toBe(false)
     expect(sessionStateByRuntimeIdRef.current.has('runtime-stale')).toBe(false)
     expect($activeSessionId.get()).toBe('runtime-1')
     expect($messages.get().length).toBe(1)
@@ -1325,6 +1513,7 @@ describe('resumeSession drops a redundant tile when the session loads into main'
 // must verify the cached state still BELONGS to the resumed session before it
 // paints, or it shows a totally different thread under the current route.
 const clientState = (storedSessionId: string | null): ClientSessionState => createClientSessionState(storedSessionId)
+const defaultSessionKey = (storedSessionId: string): string => sessionIdentityKey(storedSessionId, 'default')
 
 describe('resumeSession warm-cache mapping integrity', () => {
   afterEach(() => {
@@ -1342,7 +1531,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
     // exact "open chat A, chat B loads" corruption a reaped/respawned pooled
     // backend can leave behind.
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
-      current: new Map([['stored-A', 'rt-recycled']])
+      current: new Map([[defaultSessionKey('stored-A'), 'rt-recycled']])
     }
 
     const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
@@ -1378,7 +1567,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(resumeCalls[0][1]).toMatchObject({ session_id: 'stored-A' })
 
     // The corrupt mapping was purged so it can't mis-resolve again.
-    expect(runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)
+    expect(runtimeIdByStoredSessionIdRef.current.has(defaultSessionKey('stored-A'))).toBe(false)
     expect(sessionStateByRuntimeIdRef.current.has('rt-recycled')).toBe(false)
   })
 
@@ -1387,7 +1576,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
     // it and never reach session.resume. session.activate refreshes the live
     // projection and, critically, rebinds its event transport after reconnect.
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
-      current: new Map([['stored-A', 'rt-A']])
+      current: new Map([[defaultSessionKey('stored-A'), 'rt-A']])
     }
 
     const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
@@ -1430,13 +1619,13 @@ describe('resumeSession warm-cache mapping integrity', () => {
     const methods = requestGateway.mock.calls.map(([method]) => method)
     expect(methods).toContain('session.activate')
     expect(methods).not.toContain('session.resume')
-    expect(getSessionMessages).toHaveBeenCalledWith('stored-A', undefined)
-    expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
+    expect(getSessionMessages).toHaveBeenCalledWith('stored-A', 'default')
+    expect(runtimeIdByStoredSessionIdRef.current.get(defaultSessionKey('stored-A'))).toBe('rt-A')
   })
 
   it('preserves cached image attachments through an idle persisted transcript refresh', async () => {
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
-      current: new Map([['stored-A', 'rt-A']])
+      current: new Map([[defaultSessionKey('stored-A'), 'rt-A']])
     }
 
     const state = clientState('stored-A')
@@ -1500,13 +1689,13 @@ describe('resumeSession warm-cache mapping integrity', () => {
     await resume!('stored-A', true)
 
     expect(requestGateway.mock.calls.map(([method]) => method)).toContain('session.activate')
-    expect(getSessionMessages).toHaveBeenCalledWith('stored-A', undefined)
+    expect(getSessionMessages).toHaveBeenCalledWith('stored-A', 'default')
     expect(resumedState?.messages[0]?.attachmentRefs).toEqual(['@image:/tmp/photo.png'])
   })
 
   it('repairs an idle warm cache from a divergent equal-length persisted transcript', async () => {
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
-      current: new Map([['stored-A', 'rt-A']])
+      current: new Map([[defaultSessionKey('stored-A'), 'rt-A']])
     }
 
     const state = clientState('stored-A')
@@ -1581,7 +1770,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
 
   it('keeps a warm runtime and optimistic turn on a transient activation timeout', async () => {
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
-      current: new Map([['stored-A', 'rt-A']])
+      current: new Map([[defaultSessionKey('stored-A'), 'rt-A']])
     }
 
     const state = clientState('stored-A')
@@ -1618,7 +1807,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
     await resume!('stored-A', true)
 
     expect(requestGateway.mock.calls.map(([method]) => method)).not.toContain('session.resume')
-    expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
+    expect(runtimeIdByStoredSessionIdRef.current.get(defaultSessionKey('stored-A'))).toBe('rt-A')
     expect(sessionStateByRuntimeIdRef.current.get('rt-A')?.messages[0]?.id).toBe('user-optimistic')
   })
 })
@@ -1678,5 +1867,47 @@ describe('selectSidebarItem', () => {
     expect(navigate).toHaveBeenCalledWith('/skills', undefined)
     expect(noteActiveTreeGroup).toHaveBeenCalledWith(null)
     expect(revealTreePane).toHaveBeenCalledWith('workspace')
+  })
+})
+
+describe('profile-qualified session mutations', () => {
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    setSelectedStoredSessionId(null)
+    $activeGatewayProfile.set('default')
+    vi.restoreAllMocks()
+  })
+
+  it('deletes only the requested profile when stored ids collide', async () => {
+    const alpha = storedSession({ id: 'shared', profile: 'alpha', title: 'Alpha' })
+    const beta = storedSession({ id: 'shared', profile: 'beta', title: 'Beta' })
+    setSessions([alpha, beta])
+    vi.mocked(deleteSession).mockResolvedValue({ ok: true } as never)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={ready => (handle = ready)} requestGateway={async () => ({}) as never} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await handle!.removeSession('shared', 'beta')
+
+    expect(vi.mocked(deleteSession)).toHaveBeenCalledWith('shared', 'beta')
+    expect($sessions.get()).toEqual([alpha])
+  })
+
+  it('archives only the requested profile when stored ids collide', async () => {
+    const alpha = storedSession({ id: 'shared', profile: 'alpha', title: 'Alpha' })
+    const beta = storedSession({ id: 'shared', profile: 'beta', title: 'Beta' })
+    setSessions([alpha, beta])
+    vi.mocked(setSessionArchived).mockResolvedValue({ ok: true } as never)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={ready => (handle = ready)} requestGateway={async () => ({}) as never} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await handle!.archiveSession('shared', 'beta')
+
+    expect(vi.mocked(setSessionArchived)).toHaveBeenCalledWith('shared', true, 'beta')
+    expect($sessions.get()).toEqual([alpha])
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -8,6 +8,7 @@ import { useI18n } from '@/i18n'
 import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
+import { parseSessionIdentityKey, sessionIdentityKey, sessionMatchesIdentity } from '@/lib/session-identity'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
@@ -30,6 +31,7 @@ import {
   $currentReasoningEffort,
   $messages,
   $newChatWorkspaceTarget,
+  $selectedSessionIdentityKey,
   $sessions,
   $yoloActive,
   type NewChatWorkspaceTarget,
@@ -59,6 +61,7 @@ import {
 import {
   $sessionTiles,
   closeSessionTile,
+  discardSessionTile,
   dropSessionState,
   openSessionTile,
   patchSessionTile,
@@ -96,7 +99,11 @@ interface SessionActionsOptions {
   activeSessionIdRef: MutableRefObject<string | null>
   busyRef: MutableRefObject<boolean>
   creatingSessionRef: MutableRefObject<boolean>
-  ensureSessionState: (sessionId: string, storedSessionId?: string | null) => ClientSessionState
+  ensureSessionState: (
+    sessionId: string,
+    storedSessionId?: string | null,
+    storedSessionProfile?: null | string
+  ) => ClientSessionState
   getRouteToken: () => string
   getRoutedStoredSessionId: () => null | string
   navigate: NavigateFunction
@@ -111,18 +118,10 @@ interface SessionActionsOptions {
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
-    storedSessionId?: string | null
+    storedSessionId?: string | null,
+    storedSessionProfile?: null | string
   ) => ClientSessionState
 }
-
-// Stored ids created in THIS renderer run. A brand-new session lives only in the
-// gateway's in-memory map until its first turn persists a state.db row — so if a
-// respawning/flapping backend drops it, both resume RPC and the REST transcript
-// 404 even though the user just made it. We must NOT treat that as "gone" (which
-// yanks them to a fresh draft — the "new sessions clear themselves" bug); the
-// bounded retry rebinds it when the backend returns. Boot-into-a-stale-last-id
-// (NOT in this set) still legitimately drops to a draft.
-const createdThisRun = new Set<string>()
 
 // Reflect a stored row's persisted token counts into the live usage atom
 // (total is derived, so callers can't drift it out of sync with input/output).
@@ -157,7 +156,9 @@ function reconcileAuthoritativeMessages(
 // A no-op for single-profile/local-pooled users (a backend resolves its own launch
 // profile to None). The sticky UI model/effort/fast ride as per-session overrides,
 // never the profile default (that lives in Settings → Model).
-async function desktopSessionCreateParams(cwd: string): Promise<Record<string, unknown>> {
+async function desktopSessionCreateParams(
+  cwd: string
+): Promise<{ params: Record<string, unknown>; profile: string }> {
   // Treat Send as the linearization point for the visible selector state. The
   // profile handshake below can yield long enough for background config/model
   // refreshes to finish; reading atoms afterward would silently create the
@@ -173,15 +174,18 @@ async function desktopSessionCreateParams(cwd: string): Promise<Record<string, u
   await ensureGatewayProfile(profile)
 
   return {
-    cols: 96,
-    source: 'desktop',
-    ...(cwd && { cwd }),
-    ...(profile ? { profile } : {}),
-    ...(selection.model
-      ? { model: selection.model, ...(selection.provider ? { provider: selection.provider } : {}) }
-      : {}),
-    ...(selection.effort ? { reasoning_effort: selection.effort } : {}),
-    fast: selection.fast
+    profile,
+    params: {
+      cols: 96,
+      source: 'desktop',
+      ...(cwd && { cwd }),
+      ...(profile ? { profile } : {}),
+      ...(selection.model
+        ? { model: selection.model, ...(selection.provider ? { provider: selection.provider } : {}) }
+        : {}),
+      ...(selection.effort ? { reasoning_effort: selection.effort } : {}),
+      fast: selection.fast
+    }
   }
 }
 
@@ -254,29 +258,59 @@ export function useSessionActions({
     // the previous id (usually the lineage root) in that gap.
     const previousId = storedIdRotation.previousStoredSessionId
     const nextId = storedIdRotation.nextStoredSessionId
+
+    const selectedIdentityKey = $selectedSessionIdentityKey.get()
+    const selectedIdentity = selectedIdentityKey ? parseSessionIdentityKey(selectedIdentityKey) : null
+
+    const rotationProfile = normalizeProfileKey(
+      sessionStateByRuntimeIdRef.current.get(storedIdRotation.runtimeSessionId)?.storedSessionProfile ??
+        (selectedIdentity?.storedSessionId === previousId ? selectedIdentity.profile : $activeGatewayProfile.get())
+    )
+
     const sessions = $sessions.get()
-    const resolvedNext = resolveComposerSessionKey(nextId, sessions)
+    const previousKey = sessionIdentityKey(previousId, rotationProfile)
+    const nextKey = sessionIdentityKey(nextId, rotationProfile)
+    const resolvedNextIdentity = resolveComposerSessionKey(nextId, sessions, rotationProfile)
+    const legacyDurableIdentity = resolveComposerSessionKey(previousId, sessions, rotationProfile)
+    const resolvedNextId = resolvedNextIdentity ? parseSessionIdentityKey(resolvedNextIdentity).storedSessionId : null
 
-    const durableKey =
-      resolvedNext && resolvedNext !== nextId
-        ? resolvedNext
-        : (resolveComposerSessionKey(previousId, sessions) ?? previousId)
+    const legacyDurableId = legacyDurableIdentity
+      ? parseSessionIdentityKey(legacyDurableIdentity).storedSessionId
+      : null
 
-    migrateSessionDraft(previousId, durableKey)
-    migrateSessionDraft(nextId, durableKey)
-    migrateQueuedPrompts(previousId, durableKey)
-    migrateQueuedPrompts(nextId, durableKey)
+    const durableId = resolvedNextId && resolvedNextId !== nextId ? resolvedNextId : (legacyDurableId ?? previousId)
+    const durableKey = sessionIdentityKey(durableId, rotationProfile)
 
-    setSelectedStoredSessionId(nextId)
+    migrateSessionDraft(previousKey, durableKey)
+    migrateSessionDraft(nextKey, durableKey)
+
+    if (rotationProfile === 'default') {
+      migrateSessionDraft(previousId, durableKey)
+      migrateSessionDraft(nextId, durableKey)
+    }
+
+    migrateSessionDraft(legacyDurableIdentity, durableKey)
+    migrateQueuedPrompts(previousKey, durableKey)
+    migrateQueuedPrompts(nextKey, durableKey)
+    migrateQueuedPrompts(legacyDurableIdentity, durableKey)
+
+    setSelectedStoredSessionId(nextId, rotationProfile)
     selectedStoredSessionIdRef.current = nextId
 
     // A route overlay/page has no routed session id, but the underlying selected
     // chat still needs to follow the continuation. Update that selection in
     // place without navigating out of the surface the user deliberately opened.
     if (routedStoredSessionId === previousId) {
-      navigate(sessionRoute(nextId), { replace: true })
+      navigate(sessionRoute(nextId, rotationProfile), { replace: true })
     }
-  }, [activeSessionIdRef, getRoutedStoredSessionId, navigate, selectedStoredSessionIdRef, storedIdRotation])
+  }, [
+    activeSessionIdRef,
+    getRoutedStoredSessionId,
+    navigate,
+    selectedStoredSessionIdRef,
+    sessionStateByRuntimeIdRef,
+    storedIdRotation
+  ])
 
   const startFreshSessionDraft = useCallback(
     (options: boolean | FreshSessionDraftOptions = false) => {
@@ -367,7 +401,7 @@ export function useSessionActions({
               ? workspaceTarget.trim()
               : $currentCwd.get().trim() || resolveNewSessionCwd()
 
-        const params = await desktopSessionCreateParams(cwd)
+        const { params, profile } = await desktopSessionCreateParams(cwd)
         const created = await requestGateway<SessionCreateResponse>('session.create', params)
         const stored = created.stored_session_id ?? null
 
@@ -397,16 +431,15 @@ export function useSessionActions({
         resetViewSync()
         activeSessionIdRef.current = created.session_id
         selectedStoredSessionIdRef.current = stored
-        ensureSessionState(created.session_id, stored)
+        ensureSessionState(created.session_id, stored, profile)
 
         if (stored) {
-          createdThisRun.add(stored)
           // Seed the sidebar preview with the user's first message so the row
           // reads meaningfully while the turn is in flight, instead of flashing
           // "Untitled session" until the turn persists and auto-title runs. The
           // server later returns its own preview/title and supersedes this.
-          upsertOptimisticSession(created, stored, null, preview?.trim() || null)
-          navigate(sessionRoute(stored), { replace: true })
+          upsertOptimisticSession(created, stored, null, preview?.trim() || null, null, undefined, profile)
+          navigate(sessionRoute(stored, profile), { replace: true })
           // Other windows (e.g. the main window when this is the pop-out) can't
           // see this session until they re-pull the shared list.
           broadcastSessionsChanged()
@@ -415,13 +448,13 @@ export function useSessionActions({
         setFreshDraftReady(false)
         setNewChatWorkspaceTarget(undefined)
         setActiveSessionId(created.session_id)
-        setSelectedStoredSessionId(stored)
+        setSelectedStoredSessionId(stored, profile)
         setSessionStartedAt(Date.now())
         const yoloArmed = $yoloActive.get()
         const runtimeInfo = applyRuntimeInfo(created.info)
 
         if (runtimeInfo) {
-          updateSessionState(created.session_id, state => ({ ...state, ...runtimeInfo }), stored)
+          updateSessionState(created.session_id, state => ({ ...state, ...runtimeInfo }), stored, profile)
         }
 
         // User may have armed YOLO on the new-chat draft before the runtime
@@ -483,7 +516,7 @@ export function useSessionActions({
         // Fresh tile → the caller's workspace when one was named (the sidebar
         // "+" on a project/worktree lane), else the resolved new-session cwd
         // (project/default) — never the primary composer's live cwd.
-        const params = await desktopSessionCreateParams((options?.cwd || resolveNewSessionCwd()).trim())
+        const { params, profile } = await desktopSessionCreateParams((options?.cwd || resolveNewSessionCwd()).trim())
         const created = await requestGateway<SessionCreateResponse>('session.create', params)
         const stored = created.stored_session_id
 
@@ -494,20 +527,23 @@ export function useSessionActions({
           return
         }
 
-        createdThisRun.add(stored)
-
         // Seed the per-runtime cache so the tile renders immediately without a
         // redundant resume. Only add the row to the SIDEBAR when `listed` — an
         // unlisted (draft) tab stays out of the session list until its first
         // turn persists and a refresh surfaces it.
         if (listed) {
-          upsertOptimisticSession(created, stored, null, null)
+          upsertOptimisticSession(created, stored, null, null, null, undefined, profile)
         }
 
         const runtimeInfo = applyRuntimeInfo(created.info)
-        updateSessionState(created.session_id, state => (runtimeInfo ? { ...state, ...runtimeInfo } : state), stored)
+        updateSessionState(
+          created.session_id,
+          state => (runtimeInfo ? { ...state, ...runtimeInfo } : state),
+          stored,
+          profile
+        )
 
-        openSessionTile(stored, dir)
+        openSessionTile(stored, dir, undefined, undefined, profile)
         patchSessionTile(stored, { runtimeId: created.session_id })
         revealTreePane(`session-tile:${stored}`)
 
@@ -526,24 +562,29 @@ export function useSessionActions({
   }, [navigate])
 
   const closeSettings = useCallback(() => {
-    if (selectedStoredSessionId) {
-      navigate(sessionRoute(selectedStoredSessionId))
+    const identityKey = $selectedSessionIdentityKey.get()
+
+    if (identityKey) {
+      const { profile, storedSessionId } = parseSessionIdentityKey(identityKey)
+      navigate(sessionRoute(storedSessionId, profile))
 
       return
     }
 
     navigate(NEW_CHAT_ROUTE)
-  }, [navigate, selectedStoredSessionId])
+  }, [navigate])
 
   const resumeSession = useCallback(
-    async (storedSessionId: string, replaceRoute = false) => {
+    async (storedSessionId: string, replaceRoute = false, profile?: null | string) => {
+      const requestedProfile = normalizeProfileKey(profile ?? $activeGatewayProfile.get())
+      const identityKey = sessionIdentityKey(storedSessionId, requestedProfile)
       const requestId = resumeRequestRef.current + 1
       resumeRequestRef.current = requestId
-      const resumedSameSelectedSession = selectedStoredSessionIdRef.current === storedSessionId
+      const resumedSameSelectedSession = $selectedSessionIdentityKey.get() === identityKey
       const resumeStartMessages = resumedSameSelectedSession ? $messages.get() : []
 
       const isCurrentResume = () =>
-        resumeRequestRef.current === requestId && selectedStoredSessionIdRef.current === storedSessionId
+        resumeRequestRef.current === requestId && $selectedSessionIdentityKey.get() === identityKey
 
       // Paint the click before the profile-resolve / gateway-swap awaits below,
       // so there's zero dead air: highlight the row instantly (the sidebar reads
@@ -556,7 +597,7 @@ export function useSessionActions({
       setFreshDraftReady(false)
       clearNotifications()
       resetViewSync()
-      setSelectedStoredSessionId(storedSessionId)
+      setSelectedStoredSessionId(storedSessionId, requestedProfile)
       selectedStoredSessionIdRef.current = storedSessionId
       // A session is EITHER the main thread OR a tile — never both. openSessionTile
       // enforces this from the tile side (it refuses to tile the selected session);
@@ -574,11 +615,11 @@ export function useSessionActions({
       // we're attempting a fresh resume, so the self-heal in use-route-resume
       // must not keep treating it as stranded. It's re-armed below only if THIS
       // attempt fails terminally (RPC reject + REST fallback failure).
-      setResumeFailedSessionId(current => (current === storedSessionId ? null : current))
+      setResumeFailedSessionId(current => (current === identityKey ? null : current))
       // Also clear the exhausted-latch: a fresh attempt (manual Retry, reconnect,
       // reselect) gives the bounded auto-retry counter a clean cycle, so the
       // chat view drops the error state and shows the loader again.
-      setResumeExhaustedSessionId(current => (current === storedSessionId ? null : current))
+      setResumeExhaustedSessionId(current => (current === identityKey ? null : current))
 
       // A warm cache entry is only trustworthy when it still BELONGS to the
       // session being resumed. A pooled profile backend that gets idle-reaped
@@ -590,15 +631,18 @@ export function useSessionActions({
       // mismatch the mapping is cross-wired: purge both sides and report a miss
       // so the caller falls through to a full resume that rebinds a correct id.
       const takeWarmCache = (): { runtimeId: string; state: ClientSessionState } | null => {
-        const runtimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
+        const runtimeId = runtimeIdByStoredSessionIdRef.current.get(identityKey)
         const state = runtimeId ? sessionStateByRuntimeIdRef.current.get(runtimeId) : undefined
 
         if (!runtimeId || !state) {
           return null
         }
 
-        if (state.storedSessionId !== storedSessionId) {
-          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+        if (
+          state.storedSessionId !== storedSessionId ||
+          normalizeProfileKey(state.storedSessionProfile) !== requestedProfile
+        ) {
+          runtimeIdByStoredSessionIdRef.current.delete(identityKey)
           sessionStateByRuntimeIdRef.current.delete(runtimeId)
           dropSessionState(runtimeId)
 
@@ -621,8 +665,8 @@ export function useSessionActions({
       // gateway call (no-op when it's already on that profile / single-profile).
       // resolveStoredSession finds the row by id (cheap), so an uncached pasted
       // id loads as fast as a sidebar click instead of hanging on a list scan.
-      const storedForProfile = await resolveStoredSession(storedSessionId)
-      const sessionProfile = storedForProfile?.profile
+      const storedForProfile = await resolveStoredSession(storedSessionId, requestedProfile)
+      const sessionProfile = normalizeProfileKey(storedForProfile?.profile ?? requestedProfile)
 
       if (resumeRequestRef.current !== requestId) {
         return
@@ -640,7 +684,7 @@ export function useSessionActions({
         const cachedState = warmHit.state
 
         const stored =
-          $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ?? storedForProfile
+          $sessions.get().find(session => sessionMatchesIdentity(session, storedSessionId, sessionProfile)) ?? storedForProfile
 
         let cachedViewState =
           !cachedState.model && stored?.model != null
@@ -664,7 +708,7 @@ export function useSessionActions({
         }
 
         if (sessionShouldHaveTranscript(stored) && cachedViewState.messages.length === 0) {
-          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+          runtimeIdByStoredSessionIdRef.current.delete(identityKey)
           sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
           dropSessionState(cachedRuntimeId)
         } else {
@@ -681,7 +725,7 @@ export function useSessionActions({
 
           setFreshDraftReady(false)
           clearNotifications()
-          setSelectedStoredSessionId(storedSessionId)
+          setSelectedStoredSessionId(storedSessionId, sessionProfile)
           selectedStoredSessionIdRef.current = storedSessionId
           setActiveSessionId(cachedRuntimeId)
           activeSessionIdRef.current = cachedRuntimeId
@@ -724,7 +768,7 @@ export function useSessionActions({
             }
 
             if (activated.session_key && activated.session_key !== storedSessionId) {
-              runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+              runtimeIdByStoredSessionIdRef.current.delete(identityKey)
               sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
               dropSessionState(cachedRuntimeId)
             } else {
@@ -796,7 +840,7 @@ export function useSessionActions({
               return
             }
 
-            runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+            runtimeIdByStoredSessionIdRef.current.delete(identityKey)
             sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
             dropSessionState(cachedRuntimeId)
           }
@@ -822,12 +866,12 @@ export function useSessionActions({
       busyRef.current = true
       setAwaitingResponse(false)
       clearNotifications()
-      setSelectedStoredSessionId(storedSessionId)
+      setSelectedStoredSessionId(storedSessionId, sessionProfile)
       selectedStoredSessionIdRef.current = storedSessionId
       setSessionStartedAt(Date.now())
 
       const stored =
-        $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ?? storedForProfile
+        $sessions.get().find(session => sessionMatchesIdentity(session, storedSessionId, sessionProfile)) ?? storedForProfile
 
       applyStoredSessionPreviewRuntimeInfo(stored)
 
@@ -943,7 +987,8 @@ export function useSessionActions({
         // returns `preferredMessages` by reference, keeping the fast path
         // below intact.
         const inFlightRecovery = recoverInFlightTurnJournal(storedSessionId, preferredMessages, {
-          keepPending: resumedRunning
+          keepPending: resumedRunning,
+          profile: sessionProfile
         })
 
         recoveredInFlightTail = inFlightRecovery.applied
@@ -963,7 +1008,7 @@ export function useSessionActions({
         if (sessionShouldHaveTranscript(stored) && preferredMessages.length === 0) {
           setActiveSessionId(null)
           activeSessionIdRef.current = null
-          setResumeFailedSessionId(storedSessionId)
+          setResumeFailedSessionId(identityKey)
           resumedRunning = false
 
           return
@@ -973,7 +1018,7 @@ export function useSessionActions({
         activeSessionIdRef.current = resumed.session_id
         const runtimeInfo = applyRuntimeInfo(resumed.info)
 
-        patchSessionWorkspace(storedSessionId, runtimeInfo?.cwd)
+        patchSessionWorkspace(storedSessionId, runtimeInfo?.cwd, sessionProfile)
 
         updateSessionState(
           resumed.session_id,
@@ -995,7 +1040,8 @@ export function useSessionActions({
                 }
               : {})
           }),
-          storedSessionId
+          storedSessionId,
+          sessionProfile
         )
 
         // updateSessionState stages its view sync through requestAnimationFrame.
@@ -1018,8 +1064,6 @@ export function useSessionActions({
         // empty transcript. That is the exact state the thread loader latches on
         // forever (messagesEmpty && !activeSessionId) with no recovery path —
         // the "open in new window stays stuck loading, even after a nap" bug.
-        let fallbackError: unknown = null
-
         try {
           const fallback = await getSessionMessages(storedSessionId, sessionProfile)
 
@@ -1035,41 +1079,19 @@ export function useSessionActions({
           // only carrier of a crashed turn's progress on this path.
           const fallbackRecovery = recoverInFlightTurnJournal(
             storedSessionId,
-            reconcileAuthoritativeMessages(fallback.messages, previousMessages)
+            reconcileAuthoritativeMessages(fallback.messages, previousMessages),
+            { profile: sessionProfile }
           )
 
           setMessages(fallbackRecovery.messages)
-        } catch (e) {
+        } catch {
           // Fallback also failed: nothing to paint. Leave whatever messages are
           // already shown and fall through to arm the resume-failure latch so
           // use-route-resume re-attempts the resume on the next render / window
           // focus / gateway reconnect instead of stranding the loader.
-          fallbackError = e
         }
 
         if (!isCurrentResume()) {
-          return
-        }
-
-        // The session is genuinely gone (deleted, or a stale id from a wiped /
-        // rotated backend): the resume RPC and the authoritative REST transcript
-        // both 404. There's nothing to recover — silently drop to a fresh draft
-        // instead of toasting an error and hot-looping the bounded retry on a
-        // permanently-dead id. (Booting straight into a no-longer-existent
-        // last-session id is the common trigger.)
-        if ($messages.get().length === 0 && isSessionGoneError(fallbackError)) {
-          // A session created THIS run isn't gone — its backend just flapped
-          // before the turn-less session persisted. Keep the empty view and arm
-          // the bounded retry to rebind, rather than yanking to a fresh draft.
-          // Only a stale id from a PRIOR run drops to a draft.
-          if (createdThisRun.has(storedSessionId)) {
-            setResumeFailedSessionId(storedSessionId)
-
-            return
-          }
-
-          startFreshSessionDraft(true)
-
           return
         }
 
@@ -1082,7 +1104,7 @@ export function useSessionActions({
           // window is readable — arming here would needlessly auto-retry and,
           // once retries exhaust, blank that visible transcript behind the
           // exhausted-state error overlay (a regression vs. plain fallback success).
-          setResumeFailedSessionId(storedSessionId)
+          setResumeFailedSessionId(identityKey)
         }
 
         notifyError(err, copy.resumeFailed)
@@ -1103,7 +1125,6 @@ export function useSessionActions({
       runtimeIdByStoredSessionIdRef,
       selectedStoredSessionIdRef,
       sessionStateByRuntimeIdRef,
-      startFreshSessionDraft,
       syncSessionStateToView,
       updateSessionState
     ]
@@ -1153,10 +1174,16 @@ export function useSessionActions({
         // doesn't bubble to the top until a real message lands (backend persists
         // + auto-names it then). The selected row survives refreshes (sessionsToKeep).
         const rows = $sessions.get()
-        const parent = parentStoredId ? rows.find(session => sessionMatchesStoredId(session, parentStoredId)) : null
+
+        const parent = parentStoredId
+          ? rows.find(session => sessionMatchesIdentity(session, parentStoredId, profile))
+          : null
 
         const siblings = parentStoredId
-          ? rows.filter(session => session.parent_session_id?.trim() === parentStoredId).length
+          ? rows.filter(
+              session =>
+                normalizeProfileKey(session.profile) === profile && session.parent_session_id === parentStoredId
+            ).length
           : 0
 
         setFreshDraftReady(false)
@@ -1166,9 +1193,10 @@ export function useSessionActions({
           copy.branchTitle(siblings + 1).toLowerCase(),
           preview,
           parentStoredId,
-          parent ? parent.last_active || parent.started_at : undefined
+          parent ? parent.last_active || parent.started_at : undefined,
+          profile
         )
-        ensureSessionState(branched.session_id, routedSessionId)
+        ensureSessionState(branched.session_id, routedSessionId, profile)
         updateSessionState(
           branched.session_id,
           state => ({
@@ -1177,21 +1205,22 @@ export function useSessionActions({
             busy: false,
             awaitingResponse: false
           }),
-          routedSessionId
+          routedSessionId,
+          profile
         )
 
         const runtimeInfo = applyRuntimeInfo(branched.info)
-        patchSessionWorkspace(routedSessionId, runtimeInfo?.cwd)
+        patchSessionWorkspace(routedSessionId, runtimeInfo?.cwd, profile)
 
         if (runtimeInfo) {
-          updateSessionState(branched.session_id, state => ({ ...state, ...runtimeInfo }), routedSessionId)
+          updateSessionState(branched.session_id, state => ({ ...state, ...runtimeInfo }), routedSessionId, profile)
         }
 
         // Open the branch as its own tab and switch to it, leaving the parent
         // chat exactly where it is. Prime the tile with the create runtime so it
         // skips a redundant resume. Do NOT select it as the primary session
         // first — openSessionTile no-ops when the id is already primary.
-        openSessionTile(routedSessionId, 'center')
+        openSessionTile(routedSessionId, 'center', undefined, undefined, profile)
         patchSessionTile(routedSessionId, { runtimeId: branched.session_id })
         revealTreePane(`session-tile:${routedSessionId}`)
         broadcastSessionsChanged()
@@ -1246,7 +1275,11 @@ export function useSessionActions({
       // The open chat's owning profile, NOT the picker's / launch profile —
       // /profile only retargets new chats, so a branch of an existing thread
       // must stay on that thread's backend (cache hit for an open session).
-      const profile = await resolveSessionProfile(selectedStoredSessionIdRef.current)
+      const selectedIdentity = $selectedSessionIdentityKey.get()
+
+      const profile = selectedIdentity
+        ? parseSessionIdentityKey(selectedIdentity).profile
+        : await resolveSessionProfile(selectedStoredSessionIdRef.current)
 
       return forkBranch(
         branchMessages,
@@ -1270,7 +1303,13 @@ export function useSessionActions({
       // miss: resolve it (cache → active backend → cross-profile) so the branch
       // is created on the parent's OWNING profile, not whichever is live (#67603).
       const stored =
-        $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
+        $sessions
+          .get()
+          .find(session =>
+            sessionProfile
+              ? sessionMatchesIdentity(session, storedSessionId, sessionProfile)
+              : sessionMatchesStoredId(session, storedSessionId)
+          ) ??
         (sessionProfile ? undefined : await resolveStoredSession(storedSessionId))
 
       const profile = sessionProfile ?? stored?.profile
@@ -1297,27 +1336,33 @@ export function useSessionActions({
   )
 
   const removeSession = useCallback(
-    async (storedSessionId: string) => {
+    async (storedSessionId: string, sessionProfile?: null | string) => {
       clearNotifications()
 
-      const removed = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
-      const wasSelected = selectedStoredSessionId === storedSessionId
+      const profile = normalizeProfileKey(sessionProfile ?? $activeGatewayProfile.get())
+
+      const matchesRemoved = (session: Parameters<typeof sessionMatchesStoredId>[0]) =>
+        sessionMatchesIdentity(session, storedSessionId, profile)
+
+      const removed = $sessions.get().find(matchesRemoved)
+      const identityKey = sessionIdentityKey(storedSessionId, profile)
+      const wasSelected = $selectedSessionIdentityKey.get() === identityKey
       const closingRuntimeId = wasSelected ? activeSessionId : null
       const previousMessages = $messages.get()
       const previousPinned = $pinnedSessionIds.get()
       // Pins are keyed on the durable lineage-root id; the stored id may be the
       // live tip after compression. Drop both so the pin can't linger.
-      const removedPinId = removed ? sessionPinId(removed) : storedSessionId
+      const removedPinId = removed ? sessionPinId(removed) : identityKey
       const removedIds = [storedSessionId, removed?.id, removed?._lineage_root_id]
 
-      setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+      setSessions(prev => prev.filter(session => !matchesRemoved(session)))
       // Evict from the project tree's optimistic layer too (the backend snapshot
       // still lists it until its next refresh), so grouped + flat views drop the
       // row in lockstep. Pin the tombstone against the projects.tree prune while
       // the delete RPC is in flight, so a racing refresh can't flash it back.
-      tombstoneSessions(removedIds)
-      beginSessionMutation(removedIds)
-      $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== removedPinId))
+      tombstoneSessions(removedIds, profile)
+      beginSessionMutation(removedIds, profile)
+      $pinnedSessionIds.set(previousPinned.filter(id => id !== removedPinId))
 
       // Tear down before awaiting so the route effect can't resume the
       // doomed session via the stale /<sid> URL.
@@ -1330,8 +1375,8 @@ export function useSessionActions({
           await requestGateway('session.close', { session_id: closingRuntimeId }).catch(() => undefined)
         }
 
-        await deleteSession(storedSessionId, removed?.profile)
-        clearQueuedPrompts(storedSessionId)
+        await deleteSession(storedSessionId, profile)
+        clearQueuedPrompts(removedPinId)
 
         if (closingRuntimeId) {
           clearQueuedPrompts(closingRuntimeId)
@@ -1340,11 +1385,11 @@ export function useSessionActions({
         // A tiled copy of this session must not outlive it: collapse the pane
         // and evict its mirrored runtime state so nothing submits to (or renders)
         // a deleted session.
-        const tiledRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
-        closeSessionTile(storedSessionId)
+        const tiledRuntimeId = runtimeIdByStoredSessionIdRef.current.get(identityKey)
+        discardSessionTile(storedSessionId, profile)
 
         if (tiledRuntimeId) {
-          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+          runtimeIdByStoredSessionIdRef.current.delete(identityKey)
           sessionStateByRuntimeIdRef.current.delete(tiledRuntimeId)
           dropSessionState(tiledRuntimeId)
         }
@@ -1353,21 +1398,21 @@ export function useSessionActions({
           setSessions(prev => [removed, ...prev])
         }
 
-        untombstoneSessions(removedIds)
+        untombstoneSessions(removedIds, profile)
         $pinnedSessionIds.set(previousPinned)
 
         if (wasSelected) {
           setFreshDraftReady(false)
-          setSelectedStoredSessionId(storedSessionId)
+          setSelectedStoredSessionId(storedSessionId, profile)
           selectedStoredSessionIdRef.current = storedSessionId
-          const stored = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+          const stored = $sessions.get().find(matchesRemoved)
 
           if (stored) {
             applyStoredUsage(stored)
           }
 
           setMessages(previousMessages)
-          navigate(sessionRoute(storedSessionId), { replace: true })
+          navigate(sessionRoute(storedSessionId, profile), { replace: true })
 
           if (closingRuntimeId) {
             setActiveSessionId(closingRuntimeId)
@@ -1380,7 +1425,7 @@ export function useSessionActions({
         // Release the tombstone to the normal projects.tree prune now the RPC has
         // settled (kept on success — the backend has deleted it; cleared on the
         // rollback above on failure).
-        endSessionMutation(removedIds)
+        endSessionMutation(removedIds, profile)
       }
     },
     [
@@ -1390,7 +1435,6 @@ export function useSessionActions({
       navigate,
       requestGateway,
       runtimeIdByStoredSessionIdRef,
-      selectedStoredSessionId,
       selectedStoredSessionIdRef,
       sessionStateByRuntimeIdRef,
       startFreshSessionDraft
@@ -1398,35 +1442,41 @@ export function useSessionActions({
   )
 
   const archiveSession = useCallback(
-    async (storedSessionId: string) => {
+    async (storedSessionId: string, sessionProfile?: null | string) => {
       clearNotifications()
 
-      const archived = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
-      const wasSelected = selectedStoredSessionId === storedSessionId
+      const profile = normalizeProfileKey(sessionProfile ?? $activeGatewayProfile.get())
+
+      const matchesArchived = (session: Parameters<typeof sessionMatchesStoredId>[0]) =>
+        sessionMatchesIdentity(session, storedSessionId, profile)
+
+      const archived = $sessions.get().find(matchesArchived)
+      const identityKey = sessionIdentityKey(storedSessionId, profile)
+      const wasSelected = $selectedSessionIdentityKey.get() === identityKey
       const previousPinned = $pinnedSessionIds.get()
       // Pins are keyed on the durable lineage-root id; the stored id may be the
       // live tip after compression. Drop both so the pin can't linger.
-      const archivedPinId = archived ? sessionPinId(archived) : storedSessionId
+      const archivedPinId = archived ? sessionPinId(archived) : identityKey
       const archivedIds = [storedSessionId, archived?.id, archived?._lineage_root_id]
 
       // Soft-hide: drop from the sidebar immediately, keep the data.
-      setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
-      tombstoneSessions(archivedIds)
-      beginSessionMutation(archivedIds)
-      $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
+      setSessions(prev => prev.filter(session => !matchesArchived(session)))
+      tombstoneSessions(archivedIds, profile)
+      beginSessionMutation(archivedIds, profile)
+      $pinnedSessionIds.set(previousPinned.filter(id => id !== archivedPinId))
 
       if (wasSelected) {
         startFreshSessionDraft(true)
       }
 
       try {
-        await setSessionArchived(storedSessionId, true, archived?.profile)
+        await setSessionArchived(storedSessionId, true, profile)
         // An archived session is hidden from the sidebar; its tile must go too.
-        const tiledRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
-        closeSessionTile(storedSessionId)
+        const tiledRuntimeId = runtimeIdByStoredSessionIdRef.current.get(identityKey)
+        discardSessionTile(storedSessionId, profile)
 
         if (tiledRuntimeId) {
-          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+          runtimeIdByStoredSessionIdRef.current.delete(identityKey)
           sessionStateByRuntimeIdRef.current.delete(tiledRuntimeId)
           dropSessionState(tiledRuntimeId)
         }
@@ -1434,17 +1484,17 @@ export function useSessionActions({
         notify({ durationMs: 2_000, kind: 'success', message: copy.archived })
       } catch (err) {
         if (archived) {
-          setSessions(prev => [archived, ...prev.filter(session => !sessionMatchesStoredId(session, storedSessionId))])
+          setSessions(prev => [archived, ...prev.filter(session => !matchesArchived(session))])
         }
 
-        untombstoneSessions(archivedIds)
+        untombstoneSessions(archivedIds, profile)
         $pinnedSessionIds.set(previousPinned)
         notifyError(err, copy.archiveFailed)
       } finally {
-        endSessionMutation(archivedIds)
+        endSessionMutation(archivedIds, profile)
       }
     },
-    [copy, runtimeIdByStoredSessionIdRef, selectedStoredSessionId, sessionStateByRuntimeIdRef, startFreshSessionDraft]
+    [copy, runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef, startFreshSessionDraft]
   )
 
   return {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1,9 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { getSession } from '@/hermes'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
 import { $desktopOnboarding } from '@/store/onboarding'
 import { $activeGatewayProfile } from '@/store/profile'
+import { $sessions, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import {
@@ -15,10 +17,18 @@ import {
   isSessionGoneError,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
+  resolveStoredSession,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
-  toBranchMessages
+  toBranchMessages,
+  upsertOptimisticSession,
+  upsertResolvedSession
 } from './utils'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getSession: vi.fn()
+}))
 
 const msg = (id: string, role: ChatMessage['role'], text: string, extra: Partial<ChatMessage> = {}): ChatMessage =>
   ({ id, role, parts: [{ type: 'text', text }], ...extra }) as ChatMessage
@@ -79,6 +89,50 @@ describe('sessionMatchesStoredId', () => {
     expect(sessionMatchesStoredId(session({ id: 'a' }), 'a')).toBe(true)
     expect(sessionMatchesStoredId(session({ id: 'live', _lineage_root_id: 'root' }), 'root')).toBe(true)
     expect(sessionMatchesStoredId(session({ id: 'a' }), 'b')).toBe(false)
+  })
+})
+
+describe('profile-scoped session upserts', () => {
+  beforeEach(() => {
+    setSessions([])
+  })
+
+  it('keeps colliding optimistic ids from other profiles', () => {
+    setSessions([session({ id: 'shared', profile: 'alpha', title: 'Alpha' })])
+
+    upsertOptimisticSession({} as never, 'shared', 'Beta', null, null, undefined, 'beta')
+
+    expect($sessions.get()).toEqual([
+      expect.objectContaining({ id: 'shared', profile: 'beta', title: 'Beta' }),
+      expect.objectContaining({ id: 'shared', profile: 'alpha', title: 'Alpha' })
+    ])
+  })
+
+  it('replaces only the resolved lineage in the owning profile', () => {
+    setSessions([
+      session({ id: 'alpha-tip', _lineage_root_id: 'shared', profile: 'alpha' }),
+      session({ id: 'beta-old', _lineage_root_id: 'shared', profile: 'beta' })
+    ])
+
+    upsertResolvedSession(session({ id: 'beta-new', _lineage_root_id: 'shared', profile: 'beta' }), 'shared')
+
+    expect($sessions.get().map(({ id, profile }) => `${profile}:${id}`)).toEqual(['beta:beta-new', 'alpha:alpha-tip'])
+  })
+})
+
+describe('resolveStoredSession profile ownership', () => {
+  afterEach(() => {
+    setSessions([])
+    vi.mocked(getSession).mockReset()
+  })
+
+  it('queries the requested active profile before accepting a sole colliding cache row', async () => {
+    $activeGatewayProfile.set('beta')
+    setSessions([session({ id: 'shared', profile: 'alpha', title: 'Alpha' })])
+    vi.mocked(getSession).mockResolvedValue(session({ id: 'shared', profile: 'beta', title: 'Beta' }))
+
+    await expect(resolveStoredSession('shared')).resolves.toEqual(expect.objectContaining({ profile: 'beta' }))
+    expect(getSession).toHaveBeenCalledWith('shared', 'beta')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -2,6 +2,7 @@ import { getSession } from '@/hermes'
 import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages, textWithoutImageRefs } from '@/lib/embedded-images'
+import { normalizeProfileKey as normalizeIdentityProfile, sessionMatchesIdentity } from '@/lib/session-identity'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
@@ -523,13 +524,14 @@ export function upsertOptimisticSession(
   title: string | null = null,
   preview: string | null = null,
   parentSessionId: string | null = null,
-  lastActive?: number
+  lastActive?: number,
+  profile?: null | string
 ) {
   const now = lastActive ?? Date.now() / 1000
   // Stamp the profile the session was just created on (= the live gateway's
   // profile) so the scoped sidebar shows the new row immediately instead of
   // filtering it out as "default" until the aggregator re-fetches.
-  const profileKey = normalizeProfileKey($activeGatewayProfile.get())
+  const profileKey = normalizeIdentityProfile(profile ?? $activeGatewayProfile.get())
 
   const session: SessionInfo = {
     // Seed cwd so the grouped sidebar can place the new row in its repo/worktree
@@ -554,60 +556,87 @@ export function upsertOptimisticSession(
     tool_call_count: 0
   }
 
-  setSessions(prev => [session, ...prev.filter(s => s.id !== id)])
+  setSessions(prev => [session, ...prev.filter(s => !sessionMatchesIdentity(s, id, profileKey))])
 }
 
-export function patchSessionWorkspace(sessionId: string, cwd: string | undefined) {
+export function patchSessionWorkspace(sessionId: string, cwd: string | undefined, profile?: null | string) {
   if (!cwd) {
     return
   }
 
-  setSessions(prev => prev.map(session => (session.id === sessionId ? { ...session, cwd } : session)))
+  setSessions(prev =>
+    prev.map(session => (sessionMatchesIdentity(session, sessionId, profile) ? { ...session, cwd } : session))
+  )
 }
 
 export function sessionShouldHaveTranscript(session: SessionInfo | undefined): boolean {
   return (session?.message_count ?? 0) > 0
 }
 
-function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
+export function upsertResolvedSession(session: SessionInfo, storedSessionId: string, profile?: null | string) {
+  const owner = profile ?? session.profile
   const lineage = session._lineage_root_id ?? session.id
 
   setSessions(prev => [
     session,
     ...prev.filter(existing => {
-      if (sessionMatchesStoredId(existing, storedSessionId)) {
+      if (sessionMatchesIdentity(existing, storedSessionId, owner)) {
         return false
       }
 
-      return (existing._lineage_root_id ?? existing.id) !== lineage
+      return !sessionMatchesIdentity(existing, lineage, owner)
     })
   ])
 }
 
-export async function resolveStoredSession(storedSessionId: string): Promise<SessionInfo | undefined> {
-  const cached = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+export async function resolveStoredSession(
+  storedSessionId: string,
+  profile?: null | string
+): Promise<SessionInfo | undefined> {
+  const requestedProfile = normalizeProfileKey(profile ?? $activeGatewayProfile.get())
+  const cached = $sessions.get().find(session => sessionMatchesIdentity(session, storedSessionId, requestedProfile))
 
   if (cached) {
     return cached
   }
 
+
   // Direct by-id on the live backend — one row lookup, no list scan. Covers
   // single-profile users and any id on the active profile (e.g. an old session
   // past the sidebar's recent window). 404 just means it's not on this profile.
   try {
-    const session = await getSession(storedSessionId)
+    const session = await getSession(storedSessionId, requestedProfile)
 
-    upsertResolvedSession(session, storedSessionId)
+    upsertResolvedSession(session, storedSessionId, requestedProfile)
 
     return session
-  } catch {
-    // Not on the active profile — fall through to the cross-profile probe.
+  } catch (error) {
+    if (profile != null) {
+      return undefined
+    }
+
+    // A sole row cached under another owner is safe only after the requested
+    // active backend has definitively said this id does not exist there.
+    if (!isSessionGoneError(error)) {
+      return undefined
+    }
+  }
+
+  const cachedAcrossProfiles = $sessions
+    .get()
+    .filter(session => session.id === storedSessionId || session._lineage_root_id === storedSessionId)
+
+  if (cachedAcrossProfiles.length === 1) {
+    return cachedAcrossProfiles[0]
   }
 
   // Multi-profile only: probe each other profile by id (still one cheap lookup
   // each) rather than pulling every profile's recent sessions. The first hit
   // carries its owning `profile`, which routes the resume to the right backend.
-  const activeKey = normalizeProfileKey($activeGatewayProfile.get())
+  // Keep the owner search anchored to the profile captured before the first
+  // await. Reading the live profile here lets a mid-lookup switch exclude the
+  // very backend that owns the target.
+  const activeKey = requestedProfile
 
   const otherProfiles = $profiles
     .get()
@@ -618,7 +647,7 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
     try {
       const session = await getSession(storedSessionId, profile)
 
-      upsertResolvedSession(session, storedSessionId)
+      upsertResolvedSession(session, storedSessionId, profile)
 
       return session
     } catch {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -1,15 +1,19 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { resolveManualSessionOrderIds } from '@/app/chat/sidebar/order'
 import type { SessionInfo, SidebarSessionsResponse } from '@/hermes'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import {
   $cronSessions,
   $messagingSessions,
   $sessions,
+  $sessionsHydratedProfileScope,
   $sessionsLoading,
   setCronSessions,
   setMessagingSessions,
   setSessions,
+  setSessionsHydratedProfileScope,
   setSessionsLoading
 } from '@/store/session'
 
@@ -77,6 +81,7 @@ beforeEach(() => {
   setSessions([])
   setCronSessions([])
   setMessagingSessions([])
+  setSessionsHydratedProfileScope(null)
   setSessionsLoading(false)
 })
 
@@ -84,6 +89,7 @@ afterEach(() => {
   setSessions([])
   setCronSessions([])
   setMessagingSessions([])
+  setSessionsHydratedProfileScope(null)
   setSessionsLoading(false)
 })
 
@@ -151,11 +157,67 @@ describe('refreshSessions identity + loading hygiene', () => {
     expect(loadingStates).toEqual([false])
   })
 
+  it('does not mark a new populated profile scope hydrated until its refresh succeeds', async () => {
+    let resolveAll!: (value: SidebarSessionsResponse) => void
+
+    const pendingAll = new Promise<SidebarSessionsResponse>(resolve => {
+      resolveAll = resolve
+    })
+
+    setSessions([row('alpha', { profile: 'alpha' })])
+    setSessionsHydratedProfileScope('alpha')
+    listSidebarSessions.mockReturnValue(pendingAll)
+
+    const { rerender, result } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'alpha' } }
+    )
+
+    rerender({ profileScope: '__all__' })
+    let refresh!: Promise<void>
+
+    act(() => {
+      refresh = result.current.refreshSessions()
+    })
+
+    expect($sessionsLoading.get()).toBe(false)
+    expect($sessionsHydratedProfileScope.get()).toBe('alpha')
+
+    const alpha = sessionIdentityKey('alpha', 'alpha')
+    const beta = sessionIdentityKey('beta', 'beta')
+
+    expect(
+      resolveManualSessionOrderIds(
+        [alpha],
+        [alpha, beta],
+        true,
+        $sessionsHydratedProfileScope.get() !== '__all__',
+        ['alpha', 'beta']
+      )
+    ).toEqual([alpha, beta])
+
+    await act(async () => {
+      resolveAll(sidebar({ sessions: [row('alpha', { profile: 'alpha' })] }))
+      await refresh
+    })
+
+    expect($sessionsHydratedProfileScope.get()).toBe('__all__')
+    expect(
+      resolveManualSessionOrderIds(
+        [alpha],
+        [alpha, beta],
+        true,
+        $sessionsHydratedProfileScope.get() !== '__all__',
+        ['alpha', 'beta']
+      )
+    ).toEqual([alpha])
+  })
+
   it('drops rows the user just deleted, even when the backend page still lists them', async () => {
     // A delete RPC is in flight: the row is tombstoned optimistically but the
     // batched refresh still carries it (and a lineage-tip variant). Both must be
     // filtered so the optimistic removal never flashes back.
-    removed.ids = new Set(['b', 'root-c'])
+    removed.ids = new Set([sessionIdentityKey('b', 'default'), sessionIdentityKey('root-c', 'default')])
     listSidebarSessions.mockResolvedValue(
       sidebar({
         sessions: [row('a'), row('b'), row('c', { _lineage_root_id: 'root-c' } as Partial<SessionInfo>)]
@@ -169,6 +231,21 @@ describe('refreshSessions identity + loading hygiene', () => {
     })
 
     expect($sessions.get().map(s => s.id)).toEqual(['a'])
+  })
+
+  it('applies an optimistic tombstone only to the owning profile when stored ids collide', async () => {
+    removed.ids = new Set([sessionIdentityKey('shared', 'alpha')])
+    listSidebarSessions.mockResolvedValue(
+      sidebar({ sessions: [row('shared', { profile: 'alpha' }), row('shared', { profile: 'beta' })] })
+    )
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'all' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get().map(s => s.profile)).toEqual(['beta'])
   })
 
   it('still shows loading for the initial (empty-list) fetch', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from 'react'
 
 import { getCronJobs, listAllProfileSessions, listSidebarSessions, type SessionInfo } from '@/hermes'
+import { parseSessionIdentityKey, sessionIdentityKey } from '@/lib/session-identity'
 import { sameCronSignature } from '@/lib/session-signatures'
 import {
   isMessagingSource,
@@ -14,7 +15,7 @@ import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
 import { $removedSessionIds } from '@/store/projects'
 import {
   $messagingSessions,
-  $selectedStoredSessionId,
+  $selectedSessionIdentityKey,
   $sessions,
   CRON_SECTION_LIMIT,
   mergeSessionPage,
@@ -25,6 +26,7 @@ import {
   setMessagingTruncated,
   setSessionProfilesTruncated,
   setSessions,
+  setSessionsHydratedProfileScope,
   setSessionsLoading
 } from '@/store/session'
 import { $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
@@ -52,13 +54,13 @@ function sessionsToKeep(scope?: string): Set<string> {
     ...getRecentlySettledSessionIds()
   ])
 
-  const active = $selectedStoredSessionId.get()
+  const activeIdentity = $selectedSessionIdentityKey.get()
 
-  if (active) {
-    const session = scope ? $sessions.get().find(s => s.id === active) : null
+  if (activeIdentity) {
+    const { profile } = parseSessionIdentityKey(activeIdentity)
 
-    if (!scope || !session || normalizeProfileKey(session.profile) === scope) {
-      keep.add(active)
+    if (!scope || normalizeProfileKey(profile) === scope) {
+      keep.add(activeIdentity)
     }
   }
 
@@ -188,7 +190,9 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
         const incoming = tombstones.size
           ? recents.sessions.filter(
-              s => !tombstones.has(s.id) && !(s._lineage_root_id && tombstones.has(s._lineage_root_id))
+              s =>
+                !tombstones.has(sessionIdentityKey(s.id, s.profile)) &&
+                !(s._lineage_root_id && tombstones.has(sessionIdentityKey(s._lineage_root_id, s.profile)))
             )
           : recents.sessions
 
@@ -227,6 +231,10 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         setMessagingSessions(prev => (sameCronSignature(prev, messagingRows) ? prev : messagingRows))
         // Hit the cap → at least one platform may have more on disk than loaded.
         setMessagingTruncated(result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT)
+        // Publish scope completion only after every recents update above has
+        // landed. Until this point a populated old scope is presentation data,
+        // not evidence that newly requested profiles are empty.
+        setSessionsHydratedProfileScope(profileScope === ALL_PROFILES ? ALL_PROFILES : normalizeProfileKey(profileScope))
       }
     } finally {
       if (showLoading && refreshSessionsRequestRef.current === requestId) {

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -3,6 +3,8 @@ import { type MutableRefObject, useLayoutEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
+import { clearInFlightTurnJournal, readInFlightTurnJournal } from '@/lib/inflight-turn-journal'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import {
   $activeSessionStoredIdRotation,
   $currentFastMode,
@@ -57,8 +59,10 @@ describe('useSessionStateCache — stored-id rotation provenance', () => {
       previousStoredSessionId: 'stored-A',
       runtimeSessionId: 'runtime-A'
     })
-    expect(cache.runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)
-    expect(cache.runtimeIdByStoredSessionIdRef.current.get('stored-A-next')).toBe('runtime-A')
+    expect(cache.runtimeIdByStoredSessionIdRef.current.has(sessionIdentityKey('stored-A', 'default'))).toBe(false)
+    expect(cache.runtimeIdByStoredSessionIdRef.current.get(sessionIdentityKey('stored-A-next', 'default'))).toBe(
+      'runtime-A'
+    )
   })
 
   it('does not publish a foreground-navigation event for a background runtime rotation', () => {
@@ -75,8 +79,55 @@ describe('useSessionStateCache — stored-id rotation provenance', () => {
     })
 
     expect($activeSessionStoredIdRotation.get()).toBeNull()
-    expect(cache.runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)
-    expect(cache.runtimeIdByStoredSessionIdRef.current.get('stored-A-next')).toBe('runtime-A')
+    expect(cache.runtimeIdByStoredSessionIdRef.current.has(sessionIdentityKey('stored-A', 'default'))).toBe(false)
+    expect(cache.runtimeIdByStoredSessionIdRef.current.get(sessionIdentityKey('stored-A-next', 'default'))).toBe(
+      'runtime-A'
+    )
+  })
+
+  it('does not resurrect a settled turn journal when its stored id rotates', () => {
+    vi.useFakeTimers()
+    let cache!: Cache
+
+    try {
+      render(<Harness activeSessionId="runtime-A" onReady={value => (cache = value)} selectedStoredSessionId="root" />)
+
+      act(() => {
+        cache.updateSessionState(
+          'runtime-A',
+          state => ({
+            ...state,
+            busy: true,
+            messages: [
+              userMessage('user-1', 'prompt'),
+              { ...assistantText('old-stream', 'stale partial turn'), pending: true }
+            ],
+            streamId: 'old-stream',
+            turnStartedAt: 1
+          }),
+          'root',
+          'alpha'
+        )
+        vi.advanceTimersByTime(400)
+      })
+      expect(readInFlightTurnJournal('root', 'alpha')?.streamId).toBe('old-stream')
+
+      act(() => {
+        cache.updateSessionState(
+          'runtime-A',
+          state => ({ ...state, awaitingResponse: false, busy: false, streamId: null, turnStartedAt: null }),
+          'tip',
+          'alpha'
+        )
+      })
+
+      expect(readInFlightTurnJournal('root', 'alpha')).toBeNull()
+      expect(readInFlightTurnJournal('tip', 'alpha')).toBeNull()
+    } finally {
+      clearInFlightTurnJournal('root', 'alpha')
+      clearInFlightTurnJournal('tip', 'alpha')
+      vi.useRealTimers()
+    }
   })
 })
 
@@ -489,7 +540,7 @@ describe('useSessionStateCache — cross-thread error isolation', () => {
 
     // Simulate a recycled/cross-wired map entry. The reverse state ownership
     // check must reject it instead of allowing a submit into stored-B.
-    cache.runtimeIdByStoredSessionIdRef.current.set('stored-A', 'runtime-B')
+    cache.runtimeIdByStoredSessionIdRef.current.set(sessionIdentityKey('stored-A', 'default'), 'runtime-B')
     expect(cache.getRuntimeIdForStoredSession('stored-A')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -6,6 +6,8 @@ import { preserveLocalAssistantErrors } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { persistInFlightTurnState } from '@/lib/inflight-turn-journal'
 import { setMutableRef } from '@/lib/mutable-ref'
+import { normalizeProfileKey, sessionIdentityKey } from '@/lib/session-identity'
+import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
   $busy,
@@ -94,58 +96,56 @@ export function useSessionStateCache({
     setMutableRef(busyRef, busy)
   }, [busy, busyRef])
 
-  const ensureSessionState = useCallback((sessionId: string, storedSessionId?: string | null) => {
-    const existing = sessionStateByRuntimeIdRef.current.get(sessionId)
+  const ensureSessionState = useCallback(
+    (sessionId: string, storedSessionId?: string | null, storedSessionProfile?: null | string) => {
+      const existing = sessionStateByRuntimeIdRef.current.get(sessionId)
+      const profileKey = normalizeProfileKey(
+        storedSessionProfile ?? existing?.storedSessionProfile ?? $activeGatewayProfile.get()
+      )
 
-    if (existing) {
-      if (storedSessionId !== undefined && storedSessionId !== existing.storedSessionId) {
-        // Stored id changed (e.g. auto-compression rotated it). Create a NEW
-        // state object rather than mutating in place — updateSessionState needs
-        // the PREVIOUS state to detect transitions (busy→idle, id rotation).
-        const updated = { ...existing, storedSessionId }
+      if (existing) {
+        const storedIdChanged = storedSessionId !== undefined && storedSessionId !== existing.storedSessionId
+        const profileChanged = normalizeProfileKey(existing.storedSessionProfile) !== profileKey
 
-        sessionStateByRuntimeIdRef.current.set(sessionId, updated)
+        if (storedIdChanged || profileChanged) {
+          const nextStoredId = storedSessionId === undefined ? existing.storedSessionId : storedSessionId
+          const updated = { ...existing, storedSessionId: nextStoredId, storedSessionProfile: profileKey }
 
-        // Drop the obsolete stored→runtime reverse mapping as soon as the id
-        // rotates (e.g. auto-compression forks a continuation). Leaving the
-        // stale key lets getRuntimeIdForStoredSession resolve the old stored id
-        // to this runtime, which the compression route-follow logic relies on
-        // being absent. The rotation signal was previously emitted centrally
-        // from handleTransition (session-states.ts), but updateSessionState
-        // now skips publishSessionState (and thus handleTransition) when the
-        // updater is a no-op — fire it here so the route-follow effect still
-        // tracks compression without needing a dummy state write.
-        if (existing.storedSessionId && existing.storedSessionId !== storedSessionId) {
-          runtimeIdByStoredSessionIdRef.current.delete(existing.storedSessionId)
+          sessionStateByRuntimeIdRef.current.set(sessionId, updated)
 
-          // A rotation event needs a real next id — a null/cleared stored id
-          // is a detach, not a rotation the route-follow effect should chase.
-          if (storedSessionId && sessionId === $activeSessionId.get()) {
+          if (existing.storedSessionId) {
+            runtimeIdByStoredSessionIdRef.current.delete(
+              sessionIdentityKey(existing.storedSessionId, existing.storedSessionProfile)
+            )
+          }
+
+          if (storedIdChanged && existing.storedSessionId && nextStoredId && sessionId === $activeSessionId.get()) {
             setActiveSessionStoredIdRotation({
-              nextStoredSessionId: storedSessionId,
+              nextStoredSessionId: nextStoredId,
               previousStoredSessionId: existing.storedSessionId,
               runtimeSessionId: sessionId
             })
           }
+
+          if (nextStoredId) {
+            runtimeIdByStoredSessionIdRef.current.set(sessionIdentityKey(nextStoredId, profileKey), sessionId)
+          }
         }
 
-        if (storedSessionId) {
-          runtimeIdByStoredSessionIdRef.current.set(storedSessionId, sessionId)
-        }
+        return sessionStateByRuntimeIdRef.current.get(sessionId)!
       }
 
-      return sessionStateByRuntimeIdRef.current.get(sessionId)!
-    }
+      const created = createClientSessionState(storedSessionId ?? null, [], profileKey)
+      sessionStateByRuntimeIdRef.current.set(sessionId, created)
 
-    const created = createClientSessionState(storedSessionId ?? null)
-    sessionStateByRuntimeIdRef.current.set(sessionId, created)
+      if (storedSessionId) {
+        runtimeIdByStoredSessionIdRef.current.set(sessionIdentityKey(storedSessionId, profileKey), sessionId)
+      }
 
-    if (storedSessionId) {
-      runtimeIdByStoredSessionIdRef.current.set(storedSessionId, sessionId)
-    }
-
-    return created
-  }, [])
+      return created
+    },
+    []
+  )
 
   const resetViewSync = useCallback(() => {
     // Drop any RAF-pending transcript stage so a backgrounded turn cannot
@@ -280,9 +280,10 @@ export function useSessionStateCache({
     (
       sessionId: string,
       updater: (state: ClientSessionState) => ClientSessionState,
-      storedSessionId?: string | null
+      storedSessionId?: string | null,
+      storedSessionProfile?: null | string
     ) => {
-      const previous = ensureSessionState(sessionId, storedSessionId)
+      const previous = ensureSessionState(sessionId, storedSessionId, storedSessionProfile)
       // Give the updater the raw previous state so it can return the same
       // reference when nothing changed (the caller sees a no-op). Previously
       // the param was always a fresh spread, so every call looked like a
@@ -300,14 +301,15 @@ export function useSessionStateCache({
       }
 
       sessionStateByRuntimeIdRef.current.set(sessionId, next)
+      // Publish identity rotation first. The transition migrates any journal
+      // from the previous stored id to `next`; persisting afterward then writes
+      // the current running snapshot or clears that migrated entry when this
+      // same update also settles the turn.
+      publishSessionState(sessionId, next)
       // Crash-survivable turn progress: journal the running turn's visible
       // tail (throttled localStorage write; cleared the moment the turn
       // settles) so a renderer/app death mid-turn can be recovered on resume.
       persistInFlightTurnState(next)
-      // Publishing to $sessionStates automatically fires transition side-effects
-      // (watchdog, settle grace, unread marker, compression id rotation) inside
-      // publishSessionState — no manual transition call needed.
-      publishSessionState(sessionId, next)
       syncSessionStateToView(sessionId, next)
 
       return next
@@ -315,8 +317,9 @@ export function useSessionStateCache({
     [ensureSessionState, syncSessionStateToView]
   )
 
-  const getRuntimeIdForStoredSession = useCallback((storedSessionId: string): string | null => {
-    const runtimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
+  const getRuntimeIdForStoredSession = useCallback((storedSessionId: string, profile?: null | string): string | null => {
+    const profileKey = normalizeProfileKey(profile ?? $activeGatewayProfile.get())
+    const runtimeId = runtimeIdByStoredSessionIdRef.current.get(sessionIdentityKey(storedSessionId, profileKey))
 
     if (!runtimeId) {
       return null
@@ -324,7 +327,10 @@ export function useSessionStateCache({
 
     const runtimeState = sessionStateByRuntimeIdRef.current.get(runtimeId)
 
-    return runtimeState?.storedSessionId === storedSessionId ? runtimeId : null
+    return runtimeState?.storedSessionId === storedSessionId &&
+      normalizeProfileKey(runtimeState.storedSessionProfile) === profileKey
+      ? runtimeId
+      : null
   }, [])
 
   return {

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
+import { archivedSessionElementId } from '@/app/command-palette/session-items'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tip } from '@/components/ui/tooltip'
@@ -14,6 +15,7 @@ import { useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { Archive, ArchiveOff, FolderOpen, Loader2, Trash2 } from '@/lib/icons'
+import { sessionIdentityKey, sessionMatchesIdentity } from '@/lib/session-identity'
 import { notify, notifyError } from '@/store/notifications'
 import { untombstoneSessions } from '@/store/projects'
 import { applyConfiguredDefaultProjectDir, ensureDefaultWorkspaceCwd, setSessions } from '@/store/session'
@@ -68,15 +70,20 @@ export function SessionsSettings() {
 
   const unarchive = useCallback(
     async (session: SessionInfo) => {
-      setBusyId(session.id)
+      const identityKey = sessionIdentityKey(session.id, session.profile)
+
+      setBusyId(identityKey)
 
       try {
         await setSessionArchived(session.id, false, session.profile)
-        setLocalSessions(prev => prev.filter(s => s.id !== session.id))
+        setLocalSessions(prev => prev.filter(s => !sessionMatchesIdentity(s, session.id, session.profile)))
         // Surface it again in the sidebar without waiting for a full refresh, and
         // lift any optimistic eviction so the grouped tree shows it again too.
-        untombstoneSessions([session.id, session._lineage_root_id])
-        setSessions(prev => [{ ...session, archived: false }, ...prev.filter(s => s.id !== session.id)])
+        untombstoneSessions([session.id, session._lineage_root_id], session.profile)
+        setSessions(prev => [
+          { ...session, archived: false },
+          ...prev.filter(s => !sessionMatchesIdentity(s, session.id, session.profile))
+        ])
         triggerHaptic('selection')
         notify({ durationMs: 2_000, kind: 'success', message: s.restored })
       } catch (err) {
@@ -94,11 +101,13 @@ export function SessionsSettings() {
         return
       }
 
-      setBusyId(session.id)
+      const identityKey = sessionIdentityKey(session.id, session.profile)
+
+      setBusyId(identityKey)
 
       try {
         await deleteSession(session.id, session.profile)
-        setLocalSessions(prev => prev.filter(s => s.id !== session.id))
+        setLocalSessions(prev => prev.filter(s => !sessionMatchesIdentity(s, session.id, session.profile)))
         triggerHaptic('warning')
       } catch (err) {
         notifyError(err, s.deleteFailed)
@@ -110,9 +119,9 @@ export function SessionsSettings() {
   )
 
   useDeepLinkHighlight({
-    elementId: id => `archived-session-${id}`,
+    elementId: archivedSessionElementId,
     param: 'session',
-    ready: id => !loading && sessions.some(session => session.id === id)
+    ready: identity => !loading && sessions.some(session => sessionIdentityKey(session.id, session.profile) === identity)
   })
 
   if (loading) {
@@ -140,10 +149,11 @@ export function SessionsSettings() {
         <div className="grid gap-1">
           {sessions.map(session => {
             const label = workspaceLabel(session.cwd)
-            const busy = busyId === session.id
+            const identityKey = sessionIdentityKey(session.id, session.profile)
+            const busy = busyId === identityKey
 
             return (
-              <div className="scroll-mt-6 rounded-lg" id={`archived-session-${session.id}`} key={session.id}>
+              <div className="scroll-mt-6 rounded-lg" id={archivedSessionElementId(identityKey)} key={identityKey}>
                 <ListRow
                   action={
                     <div className="flex items-center gap-1.5">

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -11,6 +11,7 @@ import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
 import { Activity, AlertCircle, Clock, Command, FolderOpen, Globe, Hash, Loader2, Terminal } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
+import { sessionMatchesIdentity } from '@/lib/session-identity'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
@@ -28,7 +29,6 @@ import {
   $sessions,
   $sessionStartedAt,
   $turnStartedAt,
-  sessionMatchesStoredId,
   setCurrentUsage
 } from '@/store/session'
 import { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
@@ -161,7 +161,8 @@ export function useStatusbarItems({
   // every session-list write (title updates, poll refreshes, archives).
   const focusedRowStartedAt = useStoreSelector($sessions, sessions =>
     focusedStoredSessionId
-      ? (sessions.find(s => sessionMatchesStoredId(s, focusedStoredSessionId))?.started_at ?? null)
+      ? (sessions.find(s => sessionMatchesIdentity(s, focusedStoredSessionId, activeGatewayProfile))?.started_at ??
+        null)
       : null
   )
 

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -173,6 +173,7 @@ export interface SidebarNavItem {
 
 export interface ClientSessionState {
   storedSessionId: string | null
+  storedSessionProfile: string | null
   messages: ChatMessage[]
   branch: string
   cwd: string

--- a/apps/desktop/src/components/assistant-ui/artifact-card.tsx
+++ b/apps/desktop/src/components/assistant-ui/artifact-card.tsx
@@ -43,6 +43,7 @@ export function ArtifactCard({ code, detection, streaming = false }: ArtifactCar
   const view = useSessionView()
   const runtimeId = useStore(view.$runtimeId)
   const storedId = useStore(view.$storedId)
+  const profile = useStore(view.$profile)
   const registry = useStore($artifactRegistry)
   const sessionId = storedId || runtimeId || ''
 
@@ -53,20 +54,20 @@ export function ArtifactCard({ code, detection, streaming = false }: ArtifactCar
   // replays are no-ops.
   useEffect(() => {
     if (!streaming && sessionId && trimmed) {
-      upsertArtifact(sessionId, detection, trimmed)
+      upsertArtifact(sessionId, detection, trimmed, profile)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- detection derives from code
-  }, [detection.kind, detection.language, detection.title, sessionId, streaming, trimmed])
+  }, [detection.kind, detection.language, detection.title, profile, sessionId, streaming, trimmed])
 
   const record = useMemo(() => {
     void registry
 
-    const slugMatch = artifactsForSession(sessionId).find(
+    const slugMatch = artifactsForSession(sessionId, profile).find(
       candidate => candidate.kind === detection.kind && candidate.versions.some(v => v.content === trimmed)
     )
 
     return slugMatch ?? null
-  }, [detection.kind, registry, sessionId, trimmed])
+  }, [detection.kind, profile, registry, sessionId, trimmed])
 
   const lineCount = useMemo(() => trimmed.split('\n').length, [trimmed])
   const kindLabel = copy.kind[detection.kind]
@@ -80,7 +81,7 @@ export function ArtifactCard({ code, detection, streaming = false }: ArtifactCar
 
     // Ensure the registry row exists even if the completion effect hasn't
     // fired yet (e.g. clicked in the same frame the stream sealed).
-    const result = upsertArtifact(sessionId, detection, trimmed)
+    const result = upsertArtifact(sessionId, detection, trimmed, profile)
 
     if (!result) {
       return

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -494,7 +494,7 @@ const DirectiveImage: FC<{ id: string; label: string }> = ({ id, label }) => {
  *  from under the chat you're reading). Lazy-imports so the composer's rich
  *  editor can pull this module in without booting the profile/REST stack. */
 function openSessionRef(value: string) {
-  const { sessionId } = parseSessionRefValue(value)
+  const { profile, sessionId } = parseSessionRefValue(value)
 
   if (!sessionId) {
     return
@@ -502,7 +502,9 @@ function openSessionRef(value: string) {
 
   triggerHaptic('selection')
   // navigate is unused for the `tab` intent (focus-or-tile only).
-  void import('@/app/open-session').then(({ openSession }) => openSession(sessionId, () => undefined, 'tab'))
+  void import('@/app/open-session').then(({ openSession }) =>
+    openSession(sessionId, () => undefined, 'tab', profile)
+  )
 }
 
 /** A `@session:<profile>/<id>` reference in the user transcript (directive

--- a/apps/desktop/src/components/assistant-ui/session-ref-open.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/session-ref-open.test.tsx
@@ -27,7 +27,9 @@ describe('session refs open the session', () => {
 
     fireEvent.click(await screen.findByTitle('work/20260101_abc123'))
 
-    await vi.waitFor(() => expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab'))
+    await vi.waitFor(() =>
+      expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab', 'work')
+    )
   })
 
   it('opens the session from a chip in the user transcript', async () => {
@@ -38,6 +40,8 @@ describe('session refs open the session', () => {
     expect(chip.tagName).toBe('BUTTON')
     fireEvent.click(chip)
 
-    await vi.waitFor(() => expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab'))
+    await vi.waitFor(() =>
+      expect(openSession).toHaveBeenCalledWith('20260101_abc123', expect.any(Function), 'tab', 'work')
+    )
   })
 })

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -63,7 +63,7 @@ export const PendingToolApproval: FC<{ part: ToolPart }> = ({ part }) => {
 }
 
 const InlineApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
-  useEffect(() => registerApprovalInlineAnchor(request.sessionId), [request.sessionId])
+  useEffect(() => registerApprovalInlineAnchor(request.sessionId, request.profile), [request.profile, request.sessionId])
 
   return <ApprovalBar request={request} surface="inline" />
 }
@@ -129,7 +129,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
       // Another bar (or the keyboard path) may have already resolved this
       // approval; the map is the single source of truth, so bail if this
       // session's request is gone.
-      if (busy || !sessionApprovalRequest(request.sessionId).get()) {
+      if (busy || !sessionApprovalRequest(request.sessionId, request.profile).get()) {
         return
       }
 
@@ -147,13 +147,13 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
           session_id: request.sessionId ?? undefined
         })
         triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')
-        clearApprovalRequest(request.sessionId)
+        clearApprovalRequest(request.sessionId, undefined, request.profile)
       } catch (error) {
         notifyError(error, copy.sendFailed)
         setSubmitting(null)
       }
     },
-    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request.sessionId]
+    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request.profile, request.sessionId]
   )
 
   // ⌘/Ctrl+Enter → Run, Esc → Reject.

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -69,10 +69,10 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
           request_id: request.requestId
         })
         triggerHaptic('submit')
-        clearSudoRequest(request.sessionId, request.requestId)
+        clearSudoRequest(request.sessionId, request.requestId, request.profile)
       } catch (error) {
         if (isMissingPendingPromptRequest(error, 'password')) {
-          clearSudoRequest(request.sessionId, request.requestId)
+          clearSudoRequest(request.sessionId, request.requestId, request.profile)
 
           return
         }
@@ -172,10 +172,10 @@ function SecretDialog({ sessionId }: { sessionId: string | null }) {
           value: secret
         })
         triggerHaptic('submit')
-        clearSecretRequest(request.sessionId, request.requestId)
+        clearSecretRequest(request.sessionId, request.requestId, request.profile)
       } catch (error) {
         if (isMissingPendingPromptRequest(error, 'value')) {
-          clearSecretRequest(request.sessionId, request.requestId)
+          clearSecretRequest(request.sessionId, request.requestId, request.profile)
 
           return
         }

--- a/apps/desktop/src/components/session-picker.test.ts
+++ b/apps/desktop/src/components/session-picker.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { sessionIdentityKey } from '@/lib/session-identity'
+
+import { isSessionPickerItemActive } from './session-picker'
+
+describe('isSessionPickerItemActive', () => {
+  it('marks only the owning profile active when stored ids collide', () => {
+    const activeIdentity = sessionIdentityKey('shared', 'beta')
+
+    expect(isSessionPickerItemActive({ id: 'shared', profile: 'alpha' }, activeIdentity)).toBe(false)
+    expect(isSessionPickerItemActive({ id: 'shared', profile: 'beta' }, activeIdentity)).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/session-picker.tsx
+++ b/apps/desktop/src/components/session-picker.tsx
@@ -7,15 +7,22 @@ import { listAllProfileSessions } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { Check, MessageCircle } from '@/lib/icons'
+import { normalizeProfileKey, sessionIdentityKey } from '@/lib/session-identity'
 import { cn } from '@/lib/utils'
+import type { SessionInfo } from '@/types/hermes'
 
 interface SessionPickerDialogProps {
-  /** Stored id of the session currently open, so it can be flagged in the list. */
-  activeStoredSessionId?: string | null
+  /** Compound identity of the session currently open, so only its owning profile is flagged. */
+  activeSessionIdentityKey?: string | null
   onOpenChange: (open: boolean) => void
-  onResume: (storedSessionId: string) => void
+  onResume: (storedSessionId: string, profile?: null | string) => void
   open: boolean
 }
+
+export const isSessionPickerItemActive = (
+  session: Pick<SessionInfo, 'id' | 'profile'>,
+  activeSessionIdentityKey?: null | string
+): boolean => activeSessionIdentityKey === sessionIdentityKey(session.id, session.profile)
 
 /**
  * Desktop equivalent of the TUI's sessions overlay (`/resume`, `/sessions`,
@@ -24,7 +31,7 @@ interface SessionPickerDialogProps {
  * sessions only, so `/resume` feels first-class instead of falling through to
  * the headless slash worker (which can't render the picker).
  */
-export function SessionPickerDialog({ activeStoredSessionId, onOpenChange, onResume, open }: SessionPickerDialogProps) {
+export function SessionPickerDialog({ activeSessionIdentityKey, onOpenChange, onResume, open }: SessionPickerDialogProps) {
   const { t } = useI18n()
   const [search, setSearch] = useState('')
 
@@ -62,16 +69,17 @@ export function SessionPickerDialog({ activeStoredSessionId, onOpenChange, onRes
                 {sessions.map(session => {
                   const title = sessionTitle(session)
                   const preview = session.preview?.trim()
+                  const identityKey = sessionIdentityKey(session.id, session.profile)
 
                   return (
                     <CommandItem
                       className="gap-2.5"
-                      key={session.id}
+                      key={identityKey}
                       onSelect={() => {
-                        onResume(session.id)
+                        onResume(session.id, session.profile)
                         onOpenChange(false)
                       }}
-                      value={`${title} ${preview ?? ''} ${session.id}`}
+                      value={`${title} ${preview ?? ''} ${session.id} ${normalizeProfileKey(session.profile)}`}
                     >
                       <MessageCircle className="size-4 shrink-0 text-muted-foreground" />
                       <span className="flex min-w-0 flex-col leading-snug">
@@ -81,7 +89,7 @@ export function SessionPickerDialog({ activeStoredSessionId, onOpenChange, onRes
                       <Check
                         className={cn(
                           'ml-auto size-4 shrink-0 text-foreground',
-                          session.id !== activeStoredSessionId && 'invisible'
+                          !isSessionPickerItemActive(session, activeSessionIdentityKey) && 'invisible'
                         )}
                       />
                     </CommandItem>

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -33,7 +33,10 @@ declare global {
       // with an error code when the sessionId is empty/invalid. `watch` opens
       // a spectator window (lazy resume — no agent build) for live-streaming
       // a running subagent's session.
-      openSessionWindow: (sessionId: string, opts?: { watch?: boolean }) => Promise<{ ok: boolean; error?: string }>
+      openSessionWindow: (
+        sessionId: string,
+        opts?: { profile?: null | string; watch?: boolean }
+      ) => Promise<{ ok: boolean; error?: string }>
       // Open a new full-chrome app window — a peer instance of the primary that
       // renders the complete app against the shared backend, so the user can run
       // multiple GUI windows at once.
@@ -79,7 +82,7 @@ declare global {
         // Quick window subscribes to those pushes.
         onState: (callback: (payload: QuickEntryStatePush) => void) => () => void
         // Primary renderer subscribes to submits captured by the quick window.
-        onSubmit: (callback: (payload: QuickEntrySubmitPayload | string) => void) => () => void
+        onSubmit: (callback: (payload: QuickEntrySubmitPayload) => void) => () => void
         // Quick window subscribes to "you were just summoned" so it can reset
         // its draft and re-focus the input on every open.
         onShown: (callback: () => void) => () => void
@@ -231,8 +234,10 @@ declare global {
       ) => () => void
       signalDeepLinkReady?: () => Promise<{ ok: boolean }>
       onWindowStateChanged?: (callback: (payload: HermesWindowState) => void) => () => void
-      onFocusSession?: (callback: (sessionId: string) => void) => () => void
-      onNotificationAction?: (callback: (payload: { actionId: string; sessionId?: string }) => void) => () => void
+      onFocusSession?: (callback: (payload: { profile?: null | string; sessionId: string }) => void) => () => void
+      onNotificationAction?: (
+        callback: (payload: { actionId: string; profile?: null | string; sessionId?: string }) => void
+      ) => () => void
       onPreviewFileChanged: (callback: (payload: HermesPreviewFileChanged) => void) => () => void
       onBackendExit: (callback: (payload: BackendExit) => void) => () => void
       // Soft gateway-mode apply: primary backend was torn down without a window
@@ -739,6 +744,8 @@ export interface HermesNotification {
   body?: string
   silent?: boolean
   kind?: string
+  profile?: null | string
+  runtimeSessionId?: string
   sessionId?: string
   actions?: { id: string; text: string }[]
 }

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -592,8 +592,9 @@ export function setSessionPinnedRemote(id: string, pinned: boolean, profile?: st
   })
 }
 
-export function searchSessions(query: string): Promise<SessionSearchResponse> {
+export function searchSessions(query: string, profile?: string | null): Promise<SessionSearchResponse> {
   return window.hermesDesktop.api<SessionSearchResponse>({
+    ...(profile ? { profile } : {}),
     path: `/api/sessions/search?q=${encodeURIComponent(query)}`
   })
 }

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -34,10 +34,12 @@ const EMPTY_THINKING_PLACEHOLDER_RE =
 
 export function createClientSessionState(
   storedSessionId: string | null = null,
-  messages: ChatMessage[] = []
+  messages: ChatMessage[] = [],
+  storedSessionProfile: string | null = null
 ): ClientSessionState {
   return {
     storedSessionId,
+    storedSessionProfile,
     messages,
     branch: '',
     cwd: '',

--- a/apps/desktop/src/lib/inflight-turn-journal.test.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.test.ts
@@ -5,10 +5,12 @@ import {
   clearInFlightTurnJournal,
   type JournalableSessionState,
   mergeInFlightMessages,
+  migrateInFlightTurnJournal,
   persistInFlightTurnState,
   readInFlightTurnJournal,
   recoverInFlightTurnJournal
 } from '@/lib/inflight-turn-journal'
+import { sessionIdentityKey } from '@/lib/session-identity'
 
 const STORAGE_KEY = 'hermes.desktop.inflightTurnJournal.v1'
 
@@ -113,10 +115,89 @@ describe('persistInFlightTurnState', () => {
     vi.advanceTimersByTime(400)
 
     const raw = JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)
-    raw.entries['stored-1'].updatedAt = Date.now() - 8 * 24 * 60 * 60 * 1000
+    raw.entries[sessionIdentityKey('stored-1', 'default')].updatedAt = Date.now() - 8 * 24 * 60 * 60 * 1000
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(raw))
 
     expect(readInFlightTurnJournal('stored-1')).toBeNull()
+  })
+
+  it('isolates colliding stored ids by profile', () => {
+    persistInFlightTurnState(
+      journalState({
+        messages: [user('alpha-user', 'alpha prompt'), assistant('alpha-stream', 'alpha partial', { pending: true })],
+        storedSessionId: 'shared',
+        storedSessionProfile: 'alpha',
+        streamId: 'alpha-stream'
+      })
+    )
+    persistInFlightTurnState(
+      journalState({
+        messages: [user('beta-user', 'beta prompt'), assistant('beta-stream', 'beta partial', { pending: true })],
+        storedSessionId: 'shared',
+        storedSessionProfile: 'beta',
+        streamId: 'beta-stream'
+      })
+    )
+
+    vi.advanceTimersByTime(400)
+
+    expect(readInFlightTurnJournal('shared', 'alpha')?.streamId).toBe('alpha-stream')
+    expect(readInFlightTurnJournal('shared', 'beta')?.streamId).toBe('beta-stream')
+
+    clearInFlightTurnJournal('shared', 'alpha')
+
+    expect(readInFlightTurnJournal('shared', 'alpha')).toBeNull()
+    expect(readInFlightTurnJournal('shared', 'beta')?.streamId).toBe('beta-stream')
+
+    clearInFlightTurnJournal('shared', 'beta')
+  })
+
+  it('moves pending and persisted turn state when compression rotates the stored id', () => {
+    persistInFlightTurnState(
+      journalState({ storedSessionId: 'root', storedSessionProfile: 'alpha', streamId: 'alpha-stream' })
+    )
+    vi.advanceTimersByTime(400)
+    persistInFlightTurnState(
+      journalState({ storedSessionId: 'root-pending', storedSessionProfile: 'alpha', streamId: 'pending-stream' })
+    )
+
+    migrateInFlightTurnJournal('root', 'tip', 'alpha')
+    migrateInFlightTurnJournal('root-pending', 'tip-pending', 'alpha')
+
+    expect(readInFlightTurnJournal('root', 'alpha')).toBeNull()
+    expect(readInFlightTurnJournal('tip', 'alpha')?.streamId).toBe('alpha-stream')
+    vi.advanceTimersByTime(400)
+    expect(readInFlightTurnJournal('root-pending', 'alpha')).toBeNull()
+    expect(readInFlightTurnJournal('tip-pending', 'alpha')?.streamId).toBe('pending-stream')
+
+    clearInFlightTurnJournal('tip', 'alpha')
+    clearInFlightTurnJournal('tip-pending', 'alpha')
+  })
+
+  it('keeps a newer destination-side pending snapshot during rotation', () => {
+    persistInFlightTurnState(
+      journalState({
+        messages: [user('u1', 'prompt'), assistant('old-stream', 'older partial', { pending: true })],
+        storedSessionId: 'root',
+        storedSessionProfile: 'alpha',
+        streamId: 'old-stream'
+      })
+    )
+    persistInFlightTurnState(
+      journalState({
+        messages: [user('u1', 'prompt'), assistant('new-stream', 'newer partial', { pending: true })],
+        storedSessionId: 'tip',
+        storedSessionProfile: 'alpha',
+        streamId: 'new-stream'
+      })
+    )
+
+    migrateInFlightTurnJournal('root', 'tip', 'alpha')
+    vi.advanceTimersByTime(400)
+
+    expect(readInFlightTurnJournal('root', 'alpha')).toBeNull()
+    expect(readInFlightTurnJournal('tip', 'alpha')?.streamId).toBe('new-stream')
+    clearInFlightTurnJournal('tip', 'alpha')
   })
 })
 

--- a/apps/desktop/src/lib/inflight-turn-journal.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.ts
@@ -1,4 +1,5 @@
 import { type ChatMessage, type ChatMessagePart, chatMessageText } from '@/lib/chat-messages'
+import { normalizeProfileKey, sessionIdentityKey } from '@/lib/session-identity'
 
 /**
  * Crash-survivable in-flight turn journal.
@@ -37,6 +38,7 @@ export interface JournalableSessionState {
   busy: boolean
   messages: ChatMessage[]
   storedSessionId: null | string
+  storedSessionProfile?: null | string
   streamId: null | string
   turnStartedAt: null | number
 }
@@ -395,7 +397,7 @@ export function mergeInFlightMessages(
 const persistTimers = new Map<string, ReturnType<typeof setTimeout>>()
 const persistLatest = new Map<string, JournalableSessionState>()
 
-function writeSnapshot(storedSessionId: string, state: JournalableSessionState): void {
+function writeSnapshot(journalKey: string, state: JournalableSessionState): void {
   const tail = recoverableTail(state.messages, state.streamId)
 
   if (tail.length === 0) {
@@ -404,7 +406,7 @@ function writeSnapshot(storedSessionId: string, state: JournalableSessionState):
 
   const journal = loadStore()
 
-  journal.entries[storedSessionId] = {
+  journal.entries[journalKey] = {
     messages: tail,
     streamId: state.streamId,
     turnStartedAt: state.turnStartedAt,
@@ -422,47 +424,118 @@ export function persistInFlightTurnState(state: JournalableSessionState): void {
     return
   }
 
+  const journalKey = sessionIdentityKey(storedSessionId, state.storedSessionProfile)
+
   if (!state.busy && !state.awaitingResponse && !state.streamId) {
-    clearInFlightTurnJournal(storedSessionId)
+    clearInFlightTurnJournal(storedSessionId, state.storedSessionProfile)
 
     return
   }
 
-  persistLatest.set(storedSessionId, state)
+  persistLatest.set(journalKey, state)
 
-  if (persistTimers.has(storedSessionId)) {
+  if (persistTimers.has(journalKey)) {
     return
   }
 
   persistTimers.set(
-    storedSessionId,
+    journalKey,
     setTimeout(() => {
-      persistTimers.delete(storedSessionId)
-      const latest = persistLatest.get(storedSessionId)
+      persistTimers.delete(journalKey)
+      const latest = persistLatest.get(journalKey)
 
-      persistLatest.delete(storedSessionId)
+      persistLatest.delete(journalKey)
 
       if (latest) {
-        writeSnapshot(storedSessionId, latest)
+        writeSnapshot(journalKey, latest)
       }
     }, PERSIST_THROTTLE_MS)
   )
 }
 
-export function readInFlightTurnJournal(storedSessionId: null | string): InFlightTurnSnapshot | null {
+/** Move crash-recovery state when compression rotates a stored session id. */
+export function migrateInFlightTurnJournal(
+  previousStoredSessionId: string,
+  nextStoredSessionId: string,
+  profile?: null | string
+): void {
+  if (previousStoredSessionId === nextStoredSessionId) {
+    return
+  }
+
+  const profileKey = normalizeProfileKey(profile)
+  const previousKey = sessionIdentityKey(previousStoredSessionId, profileKey)
+  const nextKey = sessionIdentityKey(nextStoredSessionId, profileKey)
+  const previousTimer = persistTimers.get(previousKey)
+  const pending = persistLatest.get(previousKey)
+
+  if (previousTimer) {
+    clearTimeout(previousTimer)
+    persistTimers.delete(previousKey)
+  }
+
+  persistLatest.delete(previousKey)
+
+  const journal = loadStore()
+  const legacyPreviousKey = profileKey === 'default' ? previousStoredSessionId : null
+  const previousEntry = journal.entries[previousKey] ?? (legacyPreviousKey ? journal.entries[legacyPreviousKey] : undefined)
+
+  if (previousEntry) {
+    const currentNext = journal.entries[nextKey]
+
+    if (!currentNext || previousEntry.updatedAt >= currentNext.updatedAt) {
+      journal.entries[nextKey] = previousEntry
+    }
+
+    delete journal.entries[previousKey]
+
+    if (legacyPreviousKey) {
+      delete journal.entries[legacyPreviousKey]
+    }
+
+    saveStore(journal)
+  }
+
+  if (pending && !persistLatest.has(nextKey)) {
+    persistInFlightTurnState({
+      ...pending,
+      storedSessionId: nextStoredSessionId,
+      storedSessionProfile: profileKey
+    })
+  }
+}
+
+export function readInFlightTurnJournal(
+  storedSessionId: null | string,
+  profile?: null | string
+): InFlightTurnSnapshot | null {
   if (!storedSessionId) {
     return null
   }
 
   const journal = loadStore()
-  const entry = journal.entries[storedSessionId]
+  const journalKey = sessionIdentityKey(storedSessionId, profile)
+  let entry = journal.entries[journalKey]
+
+  // The original v1 schema keyed entries by raw stored id. Only the default
+  // profile can safely claim an ownerless legacy row; exposing it to every
+  // profile would recreate the transcript leak this compound key prevents.
+  if (!entry && normalizeProfileKey(profile) === 'default') {
+    entry = journal.entries[storedSessionId]
+
+    if (entry) {
+      journal.entries[journalKey] = entry
+      delete journal.entries[storedSessionId]
+      saveStore(journal)
+    }
+  }
 
   if (!entry) {
     return null
   }
 
   if (isExpired(entry)) {
-    delete journal.entries[storedSessionId]
+    delete journal.entries[journalKey]
     saveStore(journal)
 
     return null
@@ -476,9 +549,9 @@ export function readInFlightTurnJournal(storedSessionId: null | string): InFligh
 export function recoverInFlightTurnJournal(
   storedSessionId: null | string,
   baseMessages: ChatMessage[],
-  options: { keepPending?: boolean } = {}
+  options: { keepPending?: boolean; profile?: null | string } = {}
 ): InFlightRecoveryResult {
-  const snapshot = readInFlightTurnJournal(storedSessionId)
+  const snapshot = readInFlightTurnJournal(storedSessionId, options.profile)
 
   if (!snapshot) {
     return {
@@ -493,7 +566,7 @@ export function recoverInFlightTurnJournal(
   const recovered = mergeInFlightMessages(baseMessages, snapshot.messages, options)
 
   if (recovered.caughtUp) {
-    clearInFlightTurnJournal(storedSessionId)
+    clearInFlightTurnJournal(storedSessionId, options.profile)
   }
 
   return {
@@ -503,26 +576,32 @@ export function recoverInFlightTurnJournal(
   }
 }
 
-export function clearInFlightTurnJournal(storedSessionId: null | string): void {
+export function clearInFlightTurnJournal(storedSessionId: null | string, profile?: null | string): void {
   if (!storedSessionId) {
     return
   }
 
-  const timer = persistTimers.get(storedSessionId)
+  const journalKey = sessionIdentityKey(storedSessionId, profile)
+  const timer = persistTimers.get(journalKey)
 
   if (timer) {
     clearTimeout(timer)
-    persistTimers.delete(storedSessionId)
+    persistTimers.delete(journalKey)
   }
 
-  persistLatest.delete(storedSessionId)
+  persistLatest.delete(journalKey)
 
   const journal = loadStore()
+  const keys = [journalKey]
 
-  if (!(storedSessionId in journal.entries)) {
+  if (normalizeProfileKey(profile) === 'default') {
+    keys.push(storedSessionId)
+  }
+
+  if (!keys.some(key => key in journal.entries)) {
     return
   }
 
-  delete journal.entries[storedSessionId]
+  keys.forEach(key => delete journal.entries[key])
   saveStore(journal)
 }

--- a/apps/desktop/src/lib/session-branch-tree.test.ts
+++ b/apps/desktop/src/lib/session-branch-tree.test.ts
@@ -23,6 +23,20 @@ const session = (id: string, overrides: Partial<SessionInfo> = {}): SessionInfo 
   }) as SessionInfo
 
 describe('flattenSessionsWithBranches', () => {
+  it('does not attach or deduplicate same-id sessions across profiles', () => {
+    const alphaParent = session('shared', { profile: 'alpha' })
+    const betaParent = session('shared', { profile: 'beta' })
+    const betaBranch = session('branch', { parent_session_id: 'shared', profile: 'beta' })
+
+    const flattened = flattenSessionsWithBranches([alphaParent, betaParent, betaBranch])
+
+    expect(flattened).toEqual([
+      { session: alphaParent },
+      { session: betaParent },
+      { branchStem: '└─ ', session: betaBranch }
+    ])
+  })
+
   it('nests branch rows under their parent with tree stems', () => {
     const parent = session('parent', { last_active: 20 })
     const branchA = session('branch-a', { last_active: 15, parent_session_id: 'parent' })

--- a/apps/desktop/src/lib/session-branch-tree.ts
+++ b/apps/desktop/src/lib/session-branch-tree.ts
@@ -1,5 +1,7 @@
 import type { SessionInfo } from '@/types/hermes'
 
+import { sessionIdentityKey } from './session-identity'
+
 export interface SidebarSessionEntry {
   branchStem?: string
   session: SessionInfo
@@ -29,11 +31,11 @@ export function flattenSessionsWithBranches(
   const byVisibleId = new Map<string, SessionInfo>()
 
   for (const session of sessions) {
-    byVisibleId.set(session.id, session)
-    const rootId = session._lineage_root_id?.trim()
+    byVisibleId.set(sessionIdentityKey(session.id, session.profile), session)
+    const rootId = session._lineage_root_id
 
     if (rootId) {
-      byVisibleId.set(rootId, session)
+      byVisibleId.set(sessionIdentityKey(rootId, session.profile), session)
     }
   }
 
@@ -41,22 +43,24 @@ export function flattenSessionsWithBranches(
   const nestedIds = new Set<string>()
 
   for (const session of sessions) {
-    const parentId = session.parent_session_id?.trim()
+    const parentId = session.parent_session_id
 
     if (!parentId) {
       continue
     }
 
-    const parent = byVisibleId.get(parentId)
+    const parent = byVisibleId.get(sessionIdentityKey(parentId, session.profile))
 
-    if (!parent || parent.id === session.id) {
+    if (!parent || sessionIdentityKey(parent.id, parent.profile) === sessionIdentityKey(session.id, session.profile)) {
       continue
     }
 
-    nestedIds.add(session.id)
-    const siblings = childrenByParent.get(parent.id) ?? []
+    const sessionKey = sessionIdentityKey(session.id, session.profile)
+    const parentKey = sessionIdentityKey(parent.id, parent.profile)
+    nestedIds.add(sessionKey)
+    const siblings = childrenByParent.get(parentKey) ?? []
     siblings.push(session)
-    childrenByParent.set(parent.id, siblings)
+    childrenByParent.set(parentKey, siblings)
   }
 
   for (const siblings of childrenByParent.values()) {
@@ -70,20 +74,21 @@ export function flattenSessionsWithBranches(
   const groupRecencyMemo = new Map<string, number>()
 
   const groupRecency = (session: SessionInfo): number => {
-    const cached = groupRecencyMemo.get(session.id)
+    const identityKey = sessionIdentityKey(session.id, session.profile)
+    const cached = groupRecencyMemo.get(identityKey)
 
     if (cached !== undefined) {
       return cached
     }
 
-    groupRecencyMemo.set(session.id, recency(session)) // cycle guard
+    groupRecencyMemo.set(identityKey, recency(session)) // cycle guard
 
-    const max = (childrenByParent.get(session.id) ?? []).reduce(
+    const max = (childrenByParent.get(identityKey) ?? []).reduce(
       (acc, child) => Math.max(acc, groupRecency(child)),
       recency(session)
     )
 
-    groupRecencyMemo.set(session.id, max)
+    groupRecencyMemo.set(identityKey, max)
 
     return max
   }
@@ -95,18 +100,22 @@ export function flattenSessionsWithBranches(
   const seen = new Set<string>()
 
   const emit = (session: SessionInfo, branchStem?: string) => {
-    if (seen.has(session.id)) {
+    const identityKey = sessionIdentityKey(session.id, session.profile)
+
+    if (seen.has(identityKey)) {
       return
     }
 
-    seen.add(session.id)
+    seen.add(identityKey)
     out.push(branchStem ? { branchStem, session } : { session })
 
-    const children = childrenByParent.get(session.id)
+    const children = childrenByParent.get(identityKey)
     children?.forEach((child, index) => emit(child, index === children.length - 1 ? '└─ ' : '├─ '))
   }
 
-  const roots = sessions.filter(session => !nestedIds.has(session.id)).map((session, index) => ({ index, session }))
+  const roots = sessions
+    .filter(session => !nestedIds.has(sessionIdentityKey(session.id, session.profile)))
+    .map((session, index) => ({ index, session }))
 
   if (!options.preserveOrder) {
     roots.sort((a, b) => groupRecency(b.session) - groupRecency(a.session) || a.index - b.index)
@@ -115,7 +124,7 @@ export function flattenSessionsWithBranches(
   roots.forEach(({ session }) => emit(session))
 
   for (const session of sessions) {
-    if (!seen.has(session.id)) {
+    if (!seen.has(sessionIdentityKey(session.id, session.profile))) {
       out.push({ session })
     }
   }

--- a/apps/desktop/src/lib/session-identity.test.ts
+++ b/apps/desktop/src/lib/session-identity.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  parseSessionIdentityKey,
+  sessionIdentityKey,
+  sessionIdentityKeysFromLegacyIds,
+  sessionMatchesIdentity
+} from './session-identity'
+
+describe('session identity', () => {
+  it('normalizes the profile and keeps identical stored ids distinct across profiles', () => {
+    expect(sessionIdentityKey('shared-id', ' alpha ')).toBe(sessionIdentityKey('shared-id', 'alpha'))
+    expect(sessionIdentityKey('shared-id', 'alpha')).not.toBe(sessionIdentityKey('shared-id', 'beta'))
+    expect(sessionIdentityKey('shared-id', null)).toBe(sessionIdentityKey('shared-id', 'default'))
+  })
+
+  it('treats the raw stored id as opaque', () => {
+    expect(sessionIdentityKey(' shared-id', 'alpha')).not.toBe(sessionIdentityKey('shared-id', 'alpha'))
+    expect(sessionIdentityKey('shared-id ', 'alpha')).not.toBe(sessionIdentityKey('shared-id', 'alpha'))
+    expect(parseSessionIdentityKey(sessionIdentityKey(' shared-id ', 'alpha')).storedSessionId).toBe(' shared-id ')
+    expect(parseSessionIdentityKey(sessionIdentityKey('alpha\u0000shared', 'default')).storedSessionId).toBe(
+      'alpha\u0000shared'
+    )
+
+    expect(sessionMatchesIdentity({ id: ' shared-id ', profile: 'alpha' }, ' shared-id ', 'alpha')).toBe(true)
+    expect(sessionMatchesIdentity({ id: 'shared-id', profile: 'alpha' }, ' shared-id ', 'alpha')).toBe(false)
+  })
+
+  it('round-trips compound keys without assuming ids are globally unique', () => {
+    expect(parseSessionIdentityKey(sessionIdentityKey('shared-id', 'alpha'))).toEqual({
+      profile: 'alpha',
+      storedSessionId: 'shared-id'
+    })
+  })
+
+  it('matches stored and lineage ids only within the owning profile', () => {
+    const session = {
+      id: 'runtime-id',
+      profile: 'alpha',
+      _lineage_root_id: 'stored-id'
+    }
+
+    expect(sessionMatchesIdentity(session, 'stored-id', 'alpha')).toBe(true)
+    expect(sessionMatchesIdentity(session, 'stored-id', 'beta')).toBe(false)
+    expect(sessionMatchesIdentity(session, 'runtime-id', 'alpha')).toBe(true)
+  })
+
+  it('migrates legacy ownerless ids as opaque default-profile values', () => {
+    const sentinelLookingId = 'alpha\u0000shared'
+
+    expect(sessionIdentityKeysFromLegacyIds([sentinelLookingId, '\u0000leading', sentinelLookingId])).toEqual([
+      sessionIdentityKey(sentinelLookingId, 'default'),
+      sessionIdentityKey('\u0000leading', 'default')
+    ])
+    expect(sessionIdentityKey(sentinelLookingId, 'default')).not.toBe(sessionIdentityKey('shared', 'alpha'))
+  })
+})

--- a/apps/desktop/src/lib/session-identity.ts
+++ b/apps/desktop/src/lib/session-identity.ts
@@ -1,0 +1,61 @@
+export function normalizeProfileKey(name: null | string | undefined): string {
+  const value = (name ?? '').trim()
+
+  return value || 'default'
+}
+
+interface SessionIdentityLike {
+  _lineage_root_id?: null | string
+  id?: null | string
+  profile?: null | string
+}
+
+const SESSION_IDENTITY_SEPARATOR = '\u0000'
+
+/** Canonical identity for durable session state shared across profile backends. */
+export function sessionIdentityKey(storedSessionId: string, profile: null | string | undefined): string {
+  return `${normalizeProfileKey(profile)}${SESSION_IDENTITY_SEPARATOR}${storedSessionId}`
+}
+
+export function parseSessionIdentityKey(key: string): { profile: string; storedSessionId: string } {
+  const separator = key.indexOf(SESSION_IDENTITY_SEPARATOR)
+
+  if (separator < 0) {
+    return { profile: 'default', storedSessionId: key }
+  }
+
+  return {
+    profile: key.slice(0, separator),
+    storedSessionId: key.slice(separator + SESSION_IDENTITY_SEPARATOR.length)
+  }
+}
+
+/** Migrate a legacy ownerless-id container to default without inspecting id bytes. */
+export function sessionIdentityKeysFromLegacyIds(storedSessionIds: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const canonical: string[] = []
+
+  for (const storedSessionId of storedSessionIds) {
+    const identityKey = sessionIdentityKey(storedSessionId, 'default')
+
+    if (!seen.has(identityKey)) {
+      seen.add(identityKey)
+      canonical.push(identityKey)
+    }
+  }
+
+  return canonical
+}
+
+/** Match a durable id (direct or lineage-root) only within its owning profile. */
+export function sessionMatchesIdentity(
+  session: SessionIdentityLike,
+  storedSessionId: string,
+  profile: null | string | undefined
+): boolean {
+  if (!storedSessionId || normalizeProfileKey(session.profile) !== normalizeProfileKey(profile)) {
+    return false
+  }
+
+  return session.id === storedSessionId || session._lineage_root_id === storedSessionId
+}

--- a/apps/desktop/src/lib/session-ids.test.ts
+++ b/apps/desktop/src/lib/session-ids.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
-import { storedSessionIdForNotification } from './session-ids'
+import { sessionIdentityKey } from './session-identity'
+import { sessionIdentityForNotification, storedSessionIdForNotification } from './session-ids'
 
 describe('storedSessionIdForNotification', () => {
+  it('recovers the owning profile from a compound cache key', () => {
+    const map = new Map([[sessionIdentityKey('shared-id', 'alpha'), 'runtime-123']])
+
+    expect(sessionIdentityForNotification('runtime-123', map)).toEqual({
+      profile: 'alpha',
+      sessionId: 'shared-id'
+    })
+  })
+
   it('translates a runtime id back to its stored id', () => {
     // The route is keyed by the stored id, but notifications carry the runtime
     // id. Resolving runtime -> stored keeps notification-click navigation from

--- a/apps/desktop/src/lib/session-ids.ts
+++ b/apps/desktop/src/lib/session-ids.ts
@@ -1,3 +1,5 @@
+import { parseSessionIdentityKey } from './session-identity'
+
 // The gateway tags every event — and therefore every native notification —
 // with the *runtime* session id (the key under which the session lives in the
 // gateway's in-memory `_sessions` map). The chat route, however, is keyed by
@@ -12,15 +14,24 @@
 // returned unchanged when no mapping is known — it may already be a stored id
 // (e.g. a notification for a session this window never opened), in which case
 // the normal resume/REST lookup handles it.
+export function sessionIdentityForNotification(
+  id: string,
+  runtimeIdByStoredSessionId: ReadonlyMap<string, string>
+): { profile: string | null; sessionId: string } {
+  for (const [storedIdentity, runtimeId] of runtimeIdByStoredSessionId) {
+    if (runtimeId === id) {
+      const identity = parseSessionIdentityKey(storedIdentity)
+
+      return { profile: identity.profile, sessionId: identity.storedSessionId }
+    }
+  }
+
+  return { profile: null, sessionId: id }
+}
+
 export function storedSessionIdForNotification(
   id: string,
   runtimeIdByStoredSessionId: ReadonlyMap<string, string>
 ): string {
-  for (const [storedId, runtimeId] of runtimeIdByStoredSessionId) {
-    if (runtimeId === id) {
-      return storedId
-    }
-  }
-
-  return id
+  return sessionIdentityForNotification(id, runtimeIdByStoredSessionId).sessionId
 }

--- a/apps/desktop/src/store/active-work.test.ts
+++ b/apps/desktop/src/store/active-work.test.ts
@@ -8,10 +8,11 @@ import { clearAllSessionStates, publishSessionState } from './session-states'
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 const setActiveWork = vi.fn()
 
-const busy = (storedSessionId: string, isBusy: boolean) =>
-  ({ busy: isBusy, needsInput: false, storedSessionId }) as ClientSessionState
+const busy = (storedSessionId: string, isBusy: boolean, storedSessionProfile = 'default') =>
+  ({ busy: isBusy, needsInput: false, storedSessionId, storedSessionProfile }) as ClientSessionState
 
-const session = (id: string, title: null | string) => ({ id, title }) as (typeof $sessions.value)[number]
+const session = (id: string, title: null | string, profile = 'default') =>
+  ({ id, profile, title }) as (typeof $sessions.value)[number]
 
 beforeAll(async () => {
   desktopWindow.hermesDesktop = { setActiveWork } as unknown as Window['hermesDesktop']
@@ -38,6 +39,13 @@ describe('active work bridge', () => {
     publishSessionState('runtime-1', busy('s1', true))
 
     expect(setActiveWork).toHaveBeenLastCalledWith({ count: 1, titles: [] })
+  })
+
+  it('reports the title from the exact owner when stored ids collide', () => {
+    $sessions.set([session('shared', 'Alpha task', 'alpha'), session('shared', 'Beta task', 'beta')])
+    publishSessionState('runtime-beta', busy('shared', true, 'beta'))
+
+    expect(setActiveWork).toHaveBeenLastCalledWith({ count: 1, titles: ['Beta task'] })
   })
 
   it('drops back to nothing when the turn ends', () => {

--- a/apps/desktop/src/store/active-work.ts
+++ b/apps/desktop/src/store/active-work.ts
@@ -12,11 +12,14 @@
 import { computed } from 'nanostores'
 
 import type { HermesActiveWork } from '@/global'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { $sessions } from '@/store/session'
 import { $workingSessionIds } from '@/store/session-states'
 
 const $activeWork = computed([$workingSessionIds, $sessions], (workingIds, sessions): HermesActiveWork => {
-  const titleById = new Map(sessions.map(session => [session.id, session.title?.trim() ?? '']))
+  const titleById = new Map(
+    sessions.map(session => [sessionIdentityKey(session.id, session.profile), session.title?.trim() ?? ''])
+  )
 
   return {
     count: workingIds.length,

--- a/apps/desktop/src/store/activity.test.ts
+++ b/apps/desktop/src/store/activity.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { sessionIdentityKey } from '@/lib/session-identity'
+import type { SessionInfo } from '@/types/hermes'
+
+import { buildRailTasks } from './activity'
+
+const session = (id: string, profile: string, title: string): SessionInfo => ({
+  archived: false,
+  cwd: null,
+  ended_at: null,
+  id,
+  input_tokens: 0,
+  is_active: true,
+  last_active: 1,
+  message_count: 1,
+  model: null,
+  output_tokens: 0,
+  preview: null,
+  profile,
+  source: null,
+  started_at: 1,
+  title,
+  tool_call_count: 0
+})
+
+describe('buildRailTasks', () => {
+  it('resolves a working session by compound identity when profiles share its stored id', () => {
+    const sessions = [session('shared', 'alpha', 'Alpha task'), session('shared', 'beta', 'Beta task')]
+
+    const tasks = buildRailTasks([sessionIdentityKey('shared', 'beta')], sessions, null, {})
+
+    expect(tasks).toEqual([
+      expect.objectContaining({
+        id: `session:${sessionIdentityKey('shared', 'beta')}`,
+        label: 'Beta task'
+      })
+    ])
+  })
+})

--- a/apps/desktop/src/store/activity.ts
+++ b/apps/desktop/src/store/activity.ts
@@ -1,6 +1,7 @@
 import { atom } from 'nanostores'
 
 import { sessionTitle } from '@/lib/chat-runtime'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import type { PreviewServerRestart } from '@/store/preview'
 import type { ActionStatusResponse, SessionInfo } from '@/types/hermes'
 
@@ -34,7 +35,7 @@ export function buildRailTasks(
   previewRestart: PreviewServerRestart | null,
   actionTasks: Record<string, DesktopActionTask>
 ): RailTask[] {
-  const sessionsById = new Map(sessions.map(session => [session.id, session]))
+  const sessionsById = new Map(sessions.map(session => [sessionIdentityKey(session.id, session.profile), session]))
 
   const sessionTasks: RailTask[] = workingSessionIds.map((id, index) => {
     const session = sessionsById.get(id)

--- a/apps/desktop/src/store/artifacts.test.ts
+++ b/apps/desktop/src/store/artifacts.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import type { ArtifactDetection } from '@/lib/artifact-detect'
+import { sessionIdentityKey } from '@/lib/session-identity'
 
 import {
+  $artifactRegistry,
   $artifactVersionSelection,
   artifactsForSession,
   clearArtifactRegistry,
@@ -78,6 +80,24 @@ describe('artifacts store', () => {
 
     expect(artifactsForSession('session-1')).toHaveLength(1)
     expect(artifactsForSession('session-2')).toHaveLength(1)
+  })
+
+  it('keeps colliding stored session ids isolated by profile', () => {
+    const alpha = upsertArtifact('shared', HTML_DETECTION, '<html>alpha</html>', 'alpha')!
+    const beta = upsertArtifact('shared', HTML_DETECTION, '<html>beta</html>', 'beta')!
+
+    expect(alpha.artifactId).not.toBe(beta.artifactId)
+    expect(artifactsForSession('shared', 'alpha')[0]?.versions.at(-1)?.content).toBe('<html>alpha</html>')
+    expect(artifactsForSession('shared', 'beta')[0]?.versions.at(-1)?.content).toBe('<html>beta</html>')
+  })
+
+  it('keeps opaque stored ids distinct when they differ by whitespace', () => {
+    upsertArtifact('shared', HTML_DETECTION, '<html>plain</html>', 'alpha')
+    upsertArtifact('shared ', HTML_DETECTION, '<html>space</html>', 'alpha')
+
+    expect(artifactsForSession('shared', 'alpha')[0]?.versions.at(-1)?.content).toBe('<html>plain</html>')
+    expect(artifactsForSession('shared ', 'alpha')[0]?.versions.at(-1)?.content).toBe('<html>space</html>')
+    expect($artifactRegistry.get()).toHaveProperty(sessionIdentityKey('shared ', 'alpha'))
   })
 
   it('rejects empty sessions and empty content', () => {

--- a/apps/desktop/src/store/artifacts.ts
+++ b/apps/desktop/src/store/artifacts.ts
@@ -1,6 +1,7 @@
 import { atom } from 'nanostores'
 
 import { artifactContentHash, type ArtifactDetection, type ArtifactKind, artifactSlug } from '@/lib/artifact-detect'
+import { parseSessionIdentityKey, sessionIdentityKey } from '@/lib/session-identity'
 
 import { closeArtifactPreviewTabs, openPreview, type PreviewTarget } from './preview'
 
@@ -32,6 +33,7 @@ export interface ArtifactRecord {
   id: string
   kind: ArtifactKind
   language: string
+  profile: string
   sessionId: string
   slug: string
   title: string
@@ -90,14 +92,17 @@ export function getArtifact(artifactId: string): ArtifactRecord | null {
   return findArtifact($artifactRegistry.get(), artifactId)
 }
 
-export function artifactsForSession(sessionId: string | null | undefined): ArtifactRecord[] {
-  const id = sessionId?.trim()
+export function artifactsForSession(
+  sessionId: string | null | undefined,
+  profile: null | string | undefined = undefined
+): ArtifactRecord[] {
+  const id = sessionId
 
   if (!id) {
     return []
   }
 
-  return $artifactRegistry.get()[id] ?? []
+  return $artifactRegistry.get()[sessionIdentityKey(id, profile)] ?? []
 }
 
 interface UpsertResult {
@@ -115,9 +120,10 @@ interface UpsertResult {
 export function upsertArtifact(
   sessionId: string | null | undefined,
   detection: ArtifactDetection,
-  content: string
+  content: string,
+  profile: null | string | undefined = undefined
 ): UpsertResult | null {
-  const id = sessionId?.trim()
+  const id = sessionId
   const trimmed = content.trim()
 
   if (!id || !trimmed) {
@@ -127,7 +133,9 @@ export function upsertArtifact(
   const slug = artifactSlug(detection)
   const hash = artifactContentHash(trimmed)
   const registry = $artifactRegistry.get()
-  const records = registry[id] ?? []
+  const identity = sessionIdentityKey(id, profile)
+  const normalizedProfile = parseSessionIdentityKey(identity).profile
+  const records = registry[identity] ?? []
   const existing = records.find(record => record.slug === slug)
   const now = Date.now()
 
@@ -154,7 +162,7 @@ export function upsertArtifact(
     $artifactRegistry.set(
       pruneRegistry({
         ...registry,
-        [id]: records.map(record => (record.id === existing.id ? next : record))
+        [identity]: records.map(record => (record.id === existing.id ? next : record))
       })
     )
 
@@ -163,9 +171,10 @@ export function upsertArtifact(
 
   const record: ArtifactRecord = {
     createdAt: now,
-    id: `${id}:${slug}`,
+    id: `${identity}:${slug}`,
     kind: detection.kind,
     language: detection.language,
+    profile: normalizedProfile,
     sessionId: id,
     slug,
     title: detection.title,
@@ -173,7 +182,7 @@ export function upsertArtifact(
     versions: [{ content: trimmed, createdAt: now, hash }]
   }
 
-  $artifactRegistry.set(pruneRegistry({ ...registry, [id]: [...records, record] }))
+  $artifactRegistry.set(pruneRegistry({ ...registry, [identity]: [...records, record] }))
 
   return { artifactId: record.id, record, versionAdded: true }
 }

--- a/apps/desktop/src/store/coding-status.test.ts
+++ b/apps/desktop/src/store/coding-status.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { HermesRepoStatus } from '@/global'
 
 import { $repoStatus, $repoStatusLoading, refreshRepoStatus } from './coding-status'
-import { $currentCwd, $selectedStoredSessionId } from './session'
+import { $currentCwd, setSelectedStoredSessionId } from './session'
 
 const sampleStatus: HermesRepoStatus = {
   branch: 'feature/login',
@@ -30,7 +30,7 @@ describe('refreshRepoStatus', () => {
     vi.useFakeTimers()
     $repoStatus.set(null)
     $currentCwd.set('')
-    $selectedStoredSessionId.set(null)
+    setSelectedStoredSessionId(null)
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
   })
 
@@ -149,7 +149,7 @@ describe('refreshRepoStatus', () => {
     stubProbe(probe)
 
     $currentCwd.set('/repo')
-    $selectedStoredSessionId.set('session-a')
+    setSelectedStoredSessionId('session-a', 'default')
     // The cwd subscription fires on the set above; drain the debounced refresh.
     vi.advanceTimersByTime(200)
     await vi.runAllTicks()
@@ -160,7 +160,24 @@ describe('refreshRepoStatus', () => {
     // identical, so its subscription would not re-fire — but the stored-session
     // id did change, which must still trigger a probe so the branch label
     // tracks the new session's checked-out branch.
-    $selectedStoredSessionId.set('session-b')
+    setSelectedStoredSessionId('session-b', 'default')
+    vi.advanceTimersByTime(200)
+    await vi.runAllTicks()
+
+    expect(probe).toHaveBeenCalledWith('/repo')
+  })
+
+  it('refreshes when only the selected session profile changes', async () => {
+    const probe = vi.fn(async () => sampleStatus)
+    stubProbe(probe)
+
+    $currentCwd.set('/repo')
+    setSelectedStoredSessionId('shared', 'alpha')
+    vi.advanceTimersByTime(200)
+    await vi.runAllTicks()
+    probe.mockClear()
+
+    setSelectedStoredSessionId('shared', 'beta')
     vi.advanceTimersByTime(200)
     await vi.runAllTicks()
 

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -4,7 +4,7 @@ import type { HermesGitWorktree, HermesRepoStatus } from '@/global'
 import { desktopGit } from '@/lib/desktop-git'
 
 import { $worktreeRefreshToken } from './projects'
-import { $busy, $currentCwd, $selectedStoredSessionId } from './session'
+import { $busy, $currentCwd, $selectedSessionIdentityKey } from './session'
 import { $workspaceChangeTick } from './workspace-events'
 
 // Live working-tree status for the active session's cwd — the data backbone of
@@ -193,8 +193,9 @@ $currentCwd.subscribe(cwd => {
 // branch (the agent ran `git checkout` in another session's terminal). The cwd
 // subscription above won't fire when the path is identical, so the branch label
 // would stay stale until a window focus or turn-settle triggers a refresh.
-// Treat the stored-session id as a structural edge in its own right.
-$selectedStoredSessionId.subscribe(() => scheduleRepoStatusRefresh())
+// Treat the profile-qualified stored-session identity as a structural edge in
+// its own right. The raw id can stay unchanged across a profile collision.
+$selectedSessionIdentityKey.subscribe(() => scheduleRepoStatusRefresh())
 
 // A worktree add/remove (desktop op, or the agent's out-of-band git in a settled
 // turn / a window refocus — both already bump this token) → re-probe.

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { sessionIdentityKey } from '@/lib/session-identity'
+
 import type { ComposerAttachment } from './composer'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
   clearQueuedPrompts,
+  decodeQueuedPromptState,
   dequeueQueuedPrompt,
+  encodeQueuedPromptState,
   enqueueQueuedPrompt,
   getQueuedPrompts,
   isQueueParked,
@@ -44,6 +48,14 @@ describe('composer queue store', () => {
     expect(dequeueQueuedPrompt(SESSION_KEY)?.text).toBe('first')
     expect(dequeueQueuedPrompt(SESSION_KEY)?.text).toBe('second')
     expect(dequeueQueuedPrompt(SESSION_KEY)).toBeNull()
+  })
+
+  it('keeps opaque session keys distinct when stored ids differ by whitespace', () => {
+    enqueueQueuedPrompt('alpha\u0000shared', { attachments: [], text: 'plain' })
+    enqueueQueuedPrompt('alpha\u0000shared ', { attachments: [], text: 'trailing space' })
+
+    expect(getQueuedPrompts('alpha\u0000shared').map(entry => entry.text)).toEqual(['plain'])
+    expect(getQueuedPrompts('alpha\u0000shared ').map(entry => entry.text)).toEqual(['trailing space'])
   })
 
   it('clones attachments when queueing', () => {
@@ -117,8 +129,29 @@ describe('composer queue store', () => {
     const raw = window.localStorage.getItem(QUEUE_STORAGE_KEY)
     expect(raw).toBeTruthy()
 
-    const parsed = JSON.parse(String(raw)) as Record<string, { text: string }[]>
-    expect(parsed[SESSION_KEY]?.[0]?.text).toBe('persist me')
+    const parsed = decodeQueuedPromptState(String(raw))
+    expect(parsed[sessionIdentityKey(SESSION_KEY, 'default')]?.[0]?.text).toBe('persist me')
+  })
+
+  it('migrates legacy record keys as opaque default-profile ids', () => {
+    const sentinelLookingId = 'alpha\u0000shared'
+    const entry = { attachments: [], id: 'queued-1', queuedAt: 1, text: 'preserve me' }
+    const decoded = decodeQueuedPromptState(JSON.stringify({ [sentinelLookingId]: [entry] }))
+
+    expect(decoded).toEqual({ [sessionIdentityKey(sentinelLookingId, 'default')]: [entry] })
+  })
+
+  it('round-trips same-looking opaque and owner-qualified queue identities separately', () => {
+    const sentinelLookingId = 'alpha\u0000shared'
+    const defaultEntry = { attachments: [], id: 'queued-default', queuedAt: 1, text: 'default' }
+    const alphaEntry = { attachments: [], id: 'queued-alpha', queuedAt: 2, text: 'alpha' }
+
+    const state = {
+      [sessionIdentityKey(sentinelLookingId, 'default')]: [defaultEntry],
+      [sessionIdentityKey('shared', 'alpha')]: [alphaEntry]
+    }
+
+    expect(decodeQueuedPromptState(encodeQueuedPromptState(state))).toEqual(state)
   })
 })
 

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -1,5 +1,7 @@
 import { atom } from 'nanostores'
 
+import { parseSessionIdentityKey, sessionIdentityKey } from '@/lib/session-identity'
+
 import type { ComposerAttachment } from './composer'
 
 export interface QueuedPromptEntry {
@@ -16,6 +18,60 @@ export interface QueuedPromptEntry {
 type QueueState = Record<string, QueuedPromptEntry[]>
 
 const STORAGE_KEY = 'hermes.desktop.composerQueue.v1'
+const QUEUE_STATE_VERSION = 2
+
+interface PersistedQueueGroup {
+  entries: QueuedPromptEntry[]
+  profile: string
+  storedSessionId: string
+}
+
+function isPersistedQueueGroup(value: unknown): value is PersistedQueueGroup {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Array.isArray((value as PersistedQueueGroup).entries) &&
+    typeof (value as PersistedQueueGroup).profile === 'string' &&
+    typeof (value as PersistedQueueGroup).storedSessionId === 'string' &&
+    (value as PersistedQueueGroup).storedSessionId.length > 0
+  )
+}
+
+export function decodeQueuedPromptState(raw: string): QueueState {
+  const parsed = JSON.parse(raw) as unknown
+  const stored = parsed as { queues?: unknown; version?: unknown } | null
+
+  if (stored && typeof stored === 'object' && stored.version === QUEUE_STATE_VERSION && Array.isArray(stored.queues)) {
+    return Object.fromEntries(
+      stored.queues
+        .filter(isPersistedQueueGroup)
+        .map(group => [sessionIdentityKey(group.storedSessionId, group.profile), group.entries])
+    )
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {}
+  }
+
+  // v1 was an ownerless record keyed directly by raw stored ids. Its container
+  // establishes the legacy domain; NUL or sentinel-looking id bytes do not.
+  return Object.fromEntries(
+    Object.entries(parsed)
+      .filter((entry): entry is [string, QueuedPromptEntry[]] => entry[0].length > 0 && Array.isArray(entry[1]))
+      .map(([storedSessionId, entries]) => [sessionIdentityKey(storedSessionId, 'default'), entries])
+  )
+}
+
+export function encodeQueuedPromptState(state: QueueState): string {
+  return JSON.stringify({
+    queues: Object.entries(state).map(([identityKey, entries]) => ({
+      ...parseSessionIdentityKey(identityKey),
+      entries
+    })),
+    version: QUEUE_STATE_VERSION
+  })
+}
 
 const load = (): QueueState => {
   if (typeof window === 'undefined') {
@@ -24,9 +80,8 @@ const load = (): QueueState => {
 
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY)
-    const parsed = raw ? JSON.parse(raw) : null
 
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as QueueState) : {}
+    return raw ? decodeQueuedPromptState(raw) : {}
   } catch {
     return {}
   }
@@ -41,7 +96,7 @@ const save = (state: QueueState) => {
     if (Object.keys(state).length === 0) {
       window.localStorage.removeItem(STORAGE_KEY)
     } else {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+      window.localStorage.setItem(STORAGE_KEY, encodeQueuedPromptState(state))
     }
   } catch {
     // best-effort: storage may be unavailable, queue still works in-memory
@@ -95,9 +150,7 @@ const writeSession = (sid: string, queue: QueuedPromptEntry[]) => {
 }
 
 const sidOf = (key: string | null | undefined): null | string => {
-  const trimmed = key?.trim()
-
-  return trimmed ? trimmed : null
+  return key ? key : null
 }
 
 const queueFor = (sid: string) => $queuedPromptsBySession.get()[sid] ?? []

--- a/apps/desktop/src/store/composer-status.test.ts
+++ b/apps/desktop/src/store/composer-status.test.ts
@@ -1,6 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $backgroundStatusBySession, dismissBackgroundProcess, reconcileBackgroundProcesses } from './composer-status'
+import { createClientSessionState } from '@/lib/chat-runtime'
+
+import {
+  $backgroundStatusBySession,
+  $statusItemsBySession,
+  dismissBackgroundProcess,
+  reconcileBackgroundProcesses
+} from './composer-status'
+import { $sessionStates } from './session-states'
+import { $subagentsBySession, type SubagentProgress } from './subagents'
 
 const SID = 'sess-1'
 
@@ -149,5 +158,32 @@ describe('reconcileBackgroundProcesses', () => {
     vi.advanceTimersByTime(5_000)
 
     expect(itemsOf('sess-arm')).toEqual([])
+  })
+})
+
+describe('subagent status ownership', () => {
+  it('carries the parent runtime profile into child window items', () => {
+    const subagent = {
+      id: 'deleg-1',
+      parentId: null,
+      goal: 'review',
+      sessionId: 'shared',
+      status: 'running',
+      taskCount: 1,
+      taskIndex: 0,
+      startedAt: 1,
+      updatedAt: 1,
+      filesRead: [],
+      filesWritten: [],
+      stream: []
+    } satisfies SubagentProgress
+
+    $sessionStates.set({ runtime: { ...createClientSessionState('parent'), storedSessionProfile: 'alpha' } })
+    $subagentsBySession.set({ runtime: [subagent] })
+
+    expect($statusItemsBySession.get().runtime?.[0]).toMatchObject({ sessionId: 'shared', sessionProfile: 'alpha' })
+
+    $subagentsBySession.set({})
+    $sessionStates.set({})
   })
 })

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -1,6 +1,7 @@
 import { atom, computed } from 'nanostores'
 
 import { translateNow } from '@/i18n'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { stableArray } from '@/lib/stable-array'
 import type { TodoItem, TodoStatus } from '@/lib/todos'
 
@@ -29,6 +30,8 @@ export interface ComposerStatusItem {
   /** subagent: its own stored session id — row click opens that session window
    *  (livestreamed by the gateway's child-session mirror). */
   sessionId?: string
+  /** Owning profile inherited from the parent runtime. */
+  sessionProfile?: null | string
   state: StatusItemState
   title: string
   /** todo: the full four-state status driving the row's checkmark glyph. */
@@ -57,10 +60,11 @@ export const $backgroundRunningSessionIds = computed([$backgroundStatusBySession
 
   for (const [runtimeId, items] of Object.entries(bg)) {
     if (items.some(i => i.state === 'running')) {
-      const storedId = states[runtimeId]?.storedSessionId
+      const state = states[runtimeId]
+      const storedId = state?.storedSessionId
 
       if (storedId) {
-        ids.add(storedId)
+        ids.add(sessionIdentityKey(storedId, state.storedSessionProfile))
       }
     }
   }
@@ -129,10 +133,11 @@ function cancelAllAutoDismiss(sid: string) {
   autoClearTimers.delete(sid)
 }
 
-const subToItem = (s: SubagentProgress): ComposerStatusItem => ({
+const subToItem = (s: SubagentProgress, sessionProfile?: null | string): ComposerStatusItem => ({
   currentTool: s.currentTool,
   id: s.id,
   sessionId: s.sessionId,
+  sessionProfile,
   state: 'running',
   title: s.goal,
   type: 'subagent'
@@ -175,7 +180,8 @@ const sameStatusItem = (a: ComposerStatusItem, b: ComposerStatusItem) =>
   a.currentTool === b.currentTool &&
   a.goalStatus === b.goalStatus &&
   a.todoStatus === b.todoStatus &&
-  a.sessionId === b.sessionId
+  a.sessionId === b.sessionId &&
+  a.sessionProfile === b.sessionProfile
 
 const stabilizeItems = (prev: ComposerStatusItem[] | undefined, next: ComposerStatusItem[]): ComposerStatusItem[] => {
   if (!prev) {
@@ -190,8 +196,8 @@ const stabilizeItems = (prev: ComposerStatusItem[] | undefined, next: ComposerSt
 let prevStatusItems: Record<string, ComposerStatusItem[]> = {}
 
 export const $statusItemsBySession = computed(
-  [$goalsBySession, $subagentsBySession, $backgroundStatusBySession, $todosBySession],
-  (goals, subs, background, todos) => {
+  [$goalsBySession, $subagentsBySession, $backgroundStatusBySession, $todosBySession, $sessionStates],
+  (goals, subs, background, todos, states) => {
     const out: Record<string, ComposerStatusItem[]> = {}
 
     const push = (sid: string, items: ComposerStatusItem[]) => {
@@ -209,7 +215,12 @@ export const $statusItemsBySession = computed(
     }
 
     for (const [sid, list] of Object.entries(subs)) {
-      push(sid, list.filter(s => s.status === 'running' || s.status === 'queued').map(subToItem))
+      push(
+        sid,
+        list
+          .filter(s => s.status === 'running' || s.status === 'queued')
+          .map(subagent => subToItem(subagent, states[sid]?.storedSessionProfile))
+      )
     }
 
     for (const [sid, list] of Object.entries(background)) {

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { sessionIdentityKey } from '@/lib/session-identity'
 
 import {
   $composerAttachments,
@@ -65,6 +67,14 @@ describe('session drafts', () => {
     expect(takeSessionDraft('session-b').attachments.map(a => a.id)).toEqual(['image:b'])
   })
 
+  it('keeps opaque session scopes distinct when stored ids differ by whitespace', () => {
+    stashSessionDraft('alpha\u0000shared', 'plain', [])
+    stashSessionDraft('alpha\u0000shared ', 'trailing space', [])
+
+    expect(takeSessionDraft('alpha\u0000shared').text).toBe('plain')
+    expect(takeSessionDraft('alpha\u0000shared ').text).toBe('trailing space')
+  })
+
   it('scopes the unsaved new-session draft separately from real sessions', () => {
     stashSessionDraft(null, 'new chat draft', [])
     stashSessionDraft('session-a', 'session draft', [])
@@ -77,12 +87,13 @@ describe('session drafts', () => {
   it('persists draft text (not attachments) to localStorage', () => {
     stashSessionDraft('session-a', 'survives reload', [attachment({ id: 'file:a' })])
 
-    const persisted = JSON.parse(window.localStorage.getItem(SESSION_DRAFTS_STORAGE_KEY) ?? '{}') as Record<
-      string,
-      string
-    >
+    const persisted = JSON.parse(window.localStorage.getItem(SESSION_DRAFTS_STORAGE_KEY) ?? '{}') as {
+      drafts?: Array<{ scope: string | null; text: string }>
+      version?: number
+    }
 
-    expect(persisted['session-a']).toBe('survives reload')
+    expect(persisted.version).toBe(4)
+    expect(persisted.drafts).toContainEqual({ scope: 'session-a', text: 'survives reload' })
   })
 
   it('evicts empty drafts instead of leaving stale entries behind', () => {
@@ -131,5 +142,23 @@ describe('session drafts', () => {
 
     clearSessionDraft('from')
     clearSessionDraft('to')
+  })
+
+  it('migrates legacy v3 ownerless draft keys to the default profile without inspecting opaque id bytes', async () => {
+    const opaqueStoredId = 'alpha\u0000shared'
+
+    window.localStorage.setItem(
+      'hermes:composer-drafts:v3',
+      JSON.stringify({
+        [opaqueStoredId]: 'opaque unsent text',
+        shared: 'plain unsent text'
+      })
+    )
+    vi.resetModules()
+
+    const reloaded = await import('./composer')
+
+    expect(reloaded.takeSessionDraft(sessionIdentityKey('shared', 'default')).text).toBe('plain unsent text')
+    expect(reloaded.takeSessionDraft(sessionIdentityKey(opaqueStoredId, 'default')).text).toBe('opaque unsent text')
   })
 })

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -1,6 +1,7 @@
 import { atom } from 'nanostores'
 
 import { triggerHaptic } from '@/lib/haptics'
+import { sessionIdentityKey } from '@/lib/session-identity'
 
 export interface ComposerAttachment {
   id: string
@@ -96,9 +97,10 @@ export const mainComposerScope = createComposerAttachmentScope($composerAttachme
 // Per-thread draft stash for the decoupled composer. Session lifecycle never
 // touches this — only ChatBar's scope swap reads/writes it. Text mirrors to
 // localStorage; attachments are memory-only (blobs, upload state).
-export const SESSION_DRAFTS_STORAGE_KEY = 'hermes:composer-drafts:v3'
+export const SESSION_DRAFTS_STORAGE_KEY = 'hermes:composer-drafts:v4'
 
-const NEW_SESSION_DRAFT_KEY = '__new__'
+const LEGACY_SESSION_DRAFTS_STORAGE_KEY = 'hermes:composer-drafts:v3'
+const SESSION_DRAFTS_STORAGE_VERSION = 4
 const MAX_PERSISTED_DRAFTS = 50
 const EMPTY_SESSION_DRAFT: SessionDraft = { attachments: [], text: '' }
 
@@ -107,47 +109,97 @@ export interface SessionDraft {
   text: string
 }
 
-const draftKey = (scope: string | null | undefined) => scope?.trim() || NEW_SESSION_DRAFT_KEY
+type SessionDraftKey = string | null
+
+const draftKey = (scope: string | null | undefined): SessionDraftKey => scope ?? null
 
 const cloneDraft = (draft: SessionDraft): SessionDraft => ({
   attachments: draft.attachments.map(attachment => ({ ...attachment })),
   text: draft.text
 })
 
-function loadPersistedDraftTexts(): [string, SessionDraft][] {
+interface PersistedSessionDraftsV4 {
+  version: 4
+  drafts: Array<{ scope: SessionDraftKey; text: string }>
+}
+
+function parsePersistedDraftsV4(raw: string): [SessionDraftKey, SessionDraft][] {
+  const parsed = JSON.parse(raw) as Partial<PersistedSessionDraftsV4>
+
+  if (parsed.version !== SESSION_DRAFTS_STORAGE_VERSION || !Array.isArray(parsed.drafts)) {
+    return []
+  }
+
+  return parsed.drafts.flatMap(entry =>
+    entry &&
+    (entry.scope === null || typeof entry.scope === 'string') &&
+    typeof entry.text === 'string'
+      ? [[entry.scope, { attachments: [], text: entry.text }] as [SessionDraftKey, SessionDraft]]
+      : []
+  )
+}
+
+function loadPersistedDraftTexts(): { entries: [SessionDraftKey, SessionDraft][]; migratedLegacy: boolean } {
   try {
     const raw = window.localStorage.getItem(SESSION_DRAFTS_STORAGE_KEY)
 
-    if (!raw) {
-      return []
+    if (raw) {
+      return { entries: parsePersistedDraftsV4(raw), migratedLegacy: false }
     }
 
-    return Object.entries(JSON.parse(raw) as Record<string, string>).map(([key, text]) => [
-      key,
-      { attachments: [], text }
-    ])
+    const legacyRaw = window.localStorage.getItem(LEGACY_SESSION_DRAFTS_STORAGE_KEY)
+
+    if (!legacyRaw) {
+      return { entries: [], migratedLegacy: false }
+    }
+
+    const legacy = JSON.parse(legacyRaw) as Record<string, unknown>
+
+    const entries = Object.entries(legacy).flatMap(([storedSessionId, text]) =>
+      typeof text === 'string'
+        ? [
+            [
+              storedSessionId === '__new__' ? null : sessionIdentityKey(storedSessionId, 'default'),
+              { attachments: [], text }
+            ] as [SessionDraftKey, SessionDraft]
+          ]
+        : []
+    )
+
+    return { entries, migratedLegacy: true }
   } catch {
-    return []
+    return { entries: [], migratedLegacy: false }
   }
 }
 
-const draftsBySession = new Map<string, SessionDraft>(loadPersistedDraftTexts())
+const loadedDrafts = loadPersistedDraftTexts()
+const draftsBySession = new Map<SessionDraftKey, SessionDraft>(loadedDrafts.entries)
 
-function persistDraftTexts() {
+function persistDraftTexts(): boolean {
   try {
-    const entries = [...draftsBySession]
+    const drafts = [...draftsBySession]
       .filter(([, draft]) => draft.text)
       .slice(-MAX_PERSISTED_DRAFTS)
-      .map(([key, draft]) => [key, draft.text] as const)
+      .map(([scope, draft]) => ({ scope, text: draft.text }))
 
-    if (entries.length === 0) {
+    if (drafts.length === 0) {
       window.localStorage.removeItem(SESSION_DRAFTS_STORAGE_KEY)
     } else {
-      window.localStorage.setItem(SESSION_DRAFTS_STORAGE_KEY, JSON.stringify(Object.fromEntries(entries)))
+      window.localStorage.setItem(
+        SESSION_DRAFTS_STORAGE_KEY,
+        JSON.stringify({ drafts, version: SESSION_DRAFTS_STORAGE_VERSION } satisfies PersistedSessionDraftsV4)
+      )
     }
+
+    return true
   } catch {
     // Best-effort only — quota/private-mode must never break typing.
+    return false
   }
+}
+
+if (loadedDrafts.migratedLegacy && persistDraftTexts()) {
+  window.localStorage.removeItem(LEGACY_SESSION_DRAFTS_STORAGE_KEY)
 }
 
 export function stashSessionDraft(scope: string | null | undefined, text: string, attachments: ComposerAttachment[]) {

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -7,12 +7,14 @@ import {
   $messagingSessions,
   $sessionProfilesTruncated,
   $sessions,
+  $sessionsHydratedProfileScope,
   $sessionsLoading,
   setCronSessions,
   setFreshDraftReady,
   setMessagingSessions,
   setSessionProfilesTruncated,
   setSessions,
+  setSessionsHydratedProfileScope,
   setSessionsLoading
 } from '@/store/session'
 import { $stalledSessionIds } from '@/store/session-states'
@@ -27,6 +29,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
   beforeEach(() => {
     $gatewaySwitching.set(false)
     setSessions([{ id: 's1', title: 'old', profile: 'default' } as never])
+    setSessionsHydratedProfileScope('default')
     setSessionProfilesTruncated({ default: true })
     setCronSessions([{ id: 'c1', title: 'cron', profile: 'default' } as never])
     setMessagingSessions([{ id: 'm1', title: 'tg', profile: 'default' } as never])
@@ -39,6 +42,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
   afterEach(() => {
     resetSessionsLimit()
     setSessions([])
+    setSessionsHydratedProfileScope(null)
     setCronSessions([])
     setMessagingSessions([])
     $stalledSessionIds.set([])
@@ -50,6 +54,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     wipeSessionListsForGatewaySwitch()
 
     expect($sessions.get()).toEqual([])
+    expect($sessionsHydratedProfileScope.get()).toBeNull()
     expect($sessionProfilesTruncated.get()).toEqual({})
     expect($cronSessions.get()).toEqual([])
     expect($messagingSessions.get()).toEqual([])

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -17,6 +17,7 @@ import {
   setSelectedStoredSessionId,
   setSessionProfilesTruncated,
   setSessions,
+  setSessionsHydratedProfileScope,
   setSessionsLoading
 } from '@/store/session'
 import { clearAllSessionStates } from '@/store/session-states'
@@ -43,6 +44,7 @@ export function wipeSessionListsForGatewaySwitch(): void {
   // "batched sidebar endpoint missing" capability verdict across the switch.
   resetSidebarBatchCapability()
   setSessions([])
+  setSessionsHydratedProfileScope(null)
   setSessionProfilesTruncated({})
   setCronSessions([])
   setMessagingSessions([])

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -299,6 +299,38 @@ export async function ensureGatewayForProfile(profile: string): Promise<void> {
   setActive(key)
 }
 
+/** Resolve a profile's live gateway without changing the profile currently
+ * shown by the window. Native-notification actions use this so an approval for
+ * background profile B cannot be sent over profile A's active socket. */
+export async function gatewayForProfile(profile: null | string | undefined): Promise<HermesGateway | null> {
+  const key = normKey(profile)
+
+  if (key === g.primaryProfile) {
+    return g.primaryGateway
+  }
+
+  let entry = g.secondaries.get(key)
+
+  if (!entry) {
+    entry = createSecondary(key)
+  }
+
+  entry.wantOpen = true
+
+  if (!isOpen(entry.gateway)) {
+    clearTimer(entry)
+    entry.reconnectAttempt = 0
+
+    try {
+      await openSecondary(entry)
+    } catch {
+      scheduleReconnect(entry)
+    }
+  }
+
+  return isOpen(entry.gateway) ? entry.gateway : null
+}
+
 // Reconnect the active gateway after a transient request failure. Primary
 // reconnects are owned by use-gateway-boot, so we only drive secondaries here.
 export async function ensureActiveGatewayOpen(): Promise<HermesGateway | null> {

--- a/apps/desktop/src/store/layout-session-identity.test.ts
+++ b/apps/desktop/src/store/layout-session-identity.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { sessionIdentityKey } from '@/lib/session-identity'
+
+beforeEach(() => {
+  window.localStorage.clear()
+  vi.resetModules()
+})
+
+describe('layout session identity migration', () => {
+  it('loads a legacy default pin canonically so one unpin removes it', async () => {
+    window.localStorage.setItem('hermes.desktop.pinnedSessions', JSON.stringify(['shared']))
+    const { $pinnedSessionIds, unpinSession } = await import('./layout')
+    const canonical = sessionIdentityKey('shared', 'default')
+
+    expect($pinnedSessionIds.get()).toEqual([canonical])
+    unpinSession(canonical)
+    expect($pinnedSessionIds.get()).toEqual([])
+  })
+
+  it('loads a legacy manual order as default-profile compound identities', async () => {
+    window.localStorage.setItem('hermes.desktop.sessionOrder', JSON.stringify(['other', 'shared']))
+    const { $sidebarSessionOrderIds } = await import('./layout')
+
+    expect($sidebarSessionOrderIds.get()).toEqual([
+      sessionIdentityKey('other', 'default'),
+      sessionIdentityKey('shared', 'default')
+    ])
+  })
+
+  it('round-trips opaque legacy ids separately from same-looking compound identities', async () => {
+    const sentinelLookingId = 'alpha\u0000shared'
+    window.localStorage.setItem('hermes.desktop.pinnedSessions', JSON.stringify([sentinelLookingId]))
+    const first = await import('./layout')
+    const legacyDefault = sessionIdentityKey(sentinelLookingId, 'default')
+    const ownedAlpha = sessionIdentityKey('shared', 'alpha')
+
+    expect(first.$pinnedSessionIds.get()).toEqual([legacyDefault])
+
+    first.$pinnedSessionIds.set([legacyDefault, ownedAlpha])
+    expect(JSON.parse(window.localStorage.getItem('hermes.desktop.pinnedSessions')!)).not.toBeInstanceOf(Array)
+
+    vi.resetModules()
+    const second = await import('./layout')
+
+    expect(second.$pinnedSessionIds.get()).toEqual([legacyDefault, ownedAlpha])
+  })
+
+  it("reorders visible pins without discarding another profile's pins", async () => {
+    const alphaA = sessionIdentityKey('a', 'alpha')
+    const alphaB = sessionIdentityKey('b', 'alpha')
+    const betaA = sessionIdentityKey('a', 'beta')
+    const { $pinnedSessionIds, setPinnedSessionOrder } = await import('./layout')
+
+    $pinnedSessionIds.set([alphaA, alphaB, betaA])
+    setPinnedSessionOrder([alphaB, alphaA])
+
+    expect($pinnedSessionIds.get()).toEqual([alphaB, alphaA, betaA])
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -4,6 +4,11 @@ import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
 import { matchesQuery } from '@/hooks/use-media-query'
 import { Codecs, persistentAtom } from '@/lib/persisted'
+import {
+  parseSessionIdentityKey,
+  sessionIdentityKey,
+  sessionIdentityKeysFromLegacyIds
+} from '@/lib/session-identity'
 import { arraysEqual, insertUniqueId, readKey } from '@/lib/storage'
 
 import { $paneStates, ensurePaneRegistered, setPaneOpen, setPaneWidthOverride, togglePane } from './panes'
@@ -70,11 +75,69 @@ export const $sidebarWidth: ReadableAtom<number> = computed($paneStates, states 
   return typeof override === 'number' ? override : SIDEBAR_DEFAULT_WIDTH
 })
 
-export const $pinnedSessionIds = persistentAtom(SIDEBAR_PINNED_STORAGE_KEY, [] as string[], Codecs.stringArray)
+const SESSION_IDENTITY_ARRAY_VERSION = 1
+
+interface PersistedSessionIdentity {
+  profile: string
+  storedSessionId: string
+}
+
+function isPersistedSessionIdentity(value: unknown): value is PersistedSessionIdentity {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof (value as PersistedSessionIdentity).profile === 'string' &&
+    typeof (value as PersistedSessionIdentity).storedSessionId === 'string' &&
+    (value as PersistedSessionIdentity).storedSessionId.length > 0
+  )
+}
+
+const sessionIdentityArrayCodec = {
+  decode: (raw: string): string[] => {
+    const parsed = JSON.parse(raw) as unknown
+
+    // Main's legacy schema was an ownerless string array. The container—not
+    // delimiter-looking bytes inside an id—is the only safe migration signal.
+    if (Array.isArray(parsed)) {
+      return sessionIdentityKeysFromLegacyIds(
+        parsed.filter((item): item is string => typeof item === 'string' && item.length > 0)
+      )
+    }
+
+    const stored = parsed as { identities?: unknown; version?: unknown } | null
+
+    if (
+      !stored ||
+      typeof stored !== 'object' ||
+      stored.version !== SESSION_IDENTITY_ARRAY_VERSION ||
+      !Array.isArray(stored.identities)
+    ) {
+      return []
+    }
+
+    return [
+      ...new Set(
+        stored.identities
+          .filter(isPersistedSessionIdentity)
+          .map(identity => sessionIdentityKey(identity.storedSessionId, identity.profile))
+      )
+    ]
+  },
+  encode: (identities: string[]): null | string =>
+    identities.length === 0
+      ? null
+      : JSON.stringify({
+          identities: identities.map(parseSessionIdentityKey),
+          version: SESSION_IDENTITY_ARRAY_VERSION
+        })
+}
+
+export const $pinnedSessionIds = persistentAtom(SIDEBAR_PINNED_STORAGE_KEY, [] as string[], sessionIdentityArrayCodec)
 export const $sidebarSessionOrderIds = persistentAtom(
   SIDEBAR_SESSION_ORDER_STORAGE_KEY,
   [] as string[],
-  Codecs.stringArray
+  sessionIdentityArrayCodec
 )
 export const $sidebarSessionOrderManual = persistentAtom(SIDEBAR_SESSION_ORDER_MANUAL_STORAGE_KEY, false, Codecs.bool)
 export const $sidebarWorkspaceOrderIds = persistentAtom(
@@ -383,15 +446,24 @@ export function unpinSession(sessionId: string) {
   )
 }
 
-// Replace the whole pinned order at once (drag-reorder hands back the new order
-// rather than a single move). Keep only ids that are actually pinned so a stale
-// row can't smuggle an unpinned id into the store.
+// Reorder only the submitted visible subset. Concrete profile scopes do not
+// render other profiles' pins, so replacing the whole array here would either
+// erase those hidden pins or reject the drag entirely. Keep only ids that are
+// actually pinned so a stale row cannot smuggle an unpinned id into the store.
 export function setPinnedSessionOrder(ids: string[]) {
   const prev = $pinnedSessionIds.get()
   const pinned = new Set(prev)
-  const next = ids.filter(id => pinned.has(id))
+  const nextVisible = [...new Set(ids.filter(id => pinned.has(id)))]
 
-  if (next.length === prev.length && !arraysEqual(prev, next)) {
+  if (!nextVisible.length) {
+    return
+  }
+
+  const visible = new Set(nextVisible)
+  let nextIndex = 0
+  const next = prev.map(id => (visible.has(id) ? nextVisible[nextIndex++] : id))
+
+  if (!arraysEqual(prev, next)) {
     $pinnedSessionIds.set(next)
   }
 }

--- a/apps/desktop/src/store/native-notifications.test.ts
+++ b/apps/desktop/src/store/native-notifications.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import * as gatewayStore from './gateway'
 import { $gateway } from './gateway'
 import {
   dispatchNativeNotification,
@@ -10,6 +11,7 @@ import {
   setNativeNotifyKind
 } from './native-notifications'
 import { __resetNativeNotifyBaselineForTests, markNativeNotifyBaseline } from './notify-baseline'
+import { $activeGatewayProfile } from './profile'
 import { $approvalRequest, setApprovalRequest } from './prompts'
 import { $activeSessionId, setActiveSessionId } from './session'
 
@@ -43,6 +45,7 @@ beforeEach(() => {
   }
 
   setActiveSessionId(null)
+  $activeGatewayProfile.set('default')
   setWindowState({ focused: false, hidden: true })
   __resetNativeNotifyBaselineForTests()
 })
@@ -132,11 +135,26 @@ describe('dispatchNativeNotification preferences', () => {
     expect(notify).toHaveBeenCalledTimes(1)
   })
 
-  it('forwards kind and sessionId to the bridge', () => {
-    setActiveSessionId('abc')
-    dispatchNativeNotification({ body: 'hi', kind: 'turnError', sessionId: 'abc', title: 'boom' })
+  it('forwards stored and runtime identity to the bridge', () => {
+    setActiveSessionId('runtime-abc')
+    $activeGatewayProfile.set('beta')
+    dispatchNativeNotification({
+      body: 'hi',
+      kind: 'turnError',
+      profile: 'beta',
+      sessionId: 'runtime-abc',
+      storedSessionId: 'stored-abc',
+      title: 'boom'
+    })
     expect(notify).toHaveBeenCalledWith(
-      expect.objectContaining({ body: 'hi', kind: 'turnError', sessionId: 'abc', title: 'boom' })
+      expect.objectContaining({
+        body: 'hi',
+        kind: 'turnError',
+        profile: 'beta',
+        runtimeSessionId: 'runtime-abc',
+        sessionId: 'stored-abc',
+        title: 'boom'
+      })
     )
   })
 })
@@ -178,6 +196,17 @@ describe('dispatchNativeNotification throttle', () => {
     dispatchNativeNotification({ kind: 'turnDone', sessionId, title: 'done again' })
     expect(notify).toHaveBeenCalledTimes(1)
   })
+
+  it('does not collapse equal runtime ids from different profiles', () => {
+    const sessionId = freshSession()
+    setActiveSessionId(sessionId)
+    $activeGatewayProfile.set('alpha')
+    dispatchNativeNotification({ kind: 'turnDone', profile: 'alpha', sessionId, title: 'alpha' })
+    $activeGatewayProfile.set('beta')
+    dispatchNativeNotification({ kind: 'turnDone', profile: 'beta', sessionId, title: 'beta' })
+
+    expect(notify).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('sendTestNativeNotification', () => {
@@ -206,6 +235,7 @@ describe('respondToApprovalAction', () => {
 
   afterEach(() => {
     $gateway.set(null)
+    vi.restoreAllMocks()
   })
 
   it('approves via approval.respond {choice: "once"} and clears the prompt', async () => {
@@ -232,5 +262,29 @@ describe('respondToApprovalAction', () => {
     $gateway.set(null)
     await respondToApprovalAction('bg', 'approve')
     expect(request).not.toHaveBeenCalled()
+  })
+
+  it('does not clear a newer colliding approval while an older profile response is in flight', async () => {
+    let resolveResponse!: () => void
+
+    const pending = new Promise<void>(resolve => {
+      resolveResponse = resolve
+    })
+
+    const ownedRequest = vi.fn(async () => pending)
+
+    vi.spyOn(gatewayStore, 'gatewayForProfile').mockResolvedValue({ request: ownedRequest } as never)
+    setActiveSessionId('shared-runtime')
+    setApprovalRequest({ command: 'alpha command', description: 'alpha', profile: 'alpha', sessionId: 'shared-runtime' })
+
+    const responding = respondToApprovalAction('shared-runtime', 'approve', 'alpha')
+    await vi.waitFor(() => expect(ownedRequest).toHaveBeenCalled())
+
+    $activeGatewayProfile.set('beta')
+    setApprovalRequest({ command: 'beta command', description: 'beta', profile: 'beta', sessionId: 'shared-runtime' })
+    resolveResponse()
+    await responding
+
+    expect($approvalRequest.get()?.command).toBe('beta command')
   })
 })

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -1,9 +1,10 @@
 import { atom } from 'nanostores'
 
 import { persistString, storedString } from '@/lib/storage'
+import { $gateway, gatewayForProfile } from '@/store/gateway'
 
-import { $gateway } from './gateway'
 import { withinNativeNotifyBaseline } from './notify-baseline'
+import { $activeGatewayProfile } from './profile'
 import { clearApprovalRequest } from './prompts'
 import { $activeSessionId } from './session'
 
@@ -115,7 +116,12 @@ function isBackgrounded(): boolean {
   return typeof document.hasFocus === 'function' && !document.hasFocus()
 }
 
-function shouldFire(kind: NativeNotificationKind, sessionId?: null | string, global = false): boolean {
+function shouldFire(
+  kind: NativeNotificationKind,
+  sessionId?: null | string,
+  profile?: null | string,
+  global = false
+): boolean {
   // Global notifications aren't tied to a chat session (e.g. pet generation,
   // which runs from the command center with no active conversation). They fire
   // whenever the user is away, with no session-match requirement — otherwise a
@@ -124,14 +130,17 @@ function shouldFire(kind: NativeNotificationKind, sessionId?: null | string, glo
     return isBackgrounded()
   }
 
+  const isActiveIdentity =
+    Boolean(sessionId) && sessionId === $activeSessionId.get() && (profile ?? 'default') === $activeGatewayProfile.get()
+
   // Attention kinds break through for an off-screen session even while focused.
   if (ATTENTION_KINDS.has(kind)) {
-    return isBackgrounded() || (Boolean(sessionId) && sessionId !== $activeSessionId.get())
+    return isBackgrounded() || (Boolean(sessionId) && !isActiveIdentity)
   }
 
   // Completion kinds: only the active session, only while away — so a busy
   // gateway (messaging, kanban, cron) can't spam a toast per background session.
-  return isBackgrounded() && Boolean(sessionId) && sessionId === $activeSessionId.get()
+  return isBackgrounded() && isActiveIdentity
 }
 
 export interface NativeNotificationAction {
@@ -144,6 +153,11 @@ export interface NativeNotificationInput {
   title: string
   body?: string
   sessionId?: null | string
+  /** Stored id used for click navigation. `sessionId` remains the live runtime
+   * id used by completion gating and approval responses. */
+  storedSessionId?: null | string
+  /** Gateway profile that owns both ids. */
+  profile?: null | string
   /**
    * Not tied to a chat session (e.g. pet generation). Fires whenever the user
    * is away, bypassing the session-match gate that completion kinds normally
@@ -165,11 +179,16 @@ export function dispatchNativeNotification(input: NativeNotificationInput): void
     return
   }
 
-  if (!shouldFire(input.kind, input.sessionId, input.global)) {
+  if (!shouldFire(input.kind, input.sessionId, input.profile, input.global)) {
     return
   }
 
-  if (throttled(`${input.kind}:${input.sessionId ?? (input.global ? 'global' : '')}`, Date.now())) {
+  if (
+    throttled(
+      `${input.kind}:${input.profile ?? 'default'}:${input.sessionId ?? (input.global ? 'global' : '')}`,
+      Date.now()
+    )
+  ) {
     return
   }
 
@@ -177,7 +196,9 @@ export function dispatchNativeNotification(input: NativeNotificationInput): void
     actions: input.actions,
     body: input.body,
     kind: input.kind,
-    sessionId: input.sessionId ?? undefined,
+    profile: input.profile ?? undefined,
+    runtimeSessionId: input.sessionId ?? undefined,
+    sessionId: input.storedSessionId ?? input.sessionId ?? undefined,
     silent: input.silent,
     title: input.title
   })
@@ -185,14 +206,18 @@ export function dispatchNativeNotification(input: NativeNotificationInput): void
 
 // Resolve a pending approval from a notification button, mirroring the in-app
 // Run/Reject bar. Keyed by session id — a background approval has no local guard.
-export async function respondToApprovalAction(sessionId: null | string, actionId: string): Promise<void> {
+export async function respondToApprovalAction(
+  sessionId: null | string,
+  actionId: string,
+  profile?: null | string
+): Promise<void> {
   const choice = actionId === 'approve' ? 'once' : actionId === 'reject' ? 'deny' : null
 
   if (!choice) {
     return
   }
 
-  const gateway = $gateway.get()
+  const gateway = profile ? await gatewayForProfile(profile) : $gateway.get()
 
   if (!gateway) {
     return
@@ -200,7 +225,7 @@ export async function respondToApprovalAction(sessionId: null | string, actionId
 
   try {
     await gateway.request('approval.respond', { choice, session_id: sessionId ?? undefined })
-    clearApprovalRequest(sessionId)
+    clearApprovalRequest(sessionId, undefined, profile)
   } catch {
     // Leave the prompt parked so the user can still resolve it in-app.
   }

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { $sidebarAgentsGrouped } from '@/store/layout'
 import { $activeGatewayProfile } from '@/store/profile'
 import { applyConfiguredDefaultProjectDir } from '@/store/session'
@@ -454,8 +455,17 @@ describe('tombstone pruning', () => {
   }
 
   beforeEach(() => {
+    $activeGatewayProfile.set('default')
     $removedSessionIds.set(new Set())
     $sessionMutationsInFlight.set(new Set())
+  })
+
+  it('keeps opaque stored ids distinct when creating tombstones', () => {
+    tombstoneSessions(['shared', 'shared '], 'alpha')
+
+    expect($removedSessionIds.get()).toEqual(
+      new Set([sessionIdentityKey('shared', 'alpha'), sessionIdentityKey('shared ', 'alpha')])
+    )
   })
 
   it('keeps an in-flight delete tombstone even when the backend snapshot omits it', async () => {
@@ -469,7 +479,7 @@ describe('tombstone pruning', () => {
     openGatewayReturning([])
     await refreshProjectTree()
 
-    expect($removedSessionIds.get().has('sess-1')).toBe(true)
+    expect($removedSessionIds.get().has(sessionIdentityKey('sess-1', 'default'))).toBe(true)
   })
 
   it('prunes the tombstone once the mutation settles and scope no longer lists it', async () => {
@@ -482,6 +492,6 @@ describe('tombstone pruning', () => {
     endSessionMutation(['sess-1'])
     await refreshProjectTree()
 
-    expect($removedSessionIds.get().has('sess-1')).toBe(false)
+    expect($removedSessionIds.get().has(sessionIdentityKey('sess-1', 'default'))).toBe(false)
   })
 })

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -12,11 +12,16 @@ import { desktopDefaultCwd, isDesktopFsRemoteMode, selectDesktopPaths, writeDesk
 import { desktopGit } from '@/lib/desktop-git'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { persistentAtom } from '@/lib/persisted'
+import { parseSessionIdentityKey, sessionIdentityKey, sessionMatchesIdentity } from '@/lib/session-identity'
 import { $gateway, activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
 import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
 import { $activeGatewayProfile, requestFreshSession } from '@/store/profile'
-import { $selectedStoredSessionId, $sessions, sessionMatchesStoredId, workspaceCwdForNewSession } from '@/store/session'
+import {
+  $selectedSessionIdentityKey,
+  $sessions,
+  workspaceCwdForNewSession
+} from '@/store/session'
 import type { ProjectInfo, ProjectsPayload } from '@/types/hermes'
 
 // First-class, per-profile Projects (named, multi-folder workspaces). State is
@@ -59,15 +64,13 @@ function projectsStaleBackendError(): Error {
 // refresh once the server snapshot has caught up.
 export const $removedSessionIds = atom<Set<string>>(new Set())
 
-export function tombstoneSessions(ids: Array<null | string | undefined>): void {
+export function tombstoneSessions(ids: Array<null | string | undefined>, profile?: null | string): void {
   const next = new Set($removedSessionIds.get())
   const before = next.size
 
   for (const id of ids) {
-    const trimmed = id?.trim()
-
-    if (trimmed) {
-      next.add(trimmed)
+    if (id) {
+      next.add(sessionIdentityKey(id, profile ?? $activeGatewayProfile.get()))
     }
   }
 
@@ -76,7 +79,7 @@ export function tombstoneSessions(ids: Array<null | string | undefined>): void {
   }
 }
 
-export function untombstoneSessions(ids: Array<null | string | undefined>): void {
+export function untombstoneSessions(ids: Array<null | string | undefined>, profile?: null | string): void {
   const current = $removedSessionIds.get()
 
   if (!current.size) {
@@ -86,10 +89,8 @@ export function untombstoneSessions(ids: Array<null | string | undefined>): void
   const next = new Set(current)
 
   for (const id of ids) {
-    const trimmed = id?.trim()
-
-    if (trimmed) {
-      next.delete(trimmed)
+    if (id) {
+      next.delete(sessionIdentityKey(id, profile ?? $activeGatewayProfile.get()))
     }
   }
 
@@ -104,15 +105,14 @@ export function untombstoneSessions(ids: Array<null | string | undefined>): void
 // the backend catches up. Keyed by id, so concurrent deletes stay independent.
 export const $sessionMutationsInFlight = atom<Set<string>>(new Set())
 
-function mutateInFlight(ids: Array<null | string | undefined>, add: boolean): void {
+function mutateInFlight(ids: Array<null | string | undefined>, add: boolean, profile?: null | string): void {
   const current = $sessionMutationsInFlight.get()
   const next = new Set(current)
 
   for (const id of ids) {
-    const trimmed = id?.trim()
-
-    if (trimmed) {
-      add ? next.add(trimmed) : next.delete(trimmed)
+    if (id) {
+      const identityKey = sessionIdentityKey(id, profile ?? $activeGatewayProfile.get())
+      add ? next.add(identityKey) : next.delete(identityKey)
     }
   }
 
@@ -121,8 +121,10 @@ function mutateInFlight(ids: Array<null | string | undefined>, add: boolean): vo
   }
 }
 
-export const beginSessionMutation = (ids: Array<null | string | undefined>): void => mutateInFlight(ids, true)
-export const endSessionMutation = (ids: Array<null | string | undefined>): void => mutateInFlight(ids, false)
+export const beginSessionMutation = (ids: Array<null | string | undefined>, profile?: null | string): void =>
+  mutateInFlight(ids, true, profile)
+export const endSessionMutation = (ids: Array<null | string | undefined>, profile?: null | string): void =>
+  mutateInFlight(ids, false, profile)
 
 // True while the disk scan is in flight (drives the "finding repos" hint).
 export const $reposScanning = atom(false)
@@ -371,7 +373,8 @@ async function refreshProjectTreeOn(gateway: HermesGateway): Promise<void> {
       return
     }
 
-    const scoped = new Set(res.scoped_session_ids ?? [])
+    const profile = $activeGatewayProfile.get()
+    const scoped = new Set((res.scoped_session_ids ?? []).map(id => sessionIdentityKey(id, profile)))
     $projectTree.set(res.projects ?? [])
     $activeProjectId.set(res.active_id ?? null)
     const tombstones = $removedSessionIds.get()
@@ -835,13 +838,16 @@ export async function addProjectFolder(
 // Used so deleting a project you have a session open from kicks you back to the
 // intro draft instead of stranding you in a now-orphaned view.
 function openSessionBelongsToProject(projectId: string, projects: ProjectInfo[]): boolean {
-  const openId = $selectedStoredSessionId.get()
+  const identityKey = $selectedSessionIdentityKey.get()
+  const openIdentity = identityKey ? parseSessionIdentityKey(identityKey) : null
 
-  if (!openId) {
+  if (!openIdentity) {
     return false
   }
 
-  const open = $sessions.get().find(s => sessionMatchesStoredId(s, openId))
+  const open = $sessions
+    .get()
+    .find(s => sessionMatchesIdentity(s, openIdentity.storedSessionId, openIdentity.profile))
 
   return Boolean(open && liveSessionProjectId(open, projects) === projectId)
 }

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { clearClarifyRequest, setClarifyRequest } from './clarify'
+import { $activeGatewayProfile } from './profile'
 import {
   $activeSessionAwaitingInput,
   $approvalRequest,
@@ -20,12 +21,14 @@ import { $activeSessionId } from './session'
 // active session, so each test focuses the session it's asserting on.
 beforeEach(() => {
   $activeSessionId.set('s1')
+  $activeGatewayProfile.set('default')
 })
 
 afterEach(() => {
   clearAllPrompts()
   clearClarifyRequest()
   $activeSessionId.set(null)
+  $activeGatewayProfile.set('default')
 })
 
 describe('approval prompt store', () => {
@@ -66,6 +69,16 @@ describe('approval prompt store', () => {
     })
 
     expect($approvalRequest.get()?.allowPermanent).toBe(false)
+  })
+
+  it('does not clear a colliding approval owned by another profile', () => {
+    setApprovalRequest({ command: 'alpha', description: 'd', profile: 'alpha', sessionId: 's1' })
+    setApprovalRequest({ command: 'beta', description: 'e', profile: 'beta', sessionId: 's1' })
+    $activeGatewayProfile.set('beta')
+
+    clearApprovalRequest('s1', undefined, 'alpha')
+
+    expect($approvalRequest.get()?.command).toBe('beta')
   })
 })
 

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -1,6 +1,9 @@
 import { atom, computed, type ReadableAtom } from 'nanostores'
 
+import { sessionIdentityKey } from '@/lib/session-identity'
+
 import { $clarifyRequest, $clarifyRequests } from './clarify'
+import { $activeGatewayProfile } from './profile'
 import { $activeSessionId } from './session'
 
 // Blocking interactive prompts the gateway raises mid-turn. Each maps to a
@@ -15,16 +18,18 @@ import { $activeSessionId } from './session'
 // exported $*Request view is scoped to the active session, so a background
 // prompt never hijacks the foreground.
 
-const keyFor = (sessionId: string | null | undefined): string => sessionId ?? ''
+const keyFor = (sessionId: string | null | undefined, profile?: null | string): string =>
+  sessionIdentityKey(sessionId ?? '', profile ?? $activeGatewayProfile.get())
 
 interface KeyedPrompt {
+  profile?: null | string
   sessionId: string | null
 }
 
 interface PromptStore<T extends KeyedPrompt> {
   $active: ReadableAtom<null | T>
   $all: ReadableAtom<Record<string, T>>
-  clear: (sessionId?: string | null, requestId?: string) => void
+  clear: (sessionId?: string | null, requestId?: string, profile?: null | string) => void
   reset: () => void
   set: (request: T) => void
 }
@@ -38,15 +43,18 @@ function keyedPromptStore<T extends KeyedPrompt>(): PromptStore<T> {
   const idOf = (value: T): string | undefined => (value as { requestId?: string }).requestId
 
   return {
-    $active: computed([$all, $activeSessionId], (all, activeId) => all[keyFor(activeId)] ?? null),
+    $active: computed(
+      [$all, $activeSessionId, $activeGatewayProfile],
+      (all, activeId, profile) => all[keyFor(activeId, profile)] ?? null
+    ),
     $all,
     reset: () => $all.set({}),
-    set: request => $all.set({ ...$all.get(), [keyFor(request.sessionId)]: request }),
-    clear(sessionId, requestId) {
+    set: request => $all.set({ ...$all.get(), [keyFor(request.sessionId, request.profile)]: request }),
+    clear(sessionId, requestId, profile) {
       const all = $all.get()
 
       if (sessionId !== undefined) {
-        const key = keyFor(sessionId)
+        const key = keyFor(sessionId, profile)
         const current = all[key]
 
         if (current && !(requestId && idOf(current) !== requestId)) {
@@ -103,15 +111,21 @@ export const clearApprovalRequest = approval.clear
 
 /** The prompt request for one specific session — the tile counterpart of the
  *  active-session `$*Request` views (same map, fixed key). */
-export const sessionApprovalRequest = (sessionId: string | null) =>
-  computed(approval.$all, all => all[keyFor(sessionId)] ?? null)
-export const sessionSudoRequest = (sessionId: string | null) =>
-  computed(sudo.$all, all => all[keyFor(sessionId)] ?? null)
-export const sessionSecretRequest = (sessionId: string | null) =>
-  computed(secret.$all, all => all[keyFor(sessionId)] ?? null)
+export const sessionApprovalRequest = (sessionId: string | null, profile?: null | string) =>
+  computed([approval.$all, $activeGatewayProfile], (all, activeProfile) =>
+    all[keyFor(sessionId, profile ?? activeProfile)] ?? null
+  )
+export const sessionSudoRequest = (sessionId: string | null, profile?: null | string) =>
+  computed([sudo.$all, $activeGatewayProfile], (all, activeProfile) =>
+    all[keyFor(sessionId, profile ?? activeProfile)] ?? null
+  )
+export const sessionSecretRequest = (sessionId: string | null, profile?: null | string) =>
+  computed([secret.$all, $activeGatewayProfile], (all, activeProfile) =>
+    all[keyFor(sessionId, profile ?? activeProfile)] ?? null
+  )
 
-export function registerApprovalInlineAnchor(sessionId: string | null): () => void {
-  const key = keyFor(sessionId)
+export function registerApprovalInlineAnchor(sessionId: string | null, profile?: null | string): () => void {
+  const key = keyFor(sessionId, profile)
 
   const bump = (delta: number) => {
     const all = $approvalInlineAnchors.get()
@@ -126,8 +140,10 @@ export function registerApprovalInlineAnchor(sessionId: string | null): () => vo
 
 /** True when session `sessionId` has an inline approval bar mounted, so its
  *  floating fallback should stand down. Per-session (not global). */
-export const sessionApprovalInlineVisible = (sessionId: string | null) =>
-  computed($approvalInlineAnchors, anchors => (anchors[keyFor(sessionId)] ?? 0) > 0)
+export const sessionApprovalInlineVisible = (sessionId: string | null, profile?: null | string) =>
+  computed([$approvalInlineAnchors, $activeGatewayProfile], (anchors, activeProfile) =>
+    (anchors[keyFor(sessionId, profile ?? activeProfile)] ?? 0) > 0
+  )
 
 export const $sudoRequest = sudo.$active
 export const setSudoRequest = sudo.set
@@ -150,17 +166,21 @@ export const $activeSessionAwaitingInput = computed(
 /** Per-session `awaitingInput` — the tile composer's counterpart of
  *  `$activeSessionAwaitingInput` (same sources, fixed session instead of the
  *  active one). */
-export function sessionAwaitingInput(sessionId: string | null) {
-  return computed([$clarifyRequests, approval.$all, sudo.$all, secret.$all], (clarify, approvals, sudos, secrets) => {
-    const key = keyFor(sessionId)
+export function sessionAwaitingInput(sessionId: string | null, profile?: null | string) {
+  return computed(
+    [$clarifyRequests, approval.$all, sudo.$all, secret.$all, $activeGatewayProfile],
+    (clarify, approvals, sudos, secrets, activeProfile) => {
+      const key = keyFor(sessionId, profile ?? activeProfile)
+      const clarifyKey = sessionId ?? ''
 
-    return Boolean(clarify[key] || approvals[key] || sudos[key] || secrets[key])
-  })
+      return Boolean(clarify[clarifyKey] || approvals[key] || sudos[key] || secrets[key])
+    }
+  )
 }
 
 // Drop in-flight prompts for `sessionId` (a turn ended) across all three kinds —
 // or every parked prompt when no session is given (global reset / tests).
-export function clearAllPrompts(sessionId?: string | null): void {
+export function clearAllPrompts(sessionId?: string | null, profile?: null | string): void {
   if (sessionId === undefined) {
     approval.reset()
     sudo.reset()
@@ -170,7 +190,7 @@ export function clearAllPrompts(sessionId?: string | null): void {
     return
   }
 
-  approval.clear(sessionId)
-  sudo.clear(sessionId)
-  secret.clear(sessionId)
+  approval.clear(sessionId, undefined, profile)
+  sudo.clear(sessionId, undefined, profile)
+  secret.clear(sessionId, undefined, profile)
 }

--- a/apps/desktop/src/store/quick-entry.test.ts
+++ b/apps/desktop/src/store/quick-entry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   initialQuickComposerState,
+  normalizeQuickEntrySubmitPayload,
   QUICK_TARGET_CURRENT,
   QUICK_TARGET_NEW,
   type QuickComposerEvent,
@@ -32,8 +33,8 @@ function run(events: QuickComposerEvent[], from: QuickComposerState = initialQui
 const connect: QuickComposerEvent = {
   connected: true,
   sessions: [
-    { id: 's1', title: 'Fix the build' },
-    { id: 's2', title: 'Research trip' }
+    { id: 's1', target: { kind: 'session', profile: 'alpha', storedSessionId: 's1' }, title: 'Fix the build' },
+    { id: 's2', target: { kind: 'session', profile: 'beta', storedSessionId: 's2' }, title: 'Research trip' }
   ],
   type: 'state'
 }
@@ -53,7 +54,7 @@ describe('quickComposerReducer', () => {
   it('submit sends the trimmed draft with the target, clears it, and hides', () => {
     const { sent, state } = run([connect, { draft: '  ship it  ', type: 'edit' }, { type: 'submit' }])
 
-    expect(sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'ship it' }])
+    expect(sent).toEqual([{ target: { kind: 'current' }, text: 'ship it' }])
     expect(state.draft).toBe('')
     expect(state.submitting).toBe(true)
     expect(state.visible).toBe(false)
@@ -80,7 +81,7 @@ describe('quickComposerReducer', () => {
 
     // The gateway comes back: the same draft now sends.
     const after = run([connect, { type: 'submit' }], state)
-    expect(after.sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'hello?' }])
+    expect(after.sent).toEqual([{ target: { kind: 'current' }, text: 'hello?' }])
   })
 
   it('a disconnect push mid-composition keeps the draft but blocks the send', () => {
@@ -99,7 +100,7 @@ describe('quickComposerReducer', () => {
   it('a second submit while already submitting cannot double-send', () => {
     const { sent, state } = run([connect, { draft: 'hello', type: 'edit' }, { type: 'submit' }, { type: 'submit' }])
 
-    expect(sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'hello' }])
+    expect(sent).toEqual([{ target: { kind: 'current' }, text: 'hello' }])
     expect(state.submitting).toBe(true)
   })
 
@@ -111,7 +112,37 @@ describe('quickComposerReducer', () => {
       { type: 'submit' }
     ])
 
-    expect(sent).toEqual([{ target: 's2', text: 'send this there' }])
+    expect(sent).toEqual([
+      { target: { kind: 'session', profile: 'beta', storedSessionId: 's2' }, text: 'send this there' }
+    ])
+  })
+
+  it('rejects legacy string targets instead of confusing them with controls or compound IDs', () => {
+    expect(normalizeQuickEntrySubmitPayload('legacy prompt')).toBeNull()
+    expect(normalizeQuickEntrySubmitPayload({ target: 'current', text: 'do not redirect' })).toBeNull()
+    expect(normalizeQuickEntrySubmitPayload({ target: 'new', text: 'do not redirect' })).toBeNull()
+    expect(normalizeQuickEntrySubmitPayload({ target: 'alpha\0shared', text: 'do not redirect' })).toBeNull()
+  })
+
+  it('rejects a session target without an explicit nonblank owner', () => {
+    expect(
+      normalizeQuickEntrySubmitPayload({
+        target: { kind: 'session', profile: '   ', storedSessionId: 'shared' },
+        text: 'do not redirect'
+      })
+    ).toBeNull()
+  })
+
+  it('validates a session target while preserving the exact opaque stored ID', () => {
+    expect(
+      normalizeQuickEntrySubmitPayload({
+        target: { kind: 'session', profile: ' BETA ', storedSessionId: ' left\0right ' },
+        text: 'owned prompt'
+      })
+    ).toEqual({
+      target: { kind: 'session', profile: 'BETA', storedSessionId: ' left\0right ' },
+      text: 'owned prompt'
+    })
   })
 
   it('the new-session target rides the submit payload', () => {
@@ -122,14 +153,20 @@ describe('quickComposerReducer', () => {
       { type: 'submit' }
     ])
 
-    expect(sent).toEqual([{ target: QUICK_TARGET_NEW, text: 'fresh start' }])
+    expect(sent).toEqual([{ target: { kind: 'new' }, text: 'fresh start' }])
   })
 
   it('a picked session that vanishes from the pushed list falls back to current', () => {
     const { state } = run([
       connect,
       { target: 's2', type: 'target' },
-      { connected: true, sessions: [{ id: 's1', title: 'Fix the build' }], type: 'state' }
+      {
+        connected: true,
+        sessions: [
+          { id: 's1', target: { kind: 'session', profile: 'alpha', storedSessionId: 's1' }, title: 'Fix the build' }
+        ],
+        type: 'state'
+      }
     ])
 
     expect(state.target).toBe(QUICK_TARGET_CURRENT)
@@ -166,7 +203,7 @@ describe('quickComposerReducer', () => {
   it('the blur that follows a submit does not re-send or resurrect the draft', () => {
     const { sent, state } = run([connect, { draft: 'go', type: 'edit' }, { type: 'submit' }, { type: 'blur' }])
 
-    expect(sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'go' }])
+    expect(sent).toEqual([{ target: { kind: 'current' }, text: 'go' }])
     expect(state.draft).toBe('')
     expect(state.submitting).toBe(false)
     expect(state.visible).toBe(false)
@@ -210,7 +247,7 @@ describe('quickComposerReducer', () => {
     const first = run([connect, { draft: 'one', type: 'edit' }, { type: 'submit' }])
     const second = run([{ type: 'shown' }, { draft: 'two', type: 'edit' }, { type: 'submit' }], first.state)
 
-    expect(first.sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'one' }])
-    expect(second.sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'two' }])
+    expect(first.sent).toEqual([{ target: { kind: 'current' }, text: 'one' }])
+    expect(second.sent).toEqual([{ target: { kind: 'current' }, text: 'two' }])
   })
 })

--- a/apps/desktop/src/store/quick-entry.ts
+++ b/apps/desktop/src/store/quick-entry.ts
@@ -17,6 +17,8 @@
 
 import { atom } from 'nanostores'
 
+import { normalizeProfileKey } from '@/lib/session-identity'
+
 export interface QuickEntryState {
   enabled: boolean
   /** null before the first read; the settings row shows a skeleton until then. */
@@ -100,8 +102,18 @@ export async function saveQuickEntrySettings(patch: { enabled?: boolean; shortcu
 // ── Quick window submit state machine ───────────────────────────────────────
 
 /** A recent session the quick window can target (pushed by the primary). */
+export interface QuickEntrySessionTarget {
+  kind: 'session'
+  profile: string
+  storedSessionId: string
+}
+
+export type QuickEntryTarget = { kind: 'current' } | { kind: 'new' } | QuickEntrySessionTarget
+
 export interface QuickEntrySessionOption {
+  /** Opaque picker value. Session ownership travels separately in `target`. */
   id: string
+  target: QuickEntrySessionTarget
   title: string
 }
 
@@ -123,8 +135,8 @@ export interface QuickEntryStatePush {
 
 /** What a quick-window submit carries back to the primary renderer. */
 export interface QuickEntrySubmitPayload {
-  /** QUICK_TARGET_CURRENT, QUICK_TARGET_NEW, or a stored session id. */
-  target: string
+  /** Discriminated destination; never shares a namespace with opaque stored IDs. */
+  target: QuickEntryTarget
   text: string
 }
 
@@ -230,8 +242,21 @@ export function quickComposerReducer(state: QuickComposerState, event: QuickComp
         return { send: null, state }
       }
 
+      const target: QuickEntryTarget | null =
+        state.target === QUICK_TARGET_NEW
+          ? { kind: 'new' }
+          : state.target === QUICK_TARGET_CURRENT
+            ? { kind: 'current' }
+            : (state.sessions.find(session => session.id === state.target)?.target ?? null)
+
+      // A malformed/stale session option must not redirect a prompt to the
+      // current chat. Keep the draft and window intact so the user can retry.
+      if (!target) {
+        return { send: null, state }
+      }
+
       return {
-        send: { target: state.target, text },
+        send: { target, text },
         state: { ...state, draft: '', submitting: true, visible: false }
       }
     }
@@ -260,26 +285,49 @@ export function setQuickEntrySubmitHandler(fn: ((payload: QuickEntrySubmitPayloa
   submitHandler = fn
 }
 
-function normalizeSubmitPayload(raw: unknown): null | QuickEntrySubmitPayload {
-  // Tolerate the v1 bare-string wire shape (an older quick window after a
-  // partial update) by treating it as "send to the current chat".
-  if (typeof raw === 'string') {
-    return raw.trim() ? { target: QUICK_TARGET_CURRENT, text: raw } : null
+function normalizeQuickEntryTarget(raw: unknown): QuickEntryTarget | null {
+  if (!raw || typeof raw !== 'object') {
+    return null
   }
 
+  const target = raw as Record<string, unknown>
+
+  if (target.kind === 'current' || target.kind === 'new') {
+    return { kind: target.kind }
+  }
+
+  if (
+    target.kind === 'session' &&
+    typeof target.profile === 'string' &&
+    target.profile.trim().length > 0 &&
+    typeof target.storedSessionId === 'string' &&
+    target.storedSessionId.length > 0
+  ) {
+    return {
+      kind: 'session',
+      profile: normalizeProfileKey(target.profile),
+      storedSessionId: target.storedSessionId
+    }
+  }
+
+  return null
+}
+
+export function normalizeQuickEntrySubmitPayload(raw: unknown): null | QuickEntrySubmitPayload {
   if (!raw || typeof raw !== 'object') {
     return null
   }
 
   const record = raw as Record<string, unknown>
   const text = typeof record.text === 'string' ? record.text : ''
+  const target = normalizeQuickEntryTarget(record.target)
 
-  if (!text.trim()) {
+  if (!text.trim() || !target) {
     return null
   }
 
   return {
-    target: typeof record.target === 'string' && record.target ? record.target : QUICK_TARGET_CURRENT,
+    target,
     text
   }
 }
@@ -296,7 +344,7 @@ export function initQuickEntryBridge(): () => void {
   }
 
   unsubscribeSubmit = api.onSubmit(raw => {
-    const payload = normalizeSubmitPayload(raw)
+    const payload = normalizeQuickEntrySubmitPayload(raw)
 
     if (payload) {
       submitHandler?.(payload)

--- a/apps/desktop/src/store/session-color.test.ts
+++ b/apps/desktop/src/store/session-color.test.ts
@@ -1,10 +1,18 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
+import { sessionIdentityKey } from '@/lib/session-identity'
 import type { ProjectInfo, SessionInfo } from '@/types/hermes'
 
 import { $projects } from './projects'
-import { $sessions } from './session'
-import { $sessionColorById, $sessionColorOverrides, sessionColorFor, setSessionColorOverride } from './session-color'
+import { $sessions, sessionPinId } from './session'
+import {
+  $sessionColorById,
+  $sessionColorOverrides,
+  decodeSessionColorOverrides,
+  encodeSessionColorOverrides,
+  sessionColorFor,
+  setSessionColorOverride
+} from './session-color'
 
 let nextId = 0
 
@@ -61,9 +69,9 @@ describe('$sessionColorById', () => {
 
     const map = $sessionColorById.get()
 
-    expect(map[a.id]).toBe('#4a9eff')
+    expect(map[sessionIdentityKey(a.id, a.profile)]).toBe('#4a9eff')
     // Sessions with no colored project are absent (a sparse map, not null-filled).
-    expect(b.id in map).toBe(false)
+    expect(sessionIdentityKey(b.id, b.profile) in map).toBe(false)
   })
 
   it('omits a session whose project has no color', () => {
@@ -72,7 +80,7 @@ describe('$sessionColorById', () => {
     $projects.set([makeProject('p_app', ['/www/app'], null)])
     $sessions.set([a])
 
-    expect(a.id in $sessionColorById.get()).toBe(false)
+    expect(sessionIdentityKey(a.id, a.profile) in $sessionColorById.get()).toBe(false)
   })
 
   it('recomputes when the projects list changes (color applied later)', () => {
@@ -80,22 +88,42 @@ describe('$sessionColorById', () => {
 
     $sessions.set([a])
     $projects.set([makeProject('p_app', ['/www/app'], null)])
-    expect($sessionColorById.get()[a.id]).toBeUndefined()
+    expect($sessionColorById.get()[sessionIdentityKey(a.id, a.profile)]).toBeUndefined()
 
     $projects.set([makeProject('p_app', ['/www/app'], '#7bc86c')])
-    expect($sessionColorById.get()[a.id]).toBe('#7bc86c')
+    expect($sessionColorById.get()[sessionIdentityKey(a.id, a.profile)]).toBe('#7bc86c')
   })
 })
 
 describe('$sessionColorOverrides', () => {
+  it('migrates legacy raw ids as opaque default-profile values', () => {
+    const sentinelLookingId = 'alpha\u0000shared'
+
+    expect(decodeSessionColorOverrides(JSON.stringify({ [sentinelLookingId]: '#aa0000', shared: '#00bb00' }))).toEqual({
+      [sessionIdentityKey(sentinelLookingId, 'default')]: '#aa0000',
+      [sessionIdentityKey('shared', 'default')]: '#00bb00'
+    })
+  })
+
+  it('round-trips opaque ids without colliding with an owner-qualified identity', () => {
+    const sentinelLookingId = 'alpha\u0000shared'
+
+    const overrides = {
+      [sessionIdentityKey(sentinelLookingId, 'default')]: '#aa0000',
+      [sessionIdentityKey('shared', 'alpha')]: '#00bb00'
+    }
+
+    expect(decodeSessionColorOverrides(encodeSessionColorOverrides(overrides))).toEqual(overrides)
+  })
+
   it('an override wins over the inherited project color', () => {
     const a = makeSession('/www/app', { git_repo_root: '/www/app' })
 
     $projects.set([makeProject('p_app', ['/www/app'], '#4a9eff')])
     $sessions.set([a])
-    setSessionColorOverride(a.id, '#ff0000')
+    setSessionColorOverride(sessionPinId(a), '#ff0000')
 
-    expect($sessionColorById.get()[a.id]).toBe('#ff0000')
+    expect($sessionColorById.get()[sessionIdentityKey(a.id, a.profile)]).toBe('#ff0000')
   })
 
   it('clearing an override falls back to the project color', () => {
@@ -104,11 +132,11 @@ describe('$sessionColorOverrides', () => {
     $projects.set([makeProject('p_app', ['/www/app'], '#4a9eff')])
     $sessions.set([a])
 
-    setSessionColorOverride(a.id, '#ff0000')
-    expect($sessionColorById.get()[a.id]).toBe('#ff0000')
+    setSessionColorOverride(sessionPinId(a), '#ff0000')
+    expect($sessionColorById.get()[sessionIdentityKey(a.id, a.profile)]).toBe('#ff0000')
 
-    setSessionColorOverride(a.id, null)
-    expect($sessionColorById.get()[a.id]).toBe('#4a9eff')
+    setSessionColorOverride(sessionPinId(a), null)
+    expect($sessionColorById.get()[sessionIdentityKey(a.id, a.profile)]).toBe('#4a9eff')
   })
 
   it('keys on the durable lineage id so a color survives compression', () => {
@@ -117,10 +145,10 @@ describe('$sessionColorOverrides', () => {
     const root = makeSession('/x', { id: 'root' })
     const tip = makeSession('/x', { id: 'tip', _lineage_root_id: 'root' })
 
-    setSessionColorOverride('root', '#abcdef')
+    setSessionColorOverride(sessionPinId(root), '#abcdef')
 
     $sessions.set([tip])
-    expect($sessionColorById.get().tip).toBe('#abcdef')
+    expect($sessionColorById.get()[sessionIdentityKey('tip', tip.profile)]).toBe('#abcdef')
   })
 })
 
@@ -132,6 +160,18 @@ describe('sessionColorFor', () => {
     $sessions.set([a])
 
     expect(sessionColorFor(a)).toBe('#5865f2')
+  })
+
+  it('isolates colors when profiles share a stored session id', () => {
+    const alpha = makeSession('/alpha', { id: 'shared', profile: 'alpha' })
+    const beta = makeSession('/beta', { id: 'shared', profile: 'beta' })
+
+    setSessionColorOverride(sessionPinId(alpha), '#aa0000')
+    setSessionColorOverride(sessionPinId(beta), '#0000bb')
+    $sessions.set([alpha, beta])
+
+    expect(sessionColorFor(alpha)).toBe('#aa0000')
+    expect(sessionColorFor(beta)).toBe('#0000bb')
   })
 
   it('returns undefined for a null/absent session', () => {

--- a/apps/desktop/src/store/session-color.ts
+++ b/apps/desktop/src/store/session-color.ts
@@ -1,7 +1,8 @@
 import { computed } from 'nanostores'
 
 import { sessionProjectColor } from '@/app/chat/sidebar/projects/workspace-groups'
-import { Codecs, persistentAtom } from '@/lib/persisted'
+import { persistentAtom } from '@/lib/persisted'
+import { parseSessionIdentityKey, sessionIdentityKey } from '@/lib/session-identity'
 import { $projects } from '@/store/projects'
 import { $sessions, sessionPinId } from '@/store/session'
 import type { ProjectInfo, SessionInfo } from '@/types/hermes'
@@ -11,11 +12,70 @@ import type { ProjectInfo, SessionInfo } from '@/types/hermes'
 // lineage id so a color survives auto-compression's session-id rotation. To take
 // this to the TUI later, promote this one atom to a backend SessionInfo.color
 // field — the resolver below and the picker UI stay exactly as they are.
-export const $sessionColorOverrides = persistentAtom<Record<string, string>>(
-  'hermes.desktop.sessionColors',
-  {},
-  Codecs.stringRecord
-)
+const SESSION_COLOR_OVERRIDES_VERSION = 1
+
+interface PersistedSessionColorOverride {
+  color: string
+  profile: string
+  storedSessionId: string
+}
+
+function isPersistedSessionColorOverride(value: unknown): value is PersistedSessionColorOverride {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof (value as PersistedSessionColorOverride).color === 'string' &&
+    typeof (value as PersistedSessionColorOverride).profile === 'string' &&
+    typeof (value as PersistedSessionColorOverride).storedSessionId === 'string' &&
+    (value as PersistedSessionColorOverride).storedSessionId.length > 0
+  )
+}
+
+export function decodeSessionColorOverrides(raw: string): Record<string, string> {
+  const parsed = JSON.parse(raw) as unknown
+  const stored = parsed as { entries?: unknown; version?: unknown } | null
+
+  if (
+    stored &&
+    typeof stored === 'object' &&
+    stored.version === SESSION_COLOR_OVERRIDES_VERSION &&
+    Array.isArray(stored.entries)
+  ) {
+    return Object.fromEntries(
+      stored.entries
+        .filter(isPersistedSessionColorOverride)
+        .map(entry => [sessionIdentityKey(entry.storedSessionId, entry.profile), entry.color])
+    )
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {}
+  }
+
+  // Main's legacy schema was an ownerless string record. Every key is an
+  // opaque default-profile id, even when its bytes resemble a compound key.
+  return Object.fromEntries(
+    Object.entries(parsed)
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+      .map(([storedSessionId, color]) => [sessionIdentityKey(storedSessionId, 'default'), color])
+  )
+}
+
+export function encodeSessionColorOverrides(overrides: Record<string, string>): string {
+  return JSON.stringify({
+    entries: Object.entries(overrides).map(([identityKey, color]) => ({
+      ...parseSessionIdentityKey(identityKey),
+      color
+    })),
+    version: SESSION_COLOR_OVERRIDES_VERSION
+  })
+}
+
+export const $sessionColorOverrides = persistentAtom<Record<string, string>>('hermes.desktop.sessionColors', {}, {
+  decode: decodeSessionColorOverrides,
+  encode: encodeSessionColorOverrides
+})
 
 // Set a session's override (null clears it → falls back to the project color).
 export function setSessionColorOverride(durableId: string, color: null | string): void {
@@ -56,7 +116,7 @@ export const $sessionColorById = computed(
       const color = resolveSessionColor(session, projects, overrides)
 
       if (color) {
-        map[session.id] = color
+        map[sessionIdentityKey(session.id, session.profile)] = color
       }
     }
 
@@ -75,6 +135,7 @@ export function sessionColorFor(session: null | SessionInfo | undefined): string
   }
 
   return (
-    $sessionColorById.get()[session.id] ?? resolveSessionColor(session, $projects.get(), $sessionColorOverrides.get())
+    $sessionColorById.get()[sessionIdentityKey(session.id, session.profile)] ??
+    resolveSessionColor(session, $projects.get(), $sessionColorOverrides.get())
   )
 }

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { sessionIdentityKey } from '@/lib/session-identity'
 import type { SessionInfo } from '@/types/hermes'
 
 const patch = vi.fn<(id: string, pinned: boolean, profile?: null | string) => Promise<{ ok: boolean }>>(() =>
@@ -41,7 +42,7 @@ afterEach(() => {
 describe('watchSessionPins', () => {
   it('mirrors a new pin as pinned=true with the row profile', async () => {
     $sessions.set([row('a', { profile: 'work' })])
-    $pinnedSessionIds.set(['a'])
+    $pinnedSessionIds.set([sessionIdentityKey('a', 'work')])
     await flush()
 
     expect(patch).toHaveBeenCalledWith('a', true, 'work')
@@ -49,18 +50,18 @@ describe('watchSessionPins', () => {
 
   it('mirrors an unpin as pinned=false', async () => {
     $sessions.set([row('b')])
-    $pinnedSessionIds.set(['b'])
+    $pinnedSessionIds.set([sessionIdentityKey('b', 'default')])
     await flush()
     patch.mockClear()
 
     $pinnedSessionIds.set([])
     await flush()
 
-    expect(patch).toHaveBeenCalledWith('b', false, undefined)
+    expect(patch).toHaveBeenCalledWith('b', false, 'default')
   })
 
   it('defers a pin whose row is not loaded, then flushes once it appears', async () => {
-    $pinnedSessionIds.set(['c'])
+    $pinnedSessionIds.set([sessionIdentityKey('c', 'p2')])
     await flush()
     // No row yet -> nothing sent.
     expect(patch).not.toHaveBeenCalled()
@@ -74,15 +75,15 @@ describe('watchSessionPins', () => {
   it('matches a pin id against the lineage root', async () => {
     // pin id is the lineage root; the live row carries it as _lineage_root_id.
     $sessions.set([row('tip', { _lineage_root_id: 'root' })])
-    $pinnedSessionIds.set(['root'])
+    $pinnedSessionIds.set([sessionIdentityKey('root', 'default')])
     await flush()
 
-    expect(patch).toHaveBeenCalledWith('root', true, undefined)
+    expect(patch).toHaveBeenCalledWith('root', true, 'default')
   })
 
   it('does not re-PATCH an already-mirrored pin on unrelated session updates', async () => {
     $sessions.set([row('d')])
-    $pinnedSessionIds.set(['d'])
+    $pinnedSessionIds.set([sessionIdentityKey('d', 'default')])
     await flush()
     patch.mockClear()
 

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -12,17 +12,14 @@
  */
 
 import { setSessionPinnedRemote } from '@/hermes'
+import { parseSessionIdentityKey, sessionMatchesIdentity } from '@/lib/session-identity'
 import { $pinnedSessionIds } from '@/store/layout'
-import { $sessions, sessionMatchesStoredId } from '@/store/session'
+import { $sessions } from '@/store/session'
 
 // pin ids we've successfully PATCHed pinned=true this session.
 const mirrored = new Set<string>()
 // pin ids awaiting their row so we can resolve the owning profile before PATCH.
 const pending = new Set<string>()
-
-function profileFor(pinId: string): null | string | undefined {
-  return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
-}
 
 function reconcile(): void {
   // Config/session REST is only reachable through the Electron bridge.
@@ -37,7 +34,8 @@ function reconcile(): void {
     if (!current.has(id)) {
       mirrored.delete(id)
       pending.delete(id)
-      void setSessionPinnedRemote(id, false, profileFor(id)).catch(() => {})
+      const identity = parseSessionIdentityKey(id)
+      void setSessionPinnedRemote(identity.storedSessionId, false, identity.profile).catch(() => {})
     }
   }
 
@@ -51,7 +49,11 @@ function reconcile(): void {
   // Flush whatever we can resolve now; unresolved ids (row not loaded yet)
   // retry on the next $sessions change.
   for (const id of [...pending]) {
-    const row = $sessions.get().find(entry => sessionMatchesStoredId(entry, id))
+    const identity = parseSessionIdentityKey(id)
+
+    const row = $sessions
+      .get()
+      .find(entry => sessionMatchesIdentity(entry, identity.storedSessionId, identity.profile))
 
     if (!row) {
       continue
@@ -59,7 +61,7 @@ function reconcile(): void {
 
     pending.delete(id)
     mirrored.add(id)
-    void setSessionPinnedRemote(id, true, row.profile).catch(() => {
+    void setSessionPinnedRemote(identity.storedSessionId, true, identity.profile).catch(() => {
       // Let a later reconcile retry the mirror.
       mirrored.delete(id)
       pending.add(id)

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -28,12 +28,15 @@ import {
   noteActiveTreeGroup,
   revealTreePane
 } from '@/components/pane-shell/tree/store'
+import { migrateInFlightTurnJournal } from '@/lib/inflight-turn-journal'
+import { parseSessionIdentityKey, sessionIdentityKey } from '@/lib/session-identity'
 import { stableArray } from '@/lib/stable-array'
 import { readJson, writeJson } from '@/lib/storage'
 
-import { $activeGatewayProfile, normalizeProfileKey } from './profile'
+import { $activeGatewayProfile, ensureGatewayProfile, normalizeProfileKey } from './profile'
 import {
   $activeSessionId,
+  $selectedSessionIdentityKey,
   $selectedStoredSessionId,
   $unreadFinishedSessionIds,
   setActiveSessionStoredIdRotation
@@ -52,18 +55,23 @@ export const $sessionStates = atom<Record<string, ClientSessionState>>({})
 // presentation hint and never mutates the backend-derived busy state.
 export const $stalledSessionIds = atom<string[]>([])
 
-export function setSessionStalled(storedSessionId: string | null | undefined, stalled: boolean) {
+export function setSessionStalled(
+  storedSessionId: string | null | undefined,
+  stalled: boolean,
+  profile?: null | string
+) {
   if (!storedSessionId) {
     return
   }
 
+  const identityKey = sessionIdentityKey(storedSessionId, profile)
   const current = $stalledSessionIds.get()
-  const present = current.includes(storedSessionId)
+  const present = current.includes(identityKey)
 
   if (stalled && !present) {
-    $stalledSessionIds.set([...current, storedSessionId])
+    $stalledSessionIds.set([...current, identityKey])
   } else if (!stalled && present) {
-    $stalledSessionIds.set(current.filter(id => id !== storedSessionId))
+    $stalledSessionIds.set(current.filter(id => id !== identityKey))
   }
 }
 
@@ -85,7 +93,7 @@ function armWatchdog(runtimeId: string) {
       const current = $sessionStates.get()[runtimeId]
 
       if (current?.busy) {
-        setSessionStalled(current.storedSessionId, true)
+        setSessionStalled(current.storedSessionId, true, current.storedSessionProfile)
       }
     }, SESSION_WATCHDOG_TIMEOUT_MS)
   )
@@ -135,6 +143,10 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
   // could let a background session's delayed rotation steal the foreground
   // route.
   if (previous?.storedSessionId && next.storedSessionId && previous.storedSessionId !== next.storedSessionId) {
+    if (normalizeProfileKey(previous.storedSessionProfile) === normalizeProfileKey(next.storedSessionProfile)) {
+      migrateInFlightTurnJournal(previous.storedSessionId, next.storedSessionId, next.storedSessionProfile)
+    }
+
     if (runtimeId === $activeSessionId.get()) {
       setActiveSessionStoredIdRotation({
         nextStoredSessionId: next.storedSessionId,
@@ -143,20 +155,20 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
       })
     }
 
-    clearSettled(previous.storedSessionId)
-    setSessionStalled(previous.storedSessionId, false)
+    clearSettled(sessionIdentityKey(previous.storedSessionId, previous.storedSessionProfile))
+    setSessionStalled(previous.storedSessionId, false, previous.storedSessionProfile)
   }
 
   // Every busy publish is stream activity: clear the quiet hint and restart
   // the silence window. A real terminal transition clears both the timer and
   // any hint, but only that authoritative transition clears working/busy.
   if (next.busy) {
-    setSessionStalled(next.storedSessionId, false)
+    setSessionStalled(next.storedSessionId, false, next.storedSessionProfile)
     armWatchdog(runtimeId)
   } else {
     clearWatchdog(runtimeId)
-    setSessionStalled(next.storedSessionId, false)
-    setSessionStalled(previous?.storedSessionId, false)
+    setSessionStalled(next.storedSessionId, false, next.storedSessionProfile)
+    setSessionStalled(previous?.storedSessionId, false, previous?.storedSessionProfile)
   }
 
   const storedId = next.storedSessionId
@@ -165,18 +177,19 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
     return
   }
 
+  const identityKey = sessionIdentityKey(storedId, next.storedSessionProfile)
   const wasWorking = previous?.busy ?? false
 
   if (next.busy && !wasWorking) {
-    clearSettled(storedId)
+    clearSettled(identityKey)
   } else if (!next.busy && wasWorking) {
-    markSettled(storedId)
+    markSettled(identityKey)
 
-    if (storedId !== $selectedStoredSessionId.get()) {
+    if (identityKey !== $selectedSessionIdentityKey.get()) {
       const cur = $unreadFinishedSessionIds.get()
 
-      if (!cur.includes(storedId)) {
-        $unreadFinishedSessionIds.set([...cur, storedId])
+      if (!cur.includes(identityKey)) {
+        $unreadFinishedSessionIds.set([...cur, identityKey])
       }
     }
   }
@@ -215,7 +228,11 @@ export function dropSessionState(runtimeId: string) {
   clearWatchdog(runtimeId)
 
   const current = $sessionStates.get()
-  setSessionStalled(current[runtimeId]?.storedSessionId, false)
+  setSessionStalled(
+    current[runtimeId]?.storedSessionId,
+    false,
+    current[runtimeId]?.storedSessionProfile
+  )
 
   if (!(runtimeId in current)) {
     return
@@ -252,7 +269,7 @@ export function clearAllSessionStates() {
 const storedIds = (states: Record<string, ClientSessionState>, pred: (s: ClientSessionState) => boolean) =>
   Object.values(states)
     .filter(s => pred(s) && s.storedSessionId)
-    .map(s => s.storedSessionId!)
+    .map(s => sessionIdentityKey(s.storedSessionId!, s.storedSessionProfile))
 
 let workingIds: readonly string[] = []
 export const $workingSessionIds = computed(
@@ -438,21 +455,21 @@ export function resetTileRuntimeBindings() {
 
 export interface SessionTileDelegate {
   /** Archive a stored session (the sidebar's archive, incl. tile cleanup). */
-  archiveSession(storedSessionId: string): Promise<void>
+  archiveSession(storedSessionId: string, profile?: null | string): Promise<void>
   /** Branch a stored session into a new chat (the sidebar's branch). */
-  branchSession(storedSessionId: string): Promise<void>
+  branchSession(storedSessionId: string, profile?: null | string): Promise<void>
   /** Delete a stored session (the sidebar's delete, incl. tile cleanup). */
-  deleteSession(storedSessionId: string): Promise<void>
+  deleteSession(storedSessionId: string, profile?: null | string): Promise<void>
   /** Run a slash command against a tile's session (app-level effects — e.g.
    *  branch/handoff — act on the main surface, as they should). */
-  executeSlash(rawCommand: string, sessionId: string): Promise<void>
+  executeSlash(rawCommand: string, sessionId: string, profile: string, storedSessionId: string): Promise<void>
   /** Interrupt a tile's running turn. */
-  interruptSession(runtimeId: string): Promise<void>
+  interruptSession(runtimeId: string, profile: string): Promise<void>
   /** Bind a live runtime id for a stored session (resume without touching
    *  the main view). Returns the runtime id, or throws. */
-  resumeTile(storedSessionId: string): Promise<string>
+  resumeTile(storedSessionId: string, profile?: null | string): Promise<string>
   /** Submit a prompt to a tile's live session. */
-  submitToSession(runtimeId: string, text: string): Promise<void>
+  submitToSession(runtimeId: string, text: string, profile: string): Promise<void>
   /** THE session-state write path — routes through the wiring cache so the
    *  cache, the primary view (when active), and every tile mirror agree. */
   updateSession(runtimeId: string, updater: (state: ClientSessionState) => ClientSessionState): ClientSessionState
@@ -528,15 +545,22 @@ function syncTileStripOrder() {
  *  An unanchored open (⌘T, ⌘⇧T on a tile that predates anchors) docks into the
  *  FOCUSED chat zone — the same zone ⌘1…⌘9 and ⌘W act on — so a new tab lands
  *  in the strip the user is looking at, not always main's. */
-export function openSessionTile(
+export async function openSessionTile(
   storedSessionId: string,
   dir: TileDock = 'right',
   anchor?: string,
-  before?: null | string
-) {
+  before?: null | string,
+  profile?: null | string
+): Promise<void> {
+  const targetProfile = normalizeProfileKey(profile ?? profileKey())
+
+  if (targetProfile !== profileKey()) {
+    await ensureGatewayProfile(targetProfile)
+  }
+
   const tiles = $sessionTiles.get()
 
-  if (storedSessionId === $selectedStoredSessionId.get()) {
+  if (sessionIdentityKey(storedSessionId, targetProfile) === $selectedSessionIdentityKey.get()) {
     return
   }
 
@@ -601,7 +625,11 @@ export function nextSessionTileForWorkspace(): null | string {
  *  Callers that own the router need the `'main'` vs `'tile'` distinction: a
  *  `'main'` hit only reaches the screen if the workspace pane is actually
  *  showing the chat, whereas a tile renders in its own pane regardless. */
-export function focusOpenSession(storedSessionId: string): 'main' | 'tile' | null {
+export function focusOpenSession(storedSessionId: string, profile?: null | string): 'main' | 'tile' | null {
+  if (normalizeProfileKey(profile ?? profileKey()) !== profileKey()) {
+    return null
+  }
+
   if ($sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
     const paneId = `${TILE_PANE_PREFIX}${storedSessionId}`
     revealTreePane(paneId) // un-dismiss + adopt + front in its group
@@ -656,7 +684,24 @@ export function closeSessionTile(storedSessionId: string) {
  *  backend (resume 404s). Unlike close, it leaves no ⌘⇧T undo (resurrecting it
  *  would just 404 again) and evicts any cached state. This is what clears the
  *  "Session not found" resume spam from stale/cross-profile persisted tiles. */
-export function discardSessionTile(storedSessionId: string) {
+export function discardSessionTile(storedSessionId: string, profile?: null | string) {
+  const targetProfile = normalizeProfileKey(profile ?? profileKey())
+
+  if (targetProfile !== profileKey()) {
+    const tiles = tilesByProfile[targetProfile] ?? []
+    const stored = tiles.filter(tile => tile.storedSessionId !== storedSessionId)
+
+    if (stored.length > 0) {
+      tilesByProfile[targetProfile] = stored
+    } else {
+      delete tilesByProfile[targetProfile]
+    }
+
+    persistTiles()
+
+    return
+  }
+
   const runtimeId = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)?.runtimeId
 
   if (runtimeId) {
@@ -707,6 +752,11 @@ export const $focusedStoredSessionId = computed(
   }
 )
 
+export const $focusedSessionIdentityKey = computed(
+  [$focusedStoredSessionId, $activeGatewayProfile],
+  (storedId, profile) => (storedId ? sessionIdentityKey(storedId, profile) : null)
+)
+
 /** Live runtime id of the focused session (a tile's bound runtime, else the
  *  primary's active session). */
 export const $focusedRuntimeId = computed(
@@ -734,7 +784,9 @@ export const selectionHomesToWorkspace = (selected: null | string, tiles: readon
 
 // Homing also FRONTS the workspace tab: the resumed chat loads in the workspace
 // pane, so a zone parked on a tile tab must switch back or the click looks dead.
-$selectedStoredSessionId.listen(selected => {
+$selectedSessionIdentityKey.listen(identityKey => {
+  const selected = identityKey ? parseSessionIdentityKey(identityKey).storedSessionId : null
+
   if (!selectionHomesToWorkspace(selected, $sessionTiles.get())) {
     return
   }

--- a/apps/desktop/src/store/session-switcher.test.ts
+++ b/apps/desktop/src/store/session-switcher.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
-import { $selectedStoredSessionId, $sessions } from './session'
+import { $activeGatewayProfile } from './profile'
+import { $sessions, setSelectedStoredSessionId } from './session'
 import {
   $switcherIndex,
   $switcherOpen,
@@ -16,11 +17,11 @@ import {
   SWITCHER_REVEAL_MS
 } from './session-switcher'
 
-const session = (id: string): SessionInfo => ({ id }) as SessionInfo
+const session = (id: string, profile = 'default'): SessionInfo => ({ id, profile }) as SessionInfo
 
 const seed = (ids: string[], selected: null | string) => {
-  $sessions.set(ids.map(session))
-  $selectedStoredSessionId.set(selected)
+  $sessions.set(ids.map(id => session(id)))
+  setSelectedStoredSessionId(selected, 'default')
 }
 
 const tabTap = (direction: 1 | -1 = 1) => {
@@ -34,6 +35,7 @@ const tabTap = (direction: 1 | -1 = 1) => {
 beforeEach(() => {
   vi.useRealTimers()
   closeSwitcher()
+  $activeGatewayProfile.set('default')
   $switcherSessions.set([])
   $switcherIndex.set(0)
 })
@@ -53,7 +55,7 @@ describe('openOrAdvanceSwitcher', () => {
   it('jumps immediately on a quick Tab tap without opening the HUD', () => {
     seed(['a', 'b', 'c'], 'a')
 
-    expect(tabTap()).toBe('b')
+    expect(tabTap()).toEqual({ profile: 'default', sessionId: 'b' })
     expect($switcherOpen.get()).toBe(false)
     expect(commitOnCtrlUp()).toBeNull()
   })
@@ -83,7 +85,7 @@ describe('openOrAdvanceSwitcher', () => {
   it('opens on a second Tab while Ctrl is still down', () => {
     seed(['a', 'b', 'c'], 'a')
 
-    expect(tabTap()).toBe('b')
+    expect(tabTap()).toEqual({ profile: 'default', sessionId: 'b' })
     onSwitcherTabDown()
     openOrAdvanceSwitcher(1)
     onSwitcherTabUp()
@@ -95,12 +97,28 @@ describe('openOrAdvanceSwitcher', () => {
   it('commits the HUD highlight on Ctrl up', () => {
     seed(['a', 'b', 'c'], 'a')
 
-    expect(tabTap()).toBe('b')
+    expect(tabTap()).toEqual({ profile: 'default', sessionId: 'b' })
     onSwitcherTabDown()
     openOrAdvanceSwitcher(1)
     onSwitcherTabUp()
 
-    expect(commitOnCtrlUp()).toBe('c')
+    expect(commitOnCtrlUp()).toEqual({ profile: 'default', sessionId: 'c' })
+  })
+
+  it('preserves the selected profile when stored ids collide', () => {
+    $sessions.set([session('shared', 'alpha'), session('shared', 'beta'), session('other', 'beta')])
+    $activeGatewayProfile.set('beta')
+    setSelectedStoredSessionId('shared', 'beta')
+
+    expect(tabTap(-1)).toEqual({ profile: 'alpha', sessionId: 'shared' })
+  })
+
+  it('uses the selected identity rather than the active profile during a profile transition', () => {
+    $sessions.set([session('shared', 'alpha'), session('shared', 'beta'), session('other', 'beta')])
+    $activeGatewayProfile.set('beta')
+    setSelectedStoredSessionId('shared', 'alpha')
+
+    expect(tabTap(-1)).toEqual({ profile: 'beta', sessionId: 'other' })
   })
 })
 
@@ -110,6 +128,6 @@ describe('slotSessionId', () => {
     tabTap()
     $sessions.set([session('x')])
 
-    expect(slotSessionId(2)).toBe('b')
+    expect(slotSessionId(2)).toEqual({ profile: 'default', sessionId: 'b' })
   })
 })

--- a/apps/desktop/src/store/session-switcher.ts
+++ b/apps/desktop/src/store/session-switcher.ts
@@ -1,8 +1,9 @@
 import { atom } from 'nanostores'
 
+import { normalizeProfileKey, sessionIdentityKey } from '@/lib/session-identity'
 import type { SessionInfo } from '@/types/hermes'
 
-import { $selectedStoredSessionId, $sessions } from './session'
+import { $selectedSessionIdentityKey, $sessions } from './session'
 
 // Mac-style session switcher (^Tab). Quick tap jumps on keydown; the HUD opens
 // only when Tab is held past REVEAL_MS or tapped again while Ctrl is down.
@@ -19,6 +20,14 @@ let pendingBrowse = false
 let revealTimer: ReturnType<typeof setTimeout> | null = null
 let tabHeld = false
 let closedAt = 0
+
+export interface SessionSwitcherTarget {
+  profile: string
+  sessionId: string
+}
+
+const switcherTarget = (session: SessionInfo | undefined): SessionSwitcherTarget | null =>
+  session ? { profile: normalizeProfileKey(session.profile), sessionId: session.id } : null
 
 function clearRevealTimer(): void {
   if (revealTimer) {
@@ -57,7 +66,7 @@ export function onSwitcherTabUp(): void {
 
 // First Tab returns a session id to jump to immediately; later Tabs move the
 // highlight (Ctrl↑ commits when the HUD is open).
-export function openOrAdvanceSwitcher(direction: 1 | -1): string | null {
+export function openOrAdvanceSwitcher(direction: 1 | -1): SessionSwitcherTarget | null {
   const sessions = $sessions.get()
 
   if (sessions.length < 2) {
@@ -74,7 +83,12 @@ export function openOrAdvanceSwitcher(direction: 1 | -1): string | null {
     return null
   }
 
-  const current = sessions.findIndex(session => session.id === $selectedStoredSessionId.get())
+  const selectedIdentity = $selectedSessionIdentityKey.get()
+
+  const current = selectedIdentity
+    ? sessions.findIndex(session => sessionIdentityKey(session.id, session.profile) === selectedIdentity)
+    : -1
+
   const start = current === -1 ? (direction === 1 ? -1 : 0) : current
   const nextIndex = wrap(start + direction, sessions.length)
 
@@ -92,13 +106,16 @@ export function openOrAdvanceSwitcher(direction: 1 | -1): string | null {
   pendingBrowse = true
   scheduleReveal()
 
-  return sessions[nextIndex]?.id ?? null
+  return switcherTarget(sessions[nextIndex])
 }
 
 export const highlightedSessionId = (): string | null => $switcherSessions.get()[$switcherIndex.get()]?.id ?? null
 
-export const slotSessionId = (slot: number): string | null =>
-  ($switcherOpen.get() || pendingBrowse ? $switcherSessions.get() : $sessions.get())[slot - 1]?.id ?? null
+export const highlightedSessionTarget = (): SessionSwitcherTarget | null =>
+  switcherTarget($switcherSessions.get()[$switcherIndex.get()])
+
+export const slotSessionId = (slot: number): SessionSwitcherTarget | null =>
+  switcherTarget(($switcherOpen.get() || pendingBrowse ? $switcherSessions.get() : $sessions.get())[slot - 1])
 
 export function closeSwitcher(): void {
   closedAt = Date.now()
@@ -108,7 +125,7 @@ export function closeSwitcher(): void {
   $switcherOpen.set(false)
 }
 
-export function commitOnCtrlUp(): string | null {
+export function commitOnCtrlUp(): SessionSwitcherTarget | null {
   clearRevealTimer()
   pendingBrowse = false
 
@@ -116,7 +133,7 @@ export function commitOnCtrlUp(): string | null {
     return null
   }
 
-  const target = highlightedSessionId()
+  const target = highlightedSessionTarget()
   closeSwitcher()
 
   return target

--- a/apps/desktop/src/store/session-watchdog.test.ts
+++ b/apps/desktop/src/store/session-watchdog.test.ts
@@ -2,8 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { sessionIdentityKey } from '@/lib/session-identity'
 
-import { $activeSessionId, $selectedStoredSessionId, $unreadFinishedSessionIds } from './session'
+import {
+  $activeSessionId,
+  $selectedStoredSessionId,
+  $unreadFinishedSessionIds,
+  setSelectedStoredSessionId
+} from './session'
 import {
   $attentionSessionIds,
   $stalledSessionIds,
@@ -14,6 +20,7 @@ import {
 } from './session-states'
 
 const WATCHDOG_MS = 8 * 60 * 1000
+const identity = (storedSessionId: string) => sessionIdentityKey(storedSessionId, 'default')
 
 function state(over: Partial<ClientSessionState> = {}): ClientSessionState {
   return { ...createClientSessionState(null), storedSessionId: 's1', ...over }
@@ -44,18 +51,43 @@ describe('session status transitions', () => {
 
     publishSessionState('rt1', { ...s, busy: true })
 
-    expect($workingSessionIds.get()).toContain('s1')
+    expect($workingSessionIds.get()).toContain(identity('s1'))
+  })
+
+  it('isolates live and settled state when profiles share a stored session id', () => {
+    const alpha = state({ busy: true, needsInput: true, storedSessionId: 'shared', storedSessionProfile: 'alpha' })
+    const beta = state({ busy: false, storedSessionId: 'shared', storedSessionProfile: 'beta' })
+    const alphaKey = sessionIdentityKey('shared', 'alpha')
+    const betaKey = sessionIdentityKey('shared', 'beta')
+
+    publishSessionState('rt-alpha', alpha)
+    publishSessionState('rt-beta', beta)
+
+    expect($workingSessionIds.get()).toEqual([alphaKey])
+    expect($attentionSessionIds.get()).toEqual([alphaKey])
+
+    vi.advanceTimersByTime(WATCHDOG_MS)
+    expect($stalledSessionIds.get()).toEqual([alphaKey])
+
+    publishSessionState('rt-alpha', { ...alpha, busy: false, needsInput: false })
+
+    expect(getRecentlySettledSessionIds()).toEqual([alphaKey])
+    expect($unreadFinishedSessionIds.get()).toEqual([alphaKey])
+    expect($workingSessionIds.get()).not.toContain(betaKey)
+    expect($attentionSessionIds.get()).not.toContain(betaKey)
+    expect($stalledSessionIds.get()).not.toContain(betaKey)
+    expect($unreadFinishedSessionIds.get()).not.toContain(betaKey)
   })
 
   it('removes a session from $workingSessionIds when busy transitions to false', () => {
     const working = state({ busy: true, storedSessionId: 's1' })
     publishSessionState('rt1', working)
 
-    expect($workingSessionIds.get()).toContain('s1')
+    expect($workingSessionIds.get()).toContain(identity('s1'))
 
     publishSessionState('rt1', { ...working, busy: false })
 
-    expect($workingSessionIds.get()).not.toContain('s1')
+    expect($workingSessionIds.get()).not.toContain(identity('s1'))
   })
 
   it('adds a session to $attentionSessionIds when needsInput is true', () => {
@@ -64,7 +96,7 @@ describe('session status transitions', () => {
 
     publishSessionState('rt1', { ...s, needsInput: true })
 
-    expect($attentionSessionIds.get()).toContain('s1')
+    expect($attentionSessionIds.get()).toContain(identity('s1'))
   })
 
   it('marks a background session unread when its turn finishes', () => {
@@ -74,11 +106,11 @@ describe('session status transitions', () => {
 
     publishSessionState('rt1', { ...working, busy: false })
 
-    expect($unreadFinishedSessionIds.get()).toEqual(['s1'])
+    expect($unreadFinishedSessionIds.get()).toEqual([identity('s1')])
   })
 
   it('does NOT mark unread when the finishing session is the active one', () => {
-    $selectedStoredSessionId.set('s1')
+    setSelectedStoredSessionId('s1')
     const working = state({ busy: true, storedSessionId: 's1' })
     publishSessionState('rt1', working)
 
@@ -101,7 +133,7 @@ describe('session status transitions', () => {
 
     publishSessionState('rt1', { ...working, busy: false })
 
-    expect(getRecentlySettledSessionIds()).toEqual(['s1'])
+    expect(getRecentlySettledSessionIds()).toEqual([identity('s1')])
   })
 
   it('does not grant grace on idle→idle re-asserts', () => {
@@ -116,7 +148,7 @@ describe('session status transitions', () => {
     const idle = { ...working, busy: false }
     publishSessionState('rt1', idle)
 
-    expect(getRecentlySettledSessionIds()).toEqual(['s2'])
+    expect(getRecentlySettledSessionIds()).toEqual([identity('s2')])
 
     publishSessionState('rt1', { ...idle, busy: true })
 
@@ -147,34 +179,34 @@ describe('session watchdog', () => {
 
     vi.advanceTimersByTime(WATCHDOG_MS)
 
-    expect($workingSessionIds.get()).toContain('s1')
-    expect($stalledSessionIds.get()).toContain('s1')
+    expect($workingSessionIds.get()).toContain(identity('s1'))
+    expect($stalledSessionIds.get()).toContain(identity('s1'))
   })
 
   it('clears stalled on new activity and rearms the watchdog', () => {
     const working = state({ busy: true, storedSessionId: 's2' })
     publishSessionState('rt2', working)
     vi.advanceTimersByTime(WATCHDOG_MS)
-    expect($stalledSessionIds.get()).toContain('s2')
+    expect($stalledSessionIds.get()).toContain(identity('s2'))
 
     publishSessionState('rt2', { ...working, awaitingResponse: true })
-    expect($stalledSessionIds.get()).not.toContain('s2')
+    expect($stalledSessionIds.get()).not.toContain(identity('s2'))
 
     vi.advanceTimersByTime(WATCHDOG_MS - 1)
-    expect($stalledSessionIds.get()).not.toContain('s2')
-    expect($workingSessionIds.get()).toContain('s2')
+    expect($stalledSessionIds.get()).not.toContain(identity('s2'))
+    expect($workingSessionIds.get()).toContain(identity('s2'))
   })
 
   it('clears both running and stalled on an authoritative terminal transition', () => {
     const working = state({ busy: true, storedSessionId: 's3' })
     publishSessionState('rt3', working)
     vi.advanceTimersByTime(WATCHDOG_MS)
-    expect($stalledSessionIds.get()).toContain('s3')
+    expect($stalledSessionIds.get()).toContain(identity('s3'))
 
     publishSessionState('rt3', { ...working, busy: false })
 
-    expect($workingSessionIds.get()).not.toContain('s3')
-    expect($stalledSessionIds.get()).not.toContain('s3')
+    expect($workingSessionIds.get()).not.toContain(identity('s3'))
+    expect($stalledSessionIds.get()).not.toContain(identity('s3'))
   })
 
   it('never marks a session stalled when it settles before the window', () => {
@@ -183,14 +215,14 @@ describe('session watchdog', () => {
     publishSessionState('rt4', { ...working, busy: false })
     vi.advanceTimersByTime(WATCHDOG_MS)
 
-    expect($workingSessionIds.get()).not.toContain('s4')
-    expect($stalledSessionIds.get()).not.toContain('s4')
+    expect($workingSessionIds.get()).not.toContain(identity('s4'))
+    expect($stalledSessionIds.get()).not.toContain(identity('s4'))
   })
 
   it('clears stalled state and disarms timers on a gateway wipe', () => {
     publishSessionState('rt1', state({ busy: true, storedSessionId: 's1' }))
     vi.advanceTimersByTime(WATCHDOG_MS)
-    expect($stalledSessionIds.get()).toEqual(['s1'])
+    expect($stalledSessionIds.get()).toEqual([identity('s1')])
 
     clearAllSessionStates()
     vi.advanceTimersByTime(WATCHDOG_MS)
@@ -218,12 +250,12 @@ describe('computed $workingSessionIds', () => {
     publishSessionState('rt2', state({ busy: false, storedSessionId: 's2' }))
     publishSessionState('rt3', state({ busy: true, storedSessionId: null }))
 
-    expect($workingSessionIds.get()).toEqual(['s1'])
+    expect($workingSessionIds.get()).toEqual([identity('s1')])
   })
 
   it('updates when session state changes', () => {
     publishSessionState('rt1', state({ busy: true, storedSessionId: 's1' }))
-    expect($workingSessionIds.get()).toEqual(['s1'])
+    expect($workingSessionIds.get()).toEqual([identity('s1')])
 
     publishSessionState('rt1', state({ busy: false, storedSessionId: 's1' }))
     expect($workingSessionIds.get()).toEqual([])
@@ -243,12 +275,12 @@ describe('computed $attentionSessionIds', () => {
     publishSessionState('rt1', state({ needsInput: true, storedSessionId: 's1' }))
     publishSessionState('rt2', state({ needsInput: false, storedSessionId: 's2' }))
 
-    expect($attentionSessionIds.get()).toEqual(['s1'])
+    expect($attentionSessionIds.get()).toEqual([identity('s1')])
   })
 
   it('clears when $sessionStates is cleared', () => {
     publishSessionState('rt1', state({ needsInput: true, storedSessionId: 's1' }))
-    expect($attentionSessionIds.get()).toEqual(['s1'])
+    expect($attentionSessionIds.get()).toEqual([identity('s1')])
 
     clearAllSessionStates()
     expect($attentionSessionIds.get()).toEqual([])

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -2,19 +2,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import type { SessionInfo } from '@/types/hermes'
 
+import { clearSessionDraft, migrateSessionDraft, stashSessionDraft, takeSessionDraft } from './composer'
+import { clearQueuedPrompts, enqueueQueuedPrompt, getQueuedPrompts, migrateQueuedPrompts } from './composer-queue'
 import {
   $activeSessionId,
   $connection,
   $currentCwd,
-  $selectedStoredSessionId,
   $unreadFinishedSessionIds,
   applyConfiguredDefaultProjectDir,
   getRememberedSessionId,
   mergeSessionPage,
   rememberedSessionProfile,
+  resolveComposerMigrationKeys,
   resolveComposerSessionKey,
+  resolveSessionPinId,
   sessionPinId,
   setCurrentCwd,
   setRememberedSessionId,
@@ -27,6 +31,8 @@ import {
   getRecentlySettledSessionIds,
   publishSessionState
 } from './session-states'
+
+const identity = (storedSessionId: string) => sessionIdentityKey(storedSessionId, 'default')
 
 const session = (over: Partial<SessionInfo>): SessionInfo => ({
   archived: false,
@@ -60,12 +66,12 @@ describe('computed $attentionSessionIds', () => {
     publishSessionState('rt1', { ...createClientSessionState('s1'), needsInput: true })
     publishSessionState('rt2', { ...createClientSessionState('s2'), needsInput: false })
 
-    expect($attentionSessionIds.get()).toEqual(['s1'])
+    expect($attentionSessionIds.get()).toEqual([identity('s1')])
   })
 
   it('updates when needsInput changes', () => {
     publishSessionState('rt1', { ...createClientSessionState('s1'), needsInput: true })
-    expect($attentionSessionIds.get()).toEqual(['s1'])
+    expect($attentionSessionIds.get()).toEqual([identity('s1')])
 
     publishSessionState('rt1', { ...createClientSessionState('s1'), needsInput: false })
     expect($attentionSessionIds.get()).toEqual([])
@@ -79,13 +85,19 @@ describe('computed $attentionSessionIds', () => {
 
 describe('sessionPinId', () => {
   it('uses the live id when there is no compression lineage', () => {
-    expect(sessionPinId(session({ id: 'abc' }))).toBe('abc')
+    expect(sessionPinId(session({ id: 'abc' }))).toBe(sessionIdentityKey('abc', 'default'))
   })
 
   it('uses the lineage root so a pin survives compression', () => {
     // After auto-compression the entry surfaces under a fresh tip id but keeps
     // the original root — pinning on the root keeps the pin stable.
-    expect(sessionPinId(session({ id: 'tip', _lineage_root_id: 'root' }))).toBe('root')
+    expect(sessionPinId(session({ id: 'tip', _lineage_root_id: 'root' }))).toBe(
+      sessionIdentityKey('root', 'default')
+    )
+  })
+
+  it('qualifies an unloaded-row fallback with its owning profile', () => {
+    expect(resolveSessionPinId(null, 'shared', 'beta')).toBe(sessionIdentityKey('shared', 'beta'))
   })
 })
 
@@ -101,6 +113,73 @@ describe('resolveComposerSessionKey', () => {
 
   it('falls back to the live id when the tip row is not loaded yet', () => {
     expect(resolveComposerSessionKey('tip-new', [])).toBe('tip-new')
+  })
+
+  it('qualifies the durable composer key by owning profile', () => {
+    const sessions = [
+      session({ id: 'alpha-tip', _lineage_root_id: 'shared', profile: 'alpha' }),
+      session({ id: 'beta-tip', _lineage_root_id: 'shared', profile: 'beta' })
+    ]
+
+    expect(resolveComposerSessionKey('shared', sessions, 'alpha')).toBe(sessionIdentityKey('shared', 'alpha'))
+    expect(resolveComposerSessionKey('shared', sessions, 'beta')).toBe(sessionIdentityKey('shared', 'beta'))
+  })
+})
+
+describe('resolveComposerMigrationKeys', () => {
+  it('returns the raw legacy lineage key for an owned default-profile compression tip', () => {
+    const sessions = [session({ id: 'tip', _lineage_root_id: 'root', profile: 'default' })]
+
+    expect(resolveComposerMigrationKeys('tip', sessions, 'default')).toEqual({
+      legacyLineageKey: 'root',
+      selectedIdentity: sessionIdentityKey('tip', 'default')
+    })
+  })
+
+  it('migrates a legacy draft while preserving decoded queue state already on the compound destination', () => {
+    const sessions = [
+      session({ id: 'tip', _lineage_root_id: 'alpha-root', profile: 'alpha' }),
+      session({ id: 'tip', _lineage_root_id: 'root', profile: 'default' })
+    ]
+
+    const destination = resolveComposerSessionKey('tip', sessions, 'default')
+    const { legacyLineageKey } = resolveComposerMigrationKeys('tip', sessions, 'default')
+    const legacyQueueIdentity = sessionIdentityKey('root', 'default')
+
+    clearSessionDraft('root')
+    clearSessionDraft(destination)
+    clearQueuedPrompts(legacyQueueIdentity)
+    clearQueuedPrompts(destination)
+    stashSessionDraft('root', 'legacy draft', [])
+    enqueueQueuedPrompt(legacyQueueIdentity, { attachments: [], text: 'legacy queued prompt' })
+
+    expect(migrateSessionDraft(legacyLineageKey, destination)).toBe(true)
+    expect(migrateQueuedPrompts(legacyQueueIdentity, destination)).toBe(false)
+    expect(takeSessionDraft('root').text).toBe('')
+    expect(takeSessionDraft(destination).text).toBe('legacy draft')
+    expect(getQueuedPrompts(destination).map(entry => entry.text)).toEqual(['legacy queued prompt'])
+
+    clearSessionDraft(destination)
+    clearQueuedPrompts(destination)
+  })
+
+  it('does not derive a default-profile legacy key from a colliding non-default row', () => {
+    const sessions = [session({ id: 'shared', _lineage_root_id: 'alpha-root', profile: 'alpha' })]
+    const defaultShared = sessionIdentityKey('shared', 'default')
+
+    expect(resolveComposerMigrationKeys('shared', sessions, 'default')).toEqual({
+      legacyLineageKey: null,
+      selectedIdentity: defaultShared
+    })
+  })
+
+  it('never exposes a raw legacy lineage key to a non-default profile', () => {
+    const sessions = [session({ id: 'tip', _lineage_root_id: 'root', profile: 'beta' })]
+
+    expect(resolveComposerMigrationKeys('tip', sessions, 'beta')).toEqual({
+      legacyLineageKey: null,
+      selectedIdentity: sessionIdentityKey('tip', 'beta')
+    })
   })
 })
 
@@ -287,14 +366,14 @@ describe('getRecentlySettledSessionIds', () => {
     // clearAllSessionStates also drops settle-grace entries + watchdog timers,
     // so nothing leaks in from a previous test.
     clearAllSessionStates()
-    $selectedStoredSessionId.set(null)
+    setSelectedStoredSessionId(null)
     $unreadFinishedSessionIds.set([])
   })
 
   afterEach(() => {
     vi.useRealTimers()
     clearAllSessionStates()
-    $selectedStoredSessionId.set(null)
+    setSelectedStoredSessionId(null)
     $unreadFinishedSessionIds.set([])
   })
 
@@ -306,11 +385,11 @@ describe('getRecentlySettledSessionIds', () => {
     const idle = { ...working, busy: false }
     publishSessionState('rt1', idle)
 
-    expect(getRecentlySettledSessionIds()).toEqual(['s1'])
+    expect(getRecentlySettledSessionIds()).toEqual([identity('s1')])
 
     // Still inside the window.
     vi.setSystemTime(29_000)
-    expect(getRecentlySettledSessionIds()).toEqual(['s1'])
+    expect(getRecentlySettledSessionIds()).toEqual([identity('s1')])
 
     // Past the window: the entry is pruned on read.
     vi.setSystemTime(31_000)
@@ -330,7 +409,7 @@ describe('getRecentlySettledSessionIds', () => {
     const idle = { ...working, busy: false }
     publishSessionState('rt1', idle)
 
-    expect(getRecentlySettledSessionIds()).toEqual(['s2'])
+    expect(getRecentlySettledSessionIds()).toEqual([identity('s2')])
 
     // A new turn for the same session is "working" again — drop it from the
     // settled set so it's tracked as working, not recently-finished.
@@ -345,17 +424,17 @@ describe('unread finished sessions', () => {
   beforeEach(() => {
     clearAllSessionStates()
     $unreadFinishedSessionIds.set([])
-    $selectedStoredSessionId.set(null)
+    setSelectedStoredSessionId(null)
   })
 
   afterEach(() => {
     clearAllSessionStates()
     $unreadFinishedSessionIds.set([])
-    $selectedStoredSessionId.set(null)
+    setSelectedStoredSessionId(null)
   })
 
   it('marks a session unread when its turn finishes in the background', () => {
-    $selectedStoredSessionId.set('other-session')
+    setSelectedStoredSessionId('other-session')
 
     const working = makeState({ busy: true, storedSessionId: 's1' })
     publishSessionState('rt1', working)
@@ -363,11 +442,11 @@ describe('unread finished sessions', () => {
     const idle = { ...working, busy: false }
     publishSessionState('rt1', idle)
 
-    expect($unreadFinishedSessionIds.get()).toEqual(['s1'])
+    expect($unreadFinishedSessionIds.get()).toEqual([identity('s1')])
   })
 
   it('does NOT mark unread when the finishing session is the active one', () => {
-    $selectedStoredSessionId.set('s1')
+    setSelectedStoredSessionId('s1')
 
     const working = makeState({ busy: true, storedSessionId: 's1' })
     publishSessionState('rt1', working)
@@ -379,7 +458,7 @@ describe('unread finished sessions', () => {
   })
 
   it('does NOT mark unread on idle→idle re-asserts (no prior working state)', () => {
-    $selectedStoredSessionId.set('other-session')
+    setSelectedStoredSessionId('other-session')
 
     const idle = makeState({ busy: false, storedSessionId: 's1' })
     publishSessionState('rt1', idle)
@@ -388,7 +467,7 @@ describe('unread finished sessions', () => {
   })
 
   it('clears unread when the user opens the session', () => {
-    $selectedStoredSessionId.set('other')
+    setSelectedStoredSessionId('other')
 
     const working = makeState({ busy: true, storedSessionId: 's1' })
     publishSessionState('rt1', working)
@@ -396,7 +475,7 @@ describe('unread finished sessions', () => {
     const idle = { ...working, busy: false }
     publishSessionState('rt1', idle)
 
-    expect($unreadFinishedSessionIds.get()).toEqual(['s1'])
+    expect($unreadFinishedSessionIds.get()).toEqual([identity('s1')])
 
     setSelectedStoredSessionId('s1')
     expect($unreadFinishedSessionIds.get()).toEqual([])
@@ -455,6 +534,15 @@ describe('rememberedSessionProfile', () => {
     const sessions = [session({ _lineage_root_id: 'root-1', id: 'tip-2', profile: 'work' })]
 
     expect(rememberedSessionProfile(sessions, 'root-1', 'default')).toBe('work')
+  })
+
+  it('uses the routed profile when stored ids collide', () => {
+    const sessions = [
+      session({ id: 'shared', profile: 'alpha' }),
+      session({ id: 'shared', profile: 'beta' })
+    ]
+
+    expect(rememberedSessionProfile(sessions, 'shared', 'beta')).toBe('beta')
   })
 
   it('falls back to the active profile for a session not yet in the list', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -5,6 +5,12 @@ import { lastVisibleMessageIsUser } from '@/app/chat/thread-loading'
 import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
 import type { ChatMessage } from '@/lib/chat-messages'
+import {
+  normalizeProfileKey,
+  parseSessionIdentityKey,
+  sessionIdentityKey,
+  sessionMatchesIdentity
+} from '@/lib/session-identity'
 import { persistBoolean, persistString, storedBoolean, storedString } from '@/lib/storage'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
@@ -60,7 +66,11 @@ export function rememberedSessionProfile(
   activeProfile: null | string
 ): string {
   if (sessionId) {
-    const owner = sessions.find(session => sessionMatchesStoredId(session, sessionId))?.profile?.trim()
+    const matching = sessions.filter(session => sessionMatchesStoredId(session, sessionId))
+
+    const owner =
+      matching.find(session => sessionMatchesIdentity(session, sessionId, activeProfile))?.profile?.trim() ??
+      (matching.length === 1 ? matching[0]?.profile?.trim() : undefined)
 
     if (owner) {
       return owner
@@ -166,8 +176,15 @@ function updateAtom<T>(store: AppAtom<T>, next: Updater<T>) {
 /** Durable id for pinning. Auto-compression rotates a conversation's session
  *  id (root -> continuation tip), so pins keyed on the live id evaporate. The
  *  lineage root is stable across every compression, so we pin on that. */
-export const sessionPinId = (session: Pick<SessionInfo, '_lineage_root_id' | 'id'>): string =>
-  session._lineage_root_id ?? session.id
+export const sessionPinId = (session: Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'>): string =>
+  sessionIdentityKey(session._lineage_root_id ?? session.id, session.profile)
+
+/** Profile-safe pin id while a session row is still loading. */
+export const resolveSessionPinId = (
+  session: Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'> | null | undefined,
+  storedSessionId: string,
+  profile?: null | string
+): string => (session ? sessionPinId(session) : sessionIdentityKey(storedSessionId, profile))
 
 /** True when a stored/lineage id resolves to this session — it matches either
  *  the live id or the stable lineage root (see sessionPinId). The one place the
@@ -187,15 +204,44 @@ export const sessionMatchesStoredId = (
  */
 export function resolveComposerSessionKey(
   selectedSessionId: string | null | undefined,
-  sessions: readonly Pick<SessionInfo, '_lineage_root_id' | 'id'>[]
+  sessions: readonly Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'>[],
+  profile?: null | string
 ): string | null {
   if (!selectedSessionId) {
     return null
   }
 
-  const row = sessions.find(session => sessionMatchesStoredId(session, selectedSessionId))
+  const row = sessions.find(session =>
+    profile === undefined
+      ? sessionMatchesStoredId(session, selectedSessionId)
+      : sessionMatchesIdentity(session, selectedSessionId, profile)
+  )
 
-  return row ? sessionPinId(row) : selectedSessionId
+  const durableId = row ? (row._lineage_root_id ?? row.id) : selectedSessionId
+
+  return profile === undefined ? durableId : sessionIdentityKey(durableId, profile)
+}
+
+/** Source keys inspected while moving draft/queue state onto a durable composer key. */
+export function resolveComposerMigrationKeys(
+  selectedSessionId: string,
+  sessions: readonly Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'>[],
+  profile: null | string | undefined
+): { legacyLineageKey: string | null; selectedIdentity: string } {
+  const normalizedProfile = normalizeProfileKey(profile)
+
+  const ownedDefaultRow =
+    normalizedProfile === 'default'
+      ? sessions.find(session => sessionMatchesIdentity(session, selectedSessionId, normalizedProfile))
+      : undefined
+
+  return {
+    // Pre-profile draft/queue keys were raw ids. Only an exact row owned by the
+    // default profile may donate that raw lineage source; a colliding row from
+    // another profile must never be treated as legacy default-profile state.
+    legacyLineageKey: ownedDefaultRow ? (ownedDefaultRow._lineage_root_id ?? ownedDefaultRow.id) : null,
+    selectedIdentity: sessionIdentityKey(selectedSessionId, profile)
+  }
 }
 
 /** Merge a fresh server session page into the in-memory list, keeping any
@@ -226,21 +272,27 @@ export function mergeSessionPage(
   incoming: SessionInfo[],
   keepIds: Iterable<string>
 ): SessionInfo[] {
-  const keep = keepIds instanceof Set ? keepIds : new Set(keepIds)
+  const keep = new Set(
+    [...keepIds].map(id => {
+      const parsed = parseSessionIdentityKey(id)
+
+      return sessionIdentityKey(parsed.storedSessionId, parsed.profile)
+    })
+  )
 
   // Carry a known title onto a row that arrives title-less, so a freshly
   // submitted session (e.g. a branch draft) holds its placeholder instead of
   // flashing its raw message preview in the gap between persist and the async
   // auto-titler. A real clear sets the local title null first, so this never
   // masks one.
-  const prevById = new Map(previous.map(session => [session.id, session]))
+  const prevById = new Map(previous.map(session => [sessionIdentityKey(session.id, session.profile), session]))
 
   const merged = incoming.map(session => {
     if (session.title?.trim()) {
       return session
     }
 
-    const carried = prevById.get(session.id)?.title?.trim()
+    const carried = prevById.get(sessionIdentityKey(session.id, session.profile))?.title?.trim()
 
     return carried ? { ...session, title: carried } : session
   })
@@ -249,19 +301,22 @@ export function mergeSessionPage(
     return merged
   }
 
-  const incomingIds = new Set(merged.map(session => session.id))
+  const incomingIds = new Set(merged.map(session => sessionIdentityKey(session.id, session.profile)))
 
   // Deduplicate by compression lineage: when auto-compression rotates the tip
   // id (old #4 → new #5), the incoming page carries the new tip but the
   // previous list still holds the old one.  Without lineage-level dedup both
   // rows survive as separate sidebar entries (fixes #43483).
-  const incomingLineageKeys = new Set(merged.map(session => session._lineage_root_id ?? session.id))
+  const incomingLineageKeys = new Set(
+    merged.map(session => sessionIdentityKey(session._lineage_root_id ?? session.id, session.profile))
+  )
 
   const survivors = previous.filter(
     session =>
-      !incomingIds.has(session.id) &&
-      !incomingLineageKeys.has(session._lineage_root_id ?? session.id) &&
-      (keep.has(session.id) || (session._lineage_root_id != null && keep.has(session._lineage_root_id)))
+      !incomingIds.has(sessionIdentityKey(session.id, session.profile)) &&
+      !incomingLineageKeys.has(sessionIdentityKey(session._lineage_root_id ?? session.id, session.profile)) &&
+      (keep.has(sessionIdentityKey(session.id, session.profile)) ||
+        (session._lineage_root_id != null && keep.has(sessionIdentityKey(session._lineage_root_id, session.profile))))
   )
 
   return survivors.length ? [...survivors, ...merged] : merged
@@ -301,8 +356,15 @@ export const $messagingTruncated = atom<boolean>(false)
 // from the row count the query already returned.
 export const $sessionProfilesTruncated = atom<Record<string, boolean>>({})
 export const $sessionsLoading = atom(true)
+// Last profile scope whose recents request completed successfully. Distinct
+// from $sessionsLoading: populated refreshes deliberately avoid skeleton churn,
+// but a newly requested scope is still unresolved until its own response lands.
+// Sidebar order reconciliation uses this to preserve rows for profiles that
+// have not yet been loaded instead of treating them as confirmed empty.
+export const $sessionsHydratedProfileScope = atom<null | string>(null)
 export const $activeSessionId = atom<string | null>(null)
 export const $selectedStoredSessionId = atom<string | null>(null)
+export const $selectedSessionIdentityKey = atom<string | null>(null)
 export interface ActiveSessionStoredIdRotation {
   nextStoredSessionId: string
   previousStoredSessionId: string
@@ -385,6 +447,8 @@ export const setMessagingTruncated = (next: Updater<boolean>) => updateAtom($mes
 export const setSessionProfilesTruncated = (next: Updater<Record<string, boolean>>) =>
   updateAtom($sessionProfilesTruncated, next)
 export const setSessionsLoading = (next: Updater<boolean>) => updateAtom($sessionsLoading, next)
+export const setSessionsHydratedProfileScope = (next: Updater<null | string>) =>
+  updateAtom($sessionsHydratedProfileScope, next)
 export const setActiveSessionId = (next: Updater<string | null>) => updateAtom($activeSessionId, next)
 export const setActiveSessionStoredIdRotation = (next: Updater<ActiveSessionStoredIdRotation | null>) =>
   updateAtom($activeSessionStoredIdRotation, next)
@@ -393,13 +457,17 @@ export const setActiveSessionStoredIdRotation = (next: Updater<ActiveSessionStor
 // Written by session-states.ts (handleTransition), cleared here on session open.
 export const $unreadFinishedSessionIds = atom<string[]>([])
 
-export const setSelectedStoredSessionId = (next: Updater<string | null>) => {
+export const setSelectedStoredSessionId = (next: Updater<string | null>, profile?: null | string) => {
   updateAtom($selectedStoredSessionId, next)
   // Opening a session clears its unread state — the user is now looking at it.
   const id = $selectedStoredSessionId.get()
 
-  if (id && $unreadFinishedSessionIds.get().includes(id)) {
-    $unreadFinishedSessionIds.set($unreadFinishedSessionIds.get().filter(x => x !== id))
+  $selectedSessionIdentityKey.set(id ? sessionIdentityKey(id, profile) : null)
+
+  const identityKey = id ? sessionIdentityKey(id, profile) : null
+
+  if (identityKey && $unreadFinishedSessionIds.get().includes(identityKey)) {
+    $unreadFinishedSessionIds.set($unreadFinishedSessionIds.get().filter(x => x !== identityKey))
   }
 }
 

--- a/apps/desktop/src/store/windows.test.ts
+++ b/apps/desktop/src/store/windows.test.ts
@@ -89,6 +89,16 @@ describe('openSessionInNewWindow', () => {
     expect(notifyError).not.toHaveBeenCalled()
   })
 
+  it('forwards the owning profile for cross-profile windows', async () => {
+    const open = vi.fn().mockResolvedValue({ ok: true })
+    installBridge(open)
+
+    await openSessionInNewWindow('s1', { profile: 'ubuntu-server' })
+
+    expect(open).toHaveBeenCalledWith('s1', { profile: 'ubuntu-server' })
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
   it('notifies on an ok:false result', async () => {
     installBridge(vi.fn().mockResolvedValue({ ok: false, error: 'invalid-session-id' }))
 
@@ -149,6 +159,7 @@ describe('openNewWindow', () => {
     expect(openWindow).toHaveBeenCalledTimes(1)
     expect(notifyError).not.toHaveBeenCalled()
   })
+
 
   it('notifies on an ok:false result', async () => {
     installBridge(undefined, vi.fn().mockResolvedValue({ ok: false, error: 'nope' }))

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -81,7 +81,10 @@ async function runWindowOpen(call: () => Promise<WindowOpenResult>, failMessage:
 // Open (or focus) a standalone OS window for a single chat session. No-ops
 // gracefully outside Electron so callers can wire it unconditionally.
 // `watch: true` opens a spectator window (lazy resume, live-mirror stream).
-export async function openSessionInNewWindow(sessionId: string, opts?: { watch?: boolean }): Promise<void> {
+export async function openSessionInNewWindow(
+  sessionId: string,
+  opts?: { profile?: null | string; watch?: boolean }
+): Promise<void> {
   if (!sessionId || !canOpenSessionWindow()) {
     return
   }

--- a/apps/desktop/src/store/working-ids-stored-id.test.ts
+++ b/apps/desktop/src/store/working-ids-stored-id.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { sessionIdentityKey } from '@/lib/session-identity'
 import { $workingSessionIds, clearAllSessionStates, publishSessionState } from '@/store/session-states'
 
 /**
@@ -27,6 +28,6 @@ describe('$workingSessionIds — a busy runtime with no stored id', () => {
   it('shows the spinner as soon as the stored id is known', () => {
     publishSessionState('runtime-mapped', { ...createClientSessionState('stored-x'), busy: true })
 
-    expect($workingSessionIds.get()).toEqual(['stored-x'])
+    expect($workingSessionIds.get()).toEqual([sessionIdentityKey('stored-x', 'default')])
   })
 })


### PR DESCRIPTION
## Summary
- Preserve each Desktop session row's owning profile when opening sessions from sidebar and messaging sections, cron run lists, command center, command palette, keyboard/session pickers, and pop-out windows.
- Encode the optional profile hint in session routes, parse it during route resume, and carry it through cached and uncached session ownership resolution.
- Route `getSession`, message fallback, and `session.resume` through the same profile hint while preserving legacy fallback behavior when the hint is absent or stale.
- Carry the profile through the renderer window bridge, Electron IPC, secondary-window URL construction, and existing-window focus/reload paths.

## Motivation
Desktop aggregates sessions from multiple profiles. A row owned by a non-active profile could previously navigate or open a secondary window using only its session ID. Resume then probed the active/default profile, leaving Desktop stuck loading or reporting `session not found` even though the session existed in its owning profile.

This update covers the complete current Desktop path rather than only the original sidebar/resume implementation. It also adapts the change to the split `use-session-actions/index.ts` and `utils.ts` layout now on `main`.

## Compatibility
- Profile hints remain optional for existing callers.
- Blank profile values normalize to no hint.
- Resume retains fallback discovery when an explicit hint is stale or unavailable.
- No voice/audio changes are included in this PR.

## Testing
- `npm run test:ui --workspace apps/desktop -- src/store/windows.test.ts src/app/chat/sidebar/sessions-section.test.tsx src/app/routes.test.ts src/app/session/hooks/use-route-resume.test.tsx src/app/session/hooks/use-session-actions.test.tsx`
  - 49 tests passed
- `npm run test:desktop:platforms --workspace apps/desktop -- electron/session-windows.test.ts`
  - 15 tests passed
- `npm run typecheck --workspace apps/desktop`
- Scoped ESLint over all 28 changed Desktop files; zero errors
- `git diff --check origin/main...HEAD`
- Added-line security/scope scan across 304 added lines; no findings and no voice/audio files
