### PR TITLE
fix(cron): add direct_messages_topic_id and utf-8 encoding for Windows DM topic delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -813,6 +813,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         target_errors = []
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
             send_metadata = {"thread_id": thread_id} if thread_id else None
+            # Telegram DM topic sends need direct_messages_topic_id in metadata
+            # so the live adapter can route to the correct topic thread without
+            # a reply anchor. cron jobs are synthetic sends with no user reply
+            # context, so this field is required for DM topic delivery.
+            if send_metadata and thread_id and platform_name == "telegram":
+                try:
+                    if int(chat_id) > 0:
+                        send_metadata["direct_messages_topic_id"] = thread_id
+                except (ValueError, TypeError):
+                    pass
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
@@ -1047,6 +1057,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             argv,
             capture_output=True,
             text=True,
+            encoding='utf-8',
             timeout=script_timeout,
             cwd=str(path.parent),
             env=_sanitize_subprocess_env(os.environ.copy()),


### PR DESCRIPTION
Two fixes for cron delivery on Windows:

**1. direct_messages_topic_id for Telegram DM topic routing**

The cron live-adapter send path (`_deliver_result`) sets metadata with only `thread_id`. The Telegram adapter's `_is_private_dm_topic_send` then requires either a reply anchor or `direct_messages_topic_id` in metadata to route to the correct DM topic thread. Cron jobs are synthetic sends with no reply context, so without `direct_messages_topic_id` they fail with "Telegram DM topic delivery requires a reply anchor" and fall back to the bare DM chat.

This adds `direct_messages_topic_id` to the send metadata when the target is a Telegram private DM, matching the existing pattern in `_metadata_for_synthetic_send` in `gateway/run.py`.

**2. encoding='utf-8' for Windows subprocess**

On Windows, `subprocess.run(text=True)` defaults to cp1252 encoding. Cron no_agent scripts that output emoji or Unicode dashes (—, •) get mangled to cp1252 mojibake before delivery. Adding `encoding='utf-8'` fixes the encoding for all script-based cron jobs.

Both are 1-line changes plus comments. Tested with real cron delivery to Telegram DM Financials/Briefing/Health topics on Windows 10.