### PR TITLE
feat(gateway): category-based suppression of system messages (on current main)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -31,6 +31,7 @@ from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse, urlunparse
 
 from agent.context_compressor import ContextCompressor
+from agent.i18n import t
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import StreamingContextScrubber
 from agent.session_activity import ActivityProvenance
@@ -254,11 +255,12 @@ def _build_codex_gpt5_autoraise_notice(
         cap = "128K" if model.startswith("gpt-5.3-codex-spark") else "272K"
     from_pct = int(round(autoraise["from"] * 100))
     to_pct = int(round(autoraise["to"] * 100))
-    return (
-        f"ℹ Codex {model} caps context at {cap}, so auto-compaction was raised "
-        f"to {to_pct}% (from {from_pct}%) to use more of the window before "
-        f"summarizing.\n"
-        f"  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+    return t(
+        "gateway.codex_gpt55_autoraise_notice",
+        model=model,
+        cap=cap,
+        to_pct=to_pct,
+        from_pct=from_pct,
     )
 
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -108,7 +108,7 @@ def _emit_compaction_done(agent: Any) -> None:
     if not status_callback:
         return
     try:
-        status_callback("compacted", COMPACTION_DONE_STATUS)
+        status_callback("compacted", t("gateway.compaction_done"))
     except Exception:
         logger.debug("status_callback error in compaction completion", exc_info=True)
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -107,8 +107,13 @@ def _emit_compaction_done(agent: Any) -> None:
     status_callback = getattr(agent, "status_callback", None)
     if not status_callback:
         return
+    text = t("gateway.compaction_done")
+    # Category suppression (suppress: progress) blanks this to "". Skip the
+    # callback entirely rather than emitting an empty status line.
+    if not text.strip():
+        return
     try:
-        status_callback("compacted", t("gateway.compaction_done"))
+        status_callback("compacted", text)
     except Exception:
         logger.debug("status_callback error in compaction completion", exc_info=True)
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -71,6 +71,7 @@ from agent.context_engine import (
     automatic_compaction_status_message,
     sanitize_memory_context,
 )
+from agent.i18n import t
 from agent.model_metadata import estimate_request_tokens_rough
 from agent.session_activity import ActivityProvenance, normalize_activity_provenance
 
@@ -1622,19 +1623,12 @@ def check_compression_model_feasibility(agent: Any) -> None:
                     _aux_cfg_provider = fb_label.rsplit("(", 1)[1][:-1]
         if client is None or not aux_model:
             if _aux_cfg_provider and _aux_cfg_provider != "auto":
-                msg = (
-                    "⚠ Configured auxiliary compression provider "
-                    f"'{_aux_cfg_provider}' is unavailable — context "
-                    "compression will drop middle turns without a summary. "
-                    "Check auxiliary.compression in config.yaml and "
-                    "reauthenticate that provider."
+                msg = t(
+                    "gateway.compression_aux_unavailable",
+                    provider=_aux_cfg_provider,
                 )
             else:
-                msg = (
-                    "⚠ No auxiliary LLM provider configured — context "
-                    "compression will drop middle turns without a summary. "
-                    "Run `hermes setup` or set OPENROUTER_API_KEY."
-                )
+                msg = t("gateway.compression_no_provider")
             agent._compression_warning = msg
             agent._emit_status(msg)
             logger.warning(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -45,6 +45,7 @@ from agent.turn_context import (
     reanchor_current_turn_user_idx,
 )
 from agent.turn_retry_state import TurnRetryState
+from agent.i18n import t
 from agent.runtime_cwd import resolve_agent_cwd
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
@@ -732,10 +733,7 @@ _CODEX_INCOMPLETE_NUDGE = (
 # exception path (a provider moderation error classified as
 # ``content_policy_blocked``) end with the same actionable next steps, so they
 # share one trailer to keep the guidance from drifting between the two sites.
-_CONTENT_POLICY_RECOVERY_HINT = (
-    "Try rephrasing the request, narrowing the context, or "
-    "adding a fallback provider with `hermes fallback add`."
-)
+_CONTENT_POLICY_RECOVERY_HINT = t("gateway.cl_content_policy_recovery_hint")
 
 
 # Memo for the send-path tool-call argument canonicalization inside
@@ -1898,7 +1896,7 @@ def run_conversation(
             failed = True
             _turn_exit_reason = "ollama_runtime_context_too_small"
             messages.append({"role": "assistant", "content": final_response})
-            agent._emit_status("❌ Ollama runtime context is too small for Hermes tool use")
+            agent._emit_status(t("gateway.cl_ollama_context_too_small"))
             api_call_count -= 1
             agent._api_call_count = api_call_count
             try:
@@ -2139,9 +2137,9 @@ def run_conversation(
                     )
                     _nous_remaining = nous_rate_limit_remaining()
                     if _nous_remaining is not None and _nous_remaining > 0:
-                        _nous_msg = (
-                            f"Nous Portal rate limit active — "
-                            f"resets in {_fmt_nous_remaining(_nous_remaining)}."
+                        _nous_msg = t(
+                            "gateway.cl_nous_rate_limit",
+                            reset=_fmt_nous_remaining(_nous_remaining),
                         )
                         agent._buffer_vprint(
                             f"⏳ {_nous_msg} Trying fallback..."
@@ -2159,11 +2157,9 @@ def run_conversation(
                         agent._flush_status_buffer()
                         agent._persist_session(messages, conversation_history)
                         return {
-                            "final_response": (
-                                f"⏳ {_nous_msg}\n\n"
-                                "No fallback provider available. "
-                                "Try again after the reset, or add a "
-                                "fallback provider in config.yaml."
+                            "final_response": t(
+                                "gateway.cl_nous_no_fallback",
+                                nous=_nous_msg,
                             ),
                             "messages": messages,
                             "api_calls": api_call_count,
@@ -2588,7 +2584,7 @@ def run_conversation(
                     # rate-limit symptom.  Switch to fallback immediately
                     # rather than retrying with extended backoff.
                     if agent._fallback_index < len(agent._fallback_chain):
-                        agent._buffer_status("⚠️ Empty/malformed response — switching to fallback...")
+                        agent._buffer_status(t("gateway.cl_empty_malformed_switching"))
                     if agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
@@ -2661,7 +2657,7 @@ def run_conversation(
                     if retry_count >= max_retries:
                         # Try fallback before giving up
                         if agent._has_pending_fallback():
-                            agent._buffer_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
+                            agent._buffer_status(t("gateway.cl_max_retries_invalid_trying_fallback", max=max_retries))
                         if agent._try_activate_fallback():
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
@@ -2671,7 +2667,7 @@ def run_conversation(
                             continue
                         # Terminal — flush buffered retry trace so user sees what happened.
                         agent._flush_status_buffer()
-                        agent._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
+                        agent._emit_status(t("gateway.cl_max_retries_invalid_giving_up", max=max_retries))
                         logger.error("%sInvalid API response after %d retries.", agent.log_prefix, max_retries)
                         agent._persist_session(messages, conversation_history)
                         _final_response = f"Invalid API response after {max_retries} retries: {_failure_hint}"
@@ -2860,19 +2856,18 @@ def run_conversation(
                         _refusal_log or "(no text)",
                     )
                     agent._emit_status(
-                        "⚠️ The model declined to respond to this request (safety refusal)."
+                        t("gateway.cl_refusal_status")
                     )
 
                     _refusal_detail = (
-                        f"Model's explanation: {_refusal_text}"
+                        t("gateway.cl_refusal_explanation", explanation=_refusal_text)
                         if _refusal_text
-                        else "The model returned no explanation."
+                        else t("gateway.cl_refusal_no_explanation")
                     )
-                    _refusal_response = (
-                        "⚠️  The model declined to respond to this request "
-                        "(safety refusal — not a Hermes/gateway failure).\n\n"
-                        f"{_refusal_detail}\n\n"
-                        f"{_CONTENT_POLICY_RECOVERY_HINT}"
+                    _refusal_response = t(
+                        "gateway.cl_refusal_response",
+                        detail=_refusal_detail,
+                        hint=_CONTENT_POLICY_RECOVERY_HINT,
                     )
 
                     agent._cleanup_task_resources(effective_task_id)
@@ -2960,14 +2955,7 @@ def run_conversation(
                         # Return a user-friendly message as the response so
                         # CLI (response box) and gateway (chat message) both
                         # display it naturally instead of a suppressed error.
-                        _exhaust_response = (
-                            "⚠️ **Thinking Budget Exhausted**\n\n"
-                            "The model used all its output tokens on reasoning "
-                            "and had none left for the actual response.\n\n"
-                            "To fix this:\n"
-                            "→ Lower reasoning effort: `/thinkon low` or `/thinkon minimal`\n"
-                            "→ Or switch to a larger/non-reasoning model with `/model`"
-                        )
+                        _exhaust_response = t("gateway.cl_thinking_budget_exhausted")
                         agent._cleanup_task_resources(effective_task_id)
                         agent._persist_session(messages, conversation_history)
                         return {
@@ -4238,7 +4226,7 @@ def run_conversation(
                         _retry.restart_with_redirected_messages = True
                         break
                     agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during error handling, aborting retries.", force=True)
-                    _interrupt_text = f"Operation interrupted: handling API error ({error_type}: {agent._clean_error_message(str(api_error))})."
+                    _interrupt_text = t("gateway.cl_interrupted_handling_error", error_type=error_type, detail=agent._clean_error_message(str(api_error)))
                     close_interrupted_tool_sequence(messages, _interrupt_text)
                     agent._persist_session(messages, conversation_history)
                     agent.clear_interrupt()
@@ -4372,8 +4360,10 @@ def run_conversation(
                         )
                         if len(messages) < original_len or old_ctx > _reduced_ctx:
                             agent._buffer_status(
-                                COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE.format(
-                                    new_ctx=_reduced_ctx, old_ctx=old_ctx
+                                t(
+                                    "gateway.cl_context_reduced",
+                                    reduced=f"{_reduced_ctx:,}",
+                                    old=f"{old_ctx:,}",
                                 )
                             )
                             time.sleep(2)
@@ -4440,14 +4430,14 @@ def run_conversation(
                             )
                         elif classified.reason == FailoverReason.billing:
                             agent._buffer_status(
-                                "⚠️ Billing or credits exhausted — switching to fallback provider..."
+                                t("gateway.cl_billing_switching_fallback")
                             )
                         elif _is_transport_failure:
                             agent._buffer_status(
                                 "⚠️ Provider unreachable — switching to fallback provider..."
                             )
                         else:
-                            agent._buffer_status("⚠️ Rate limited — switching to fallback provider...")
+                            agent._buffer_status(t("gateway.cl_rate_limited_switching_fallback"))
                         if agent._try_activate_fallback(reason=classified.reason):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
@@ -4614,7 +4604,7 @@ def run_conversation(
                             "failed": True,
                             "compression_exhausted": True,
                         }
-                    agent._buffer_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
+                    agent._buffer_status(t("gateway.cl_payload_too_large", n=compression_attempts, max=max_compression_attempts))
 
                     original_len = len(messages)
                     original_tokens = estimate_messages_tokens_rough(messages)
@@ -4651,7 +4641,7 @@ def run_conversation(
 
                     if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95):
                         if len(messages) < original_len:
-                            agent._buffer_status(COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE.format(before=original_len, after=len(messages)))
+                            agent._buffer_status(t("gateway.cl_compressed_retrying", before=original_len, after=len(messages)))
                         else:
                             agent._buffer_status(COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
                         time.sleep(2)  # Brief pause between compression retries
@@ -4878,7 +4868,7 @@ def run_conversation(
                             "failed": True,
                             "compression_exhausted": True,
                         }
-                    agent._buffer_status(COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE.format(tokens=approx_tokens, attempt=compression_attempts, cap=max_compression_attempts))
+                    agent._buffer_status(t("gateway.cl_context_too_large_compressing", tokens=f"{approx_tokens:,}", n=compression_attempts, max=max_compression_attempts))
 
                     original_len = len(messages)
                     original_tokens = estimate_messages_tokens_rough(messages)
@@ -4917,7 +4907,7 @@ def run_conversation(
 
                     if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95) or (new_ctx and new_ctx < old_ctx):
                         if len(messages) < original_len:
-                            agent._buffer_status(COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE.format(before=original_len, after=len(messages)))
+                            agent._buffer_status(t("gateway.cl_compressed_retrying", before=original_len, after=len(messages)))
                         elif new_tokens > 0 and new_tokens < original_tokens * 0.95:
                             agent._buffer_status(COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
                         time.sleep(2)  # Brief pause between compression retries
@@ -5048,11 +5038,11 @@ def run_conversation(
                     # abort silently (#35314, #17446).
                     if agent._has_pending_fallback():
                         if classified.reason == FailoverReason.content_policy_blocked:
-                            agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
+                            agent._buffer_status(t("gateway.api_safety_trying_fallback"))
                         elif classified.reason == FailoverReason.ssl_cert_verification:
                             agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
                         else:
-                            agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                            agent._buffer_status(t("gateway.api_non_retryable_trying_fallback", status_code=status_code))
                     if agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
@@ -5076,8 +5066,7 @@ def run_conversation(
                     _nonretryable_summary = agent._summarize_api_error(api_error)
                     if classified.reason == FailoverReason.content_policy_blocked:
                         agent._emit_status(
-                            f"❌ Provider safety filter blocked this request: "
-                            f"{_nonretryable_summary}"
+                            t("gateway.api_safety_blocked", summary=_nonretryable_summary)
                         )
                     elif classified.reason == FailoverReason.ssl_cert_verification:
                         agent._emit_status(
@@ -5086,8 +5075,7 @@ def run_conversation(
                         )
                     else:
                         agent._emit_status(
-                            f"❌ Non-retryable error (HTTP {status_code}): "
-                            f"{_nonretryable_summary}"
+                            t("gateway.api_non_retryable", status_code=status_code, summary=_nonretryable_summary)
                         )
                     agent._vprint(f"{agent.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.", force=True)
                     agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
@@ -5209,11 +5197,10 @@ def run_conversation(
                     else:
                         agent._persist_session(messages, conversation_history)
                     if classified.reason == FailoverReason.content_policy_blocked:
-                        _policy_response = (
-                            "⚠️  The model provider's safety filter blocked this request "
-                            "(not a Hermes/gateway failure).\n\n"
-                            f"Provider message: {_nonretryable_summary}\n\n"
-                            f"{_CONTENT_POLICY_RECOVERY_HINT}"
+                        _policy_response = t(
+                            "gateway.cl_policy_blocked_response",
+                            summary=_nonretryable_summary,
+                            hint=_CONTENT_POLICY_RECOVERY_HINT,
                         )
                         return _content_policy_blocked_result(
                             messages,
@@ -5275,7 +5262,7 @@ def run_conversation(
                         continue
                     # Try fallback before giving up entirely
                     if agent._has_pending_fallback():
-                        agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
+                        agent._buffer_status(t("gateway.api_max_retries_trying_fallback", max_retries=max_retries))
                     if agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
@@ -5288,7 +5275,7 @@ def run_conversation(
                     _final_summary = agent._summarize_api_error(api_error)
                     _billing_guidance = ""
                     if classified.reason == FailoverReason.billing:
-                        agent._emit_status(f"❌ Billing or credits exhausted — {_final_summary}")
+                        agent._emit_status(t("gateway.api_error_billing", summary=_final_summary))
                         _billing_guidance = _billing_or_entitlement_message(
                             capability="model access",
                             provider=_provider,
@@ -5303,9 +5290,9 @@ def run_conversation(
                             model=_model,
                         )
                     elif is_rate_limited:
-                        agent._emit_status(f"❌ Rate limited after {max_retries} retries — {_final_summary}")
+                        agent._emit_status(t("gateway.api_error_rate_limited", max_retries=max_retries, summary=_final_summary))
                     else:
-                        agent._emit_status(f"❌ API failed after {max_retries} retries — {_final_summary}")
+                        agent._emit_status(t("gateway.api_error_failed", max_retries=max_retries, summary=_final_summary))
                     agent._vprint(f"{agent.log_prefix}   💀 Final error: {_final_summary}", force=True)
 
                     # Detect SSE stream-drop pattern (e.g. "Network
@@ -5408,7 +5395,7 @@ def run_conversation(
                     agent._persist_session(messages, conversation_history)
                     _billing_block = None
                     if classified.reason == FailoverReason.billing:
-                        _final_response = f"Billing or credits exhausted: {_final_summary}"
+                        _final_response = t("gateway.cl_billing_exhausted", summary=_final_summary)
                         if _billing_guidance:
                             _final_response += f"\n\n{_billing_guidance}"
                         # Structured recovery descriptor so every surface renders
@@ -5432,14 +5419,7 @@ def run_conversation(
                             model=_model,
                         )
                     elif _is_stream_drop:
-                        _final_response += (
-                            "\n\nThe provider's stream connection keeps "
-                            "dropping — this often happens when generating "
-                            "very large tool call responses (e.g. write_file "
-                            "with long content). Try asking me to use "
-                            "execute_code with Python's open() for large "
-                            "files, or to write in smaller sections."
-                        )
+                        _final_response += t("gateway.cl_stream_drop_hint")
                     return {
                         "final_response": _final_response,
                         "messages": messages,
@@ -5490,8 +5470,18 @@ def run_conversation(
                         _policy_note = " (Z.AI Coding overload adaptive long backoff)"
                     elif _backoff_policy == "zai_coding_overload_short":
                         _policy_note = " (Z.AI Coding overload short retry)"
-                    _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
-                    _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
+                    if _is_zai_coding_overload and not is_rate_limited:
+                        _rate_limit_status = (
+                            f"⏱️ Provider overloaded. Waiting {wait_time:.1f}s "
+                            f"(attempt {retry_count + 1}/{max_retries}){_policy_note}..."
+                        )
+                    else:
+                        _rate_limit_status = t(
+                            "gateway.cl_rate_limited_waiting",
+                            wait=f"{wait_time:.1f}",
+                            n=retry_count + 1,
+                            max=max_retries,
+                        ) + _policy_note
                     # Normal retries are buffered to avoid noisy transient chatter. Long
                     # Z.AI Coding waits are different: they can last minutes, so surface
                     # progress immediately instead of making the TUI look frozen.
@@ -5500,7 +5490,7 @@ def run_conversation(
                     else:
                         agent._buffer_status(_rate_limit_status)
                 else:
-                    agent._buffer_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
+                    agent._buffer_status(t("gateway.cl_retrying_in", wait=f"{wait_time:.1f}", n=retry_count, max=max_retries))
                 logger.warning(
                     "Retrying API call in %ss (attempt %s/%s) %s policy=%s error=%s",
                     wait_time,
@@ -5523,7 +5513,7 @@ def run_conversation(
                             _retry.restart_with_redirected_messages = True
                             break
                         agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
-                        _interrupt_text = f"Operation interrupted: retrying API call after error (retry {retry_count}/{max_retries})."
+                        _interrupt_text = t("gateway.cl_interrupted_retrying", n=retry_count, max=max_retries)
                         close_interrupted_tool_sequence(messages, _interrupt_text)
                         agent._persist_session(messages, conversation_history)
                         agent.clear_interrupt()
@@ -6292,7 +6282,7 @@ def run_conversation(
                     _turn_exit_reason = "guardrail_halt"
                     final_response = agent._toolguard_controlled_halt_response(decision)
                     agent._emit_status(
-                        f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}"
+                        t("gateway.tool_guardrail_halted", tool=decision.tool_name, code=decision.code)
                     )
                     messages.append({"role": "assistant", "content": final_response})
                     # Emit the halt message to the client so it's not
@@ -6544,7 +6534,7 @@ def run_conversation(
                     if fallback and getattr(agent, '_last_content_tools_all_housekeeping', False):
                         _turn_exit_reason = "fallback_prior_turn_content"
                         logger.info("Empty follow-up after tool calls — using prior turn content as final response")
-                        agent._emit_status("↻ Empty response after tool calls — using earlier content as final answer")
+                        agent._emit_status(t("gateway.cl_empty_after_tools_using_earlier"))
                         agent._last_content_with_tools = None
                         agent._last_content_tools_all_housekeeping = False
                         agent._empty_content_retries = 0
@@ -6646,8 +6636,7 @@ def run_conversation(
                             agent._thinking_prefill_retries,
                         )
                         agent._buffer_status(
-                            f"↻ Thinking-only response — prefilling to continue "
-                            f"({agent._thinking_prefill_retries}/2)"
+                            t("gateway.thinking_prefill_retry", n=agent._thinking_prefill_retries)
                         )
                         interim_msg = agent._build_assistant_message(
                             assistant_message, "incomplete"
@@ -6686,8 +6675,7 @@ def run_conversation(
                             agent._empty_content_retries, wait_time, agent.model,
                         )
                         agent._buffer_status(
-                            f"⚠️ Empty response from model — retrying "
-                            f"({agent._empty_content_retries}/3) in {wait_time:.0f}s"
+                            t("gateway.empty_response_retry", n=agent._empty_content_retries)
                         )
                         # Sleep in small increments to stay responsive to interrupts
                         sleep_end = time.time() + wait_time
@@ -6732,8 +6720,7 @@ def run_conversation(
                             agent.provider,
                         )
                         agent._buffer_status(
-                            "⚠️ Model returning empty responses — "
-                            "switching to fallback provider..."
+                            t("gateway.empty_response_switching_fallback")
                         )
                         if agent._try_activate_fallback():
                             active_system_prompt = _sync_failover_system_message(
@@ -6777,8 +6764,7 @@ def run_conversation(
                             "Reasoning: %s", reasoning_preview,
                         )
                         agent._emit_status(
-                            "⚠️ Model produced reasoning but no visible "
-                            "response after all retries. Returning empty."
+                            t("gateway.empty_response_reasoning_only")
                         )
                     else:
                         logger.warning(
@@ -6789,9 +6775,9 @@ def run_conversation(
                             agent.provider,
                         )
                         agent._emit_status(
-                            "❌ Model returned no content after all retries"
-                            + (" and fallback attempts." if agent._fallback_chain else
-                               ". No fallback providers configured.")
+                            t("gateway.empty_response_no_content")
+                            if agent._fallback_chain
+                            else t("gateway.empty_response_no_content_no_fallback")
                         )
 
                     # Deliver a labeled reasoning excerpt instead of a bare
@@ -7214,10 +7200,12 @@ def run_conversation(
             ):
                 if _is_local_processing_error:
                     _turn_exit_reason = f"local_processing_error({error_msg[:80]})"
-                    final_response = f"I apologize, but I encountered an error while processing the model response: {error_msg}"
+                    final_response = t(
+                        "gateway.cl_local_processing_error", error=error_msg
+                    )
                 else:
                     _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
-                    final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
+                    final_response = t("gateway.cl_repeated_errors", error=error_msg)
                 # Append as assistant so the history stays valid for
                 # session resume (avoids consecutive user messages).
                 messages.append({"role": "assistant", "content": final_response})

--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -85,11 +85,53 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "ar-sa": "ar", "ar-eg": "ar", "ar-ae": "ar", "ar-ma": "ar", "ar-dz": "ar",
 }
 
+_MUTABLE_CATEGORIES: frozenset[str] = frozenset({"progress", "lifecycle", "info"})
+
+# PROVISIONAL (upstream migration): keys below are re-derived in Phase 3 against
+# the gateway strings actually wrapped on current upstream/main. A key absent from
+# the catalog never matches, so suppression is a harmless no-op for it until then.
+# Full catalog key -> suppression category. ONLY notification-class keys whose
+# emit path drops empty content (direct adapter.send guarded by
+# _send_unless_empty, or status_callback via _prepare_gateway_status_message).
+# Return-value reply messages are intentionally excluded (see plan §Global
+# Constraints). errors/approval/commands keys are absent here => never suppressed.
+GATEWAY_MESSAGE_CATEGORIES: dict[str, str] = {
+    # progress — ephemeral work status
+    "gateway.long_running": "progress",
+    "gateway.no_activity_warning": "progress",
+    "gateway.subagent_working": "progress",
+    "gateway.queued_next_turn": "progress",
+    "gateway.interrupting_task": "progress",
+    "gateway.steered_into_run": "progress",
+    # lifecycle — gateway daemon lifecycle notifications
+    "gateway.restart_success": "lifecycle",
+    "gateway.gateway_online": "lifecycle",
+    "gateway.shutdown_restarting": "lifecycle",
+    "gateway.shutdown_shutting_down": "lifecycle",
+    # info — one-shot notices
+    "gateway.codex_gpt55_autoraise_notice": "info",
+    "gateway.kanban_done": "info",
+    "gateway.kanban_blocked": "info",
+    "gateway.kanban_crashed": "info",
+    "gateway.kanban_gave_up": "info",
+    "gateway.kanban_timed_out": "info",
+    "gateway.compression_aux_unavailable": "info",
+    "gateway.compression_no_provider": "info",
+    "gateway.compress_aux_model_failed": "info",
+    "gateway.preflight_compression": "info",
+    "gateway.stale_connections_cleaned": "info",
+    "gateway.iteration_budget_exhausted": "info",
+    "gateway.thinking_prefill_retry": "info",
+}
+
 _catalog_cache: dict[str, dict[str, str]] = {}
 _catalog_lock = threading.Lock()
 
 _overrides_cache: dict[str, str] | None = None
 _overrides_lock = threading.Lock()
+
+_suppress_cache: frozenset[str] | None = None
+_suppress_lock = threading.Lock()
 
 
 def _locales_dir() -> Path:
@@ -260,6 +302,9 @@ def reset_language_cache() -> None:
     global _overrides_cache
     with _overrides_lock:
         _overrides_cache = None
+    global _suppress_cache
+    with _suppress_lock:
+        _suppress_cache = None
 
 
 def get_language() -> str:
@@ -373,6 +418,35 @@ def _gateway_overrides() -> dict[str, str]:
         return _overrides_cache
 
 
+def _suppressed_categories() -> frozenset[str]:
+    """Categories the user has muted via ``gateway.system_messages.suppress``.
+
+    Accepts a list of category names or the string ``"all"`` (== all mutable
+    categories). Non-mutable / unknown names are ignored with a warning. Cached
+    for the process; ``reset_language_cache()`` clears it.
+    """
+    global _suppress_cache
+    with _suppress_lock:
+        if _suppress_cache is not None:
+            return _suppress_cache
+    raw = (_load_config_dict().get("gateway") or {}).get("system_messages") or {}
+    spec = raw.get("suppress") if isinstance(raw, dict) else None
+    result: set[str] = set()
+    items = [spec] if isinstance(spec, str) else (spec if isinstance(spec, list) else [])
+    for item in items:
+        if item == "all":
+            result |= set(_MUTABLE_CATEGORIES)
+        elif item in _MUTABLE_CATEGORIES:
+            result.add(item)
+        elif item is not None:
+            logger.warning("Ignoring non-suppressible/unknown system-message category %r", item)
+    frozen = frozenset(result)
+    with _suppress_lock:
+        if _suppress_cache is None:
+            _suppress_cache = frozen
+        return _suppress_cache
+
+
 def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
     """Translate a dotted key to the active language.
 
@@ -397,6 +471,9 @@ def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
     a matching override short-circuits both the language catalog and the
     English fallback.
     """
+    category = GATEWAY_MESSAGE_CATEGORIES.get(key)
+    if category is not None and category in _suppressed_categories():
+        return ""
     target = _normalize_lang(lang) if lang else get_language()
     # Gateway overrides win over the catalog (populated from gateway.system_messages).
     value = _gateway_overrides().get(key)
@@ -425,6 +502,7 @@ def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
 __all__ = [
     "SUPPORTED_LANGUAGES",
     "DEFAULT_LANGUAGE",
+    "GATEWAY_MESSAGE_CATEGORIES",
     "t",
     "get_language",
     "reset_language_cache",

--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import logging
 import os
+import string
 import threading
 from functools import lru_cache
 from pathlib import Path
@@ -86,6 +87,9 @@ _LANGUAGE_ALIASES: dict[str, str] = {
 
 _catalog_cache: dict[str, dict[str, str]] = {}
 _catalog_lock = threading.Lock()
+
+_overrides_cache: dict[str, str] | None = None
+_overrides_lock = threading.Lock()
 
 
 def _locales_dir() -> Path:
@@ -187,6 +191,20 @@ def _flatten_into(node: Any, prefix: str, out: dict[str, str]) -> None:
     # Non-string, non-dict leaves are ignored -- catalogs are text-only.
 
 
+def _load_config_dict() -> dict:
+    """Read config.yaml as a plain dict, or ``{}`` on any failure.
+
+    Single seam for every config-derived i18n value (language, agent name,
+    overrides) so tests can patch one function and callers stay crash-proof.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        return load_config_readonly() or {}
+    except Exception as exc:  # config missing / malformed / import error
+        logger.debug("i18n could not read config.yaml: %s", exc)
+        return {}
+
+
 @lru_cache(maxsize=1)
 def _config_language_cached() -> str | None:
     """Read ``display.language`` from config.yaml once per process.
@@ -196,15 +214,27 @@ def _config_language_cached() -> str | None:
     ``reset_language_cache()`` clears this when config changes at runtime
     (e.g. after the setup wizard).
     """
-    try:
-        from hermes_cli.config import load_config_readonly
-        cfg = load_config_readonly()
-        lang = (cfg.get("display") or {}).get("language")
-        if lang:
-            return _normalize_lang(lang)
-    except Exception as exc:
-        logger.debug("Could not read display.language from config: %s", exc)
+    cfg = _load_config_dict()
+    lang = (cfg.get("display") or {}).get("language")
+    if lang:
+        return _normalize_lang(lang)
     return None
+
+
+@lru_cache(maxsize=1)
+def agent_display_name() -> str:
+    """Configured agent name for ``{name}`` substitution; ``"Hermes"`` fallback.
+
+    Sourced from ``ui.theme.branding.agent_name`` (the only user-set agent name
+    in config; unused elsewhere in the gateway, so reusing it is safe).
+    """
+    branding = (
+        ((_load_config_dict().get("ui") or {}).get("theme") or {}).get("branding") or {}
+    )
+    name = branding.get("agent_name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return "Hermes"
 
 
 def reset_language_cache() -> None:
@@ -214,8 +244,12 @@ def reset_language_cache() -> None:
     needs to pick up a changed ``display.language`` without restart.
     """
     _config_language_cached.cache_clear()
+    agent_display_name.cache_clear()
     with _catalog_lock:
         _catalog_cache.clear()
+    global _overrides_cache
+    with _overrides_lock:
+        _overrides_cache = None
 
 
 def get_language() -> str:
@@ -227,6 +261,87 @@ def get_language() -> str:
     if cfg_lang:
         return cfg_lang
     return DEFAULT_LANGUAGE
+
+
+class _MissingField(str):
+    """Sentinel returned by ``_SafeFormatter.get_value`` for an unknown key.
+
+    Subclasses ``str`` so the value already IS the ``"{key}"`` token and
+    normal string operations still work.  The distinct type lets
+    ``format_field`` unambiguously distinguish a re-emitted placeholder from
+    a real kwarg value that happens to look like ``"{...}"``.
+    """
+
+    __slots__ = ()
+
+
+class _SafeFormatter(string.Formatter):
+    """``str.format`` that leaves unknown placeholders intact instead of raising.
+
+    A user-supplied override template (``gateway.system_messages.*``) may contain
+    a placeholder the call site never provides -- a typo, or ``{minutes}`` on a
+    key that isn't the heartbeat.  Stock ``str.format`` raises on the first such
+    token and the whole string is lost.  This formatter substitutes the kwargs it
+    knows and re-emits the rest as the literal ``{token}`` so a broken template
+    degrades gracefully instead of crashing the gateway.
+    """
+
+    def get_value(self, key: Any, args: Any, kwargs: Any) -> Any:
+        if isinstance(key, str):
+            return kwargs[key] if key in kwargs else _MissingField("{" + key + "}")
+        try:
+            return args[key]
+        except (IndexError, KeyError):
+            return _MissingField("{" + str(key) + "}")
+
+    def format_field(self, value: Any, format_spec: str) -> str:
+        # If get_value returned a sentinel for a missing placeholder, reconstruct
+        # the raw token -- with or without a format spec.
+        if isinstance(value, _MissingField):
+            if format_spec:
+                # Reconstruct e.g. "{n:02d}" from token "{n}" + spec "02d".
+                return value[:-1] + ":" + format_spec + "}"
+            return str(value)
+        try:
+            return super().format_field(value, format_spec)
+        except (ValueError, TypeError):
+            # A real value with an unsatisfiable format spec degrades without
+            # crashing (e.g. a non-numeric value passed where ":02d" expected).
+            return str(value)
+
+
+_SAFE_FORMATTER = _SafeFormatter()
+
+
+def _safe_format(template: str, **kwargs: Any) -> str:
+    """Format ``template`` with ``kwargs``; unknown ``{tokens}`` stay literal."""
+    try:
+        return _SAFE_FORMATTER.vformat(template, (), kwargs)
+    except (KeyError, IndexError, ValueError) as exc:
+        logger.warning("i18n safe-format failed for template %r: %s", template, exc)
+        return template
+
+
+def _gateway_overrides() -> dict[str, str]:
+    """Load ``gateway.system_messages`` overrides as a ``{full_key: template}`` map.
+
+    ``gateway.system_messages.restart_success`` -> ``gateway.restart_success``.
+    Cached for the process; ``reset_language_cache()`` clears it on config reload.
+    """
+    global _overrides_cache
+    with _overrides_lock:
+        if _overrides_cache is not None:
+            return _overrides_cache
+    result: dict[str, str] = {}
+    raw = (_load_config_dict().get("gateway") or {}).get("system_messages") or {}
+    if isinstance(raw, dict):
+        for short_key, template in raw.items():
+            if isinstance(template, str):
+                result[f"gateway.{short_key}"] = template
+    with _overrides_lock:
+        if _overrides_cache is None:
+            _overrides_cache = result
+        return _overrides_cache
 
 
 def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
@@ -246,10 +361,19 @@ def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
     -------
     The translated string, or the English fallback if the key is missing in
     the target language, or the bare key if English is also missing.
+
+    Notes
+    -----
+    ``gateway.*`` keys are checked against :func:`_gateway_overrides` first;
+    a matching override short-circuits both the language catalog and the
+    English fallback.
     """
     target = _normalize_lang(lang) if lang else get_language()
-    catalog = _load_catalog(target)
-    value = catalog.get(key)
+    # Gateway overrides win over the catalog (populated from gateway.system_messages).
+    value = _gateway_overrides().get(key)
+    if value is None:
+        catalog = _load_catalog(target)
+        value = catalog.get(key)
 
     if value is None and target != DEFAULT_LANGUAGE:
         # Fall through to English rather than showing a key path to the user.
@@ -261,15 +385,11 @@ def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
         logger.debug("i18n miss: key=%r lang=%r", key, target)
         value = key
 
+    if "{name}" in value and "name" not in format_kwargs:
+        format_kwargs = {**format_kwargs, "name": agent_display_name()}
+
     if format_kwargs:
-        try:
-            return value.format(**format_kwargs)
-        except (KeyError, IndexError, ValueError) as exc:
-            logger.warning(
-                "i18n format failed for key=%r lang=%r kwargs=%r: %s",
-                key, target, format_kwargs, exc,
-            )
-            return value
+        return _safe_format(value, **format_kwargs)
     return value
 
 
@@ -279,4 +399,5 @@ __all__ = [
     "t",
     "get_language",
     "reset_language_cache",
+    "agent_display_name",
 ]

--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -103,6 +103,11 @@ GATEWAY_MESSAGE_CATEGORIES: dict[str, str] = {
     "gateway.queued_next_turn": "progress",
     "gateway.interrupting_task": "progress",
     "gateway.steered_into_run": "progress",
+    # The compaction START status is already swallowed by the gateway noise
+    # regex; this completion edge is deliberately delivered to chat instead
+    # (test_compaction_completion_notice_reaches_chat), so muting it needs
+    # this category entry — the noise filter will never do it.
+    "gateway.compaction_done": "progress",
     # lifecycle — gateway daemon lifecycle notifications
     "gateway.restart_success": "lifecycle",
     "gateway.gateway_online": "lifecycle",

--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -225,15 +225,25 @@ def _config_language_cached() -> str | None:
 def agent_display_name() -> str:
     """Configured agent name for ``{name}`` substitution; ``"Hermes"`` fallback.
 
-    Sourced from ``ui.theme.branding.agent_name`` (the only user-set agent name
-    in config; unused elsewhere in the gateway, so reusing it is safe).
+    Sourced from the skin selected by ``display.skin``, matching the CLI/TUI
+    branding path. Loading is cached with the other config-derived i18n state.
     """
-    branding = (
-        ((_load_config_dict().get("ui") or {}).get("theme") or {}).get("branding") or {}
-    )
-    name = branding.get("agent_name")
-    if isinstance(name, str) and name.strip():
-        return name.strip()
+    config = _load_config_dict()
+    display = config.get("display") or {}
+    if not isinstance(display, dict):
+        display = {}
+    skin_name = display.get("skin", "default")
+    if not isinstance(skin_name, str) or not skin_name.strip():
+        skin_name = "default"
+
+    try:
+        from hermes_cli.skin_engine import load_skin
+
+        name = load_skin(skin_name.strip()).get_branding("agent_name", "Hermes")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    except Exception as exc:
+        logger.debug("i18n could not resolve display skin branding: %s", exc)
     return "Hermes"
 
 
@@ -294,6 +304,25 @@ class _SafeFormatter(string.Formatter):
         except (IndexError, KeyError):
             return _MissingField("{" + str(key) + "}")
 
+    def get_field(self, field_name: str, args: Any, kwargs: Any) -> tuple[Any, Any]:
+        """Preserve an unresolved compound field as its complete raw token.
+
+        ``string.Formatter.get_field`` performs ``.attr`` / ``[item]``
+        traversal after :meth:`get_value`. A missing root is therefore not
+        enough on its own: traversing the ``_MissingField`` sentinel would
+        otherwise raise ``AttributeError`` or ``TypeError``. Known roots whose
+        requested attribute/item is absent degrade the same way.
+        """
+        root = field_name.split(".", 1)[0].split("[", 1)[0]
+        lookup_key: Any = int(root) if root.isdecimal() else root
+        root_value = self.get_value(lookup_key, args, kwargs)
+        if isinstance(root_value, _MissingField):
+            return _MissingField("{" + field_name + "}"), lookup_key
+        try:
+            return super().get_field(field_name, args, kwargs)
+        except (AttributeError, KeyError, IndexError, TypeError):
+            return _MissingField("{" + field_name + "}"), lookup_key
+
     def format_field(self, value: Any, format_spec: str) -> str:
         # If get_value returned a sentinel for a missing placeholder, reconstruct
         # the raw token -- with or without a format spec.
@@ -317,7 +346,7 @@ def _safe_format(template: str, **kwargs: Any) -> str:
     """Format ``template`` with ``kwargs``; unknown ``{tokens}`` stay literal."""
     try:
         return _SAFE_FORMATTER.vformat(template, (), kwargs)
-    except (KeyError, IndexError, ValueError) as exc:
+    except (AttributeError, KeyError, IndexError, TypeError, ValueError) as exc:
         logger.warning("i18n safe-format failed for template %r: %s", template, exc)
         return template
 

--- a/agent/onboarding.py
+++ b/agent/onboarding.py
@@ -16,6 +16,8 @@ import logging
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
+from agent.i18n import t
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,31 +42,12 @@ def busy_input_hint_gateway(mode: str) -> str:
     message matches reality ("I just interrupted…" vs "I just queued…").
     """
     if mode == "queue":
-        return (
-            "💡 First-time tip — I queued your message instead of interrupting. "
-            "Send `/busy interrupt` to make new messages stop the current task "
-            "immediately, or `/busy status` to check. This notice won't appear again."
-        )
+        return t("gateway.busy_hint_queued")
     if mode == "steer":
-        return (
-            "💡 First-time tip — I steered your message into the current run; "
-            "it will arrive after the next tool call instead of interrupting. "
-            "Send `/busy interrupt` or `/busy queue` to change this, or "
-            "`/busy status` to check. This notice won't appear again."
-        )
+        return t("gateway.busy_hint_steered")
     if mode == "redirect":
-        return (
-            "💡 First-time tip — I redirected the current run using your message. "
-            "Completed work stays in context, and `/stop` still cancels the task. "
-            "Send `/busy queue` to wait for a separate turn, or `/busy status` "
-            "to check. This notice won't appear again."
-        )
-    return (
-        "💡 First-time tip — I just interrupted my current task to answer you. "
-        "Send `/busy queue` to queue follow-ups for after the current task instead, "
-        "`/busy steer` to inject them mid-run without interrupting, or "
-        "`/busy status` to check. This notice won't appear again."
-    )
+        return t("gateway.busy_hint_redirect")
+    return t("gateway.busy_hint_interrupt")
 
 
 def busy_input_hint_cli(mode: str) -> str:
@@ -95,11 +78,7 @@ def busy_input_hint_cli(mode: str) -> str:
 
 
 def tool_progress_hint_gateway() -> str:
-    return (
-        "💡 First-time tip — that tool took a while and I'm streaming every step. "
-        "If the progress messages feel noisy, send `/verbose` to cycle modes "
-        "(all → new → off). This notice won't appear again."
-    )
+    return t("gateway.tool_progress_hint")
 
 
 def tool_progress_hint_cli() -> str:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -39,6 +39,7 @@ from agent.conversation_compression import (
     recover_rotated_compression_session,
 )
 from agent.context_engine import automatic_compaction_status_message
+from agent.i18n import t
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
 from agent.memory_provider import is_trivial_prompt
@@ -476,11 +477,7 @@ def build_turn_context(
     if agent.api_mode != "anthropic_messages":
         try:
             if agent._cleanup_dead_connections():
-                agent._emit_status(
-                    "🔌 Detected stale connections from a previous provider "
-                    "issue — cleaned up automatically. Proceeding with fresh "
-                    "connection."
-                )
+                agent._emit_status(t("gateway.stale_connections_cleaned"))
         except Exception:
             pass
     # Replay compression warning through status_callback for gateway platforms.
@@ -860,9 +857,10 @@ def build_turn_context(
             _preflight_status = automatic_compaction_status_message(
                 _compressor,
                 phase="preflight",
-                default_message=PREFLIGHT_COMPRESSION_STATUS_TEMPLATE.format(
-                    tokens=_preflight_tokens,
-                    threshold=_compressor.threshold_tokens,
+                default_message=t(
+                    "gateway.preflight_compression",
+                    tokens=f"{_preflight_tokens:,}",
+                    threshold=f"{_compressor.threshold_tokens:,}",
                 ),
                 approx_tokens=_preflight_tokens,
                 threshold_tokens=_compressor.threshold_tokens,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.i18n import t
 from agent.message_content import flatten_message_text
 
 
@@ -130,8 +131,11 @@ def finalize_turn(
         # user message and makes a single toolless request.
         _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
         agent._emit_status(
-            f"⚠️ Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
-            "— asking model to summarise"
+            t(
+                "gateway.iteration_budget_exhausted",
+                n=api_call_count,
+                max=agent.max_iterations,
+            )
         )
         if not agent.quiet_mode:
             agent._safe_print(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -39,6 +39,7 @@ from typing import Any, List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from agent.i18n import t
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import (
@@ -110,27 +111,16 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
             reason = "weekly usage limit"
         elif "quota" in lower:
             reason = "quota limit"
-        return (
-            f"⚠️ Cron '{job_name}' failed: provider {reason}. "
-            "Fallback chain was exhausted or unavailable. "
-            "Full details saved in cron output."
-        )
+        return t("gateway.cron_failure_rate_limit", job_name=job_name, reason=reason)
 
     if "readtimeout" in lower or "timed out" in lower or "timeout" in lower:
-        return (
-            f"⚠️ Cron '{job_name}' failed: provider timeout. "
-            "Fallback chain was exhausted or unavailable. "
-            "Full details saved in cron output."
-        )
+        return t("gateway.cron_failure_timeout", job_name=job_name)
 
     # Match authentication/authorization wording at a word boundary and the
     # 401/403 status codes as whole tokens, so "oauth", "4015" and similar do
     # not trip a misleading auth message.
     if re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text):
-        return (
-            f"⚠️ Cron '{job_name}' failed: provider authentication error. "
-            "Full details saved in cron output."
-        )
+        return t("gateway.cron_failure_auth", job_name=job_name)
 
     # Strip common exception wrappers and collapse provider payloads. Bound
     # the input first so a multi-KB provider blob cannot slow the
@@ -142,7 +132,7 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
     if len(cleaned) > 180:
         cleaned = cleaned[:177].rstrip() + "..."
-    return f"⚠️ Cron '{job_name}' failed: {cleaned}"
+    return t("gateway.cron_failure_generic", job_name=job_name, cleaned=cleaned)
 
 
 class CronPromptInjectionBlocked(Exception):
@@ -1509,11 +1499,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
         delivery_content = (
-            f"Cronjob Response: {task_name}\n"
+            t("gateway.cron_response_prefix") + f"{task_name}\n"
             f"(job_id: {job_id})\n"
             f"-------------\n\n"
-            f"{content}\n\n"
-            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+            f"{content}"
+            + t("gateway.cron_stop_hint_prefix") + f"{task_name}\")."
         )
     else:
         delivery_content = content
@@ -2836,10 +2826,11 @@ def run_job(
             # Script crashed / timed out / exited non-zero.  Deliver the
             # error so the user knows the watchdog itself broke — silent
             # failure for an alerting job is the worst-case outcome.
-            alert = (
-                f"⚠ Cron watchdog '{job_name}' script failed\n\n"
-                f"{output}\n\n"
-                f"Time: {now_iso}"
+            alert = t(
+                "gateway.cron_watchdog_failed",
+                job_name=job_name,
+                output=output,
+                now_iso=now_iso,
             )
             doc = (
                 f"# Cron Job: {job_name}\n\n"

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -254,6 +254,30 @@ if [ "$needs_chown" = true ]; then
     done
 fi
 
+# Top-level files in the data volume (config.yaml, .env, SOUL.md, restart/update
+# markers, ...) are hermes-managed state — NOT host-bind mounts, which are always
+# mounted at a subdir (e.g. /opt/data/homeassistant), never a bare top-level file.
+# Two ways these break a reader/writer running as hermes with EACCES:
+#   1. Wrong OWNER (root-written seed / UID remap) — fixed by chown.
+#   2. Wrong MODE — e.g. SOUL.md is seeded 0444 (read-only). config migration
+#      rewrites it via shutil.copy2; on a read-only file that raises EACCES,
+#      which aborts + rolls back the WHOLE migration, leaving the config at an
+#      old schema the new loader rejects ("Could not load config.yaml") so the
+#      gateway silently falls back to defaults (wrong language, no suppression,
+#      streaming re-enabled). kanban hits the same EACCES and disables.
+# Give hermes ownership + owner read/write on just the depth-1 regular files so
+# the runtime can always read AND rewrite them, without recursing into subdirs
+# (that would clobber bind-mounted host files). Latent all along; only surfaced
+# once a newer migration step began touching SOUL.md. Runs unconditionally — a
+# mis-owned/mis-moded top-level file can exist even when $HERMES_HOME itself
+# already has the right owner.
+if [ -d "$HERMES_HOME" ] && ! refuse_symlinked_path "top-level file perms" "$HERMES_HOME"; then
+    find "$HERMES_HOME" -maxdepth 1 -type f -exec chown hermes:hermes {} + 2>/dev/null \
+        || echo "[stage2] Warning: top-level data-file chown failed (rootless container?) — continuing"
+    find "$HERMES_HOME" -maxdepth 1 -type f -exec chmod u+rw {} + 2>/dev/null \
+        || echo "[stage2] Warning: top-level data-file chmod failed (rootless container?) — continuing"
+fi
+
 # --- Immutable install tree ---
 # Do not chown runtime code or dependency trees under $INSTALL_DIR back to the
 # hermes user. Hosted/container instances keep mutable state under

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -545,25 +545,28 @@ class GatewayKanbanWatchersMixin:
                             # the self-post outcome, not by skipping the send.
                             continue
                         try:
-                            _send_res = await adapter.send(
-                                sub["chat_id"], msg, metadata=metadata,
-                            )
-                            # A SendResult(success=False) without an exception
-                            # (returned by push-capable adapters on a genuine
-                            # transient failure) must count as a FAILED
-                            # delivery — otherwise the cursor advances and the
-                            # event is permanently lost. Adapters returning
-                            # None (or anything non-SendResult shaped) keep
-                            # the legacy "no exception == delivered" contract.
-                            if getattr(_send_res, "success", True) is False:
-                                raise RuntimeError(
-                                    "adapter send() reported failure: "
-                                    f"{getattr(_send_res, 'error', None) or 'unknown error'}"
+                            # Skip the text notification when category suppression
+                            # (gateway.system_messages.suppress) blanked it to "".
+                            if msg and msg.strip():
+                                _send_res = await adapter.send(
+                                    sub["chat_id"], msg, metadata=metadata,
                                 )
-                            logger.debug(
-                                "kanban notifier: delivered %s event for %s to %s/%s on board %s",
-                                kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
-                            )
+                                # A SendResult(success=False) without an exception
+                                # (returned by push-capable adapters on a genuine
+                                # transient failure) must count as a FAILED
+                                # delivery — otherwise the cursor advances and the
+                                # event is permanently lost. Adapters returning
+                                # None (or anything non-SendResult shaped) keep
+                                # the legacy "no exception == delivered" contract.
+                                if getattr(_send_res, "success", True) is False:
+                                    raise RuntimeError(
+                                        "adapter send() reported failure: "
+                                        f"{getattr(_send_res, 'error', None) or 'unknown error'}"
+                                    )
+                                logger.debug(
+                                    "kanban notifier: delivered %s event for %s to %s/%s on board %s",
+                                    kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
+                                )
                             # After delivering the text notification, surface
                             # any artifact paths the worker referenced in
                             # ``kanban_complete(summary=..., artifacts=[...])``

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -428,35 +428,53 @@ class GatewayKanbanWatchersMixin:
                                 lines = task.result.strip().splitlines()
                                 r = lines[0][:160] if lines else task.result[:160]
                                 handoff = f"\n{r}"
-                            msg = (
-                                f"✔ {board_tag}{tag}Kanban {sub['task_id']} done"
-                                f" — {title}{handoff}"
+                            msg = t(
+                                "gateway.kanban_done",
+                                board_tag=board_tag,
+                                tag=tag,
+                                task_id=sub["task_id"],
+                                title=title,
+                                handoff=handoff,
                             )
                         elif kind == "blocked":
                             reason = ""
                             if ev.payload and ev.payload.get("reason"):
                                 reason = f": {str(ev.payload['reason'])[:160]}"
-                            msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
+                            msg = t(
+                                "gateway.kanban_blocked",
+                                board_tag=board_tag,
+                                tag=tag,
+                                task_id=sub["task_id"],
+                                reason=reason,
+                            )
                         elif kind == "gave_up":
                             err = ""
                             if ev.payload and ev.payload.get("error"):
                                 err = f"\n{str(ev.payload['error'])[:200]}"
-                            msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
-                                f"after repeated spawn failures{err}"
+                            msg = t(
+                                "gateway.kanban_gave_up",
+                                board_tag=board_tag,
+                                tag=tag,
+                                task_id=sub["task_id"],
+                                err=err,
                             )
                         elif kind == "crashed":
-                            msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} worker crashed "
-                                f"(pid gone); dispatcher will retry"
+                            msg = t(
+                                "gateway.kanban_crashed",
+                                board_tag=board_tag,
+                                tag=tag,
+                                task_id=sub["task_id"],
                             )
                         elif kind == "timed_out":
                             limit = 0
                             if ev.payload and ev.payload.get("limit_seconds"):
                                 limit = int(ev.payload["limit_seconds"])
-                            msg = (
-                                f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
-                                f"(max_runtime={limit}s); will retry"
+                            msg = t(
+                                "gateway.kanban_timed_out",
+                                board_tag=board_tag,
+                                tag=tag,
+                                task_id=sub["task_id"],
+                                limit=limit,
                             )
                         elif kind == "status":
                             new_status = ""

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -23,6 +23,7 @@ from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
+from agent.i18n import t
 
 logger = logging.getLogger(__name__)
 
@@ -3688,6 +3689,10 @@ class BasePlatformAdapter(ABC):
         """
         return text
 
+    def _ea_header(self) -> str:
+        """Resolve the approval header at send time for localized adapters."""
+        return self._EA_HEADER
+
     def _format_exec_approval(
         self,
         command: str,
@@ -3704,7 +3709,7 @@ class BasePlatformAdapter(ABC):
         """
         cmd_preview = self._truncate_preview(str(command or ""), self._EA_CMD_BUDGET)
         text = (
-            f"{self._EA_HEADER}"
+            f"{self._ea_header()}"
             f"{self._EA_CODE_OPEN}{self._ea_escape(cmd_preview)}{self._EA_CODE_CLOSE}"
             f"{self._EA_REASON_LABEL}{self._ea_escape(description)}"
         )
@@ -3826,25 +3831,21 @@ class BasePlatformAdapter(ABC):
                 _is_multi = bool(_entry and getattr(_entry, "multi_select", False))
             except Exception:
                 _is_multi = False
-            lines = [f"❓ {question}", ""]
+            lines = [t("gateway.clarify_question", question=question), ""]
             for i, choice in enumerate(choices, start=1):
                 lines.append(f"  {i}. {choice}")
             lines.append("")
             if _is_multi:
-                lines.append(
-                    "Multiple selections allowed — reply with the numbers "
-                    "separated by commas or spaces (e.g. \"1, 3\"), the option "
-                    "text, or your own answer."
-                )
+                lines.append(t("gateway.clarify_instructions_multi"))
             else:
-                lines.append("Reply with the number, the option text, or your own answer.")
+                lines.append(t("gateway.clarify_instructions"))
             text = "\n".join(lines)
             # Text fallback: enable text-capture so the gateway intercept
             # picks up the user's typed reply (e.g. "2" or choice text).
             from tools.clarify_gateway import mark_awaiting_text
             mark_awaiting_text(clarify_id)
         else:
-            text = f"❓ {question}"
+            text = t("gateway.clarify_question", question=question)
         return await self.send(
             chat_id=chat_id,
             content=text,
@@ -5108,10 +5109,7 @@ class BasePlatformAdapter(ABC):
             else:
                 # All retries exhausted (loop completed without break) — notify user
                 logger.error("[%s] Failed to deliver response after %d retries: %s", self.name, max_retries, error_str)
-                notice = (
-                    "\u26a0\ufe0f Message delivery failed after multiple attempts. "
-                    "Please try again \u2014 your request was processed but the response could not be sent."
-                )
+                notice = t("gateway.delivery_failed")
                 try:
                     await self.send(chat_id=chat_id, content=notice, reply_to=reply_to, metadata=metadata)
                 except Exception as notify_err:
@@ -5122,7 +5120,7 @@ class BasePlatformAdapter(ABC):
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
         fallback_result = await self.send(
             chat_id=chat_id,
-            content=f"(Response formatting failed, plain text:)\n\n{content[:3500]}",
+            content=t("gateway.response_formatting_failed", content=content[:3500]),
             reply_to=reply_to,
             metadata=metadata,
         )

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -38,6 +38,8 @@ from pathlib import Path
 from abc import ABC, abstractmethod
 from typing import Any, Callable, ClassVar, Dict, Iterator, List, Optional, Tuple
 
+from agent.i18n import t
+
 import sys
 
 import httpx
@@ -4740,11 +4742,14 @@ class MessageSender:
     @staticmethod
     def strip_cron_wrapper(content: str) -> str:
         """Strip scheduler cron header/footer wrapper for cleaner Yuanbao output."""
-        if not content.startswith("Cronjob Response: "):
+        # Match the same localized prefixes the scheduler produces (t() renders
+        # in the active language for both producer and consumer, keeping the
+        # wrapper strip locale-symmetric).
+        if not content.startswith(t("gateway.cron_response_prefix")):
             return content
 
         divider = "\n-------------\n\n"
-        footer_prefix = '\n\nTo stop or manage this job, send me a new message (e.g. "stop reminder '
+        footer_prefix = t("gateway.cron_stop_hint_prefix")
         divider_pos = content.find(divider)
         footer_pos = content.rfind(footer_prefix)
         if divider_pos < 0 or footer_pos < 0 or footer_pos <= divider_pos:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16335,22 +16335,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter = self._adapter_for_source(source)
                     if adapter:
                         if reset_reason == "suspended":
-                            reason_text = "previous session was stopped or interrupted"
+                            reason_text = t("gateway.session_reset_reason_suspended")
                         elif reset_reason == "resume_pending_expired":
-                            reason_text = "gateway restart recovery timed out"
+                            reason_text = t(
+                                "gateway.session_reset_reason_resume_pending_expired"
+                            )
                         elif reset_reason == "daily":
-                            reason_text = f"daily schedule at {policy.at_hour}:00"
+                            reason_text = t("gateway.session_reset_reason_daily", hour=policy.at_hour)
                         else:
                             hours = policy.idle_minutes // 60
                             mins = policy.idle_minutes % 60
                             duration = f"{hours}h" if not mins else f"{hours}h {mins}m" if hours else f"{mins}m"
-                            reason_text = f"inactive for {duration}"
-                        notice = (
-                            f"◐ Session automatically reset ({reason_text}). "
-                            f"Conversation history cleared.\n"
-                            f"Use /resume to browse and restore a previous session.\n"
-                            f"Adjust reset timing in config.yaml under session_reset."
-                        )
+                            reason_text = t("gateway.session_reset_reason_idle", duration=duration)
+                        notice = t("gateway.session_reset_notice", reason=reason_text)
                         try:
                             session_info = await asyncio.to_thread(
                                 self._reset_notice_session_info, source

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20891,10 +20891,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     metadata["user_id"] = str(data["user_id"])
                 if data.get("scope_id"):
                     metadata["scope_id"] = str(data["scope_id"])
+            _restart_text = t("gateway.restart_success")
+            # Category suppression (suppress: lifecycle) blanks this to "".
+            if not (_restart_text and _restart_text.strip()):
+                return None
             result = await transport.send(
                 platform,
                 str(chat_id),
-                t("gateway.restart_success"),
+                _restart_text,
                 metadata=_non_conversational_metadata(metadata, platform=platform),
             )
             # adapter.send() catches provider errors (e.g. "Chat not found")
@@ -20936,6 +20940,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         delivered: set[tuple[str, str, Optional[str]]] = set()
         skipped = skip_targets or set()
         message = t("gateway.gateway_online")
+        # Category suppression (gateway.system_messages.suppress: lifecycle)
+        # blanks this to ""; skip the whole online broadcast then.
+        if not (message and message.strip()):
+            return delivered
 
         for platform, platform_cfg in self.config.platforms.items():
             home = platform_cfg.home_channel
@@ -24720,7 +24728,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 try:
                     _notify_res = None
-                    if _heartbeat_msg_id:
+                    # Category suppression (gateway.system_messages.suppress: progress)
+                    # blanks the heartbeat to ""; skip the edit/send so no empty
+                    # progress bubble is delivered.
+                    _hb_visible = bool(_heartbeat_text and _heartbeat_text.strip())
+                    if _heartbeat_msg_id and _hb_visible:
                         try:
                             _notify_res = await _notify_adapter.edit_message(
                                 source.chat_id,
@@ -24730,7 +24742,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         except Exception as _ee:
                             logger.debug("Heartbeat edit failed: %s", _ee)
                             _notify_res = None
-                    if not (_notify_res and getattr(_notify_res, "success", False)):
+                    if _hb_visible and not (_notify_res and getattr(_notify_res, "success", False)):
                         _notify_res = await _notify_adapter.send(
                             source.chat_id,
                             _heartbeat_text,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -501,6 +501,14 @@ def _format_exec_approval_fallback(
 ) -> str:
     """Render the text fallback from approval capabilities, not platform names."""
     cmd_preview = command[:200] + "..." if len(command) > 200 else command
+    if allow_permanent and not smart_denied:
+        return t(
+            "gateway.dangerous_command_approval_text",
+            command=cmd_preview,
+            reason=description,
+            prefix=command_prefix,
+        )
+
     heading = "⚠️ **Dangerous command requires approval:**"
     if smart_denied:
         heading = "⚠️ **Smart DENY — owner override for one operation:**"
@@ -522,21 +530,12 @@ def _format_exec_approval_fallback(
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
-        return (
-            "⚠️ Provider authentication failed. Check the configured credentials; "
-            "raw provider details are in the gateway logs."
-        )
+        return t("gateway.provider_auth_failed")
     if _GATEWAY_PROVIDER_POLICY_RE.search(text):
-        return (
-            "⚠️ The model provider rejected the request. I kept the raw provider "
-            "error out of chat; check gateway logs for details or try rephrasing."
-        )
+        return t("gateway.provider_rejected")
     if _GATEWAY_RATE_LIMIT_RE.search(text):
-        return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
-    return (
-        "⚠️ The model provider failed after retries. I kept raw provider details "
-        "out of chat; check gateway logs for diagnostics."
-    )
+        return t("gateway.provider_rate_limited")
+    return t("gateway.provider_failed")
 
 
 _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
@@ -3352,15 +3351,8 @@ def _normalize_empty_agent_response(
             for p in ("context", "token", "too large", "too long", "exceed", "payload")
         ) or ("400" in error_str and history_len > 50)
         if is_context_failure:
-            return (
-                "⚠️ Session too large for the model's context window.\n"
-                "Use /compact to compress the conversation, or "
-                "/reset to start fresh."
-            )
-        return (
-            f"The request failed: {str(error_detail)[:300]}\n"
-            "Try again or use /reset to start a fresh session."
-        )
+            return t("gateway.session_too_large")
+        return t("gateway.request_failed", error=str(error_detail)[:300])
 
     api_calls = int(agent_result.get("api_calls", 0) or 0)
     if agent_result.get("interrupted"):
@@ -3383,11 +3375,8 @@ def _normalize_empty_agent_response(
             return ""
         if agent_result.get("partial"):
             err = agent_result.get("error", "processing incomplete")
-            return f"⚠️ Processing stopped: {str(err)[:200]}. Try again."
-        return (
-            "⚠️ Processing completed but no response was generated. "
-            "This may be a transient error — try sending your message again."
-        )
+            return t("gateway.processing_stopped", error=str(err)[:200])
+        return t("gateway.empty_response")
 
     # api_calls == 0, not failed, not interrupted: the agent never ran for
     # this turn. This is the post-/stop generation-race pattern where the
@@ -8647,9 +8636,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
             if self._queue_during_drain_enabled():
                 self._queue_or_replace_pending_event(session_key, event)
-                message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                message = t("gateway.busy_queued_drain", gerund=self._status_action_gerund())
             else:
-                message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
+                message = t("gateway.busy_not_accepting_turn", gerund=self._status_action_gerund())
 
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
@@ -8980,38 +8969,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
         if is_steer_mode:
-            message = (
-                f"⏩ Steered into current run{status_detail}. "
-                f"Your message arrives after the next tool call."
-            )
+            message = t("gateway.steered_into_run", status_detail=status_detail)
         elif is_redirect_mode:
-            message = (
-                f"↪ Redirected current run{status_detail}. "
-                f"I'll adjust using your correction."
-            )
+            message = t("gateway.redirected_current_run", status_detail=status_detail)
         elif is_queue_mode and demoted_for_subagents:
             # #30170 — explain the demotion so the user knows their
             # follow-up didn't accidentally kill the subagent and
             # discovers `/stop` as the explicit escape hatch.
-            message = (
-                f"⏳ Subagent working{status_detail} — your message is queued for "
-                f"when it finishes (use /stop to cancel everything)."
-            )
+            message = t("gateway.subagent_working", status_detail=status_detail)
         elif is_queue_mode and demoted_for_compression:
-            message = (
-                f"⏳ Compressing context{status_detail} — your message is queued for "
-                f"when it finishes (use /stop to cancel everything)."
-            )
+            message = t("gateway.compressing_context", status_detail=status_detail)
         elif is_queue_mode:
-            message = (
-                f"⏳ Queued for the next turn{status_detail}. "
-                f"I'll respond once the current task finishes."
-            )
+            message = t("gateway.queued_next_turn", status_detail=status_detail)
         else:
-            message = (
-                f"⚡ Interrupting current task{status_detail}. "
-                f"I'll respond to your message shortly."
-            )
+            message = t("gateway.interrupting_task", status_detail=status_detail)
 
         # First-touch onboarding: the very first time a user sends a message
         # while the agent is busy, append a one-time hint explaining the
@@ -9141,14 +9112,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         active = self._snapshot_running_agents()
         restart_source = self._restart_command_source if self._restart_requested else None
 
-        action = "restarting" if self._restart_requested else "shutting down"
-        hint = (
-            "Your current task will be interrupted. "
-            "Send any message after restart and I'll try to resume where you left off."
+        msg = (
+            t("gateway.shutdown_restarting")
             if self._restart_requested
-            else "Your current task will be interrupted."
+            else t("gateway.shutdown_shutting_down")
         )
-        msg = f"⚠️ Gateway {action} — {hint}"
 
         notified: set[tuple[str, str, Optional[str]]] = set()
         for session_key in active:
@@ -14433,10 +14401,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     prompt_path.unlink(missing_ok=True)
                 except OSError as e:
                     logger.warning("Failed to write update response: %s", e)
-                    return f"✗ Failed to send response to update process: {e}"
+                    return t("gateway.steer_update_send_failed", error=e)
                 _up_state.persistent.update_prompt_pending = False
                 label = response_text if len(response_text) <= 20 else response_text[:20] + "…"
-                return f"✓ Sent `{label}` to the update process."
+                return t("gateway.steer_update_sent", label=label)
             # Recognized slash command during a pending update prompt:
             # unblock the detached update subprocess by writing a blank
             # response so ``_gateway_prompt`` returns the prompt's default
@@ -14714,7 +14682,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Force-clean the sentinel so the session is unlocked.
                     self._release_running_agent_state(_quick_key)
                     logger.info("HARD STOP (pending) for session %s — sentinel cleared", _quick_key)
-                    return EphemeralReply("⚡ Force-stopped. The agent was still starting — session unlocked.")
+                    return EphemeralReply(t("gateway.force_stopped_starting"))
                 # Queue the message so it will be picked up after the
                 # agent starts.
                 adapter = self._adapter_for_source(source)
@@ -14730,9 +14698,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if self._queue_during_drain_enabled():
                     self._queue_or_replace_pending_event(_quick_key, event)
                 return (
-                    f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                    t("gateway.busy_queued_drain", gerund=self._status_action_gerund())
                     if self._queue_during_drain_enabled()
-                    else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
+                    else t("gateway.busy_not_accepting_turn", gerund=self._status_action_gerund())
                 )
             if self._busy_input_mode == "queue":
                 logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
@@ -14919,7 +14887,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message = hook_result.get("message")
                     if isinstance(message, str) and message:
                         return message
-                    return f"Command `/{command}` was blocked by a hook."
+                    return t("gateway.command_blocked_hook", command=command)
                 if decision == "handled":
                     message = hook_result.get("message")
                     return message if isinstance(message, str) and message else None
@@ -15218,7 +15186,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # message. If the payload is empty, surface the usage hint.
             steer_payload = event.get_command_args().strip()
             if not steer_payload:
-                return "Usage: /steer <prompt>  (no agent is running; sending as a normal message)"
+                return t("gateway.steer_usage_no_agent")
             try:
                 event.text = steer_payload
             except Exception:
@@ -15273,7 +15241,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return await self._handle_voice_command(event)
 
         if self._draining:
-            return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
+            return t("gateway.busy_not_accepting_work", gerund=self._status_action_gerund())
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
@@ -15316,13 +15284,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             if output:
                                 from agent.redact import redact_sensitive_text
                                 output = redact_sensitive_text(output)
-                            return output if output else "Command returned no output."
+                            return output if output else t("gateway.quick_cmd_no_output")
                         except asyncio.TimeoutError:
-                            return "Quick command timed out (30s)."
+                            return t("gateway.quick_cmd_timeout")
                         except Exception as e:
-                            return f"Quick command error: {e}"
+                            return t("gateway.quick_cmd_error", error=e)
                     else:
-                        return f"Quick command '/{command}' has no command defined."
+                        return t("gateway.quick_cmd_no_command", command=command)
                 elif qcmd.get("type") == "alias":
                     target = (qcmd.get("target") or "").strip()
                     if target:
@@ -15333,9 +15301,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         command = target_command.split()[0] if target_command else target_command
                         # Fall through to normal command dispatch below
                     else:
-                        return f"Quick command '/{command}' has no target defined."
+                        return t("gateway.quick_cmd_no_target", command=command)
                 else:
-                    return f"Quick command '/{command}' has unsupported type (supported: 'exec', 'alias')."
+                    return t("gateway.quick_cmd_unsupported_type", command=command)
 
         # Plugin-registered slash commands
         if command:
@@ -17125,14 +17093,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         # reaches gateway users directly.
                                         from agent.redact import redact_sensitive_text
                                         _err = redact_sensitive_text(_err, force=True)
-                                        _warn_msg = (
-                                            "⚠️ Context compression aborted "
-                                            f"({_err}). No messages were dropped — "
-                                            "conversation is unchanged. Run /compress "
-                                            "to retry, /reset for a clean session, or "
-                                            "check your auxiliary.compression model "
-                                            "configuration."
-                                        )
+                                        _warn_msg = t("gateway.compress_aborted", err=_err)
                                         try:
                                             _adapter = self._adapter_for_source(source)
                                             if _adapter and source.chat_id:
@@ -17151,11 +17112,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     elif _comp is not None and getattr(_comp, "_last_aux_model_failure_model", None):
                                         _aux_model = getattr(_comp, "_last_aux_model_failure_model", "")
                                         _aux_err = getattr(_comp, "_last_aux_model_failure_error", None) or "unknown error"
-                                        _aux_msg = (
-                                            f"ℹ️ Configured compression model `{_aux_model}` "
-                                            f"failed ({_aux_err}). Recovered using your main "
-                                            "model — context is intact — but you may want to "
-                                            "check `auxiliary.compression.model` in config.yaml."
+                                        _aux_msg = t(
+                                            "gateway.compress_aux_model_failed",
+                                            model=_aux_model,
+                                            err=_aux_err,
                                         )
                                         try:
                                             _adapter = self._adapter_for_source(source)
@@ -17459,11 +17419,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # prefill, empty-retry, fallback).  Sending the raw sentinel
             # looks like a bug; a short explanation is more helpful.
             if response == "(empty)" and not _intentional_silence:
-                response = (
-                    "⚠️ The model returned no response after processing tool "
-                    "results. This can happen with some models — try again or "
-                    "rephrase your question."
-                )
+                response = t("gateway.model_no_response_tool_results")
             agent_messages = agent_result.get("messages", [])
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
@@ -17774,11 +17730,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         self._sync_telegram_topic_binding,
                         source, session_entry, reason="compression-exhausted-reset",
                     )
-                response = (response or "") + (
-                    "\n\n🔄 Session auto-reset — the conversation exceeded the "
-                    "maximum context size and could not be compressed further. "
-                    "Your next message will start a fresh session."
-                )
+                response = (response or "") + t("gateway.session_auto_reset")
 
             ts = time.time()  # Unix epoch float — consistent with DB storage
             
@@ -18083,9 +18035,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             status_code = getattr(e, "status_code", None)
             _hist_len = len(history) if 'history' in locals() else 0
             if status_code == 401:
-                status_hint = " Check your API key or run `claude /login` to refresh OAuth credentials."
+                status_hint = t("gateway.api_hint_auth")
             elif status_code == 402:
-                status_hint = " Your API balance or quota is exhausted. Check your provider dashboard."
+                status_hint = t("gateway.api_hint_billing")
             elif status_code == 429:
                 # Check if this is a plan usage limit (resets on a schedule) vs a transient rate limit
                 _err_body = getattr(e, "response", None)
@@ -18102,28 +18054,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _resets_in and _resets_in > 0:
                         import math
                         _hours = math.ceil(_resets_in / 3600)
-                        status_hint = f" Your plan's usage limit has been reached. It resets in ~{_hours}h."
+                        status_hint = t("gateway.api_hint_plan_limit_hours", hours=_hours)
                     else:
-                        status_hint = " Your plan's usage limit has been reached. Please wait until it resets."
+                        status_hint = t("gateway.api_hint_plan_limit")
                 else:
-                    status_hint = " You are being rate-limited. Please wait a moment and try again."
+                    status_hint = t("gateway.api_hint_rate_limited")
             elif status_code == 529:
-                status_hint = " The API is temporarily overloaded. Please try again shortly."
+                status_hint = t("gateway.api_hint_overloaded")
             elif status_code in {400, 500}:
                 # 400 with a large session is context overflow.
                 # 500 with a large session often means the payload is too large
                 # for the API to process — treat it the same way.
                 if _hist_len > 50:
-                    return (
-                        "⚠️ Session too large for the model's context window.\n"
-                        "Use /compact to compress the conversation, or "
-                        "/reset to start fresh."
-                    )
+                    return t("gateway.session_too_large")
                 elif status_code == 400:
-                    status_hint = " The request was rejected by the API."
-            return (
-                f"Sorry, I encountered an unexpected error.{status_hint}\n"
-                "Try again or use /reset to start a fresh session."
+                    status_hint = t("gateway.api_hint_rejected")
+            return t(
+                "gateway.api_error_generic",
+                error_type="",
+                error_detail="",
+                status_hint=status_hint,
             )
         finally:
             # Restore session context variables to their pre-handler state
@@ -18300,19 +18250,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         allowed_preview = sorted(policy.user_allowed_commands)
         if allowed_preview:
-            suffix = (
-                "You can run: "
-                + ", ".join(f"/{c}" for c in allowed_preview[:12])
+            allowed_list = (
+                ", ".join(f"/{c}" for c in allowed_preview[:12])
                 + ("…" if len(allowed_preview) > 12 else "")
-                + ". Use /whoami for the full list."
             )
-        else:
-            suffix = (
-                "No slash commands are enabled for non-admins on this "
-                "platform. Ask an admin to add you to allow_admin_from "
-                "or to set user_allowed_commands."
+            return t(
+                "gateway.admin_only_with_allowed",
+                cmd=canonical_cmd,
+                allowed_list=allowed_list,
             )
-        return f"⛔ /{canonical_cmd} is admin-only here. {suffix}"
+        return t("gateway.admin_only_no_commands", cmd=canonical_cmd)
 
 
 
@@ -18479,7 +18426,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return handle_suggestions_command(args, origin=origin, surface="gateway")
         except Exception as e:
             logger.debug("suggestions command failed: %s", e)
-            return f"Suggestions command failed: {e}"
+            return t("gateway.suggestions_failed", error=e)
 
     async def _handle_blueprint_command(self, event: MessageEvent):
         """Handle /blueprint in the gateway.
@@ -19254,7 +19201,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not runtime_kwargs.get("api_key"):
                 await adapter.send(
                     source.chat_id,
-                    f"❌ Background task {task_id} failed: no provider credentials configured.",
+                    t("gateway.bg_task_no_creds", task_id=task_id),
                     metadata=_thread_metadata,
                 )
                 return
@@ -19346,7 +19293,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 images, text_content = adapter.extract_images(response)
 
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
-                header = f'✅ Background task complete\nPrompt: "{preview}"\n\n'
+                header = t("gateway.bg_task_complete", preview=preview)
 
                 if text_content:
                     await adapter.send(
@@ -19357,7 +19304,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 elif not images and not media_files:
                     await adapter.send(
                         chat_id=source.chat_id,
-                        content=header + "(No response generated)",
+                        content=header + t("gateway.no_response_generated"),
                         metadata=_thread_metadata,
                     )
 
@@ -19414,7 +19361,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
                 await adapter.send(
                     chat_id=source.chat_id,
-                    content=f'✅ Background task complete\nPrompt: "{preview}"\n\n(No response generated)',
+                    content=t("gateway.bg_task_complete", preview=preview)
+                    + t("gateway.no_response_generated"),
                     metadata=_thread_metadata,
                 )
 
@@ -19423,7 +19371,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 await adapter.send(
                     chat_id=source.chat_id,
-                    content=f"❌ Background task {task_id} failed: {e}",
+                    content=t("gateway.bg_task_failed", task_id=task_id, error=e),
                     metadata=_thread_metadata,
                 )
             except Exception:
@@ -19963,7 +19911,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return format_session_db_unavailable(prefix=t("gateway.shared.session_db_unavailable_prefix"))
         chat_id = str(source.chat_id or "")
         if not chat_id:
-            return "Could not determine chat ID."
+            return t("gateway.topic_no_chat_id")
         # No-op if never enabled.
         try:
             currently_enabled = await self._session_db.is_telegram_topic_mode_enabled(
@@ -19973,7 +19921,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             currently_enabled = False
         if not currently_enabled:
-            return "Multi-session topic mode is not currently enabled for this chat."
+            return t("gateway.topic_not_enabled")
         try:
             await self._session_db.disable_telegram_topic_mode(chat_id=chat_id)
         except Exception as exc:
@@ -19985,12 +19933,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             store = getattr(self, attr, None)
             if isinstance(store, dict):
                 store.pop(chat_id, None)
-        return (
-            "Multi-session topic mode is now OFF for this chat.\n\n"
-            "Existing topics in Telegram aren't removed — they'll just stop "
-            "being gated as independent sessions. The root DM works as a "
-            "normal Hermes chat again. Run /topic to re-enable later."
-        )
+        return t("gateway.topic_disabled")
 
 
     async def _telegram_topic_root_status_message(self, source: SessionSource) -> str:
@@ -20031,11 +19974,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ])
         else:
             lines.extend([
-                "No previous unlinked Telegram sessions found.",
+                t("gateway.topic_no_unlinked_sessions"),
                 "",
-                "To restore a previous session later:",
-                "1. Create or open a topic. To create a new one, open All Messages and send any message there.",
-                "2. Send /topic <session-id> inside that topic.",
+                t("gateway.topic_restore_instructions"),
             ])
         return "\n".join(lines)
 
@@ -20044,15 +19985,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         source = event.source
         session_id = await self._session_db.resolve_session_id(raw_session_id.strip())
         if not session_id:
-            return f"Session not found: {raw_session_id.strip()}"
+            return t("gateway.session_not_found", session_id=raw_session_id.strip())
 
         session = await self._session_db.get_session(session_id)
         if not session:
-            return f"Session not found: {raw_session_id.strip()}"
+            return t("gateway.session_not_found", session_id=raw_session_id.strip())
         if str(session.get("source") or "") != "telegram":
-            return "That session is not a Telegram session and cannot be restored into this topic."
+            return t("gateway.session_not_telegram")
         if str(session.get("user_id") or "") != str(source.user_id):
-            return "That session does not belong to this Telegram user."
+            return t("gateway.session_wrong_user")
 
         linked = await self._session_db.is_telegram_session_linked_to_topic(session_id=session_id)
         current_binding = await self._session_db.get_telegram_topic_binding(
@@ -20061,7 +20002,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         if linked:
             if not current_binding or current_binding.get("session_id") != session_id:
-                return "That session is already linked to another Telegram topic."
+                return t("gateway.session_already_linked")
 
         session_key = self._session_key_for_source(source)
         try:
@@ -20075,7 +20016,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         except ValueError as exc:
             if "already linked" in str(exc):
-                return "That session is already linked to another Telegram topic."
+                return t("gateway.session_already_linked")
             raise
 
         title = await self._session_db.get_session_title(session_id) or session_id
@@ -20088,9 +20029,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             last_assistant = None
 
-        response = f"Session restored: {title}"
+        response = t("gateway.session_restored", title=title)
         if last_assistant:
-            response += f"\n\nLast Hermes message:\n{last_assistant}"
+            response += t("gateway.session_restored_last_msg", content=last_assistant)
         return response
 
 
@@ -20266,7 +20207,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         async def _on_confirm(choice: str):
             if choice == "cancel":
-                return f"🟡 /{command} cancelled. Conversation unchanged."
+                return t("gateway.command_cancelled", command=command)
             persisted = False
             if choice == "always":
                 try:
@@ -20295,11 +20236,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             result = await execute()
             if choice == "always":
                 if persisted:
-                    note = (
-                        "\n\nℹ️ Future /clear, /new, /reset, and /undo will run "
-                        "without confirmation. Re-enable via "
-                        "`approvals.destructive_slash_confirm: true` in config.yaml."
-                    )
+                    note = t("gateway.slash_confirm_disabled_note")
                 else:
                     # The user did approve this run, so the action still goes
                     # ahead, but the preference did not stick and the prompt
@@ -20319,14 +20256,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return result
 
         _p = self._typed_command_prefix_for(event.source.platform)
-        prompt_message = (
-            f"⚠️ **Confirm /{command}**\n\n"
-            f"{detail}\n\n"
-            "Choose:\n"
-            "• **Approve Once** — proceed this time only\n"
-            "• **Always Approve** — proceed and silence this prompt permanently\n"
-            "• **Cancel** — keep current conversation\n\n"
-            f"_Text fallback: reply `{_p}approve`, `{_p}always`, or `{_p}cancel`._"
+        prompt_message = t(
+            "gateway.slash_confirm_prompt",
+            command=command,
+            detail=detail,
+            prefix=_p,
         )
         return await self._request_slash_confirm(
             event=event,
@@ -20675,13 +20609,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if exit_code == 0:
                         await adapter.send(
                             chat_id,
-                            "✅ Hermes update finished.",
+                            t("gateway.update_finished"),
                             metadata=_non_conversational_metadata(metadata, platform=platform),
                         )
                     else:
                         await adapter.send(
                             chat_id,
-                            "❌ Hermes update failed (exit code {}).".format(exit_code),
+                            t("gateway.update_failed_exit_code", exit_code=exit_code),
                             metadata=_non_conversational_metadata(metadata, platform=platform),
                         )
                     logger.info("Update finished (exit=%s), notified %s", exit_code, session_key)
@@ -20780,7 +20714,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 await adapter.send(
                     chat_id,
-                    "❌ Hermes update timed out after 30 minutes.",
+                    t("gateway.update_timed_out"),
                     metadata=_non_conversational_metadata(metadata, platform=platform),
                 )
             except Exception:
@@ -20883,13 +20817,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if len(output) > 3500:
                         output = "…" + output[-3500:]
                     if exit_code == 0:
-                        msg = f"✅ Hermes update finished.\n\n```\n{output}\n```"
+                        msg = t("gateway.update_finished_output", output=output)
                     else:
-                        msg = f"❌ Hermes update failed.\n\n```\n{output}\n```"
+                        msg = t("gateway.update_failed_output", output=output)
                 elif exit_code == 0:
-                    msg = "✅ Hermes update finished successfully."
+                    msg = t("gateway.update_finished_ok")
                 else:
-                    msg = "❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details."
+                    msg = t("gateway.update_failed_generic")
                 await adapter.send(
                     chat_id,
                     msg,
@@ -20963,7 +20897,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             result = await transport.send(
                 platform,
                 str(chat_id),
-                "♻ Gateway restarted successfully. Your session continues.",
+                t("gateway.restart_success"),
                 metadata=_non_conversational_metadata(metadata, platform=platform),
             )
             # adapter.send() catches provider errors (e.g. "Chat not found")
@@ -21004,7 +20938,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         delivered: set[tuple[str, str, Optional[str]]] = set()
         skipped = skip_targets or set()
-        message = "♻️ Gateway online — Hermes is back and ready."
+        message = t("gateway.gateway_online")
 
         for platform, platform_cfg in self.config.platforms.items():
             home = platform_cfg.home_channel
@@ -23741,7 +23675,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             resp.status, proxy_url, error_text[:500],
                         )
                         return {
-                            "final_response": f"⚠️ Proxy error ({resp.status}): {error_text[:300]}",
+                            "final_response": t("gateway.proxy_error", status=resp.status, detail=error_text[:300]),
                             "messages": [],
                             "api_calls": 0,
                             "tools": [],
@@ -23801,7 +23735,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.error("Proxy connection error to %s: %s", proxy_url, e)
             if not full_response:
                 return {
-                    "final_response": f"⚠️ Proxy connection error: {e}",
+                    "final_response": t("gateway.proxy_connection_error", error=e),
                     "messages": [],
                     "api_calls": 0,
                     "tools": [],
@@ -24781,7 +24715,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _heartbeat_text = (
                     _generic_status_phrase("status")
                     if _long_running_mode == "generic"
-                    else f"⏳ Working — {_elapsed_mins} min{_status_detail}"
+                    else t(
+                        "gateway.long_running",
+                        minutes=_elapsed_mins,
+                        status_detail=_status_detail,
+                    )
                 )
                 try:
                     _notify_res = None
@@ -25025,10 +24963,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             try:
                                 await _warn_adapter.send(
                                     source.chat_id,
-                                    f"⚠️ No activity for {_elapsed_warn} min. "
-                                    f"If the agent does not respond soon, it will "
-                                    f"be timed out in {_remaining_mins} min. "
-                                    f"You can continue waiting or use /reset.",
+                                    t(
+                                        "gateway.no_activity_warning",
+                                        minutes=_elapsed_warn,
+                                        remaining=_remaining_mins,
+                                    ),
                                     metadata=_status_thread_metadata,
                                 )
                             except Exception as _warn_err:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -396,19 +396,19 @@ class GatewaySlashCommandsMixin:
         user_id = (source.user_id if source else None) or "?"
 
         if not policy.enabled:
-            return (
-                f"**You** — {platform} ({scope})\n"
-                f"User ID: `{user_id}`\n"
-                f"Tier: unrestricted (no admin list configured for this scope)\n"
-                f"Slash commands: all available"
+            return t(
+                "gateway.whoami_unrestricted",
+                platform=platform,
+                scope=scope,
+                user_id=user_id,
             )
 
         if policy.is_admin(user_id):
-            return (
-                f"**You** — {platform} ({scope})\n"
-                f"User ID: `{user_id}`\n"
-                f"Tier: **admin**\n"
-                f"Slash commands: all available"
+            return t(
+                "gateway.whoami_admin",
+                platform=platform,
+                scope=scope,
+                user_id=user_id,
             )
 
         # Non-admin user. Show what's actually reachable.
@@ -422,11 +422,12 @@ class GatewaySlashCommandsMixin:
                 seen.add(c)
                 runnable.append(c)
         runnable_str = ", ".join(f"/{c}" for c in runnable) if runnable else "(none)"
-        return (
-            f"**You** — {platform} ({scope})\n"
-            f"User ID: `{user_id}`\n"
-            f"Tier: user\n"
-            f"Slash commands you can run: {runnable_str}"
+        return t(
+            "gateway.whoami_user",
+            platform=platform,
+            scope=scope,
+            user_id=user_id,
+            runnable_str=runnable_str,
         )
 
     async def _handle_kanban_command(self, event: MessageEvent) -> str:
@@ -1455,71 +1456,52 @@ class GatewaySlashCommandsMixin:
             return None
 
         if action == "list":
-            lines = ["**Gateway platforms**"]
+            lines = [t("gateway.platform_list_header")]
             connected = sorted(p.value for p in self.adapters.keys())
             if connected:
-                lines.append("Connected: " + ", ".join(connected))
+                lines.append(t("gateway.platform_connected", platforms=", ".join(connected)))
             else:
-                lines.append("Connected: (none)")
+                lines.append(t("gateway.platform_connected_none"))
             failed = getattr(self, "_failed_platforms", {}) or {}
             if failed:
                 for p, info in failed.items():
                     if info.get("paused"):
                         reason = info.get("pause_reason") or "paused"
                         lines.append(
-                            f"  · {p.value} — PAUSED ({reason}). "
-                            f"Resume with `/platform resume {p.value}`."
+                            t("gateway.platform_failed_paused", platform=p.value, reason=reason)
                         )
                     else:
                         attempts = info.get("attempts", 0)
                         lines.append(
-                            f"  · {p.value} — retrying (attempt {attempts})"
+                            t("gateway.platform_retrying", platform=p.value, attempts=attempts)
                         )
             else:
-                lines.append("Failed/paused: (none)")
+                lines.append(t("gateway.platform_failed_none"))
             return "\n".join(lines)
 
         if action in {"pause", "resume"}:
             if not target:
-                return f"Usage: /platform {action} <name>"
+                return t("gateway.platform_usage", action=action)
             platform = _resolve_platform(target)
             if platform is None:
-                return f"Unknown platform: {target}"
+                return t("gateway.platform_unknown", target=target)
             failed = getattr(self, "_failed_platforms", {}) or {}
             if action == "pause":
                 if platform not in failed:
-                    return (
-                        f"{platform.value} is not in the retry queue "
-                        f"(it's either connected or not enabled)."
-                    )
+                    return t("gateway.platform_not_in_queue", platform=platform.value)
                 if failed[platform].get("paused"):
-                    return f"{platform.value} is already paused."
+                    return t("gateway.platform_already_paused", platform=platform.value)
                 self._pause_failed_platform(platform, reason="paused via /platform pause")
-                return (
-                    f"✓ {platform.value} paused. "
-                    f"Resume with `/platform resume {platform.value}` or "
-                    f"`hermes gateway restart` to reset."
-                )
+                return t("gateway.platform_paused_ok", platform=platform.value)
             # action == "resume"
             if platform not in failed:
-                return (
-                    f"{platform.value} is not in the retry queue — "
-                    f"nothing to resume."
-                )
+                return t("gateway.platform_not_in_queue_resume", platform=platform.value)
             if not failed[platform].get("paused"):
-                return (
-                    f"{platform.value} is already retrying — "
-                    f"no resume needed."
-                )
+                return t("gateway.platform_already_retrying", platform=platform.value)
             self._resume_paused_platform(platform)
-            return f"✓ {platform.value} resumed — retrying on next watcher tick."
+            return t("gateway.platform_resumed_ok", platform=platform.value)
 
-        return (
-            "Usage: /platform <list|pause|resume> [name]\n"
-            "  /platform list — show platform status\n"
-            "  /platform pause <name> — stop retrying a failing platform\n"
-            "  /platform resume <name> — re-queue a paused platform"
-        )
+        return t("gateway.platform_usage_full")
 
     async def _handle_restart_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /restart command - drain active work, then restart the gateway."""
@@ -2434,10 +2416,10 @@ class GatewaySlashCommandsMixin:
                 event=event,
                 command="model",
                 title="Expensive Model Warning",
-                message=(
-                    f"⚠️ **Expensive Model Warning**\n\n{_cost_warning.message}\n\n"
-                    f"_Text fallback: reply `{_p}approve` to switch or `{_p}cancel` to keep "
-                    "the current model._"
+                message=t(
+                    "gateway.model_expensive_warning",
+                    warning_message=_cost_warning.message,
+                    prefix=_p,
                 ),
                 handler=_on_cost_confirm,
             )
@@ -2461,13 +2443,13 @@ class GatewaySlashCommandsMixin:
         raw_args = event.get_command_args().strip() if event else ""
         new_value, errors = crs.parse_args(raw_args)
         if errors:
-            return "❌ " + "\n❌ ".join(errors)
+            return t("gateway.codex_runtime_errors", errors="\n❌ ".join(errors))
 
         # Load + persist via the same helpers used for /model and /yolo
         try:
             from hermes_cli.config import load_config, save_config
         except Exception as exc:
-            return f"❌ Could not load config: {exc}"
+            return t("gateway.codex_runtime_config_error", exc=exc)
         cfg = load_config()
 
         result = crs.apply(
@@ -2487,7 +2469,7 @@ class GatewaySlashCommandsMixin:
                              exc_info=True)
 
         prefix = "✓" if result.success else "✗"
-        return f"{prefix} {result.message}"
+        return t("gateway.codex_runtime_result", prefix=prefix, message=result.message)
 
     async def _handle_personality_command(self, event: MessageEvent) -> str:
         """Handle /personality command - list or set a personality."""
@@ -2752,7 +2734,7 @@ class GatewaySlashCommandsMixin:
         if mgr is None:
             return t("gateway.goal.unavailable")
         if not mgr.has_goal():
-            return "No active goal. Set one with /goal <text>."
+            return t("gateway.subgoal_no_active_goal")
 
         # No args → list current subgoals.
         if not args:
@@ -2764,32 +2746,35 @@ class GatewaySlashCommandsMixin:
 
         if verb == "remove":
             if not rest:
-                return "Usage: /subgoal remove <n>"
+                return t("gateway.subgoal_remove_usage")
             try:
                 idx = int(rest.split()[0])
             except ValueError:
-                return "/subgoal remove: <n> must be an integer (1-based index)."
+                return t("gateway.subgoal_remove_not_integer")
             try:
                 removed = mgr.remove_subgoal(idx)
             except (IndexError, RuntimeError) as exc:
-                return f"/subgoal remove: {exc}"
-            return f"✓ Removed subgoal {idx}: {removed}"
+                return t("gateway.subgoal_remove_error", exc=exc)
+            return t("gateway.subgoal_removed", idx=idx, removed=removed)
 
         if verb == "clear":
             try:
                 prev = mgr.clear_subgoals()
             except RuntimeError as exc:
-                return f"/subgoal clear: {exc}"
+                return t("gateway.subgoal_clear_error", exc=exc)
             if prev:
-                return f"✓ Cleared {prev} subgoal{'s' if prev != 1 else ''}."
-            return "No subgoals to clear."
+                return t(
+                    "gateway.subgoal_cleared_one" if prev == 1 else "gateway.subgoal_cleared_many",
+                    count=prev,
+                )
+            return t("gateway.subgoal_none_to_clear")
 
         try:
             text = mgr.add_subgoal(args)
         except (ValueError, RuntimeError) as exc:
-            return f"/subgoal: {exc}"
+            return t("gateway.subgoal_add_error", exc=exc)
         idx = len(mgr.state.subgoals) if mgr.state else 0
-        return f"✓ Added subgoal {idx}: {text}"
+        return t("gateway.subgoal_added", idx=idx, text=text)
 
     async def _handle_undo_command(self, event: MessageEvent) -> str:
         """Handle /undo [N] — back up N user turns (default 1), soft-deleting
@@ -3463,8 +3448,7 @@ class GatewaySlashCommandsMixin:
             wa.MEMORY, args, memory_store=store, set_mode_fn=_set_approval,
         )
         if out is None:
-            out = ("Unknown /memory subcommand. Use: pending, approve <id>, "
-                   "reject <id>, approval <on|off>.")
+            out = t("gateway.memory_unknown_subcommand")
         return out
 
     async def _handle_skills_command(self, event: MessageEvent) -> str:
@@ -3495,9 +3479,7 @@ class GatewaySlashCommandsMixin:
         gate_on = wa.write_approval_enabled(wa.SKILLS)
         wants_toggle = bool(args) and args[0].lower() in {"approval", "mode"}
         if not gate_on and not wants_toggle and wa.pending_count(wa.SKILLS) == 0:
-            return ("Skill write approval is off (skills.write_approval). "
-                    "Enable it with /skills approval on, then review staged "
-                    "writes here with /skills pending.")
+            return t("gateway.skills_write_approval_off")
 
         def _set_approval(enabled: bool):
             # Write-back round-trip: raw read is correct (merged defaults must
@@ -3513,9 +3495,7 @@ class GatewaySlashCommandsMixin:
             wa.SKILLS, args, set_mode_fn=_set_approval,
         )
         if out is None:
-            return ("Unknown /skills subcommand on this platform. Use: pending, "
-                    "approve <id>, reject <id>, diff <id>, approval <on|off>. "
-                    "(Search/install are CLI-only.)")
+            return t("gateway.skills_unknown_subcommand")
 
         # Chat bubbles can't hold a full skill diff — truncate and point at
         # the real review surface. (Note: `hermes skills diff <name>` is a
@@ -3523,9 +3503,7 @@ class GatewaySlashCommandsMixin:
         # version — so we point at the pending JSON file, not that command.)
         if args and args[0].lower() == "diff" and len(out) > 3000:
             pending_id = args[1] if len(args) > 1 else "<id>"
-            out = (out[:3000]
-                   + "\n… (truncated — full diff in "
-                     f"~/.hermes/pending/skills/{pending_id}.json)")
+            out = out[:3000] + t("gateway.skills_diff_truncated", pending_id=pending_id)
         return out
 
     async def _handle_fast_command(self, event: MessageEvent) -> Optional[str]:
@@ -5199,14 +5177,12 @@ class GatewaySlashCommandsMixin:
 
         bundles = reply.data["bundles"]
         if not bundles:
-            return (
-                "No skill bundles installed.\n"
-                "Create one on the host with:\n"
-                "  `hermes bundles create <name> --skill <s1> --skill <s2>`\n"
-                f"Directory: `{reply.data['dir']}`"
+            return t(
+                "gateway.bundles_none_installed",
+                bundles_dir=reply.data["dir"],
             )
 
-        lines = [f"**Skill Bundles** ({len(bundles)} installed):", ""]
+        lines = [t("gateway.bundles_header", n=len(bundles)), ""]
         for info in bundles:
             skill_count = len(info.get("skills", []))
             desc = info.get("description") or f"Load {skill_count} skills"
@@ -5216,7 +5192,7 @@ class GatewaySlashCommandsMixin:
             for s in info.get("skills", []):
                 lines.append(f"    · {s}")
         lines.append("")
-        lines.append("Invoke a bundle with `/<slug>` to load all its skills.")
+        lines.append(t("gateway.bundles_invoke_hint"))
         return "\n".join(lines)
 
     async def _handle_approve_command(self, event: MessageEvent) -> Optional[str]:
@@ -5412,7 +5388,7 @@ class GatewaySlashCommandsMixin:
                 return t("gateway.update.platform_not_messaging")
 
         if is_managed():
-            return f"✗ {format_managed_message('update Hermes Agent')}"
+            return t("gateway.update_managed", managed_msg=format_managed_message('update Hermes Agent'))
 
         project_root = Path(__file__).parent.parent.resolve()
         git_dir = project_root / '.git'

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2461,6 +2461,12 @@ DEFAULT_CONFIG = {
         # crash/restart, as before.
         "delivery_ledger": True,
 
+        # Optional per-key text overrides for Hermes-authored gateway messages.
+        # Keys omit the leading ``gateway.`` catalog prefix; values may reuse
+        # the placeholders from the corresponding locale entry. An empty map
+        # preserves locale -> English -> dotted-key fallback behavior.
+        "system_messages": {},
+
         # Seconds the gateway waits for a single messaging platform to finish
         # connecting during startup (and on reconnect). Discord in particular
         # can blow past the old fixed 30s when an account has many slash

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2465,7 +2465,11 @@ DEFAULT_CONFIG = {
         # Keys omit the leading ``gateway.`` catalog prefix; values may reuse
         # the placeholders from the corresponding locale entry. An empty map
         # preserves locale -> English -> dotted-key fallback behavior.
-        "system_messages": {},
+        "system_messages": {
+            # Suppressible notification categories: progress, lifecycle, info.
+            # Errors, approvals, and command replies are never suppressible.
+            "suppress": [],
+        },
 
         # Seconds the gateway waits for a single messaging platform to finish
         # connecting during startup (and on reconnect). Discord in particular

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Sessie-databasis is nie beskikbaar"
     session_not_found:           "Sessie nie in databasis gevind nie."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -567,6 +567,7 @@ gateway:
 
     For full setup instructions, type: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were dropped — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model configuration.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` failed ({err}). Recovered using your main model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only here. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only here. No slash commands are enabled for non-admins on this platform. Ask an admin to add you to allow_admin_from or to set user_allowed_commands.

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -440,3 +440,463 @@ gateway:
     session_db_unavailable_prefix: "قاعدة بيانات الجلسات غير متاحة"
     session_not_found:           "لم يُعثر على الجلسة في قاعدة البيانات."
     warn_passthrough:            "⚠️ {error}"
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway restarting — Your current task will be interrupted. Send any message after restart and I'll try to resume where you left off.
+  shutdown_shutting_down: ⚠️ Gateway shutting down — Your current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send response to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to the update process.
+  queued_next_turn_simple: Queued for the next turn.
+  queued_next_turn_depth: Queued for the next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent still starting — /steer queued for the next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — arrives after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty payload).
+  steer_no_agent: No active agent — /steer queued for the next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent is running; sending as a normal message)'
+  agent_running_switch_model: Agent is running — wait or /stop first, then switch models.
+  agent_running_change_runtime: Agent is running — wait or /stop first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear mid-run, or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run mid-turn. Wait for the current response or `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. The agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit has been reached. It resets in ~{hours}h.'
+  api_hint_plan_limit: ' Your plan''s usage limit has been reached. Please wait until it resets.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again shortly.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, I encountered an error ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your question.
+  session_auto_reset: '
+
+
+    🔄 Session auto-reset — the conversation exceeded the maximum context size and could not be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` in the Hermes venv; `pip install faster-whisper` also works if pip is on PATH) and set `stt.enabled: true` in config.yaml, then /restart the gateway.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions, type: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were dropped — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model configuration.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` failed ({err}). Recovered using your main model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only here. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only here. No slash commands are enabled for non-admins on this platform. Ask an admin to add you to allow_admin_from or to set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: no provider credentials configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Prompt: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is now OFF for this chat.
+
+
+    Existing topics in Telegram aren''t removed — they''ll just stop being gated as independent sessions. The root DM works as a normal Hermes chat again. Run /topic to re-enable later.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send any message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: That session is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: That session does not belong to this Telegram user.
+  session_already_linked: That session is already linked to another Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Session-Datenbank nicht verfügbar"
     session_not_found:           "Session nicht in der Datenbank gefunden."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -579,6 +579,7 @@ gateway:
 
     For full setup instructions, type: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were dropped — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model configuration.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` failed ({err}). Recovered using your main model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only here. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only here. No slash commands are enabled for non-admins on this platform. Ask an admin to add you to allow_admin_from or to set user_allowed_commands.

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -451,3 +451,455 @@ gateway:
     session_db_unavailable_prefix: "Session database not available"
     session_not_found:           "Session not found in database."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway restarting — Your current task will be interrupted. Send any message after restart and I'll try to resume where you left off.
+  shutdown_shutting_down: ⚠️ Gateway shutting down — Your current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send response to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to the update process.
+  queued_next_turn_simple: Queued for the next turn.
+  queued_next_turn_depth: Queued for the next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent still starting — /steer queued for the next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — arrives after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty payload).
+  steer_no_agent: No active agent — /steer queued for the next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent is running; sending as a normal message)'
+  agent_running_switch_model: Agent is running — wait or /stop first, then switch models.
+  agent_running_change_runtime: Agent is running — wait or /stop first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear mid-run, or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run mid-turn. Wait for the current response or `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. The agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit has been reached. It resets in ~{hours}h.'
+  api_hint_plan_limit: ' Your plan''s usage limit has been reached. Please wait until it resets.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again shortly.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, I encountered an error ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your question.
+  session_auto_reset: '
+
+
+    🔄 Session auto-reset — the conversation exceeded the maximum context size and could not be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` in the Hermes venv; `pip install faster-whisper` also works if pip is on PATH) and set `stt.enabled: true` in config.yaml, then /restart the gateway.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions, type: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were dropped — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model configuration.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` failed ({err}). Recovered using your main model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only here. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only here. No slash commands are enabled for non-admins on this platform. Ask an admin to add you to allow_admin_from or to set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: no provider credentials configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Prompt: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is now OFF for this chat.
+
+
+    Existing topics in Telegram aren''t removed — they''ll just stop being gated as independent sessions. The root DM works as a normal Hermes chat again. Run /topic to re-enable later.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send any message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: That session is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: That session does not belong to this Telegram user.
+  session_already_linked: That session is already linked to another Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -903,3 +903,12 @@ gateway:
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -887,3 +887,12 @@ gateway:
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -435,3 +435,455 @@ gateway:
     session_db_unavailable_prefix: "Base de datos de sesiones no disponible"
     session_not_found:           "Sesión no encontrada en la base de datos."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -563,6 +563,7 @@ gateway:
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Base de données de sessions indisponible"
     session_not_found:           "Session introuvable dans la base de données."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -442,3 +442,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Níl bunachar sonraí na seisiún ar fáil"
     session_not_found:           "Seisiún gan a aimsiú sa bhunachar sonraí."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -570,6 +570,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -894,3 +894,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "A munkamenet-adatbázis nem érhető el"
     session_not_found:           "A munkamenet nem található az adatbázisban."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Database delle sessioni non disponibile"
     session_not_found:           "Sessione non trovata nel database."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "セッションデータベースが利用できません"
     session_not_found:           "データベースにセッションが見つかりません。"
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "세션 데이터베이스를 사용할 수 없습니다"
     session_not_found:           "데이터베이스에서 세션을 찾을 수 없습니다."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Base de dados de sessões indisponível"
     session_not_found:           "Sessão não encontrada na base de dados."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     Для получения полных инструкций по настройке введите: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Сжатие контекста прервано ({err}). Сообщения не удалялись — беседа не изменена. Запустите /compress для повторной попытки, /reset для чистой сессии или проверьте настройку вашей модели auxiliary.compression.
+  compaction_done: ✓ Сжатие контекста завершено — продолжаю ход...
   compress_aux_model_failed: ℹ️ Настроенная модель сжатия `{model}` завершилась с ошибкой ({err}). Выполнено восстановление с использованием основной модели — контекст цел — но возможно стоит проверить `auxiliary.compression.model` в config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} доступна только администраторам. Вы можете запустить: {allowed_list}. Используйте /whoami для полного списка.'
   admin_only_no_commands: ⛔ /{cmd} доступна только администраторам. Для не-администраторов команды не включены на этой платформе. Попросите администратора добавить вас в allow_admin_from или задать user_allowed_commands.
@@ -705,7 +706,7 @@ Future messages in this room will use that transcript until `/reset` or another 
   tg_select_model: Выберите модель:{extra}
   tg_provider_family: 'Семейство провайдеров: *{family}*'
   tg_error_switching_model: 'Ошибка при переключении модели: {error}'
-  tg_resolved: Решено
+  tg_resolved: Обработано
   tg_decision_by: '{label} — {user}'
   tg_decision_appended: '{original}
 

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "База данных сеансов недоступна"
     session_not_found:           "Сеанс не найден в базе данных."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} ограничивает контекст {cap} токенами, поэтому автосжатие было повышено до {to_pct}% (с {from_pct}%), чтобы использовать больше окна перед обобщением.\n  Отказаться: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway перезапущен. Сессия продолжается.
+  gateway_online: ♻️ Gateway снова онлайн — Hermes снова в строю.
+  subagent_working: ⏳ Подагент работает{status_detail} — ваше сообщение в очереди и будет обработано после завершения (используйте /stop, чтобы отменить всё).
+  compressing_context: ⏳ Сжатие контекста{status_detail} — ваше сообщение в очереди и будет обработано после завершения (используйте /stop, чтобы отменить всё).
+  queued_next_turn: ⏳ В очереди на следующий ход{status_detail}. Отвечу, как только завершится текущая задача.
+  interrupting_task: ⚡ Прерываю текущую задачу{status_detail}. Скоро отвечу на ваше сообщение.
+  steered_into_run: ⏩ Влито в текущий запуск{status_detail}. Ваше сообщение поступит после следующего вызова инструмента.
+  redirected_current_run: ↪ Текущий запуск перенаправлен{status_detail}. Я учту вашу правку.
+  long_running: ⏳ Работаю — {minutes} мин{status_detail}
+  no_activity_warning: ⚠️ Нет активности уже {minutes} мин. Если агент скоро не ответит, он будет остановлен по таймауту через {remaining} мин. Можно подождать ещё или использовать /reset.
+  provider_auth_failed: ⚠️ Ошибка аутентификации провайдера. Проверьте настроенные учётные данные; подробности провайдера — в логах gateway.
+  provider_rejected: ⚠️ Провайдер модели отклонил запрос. Я не стал выводить сырую ошибку провайдера в чат; смотрите логи gateway или попробуйте переформулировать.
+  provider_rate_limited: ⏱️ Провайдер модели ограничивает частоту запросов. Подождите немного и попробуйте снова.
+  provider_failed: ⚠️ Провайдер модели не ответил после повторных попыток. Я не стал выводить сырые детали провайдера в чат; смотрите логи gateway для диагностики.
+  session_too_large: '⚠️ Сессия слишком велика для контекстного окна модели.
+
+    Используйте /compact, чтобы сжать беседу, или /reset, чтобы начать заново.'
+  request_failed: 'Запрос не удался: {error}
+
+    Попробуйте снова или используйте /reset, чтобы начать новую сессию.'
+  processing_stopped: '⚠️ Обработка остановлена: {error}. Попробуйте снова.'
+  empty_response: ⚠️ Обработка завершена, но ответ не сгенерирован. Возможно, это временная ошибка — попробуйте отправить сообщение ещё раз.
+  no_response_generated: (Ответ не сгенерирован)
+  self_review_header: '💾 Обзор самосовершенствования: {summary}'
+  review_skill_patched: '📝 Навык ''{name}'' обновлён (патч): "{old}" → "{new}"'
+  review_skill_created: '📝 Навык ''{name}'' создан: {description}'
+  review_skill_rewritten: '📝 Навык ''{name}'' переработан: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Навык {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: 'Обновлено: {label}'
+  review_label_skill: Навык
+  review_label_memory: Память
+  review_label_user_profile: Профиль пользователя
+  iteration_budget_exhausted: ⚠️ Бюджет итераций исчерпан ({n}/{max}) — прошу модель сформировать сводку
+  stale_connections_cleaned: 🔌 Обнаружены устаревшие соединения от предыдущей ошибки провайдера — автоматически очищены. Продолжаем с новым соединением.
+  preflight_compression: '📦 Предварительное сжатие: ~{tokens} токенов >= порога {threshold}. Это может занять некоторое время.'
+  compression_aux_unavailable: ⚠ Настроенный вспомогательный провайдер сжатия '{provider}' недоступен — сжатие контекста будет удалять промежуточные ходы без сводки. Проверьте auxiliary.compression в config.yaml и повторно аутентифицируйтесь у этого провайдера.
+  compression_no_provider: ⚠ Вспомогательный провайдер LLM не настроен — сжатие контекста будет удалять промежуточные ходы без сводки. Запустите `hermes setup` или задайте OPENROUTER_API_KEY.
+  api_error_billing: ❌ Баланс или кредиты исчерпаны — {summary}
+  api_error_rate_limited: ❌ Ограничение частоты запросов после {max_retries} попыток — {summary}
+  api_error_failed: ❌ Сбой API после {max_retries} попыток — {summary}
+  api_safety_blocked: '❌ Фильтр безопасности провайдера заблокировал этот запрос: {summary}'
+  api_non_retryable: '❌ Неповторяемая ошибка (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Фильтр безопасности провайдера заблокировал запрос — пробую резервный вариант...
+  api_non_retryable_trying_fallback: ⚠️ Неповторяемая ошибка (HTTP {status_code}) — пробую резервный вариант...
+  api_max_retries_trying_fallback: ⚠️ Максимальное число попыток ({max_retries}) исчерпано — пробую резервный вариант...
+  tool_guardrail_halted: '⚠️ Защита инструментов остановила {tool}: {code}'
+  empty_response_retry: ⚠️ Модель вернула пустой ответ — повтор ({n}/3)
+  empty_response_switching_fallback: ⚠️ Модель возвращает пустые ответы — переключаюсь на резервного провайдера...
+  empty_response_reasoning_only: ⚠️ Модель сформировала рассуждение, но не дала видимого ответа после всех попыток. Возвращаю пустой ответ.
+  empty_response_no_content: ❌ Модель не вернула контент после всех попыток и резервных вариантов.
+  empty_response_no_content_no_fallback: ❌ Модель не вернула контент после всех попыток. Резервные провайдеры не настроены.
+  thinking_prefill_retry: ↻ Ответ только с рассуждением — добавляю префикс для продолжения ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} завершён — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} заблокирован{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} отказался после многократных ошибок запуска{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} воркер упал (pid исчез); диспетчер повторит попытку
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} истекло время ожидания (max_runtime={limit}с); будет повторено
+  busy_queued_drain: ⏳ Gateway {gerund} — в очереди на следующий ход после возобновления.
+  busy_not_accepting_turn: ⏳ Gateway {gerund} и не принимает ещё один ход прямо сейчас.
+  busy_not_accepting_work: ⏳ Gateway {gerund} и не принимает новую работу прямо сейчас.
+  shutdown_restarting: ⚠️ Gateway перезапускается — Текущая задача будет прервана. Отправьте любое сообщение после перезапуска, и я постараюсь продолжить с того места, где остановился.
+  shutdown_shutting_down: ⚠️ Gateway завершает работу — Текущая задача будет прервана.
+  steer_update_send_failed: '✗ Не удалось отправить ответ процессу обновления: {error}'
+  steer_update_sent: ✓ Отправлено `{label}` процессу обновления.
+  queued_next_turn_simple: В очереди на следующий ход.
+  queued_next_turn_depth: В очереди на следующий ход. ({depth} в очереди)
+  steer_usage: 'Использование: /steer <запрос>'
+  steer_agent_starting: Агент ещё запускается — /steer поставлен в очередь на следующий ход.
+  steer_failed: '⚠️ Steer не выполнен: {error}'
+  steer_queued: '⏩ Steer в очереди — поступит после следующего вызова инструмента: ''{preview}'''
+  steer_rejected: Steer отклонён (пустой запрос).
+  steer_no_agent: Нет активного агента — /steer поставлен в очередь на следующий ход.
+  steer_usage_no_agent: 'Использование: /steer <запрос>  (агент не запущен; отправляется как обычное сообщение)'
+  agent_running_switch_model: Агент выполняется — подождите или сначала используйте /stop, затем смените модель.
+  agent_running_change_runtime: Агент выполняется — подождите или сначала используйте /stop, затем измените runtime.
+  agent_running_goal: Агент выполняется — используйте /goal status / pause / clear во время выполнения или /stop перед установкой новой цели.
+  agent_running_cant_run_cmd: ⏳ Агент выполняется — `/{name}` не может запуститься в процессе хода. Дождитесь текущего ответа или сначала используйте `/stop`.
+  force_stopped_starting: ⚡ Принудительно остановлено. Агент ещё запускался — сессия разблокирована.
+  command_blocked_hook: Команда `/{command}` была заблокирована хуком.
+  quick_cmd_no_output: Команда не вернула вывода.
+  quick_cmd_timeout: Быстрая команда превысила время ожидания (30 с).
+  quick_cmd_error: 'Ошибка быстрой команды: {error}'
+  quick_cmd_no_command: Быстрая команда '/{command}' не имеет определённой команды.
+  quick_cmd_no_target: Быстрая команда '/{command}' не имеет определённой цели.
+  quick_cmd_unsupported_type: 'Быстрая команда ''/{command}'' имеет неподдерживаемый тип (поддерживаются: ''exec'', ''alias'').'
+  api_hint_auth: ' Проверьте ваш API-ключ или запустите `claude /login` для обновления OAuth-учётных данных.'
+  api_hint_billing: ' Ваш баланс API или квота исчерпаны. Проверьте панель управления провайдера.'
+  api_hint_plan_limit_hours: ' Лимит использования вашего плана достигнут. Он сбросится примерно через ~{hours} ч.'
+  api_hint_plan_limit: ' Лимит использования вашего плана достигнут. Пожалуйста, подождите до сброса.'
+  api_hint_rate_limited: ' Вы ограничены по частоте запросов. Подождите немного и попробуйте снова.'
+  api_hint_overloaded: ' API временно перегружен. Попробуйте ещё раз немного позже.'
+  api_hint_rejected: ' Запрос был отклонён API.'
+  api_error_generic: 'Извините, произошла ошибка ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Попробуйте снова или используйте /reset для начала новой сессии.'
+  delivery_failed: ⚠️ Сообщение не удалось доставить после нескольких попыток. Пожалуйста, попробуйте ещё раз — ваш запрос был обработан, но ответ не удалось отправить.
+  response_formatting_failed: '(Форматирование ответа не удалось, простой текст:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Аудио: {audio_path}'
+  file_fallback_caption: '📎 Файл: {file_path}'
+  image_fallback_caption: '🖼️ Изображение: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Ответьте номером, текстом варианта или своим ответом.
+  clarify_instructions_multi: Допустим выбор нескольких вариантов — ответьте номерами через запятую или пробел (например, "1, 3"), текстом варианта или своим ответом.
+  model_no_response_tool_results: ⚠️ Модель не вернула ответ после обработки результатов инструментов. Это может происходить с некоторыми моделями — попробуйте снова или перефразируйте вопрос.
+  session_auto_reset: '
+
+
+    🔄 Автоматический сброс сессии — беседа превысила максимальный размер контекста и не может быть дополнительно сжата. Ваше следующее сообщение начнёт новую сессию.'
+  voice_no_stt: '🎤 Я получил ваше голосовое сообщение, но не могу его расшифровать — провайдер распознавания речи не настроен.
+
+
+    Чтобы включить голос: установите faster-whisper (`uv pip install faster-whisper` в виртуальной среде Hermes; `pip install faster-whisper` тоже работает, если pip есть в PATH) и задайте `stt.enabled: true` в config.yaml, затем выполните /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    Для получения полных инструкций по настройке введите: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Сжатие контекста прервано ({err}). Сообщения не удалялись — беседа не изменена. Запустите /compress для повторной попытки, /reset для чистой сессии или проверьте настройку вашей модели auxiliary.compression.
+  compress_aux_model_failed: ℹ️ Настроенная модель сжатия `{model}` завершилась с ошибкой ({err}). Выполнено восстановление с использованием основной модели — контекст цел — но возможно стоит проверить `auxiliary.compression.model` в config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} доступна только администраторам. Вы можете запустить: {allowed_list}. Используйте /whoami для полного списка.'
+  admin_only_no_commands: ⛔ /{cmd} доступна только администраторам. Для не-администраторов команды не включены на этой платформе. Попросите администратора добавить вас в allow_admin_from или задать user_allowed_commands.
+  suggestions_failed: 'Команда предложений завершилась с ошибкой: {error}'
+  bg_task_no_creds: '❌ Фоновая задача {task_id} завершилась неудачей: учётные данные провайдера не настроены.'
+  bg_task_complete: '✅ Фоновая задача завершена
+
+    Запрос: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Фоновая задача {task_id} завершилась неудачей: {error}'
+  busy_hint_queued: 💡 Подсказка для новых — я поставил ваше сообщение в очередь, а не прервал текущую задачу. Отправьте `/busy interrupt`, чтобы новые сообщения останавливали задачу немедленно, или `/busy status` для проверки. Это уведомление больше не появится.
+  busy_hint_steered: 💡 Подсказка для новых — я направил ваше сообщение в текущий запуск; оно поступит после следующего вызова инструмента, а не прервёт его. Отправьте `/busy interrupt` или `/busy queue`, чтобы изменить это, или `/busy status` для проверки. Это уведомление больше не появится.
+  busy_hint_redirect: 💡 Подсказка для новых — я перенаправил текущий запуск, использовав ваше сообщение. Выполненная работа остаётся в контексте, а `/stop` по-прежнему отменяет задачу. Отправьте `/busy queue`, чтобы дождаться отдельного хода, или `/busy status` для проверки. Это уведомление больше не появится.
+  busy_hint_interrupt: 💡 Подсказка для новых — я прервал текущую задачу, чтобы ответить вам. Отправьте `/busy queue` для постановки ответов в очередь после текущей задачи, `/busy steer` — для добавления на ходу без прерывания, или `/busy status` для проверки. Это уведомление больше не появится.
+  tool_progress_hint: 💡 Подсказка для новых — этот инструмент выполнялся некоторое время, и я передаю каждый шаг в потоке. Если сообщения о прогрессе кажутся избыточными, отправьте `/verbose` для переключения режимов (all → new → off). Это уведомление больше не появится.
+  bundles_unavailable: 'Подсистема бандлов недоступна: {exc}'
+  bundles_none_installed: "Бандлы навыков не установлены.\nСоздайте бандл на хосте:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nКаталог: `{bundles_dir}`"
+  bundles_header: '**Бандлы навыков** (установлено: {n}):'
+  bundles_invoke_hint: Активируйте бандл командой `/<slug>`, чтобы загрузить все его навыки.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Не удалось определить ID чата.
+  topic_not_enabled: Режим мультисессионных тем в данный момент не включён для этого чата.
+  topic_disabled: 'Режим мультисессионных тем для этого чата выключен.
+
+
+    Существующие темы в Telegram не удаляются — они просто перестанут работать как независимые сессии. Корневой чат снова работает как обычный чат Hermes. Запустите /topic для повторного включения.'
+  topic_no_unlinked_sessions: Предыдущих несвязанных сессий Telegram не найдено.
+  topic_restore_instructions: 'Чтобы восстановить предыдущую сессию позже:
+
+    1. Создайте или откройте тему. Для создания новой откройте Все сообщения и отправьте туда любое сообщение.
+
+    2. Отправьте /topic <session-id> внутри этой темы.'
+  session_not_found: 'Сессия не найдена: {session_id}'
+  session_not_telegram: Это не Telegram-сессия и её нельзя восстановить в данной теме.
+  session_wrong_user: Эта сессия не принадлежит данному пользователю Telegram.
+  session_already_linked: Эта сессия уже привязана к другой теме Telegram.
+  session_restored: 'Сессия восстановлена: {title}'
+  session_restored_last_msg: '
+
+
+    Последнее сообщение Hermes:
+
+    {content}'
+  command_cancelled: 🟡 /{command} отменена. Беседа не изменена.
+  whoami_unrestricted: '**Вы** — {platform} ({scope})
+
+    ID пользователя: `{user_id}`
+
+    Уровень: без ограничений (список администраторов не настроен для этой области)
+
+    Команды со слешем: все доступны'
+  whoami_admin: '**Вы** — {platform} ({scope})
+
+    ID пользователя: `{user_id}`
+
+    Уровень: **admin**
+
+    Команды со слешем: все доступны'
+  whoami_user: '**Вы** — {platform} ({scope})
+
+    ID пользователя: `{user_id}`
+
+    Уровень: пользователь
+
+    Доступные команды со слешем: {runnable_str}'
+  platform_list_header: '**Платформы Gateway**'
+  platform_connected: 'Подключено: {platforms}'
+  platform_connected_none: 'Подключено: (нет)'
+  platform_failed_paused: '  · {platform} — ПРИОСТАНОВЛЕНО ({reason}). Возобновите через `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — повторная попытка (попытка {attempts})'
+  platform_failed_none: 'Сбой/приостановлено: (нет)'
+  platform_usage: 'Использование: /platform {action} <имя>'
+  platform_unknown: 'Неизвестная платформа: {target}'
+  platform_not_in_queue: '{platform} отсутствует в очереди повторных попыток (она либо подключена, либо не включена).'
+  platform_already_paused: '{platform} уже приостановлена.'
+  platform_paused_ok: ✓ {platform} приостановлена. Возобновите через `/platform resume {platform}` или `hermes gateway restart` для сброса.
+  platform_not_in_queue_resume: '{platform} отсутствует в очереди повторных попыток — нечего возобновлять.'
+  platform_already_retrying: '{platform} уже повторяет попытки — возобновление не требуется.'
+  platform_resumed_ok: ✓ {platform} возобновлена — повторная попытка при следующем тике наблюдателя.
+  platform_usage_full: "Использование: /platform <list|pause|resume> [имя]\n  /platform list — показать статус платформ\n  /platform pause <имя> — остановить повторные попытки для платформы с ошибкой\n  /platform resume <имя> — вернуть приостановленную платформу в очередь"
+  model_expensive_warning: '⚠️ **Предупреждение о дорогой модели**
+
+
+    {warning_message}
+
+
+    _Текстовый вариант: ответьте `{prefix}approve` для переключения или `{prefix}cancel` для сохранения текущей модели._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Не удалось загрузить конфигурацию: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: Нет активной цели. Установите её с помощью /goal <текст>.
+  subgoal_remove_usage: 'Использование: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> должен быть целым числом (индекс с 1).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Удалена подцель {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Очищена {count} подцель.
+  subgoal_cleared_many: ✓ Очищено {count} подцелей.
+  subgoal_none_to_clear: Нет подцелей для очистки.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Добавлена подцель {idx}: {text}'
+  memory_unknown_subcommand: 'Неизвестная подкоманда /memory. Используйте: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Одобрение записи навыков отключено (skills.write_approval). Включите с помощью /skills approval on, затем проверяйте отложенные записи здесь с /skills pending.
+  skills_unknown_subcommand: 'Неизвестная подкоманда /skills на этой платформе. Используйте: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Поиск/установка доступны только в CLI.)'
+  skills_diff_truncated: '
+
+    … (усечено — полный diff в ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Требуется ваш ввод:*
+
+
+    '
+  tg_btn_yes: ✓ Да
+  tg_btn_no: ✗ Нет
+  tg_approval_header: ⚠️ <b>Требуется подтверждение команды</b>
+  tg_btn_allow_once: ✅ Разрешить однократно
+  tg_btn_allow_session: ✅ На сессию
+  tg_btn_allow_always: ✅ Всегда
+  tg_btn_deny: ❌ Отклонить
+  tg_btn_approve_once: ✅ Подтвердить однократно
+  tg_btn_always_approve: 🔒 Всегда подтверждать
+  tg_btn_cancel: ❌ Отмена
+  tg_btn_cancel_x: ✗ Отмена
+  tg_btn_prev: ◀ Пред
+  tg_btn_next: Далее ▶
+  tg_btn_back: ◀ Назад
+  tg_btn_switch_anyway: Переключить всё равно
+  tg_more_available: '
+
+    _{n} ещё доступно — введите `/model <name>` напрямую_'
+  tg_model_config_header: ⚙ *Настройка модели*
+  tg_current_model: 'Текущая модель: `{model}`'
+  tg_provider_line: 'Провайдер: {provider}'
+  tg_select_provider: 'Выберите провайдера:'
+  tg_provider_bold: 'Провайдер: *{provider}*{page_info}'
+  tg_select_model: Выберите модель:{extra}
+  tg_provider_family: 'Семейство провайдеров: *{family}*'
+  tg_error_switching_model: 'Ошибка при переключении модели: {error}'
+  tg_resolved: Решено
+  tg_decision_by: '{label} — {user}'
+  tg_decision_appended: '{original}
+
+    — {label} — {user}'
+  tg_picker_expired: Меню устарело — используйте /model снова.
+  tg_provider_not_found: Провайдер не найден.
+  tg_invalid_page: Неверная страница.
+  tg_invalid_selection: Неверный выбор.
+  tg_invalid_model_index: Неверный индекс модели.
+  tg_picker_expired_short: Меню устарело.
+  tg_switch_failed: Переключение не удалось.
+  tg_model_switched: Модель переключена!
+  tg_confirm_expensive: Подтвердите дорогостоящую модель
+  tg_group_not_found: Группа не найдена.
+  tg_model_selection_cancelled: Выбор модели отменён.
+  tg_expensive_warning_header: ⚠ *Предупреждение о дорогостоящей модели*
+  tg_approved_once: ✅ Одобрено однократно
+  tg_denied: ❌ Отклонено
+  tg_approval_expired: ⌛ Срок подтверждения истёк
+  tg_approval_expired_detail: '{label} — ни одна команда не ожидала подтверждения. Она уже истекла по таймауту (и была отклонена) либо была обработана в другом месте.'
+  tg_approval_resolved: Это подтверждение уже обработано.
+  tg_prompt_resolved: Этот запрос уже обработан.
+  tg_approved_session: ✅ Разрешено на сессию
+  tg_approved_permanently: ✅ Разрешено навсегда
+  tg_always_approve_label: 🔒 Всегда подтверждать
+  tg_cancelled_label: ❌ Отменено
+  tg_not_authorized_approve: ⛔ У вас нет прав на подтверждение команд.
+  tg_not_authorized_prompt: ⛔ У вас нет прав на ответ на этот запрос.
+  tg_not_authorized_update: ⛔ У вас нет прав на ответ на запросы обновления.
+  tg_not_authorized_email: ⛔ У вас нет прав на действия с этим письмом.
+  tg_type_answer: ✏️ Введите ваш ответ в чате.
+  tg_invalid_choice: Неверный вариант.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Ответ '{answer}' отправлен в процесс обновления.
+  tg_update_answered: '⚕ Ответ на запрос обновления: *{label}*'
+  tg_gmail_invalid_data: Неверные данные gmail-triage.
+  tg_gmail_unknown_verb: 'Неизвестная команда: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} не найден
+  tg_gmail_verb_failed: '❌ {verb} не выполнено: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} истекло время ожидания
+  tg_gmail_verb_error: '❌ ошибка {verb}: {error}'
+  tg_invalid_approval_data: Неверные данные подтверждения.
+  cl_ollama_context_too_small: ❌ Контекст среды выполнения Ollama слишком мал для использования инструментов Hermes
+  cl_nous_rate_limit: Действует ограничение частоты запросов Nous Portal — сбрасывается через {reset}.
+  cl_empty_malformed_switching: ⚠️ Пустой или некорректный ответ — переключаюсь на резервный провайдер...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Достигнут лимит повторов ({max}) для некорректных ответов — пробую резервный провайдер...
+  cl_max_retries_invalid_giving_up: ❌ Превышен лимит повторов ({max}) для некорректных ответов. Прекращаю.
+  cl_refusal_status: ⚠️ Модель отказалась отвечать на этот запрос (отказ по соображениям безопасности).
+  cl_context_reduced: 🗜️ Контекст уменьшен до {reduced} токенов (было {old}), повторяю...
+  cl_billing_switching_fallback: ⚠️ Исчерпаны средства или кредиты — переключаюсь на резервный провайдер...
+  cl_rate_limited_switching_fallback: ⚠️ Превышен лимит частоты запросов — переключаюсь на резервный провайдер...
+  cl_payload_too_large: ⚠️  Слишком большой размер запроса (413) — попытка сжатия {n}/{max}...
+  cl_compressed_retrying: 🗜️ Сжато с {before} → {after} сообщений, повторяю...
+  cl_context_too_large_compressing: 🗜️ Слишком большой контекст (~{tokens} токенов) — сжимаю ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Превышен лимит частоты запросов. Ожидание {wait}с (попытка {n}/{max})...
+  cl_retrying_in: ⏳ Повтор через {wait}с (попытка {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Пустой ответ после вызова инструментов — использую более ранний текст как итоговый ответ
+  cl_content_policy_recovery_hint: Попробуйте переформулировать запрос, сузить контекст или добавить резервный провайдер командой `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    Резервный провайдер недоступен. Повторите попытку после сброса или добавьте резервный провайдер в config.yaml.'
+  cl_refusal_explanation: 'Пояснение модели: {explanation}'
+  cl_refusal_no_explanation: Модель не вернула пояснений.
+  cl_refusal_response: '⚠️  Модель отказалась отвечать на этот запрос (отказ по соображениям безопасности — это не сбой Hermes/шлюза).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Бюджет рассуждений исчерпан**
+
+
+    Модель израсходовала все выходные токены на рассуждения, и для самого ответа их не осталось.
+
+
+    Как это исправить:
+
+    → Снизьте уровень рассуждений: `/thinkon low` или `/thinkon minimal`
+
+    → Либо переключитесь на более крупную модель без рассуждений командой `/model`'
+  cl_interrupted_handling_error: 'Операция прервана: обработка ошибки API ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  Фильтр безопасности провайдера модели заблокировал этот запрос (это не сбой Hermes/шлюза).
+
+
+    Сообщение провайдера: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Исчерпаны средства или кредиты: {summary}'
+  cl_stream_drop_hint: '
+
+
+    Потоковое соединение провайдера постоянно обрывается — это часто происходит при генерации очень больших ответов с вызовом инструментов (например, write_file с длинным содержимым). Попробуйте попросить меня использовать execute_code с Python-функцией open() для больших файлов или писать меньшими частями.'
+  cl_interrupted_retrying: 'Операция прервана: повтор вызова API после ошибки (повтор {n}/{max}).'
+  cl_repeated_errors: 'Прошу прощения, но я столкнулся с повторяющимися ошибками: {error}'
+  cl_local_processing_error: 'Прошу прощения, но я столкнулся с ошибкой при обработке ответа модели: {error}'
+  cron_response_prefix: 'Ответ задачи: '
+  cron_stop_hint_prefix: '
+
+
+    Чтобы остановить или управлять этой задачей, отправьте мне новое сообщение (например, "остановить напоминание '
+  cron_failure_rate_limit: '⚠️ Задача ''{job_name}'' завершилась с ошибкой: превышен {reason} провайдера. Цепочка резервных вариантов исчерпана или недоступна. Подробности сохранены в выводе задачи.'
+  cron_failure_timeout: '⚠️ Задача ''{job_name}'' завершилась с ошибкой: таймаут провайдера. Цепочка резервных вариантов исчерпана или недоступна. Подробности сохранены в выводе задачи.'
+  cron_failure_auth: '⚠️ Задача ''{job_name}'' завершилась с ошибкой: ошибка аутентификации провайдера. Подробности сохранены в выводе задачи.'
+  cron_failure_generic: '⚠️ Задача ''{job_name}'' завершилась с ошибкой: {cleaned}'
+  cron_watchdog_failed: '⚠ Скрипт watchdog задачи ''{job_name}'' завершился с ошибкой
+
+
+    {output}
+
+
+    Время: {now_iso}'
+  aux_task_failed: '⚠ Вспомогательная задача {task} завершилась с ошибкой: {detail}'
+  file_mutation_header: '⚠️ Верификатор мутаций файлов: {count} файл(ов) НЕ были изменены в этом ходу, несмотря на формулировки выше. Проверьте с помощью `git status` или `read_file`.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … и ещё {remaining}'
+  no_reply_empty_response_exhausted: '⚠️ Нет ответа: модель вернула пустое содержимое после повторных попыток и всех резервных провайдеров. Попробуйте `continue`, смените модель/провайдера или проверьте вывод инструмента выше.'
+  no_reply_all_retries_exhausted: '⚠️ Нет ответа: все попытки API исчерпаны до получения ответа (ошибки провайдера / ограничения частоты). Попробуйте `continue` или смените провайдера.'
+  no_reply_partial_stream_recovery: '⚠️ Нет ответа: стриминг прервался досрочно, восстановлен лишь частичный ответ. Отправьте `continue` для продолжения с того места, где остановились.'
+  no_reply_fallback_prior_turn_content: '⚠️ Нет ответа: в этом ходу новый контент не был произведён; отображается восстановленный предыдущий контекст. Отправьте `continue` для повтора.'
+  no_reply_interrupted_during_api_call: '⚠️ Нет ответа: запрос был прерван в процессе вызова до получения ответа. Отправьте `continue` для повтора.'
+  no_reply_budget_exhausted: '⚠️ Нет ответа: бюджет итераций/стоимости за ход исчерпан до получения финального ответа. Отправьте `continue` для продолжения.'
+  no_reply_ollama_context_too_small: '⚠️ Нет ответа: контекстное окно локальной модели слишком мало для завершения. Увеличьте размер контекста или используйте более крупную модель.'
+  no_reply_max_iterations_reached: '⚠️ Нет ответа: достигнут максимальный лимит итераций инструментов до получения финального ответа. Отправьте `continue` для продолжения или увеличьте `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ Нет ответа: возникла ошибка вблизи лимита итераций до получения финального ответа. Проверьте вывод инструмента выше, затем отправьте `continue`.'
+  no_reply_pending_tool_result: '⚠️ Нет ответа: ход остановился, пока результат инструмента ещё ожидался, а модель не произвела текст-продолжение. Отправьте `continue`, чтобы она подвела итог.'
+  no_reply_session_persistence_failed: '⚠️ Нет ответа: ход остановлен, потому что не удалось записать хранилище сессии (расшифровка была бы потеряна при перезапуске). Проверьте место на диске и права доступа к БД состояния, затем отправьте сообщение снова.'
+  slash_confirm_prompt: '⚠️ **Подтвердите /{command}**
+
+
+    {detail}
+
+
+    Выберите:
+
+    • **Подтвердить один раз** — выполнить только сейчас
+
+    • **Подтверждать всегда** — выполнить и навсегда отключить этот запрос
+
+    • **Отмена** — сохранить текущий диалог
+
+
+    _Текстовый вариант: ответьте `{prefix}approve`, `{prefix}always` или `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Дальнейшие /clear, /new, /reset и /undo будут выполняться без подтверждения. Снова включить можно через `approvals.destructive_slash_confirm: true` в config.yaml.'
+  update_failed_exit_code: ❌ Обновление Hermes не удалось (код выхода {exit_code}).
+  update_timed_out: ❌ Обновление Hermes прервано по таймауту через 30 минут.
+  update_finished_output: '✅ Обновление Hermes завершено.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Обновление Hermes не удалось.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Обновление Hermes успешно завершено.
+  update_finished: ✅ Обновление Hermes завершено.
+  update_failed_generic: ❌ Обновление Hermes не удалось. Проверьте логи шлюза или запустите `hermes update` вручную для подробностей.
+  proxy_error: '⚠️ Ошибка прокси ({status}): {detail}'
+  proxy_connection_error: '⚠️ Ошибка подключения к прокси: {error}'
+  dangerous_command_approval_text: '⚠️ **Опасная команда требует подтверждения:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Причина: {reason}
+
+
+    Ответьте `{prefix}approve` для выполнения, `{prefix}approve session` чтобы одобрить этот шаблон на сессию, `{prefix}approve always` чтобы одобрить навсегда, или `{prefix}deny` для отмены.'

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Ответьте `{prefix}approve` для выполнения, `{prefix}approve session` чтобы одобрить этот шаблон на сессию, `{prefix}approve always` чтобы одобрить навсегда, или `{prefix}deny` для отмены.'
+  session_reset_reason_suspended: предыдущая сессия была остановлена или прервана
+  session_reset_reason_resume_pending_expired: восстановление после перезапуска шлюза не уложилось в тайм-аут
+  session_reset_reason_daily: по расписанию в {hour}:00
+  session_reset_reason_idle: неактивность {duration}
+  session_reset_notice: '◐ Сессия автоматически сброшена ({reason}). История разговора очищена.
+
+    Используйте /resume, чтобы просмотреть и восстановить предыдущую сессию.
+
+    Настройте тайминг сброса в config.yaml в разделе session_reset.'

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "Oturum veritabanı kullanılamıyor"
     session_not_found:           "Oturum veritabanında bulunamadı."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "База даних сеансів недоступна"
     session_not_found:           "Сеанс не знайдено в базі даних."
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "工作階段資料庫無法使用"
     session_not_found:           "資料庫中找不到此工作階段。"
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -438,3 +438,455 @@ Future messages in this room will use that transcript until `/reset` or another 
     session_db_unavailable_prefix: "会话数据库不可用"
     session_not_found:           "数据库中未找到该会话。"
     warn_passthrough:            "⚠️ {error}"
+  # --- fork additions: system-message i18n + category suppression ---
+  codex_gpt55_autoraise_notice: "ℹ Codex {model} caps context at {cap}, so auto-compaction was raised to {to_pct}% (from {from_pct}%) to use more of the window before summarizing.\n  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+  restart_success: ♻ Gateway restarted successfully. Your session continues.
+  gateway_online: ♻️ Gateway online — Hermes is back and ready.
+  subagent_working: ⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  compressing_context: ⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything).
+  queued_next_turn: ⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes.
+  interrupting_task: ⚡ Interrupting current task{status_detail}. I'll respond to your message shortly.
+  steered_into_run: ⏩ Steered into current run{status_detail}. Your message arrives after the next tool call.
+  redirected_current_run: ↪ Redirected current run{status_detail}. I'll adjust using your correction.
+  long_running: ⏳ Working — {minutes} min{status_detail}
+  no_activity_warning: ⚠️ No activity for {minutes} min. If the agent does not respond soon, it will be timed out in {remaining} min. You can continue waiting or use /reset.
+  provider_auth_failed: ⚠️ Provider authentication failed. Check the configured credentials; raw provider details are in the gateway logs.
+  provider_rejected: ⚠️ The model provider rejected the request. I kept the raw provider error out of chat; check gateway logs for details or try rephrasing.
+  provider_rate_limited: ⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.
+  provider_failed: ⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.
+  session_too_large: '⚠️ Session too large for the model''s context window.
+
+    Use /compact to compress the conversation, or /reset to start fresh.'
+  request_failed: 'The request failed: {error}
+
+    Try again or use /reset to start a fresh session.'
+  processing_stopped: '⚠️ Processing stopped: {error}. Try again.'
+  empty_response: ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.
+  no_response_generated: (No response generated)
+  self_review_header: '💾 Self-improvement review: {summary}'
+  review_skill_patched: '📝 Skill ''{name}'' patched: "{old}" → "{new}"'
+  review_skill_created: '📝 Skill ''{name}'' created: {description}'
+  review_skill_rewritten: '📝 Skill ''{name}'' rewritten: {description}'
+  review_skill_message: 📝 {message}
+  review_skill_action: Skill {action}
+  review_mem_add: '{label} ➕ {preview}'
+  review_mem_edit: '{label} ✏️ {preview}'
+  review_mem_remove: '{label} ➖ {preview}'
+  review_mem_updated: '{label} updated'
+  review_label_skill: Skill
+  review_label_memory: Memory
+  review_label_user_profile: User profile
+  iteration_budget_exhausted: ⚠️ Iteration budget exhausted ({n}/{max}) — asking model to summarise
+  stale_connections_cleaned: 🔌 Detected stale connections from a previous provider issue — cleaned up automatically. Proceeding with fresh connection.
+  preflight_compression: '📦 Preflight compression: ~{tokens} tokens >= {threshold} threshold. This may take a moment.'
+  compression_aux_unavailable: ⚠ Configured auxiliary compression provider '{provider}' is unavailable — context compression will drop middle turns without a summary. Check auxiliary.compression in config.yaml and reauthenticate that provider.
+  compression_no_provider: ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set OPENROUTER_API_KEY.
+  api_error_billing: ❌ Billing or credits exhausted — {summary}
+  api_error_rate_limited: ❌ Rate limited after {max_retries} retries — {summary}
+  api_error_failed: ❌ API failed after {max_retries} retries — {summary}
+  api_safety_blocked: '❌ Provider safety filter blocked this request: {summary}'
+  api_non_retryable: '❌ Non-retryable error (HTTP {status_code}): {summary}'
+  api_safety_trying_fallback: ⚠️ Provider safety filter blocked this request — trying fallback...
+  api_non_retryable_trying_fallback: ⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...
+  api_max_retries_trying_fallback: ⚠️ Max retries ({max_retries}) exhausted — trying fallback...
+  tool_guardrail_halted: '⚠️ Tool guardrail halted {tool}: {code}'
+  empty_response_retry: ⚠️ Empty response from model — retrying ({n}/3)
+  empty_response_switching_fallback: ⚠️ Model returning empty responses — switching to fallback provider...
+  empty_response_reasoning_only: ⚠️ Model produced reasoning but no visible response after all retries. Returning empty.
+  empty_response_no_content: ❌ Model returned no content after all retries and fallback attempts.
+  empty_response_no_content_no_fallback: ❌ Model returned no content after all retries. No fallback providers configured.
+  thinking_prefill_retry: ↻ Thinking-only response — prefilling to continue ({n}/2)
+  kanban_done: ✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}
+  kanban_blocked: ⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}
+  kanban_gave_up: ✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}
+  kanban_crashed: ✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry
+  kanban_timed_out: ⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry
+  busy_queued_drain: ⏳ Gateway {gerund} — queued for the next turn after it comes back.
+  busy_not_accepting_turn: ⏳ Gateway is {gerund} and is not accepting another turn right now.
+  busy_not_accepting_work: ⏳ Gateway is {gerund} and is not accepting new work right now.
+  shutdown_restarting: ⚠️ Gateway is restarting — The current task will be interrupted. Send any message after it restarts and I'll try to pick up where we left off.
+  shutdown_shutting_down: ⚠️ Gateway is shutting down — The current task will be interrupted.
+  steer_update_send_failed: '✗ Failed to send reply to update process: {error}'
+  steer_update_sent: ✓ Sent `{label}` to update process.
+  queued_next_turn_simple: Queued for next turn.
+  queued_next_turn_depth: Queued for next turn. ({depth} queued)
+  steer_usage: 'Usage: /steer <prompt>'
+  steer_agent_starting: Agent is still starting — /steer queued for next turn.
+  steer_failed: '⚠️ Steer failed: {error}'
+  steer_queued: '⏩ Steer queued — will be injected after the next tool call: ''{preview}'''
+  steer_rejected: Steer rejected (empty prompt).
+  steer_no_agent: No active agent — /steer queued for next turn.
+  steer_usage_no_agent: 'Usage: /steer <prompt>  (no agent running; sending as plain message)'
+  agent_running_switch_model: Agent is running — wait for it to finish or /stop it first, then switch model.
+  agent_running_change_runtime: Agent is running — wait for it to finish or /stop it first, then change runtime.
+  agent_running_goal: Agent is running — use /goal status / pause / clear while running or /stop before setting a new goal.
+  agent_running_cant_run_cmd: ⏳ Agent is running — `/{name}` can't run during a turn. Wait for the current response or use `/stop` first.
+  force_stopped_starting: ⚡ Force-stopped. Agent was still starting — session unlocked.
+  command_blocked_hook: Command `/{command}` was blocked by a hook.
+  quick_cmd_no_output: Command returned no output.
+  quick_cmd_timeout: Quick command timed out (30 s).
+  quick_cmd_error: 'Quick command error: {error}'
+  quick_cmd_no_command: Quick command '/{command}' has no command defined.
+  quick_cmd_no_target: Quick command '/{command}' has no target defined.
+  quick_cmd_unsupported_type: 'Quick command ''/{command}'' has unsupported type (supported: ''exec'', ''alias'').'
+  api_hint_auth: ' Check your API key or run `claude /login` to refresh OAuth credentials.'
+  api_hint_billing: ' Your API balance or quota is exhausted. Check your provider dashboard.'
+  api_hint_plan_limit_hours: ' Your plan''s usage limit was reached. It will reset in approximately ~{hours} h.'
+  api_hint_plan_limit: ' Your plan''s usage limit was reached. Please wait for it to reset.'
+  api_hint_rate_limited: ' You are being rate-limited. Please wait a moment and try again.'
+  api_hint_overloaded: ' The API is temporarily overloaded. Please try again in a little while.'
+  api_hint_rejected: ' The request was rejected by the API.'
+  api_error_generic: 'Sorry, an error occurred ({error_type}).
+
+    {error_detail}
+
+    {status_hint}Try again or use /reset to start a fresh session.'
+  delivery_failed: ⚠️ Message delivery failed after multiple attempts. Please try again — your request was processed but the response could not be sent.
+  response_formatting_failed: '(Response formatting failed, plain text:)
+
+
+    {content}'
+  audio_fallback_caption: '🔊 Audio: {audio_path}'
+  file_fallback_caption: '📎 File: {file_path}'
+  image_fallback_caption: '🖼️ Image: {image_path}'
+  clarify_question: ❓ {question}
+  clarify_instructions: Reply with the number, the option text, or your own answer.
+  clarify_instructions_multi: Multiple selections allowed — reply with the numbers separated by commas or spaces (e.g. "1, 3"), the option text, or your own answer.
+  model_no_response_tool_results: ⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your request.
+  session_auto_reset: '
+
+
+    🔄 Auto-reset — the conversation exceeded the maximum context size and cannot be compressed further. Your next message will start a fresh session.'
+  voice_no_stt: '🎤 I received your voice message but can''t transcribe it — no speech-to-text provider is configured.
+
+
+    To enable voice: install faster-whisper (`uv pip install faster-whisper` inside the Hermes venv; `pip install faster-whisper` also works if pip is on your PATH) and set `stt.enabled: true` in config.yaml, then /restart.'
+  voice_no_stt_setup_suffix: '
+
+
+    For full setup instructions run: `/skill hermes-agent-setup`'
+  compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
+  admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
+  admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.
+  suggestions_failed: 'Suggestions command failed: {error}'
+  bg_task_no_creds: '❌ Background task {task_id} failed: provider credentials not configured.'
+  bg_task_complete: '✅ Background task complete
+
+    Request: "{preview}"
+
+
+    '
+  bg_task_failed: '❌ Background task {task_id} failed: {error}'
+  busy_hint_queued: 💡 First-time tip — I queued your message instead of interrupting. Send `/busy interrupt` to make new messages stop the current task immediately, or `/busy status` to check. This notice won't appear again.
+  busy_hint_steered: 💡 First-time tip — I steered your message into the current run; it will arrive after the next tool call instead of interrupting. Send `/busy interrupt` or `/busy queue` to change this, or `/busy status` to check. This notice won't appear again.
+  busy_hint_redirect: 💡 First-time tip — I redirected the current run using your message. Completed work stays in context, and `/stop` still cancels the task. Send `/busy queue` to wait for a separate turn, or `/busy status` to check. This notice won't appear again.
+  busy_hint_interrupt: 💡 First-time tip — I just interrupted my current task to answer you. Send `/busy queue` to queue follow-ups for after the current task instead, `/busy steer` to inject them mid-run without interrupting, or `/busy status` to check. This notice won't appear again.
+  tool_progress_hint: 💡 First-time tip — that tool took a while and I'm streaming every step. If the progress messages feel noisy, send `/verbose` to cycle modes (all → new → off). This notice won't appear again.
+  bundles_unavailable: 'Bundles subsystem unavailable: {exc}'
+  bundles_none_installed: "No skill bundles installed.\nCreate one on the host with:\n  `hermes bundles create <name> --skill <s1> --skill <s2>`\nDirectory: `{bundles_dir}`"
+  bundles_header: '**Skill Bundles** ({n} installed):'
+  bundles_invoke_hint: Invoke a bundle with `/<slug>` to load all its skills.
+  update_managed: ✗ {managed_msg}
+  topic_no_chat_id: Could not determine chat ID.
+  topic_not_enabled: Multi-session topic mode is not currently enabled for this chat.
+  topic_disabled: 'Multi-session topic mode is disabled for this chat.
+
+
+    Existing Telegram topics are not deleted — they just won''t work as independent sessions anymore. The root chat is back to being a normal Hermes chat. Run /topic to re-enable.'
+  topic_no_unlinked_sessions: No previous unlinked Telegram sessions found.
+  topic_restore_instructions: 'To restore a previous session later:
+
+    1. Create or open a topic. To create a new one, open All Messages and send a message there.
+
+    2. Send /topic <session-id> inside that topic.'
+  session_not_found: 'Session not found: {session_id}'
+  session_not_telegram: This is not a Telegram session and cannot be restored into this topic.
+  session_wrong_user: This session does not belong to this Telegram user.
+  session_already_linked: This session is already linked to a different Telegram topic.
+  session_restored: 'Session restored: {title}'
+  session_restored_last_msg: '
+
+
+    Last Hermes message:
+
+    {content}'
+  command_cancelled: 🟡 /{command} cancelled. Conversation unchanged.
+  whoami_unrestricted: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: unrestricted (no admin list configured for this scope)
+
+    Slash commands: all available'
+  whoami_admin: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: **admin**
+
+    Slash commands: all available'
+  whoami_user: '**You** — {platform} ({scope})
+
+    User ID: `{user_id}`
+
+    Tier: user
+
+    Slash commands you can run: {runnable_str}'
+  platform_list_header: '**Gateway platforms**'
+  platform_connected: 'Connected: {platforms}'
+  platform_connected_none: 'Connected: (none)'
+  platform_failed_paused: '  · {platform} — PAUSED ({reason}). Resume with `/platform resume {platform}`.'
+  platform_retrying: '  · {platform} — retrying (attempt {attempts})'
+  platform_failed_none: 'Failed/paused: (none)'
+  platform_usage: 'Usage: /platform {action} <name>'
+  platform_unknown: 'Unknown platform: {target}'
+  platform_not_in_queue: '{platform} is not in the retry queue (it''s either connected or not enabled).'
+  platform_already_paused: '{platform} is already paused.'
+  platform_paused_ok: ✓ {platform} paused. Resume with `/platform resume {platform}` or `hermes gateway restart` to reset.
+  platform_not_in_queue_resume: '{platform} is not in the retry queue — nothing to resume.'
+  platform_already_retrying: '{platform} is already retrying — no resume needed.'
+  platform_resumed_ok: ✓ {platform} resumed — retrying on next watcher tick.
+  platform_usage_full: "Usage: /platform <list|pause|resume> [name]\n  /platform list — show platform status\n  /platform pause <name> — stop retrying a failing platform\n  /platform resume <name> — re-queue a paused platform"
+  model_expensive_warning: '⚠️ **Expensive Model Warning**
+
+
+    {warning_message}
+
+
+    _Text fallback: reply `{prefix}approve` to switch or `{prefix}cancel` to keep the current model._'
+  codex_runtime_errors: ❌ {errors}
+  codex_runtime_config_error: '❌ Could not load config: {exc}'
+  codex_runtime_result: '{prefix} {message}'
+  subgoal_no_active_goal: No active goal. Set one with /goal <text>.
+  subgoal_remove_usage: 'Usage: /subgoal remove <n>'
+  subgoal_remove_not_integer: '/subgoal remove: <n> must be an integer (1-based index).'
+  subgoal_remove_error: '/subgoal remove: {exc}'
+  subgoal_removed: '✓ Removed subgoal {idx}: {removed}'
+  subgoal_clear_error: '/subgoal clear: {exc}'
+  subgoal_cleared_one: ✓ Cleared {count} subgoal.
+  subgoal_cleared_many: ✓ Cleared {count} subgoals.
+  subgoal_none_to_clear: No subgoals to clear.
+  subgoal_add_error: '/subgoal: {exc}'
+  subgoal_added: '✓ Added subgoal {idx}: {text}'
+  memory_unknown_subcommand: 'Unknown /memory subcommand. Use: pending, approve <id>, reject <id>, approval <on|off>.'
+  skills_write_approval_off: Skill write approval is off (skills.write_approval). Enable it with /skills approval on, then review staged writes here with /skills pending.
+  skills_unknown_subcommand: 'Unknown /skills subcommand on this platform. Use: pending, approve <id>, reject <id>, diff <id>, approval <on|off>. (Search/install are CLI-only.)'
+  skills_diff_truncated: '
+
+    … (truncated — full diff in ~/.hermes/pending/skills/{pending_id}.json)'
+  tg_update_prompt_header: '⚕ *Update needs your input:*
+
+
+    '
+  tg_btn_yes: ✓ Yes
+  tg_btn_no: ✗ No
+  tg_approval_header: ⚠️ <b>Command Approval Required</b>
+  tg_btn_allow_once: ✅ Allow Once
+  tg_btn_allow_session: ✅ Session
+  tg_btn_allow_always: ✅ Always
+  tg_btn_deny: ❌ Deny
+  tg_btn_approve_once: ✅ Approve Once
+  tg_btn_always_approve: 🔒 Always Approve
+  tg_btn_cancel: ❌ Cancel
+  tg_btn_cancel_x: ✗ Cancel
+  tg_btn_prev: ◀ Prev
+  tg_btn_next: Next ▶
+  tg_btn_back: ◀ Back
+  tg_btn_switch_anyway: Switch anyway
+  tg_more_available: '
+
+    _{n} more available — type `/model <name>` directly_'
+  tg_model_config_header: ⚙ *Model Configuration*
+  tg_current_model: 'Current model: `{model}`'
+  tg_provider_line: 'Provider: {provider}'
+  tg_select_provider: 'Select a provider:'
+  tg_provider_bold: 'Provider: *{provider}*{page_info}'
+  tg_select_model: Select a model:{extra}
+  tg_provider_family: 'Provider family: *{family}*'
+  tg_error_switching_model: 'Error switching model: {error}'
+  tg_resolved: Resolved
+  tg_decision_by: '{label} by {user}'
+  tg_decision_appended: '{original}
+
+    — {label} by {user}'
+  tg_picker_expired: Picker expired — use /model again.
+  tg_provider_not_found: Provider not found.
+  tg_invalid_page: Invalid page.
+  tg_invalid_selection: Invalid selection.
+  tg_invalid_model_index: Invalid model index.
+  tg_picker_expired_short: Picker expired.
+  tg_switch_failed: Switch failed.
+  tg_model_switched: Model switched!
+  tg_confirm_expensive: Confirm expensive model
+  tg_group_not_found: Group not found.
+  tg_model_selection_cancelled: Model selection cancelled.
+  tg_expensive_warning_header: ⚠ *Expensive Model Warning*
+  tg_approved_once: ✅ Approved once
+  tg_denied: ❌ Denied
+  tg_approval_expired: ⌛ Approval expired
+  tg_approval_expired_detail: '{label} — no command was waiting. It already timed out (and was denied) or was resolved elsewhere.'
+  tg_approval_resolved: This approval has already been resolved.
+  tg_prompt_resolved: This prompt has already been resolved.
+  tg_approved_session: ✅ Approved for session
+  tg_approved_permanently: ✅ Approved permanently
+  tg_always_approve_label: 🔒 Always approve
+  tg_cancelled_label: ❌ Cancelled
+  tg_not_authorized_approve: ⛔ You are not authorized to approve commands.
+  tg_not_authorized_prompt: ⛔ You are not authorized to answer this prompt.
+  tg_not_authorized_update: ⛔ You are not authorized to answer update prompts.
+  tg_not_authorized_email: ⛔ You are not authorized to act on this email.
+  tg_type_answer: ✏️ Type your answer in the chat.
+  tg_invalid_choice: Invalid choice.
+  tg_clarify_resolved: ✓ {resolved_text}
+  tg_sent_answer: Sent '{answer}' to the update process.
+  tg_update_answered: '⚕ Update prompt answered: *{label}*'
+  tg_gmail_invalid_data: Invalid gmail-triage data.
+  tg_gmail_unknown_verb: 'Unknown verb: {verb}'
+  tg_gmail_script_missing: ❌ {script_name} missing
+  tg_gmail_verb_failed: '❌ {verb} failed: {detail}'
+  tg_gmail_verb_timed_out: ❌ {verb} timed out
+  tg_gmail_verb_error: '❌ {verb} error: {error}'
+  tg_invalid_approval_data: Invalid approval data.
+  cl_ollama_context_too_small: ❌ Ollama runtime context is too small for Hermes tool use
+  cl_nous_rate_limit: Nous Portal rate limit active — resets in {reset}.
+  cl_empty_malformed_switching: ⚠️ Empty/malformed response — switching to fallback...
+  cl_max_retries_invalid_trying_fallback: ⚠️ Max retries ({max}) for invalid responses — trying fallback...
+  cl_max_retries_invalid_giving_up: ❌ Max retries ({max}) exceeded for invalid responses. Giving up.
+  cl_refusal_status: ⚠️ The model declined to respond to this request (safety refusal).
+  cl_context_reduced: 🗜️ Context reduced to {reduced} tokens (was {old}), retrying...
+  cl_billing_switching_fallback: ⚠️ Billing or credits exhausted — switching to fallback provider...
+  cl_rate_limited_switching_fallback: ⚠️ Rate limited — switching to fallback provider...
+  cl_payload_too_large: ⚠️  Request payload too large (413) — compression attempt {n}/{max}...
+  cl_compressed_retrying: 🗜️ Compressed {before} → {after} messages, retrying...
+  cl_context_too_large_compressing: 🗜️ Context too large (~{tokens} tokens) — compressing ({n}/{max})...
+  cl_rate_limited_waiting: ⏱️ Rate limited. Waiting {wait}s (attempt {n}/{max})...
+  cl_retrying_in: ⏳ Retrying in {wait}s (attempt {n}/{max})...
+  cl_empty_after_tools_using_earlier: ↻ Empty response after tool calls — using earlier content as final answer
+  cl_content_policy_recovery_hint: Try rephrasing the request, narrowing the context, or adding a fallback provider with `hermes fallback add`.
+  cl_nous_no_fallback: '⏳ {nous}
+
+
+    No fallback provider available. Try again after the reset, or add a fallback provider in config.yaml.'
+  cl_refusal_explanation: 'Model''s explanation: {explanation}'
+  cl_refusal_no_explanation: The model returned no explanation.
+  cl_refusal_response: '⚠️  The model declined to respond to this request (safety refusal — not a Hermes/gateway failure).
+
+
+    {detail}
+
+
+    {hint}'
+  cl_thinking_budget_exhausted: '⚠️ **Thinking Budget Exhausted**
+
+
+    The model used all its output tokens on reasoning and had none left for the actual response.
+
+
+    To fix this:
+
+    → Lower reasoning effort: `/thinkon low` or `/thinkon minimal`
+
+    → Or switch to a larger/non-reasoning model with `/model`'
+  cl_interrupted_handling_error: 'Operation interrupted: handling API error ({error_type}: {detail}).'
+  cl_policy_blocked_response: '⚠️  The model provider''s safety filter blocked this request (not a Hermes/gateway failure).
+
+
+    Provider message: {summary}
+
+
+    {hint}'
+  cl_billing_exhausted: 'Billing or credits exhausted: {summary}'
+  cl_stream_drop_hint: '
+
+
+    The provider''s stream connection keeps dropping — this often happens when generating very large tool call responses (e.g. write_file with long content). Try asking me to use execute_code with Python''s open() for large files, or to write in smaller sections.'
+  cl_interrupted_retrying: 'Operation interrupted: retrying API call after error (retry {n}/{max}).'
+  cl_repeated_errors: 'I apologize, but I encountered repeated errors: {error}'
+  cl_local_processing_error: 'I apologize, but I encountered an error while processing the model response: {error}'
+  cron_response_prefix: 'Cronjob Response: '
+  cron_stop_hint_prefix: '
+
+
+    To stop or manage this job, send me a new message (e.g. "stop reminder '
+  cron_failure_rate_limit: '⚠️ Cron ''{job_name}'' failed: provider {reason}. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_timeout: '⚠️ Cron ''{job_name}'' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.'
+  cron_failure_auth: '⚠️ Cron ''{job_name}'' failed: provider authentication error. Full details saved in cron output.'
+  cron_failure_generic: '⚠️ Cron ''{job_name}'' failed: {cleaned}'
+  cron_watchdog_failed: '⚠ Cron watchdog ''{job_name}'' script failed
+
+
+    {output}
+
+
+    Time: {now_iso}'
+  aux_task_failed: '⚠ Auxiliary {task} failed: {detail}'
+  file_mutation_header: '⚠️ File-mutation verifier: {count} file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.'
+  file_mutation_bullet: '  • `{path}` — [{tool}] {preview}'
+  file_mutation_more: '  • … and {remaining} more'
+  no_reply_empty_response_exhausted: '⚠️ No reply: the model returned empty content after retries and any fallback providers. Try `continue`, switch model/provider, or inspect the tool output above.'
+  no_reply_all_retries_exhausted: '⚠️ No reply: all API retries were exhausted before a response was produced (provider errors / rate limits). Try `continue` or switch provider.'
+  no_reply_partial_stream_recovery: '⚠️ No reply: streaming stopped early and only a partial response was recovered. Send `continue` to resume from where it stopped.'
+  no_reply_fallback_prior_turn_content: '⚠️ No reply: no new content was produced this turn; showing recovered prior context. Send `continue` to retry.'
+  no_reply_interrupted_during_api_call: '⚠️ No reply: the request was interrupted mid-call before a reply was received. Send `continue` to retry.'
+  no_reply_budget_exhausted: '⚠️ No reply: the per-turn iteration/cost budget was exhausted before a final answer. Send `continue` to keep going.'
+  no_reply_ollama_context_too_small: '⚠️ No reply: the local model''s context window was too small to finish. Increase the context size or use a larger model.'
+  no_reply_max_iterations_reached: '⚠️ No reply: the maximum tool-iteration limit was reached before a final answer. Send `continue` to keep going, or raise `max_iterations`.'
+  no_reply_error_near_max_iterations: '⚠️ No reply: an error occurred near the iteration limit before a final answer. Check the tool output above, then send `continue`.'
+  no_reply_pending_tool_result: '⚠️ No reply: the turn stopped while a tool result was still pending and the model produced no follow-up text. Send `continue` to let it summarize.'
+  no_reply_session_persistence_failed: '⚠️ No reply: the turn was stopped because session storage could not be written (the transcript would have been lost on restart). Check disk space / permissions for the state DB, then send your message again.'
+  slash_confirm_prompt: '⚠️ **Confirm /{command}**
+
+
+    {detail}
+
+
+    Choose:
+
+    • **Approve Once** — proceed this time only
+
+    • **Always Approve** — proceed and silence this prompt permanently
+
+    • **Cancel** — keep current conversation
+
+
+    _Text fallback: reply `{prefix}approve`, `{prefix}always`, or `{prefix}cancel`._'
+  slash_confirm_disabled_note: '
+
+
+    ℹ️ Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.'
+  update_failed_exit_code: ❌ Hermes update failed (exit code {exit_code}).
+  update_timed_out: ❌ Hermes update timed out after 30 minutes.
+  update_finished_output: '✅ Hermes update finished.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_failed_output: '❌ Hermes update failed.
+
+
+    ```
+
+    {output}
+
+    ```'
+  update_finished_ok: ✅ Hermes update finished successfully.
+  update_finished: ✅ Hermes update finished.
+  update_failed_generic: ❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details.
+  proxy_error: '⚠️ Proxy error ({status}): {detail}'
+  proxy_connection_error: '⚠️ Proxy connection error: {error}'
+  dangerous_command_approval_text: '⚠️ **Dangerous command requires approval:**
+
+    ```
+
+    {command}
+
+    ```
+
+    Reason: {reason}
+
+
+    Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -566,6 +566,7 @@ Future messages in this room will use that transcript until `/reset` or another 
 
     For full setup instructions run: `/skill hermes-agent-setup`'
   compress_aborted: ⚠️ Context compression aborted ({err}). No messages were removed — conversation is unchanged. Run /compress to retry, /reset for a clean session, or check your auxiliary.compression model setting.
+  compaction_done: ✓ Context compaction complete — continuing turn...
   compress_aux_model_failed: ℹ️ Configured compression model `{model}` errored ({err}). Fell back to the primary model — context is intact — but you may want to check `auxiliary.compression.model` in config.yaml.
   admin_only_with_allowed: '⛔ /{cmd} is admin-only. You can run: {allowed_list}. Use /whoami for the full list.'
   admin_only_no_commands: ⛔ /{cmd} is admin-only. No commands are enabled for non-admins on this platform. Ask the admin to add you to allow_admin_from or set user_allowed_commands.

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -890,3 +890,12 @@ Future messages in this room will use that transcript until `/reset` or another 
 
 
     Reply `{prefix}approve` to execute, `{prefix}approve session` to approve this pattern for the session, `{prefix}approve always` to approve permanently, or `{prefix}deny` to cancel.'
+  session_reset_reason_suspended: previous session was stopped or interrupted
+  session_reset_reason_resume_pending_expired: gateway restart recovery timed out
+  session_reset_reason_daily: daily schedule at {hour}:00
+  session_reset_reason_idle: inactive for {duration}
+  session_reset_notice: '◐ Session automatically reset ({reason}). Conversation history cleared.
+
+    Use /resume to browse and restore a previous session.
+
+    Adjust reset timing in config.yaml under session_reset.'

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -306,6 +306,7 @@ from plugins.platforms.telegram.telegram_network import (
     parse_fallback_ip_env,
 )
 from utils import atomic_replace, env_float, env_int
+from agent.i18n import t
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 _TELEGRAM_IMAGE_MIME_TO_EXT = {
@@ -5383,11 +5384,11 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         try:
             default_hint = f" (default: {default})" if default else ""
-            text = self.format_message(f"⚕ *Update needs your input:*\n\n{prompt}{default_hint}")
+            text = self.format_message(f"{t('gateway.tg_update_prompt_header')}{prompt}{default_hint}")
             keyboard = InlineKeyboardMarkup([
                 [
-                    InlineKeyboardButton("✓ Yes", callback_data="update_prompt:y"),
-                    InlineKeyboardButton("✗ No", callback_data="update_prompt:n"),
+                    InlineKeyboardButton(t("gateway.tg_btn_yes"), callback_data="update_prompt:y"),
+                    InlineKeyboardButton(t("gateway.tg_btn_no"), callback_data="update_prompt:n"),
                 ]
             ])
             thread_id = self._metadata_thread_id(metadata)
@@ -5422,6 +5423,9 @@ class TelegramAdapter(BasePlatformAdapter):
     def _ea_escape(self, text: str) -> str:
         return _html.escape(text)
 
+    def _ea_header(self) -> str:
+        return f"{t('gateway.tg_approval_header')}\n\n"
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -5453,17 +5457,31 @@ class TelegramAdapter(BasePlatformAdapter):
             approval_id = next(self._approval_counter)
 
             buttons = [
-                InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{approval_id}")
+                InlineKeyboardButton(
+                    t("gateway.tg_btn_allow_once"),
+                    callback_data=f"ea:once:{approval_id}",
+                )
             ]
             if not smart_denied and allow_session:
                 buttons.append(
-                    InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{approval_id}")
+                    InlineKeyboardButton(
+                        t("gateway.tg_btn_allow_session"),
+                        callback_data=f"ea:session:{approval_id}",
+                    )
                 )
                 if allow_permanent:
                     buttons.append(
-                        InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}")
+                        InlineKeyboardButton(
+                            t("gateway.tg_btn_allow_always"),
+                            callback_data=f"ea:always:{approval_id}",
+                        )
                     )
-            buttons.append(InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}"))
+            buttons.append(
+                InlineKeyboardButton(
+                    t("gateway.tg_btn_deny"),
+                    callback_data=f"ea:deny:{approval_id}",
+                )
+            )
             # Pair into rows (2x2 for the full set) so labels stay readable on
             # mobile — a single 4-button row truncates to "Allo… / Ses… / …".
             rows = [buttons[i:i + 2] for i in range(0, len(buttons), 2)]
@@ -5511,11 +5529,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
             keyboard = InlineKeyboardMarkup([
                 [
-                    InlineKeyboardButton("✅ Approve Once", callback_data=f"sc:once:{confirm_id}"),
-                    InlineKeyboardButton("🔒 Always Approve", callback_data=f"sc:always:{confirm_id}"),
+                    InlineKeyboardButton(t("gateway.tg_btn_approve_once"), callback_data=f"sc:once:{confirm_id}"),
+                    InlineKeyboardButton(t("gateway.tg_btn_always_approve"), callback_data=f"sc:always:{confirm_id}"),
                 ],
                 [
-                    InlineKeyboardButton("❌ Cancel", callback_data=f"sc:cancel:{confirm_id}"),
+                    InlineKeyboardButton(t("gateway.tg_btn_cancel"), callback_data=f"sc:cancel:{confirm_id}"),
                 ],
             ])
 
@@ -5917,15 +5935,15 @@ class TelegramAdapter(BasePlatformAdapter):
         if total_pages > 1:
             nav: list = []
             if page > 0:
-                nav.append(InlineKeyboardButton("◀ Prev", callback_data=f"mg:{page - 1}"))
+                nav.append(InlineKeyboardButton(t("gateway.tg_btn_prev"), callback_data=f"mg:{page - 1}"))
             nav.append(InlineKeyboardButton(f"{page + 1}/{total_pages}", callback_data="mx:noop"))
             if page < total_pages - 1:
-                nav.append(InlineKeyboardButton("Next ▶", callback_data=f"mg:{page + 1}"))
+                nav.append(InlineKeyboardButton(t("gateway.tg_btn_next"), callback_data=f"mg:{page + 1}"))
             rows.append(nav)
 
         rows.append([
-            InlineKeyboardButton("◀ Back", callback_data="mb"),
-            InlineKeyboardButton("✗ Cancel", callback_data="mx"),
+            InlineKeyboardButton(t("gateway.tg_btn_back"), callback_data="mb"),
+            InlineKeyboardButton(t("gateway.tg_btn_cancel_x"), callback_data="mx"),
         ])
 
         return InlineKeyboardMarkup(rows), page_meta["page_info"]
@@ -5936,7 +5954,7 @@ class TelegramAdapter(BasePlatformAdapter):
         """Handle model picker inline keyboard callbacks (mp:/mm:/mc:/mb:/mx:/mg:)."""
         state = self._model_picker_state.get(chat_id)
         if not state:
-            await query.answer(text="Picker expired — use /model again.")
+            await query.answer(text=t("gateway.tg_picker_expired"))
             return
 
         try:
@@ -5953,7 +5971,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 None,
             )
             if not provider:
-                await query.answer(text="Provider not found.")
+                await query.answer(text=t("gateway.tg_provider_not_found"))
                 return
 
             models = provider.get("models", [])
@@ -5967,14 +5985,14 @@ class TelegramAdapter(BasePlatformAdapter):
             pname = provider.get("name", provider_slug)
             total = provider.get("total_models", len(models))
             shown = len(models)
-            extra = f"\n_{total - shown} more available — type `/model <name>` directly_" if total > shown else ""
+            extra = t("gateway.tg_more_available", n=total - shown) if total > shown else ""
 
             await query.edit_message_text(
                 text=self.format_message(
                     (
-                        f"⚙ *Model Configuration*\n\n"
-                        f"Provider: *{pname}*{page_info}\n"
-                        f"Select a model:{extra}"
+                        f"{t('gateway.tg_model_config_header')}\n\n"
+                        f"{t('gateway.tg_provider_bold', provider=pname, page_info=page_info)}\n"
+                        f"{t('gateway.tg_select_model', extra=extra)}"
                     )
                 ),
                 parse_mode=ParseMode.MARKDOWN_V2,
@@ -5987,7 +6005,7 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 page = int(data[3:])
             except ValueError:
-                await query.answer(text="Invalid page.")
+                await query.answer(text=t("gateway.tg_invalid_page"))
                 return
 
             models = state.get("model_list", [])
@@ -6003,14 +6021,14 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             total = provider.get("total_models", len(models)) if provider else len(models)
             shown = len(models)
-            extra = f"\n_{total - shown} more available — type `/model <name>` directly_" if total > shown else ""
+            extra = t("gateway.tg_more_available", n=total - shown) if total > shown else ""
 
             await query.edit_message_text(
                 text=self.format_message(
                     (
-                        f"⚙ *Model Configuration*\n\n"
-                        f"Provider: *{pname}*{page_info}\n"
-                        f"Select a model:{extra}"
+                        f"{t('gateway.tg_model_config_header')}\n\n"
+                        f"{t('gateway.tg_provider_bold', provider=pname, page_info=page_info)}\n"
+                        f"{t('gateway.tg_select_model', extra=extra)}"
                     )
                 ),
                 parse_mode=ParseMode.MARKDOWN_V2,
@@ -6055,12 +6073,12 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 idx = int(data[3:])
             except ValueError:
-                await query.answer(text="Invalid selection.")
+                await query.answer(text=t("gateway.tg_invalid_selection"))
                 return
 
             model_list = state.get("model_list", [])
             if idx < 0 or idx >= len(model_list):
-                await query.answer(text="Invalid model index.")
+                await query.answer(text=t("gateway.tg_invalid_model_index"))
                 return
 
             model_id = model_list[idx]
@@ -6068,7 +6086,7 @@ class TelegramAdapter(BasePlatformAdapter):
             callback = state.get("on_model_selected")
 
             if not callback:
-                await query.answer(text="Picker expired.")
+                await query.answer(text=t("gateway.tg_picker_expired_short"))
                 return
 
             switch_failed = False
@@ -6076,7 +6094,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 result_text = await callback(chat_id, model_id, provider_slug)
             except Exception as exc:
                 logger.error("Model picker switch failed: %s", exc)
-                result_text = f"Error switching model: {exc}"
+                result_text = t("gateway.tg_error_switching_model", error=exc)
                 switch_failed = True
 
             try:
@@ -6095,7 +6113,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
             await query.answer(
-                text="Switch failed." if switch_failed else "Model switched!"
+                text=t("gateway.tg_switch_failed") if switch_failed else t("gateway.tg_model_switched")
             )
             self._model_picker_state.pop(chat_id, None)
 
@@ -6104,12 +6122,12 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 idx = int(data[3:])
             except ValueError:
-                await query.answer(text="Invalid selection.")
+                await query.answer(text=t("gateway.tg_invalid_selection"))
                 return
 
             model_list = state.get("model_list", [])
             if idx < 0 or idx >= len(model_list):
-                await query.answer(text="Invalid model index.")
+                await query.answer(text=t("gateway.tg_invalid_model_index"))
                 return
 
             model_id = model_list[idx]
@@ -6117,7 +6135,7 @@ class TelegramAdapter(BasePlatformAdapter):
             callback = state.get("on_model_selected")
 
             if not callback:
-                await query.answer(text="Picker expired.")
+                await query.answer(text=t("gateway.tg_picker_expired_short"))
                 return
 
             try:
@@ -6134,20 +6152,20 @@ class TelegramAdapter(BasePlatformAdapter):
                 warning = None
             if warning is not None:
                 keyboard = InlineKeyboardMarkup([
-                    [InlineKeyboardButton("Switch anyway", callback_data=f"mc:{idx}")],
+                    [InlineKeyboardButton(t("gateway.tg_btn_switch_anyway"), callback_data=f"mc:{idx}")],
                     [
-                        InlineKeyboardButton("◀ Back", callback_data="mb"),
-                        InlineKeyboardButton("✗ Cancel", callback_data="mx"),
+                        InlineKeyboardButton(t("gateway.tg_btn_back"), callback_data="mb"),
+                        InlineKeyboardButton(t("gateway.tg_btn_cancel_x"), callback_data="mx"),
                     ],
                 ])
                 await query.edit_message_text(
                     text=self.format_message(
-                        f"⚠ *Expensive Model Warning*\n\n{warning.message}"
+                        f"{t('gateway.tg_expensive_warning_header')}\n\n{warning.message}"
                     ),
                     parse_mode=ParseMode.MARKDOWN_V2,
                     reply_markup=keyboard,
                 )
-                await query.answer(text="Confirm expensive model")
+                await query.answer(text=t("gateway.tg_confirm_expensive"))
                 return
 
             switch_failed = False
@@ -6155,7 +6173,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 result_text = await callback(chat_id, model_id, provider_slug)
             except Exception as exc:
                 logger.error("Model picker switch failed: %s", exc)
-                result_text = f"Error switching model: {exc}"
+                result_text = t("gateway.tg_error_switching_model", error=exc)
                 switch_failed = True
 
             # Edit message to show confirmation, remove buttons
@@ -6176,7 +6194,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
             await query.answer(
-                text="Switch failed." if switch_failed else "Model switched!"
+                text=t("gateway.tg_switch_failed") if switch_failed else t("gateway.tg_model_switched")
             )
 
             # Clean up state
@@ -6194,7 +6212,7 @@ class TelegramAdapter(BasePlatformAdapter):
             by_slug = {p["slug"]: p for p in state["providers"]}
             members = [by_slug[m] for m in member_slugs if m in by_slug]
             if not members:
-                await query.answer(text="Group not found.")
+                await query.answer(text=t("gateway.tg_group_not_found"))
                 return
 
             buttons = []
@@ -6208,17 +6226,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
             rows.append([
-                InlineKeyboardButton("◀ Back", callback_data="mb"),
-                InlineKeyboardButton("✗ Cancel", callback_data="mx"),
+                InlineKeyboardButton(t("gateway.tg_btn_back"), callback_data="mb"),
+                InlineKeyboardButton(t("gateway.tg_btn_cancel_x"), callback_data="mx"),
             ])
             keyboard = InlineKeyboardMarkup(rows)
 
             await query.edit_message_text(
                 text=self.format_message(
                     (
-                        f"⚙ *Model Configuration*\n\n"
-                        f"Provider family: *{_label or group_id}*\n\n"
-                        f"Select a provider:"
+                        f"{t('gateway.tg_model_config_header')}\n\n"
+                        f"{t('gateway.tg_provider_family', family=_label or group_id)}\n\n"
+                        f"{t('gateway.tg_select_provider')}"
                     )
                 ),
                 parse_mode=ParseMode.MARKDOWN_V2,
@@ -6256,7 +6274,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # --- Cancel ---
             self._model_picker_state.pop(chat_id, None)
             await query.edit_message_text(
-                text="Model selection cancelled.",
+                text=t("gateway.tg_model_selection_cancelled"),
                 reply_markup=None,
             )
             await query.answer()
@@ -6339,7 +6357,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 try:
                     approval_id = int(parts[2])
                 except (ValueError, IndexError):
-                    await query.answer(text="Invalid approval data.")
+                    await query.answer(text=t("gateway.tg_invalid_approval_data"))
                     return
 
                 # Only authorized users may click approval buttons.
@@ -6351,12 +6369,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     thread_id=str(query_thread_id) if query_thread_id is not None else None,
                     user_name=query_user_name,
                 ):
-                    await query.answer(text="⛔ You are not authorized to approve commands.")
+                    await query.answer(text=t("gateway.tg_not_authorized_approve"))
                     return
 
                 session_key = self._approval_state.pop(approval_id, None)
                 if not session_key:
-                    await query.answer(text="This approval has already been resolved.")
+                    await query.answer(text=t("gateway.tg_approval_resolved"))
                     return
 
                 user_display = getattr(query.from_user, "first_name", "User")
@@ -6381,19 +6399,18 @@ class TelegramAdapter(BasePlatformAdapter):
                 if count:
                     # Map choice to human-readable label
                     label_map = {
-                        "once": "✅ Approved once",
-                        "session": "✅ Approved for session",
-                        "always": "✅ Approved permanently",
-                        "deny": "❌ Denied",
+                        "once": t("gateway.tg_approved_once"),
+                        "session": t("gateway.tg_approved_session"),
+                        "always": t("gateway.tg_approved_permanently"),
+                        "deny": t("gateway.tg_denied"),
                     }
-                    label = label_map.get(choice, "Resolved")
-                    edit_text = f"{label} by {user_display}"
-                else:
-                    label = "⌛ Approval expired"
-                    edit_text = (
-                        f"{label} — no command was waiting. "
-                        f"It already timed out (and was denied) or was resolved elsewhere."
+                    label = label_map.get(choice, t("gateway.tg_resolved"))
+                    edit_text = t(
+                        "gateway.tg_decision_by", label=label, user=user_display
                     )
+                else:
+                    label = t("gateway.tg_approval_expired")
+                    edit_text = t("gateway.tg_approval_expired_detail", label=label)
 
                 await query.answer(text=label)
 
@@ -6431,27 +6448,27 @@ class TelegramAdapter(BasePlatformAdapter):
                     thread_id=str(query_thread_id) if query_thread_id is not None else None,
                     user_name=query_user_name,
                 ):
-                    await query.answer(text="⛔ You are not authorized to answer this prompt.")
+                    await query.answer(text=t("gateway.tg_not_authorized_prompt"))
                     return
 
                 session_key = self._slash_confirm_state.pop(confirm_id, None)
                 if not session_key:
-                    await query.answer(text="This prompt has already been resolved.")
+                    await query.answer(text=t("gateway.tg_prompt_resolved"))
                     return
 
                 label_map = {
-                    "once": "✅ Approved once",
-                    "always": "🔒 Always approve",
-                    "cancel": "❌ Cancelled",
+                    "once": t("gateway.tg_approved_once"),
+                    "always": t("gateway.tg_always_approve_label"),
+                    "cancel": t("gateway.tg_cancelled_label"),
                 }
                 user_display = getattr(query.from_user, "first_name", "User")
-                label = label_map.get(choice, "Resolved")
+                label = label_map.get(choice, t("gateway.tg_resolved"))
 
                 await query.answer(text=label)
 
                 try:
                     await query.edit_message_text(
-                        text=self.format_message(f"{label} by {user_display}"),
+                        text=self.format_message(t("gateway.tg_decision_by", label=label, user=user_display)),
                         parse_mode=ParseMode.MARKDOWN_V2,
                         reply_markup=None,
                     )
@@ -6531,12 +6548,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     thread_id=str(query_thread_id) if query_thread_id is not None else None,
                     user_name=query_user_name,
                 ):
-                    await query.answer(text="⛔ You are not authorized to answer this prompt.")
+                    await query.answer(text=t("gateway.tg_not_authorized_prompt"))
                     return
 
                 session_key = self._clarify_state.get(clarify_id)
                 if not session_key:
-                    await query.answer(text="This prompt has already been resolved.")
+                    await query.answer(text=t("gateway.tg_prompt_resolved"))
                     return
 
                 user_display = getattr(query.from_user, "first_name", "User")
@@ -6562,7 +6579,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._notify_clarify_expired(query, user_display)
                         return
 
-                    await query.answer(text="✏️ Type your answer in the chat.")
+                    await query.answer(text=t("gateway.tg_type_answer"))
                     try:
                         await query.edit_message_text(
                             text=f"❓ {query.message.text or ''}\n\n<i>Awaiting typed response from {_html.escape(user_display)}…</i>",
@@ -6577,7 +6594,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 try:
                     idx = int(choice_token)
                 except (ValueError, TypeError):
-                    await query.answer(text="Invalid choice.")
+                    await query.answer(text=t("gateway.tg_invalid_choice"))
                     return
 
                 # Look up the choice text from the entry registered in the
@@ -6608,7 +6625,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     resolved = False
 
                 if resolved:
-                    await query.answer(text=f"✓ {resolved_text[:60]}")
+                    await query.answer(text=t("gateway.tg_clarify_resolved", resolved_text=resolved_text[:60]))
                     try:
                         await query.edit_message_text(
                             text=f"❓ {_html.escape(query.message.text or '')}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}",
@@ -6644,14 +6661,14 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id=str(query_thread_id) if query_thread_id is not None else None,
             user_name=query_user_name,
         ):
-            await query.answer(text="⛔ You are not authorized to answer update prompts.")
+            await query.answer(text=t("gateway.tg_not_authorized_update"))
             return
-        await query.answer(text=f"Sent '{answer}' to the update process.")
+        await query.answer(text=t("gateway.tg_sent_answer", answer=answer))
         # Edit the message to show the choice and remove buttons
         label = "Yes" if answer == "y" else "No"
         try:
             await query.edit_message_text(
-                text=self.format_message(f"⚕ Update prompt answered: *{label}*"),
+                text=self.format_message(t("gateway.tg_update_answered", label=label)),
                 parse_mode=ParseMode.MARKDOWN_V2,
                 reply_markup=None,
             )
@@ -6703,7 +6720,7 @@ class TelegramAdapter(BasePlatformAdapter):
         """Dispatch a gmail-triage inline-button callback (gt:verb:arg)."""
         parts = data.split(":", 2)
         if len(parts) != 3:
-            await query.answer(text="Invalid gmail-triage data.")
+            await query.answer(text=t("gateway.tg_gmail_invalid_data"))
             return
         verb, arg = parts[1], parts[2]
 
@@ -6715,18 +6732,18 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id=str(query_thread_id) if query_thread_id is not None else None,
             user_name=query_user_name,
         ):
-            await query.answer(text="⛔ You are not authorized to act on this email.")
+            await query.answer(text=t("gateway.tg_not_authorized_email"))
             return
 
         entry = self._GT_VERB_DISPATCH.get(verb)
         if not entry:
-            await query.answer(text=f"Unknown verb: {verb}")
+            await query.answer(text=t("gateway.tg_gmail_unknown_verb", verb=verb))
             return
         script_name, extra_args, success_label, is_state_verb = entry
 
         script_path = _Path.home() / ".hermes" / "scripts" / "gmail-triage" / script_name
         if not script_path.exists():
-            await query.answer(text=f"❌ {script_name} missing")
+            await query.answer(text=t("gateway.tg_gmail_script_missing", script_name=script_name))
             logger.error("[%s] gmail-triage script missing: %s", self.name, script_path)
             return
 
@@ -6751,16 +6768,16 @@ class TelegramAdapter(BasePlatformAdapter):
             else:
                 stderr_text = stderr_bytes.decode("utf-8", errors="replace").strip()
                 last_line = stderr_text.splitlines()[-1] if stderr_text else f"exit {proc.returncode}"
-                label = f"❌ {verb} failed: {last_line[:80]}"
+                label = t("gateway.tg_gmail_verb_failed", verb=verb, detail=last_line[:80])
                 logger.error(
                     "[%s] gmail-triage callback failed: verb=%s arg=%s rc=%s stderr=%s",
                     self.name, verb, arg, proc.returncode, stderr_text,
                 )
         except asyncio.TimeoutError:
-            label = f"❌ {verb} timed out"
+            label = t("gateway.tg_gmail_verb_timed_out", verb=verb)
             logger.error("[%s] gmail-triage callback timed out: verb=%s arg=%s", self.name, verb, arg)
         except Exception as exc:
-            label = f"❌ {verb} error: {exc}"
+            label = t("gateway.tg_gmail_verb_error", verb=verb, error=exc)
             logger.error(
                 "[%s] gmail-triage callback exception: verb=%s arg=%s err=%s",
                 self.name, verb, arg, exc, exc_info=True,
@@ -6772,7 +6789,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         user_display = getattr(query.from_user, "first_name", "User")
         original_text = (query.message.text or "") if query.message else ""
-        appended = f"{original_text}\n— {label} by {user_display}"
+        appended = t("gateway.tg_decision_appended", original=original_text, label=label, user=user_display)
         try:
             if is_state_verb:
                 # Sticky state change: append confirmation, KEEP keyboard so

--- a/run_agent.py
+++ b/run_agent.py
@@ -116,6 +116,7 @@ from agent.process_bootstrap import (
 )
 from agent.iteration_budget import IterationBudget
 from agent.interrupt_compat import request_hard_interrupt
+from agent.i18n import t
 
 
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -1301,7 +1302,7 @@ class AIAgent:
         detail = (detail or exc.__class__.__name__).strip()
         if len(detail) > 220:
             detail = detail[:217].rstrip() + "..."
-        self._emit_warning(f"⚠ Auxiliary {task} failed: {detail}")
+        self._emit_warning(t("gateway.aux_task_failed", task=task, detail=detail))
 
     def _current_main_runtime(self) -> Dict[str, str]:
         """Return the live main runtime for session-scoped auxiliary routing."""
@@ -3498,10 +3499,7 @@ class AIAgent:
         if not failed:
             return ""
         lines = [
-            "⚠️ File-mutation verifier: "
-            f"{len(failed)} file(s) were NOT modified this turn despite any "
-            "wording above that may suggest otherwise. Run `git status` or "
-            "`read_file` to confirm."
+            t("gateway.file_mutation_header", count=len(failed))
         ]
         shown = 0
         for path, info in failed.items():
@@ -3510,13 +3508,13 @@ class AIAgent:
             preview = (info.get("error_preview") or "").strip()
             tool = info.get("tool") or "patch"
             if preview:
-                lines.append(f"  • `{path}` — [{tool}] {preview}")
+                lines.append(t("gateway.file_mutation_bullet", path=path, tool=tool, preview=preview))
             else:
-                lines.append(f"  • `{path}` — [{tool}] failed")
+                lines.append(t("gateway.file_mutation_bullet", path=path, tool=tool, preview="failed"))
             shown += 1
         remaining = len(failed) - shown
         if remaining > 0:
-            lines.append(f"  • … and {remaining} more")
+            lines.append(t("gateway.file_mutation_more", remaining=remaining))
         # Neutralize any path the preview text echoed (the bullet path is
         # already backticked above; the lookbehind keeps it from being
         # double-wrapped).
@@ -3573,79 +3571,28 @@ class AIAgent:
         if reason.startswith("text_response"):
             return ""
 
-        prefix = "⚠️ No reply: "
         if reason == "empty_response_exhausted":
-            return (
-                prefix
-                + "the model returned empty content after retries and any "
-                "fallback providers. Try `continue`, switch model/provider, "
-                "or inspect the tool output above."
-            )
+            return t("gateway.no_reply_empty_response_exhausted")
         if reason == "all_retries_exhausted_no_response":
-            return (
-                prefix
-                + "all API retries were exhausted before a response was "
-                "produced (provider errors / rate limits). Try `continue` "
-                "or switch provider."
-            )
+            return t("gateway.no_reply_all_retries_exhausted")
         if reason == "partial_stream_recovery":
-            return (
-                prefix
-                + "streaming stopped early and only a partial response was "
-                "recovered. Send `continue` to resume from where it stopped."
-            )
+            return t("gateway.no_reply_partial_stream_recovery")
         if reason == "fallback_prior_turn_content":
-            return (
-                prefix
-                + "no new content was produced this turn; showing recovered "
-                "prior context. Send `continue` to retry."
-            )
+            return t("gateway.no_reply_fallback_prior_turn_content")
         if reason == "interrupted_during_api_call":
-            return (
-                prefix
-                + "the request was interrupted mid-call before a reply was "
-                "received. Send `continue` to retry."
-            )
+            return t("gateway.no_reply_interrupted_during_api_call")
         if reason == "budget_exhausted":
-            return (
-                prefix
-                + "the per-turn iteration/cost budget was exhausted before a "
-                "final answer. Send `continue` to keep going."
-            )
+            return t("gateway.no_reply_budget_exhausted")
         if reason == "ollama_runtime_context_too_small":
-            return (
-                prefix
-                + "the local model's context window was too small to finish. "
-                "Increase the context size or use a larger model."
-            )
+            return t("gateway.no_reply_ollama_context_too_small")
         if reason.startswith("max_iterations_reached"):
-            return (
-                prefix
-                + "the maximum tool-iteration limit was reached before a "
-                "final answer. Send `continue` to keep going, or raise "
-                "`max_iterations`."
-            )
+            return t("gateway.no_reply_max_iterations_reached")
         if reason.startswith("error_near_max_iterations"):
-            return (
-                prefix
-                + "an error occurred near the iteration limit before a final "
-                "answer. Check the tool output above, then send `continue`."
-            )
+            return t("gateway.no_reply_error_near_max_iterations")
         if reason == "pending_tool_result":
-            return (
-                prefix
-                + "the turn stopped while a tool result was still pending and "
-                "the model produced no follow-up text. Send `continue` to "
-                "let it summarize."
-            )
+            return t("gateway.no_reply_pending_tool_result")
         if reason == "session_persistence_failed":
-            return (
-                prefix
-                + "the turn was stopped because session storage could not be "
-                "written (the transcript would have been lost on restart). "
-                "This is often a full disk — free some space (or fix state.db "
-                "permissions), then send your message again."
-            )
+            return t("gateway.no_reply_session_persistence_failed")
         # Unknown/diagnostic-only reasons (e.g. "unknown", guardrail_halt
         # which already surfaces its own message) — don't second-guess.
         return ""

--- a/tests/gateway/test_migration_i18n_suppression.py
+++ b/tests/gateway/test_migration_i18n_suppression.py
@@ -1,9 +1,8 @@
-"""Fork migration: gateway.system_messages custom-text override.
+"""Fork migration: gateway.system_messages override + category suppression.
 
-Locks the fork's ``gateway.system_messages.<key>`` override layer grafted onto
-upstream's i18n engine (agent/i18n.py) after the upstream/main rebase. Upstream's
-own i18n behaviour is covered by tests/agent/test_i18n.py (unchanged, still
-passing). Category suppression is a separate feature (see its own test module).
+These lock the novel fork additions grafted onto upstream's i18n engine
+(agent/i18n.py) after the upstream/main rebase. Upstream's own i18n behaviour
+is covered by tests/agent/test_i18n.py (unchanged, still passing).
 """
 from __future__ import annotations
 
@@ -13,6 +12,7 @@ from unittest.mock import patch
 import pytest
 
 import agent.i18n as i18n
+from agent.i18n import GATEWAY_MESSAGE_CATEGORIES, _MUTABLE_CATEGORIES
 
 
 def _cfg(**system_messages):
@@ -63,10 +63,60 @@ def test_name_autofill_uses_configured_custom_skin(tmp_path, monkeypatch):
     i18n.reset_language_cache()
 
 
-def test_gateway_system_messages_is_registered_in_default_config():
+# ---- category suppression ---------------------------------------------------
+
+@pytest.mark.parametrize("key", sorted(GATEWAY_MESSAGE_CATEGORIES))
+def test_map_key_exists_in_catalog(key):
+    """Every category-map key must resolve to a real English catalog entry."""
+    i18n.reset_language_cache()
+    en = i18n._load_catalog("en")
+    assert key in en, f"{key} is in the suppression map but missing from en.yaml"
+
+
+def test_map_only_mutable_categories():
+    assert set(GATEWAY_MESSAGE_CATEGORIES.values()) <= set(_MUTABLE_CATEGORIES)
+
+
+@pytest.mark.parametrize("category", sorted(_MUTABLE_CATEGORIES))
+def test_suppress_single_category(category):
+    with patch.object(i18n, "_load_config_dict", return_value=_cfg(suppress=[category])):
+        i18n.reset_language_cache()
+        for key, cat in GATEWAY_MESSAGE_CATEGORIES.items():
+            if cat == category:
+                assert i18n.t(key) == "", f"{key} should be suppressed under {category}"
+    i18n.reset_language_cache()
+
+
+def test_suppress_all_mutes_all_mutable():
+    with patch.object(i18n, "_load_config_dict", return_value=_cfg(suppress="all")):
+        i18n.reset_language_cache()
+        for key in GATEWAY_MESSAGE_CATEGORIES:
+            assert i18n.t(key) == ""
+    i18n.reset_language_cache()
+
+
+def test_errors_never_suppressed():
+    """provider_* category replies are NOT in the map -> always shown."""
+    with patch.object(i18n, "_load_config_dict", return_value=_cfg(suppress="all")):
+        i18n.reset_language_cache()
+        for key in ("gateway.provider_auth_failed", "gateway.provider_failed"):
+            assert i18n.t(key), f"{key} must stay visible even under suppress: all"
+    i18n.reset_language_cache()
+
+
+def test_invalid_category_ignored_not_crashing():
+    with patch.object(i18n, "_load_config_dict", return_value=_cfg(suppress=["errors", "bogus", "info"])):
+        i18n.reset_language_cache()
+        # info still suppressed, errors/bogus ignored, no crash
+        assert i18n.t("gateway.kanban_done") == ""
+        assert i18n.t("gateway.provider_failed")
+    i18n.reset_language_cache()
+
+
+def test_gateway_system_message_suppression_is_registered_in_default_config():
     from hermes_cli.config import DEFAULT_CONFIG
 
-    assert DEFAULT_CONFIG["gateway"]["system_messages"] == {}
+    assert DEFAULT_CONFIG["gateway"]["system_messages"]["suppress"] == []
 
 
 # ---- marker-coupling preserved ---------------------------------------------

--- a/tests/gateway/test_migration_i18n_suppression.py
+++ b/tests/gateway/test_migration_i18n_suppression.py
@@ -1,0 +1,76 @@
+"""Fork migration: gateway.system_messages custom-text override.
+
+Locks the fork's ``gateway.system_messages.<key>`` override layer grafted onto
+upstream's i18n engine (agent/i18n.py) after the upstream/main rebase. Upstream's
+own i18n behaviour is covered by tests/agent/test_i18n.py (unchanged, still
+passing). Category suppression is a separate feature (see its own test module).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import agent.i18n as i18n
+
+
+def _cfg(**system_messages):
+    return {"gateway": {"system_messages": system_messages}, "display": {"language": "ru"}}
+
+
+# ---- custom-text override (gateway.system_messages.<key>) -------------------
+
+def test_override_replaces_catalog_value():
+    with patch.object(i18n, "_load_config_dict", return_value=_cfg(draining="СВОЙ {count}")):
+        i18n.reset_language_cache()
+        assert i18n.t("gateway.draining", count=3) == "СВОЙ 3"
+    i18n.reset_language_cache()
+
+
+def test_override_missing_placeholder_stays_literal():
+    with patch.object(i18n, "_load_config_dict", return_value=_cfg(draining="X {count} {bogus}")):
+        i18n.reset_language_cache()
+        out = i18n.t("gateway.draining", count=1)
+        assert "{bogus}" in out and "1" in out  # safe formatter degrades
+    i18n.reset_language_cache()
+
+
+def test_name_autofill():
+    with patch.object(i18n, "_load_config_dict",
+                      return_value={"ui": {"theme": {"branding": {"agent_name": "Гермес"}}},
+                                    "gateway": {"system_messages": {"draining": "{name} drains {count}"}},
+                                    "display": {"language": "ru"}}):
+        i18n.reset_language_cache()
+        assert i18n.t("gateway.draining", count=2) == "Гермес drains 2"
+    i18n.reset_language_cache()
+
+
+# ---- marker-coupling preserved ---------------------------------------------
+
+def test_provider_auth_envelope_stays_english_literal():
+    """The raw 'Provider authentication failed: {exc}' envelope must remain a
+    literal in run.py so _GATEWAY_PROVIDER_ERROR_SHAPE_RE still rewrites it."""
+    src = Path("gateway/run.py").read_text(encoding="utf-8")
+    assert 'f"⚠️ Provider authentication failed: {exc}"' in src
+
+
+# ---- sample net-new keys resolve in Russian --------------------------------
+
+@pytest.mark.parametrize("key,kwargs", [
+    ("gateway.long_running", {"minutes": 5, "status_detail": ""}),
+    ("gateway.kanban_done", {"tag": "", "task_id": "t1", "title": "X", "handoff": ""}),
+    (
+        "gateway.codex_gpt55_autoraise_notice",
+        {"model": "gpt-5.6-terra", "cap": "272K", "from_pct": 80, "to_pct": 85},
+    ),
+    ("gateway.subgoal_cleared_many", {"count": 3}),
+    ("gateway.tool_guardrail_halted", {"tool": "exec", "code": "E1"}),
+])
+def test_sample_keys_resolve_russian(key, kwargs):
+    i18n.reset_language_cache()
+    ru = i18n.t(key, lang="ru", **kwargs)
+    en = i18n.t(key, lang="en", **kwargs)
+    assert ru and ru != en
+    for name in kwargs:
+        assert "{" + name + "}" not in ru

--- a/tests/gateway/test_migration_i18n_suppression.py
+++ b/tests/gateway/test_migration_i18n_suppression.py
@@ -36,14 +36,37 @@ def test_override_missing_placeholder_stays_literal():
     i18n.reset_language_cache()
 
 
-def test_name_autofill():
+def test_override_compound_missing_placeholders_stay_literal():
+    template = "X {count} {missing.attr} {missing[key]}"
+    with patch.object(i18n, "_load_config_dict", return_value=_cfg(draining=template)):
+        i18n.reset_language_cache()
+        assert i18n.t("gateway.draining", count=1) == "X 1 {missing.attr} {missing[key]}"
+    i18n.reset_language_cache()
+
+
+def test_name_autofill_uses_configured_custom_skin(tmp_path, monkeypatch):
+    from hermes_cli import skin_engine
+
+    skins_dir = tmp_path / "skins"
+    skins_dir.mkdir()
+    (skins_dir / "reviewer.yaml").write_text(
+        "name: reviewer\nbranding:\n  agent_name: Гермес\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(skin_engine, "get_hermes_home", lambda: tmp_path)
+
     with patch.object(i18n, "_load_config_dict",
-                      return_value={"ui": {"theme": {"branding": {"agent_name": "Гермес"}}},
-                                    "gateway": {"system_messages": {"draining": "{name} drains {count}"}},
-                                    "display": {"language": "ru"}}):
+                      return_value={"gateway": {"system_messages": {"draining": "{name} drains {count}"}},
+                                    "display": {"language": "ru", "skin": "reviewer"}}):
         i18n.reset_language_cache()
         assert i18n.t("gateway.draining", count=2) == "Гермес drains 2"
     i18n.reset_language_cache()
+
+
+def test_gateway_system_messages_is_registered_in_default_config():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["gateway"]["system_messages"] == {}
 
 
 # ---- marker-coupling preserved ---------------------------------------------

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1929,6 +1929,33 @@ For separate natural mid-turn assistant updates without progressive token editin
 The master `streaming.enabled` switch is `false` by default — nothing streams until you flip it. Once enabled, streaming is decided **per platform**: Telegram ships with `display.platforms.telegram.streaming: true` (streams) and Discord with `display.platforms.discord.streaming: false` (does not). So after enabling streaming, Telegram streams out of the box and Discord stays on whole-message replies until you change its toggle. You can adjust these per-platform switches from the dashboard's **Channels** toggles or directly in `~/.hermes/config.yaml`.
 :::
 
+## Gateway System Messages
+
+Override the wording of Hermes-authored gateway messages without editing locale
+catalogs. Keys are the catalog paths below `gateway.` and values are standard
+format strings using the placeholders supported by that message:
+
+```yaml
+gateway:
+  system_messages:
+    draining: "{name} is finishing {count} active task(s) before restart."
+    restart_success: "{name} restarted successfully."
+```
+
+Overrides apply in every language. Resolution order is:
+
+1. `gateway.system_messages.<key>` from `config.yaml`
+2. the catalog entry for `display.language`
+3. the English catalog entry
+4. the dotted key itself, if no catalog contains it
+
+Hermes fills `{name}` from the `agent_name` branding field of the skin selected
+by `display.skin`, unless the call site supplies a name explicitly. Other
+placeholders vary by message. Unknown placeholders, including compound forms
+such as `{missing.attr}` or `{missing[key]}`, remain literal instead of crashing
+the gateway. Restart the gateway after changing these overrides so its cached
+configuration is reloaded.
+
 ## Group Chat Session Isolation
 
 Limit how many chat sessions can actively be open across CLI, TUI/dashboard,

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1956,6 +1956,21 @@ such as `{missing.attr}` or `{missing[key]}`, remain literal instead of crashing
 the gateway. Restart the gateway after changing these overrides so its cached
 configuration is reloaded.
 
+Non-critical notifications can also be muted by category:
+
+```yaml
+gateway:
+  system_messages:
+    suppress:
+      - progress   # work-status updates
+      - lifecycle  # gateway start/restart/shutdown notices
+      - info       # optional informational notices
+```
+
+Use `suppress: all` to mute all three categories. Error messages, approval
+prompts, and command replies are never suppressible. Unknown category names are
+ignored with a warning.
+
 ## Group Chat Session Isolation
 
 Limit how many chat sessions can actively be open across CLI, TUI/dashboard,


### PR DESCRIPTION
## What

Adds `gateway.system_messages.suppress` so users can mute categories of ambient
gateway notifications without disabling the features that emit them:

```yaml
gateway:
  system_messages:
    suppress: [progress, info]   # or: suppress: all
```

- Mutable categories: `progress`, `lifecycle`, and `info`.
- Errors, approval prompts, and command replies are never suppressible.
- `GATEWAY_MESSAGE_CATEGORIES` maps message keys to categories.
- Empty-send guards prevent a suppressed notification from producing a blank
  message bubble.
- The default config and configuration guide register and document `suppress`,
  its accepted values, and the non-suppressible categories.

This generalizes the existing narrow
`gateway.platforms.<platform>.gateway_restart_notification` opt-out, which only
controls restart notifications.

## Dependency and image branch

This is the top of the #49317 → #49330 → #49620 stack. GitHub cross-repository
PRs cannot use fork feature branches as their base, so the PR diff includes the
two lower PRs and should be merged after them. The top
`feat/system-message-suppression` branch contains all three patch sets and is
the direct source for the combined GHCR image; no aggregate branch is used.

## Semantic audit after rebase

- The Kanban review notification remains ambient `info` and suppressible.
- Persistence recovery, pause/heartbeat/goal/refine replies, turn-lease errors,
  provider-offline hints, and compaction handoff completion remain
  non-suppressible because they are required replies or errors.
- The latest three upstream commits (`87af576e6`, `356c702b5`, `76d832d38`) add
  config, operational logs, and relay-cron routing but no new suppressible
  notification paths.

## Verification after rebase

- 319 combined focused tests passed, including all regression tests from the
  three new upstream commits; 1 expected xfail and 1 unrelated
  live-system-guard test deselected (`test_run_gate_timeout`).
- The three suppression commits are unchanged by `range-diff`.
- Ruff, Python `compileall`, and `git diff --check` passed.
- The fork-only GHCR workflow is not part of this PR.
