### PR TITLE
fix(gateway): resume codex app-server threads

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -207,6 +207,7 @@ def run_codex_app_server_turn(
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
+            resume_thread_id=getattr(agent, "_resume_codex_thread_id", None),
         )
 
     # NOTE: the user message is ALREADY appended to messages by the

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -208,6 +208,7 @@ class CodexAppServerSession:
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
+        resume_thread_id: Optional[str] = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
@@ -225,6 +226,11 @@ class CodexAppServerSession:
 
         self._client: Optional[CodexAppServerClient] = None
         self._thread_id: Optional[str] = None
+        self._resume_thread_id: Optional[str] = (
+            str(resume_thread_id).strip() or None
+            if resume_thread_id
+            else None
+        )
         self._interrupt_event = threading.Event()
         # Pending file-change items, keyed by item id. Populated on
         # item/started for fileChange items; consumed by the approval
@@ -251,6 +257,22 @@ class CodexAppServerSession:
             client_title="Hermes Agent",
             client_version=_get_hermes_version(),
         )
+        if self._resume_thread_id:
+            resumed_id = self._try_resume(self._resume_thread_id)
+            if resumed_id:
+                self._thread_id = resumed_id
+                logger.info(
+                    "codex app-server thread resumed: id=%s cwd=%s",
+                    self._thread_id[:8],
+                    self._cwd,
+                )
+                return self._thread_id
+            logger.info(
+                "codex app-server thread resume failed for id=%s; starting fresh thread",
+                self._resume_thread_id[:8],
+            )
+            self._resume_thread_id = None
+
         # Permission selection is intentionally NOT sent on thread/start.
         # Two reasons (live-tested against codex 0.130.0):
         #   1. `thread/start.permissions` is gated behind the experimentalApi
@@ -295,6 +317,29 @@ class CodexAppServerSession:
             self._cwd,
         )
         return self._thread_id
+
+    def _try_resume(self, thread_id: str) -> Optional[str]:
+        """Attempt to attach to a previously-created Codex thread."""
+        if self._client is None:
+            return None
+        try:
+            result = self._client.request(
+                "thread/resume",
+                {"threadId": thread_id},
+                timeout=30,
+            )
+        except (CodexAppServerError, TimeoutError) as exc:
+            logger.debug("codex thread/resume failed for %s: %s", thread_id[:8], exc)
+            return None
+
+        thread_obj = result.get("thread") or {}
+        resumed_id = (
+            thread_obj.get("id")
+            or thread_obj.get("sessionId")
+            or result.get("sessionId")
+            or result.get("threadId")
+        )
+        return str(resumed_id) if resumed_id else None
 
     def close(self) -> None:
         if self._closed:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2349,6 +2349,8 @@ def _preserve_queued_followup_history_offset(
 
     merged = dict(followup_result)
     merged["history_offset"] = current_offset
+    if not merged.get("codex_thread_id") and current_result.get("codex_thread_id"):
+        merged["codex_thread_id"] = current_result.get("codex_thread_id")
     return merged
 
 
@@ -9882,6 +9884,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self.session_store.update_session(
                 session_entry.session_key,
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
+                codex_thread_id=agent_result.get("codex_thread_id"),
             )
 
             # Intentional silence is a delivery decision, not a transcript
@@ -13651,6 +13654,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if cached[2] != _live:
                     _cache[session_key] = (cached[0], cached[1], _live)
 
+    @staticmethod
+    def _session_entry_codex_thread_id(session_store, session_key: str) -> Optional[str]:
+        try:
+            session_entry = session_store._entries.get(session_key)
+        except Exception:
+            return None
+        thread_id = getattr(session_entry, "codex_thread_id", None)
+        thread_id = str(thread_id).strip() if thread_id else ""
+        return thread_id or None
+
+    @staticmethod
+    def _codex_thread_id_from_agent(agent: Any) -> Optional[str]:
+        if agent is None or agent is _AGENT_PENDING_SENTINEL:
+            return None
+        codex_session = getattr(agent, "_codex_session", None)
+        if codex_session is None:
+            return None
+        thread_id = getattr(codex_session, "_thread_id", None)
+        return str(thread_id) if thread_id else None
+
     def _evict_cached_agent(self, session_key: str) -> None:
         """Remove a cached agent for a session (called on /new, /model, etc).
 
@@ -15415,6 +15438,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
+            try:
+                _resume_codex_tid = self._session_entry_codex_thread_id(
+                    self.session_store,
+                    session_key,
+                )
+                if _resume_codex_tid:
+                    agent._resume_codex_thread_id = _resume_codex_tid
+            except Exception:
+                logger.debug("codex resume-thread pin skipped", exc_info=True)
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []
@@ -15953,6 +15985,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "interrupt_message": result.get("interrupt_message"),
                     "error": result.get("error"),
                     "compression_exhausted": result.get("compression_exhausted", False),
+                    "codex_thread_id": (
+                        self._codex_thread_id_from_agent(agent_holder[0])
+                        or result.get("codex_thread_id")
+                    ),
                     "tools": tools_holder[0] or [],
                     "history_offset": _effective_history_offset,
                     "session_id": effective_session_id,
@@ -16053,6 +16089,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "partial": result_holder[0].get("partial", False) if result_holder[0] else False,
                 "error": result_holder[0].get("error") if result_holder[0] else None,
                 "interrupt_message": result_holder[0].get("interrupt_message") if result_holder[0] else None,
+                "codex_thread_id": (
+                    self._codex_thread_id_from_agent(agent)
+                    or (
+                        result_holder[0].get("codex_thread_id")
+                        if result_holder[0]
+                        else None
+                    )
+                ),
                 "tools": tools_holder[0] or [],
                 "history_offset": _effective_history_offset,
                 "last_prompt_tokens": _last_prompt_toks,
@@ -16468,6 +16512,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "api_calls": _iter_n,
                     "tools": tools_holder[0] or [],
                     "history_offset": 0,
+                    "codex_thread_id": (
+                        self._codex_thread_id_from_agent(_timed_out_agent)
+                        or (
+                            result_holder[0].get("codex_thread_id")
+                            if result_holder[0]
+                            else None
+                        )
+                    ),
                     "failed": True,
                 }
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -478,6 +478,11 @@ class SessionEntry:
     
     # Last API-reported prompt tokens (for accurate compression pre-check)
     last_prompt_tokens: int = 0
+
+    # Codex app-server thread id for this gateway session.  Persisting it lets
+    # a freshly-built AIAgent resume the same Codex thread after gateway
+    # restart, cache eviction, or app-server retirement.
+    codex_thread_id: Optional[str] = None
     
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
@@ -532,6 +537,7 @@ class SessionEntry:
             "cache_write_tokens": self.cache_write_tokens,
             "total_tokens": self.total_tokens,
             "last_prompt_tokens": self.last_prompt_tokens,
+            "codex_thread_id": self.codex_thread_id,
             "estimated_cost_usd": self.estimated_cost_usd,
             "cost_status": self.cost_status,
             "expiry_finalized": self.expiry_finalized,
@@ -588,6 +594,7 @@ class SessionEntry:
             cache_write_tokens=data.get("cache_write_tokens", 0),
             total_tokens=data.get("total_tokens", 0),
             last_prompt_tokens=data.get("last_prompt_tokens", 0),
+            codex_thread_id=data.get("codex_thread_id"),
             estimated_cost_usd=data.get("estimated_cost_usd", 0.0),
             cost_status=data.get("cost_status", "unknown"),
             expiry_finalized=data.get("expiry_finalized", data.get("memory_flushed", False)),
@@ -1047,6 +1054,7 @@ class SessionStore:
         self,
         session_key: str,
         last_prompt_tokens: int = None,
+        codex_thread_id: str = None,
     ) -> None:
         """Update lightweight session metadata after an interaction."""
         with self._lock:
@@ -1057,6 +1065,8 @@ class SessionStore:
                 entry.updated_at = _now()
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
+                if codex_thread_id:
+                    entry.codex_thread_id = str(codex_thread_id)
                 self._save()
 
     def suspend_session(self, session_key: str) -> bool:

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -161,6 +161,41 @@ class TestLifecycle:
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
 
+    def test_resume_thread_id_uses_thread_resume(self):
+        client = FakeClient()
+
+        def handler(method, params):
+            if method == "thread/resume":
+                return {"thread": {"id": params["threadId"]}}
+            if method == "thread/start":
+                raise AssertionError("thread/start should not run after resume")
+            return {}
+
+        client._request_handler = handler
+        s = make_session(client, resume_thread_id="thread-existing-001")
+
+        assert s.ensure_started() == "thread-existing-001"
+        assert [method for method, _ in client.requests] == ["thread/resume"]
+
+    def test_resume_failure_falls_back_to_thread_start(self):
+        client = FakeClient()
+
+        def handler(method, params):
+            if method == "thread/resume":
+                return {}
+            if method == "thread/start":
+                return {"thread": {"id": "thread-fresh-002"}}
+            return {}
+
+        client._request_handler = handler
+        s = make_session(client, resume_thread_id="thread-missing-001")
+
+        assert s.ensure_started() == "thread-fresh-002"
+        assert [method for method, _ in client.requests] == [
+            "thread/resume",
+            "thread/start",
+        ]
+
     def test_close_idempotent(self):
         client = FakeClient()
         s = make_session(client)

--- a/tests/gateway/test_codex_thread_resume.py
+++ b/tests/gateway/test_codex_thread_resume.py
@@ -1,0 +1,233 @@
+"""Regression tests for gateway-owned Codex app-server thread continuity."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import types
+from collections import OrderedDict
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+import gateway.run as gateway_run
+
+
+class _CodexThreadAgent:
+    last_instance = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_instance = self
+        self.tools = []
+        self.session_id = kwargs.get("session_id")
+        self.model = kwargs.get("model")
+        self.provider = kwargs.get("provider")
+        self.base_url = kwargs.get("base_url")
+        self.api_key = kwargs.get("api_key")
+        self.api_mode = kwargs.get("api_mode")
+        self.context_compressor = SimpleNamespace(
+            last_prompt_tokens=0,
+            last_input_tokens=0,
+            last_output_tokens=0,
+            context_length=0,
+        )
+        self._codex_session = SimpleNamespace(_thread_id="thread-live-123")
+
+    def run_conversation(self, user_message: str, **kwargs):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "codex_thread_id": "thread-result-456",
+        }
+
+
+class _TimedOutCodexThreadAgent(_CodexThreadAgent):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._codex_session = SimpleNamespace(_thread_id="thread-timeout-123")
+        self._interrupted = threading.Event()
+        self.released = False
+
+    def run_conversation(self, user_message: str, **kwargs):
+        self._interrupted.wait(timeout=2.0)
+        return {
+            "final_response": "late",
+            "messages": [],
+            "api_calls": 3,
+            "codex_thread_id": "thread-late-result",
+        }
+
+    def get_activity_summary(self):
+        return {
+            "last_activity_desc": "waiting on codex app-server",
+            "seconds_since_activity": 999.0,
+            "current_tool": None,
+            "api_call_count": 3,
+            "max_iterations": 20,
+        }
+
+    def interrupt(self, reason=None):
+        self._interrupted.set()
+
+    def release_clients(self):
+        self.released = True
+        self._interrupted.set()
+
+
+def _make_runner(persisted_thread_id: str):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._pending_messages = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_ack_ts = {}
+    runner._session_run_generation = {}
+    runner._agent_cache = OrderedDict()
+    runner._agent_cache_lock = gateway_run.threading.Lock()
+    runner._pending_skills_reload_notes = {}
+    runner._pending_approvals = {}
+    runner._update_prompt_pending = {}
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._voice_mode = {}
+    runner._show_reasoning = False
+    runner._service_tier = None
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        streaming=SimpleNamespace(
+            enabled=False,
+            transport="off",
+            cursor="",
+            edit_interval=1.0,
+            buffer_threshold=20,
+            fresh_final_after_seconds=0.0,
+        ),
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+    )
+    runner.session_store = SimpleNamespace(
+        _entries={
+            "agent:main:local:dm": SimpleNamespace(
+                codex_thread_id=persisted_thread_id,
+            )
+        }
+    )
+    return runner
+
+
+def _patch_runtime(monkeypatch, tmp_path, agent_cls):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("agent:\n  model: test\n", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai",
+            "api_mode": "codex_app_server",
+            "base_url": "https://stub.invalid",
+            "api_key": "stub",
+        },
+    )
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = agent_cls
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def test_run_agent_pins_persisted_codex_thread_and_returns_live_thread_id(
+    monkeypatch, tmp_path
+):
+    _patch_runtime(monkeypatch, tmp_path, _CodexThreadAgent)
+
+    _CodexThreadAgent.last_instance = None
+    runner = _make_runner("thread-persisted-789")
+    source = SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="cli",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+    result = asyncio.run(
+        runner._run_agent(
+            message="ping",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key="agent:main:local:dm",
+        )
+    )
+
+    assert result["final_response"] == "ok"
+    assert result["codex_thread_id"] == "thread-live-123"
+    assert _CodexThreadAgent.last_instance is not None
+    assert (
+        _CodexThreadAgent.last_instance._resume_codex_thread_id
+        == "thread-persisted-789"
+    )
+
+
+def test_queued_followup_merge_preserves_codex_thread_id_when_followup_lacks_it():
+    current = {"history_offset": 1, "codex_thread_id": "thread-current-123"}
+    followup = {"history_offset": 9, "final_response": "next"}
+
+    merged = gateway_run._preserve_queued_followup_history_offset(current, followup)
+
+    assert merged["history_offset"] == 1
+    assert merged["codex_thread_id"] == "thread-current-123"
+
+
+def test_inactivity_timeout_returns_live_codex_thread_id(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "0.001")
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT_WARNING", "0")
+    _patch_runtime(monkeypatch, tmp_path, _TimedOutCodexThreadAgent)
+
+    real_wait = asyncio.wait
+
+    async def fast_wait(awaitables, *, timeout=None, return_when=asyncio.ALL_COMPLETED):
+        effective_timeout = 0.01 if timeout == 5.0 else timeout
+        return await real_wait(
+            awaitables,
+            timeout=effective_timeout,
+            return_when=return_when,
+        )
+
+    monkeypatch.setattr(gateway_run.asyncio, "wait", fast_wait)
+
+    _TimedOutCodexThreadAgent.last_instance = None
+    runner = _make_runner("")
+    source = SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="cli",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+    result = asyncio.run(
+        runner._run_agent(
+            message="ping",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key="agent:main:local:dm",
+        )
+    )
+
+    assert result["failed"] is True
+    assert result["codex_thread_id"] == "thread-timeout-123"
+    assert _TimedOutCodexThreadAgent.last_instance is not None

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1223,6 +1223,74 @@ class TestLastPromptTokens:
         store.update_session("k1", last_prompt_tokens=0)
         assert entry.last_prompt_tokens == 0
 
+
+class TestCodexThreadId:
+    """Codex app-server thread ids must survive gateway session persistence."""
+
+    def test_session_entry_default(self):
+        from datetime import datetime
+        from gateway.session import SessionEntry
+
+        entry = SessionEntry(
+            session_key="test",
+            session_id="s1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+        assert entry.codex_thread_id is None
+
+    def test_session_entry_roundtrip(self):
+        from datetime import datetime
+        from gateway.session import SessionEntry
+
+        entry = SessionEntry(
+            session_key="test",
+            session_id="s1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            codex_thread_id="thread-abc",
+        )
+
+        restored = SessionEntry.from_dict(entry.to_dict())
+
+        assert restored.codex_thread_id == "thread-abc"
+
+    def test_session_entry_from_old_data(self):
+        from gateway.session import SessionEntry
+
+        entry = SessionEntry.from_dict({
+            "session_key": "test",
+            "session_id": "s1",
+            "created_at": "2025-01-01T00:00:00",
+            "updated_at": "2025-01-01T00:00:00",
+        })
+
+        assert entry.codex_thread_id is None
+
+    def test_update_session_sets_codex_thread_id(self, tmp_path):
+        from datetime import datetime
+        from gateway.session import SessionEntry
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._loaded = True
+        store._db = None
+        store._save = MagicMock()
+        entry = SessionEntry(
+            session_key="k1",
+            session_id="s1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        store._entries = {"k1": entry}
+
+        store.update_session("k1", codex_thread_id="thread-live-123")
+
+        assert entry.codex_thread_id == "thread-live-123"
+
+
 class TestRewriteTranscriptPreservesReasoning:
     """rewrite_transcript must not drop reasoning fields from SQLite."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes Codex app-server thread continuity in the messaging gateway.

Before this change, a stable Hermes gateway session could still create a fresh Codex app-server thread after an `AIAgent` rebuild, gateway restart, cache eviction, timeout, or queued follow-up result wrapper. Hermes kept the transcript, but Codex server-side thread state was lost.

This PR persists the live Codex thread id on the gateway session and passes it back into newly-created Codex app-server sessions so they can call `thread/resume` before falling back to `thread/start`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/transports/codex_app_server_session.py`: add optional `resume_thread_id` support and attempt `thread/resume` before `thread/start`.
- `agent/codex_runtime.py`: pass a persisted gateway Codex thread id into new Codex app-server sessions.
- `gateway/session.py`: persist `codex_thread_id` in `SessionEntry` and `SessionStore.update_session()`.
- `gateway/run.py`: preserve and return the live Codex thread id from normal, empty-response, inactivity-timeout, and queued-follow-up paths.
- `tests/agent/transports/test_codex_app_server_session.py`: cover `thread/resume` and fallback to `thread/start`.
- `tests/gateway/test_session.py`: cover `codex_thread_id` serialization and update behavior.
- `tests/gateway/test_codex_thread_resume.py`: cover gateway resume pinning, live thread id return, timeout preservation, and queued follow-up preservation.

## How to Test

1. Run the focused regression tests:

   ```bash
   pytest tests/agent/transports/test_codex_app_server_session.py::TestLifecycle tests/gateway/test_session.py::TestCodexThreadId tests/gateway/test_codex_thread_resume.py -q
   ```

2. Run the broader related suite:

   ```bash
   pytest tests/gateway/test_codex_thread_resume.py tests/agent/transports/test_codex_app_server_session.py tests/gateway/test_session.py::TestLastPromptTokens tests/gateway/test_session.py::TestCodexThreadId tests/gateway/test_agent_cache.py tests/run_agent/test_codex_app_server_integration.py tests/hermes_cli/test_codex_runtime_plugin_migration.py -q
   ```

3. Confirm the broader suite passes.

Result from my branch: `225 passed in 52.13s`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
12 passed in 2.72s
73 passed in 15.63s
225 passed in 52.13s
git diff --check: passed
```