### PR TITLE
fix(test): add has_platform_message_id mock in test_42039_duplicate_user_message

### DIFF
--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -65,6 +65,7 @@ def _bootstrap(monkeypatch, tmp_path):
     )
     runner.session_store.load_transcript.return_value = []
     runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.has_platform_message_id = MagicMock(return_value=False)
     runner.session_store.update_session = MagicMock()
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)


### PR DESCRIPTION
## Summary

Fix test bootstrap for `test_42039_duplicate_user_message.py` — adds a mock for `has_platform_message_id` on `session_store`, returning `False`.

## Context

PR #47869 adds a `has_platform_message_id` dedupe guard to production code. The test's `_bootstrap()` helper creates a `MagicMock` for `session_store`, which auto-returns a truthy value for any attribute — causing the dedupe check to skip `append_to_transcript`. This fix ensures the mock returns `False` (not-a-duplicate) so the append path is exercised.

## Change

- `tests/gateway/test_42039_duplicate_user_message.py:68`: Add `runner.session_store.has_platform_message_id = MagicMock(return_value=False)` in `_bootstrap()`

## Verification

- All 4 tests in the file pass
- The mock matches existing patterns in the same bootstrap function
- Forward-looking: when PR #47869 lands, the tests will correctly exercise the dedupe path
