### PR TITLE
fix(hermes-cli): replace bare asserts with proper error handling

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4587,7 +4587,8 @@ def _run_with_idle_timeout(
 
     def _reader() -> None:
         nonlocal last_output_ts
-        assert proc.stdout is not None
+        if proc.stdout is None:
+            raise RuntimeError("proc.stdout must not be None when stdout=subprocess.PIPE")
         for line in proc.stdout:
             try:
                 print(f"{indent}{line.rstrip()}", flush=True)

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -374,7 +374,8 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
 def _do_git_install(entry: CatalogEntry) -> Path:
     """Clone the entry's repo into ``~/.hermes/mcp-installs/<name>`` and run
     bootstrap commands. Returns the install directory."""
-    assert entry.install is not None and entry.install.type == "git"
+    if not entry.install or entry.install.type != "git":
+        raise RuntimeError("entry must have a git install configured")
     install = entry.install
     dest = _install_root() / entry.name
 

--- a/hermes_cli/mcp_picker.py
+++ b/hermes_cli/mcp_picker.py
@@ -219,7 +219,8 @@ def _handle_row(row: _Row) -> None:
                 print(color(f"  '{row.name}' was not installed", Colors.DIM))
     elif choice == 3:
         try:
-            assert row.entry is not None
+            if row.entry is None:
+                raise RuntimeError("row.entry must not be None for reinstall")
             install_entry(row.entry, enable=True)
         except CatalogError as exc:
             print(color(f"  ✗ reinstall failed: {exc}", Colors.RED))

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -218,7 +218,8 @@ def run_oneshot(
         real_stderr.flush()
         return 1
 
-    assert response is not None  # narrowed by the empty-response guard above
+    if response is None:
+        raise RuntimeError("response must not be None after empty-response guard")
     real_stdout.write(response)
     if not response.endswith("\n"):
         real_stdout.write("\n")


### PR DESCRIPTION
## Summary

Replace 4 bare `assert` statements in `hermes_cli/` with explicit `if`/`raise RuntimeError` checks.

`assert` is stripped when Python runs with `-O` flag, silently removing these safety checks at runtime.

## Changes

| File | Line | Assert | Fix |
|------|------|--------|-----|
| `mcp_catalog.py` | 377 | `assert entry.install is not None and entry.install.type == "git"` | `if not entry.install or entry.install.type != "git": raise RuntimeError(...)` |
| `mcp_picker.py` | 222 | `assert row.entry is not None` | `if row.entry is None: raise RuntimeError(...)` |
| `main.py` | 4590 | `assert proc.stdout is not None` | `if proc.stdout is None: raise RuntimeError(...)` |
| `oneshot.py` | 221 | `assert response is not None` | `if response is None: raise RuntimeError(...)` |

## Test Plan

- [x] `pytest tests/hermes_cli/test_mcp_catalog.py -xvs` passes
- [x] `pytest tests/hermes_cli/test_tui_resume_flow.py -xvs -k oneshot` passes
- [x] All affected test files pass
