### PR TITLE
fix(mcp): pass legacy HTTP timeouts as timedeltas (#49629)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1907,6 +1907,57 @@ class TestHTTPConfig:
         assert captured["legacy_headers"]["MCP-Protocol-Version"] == "custom-version"
         assert "mcp-protocol-version" not in captured["legacy_headers"]
 
+    def test_legacy_streamable_http_timeouts_are_timedeltas(self):
+        from datetime import timedelta
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("remote")
+        captured = {}
+
+        class DummyTransport:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                kwargs["timeout"].seconds
+                kwargs["sse_read_timeout"].seconds
+
+            async def __aenter__(self):
+                return MagicMock(), MagicMock(), (lambda: None)
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class DummySession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def initialize(self):
+                return None
+
+        async def _discover_tools(self):
+            self._shutdown_event.set()
+
+        async def _test():
+            with patch("tools.mcp_tool._MCP_HTTP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._MCP_NEW_HTTP", False), \
+                 patch("tools.mcp_tool.streamablehttp_client", side_effect=lambda url, **kwargs: DummyTransport(**kwargs)), \
+                 patch("tools.mcp_tool.ClientSession", DummySession), \
+                 patch.object(MCPServerTask, "_discover_tools", _discover_tools):
+                await server._run_http({
+                    "url": "https://example.com/mcp",
+                    "connect_timeout": 7,
+                })
+
+        asyncio.run(_test())
+
+        assert captured["timeout"] == timedelta(seconds=7)
+        assert captured["sse_read_timeout"] == timedelta(seconds=300)
+
 
 # ---------------------------------------------------------------------------
 # Reconnection logic

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -104,7 +104,7 @@ import threading
 import time
 from types import SimpleNamespace
 from typing import Callable
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Coroutine, Dict, List, Optional
 from urllib.parse import urlparse
 
@@ -2736,7 +2736,9 @@ class MCPServerTask:
             # Deprecated API (mcp < 1.24.0): manages httpx client internally.
             _http_kwargs: dict = {
                 "headers": headers,
-                "timeout": float(connect_timeout),
+                # Legacy MCP SDKs access ``.seconds`` on these values.
+                "timeout": timedelta(seconds=float(connect_timeout)),
+                "sse_read_timeout": timedelta(seconds=300),
                 "verify": ssl_verify,
             }
             if _oauth_auth is not None:


### PR DESCRIPTION
## Summary

Fixes #49629.

- Convert legacy Streamable HTTP MCP `timeout` to `datetime.timedelta` before calling the deprecated SDK-managed `streamablehttp_client` path.
- Pass companion `sse_read_timeout` as `datetime.timedelta` as well, matching the MCP SDK transport contract.
- Leaves stdio MCP servers and the newer explicit `httpx.AsyncClient` HTTP path unchanged.

## Verification

- Regression proof on upstream/main: `tests/tools/test_mcp_tool.py::TestHTTPConfig::test_legacy_streamable_http_timeouts_are_timedeltas` fails with `AttributeError: 'float' object has no attribute 'seconds'`.
- After the fix, ran:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/tools/test_mcp_tool.py::TestHTTPConfig -v -o "addopts=" --tb=short`
  - Result: `7 passed in 0.70s`
- Verified branch is exactly one commit ahead of upstream/main: `0 1`.

## Duplicate / competitor check

Before publishing, checked open PRs by issue number, same-author branch pattern, and topic keywords (`HTTP MCP timeout timedelta`, `StreamableHTTPTransport timeout timedelta`). No focused open competing PR was found.

Auto-published by Moonsong via Path B automated pipeline.
