### PR TITLE
fix: honor plugin auth env from Hermes dotenv

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -28,6 +28,29 @@ from gateway.whatsapp_identity import (
 )
 
 
+def _auth_env_value(name: str) -> str:
+    """Return an authorization env value from the live env or Hermes .env.
+
+    Built-in platforms normally have their allowlists in ``os.environ`` because
+    the gateway loads ``~/.hermes/.env`` at startup.  Plugin platform auth env
+    names are discovered later through the registry, and some service-managed
+    deployments can reach this authorization path with those plugin-specific
+    keys absent from the process environment even though they are present in
+    Hermes' canonical .env file.  Falling back to ``get_env_value`` keeps
+    plugin platform authorization consistent with CLI/status helpers without
+    weakening precedence: an explicit process env value still wins.
+    """
+    if not name:
+        return ""
+    if name in os.environ:
+        return os.getenv(name, "").strip()
+    try:
+        from hermes_cli.config import get_env_value
+    except Exception:
+        return ""
+    return (get_env_value(name) or "").strip()
+
+
 class GatewayAuthorizationMixin:
     """User/chat authorization methods for ``GatewayRunner``."""
 
@@ -211,7 +234,7 @@ class GatewayAuthorizationMixin:
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
             if chat_allowlist_env:
-                raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
+                raw_chat_allowlist = _auth_env_value(chat_allowlist_env)
                 if raw_chat_allowlist:
                     allowed_group_ids = {
                         cid.strip()
@@ -292,7 +315,7 @@ class GatewayAuthorizationMixin:
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
-        if platform_allow_all_var and os.getenv(platform_allow_all_var, "").lower() in {"true", "1", "yes"}:
+        if platform_allow_all_var and _auth_env_value(platform_allow_all_var).lower() in {"true", "1", "yes"}:
             return True
 
         # Adapter-verified role auth: the Discord adapter already confirmed the
@@ -314,13 +337,13 @@ class GatewayAuthorizationMixin:
             return True
 
         # Check platform-specific and global allowlists
-        platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
+        platform_allowlist = _auth_env_value(platform_env_map.get(source.platform, ""))
         group_user_allowlist = ""
         group_chat_allowlist = ""
         if source.chat_type in {"group", "forum"}:
-            group_user_allowlist = os.getenv(platform_group_user_env_map.get(source.platform, ""), "").strip()
-            group_chat_allowlist = os.getenv(platform_group_chat_env_map.get(source.platform, ""), "").strip()
-        global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
+            group_user_allowlist = _auth_env_value(platform_group_user_env_map.get(source.platform, ""))
+            group_chat_allowlist = _auth_env_value(platform_group_chat_env_map.get(source.platform, ""))
+        global_allowlist = _auth_env_value("GATEWAY_ALLOWED_USERS")
 
         if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
             # No env allowlist configured. Adapters that own their own
@@ -359,7 +382,7 @@ class GatewayAuthorizationMixin:
                 if effective_policy == "allowlist":
                     return True
             # No allowlists configured -- check global allow-all flag
-            return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+            return _auth_env_value("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
 
         # Telegram can optionally authorize group traffic by chat ID.
         # Keep this separate from TELEGRAM_GROUP_ALLOWED_USERS, which gates
@@ -524,13 +547,22 @@ class GatewayAuthorizationMixin:
                 ),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
-            if os.getenv(platform_env_map.get(platform, ""), "").strip():
+            if platform not in platform_env_map:
+                try:
+                    from gateway.platform_registry import platform_registry
+                    entry = platform_registry.get(platform.value)
+                    if entry and entry.allowed_users_env:
+                        platform_env_map[platform] = entry.allowed_users_env
+                except Exception:
+                    pass
+
+            if _auth_env_value(platform_env_map.get(platform, "")):
                 return "ignore"
             for env_key in platform_group_env_map.get(platform, ()):
-                if os.getenv(env_key, "").strip():
+                if _auth_env_value(env_key):
                     return "ignore"
 
-        if os.getenv("GATEWAY_ALLOWED_USERS", "").strip():
+        if _auth_env_value("GATEWAY_ALLOWED_USERS"):
             return "ignore"
 
         return "pair"

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -17,6 +17,7 @@ import time -> no import cycle. The lazy import preserves the exact logger name
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Optional
 
@@ -26,6 +27,8 @@ from gateway.whatsapp_identity import (
     expand_whatsapp_aliases as _expand_whatsapp_auth_aliases,
     normalize_whatsapp_identifier as _normalize_whatsapp_identifier,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _auth_env_value(name: str) -> str:
@@ -46,7 +49,10 @@ def _auth_env_value(name: str) -> str:
         return os.getenv(name, "").strip()
     try:
         from hermes_cli.config import get_env_value
+    except ImportError:
+        return ""
     except Exception:
+        logger.warning("Failed to load Hermes .env fallback for %s", name, exc_info=True)
         return ""
     return (get_env_value(name) or "").strip()
 

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -318,9 +318,13 @@ def _cmd_status(_args: argparse.Namespace) -> int:
 
 
 def _refresh_status_numbers() -> None:
-    phone, assigned = photon_auth.load_user_numbers()
-    if phone and assigned:
-        return
+    """Refresh cached Photon user routing before showing status.
+
+    Photon shared-line assignments can change, and older setup retries could
+    leave ``photon_user.assigned_phone_number`` pointing at a stale shared line.
+    Always ask Spectrum for the current user row when credentials are available
+    so ``hermes photon status`` does not tell the operator to text a dead line.
+    """
     spectrum_id, project_secret = photon_auth.load_project_credentials()
     if not spectrum_id or not project_secret:
         return

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -203,6 +203,142 @@ def test_simplex_allowlist_denies_unlisted(monkeypatch):
     assert runner._is_user_authorized(source) is False
 
 
+def test_plugin_allowlist_reads_hermes_env_file_when_process_env_missing(monkeypatch, tmp_path):
+    """Plugin platform allowlists should work from Hermes' canonical .env.
+
+    Reproduces Photon/iMessage service deployments where the plugin's
+    ``*_ALLOWED_USERS`` key is present in ``~/.hermes/.env`` (and visible to
+    setup/status helpers) but absent from the gateway process environment at
+    authorization time.
+    """
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TEST_PLUGIN_ALLOWED_USERS", raising=False)
+
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    from hermes_cli.config import save_env_value
+
+    save_env_value("TEST_PLUGIN_ALLOWED_USERS", "+155****4567")
+    platform_registry.register(PlatformEntry(
+        name="testplugdotenv",
+        label="Test Plugin Dotenv",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="TEST_PLUGIN_ALLOWED_USERS",
+        allow_all_env="TEST_PLUGIN_ALLOW_ALL_USERS",
+    ))
+
+    platform = Platform("testplugdotenv")
+    runner, _adapter = _make_runner(
+        platform,
+        GatewayConfig(platforms={platform: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=platform,
+        user_id="+155****4567",
+        chat_id="+155****4567",
+        user_name="+155****4567",
+        chat_type="dm",
+    )
+    assert runner._is_user_authorized(source) is True
+
+
+
+def test_empty_process_env_overrides_hermes_env_file(monkeypatch, tmp_path):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    from hermes_cli.config import save_env_value
+
+    save_env_value("TEST_PLUGIN_EMPTY_ALLOWED_USERS", "+155****4567")
+    monkeypatch.setenv("TEST_PLUGIN_EMPTY_ALLOWED_USERS", "")
+    platform_registry.register(PlatformEntry(
+        name="testplugempty",
+        label="Test Plugin Empty Env",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="TEST_PLUGIN_EMPTY_ALLOWED_USERS",
+        allow_all_env="TEST_PLUGIN_EMPTY_ALLOW_ALL_USERS",
+    ))
+
+    platform = Platform("testplugempty")
+    runner, _adapter = _make_runner(
+        platform,
+        GatewayConfig(platforms={platform: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=platform,
+        user_id="+155****4567",
+        chat_id="+155****4567",
+        user_name="+155****4567",
+        chat_type="dm",
+    )
+    assert runner._is_user_authorized(source) is False
+
+def test_plugin_allow_all_reads_hermes_env_file_when_process_env_missing(monkeypatch, tmp_path):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TEST_PLUGIN2_ALLOW_ALL_USERS", raising=False)
+
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    from hermes_cli.config import save_env_value
+
+    save_env_value("TEST_PLUGIN2_ALLOW_ALL_USERS", "true")
+    platform_registry.register(PlatformEntry(
+        name="testplugdotenv2",
+        label="Test Plugin Dotenv 2",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="TEST_PLUGIN2_ALLOWED_USERS",
+        allow_all_env="TEST_PLUGIN2_ALLOW_ALL_USERS",
+    ))
+
+    platform = Platform("testplugdotenv2")
+    runner, _adapter = _make_runner(
+        platform,
+        GatewayConfig(platforms={platform: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=platform,
+        user_id="stranger",
+        chat_id="stranger",
+        user_name="stranger",
+        chat_type="dm",
+    )
+    assert runner._is_user_authorized(source) is True
+
+
+
+def test_plugin_dotenv_allowlist_makes_unauthorized_dm_ignored(monkeypatch, tmp_path):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TEST_PLUGIN3_ALLOWED_USERS", raising=False)
+
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    from hermes_cli.config import save_env_value
+
+    save_env_value("TEST_PLUGIN3_ALLOWED_USERS", "+155****4567")
+    platform_registry.register(PlatformEntry(
+        name="testplugdotenv3",
+        label="Test Plugin Dotenv 3",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="TEST_PLUGIN3_ALLOWED_USERS",
+        allow_all_env="TEST_PLUGIN3_ALLOW_ALL_USERS",
+    ))
+
+    platform = Platform("testplugdotenv3")
+    runner, _adapter = _make_runner(
+        platform,
+        GatewayConfig(platforms={platform: PlatformConfig(enabled=True)}),
+    )
+
+    assert runner._get_unauthorized_dm_behavior(platform) == "ignore"
+
 def test_star_wildcard_in_allowlist_authorizes_any_user(monkeypatch):
     """WHATSAPP_ALLOWED_USERS=* should act as allow-all wildcard."""
     _clear_auth_env(monkeypatch)

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -219,6 +219,7 @@ def test_plugin_allowlist_reads_hermes_env_file_when_process_env_missing(monkeyp
     from hermes_cli.config import save_env_value
 
     save_env_value("TEST_PLUGIN_ALLOWED_USERS", "+155****4567")
+    monkeypatch.delenv("TEST_PLUGIN_ALLOWED_USERS", raising=False)
     platform_registry.register(PlatformEntry(
         name="testplugdotenv",
         label="Test Plugin Dotenv",
@@ -287,6 +288,7 @@ def test_plugin_allow_all_reads_hermes_env_file_when_process_env_missing(monkeyp
     from hermes_cli.config import save_env_value
 
     save_env_value("TEST_PLUGIN2_ALLOW_ALL_USERS", "true")
+    monkeypatch.delenv("TEST_PLUGIN2_ALLOW_ALL_USERS", raising=False)
     platform_registry.register(PlatformEntry(
         name="testplugdotenv2",
         label="Test Plugin Dotenv 2",
@@ -322,6 +324,7 @@ def test_plugin_dotenv_allowlist_makes_unauthorized_dm_ignored(monkeypatch, tmp_
     from hermes_cli.config import save_env_value
 
     save_env_value("TEST_PLUGIN3_ALLOWED_USERS", "+155****4567")
+    monkeypatch.delenv("TEST_PLUGIN3_ALLOWED_USERS", raising=False)
     platform_registry.register(PlatformEntry(
         name="testplugdotenv3",
         label="Test Plugin Dotenv 3",

--- a/tests/plugins/platforms/photon/test_setup_access.py
+++ b/tests/plugins/platforms/photon/test_setup_access.py
@@ -71,6 +71,36 @@ def test_env_enablement_home_channel_defaults_name(monkeypatch: pytest.MonkeyPat
     }
 
 
+def test_status_refreshes_cached_assignment_even_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`hermes photon status` should not trust stale shared-line metadata.
+
+    Photon shared-line assignments can change after setup/user cleanup.  A
+    cached assigned number is only a status hint, so status must refresh from
+    Spectrum whenever credentials are available instead of returning early.
+    """
+    monkeypatch.setattr(
+        cli.photon_auth,
+        "load_user_numbers",
+        lambda: ("+155****4567", "+141****0000"),
+    )
+    monkeypatch.setattr(
+        cli.photon_auth,
+        "load_project_credentials",
+        lambda: ("project_123", "secret_123"),
+    )
+    calls = []
+    monkeypatch.setattr(
+        cli.photon_auth,
+        "refresh_user_numbers",
+        lambda project_id, secret: calls.append((project_id, secret)),
+    )
+
+    cli._refresh_status_numbers()
+
+    assert calls == [("project_123", "secret_123")]
+
 def test_setup_hint_uses_gateway_service_command(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
     monkeypatch.setattr(cli.photon_auth, "load_photon_token", lambda: "token")
     # The dashboard id *is* the Spectrum project id (ids unified), so setup no


### PR DESCRIPTION
## Summary
- fall back to Hermes `.env` for gateway authorization env values when the process env is missing them
- apply the same fallback to unauthorized-DM behavior so plugin allowlists do not leak pairing codes
- refresh Photon shared-line assignment on `hermes photon status` instead of trusting stale cached numbers

## Background
While configuring Photon iMessage, inbound blue-bubble messages reached the gateway but were rejected as unauthorized because `PHOTON_ALLOWED_USERS` existed in Hermes `.env` / Photon setup metadata but was absent from the running gateway process env. The session also exposed stale Photon shared-line status after repeated setup/user cleanup.

## Tests
- `python -m pytest tests/gateway/test_unauthorized_dm_behavior.py tests/plugins/platforms/photon/test_setup_access.py tests/plugins/platforms/photon/test_auth.py -q`
- `python -m ruff check gateway/authz_mixin.py plugins/platforms/photon/cli.py tests/gateway/test_unauthorized_dm_behavior.py tests/plugins/platforms/photon/test_setup_access.py`
