### PR TITLE
fix(tools,agent): replace bare asserts with proper error handling

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -396,7 +396,8 @@ class CodexAppServerSession:
             # turn re-spawns cleanly.
             result.should_retire = True
             return result
-        assert self._client is not None and self._thread_id is not None
+        if self._client is None or self._thread_id is None:
+            raise RuntimeError("client and thread_id must be initialized before use")
         result.thread_id = self._thread_id
 
         self._interrupt_event.clear()

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -107,7 +107,8 @@ async def _cdp_call(
     works for ``Target.*``, ``Browser.*``, ``Storage.*`` and a few other
     globally-scoped domains.
     """
-    assert websockets is not None  # guarded by _WS_AVAILABLE at call-site
+    if websockets is None:
+        raise RuntimeError("websockets must be installed (guarded by _WS_AVAILABLE at call-site)")
 
     async with websockets.connect(
         ws_url,

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -810,7 +810,8 @@ class CDPSupervisor:
 
     async def _read_loop(self) -> None:
         """Continuously dispatch incoming CDP frames."""
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("_read_loop called before WebSocket connection established")
         try:
             async for raw in self._ws:
                 if self._stop_requested:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -944,7 +944,8 @@ class DockerEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
-        assert self._container_id, "Container not started"
+        if not self._container_id:
+            raise RuntimeError("Container not started")
         cmd = [self._docker_exe, "exec"]
         if stdin_data is not None:
             cmd.append("-i")


### PR DESCRIPTION
## Summary

Replace 4 bare `assert` statements in `tools/` and `agent/` with explicit `if`/`raise RuntimeError` checks.

`assert` is stripped when Python runs with `-O` flag, silently removing these safety checks at runtime.

## Changes

| File | Line | Assert | Fix |
|------|------|--------|-----|
| `tools/browser_cdp_tool.py` | 110 | `assert websockets is not None` | `if websockets is None: raise RuntimeError(...)` |
| `tools/environments/docker.py` | 947 | `assert self._container_id` | `if not self._container_id: raise RuntimeError(...)` |
| `tools/browser_supervisor.py` | 813 | `assert self._ws is not None` | `if self._ws is None: raise RuntimeError(...)` |
| `agent/transports/codex_app_server_session.py` | 399 | `assert self._client is not None and self._thread_id is not None` | `if self._client is None or self._thread_id is None: raise RuntimeError(...)` |

## Test Plan

- [x] All modified files import successfully
- [x] Lint passes on all files
