### PR TITLE
fix(desktop): show tooltips on all statusbar item variants

### DIFF
--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -181,6 +181,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
         item.onSelect?.({ shiftKey: event.shiftKey })
       }}
+	  title={item.title}
       type="button"
     >
       {content}

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -156,6 +156,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
           'inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
           item.className
         )}
+		title={item.title}
       >
         {content}
       </div>


### PR DESCRIPTION
## What does this PR do?
Statusbar items (Terminal, YOLO, Gateway, Agents, Cron, version, timers) all had `title` strings defined in `useStatusbarItems`, but the `title` prop was never forwarded to the underlying HTML elements in `StatusbarItemView`. As a result, no tooltips appeared on hover making it hard to discover what each icon/button does without prior knowledge.
(e.g. the terminal toggle was undiscoverable without prior knowledge personally spent 20 minutes looking for it before finding it via the agent)

## Related Issue
Fixes #

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `apps/desktop/src/app/shell/statusbar-controls.tsx`: added 
  `title={item.title}` to the `<button>` (action variant) and `<div>` 
  (text variant) render branches in `StatusbarItemView`

## How to Test
1. Build and launch the desktop app
2. Hover over any statusbar item (Terminal, YOLO, Agents, Cron, version, 
   running timer, context usage, session timer)
3. Verify a tooltip appears with a descriptive label
4. Before this fix: no tooltips appeared on any statusbar item

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Windows 10, Windows 11

### Documentation & Housekeeping
- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — tested on Windows 10 and Windows 11, macOS not verified
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs
**Before**
<img width="1230" height="35" alt="image" src="https://github.com/user-attachments/assets/ba05c9c4-4c98-4a40-bd48-8ab925a44493" />


**After**
<img width="373" height="311" alt="image" src="https://github.com/user-attachments/assets/0924673c-863f-4316-83e8-bb6cb4f6df85" />
<img width="379" height="360" alt="image" src="https://github.com/user-attachments/assets/dca3832c-83ad-4fcf-96bf-033c442bc6b0" />

