### PR TITLE
fix(cron): route WebUI origin delivery to home channel

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -203,6 +203,8 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
+_gateway_delivery_env_loaded = False
+
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -487,14 +489,16 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         return None
 
     if deliver_value == "origin":
-        if origin:
+        if origin and _is_known_delivery_platform(origin.get("platform", "")):
             return {
                 "platform": origin["platform"],
                 "chat_id": str(origin["chat_id"]),
                 "thread_id": origin.get("thread_id"),
             }
-        # Origin missing (e.g. job created via API/script) — try each
-        # platform's home channel as a fallback instead of silently dropping.
+        # Origin missing or its platform is not a real messaging target
+        # (e.g. WebUI, CLI) — the scheduler has no live adapter to push
+        # messages back to that surface.  Fall back to the first configured
+        # home channel instead of logging a hard failure.
         for platform_name in _iter_home_target_platforms():
             chat_id = _get_home_target_chat_id(platform_name)
             if chat_id:
@@ -564,6 +568,27 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
     }
 
 
+def _ensure_gateway_delivery_env_loaded() -> None:
+    """Load gateway config once before resolving cron delivery targets.
+
+    Gateway config loading applies platform/home-channel values from config.yaml
+    and ~/.hermes/.env into os.environ.  Cron target resolution historically
+    read TELEGRAM_HOME_CHANNEL/TELEGRAM_PROXY directly, so a scheduler process
+    that had not loaded gateway config yet could fail to resolve deliver=origin
+    and then fall back to a direct Telegram path later.
+    """
+    global _gateway_delivery_env_loaded
+    if _gateway_delivery_env_loaded:
+        return
+    try:
+        from gateway.config import load_gateway_config
+        load_gateway_config()
+    except Exception:
+        logger.debug("cron delivery: gateway config unavailable while priming env", exc_info=True)
+    finally:
+        _gateway_delivery_env_loaded = True
+
+
 def _normalize_deliver_value(deliver) -> str:
     """Normalize a stored/submitted ``deliver`` value to its canonical string form.
 
@@ -619,6 +644,7 @@ def _resolve_delivery_targets(job: dict) -> List[dict]:
     Duplicate (platform, chat_id, thread_id) tuples are collapsed by the
     existing dedup pass.
     """
+    _ensure_gateway_delivery_env_loaded()
     deliver = _normalize_deliver_value(job.get("deliver", "local"))
     if deliver == "local":
         return []

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -12,6 +12,32 @@ from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
 
+def _clear_cron_home_env(monkeypatch):
+    """Remove every built-in/plugin cron home-target env var from a test.
+
+    Cron delivery routing accepts plugin platforms via the platform registry,
+    so tests must not hand-maintain a partial list of ``*_HOME_CHANNEL`` vars.
+    A developer machine with Photon/iMessage configured can otherwise leak
+    ``PHOTON_HOME_CHANNEL`` into ``deliver='all'`` expectations.
+    """
+    from cron import scheduler
+
+    env_vars = set(scheduler._HOME_TARGET_ENV_VARS.values())
+    env_vars.update(scheduler._LEGACY_HOME_TARGET_ENV_VARS.keys())
+    env_vars.update(scheduler._LEGACY_HOME_TARGET_ENV_VARS.values())
+    env_vars.add("MATRIX_HOME_CHANNEL")  # legacy alias from older tests/configs
+
+    for platform_name in scheduler._iter_home_target_platforms():
+        env_var = scheduler._resolve_home_env_var(platform_name)
+        if env_var:
+            env_vars.add(env_var)
+
+    for env_var in env_vars:
+        monkeypatch.delenv(env_var, raising=False)
+        monkeypatch.delenv(f"{env_var}_THREAD_ID", raising=False)
+    monkeypatch.delenv("TELEGRAM_CRON_THREAD_ID", raising=False)
+
+
 class TestResolveOrigin:
     def test_full_origin(self):
         job = {
@@ -105,29 +131,53 @@ class TestResolveDeliveryTarget:
     def test_origin_delivery_without_origin_falls_back_to_supported_home_channels(
         self, monkeypatch, platform, env_var, chat_id
     ):
-        for fallback_env in (
-            "MATRIX_HOME_ROOM",
-            "MATRIX_HOME_CHANNEL",
-            "TELEGRAM_HOME_CHANNEL",
-            "DISCORD_HOME_CHANNEL",
-            "SLACK_HOME_CHANNEL",
-            "SIGNAL_HOME_CHANNEL",
-            "MATTERMOST_HOME_CHANNEL",
-            "SMS_HOME_CHANNEL",
-            "EMAIL_HOME_ADDRESS",
-            "DINGTALK_HOME_CHANNEL",
-            "BLUEBUBBLES_HOME_CHANNEL",
-            "FEISHU_HOME_CHANNEL",
-            "WECOM_HOME_CHANNEL",
-            "WEIXIN_HOME_CHANNEL",
-            "QQ_HOME_CHANNEL",
-        ):
-            monkeypatch.delenv(fallback_env, raising=False)
+        _clear_cron_home_env(monkeypatch)
         monkeypatch.setenv(env_var, chat_id)
 
         assert _resolve_delivery_target({"deliver": "origin"}) == {
             "platform": platform,
             "chat_id": chat_id,
+            "thread_id": None,
+        }
+
+    def test_origin_delivery_with_webui_origin_falls_back_to_home_channel(self, monkeypatch):
+        """WebUI sessions are not async messaging targets for cron delivery."""
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "441846490")
+        job = {
+            "deliver": "origin",
+            "origin": {
+                "platform": "webui",
+                "chat_id": "762f0218cca7",
+                "thread_id": None,
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "telegram",
+            "chat_id": "441846490",
+            "thread_id": None,
+        }
+
+    def test_origin_delivery_primes_gateway_config_env_before_home_fallback(self, monkeypatch):
+        """Cron delivery must load gateway config before resolving origin fallback.
+
+        LaunchAgent scheduler processes can start with only HERMES_HOME in the
+        environment.  load_gateway_config() then injects TELEGRAM_HOME_CHANNEL
+        from config/.env; resolving before that leaves deliver=origin jobs with
+        no target.
+        """
+        _clear_cron_home_env(monkeypatch)
+        monkeypatch.setattr("cron.scheduler._gateway_delivery_env_loaded", False)
+
+        def fake_load_gateway_config():
+            monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "441846490")
+            return object()
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", fake_load_gateway_config)
+
+        assert _resolve_delivery_target({"deliver": "origin", "origin": None}) == {
+            "platform": "telegram",
+            "chat_id": "441846490",
             "thread_id": None,
         }
 
@@ -400,6 +450,13 @@ class TestResolveDeliveryTarget:
 
 class TestRoutingIntents:
     """``all`` routing intent expands at fire time."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_cron_home_env(self, monkeypatch):
+        # Routing-intent unit tests own their env explicitly.  Do not let the
+        # operator's real gateway/plugin config (e.g. PHOTON_HOME_CHANNEL) leak in.
+        monkeypatch.setattr("cron.scheduler._gateway_delivery_env_loaded", True)
+        _clear_cron_home_env(monkeypatch)
 
     def test_all_expands_to_every_connected_home_channel(self, monkeypatch):
         """deliver='all' fans out to every platform with a configured home channel."""


### PR DESCRIPTION
## Summary
- route cron `deliver=origin` jobs created from WebUI/API sessions to a configured messaging home channel
- prime gateway delivery env once before cron origin fallback resolution
- isolate cron routing tests from developer/plugin home-channel env such as `PHOTON_HOME_CHANNEL`

## Tests
- `python -m pytest tests/cron/test_scheduler.py::TestRoutingIntents::test_all_with_no_connected_channels_returns_empty tests/cron/test_scheduler.py::TestRoutingIntents::test_all_token_case_insensitive -q`
- `scripts/run_tests.sh tests/cron/test_scheduler.py`
