### PR TITLE
fix(telegram): drop live-location update floods

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3939,6 +3939,22 @@ class BasePlatformAdapter(ABC):
 
         coerce_plaintext_gateway_command(event)
 
+        event_platform = event.source.platform.value if hasattr(event.source.platform, "value") else str(event.source.platform)
+        event_text_lower = (event.text or "").lower()
+        if (
+            event_platform == "telegram"
+            and (
+                ("location" in event_text_lower and "pin" in event_text_lower)
+                or (
+                    "latitude" in event_text_lower
+                    and "longitude" in event_text_lower
+                    and "map" in event_text_lower
+                )
+            )
+        ):
+            logger.info("[%s] Dropping Telegram location-pin event before session dispatch", self.name)
+            return
+
         # Rewrite ``event.source.thread_id`` via the installed recovery hook
         # (Telegram DM topic mode) so the session key, guard checks, and
         # downstream delivery all agree on the same lane.

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -16,6 +16,7 @@ import os
 import tempfile
 import html as _html
 import re
+import time
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
@@ -406,6 +407,13 @@ class TelegramAdapter(BasePlatformAdapter):
             value = min(value, max_value)
         return value
 
+    @staticmethod
+    def _env_bool(name: str, default: bool = False) -> bool:
+        raw = os.getenv(name)
+        if raw is None:
+            return bool(default)
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+
     @property
     def message_len_fn(self):
         """Telegram measures message length in UTF-16 code units."""
@@ -459,6 +467,20 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        # Telegram live locations and some mobile share-sheet automations can
+        # emit location updates every few seconds. Treat each chat/user burst as
+        # one intent, not a new prompt that interrupts the active turn.
+        self._ignore_locations: bool = self._env_bool(
+            "HERMES_TELEGRAM_IGNORE_LOCATIONS",
+            self._coerce_bool_extra("ignore_locations", False),
+        )
+        self._location_live_update_suppression_seconds = self._env_float_clamped(
+            "HERMES_TELEGRAM_LOCATION_LIVE_SUPPRESSION_SECONDS",
+            300.0,
+            min_value=5.0,
+            max_value=3600.0,
+        )
+        self._recent_live_locations: Dict[str, float] = {}
         self._polling_error_task: Optional[asyncio.Task] = None
         self._polling_conflict_count: int = 0
         self._polling_network_error_count: int = 0
@@ -6002,15 +6024,71 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = self._effective_update_message(update)
         if not msg:
             return
-        if not self._should_process_message(msg):
-            if self._should_observe_unmentioned_group_message(msg):
-                self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
+
+        # Location shares can be live-location streams rather than explicit
+        # requests for help.  When this is enabled, Telegram pins are treated as
+        # passive context and never start/interrupt an agent turn. Users can
+        # still ask in text: "find coffee near me" and include coordinates.
+        extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        ignore_locations = bool(getattr(self, "_ignore_locations", False)) or bool(extra.get("ignore_locations", False))
+        if ignore_locations:
+            logger.info(
+                "[%s] Ignoring Telegram location message because telegram.extra.ignore_locations is enabled chat=%s message=%s update=%s",
+                self.name,
+                getattr(msg, "chat_id", getattr(getattr(msg, "chat", None), "id", "")),
+                getattr(msg, "message_id", ""),
+                getattr(update, "update_id", None),
+            )
             return
 
         venue = getattr(msg, "venue", None)
         location = getattr(venue, "location", None) if venue else getattr(msg, "location", None)
 
         if not location:
+            return
+
+        chat_id = str(
+            getattr(msg, "chat_id", "")
+            or getattr(getattr(msg, "chat", None), "id", "")
+        )
+        user_id = str(getattr(getattr(msg, "from_user", None), "id", ""))
+        message_id = str(getattr(msg, "message_id", ""))
+        burst_key = f"{chat_id}:{user_id}"
+        message_key = f"{burst_key}:{message_id}"
+        now = time.monotonic()
+        self._recent_live_locations = {
+            k: ts for k, ts in self._recent_live_locations.items()
+            if now - ts < self._location_live_update_suppression_seconds
+        }
+
+        live_period = getattr(location, "live_period", None)
+        is_edited_location_update = (
+            getattr(update, "edited_message", None) is not None
+            and getattr(update, "message", None) is None
+        )
+        is_repeated_location_burst = (
+            burst_key in self._recent_live_locations
+            or message_key in self._recent_live_locations
+        )
+        if is_edited_location_update or is_repeated_location_burst:
+            logger.info(
+                "[%s] Ignoring repeated Telegram location update chat=%s user=%s message=%s update=%s live=%s edited=%s",
+                self.name,
+                chat_id,
+                user_id,
+                message_id,
+                getattr(update, "update_id", None),
+                bool(live_period),
+                bool(is_edited_location_update),
+            )
+            return
+        self._recent_live_locations[burst_key] = now
+        if live_period:
+            self._recent_live_locations[message_key] = now
+
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
             return
 
         lat = getattr(location, "latitude", None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4120,6 +4120,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._enqueue_fifo(session_key, event, adapter)
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
+        busy_platform = event.source.platform.value if hasattr(event.source.platform, "value") else str(event.source.platform)
+        busy_text_lower = (event.text or "").lower()
+        if (
+            busy_platform == "telegram"
+            and (
+                ("location" in busy_text_lower and "pin" in busy_text_lower)
+                or (
+                    "latitude" in busy_text_lower
+                    and "longitude" in busy_text_lower
+                    and "map" in busy_text_lower
+                )
+            )
+        ):
+            logger.info("Dropping Telegram location-pin event while session is active: session=%s", session_key)
+            return True
+
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
         # creating a session.  The busy path must enforce the same check;
@@ -7207,6 +7223,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         7. Return response
         """
         source = event.source
+        _early_platform = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
+        _early_text = event.text or ""
+        _early_text_lower = _early_text.lower()
+        # Hard ingress drop for Telegram live-location/location-pin floods. Do
+        # this before startup replay, plugins, authorization, interrupt logic,
+        # or session lookup so a mobile live-location stream cannot poison the
+        # conversation or keep restarting the active turn.
+        if (
+            _early_platform == "telegram"
+            and (
+                ("location" in _early_text_lower and "pin" in _early_text_lower)
+                or (
+                    "latitude" in _early_text_lower
+                    and "longitude" in _early_text_lower
+                    and "map" in _early_text_lower
+                )
+            )
+        ):
+            logger.info(
+                "dropping Telegram location pin at gateway ingress chat=%s user=%s",
+                source.chat_id or "unknown",
+                source.user_id or source.user_name or "unknown",
+            )
+            return None
 
         if (
             getattr(self, "_startup_restore_in_progress", False)

--- a/tests/gateway/test_telegram_location_burst.py
+++ b/tests/gateway/test_telegram_location_burst.py
@@ -1,0 +1,114 @@
+# FILE: tests/gateway/test_telegram_location_burst.py | PURPOSE: Regression tests for Telegram location bursts so live location updates do not interrupt agents repeatedly.
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.platforms.telegram import TelegramAdapter
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _adapter(*, ignore_locations: bool = False):
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    setattr(adapter, "config", SimpleNamespace(extra={"ignore_locations": ignore_locations}))
+    adapter._location_live_update_suppression_seconds = 300.0
+    adapter._recent_live_locations = {}
+    adapter._should_process_message = cast(Any, lambda message, *args, **kwargs: True)
+    adapter._should_observe_unmentioned_group_message = cast(Any, lambda message: False)
+    adapter._observe_unmentioned_group_message = lambda *args, **kwargs: None
+    adapter._build_message_event = cast(
+        Any,
+        lambda message, msg_type, update_id=None: SimpleNamespace(text="", source=SimpleNamespace()),
+    )
+    adapter._apply_telegram_group_observe_attribution = lambda event: event
+    return adapter
+
+
+def _location_update(
+    *,
+    message_id: int,
+    lat: float = 52.0,
+    lon: float = 13.0,
+    live_period=None,
+    edited=False,
+):
+    location = SimpleNamespace(latitude=lat, longitude=lon)
+    if live_period is not None:
+        location.live_period = live_period
+    message = SimpleNamespace(
+        location=location,
+        venue=None,
+        chat_id=2141906339,
+        chat=SimpleNamespace(id=2141906339),
+        from_user=SimpleNamespace(id=2141906339),
+        message_id=message_id,
+    )
+    return SimpleNamespace(
+        message=None if edited else message,
+        edited_message=message if edited else None,
+        effective_message=message,
+        update_id=message_id,
+    )
+
+
+def test_static_location_pin_is_processed_once():
+    adapter = _adapter()
+    calls = []
+
+    async def handle(event):
+        calls.append(event.text)
+
+    adapter.handle_message = handle
+    asyncio.run(adapter._handle_location_message(_location_update(message_id=1), None))
+
+    assert len(calls) == 1
+
+
+def test_location_burst_from_same_chat_user_is_suppressed():
+    adapter = _adapter()
+    calls = []
+
+    async def handle(event):
+        calls.append(event.text)
+
+    adapter.handle_message = handle
+    asyncio.run(adapter._handle_location_message(_location_update(message_id=1, live_period=600), None))
+    asyncio.run(adapter._handle_location_message(_location_update(message_id=2, lat=52.1, lon=13.1), None))
+    asyncio.run(adapter._handle_location_message(_location_update(message_id=1, live_period=600, edited=True), None))
+
+    assert len(calls) == 1
+
+
+def test_location_messages_can_be_globally_ignored():
+    adapter = _adapter(ignore_locations=True)
+    calls = []
+
+    async def handle(event):
+        calls.append(event.text)
+
+    adapter.handle_message = handle
+    asyncio.run(adapter._handle_location_message(_location_update(message_id=1, live_period=600), None))
+    asyncio.run(adapter._handle_location_message(_location_update(message_id=2, lat=52.1, lon=13.1), None))
+
+    assert calls == []
+
+
+def test_gateway_ingress_drops_generated_location_text_before_session_lookup():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    event = MessageEvent(
+        text="[The user shared a location pin.]\nlatitude: 52.478236\nlongitude: 13.36116",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="2141906339",
+            chat_type="dm",
+            user_id="2141906339",
+            user_name="Justin Frederick Schafer",
+        ),
+    )
+
+    assert asyncio.run(GatewayRunner._handle_message(runner, event)) is None
+    assert not hasattr(runner, "session_store")


### PR DESCRIPTION
## Summary
- suppress repeated Telegram live-location/location-pin updates before they can interrupt an active agent turn
- add a config/env kill switch for treating Telegram location pins as passive context
- add a gateway ingress fallback so generated location-pin text is dropped before session lookup if it bypasses the adapter

## Test plan
- `PYTHONPATH="$PWD" /Users/justinfrederickschafer/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_telegram_location_burst.py -q -o 'addopts='`

## Incident notes
A live-location stream can deliver edited location updates every few seconds. Before this fix each update became a fresh prompt, repeatedly interrupting the current turn and polluting long-lived session context.
