### PR TITLE
feat(discord): transcribe voice messages in channel history via STT

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4264,6 +4264,35 @@ class DiscordAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             return 50
 
+    async def _transcribe_history_attachments(self, msg: Any, fallback_line: str) -> str:
+        """Try to STT-transcribe audio attachments in a history message.
+
+        Returns a line like ``[Alice] [voice: hey there]``, or the original
+        ``fallback_line`` (which ends with ``(attachment)``) on any failure.
+        """
+        from tools.transcription_tools import transcribe_audio
+        prefix = fallback_line[: fallback_line.rfind("(attachment)")]
+        audio_transcripts = []
+        for att in msg.attachments:
+            ct = getattr(att, "content_type", None) or ""
+            if not ct.startswith("audio/"):
+                continue
+            try:
+                ext = "." + ct.split("/")[-1].split(";")[0]
+                if ext not in {".ogg", ".mp3", ".wav", ".webm", ".m4a"}:
+                    ext = ".ogg"
+                cached_path = await self._cache_discord_audio(att, ext)
+                result = await asyncio.to_thread(transcribe_audio, cached_path)
+                if result.get("success"):
+                    transcript = result.get("transcript", "").strip()
+                    if transcript:
+                        audio_transcripts.append(f"[voice: {transcript}]")
+            except Exception as exc:
+                logger.debug("[Discord] History audio transcription failed: %s", exc)
+        if audio_transcripts:
+            return prefix + " ".join(audio_transcripts)
+        return fallback_line
+
     async def _fetch_channel_context(
         self,
         channel: Any,
@@ -4390,6 +4419,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 line = _keep(msg)
                 if line is None:
                     continue
+                if line.endswith("(attachment)") and msg.attachments:
+                    line = await self._transcribe_history_attachments(msg, line)
                 mid = str(getattr(msg, "id", ""))
                 collected.append((mid, line))
                 if mid:
@@ -4425,6 +4456,8 @@ class DiscordAdapter(BasePlatformAdapter):
                     line = _keep(msg)
                     if line is None:
                         continue
+                    if line.endswith("(attachment)") and msg.attachments:
+                        line = await self._transcribe_history_attachments(msg, line)
                     mid = str(getattr(msg, "id", ""))
                     if mid and mid in seen_ids:
                         continue

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -1154,3 +1154,91 @@ async def test_discord_non_reply_free_channel_skips_backfill(adapter, monkeypatc
 
     adapter._fetch_channel_context.assert_not_awaited()
 
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_transcribes_voice_message(adapter, monkeypatch):
+    """Voice messages in history are transcribed via STT instead of shown as (attachment)."""
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    voice_att = SimpleNamespace(
+        content_type="audio/ogg",
+        url="https://cdn.discordapp.com/voice.ogg",
+        duration=3.0,
+        waveform="abc",
+    )
+    channel = FakeHistoryChannel(
+        [make_history_message(author=human, content="", msg_id=2, attachments=[voice_att])],
+        channel_id=123,
+    )
+
+    async def fake_cache_audio(att, ext):
+        return "/tmp/fake_voice.ogg"
+
+    monkeypatch.setattr(adapter, "_cache_discord_audio", fake_cache_audio)
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter.asyncio.to_thread",
+        AsyncMock(return_value={"success": True, "transcript": "hey can you help me"}),
+    )
+
+    result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="@bot"))
+
+    assert "[voice: hey can you help me]" in result
+    assert "[Alice]" in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_falls_back_when_transcription_fails(adapter, monkeypatch):
+    """Failed STT falls back to (attachment) instead of crashing."""
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    voice_att = SimpleNamespace(
+        content_type="audio/ogg",
+        url="https://cdn.discordapp.com/voice.ogg",
+        duration=3.0,
+        waveform="abc",
+    )
+    channel = FakeHistoryChannel(
+        [make_history_message(author=human, content="", msg_id=2, attachments=[voice_att])],
+        channel_id=123,
+    )
+
+    async def fake_cache_audio(att, ext):
+        raise RuntimeError("network error")
+
+    monkeypatch.setattr(adapter, "_cache_discord_audio", fake_cache_audio)
+
+    result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="@bot"))
+
+    assert "(attachment)" in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_skips_non_audio_attachments(adapter, monkeypatch):
+    """Non-audio attachments are not transcribed and appear as (attachment)."""
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    image_att = SimpleNamespace(
+        content_type="image/png",
+        url="https://cdn.discordapp.com/image.png",
+    )
+    channel = FakeHistoryChannel(
+        [make_history_message(author=human, content="", msg_id=2, attachments=[image_att])],
+        channel_id=123,
+    )
+
+    cache_called = []
+
+    async def fake_cache_audio(att, ext):
+        cache_called.append(att)
+        return "/tmp/fake.ogg"
+
+    monkeypatch.setattr(adapter, "_cache_discord_audio", fake_cache_audio)
+
+    result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="@bot"))
+
+    assert cache_called == []
+    assert "(attachment)" in result
+


### PR DESCRIPTION
## Summary

- Voice messages sent before an @mention were invisible to the agent — `_fetch_channel_context` rendered them as `(attachment)` with no STT path
- Add `_transcribe_history_attachments()` async helper that downloads `audio/*` attachments and runs them through the existing `transcribe_audio` pipeline
- Called from both the primary and reply-window loops in `_fetch_channel_context`; falls back gracefully to `(attachment)` on any error

Fixes #49616

## What changed

**`plugins/platforms/discord/adapter.py`**
- New `_transcribe_history_attachments(msg, fallback_line)` method: detects audio attachments (by `content_type`), caches via `_cache_discord_audio`, transcribes via `asyncio.to_thread(transcribe_audio, ...)`, returns `[voice: <transcript>]` line or the original fallback
- Primary history loop and reply-window loop both call it when `_keep()` returns a line ending with `(attachment)`

**`tests/gateway/test_discord_free_response.py`**
- `test_fetch_channel_context_transcribes_voice_message` — happy path: `audio/ogg` attachment with waveform → `[voice: hey can you help me]`
- `test_fetch_channel_context_falls_back_when_transcription_fails` — STT error → `(attachment)` (no crash)
- `test_fetch_channel_context_skips_non_audio_attachments` — `image/png` → `(attachment)`, no STT call

## Test plan

- [ ] `pytest tests/gateway/test_discord_free_response.py -v` — 46 passed
- [ ] Manual: send a Discord voice message, @mention the bot in the same channel, verify the bot's response references the spoken content

## Platforms tested

Linux (Ubuntu) — Python 3.11