### PR TITLE
fix(type-annotation): replace lowercase callable with proper Callable types

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -25,7 +25,7 @@ import ssl
 import threading
 import time
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
@@ -472,7 +472,7 @@ def run_conversation(
     system_message: str = None,
     conversation_history: List[Dict[str, Any]] = None,
     task_id: str = None,
-    stream_callback: Optional[callable] = None,
+    stream_callback: Optional[Callable[[Optional[str]], None]] = None,
     persist_user_message: Optional[str] = None,
     persist_user_timestamp: Optional[float] = None,
 ) -> Dict[str, Any]:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -118,7 +118,7 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
-        on_new_message: Optional[callable] = None,
+        on_new_message: Optional[Callable[[], None]] = None,
         initial_reply_to_id: Optional[str] = None,
     ):
         self.adapter = adapter

--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -17,7 +17,7 @@ import os
 import sys
 import time
 import logging
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import requests
 
@@ -107,7 +107,7 @@ def wait_for_registration_success(
     device_code: str,
     interval: int = 3,
     expires_in: int = 7200,
-    on_waiting: Optional[callable] = None,
+    on_waiting: Optional[Callable[[], None]] = None,
 ) -> Tuple[str, str]:
     """Block until the registration succeeds or times out.
 

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -26,7 +26,7 @@ import logging
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 try:
     from hermes_constants import get_hermes_home
@@ -420,7 +420,7 @@ def quick() -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 def deep(
-    confirm: Optional[callable] = None,
+    confirm: Optional[Callable[[Dict[str, Any]], bool]] = None,
 ) -> Dict[str, Any]:
     """Deep cleanup.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5230,7 +5230,7 @@ class AIAgent:
         system_message: str = None,
         conversation_history: List[Dict[str, Any]] = None,
         task_id: str = None,
-        stream_callback: Optional[callable] = None,
+        stream_callback: Optional[Callable[[Optional[str]], None]] = None,
         persist_user_message: Optional[str] = None,
         persist_user_timestamp: Optional[float] = None,
     ) -> Dict[str, Any]:
@@ -5247,7 +5247,7 @@ class AIAgent:
             persist_user_timestamp,
         )
 
-    def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
+    def chat(self, message: str, stream_callback: Optional[Callable[[Optional[str]], None]] = None) -> str:
         """
         Simple chat interface that returns just the final response.
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -28,7 +28,7 @@ from concurrent.futures import (
     ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
 )
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from toolsets import TOOLSETS
 
@@ -779,7 +779,7 @@ def _build_child_progress_callback(
     model: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     session_ref: Optional[Dict[str, Any]] = None,
-) -> Optional[callable]:
+) -> Optional[Callable[..., None]]:
     """Build a callback that relays child agent tool calls to the parent display.
 
     Two display paths:


### PR DESCRIPTION
## Summary

The Python builtin `callable` (lowercase) is **not** a valid generic type for static type checkers. Using `Optional[callable]` works at runtime but will flag errors in strict mypy/pyright mode.

This was previously fixed in PR #45651 (June 13) but re-introduced in PR #49072 (June 19).

## Changes

Replaced 7 instances of `Optional[callable]` with proper `Callable` types across 6 files:

| File | Type |
|------|------|
| `tools/delegate_tool.py` | `Callable[..., None]` (generic callback) |
| `hermes_cli/dingtalk_auth.py` | `Callable[[], None]` (no-arg callback) |
| `plugins/disk-cleanup/disk_cleanup.py` | `Callable[[Dict[str, Any]], bool]` (confirm callback) |
| `run_agent.py` | `Callable[[Optional[str]], None]` (stream delta callback, 2 instances) |
| `agent/conversation_loop.py` | `Callable[[Optional[str]], None]` (stream delta callback) |
| `gateway/stream_consumer.py` | `Callable[[], None]` (no-arg callback) |

## Verification

- `grep -rn "Optional\[callable\]"` returns zero matches
- All files pass lint checks
- Diff is minimal: 6 files, 11 insertions, 11 deletions