### PR TITLE
fix(gateway): replace bare asserts with proper error handling

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4244,7 +4244,8 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
-            assert self._app is not None
+            if self._app is None:
+                raise RuntimeError("web.Application creation failed")
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -216,13 +216,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return text
 
     async def _api_get(self, path: str) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError("client must be initialized before API calls")
         res = await self.client.get(self._api_url(path))
         res.raise_for_status()
         return res.json()
 
     async def _api_post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError("client must be initialized before API calls")
         res = await self.client.post(self._api_url(path), json=payload)
         res.raise_for_status()
         return res.json()

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1334,7 +1334,8 @@ class WeixinAdapter(BasePlatformAdapter):
         logger.info("[%s] Disconnected", self.name)
 
     async def _poll_loop(self) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError("_poll_loop called before _poll_session initialized")
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
         timeout_ms = LONG_POLL_TIMEOUT_MS
         consecutive_failures = 0
@@ -1400,7 +1401,8 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.error("[%s] unhandled inbound error from=%s: %s", self.name, _safe_id(message.get("from_user_id")), exc, exc_info=True)
 
     async def _process_message(self, message: Dict[str, Any]) -> None:
-        assert self._poll_session is not None
+        if self._poll_session is None:
+            raise RuntimeError("_process_message called before _poll_session initialized")
         sender_id = str(message.get("from_user_id") or "").strip()
         if not sender_id:
             return
@@ -1812,7 +1814,8 @@ class WeixinAdapter(BasePlatformAdapter):
                 )
                 if wait > 0:
                     await asyncio.sleep(wait)
-        assert last_error is not None
+        if last_error is None:
+            raise RuntimeError("retry loop completed without capturing error")
         raise last_error
 
     async def send(
@@ -2067,7 +2070,8 @@ class WeixinAdapter(BasePlatformAdapter):
         if not is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
-        assert self._send_session is not None
+        if self._send_session is None:
+            raise RuntimeError("_send_session not initialized")
         # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
         # "Timeout context manager should be used inside a task" errors.
         async def _do_fetch():
@@ -2087,7 +2091,8 @@ class WeixinAdapter(BasePlatformAdapter):
         caption: str,
         force_file_attachment: bool = False,
     ) -> str:
-        assert self._send_session is not None and self._token is not None
+        if self._send_session is None or self._token is None:
+            raise RuntimeError("_send_session and _token must be initialized")
         plaintext = Path(path).read_bytes()
         media_type, item_builder = self._outbound_media_builder(path, force_file_attachment=force_file_attachment)
         filekey = secrets.token_hex(16)

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -277,7 +277,8 @@ class WebSocketRelayTransport:
         await self._ws.send(json.dumps(frame) + "\n")
 
     async def _read_loop(self) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("relay transport not connected")
         buf = ""
         try:
             async for chunk in self._ws:


### PR DESCRIPTION
## Summary

Replace 9 bare `assert` statements in `gateway/` with explicit `if`/`raise RuntimeError` checks.

`assert` is stripped when Python runs with `-O` flag, silently removing these safety checks at runtime.

## Changes

| File | Line | Assert | Fix |
|------|------|--------|-----|
| `api_server.py` | 4247 | `assert self._app is not None` | `if self._app is None: raise RuntimeError(...)` |
| `weixin.py` | 1337 | `assert self._poll_session is not None` | `if self._poll_session is None: raise RuntimeError(...)` |
| `weixin.py` | 1404 | `assert self._poll_session is not None` | `if self._poll_session is None: raise RuntimeError(...)` |
| `weixin.py` | 1816 | `assert last_error is not None` | `if last_error is None: raise RuntimeError(...)` |
| `weixin.py` | 2071 | `assert self._send_session is not None` | `if self._send_session is None: raise RuntimeError(...)` |
| `weixin.py` | 2094 | `assert self._send_session and self._token` | `if ... is None: raise RuntimeError(...)` |
| `bluebubbles.py` | 219 | `assert self.client is not None` | `if self.client is None: raise RuntimeError(...)` |
| `bluebubbles.py` | 225 | `assert self.client is not None` | `if self.client is None: raise RuntimeError(...)` |
| `ws_transport.py` | 280 | `assert self._ws is not None` | `if self._ws is None: raise RuntimeError(...)` |

## Test Plan

- [x] All modified files import successfully
- [x] Lint passes on all files
