### PR TITLE
fix(photon): recover sidecar after transport drops

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -220,6 +220,7 @@ class PhotonAdapter(BasePlatformAdapter):
         # Runtime state
         self._sidecar_proc: Optional[subprocess.Popen] = None
         self._sidecar_supervisor_task: Optional[asyncio.Task] = None
+        self._sidecar_restart_lock = asyncio.Lock()
         self._inbound_task: Optional[asyncio.Task] = None
         self._inbound_running = False
         self._http_client: Optional["httpx.AsyncClient"] = None
@@ -399,6 +400,7 @@ class PhotonAdapter(BasePlatformAdapter):
         backoff = 1.0
         while self._inbound_running:
             try:
+                await self._ensure_sidecar_running()
                 async with client.stream(
                     "GET", url, headers=headers, timeout=None,
                 ) as resp:
@@ -825,6 +827,40 @@ class PhotonAdapter(BasePlatformAdapter):
             f"Photon sidecar did not become ready within 15s: {last_err}"
         )
 
+    async def _ensure_sidecar_running(self) -> None:
+        """Restart the supervised sidecar if it exited after initial connect."""
+        if not self._autostart_sidecar:
+            return
+        proc = self._sidecar_proc
+        if proc is not None and proc.poll() is None:
+            return
+        async with self._sidecar_restart_lock:
+            proc = self._sidecar_proc
+            if proc is not None and proc.poll() is None:
+                return
+            exit_code = proc.returncode if proc is not None else None
+            logger.warning(
+                "[photon] sidecar exited%s; restarting before reconnecting inbound stream",
+                f" with code {exit_code}" if exit_code is not None else "",
+            )
+            self._sidecar_proc = None
+            if self._sidecar_supervisor_task is not None:
+                self._sidecar_supervisor_task.cancel()
+                self._sidecar_supervisor_task = None
+            await self._start_sidecar()
+
+    async def _restart_sidecar_for_outbound_error(self, reason: str) -> None:
+        """Force a clean sidecar restart after a recoverable outbound transport fault."""
+        if not self._autostart_sidecar:
+            return
+        async with self._sidecar_restart_lock:
+            logger.warning(
+                "[photon] restarting sidecar after recoverable outbound error: %s",
+                reason,
+            )
+            await self._stop_sidecar()
+            await self._start_sidecar()
+
     async def _supervise_sidecar(self, proc: subprocess.Popen) -> None:
         """Pump the sidecar's stdout/stderr into our logger."""
         if proc.stdout is None:  # subprocess was launched without stdout=PIPE
@@ -892,7 +928,40 @@ class PhotonAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self._sidecar_send(chat_id, self.format_message(content))
+        """Send one text message through the sidecar.
+
+        Cron live-delivery calls adapter.send() directly, bypassing the
+        gateway response retry wrapper.  Keep recoverable sidecar restart logic
+        at this lowest text-send layer so cron, tools, and agent replies all
+        share it.
+        """
+        text = self.format_message(content)
+        result = await self._sidecar_send(chat_id, text)
+        if result.success or not self._is_recoverable_outbound_drop(result.error or ""):
+            return result
+        try:
+            await self._restart_sidecar_for_outbound_error(
+                "upstream_connection_dropped during direct /send"
+            )
+        except Exception as e:
+            logger.warning(
+                "[photon] sidecar restart after direct outbound drop failed: %s",
+                e,
+            )
+            return result
+        recovered = await self._sidecar_send(chat_id, text)
+        if recovered.success:
+            logger.info("[photon] recovered direct outbound send after sidecar restart")
+            return recovered
+        return recovered
+
+    @staticmethod
+    def _is_recoverable_outbound_drop(error_str: str) -> bool:
+        return (
+            "error_code=upstream_connection_dropped" in error_str
+            or "upstream_connection_dropped" in error_str
+            or "[upstream] Connection dropped" in error_str
+        )
 
     # -- Outbound media (parity with the BlueBubbles iMessage channel) -----
     #
@@ -1215,6 +1284,31 @@ class PhotonAdapter(BasePlatformAdapter):
             return result
 
         error_str = result.error or ""
+        if "error_code=upstream_connection_dropped" in error_str:
+            try:
+                await self._restart_sidecar_for_outbound_error(
+                    "upstream_connection_dropped during /send"
+                )
+            except Exception as e:
+                logger.warning(
+                    "[photon] sidecar restart after outbound drop failed: %s",
+                    e,
+                )
+            else:
+                recovered = await self.send(
+                    chat_id=chat_id,
+                    content=text,
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+                if recovered.success:
+                    logger.info(
+                        "[photon] recovered outbound send after sidecar restart"
+                    )
+                    return recovered
+                error_str = recovered.error or error_str
+                result = recovered
+
         is_network = result.retryable or self._is_retryable_error(error_str)
         if not is_network and self._is_timeout_error(error_str):
             return result
@@ -1340,14 +1434,23 @@ class PhotonAdapter(BasePlatformAdapter):
         headers = {"X-Hermes-Sidecar-Token": self._sidecar_token}
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(url, json=body, headers=headers)
+        payload: Dict[str, Any] = {}
+        try:
+            payload = resp.json() or {}
+        except Exception:
+            payload = {}
         if resp.status_code != 200:
+            error_code = payload.get("error_code")
+            suffix = f" error_code={error_code}" if error_code else ""
             raise RuntimeError(
-                f"Photon sidecar {path} returned {resp.status_code}: {resp.text[:200]}"
+                f"Photon sidecar {path} returned {resp.status_code}{suffix}: {resp.text[:200]}"
             )
-        data = resp.json() or {}
+        data = payload
         if not data.get("ok"):
+            error_code = data.get("error_code")
+            suffix = f" error_code={error_code}" if error_code else ""
             raise RuntimeError(
-                f"Photon sidecar {path} reported error: {data.get('error')}"
+                f"Photon sidecar {path} reported error{suffix}: {data.get('error')}"
             )
         return data
 

--- a/plugins/platforms/photon/sidecar/fatal-errors.mjs
+++ b/plugins/platforms/photon/sidecar/fatal-errors.mjs
@@ -1,0 +1,47 @@
+// Fatal-error helpers for the Photon Spectrum sidecar.
+//
+// Keep this separate from index.mjs so the detection logic can be unit-tested
+// without starting Spectrum or requiring real Photon credentials.
+
+function appendErrorParts(parts, value, seen) {
+  if (value == null) return;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    parts.push(String(value));
+    return;
+  }
+  if (typeof value !== "object") return;
+  if (seen.has(value)) return;
+  seen.add(value);
+
+  for (const key of ["name", "message", "stack", "code", "grpcCode", "details", "path"]) {
+    if (value[key] != null) parts.push(String(value[key]));
+  }
+  if (value.cause) appendErrorParts(parts, value.cause, seen);
+  if (Array.isArray(value.errors)) {
+    for (const error of value.errors) appendErrorParts(parts, error, seen);
+  }
+}
+
+export function errorToText(error) {
+  const parts = [];
+  appendErrorParts(parts, error, new Set());
+  if (!parts.length) return String(error ?? "");
+  return parts.join("\n");
+}
+
+export function isFatalInboundStreamError(error) {
+  const text = errorToText(error);
+  return (
+    /catchUpEvents concurrency limit/i.test(text) ||
+    /EventService\/CatchUpEvents[\s\S]*RESOURCE_EXHAUSTED/i.test(text) ||
+    /RESOURCE_EXHAUSTED[\s\S]*EventService\/CatchUpEvents/i.test(text)
+  );
+}
+
+export function classifyRecoverableOutboundError(error) {
+  const text = errorToText(error);
+  if (/\[upstream\]\s*Connection dropped/i.test(text)) {
+    return "upstream_connection_dropped";
+  }
+  return null;
+}

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -57,6 +57,7 @@
 import http from "node:http";
 import crypto from "node:crypto";
 import { once } from "node:events";
+import { isFatalInboundStreamError, classifyRecoverableOutboundError } from "./fatal-errors.mjs";
 import { patchSpectrumTs } from "./patch-spectrum-mixed-attachments.mjs";
 
 const projectId = process.env.PHOTON_PROJECT_ID;
@@ -80,6 +81,8 @@ const E164_RE = /^\+\d{6,}$/;
 const MAX_KNOWN_SPACES = 2048;
 const MAX_KNOWN_MESSAGES = 1024;
 const MAX_REACTION_HANDLES = 512;
+const FATAL_INBOUND_EXIT_CODE = 75;
+let fatalInboundExitScheduled = false;
 
 if (!projectId || !projectSecret || !sharedToken) {
   console.error(
@@ -143,6 +146,39 @@ const app = await Spectrum({
   options: { flattenGroups: true },
   telemetry,
 });
+
+async function stopAppForFatalInboundExit() {
+  try {
+    await Promise.race([
+      app.stop(),
+      new Promise((resolve) => setTimeout(resolve, 3000)),
+    ]);
+  } catch {
+    /* best effort */
+  }
+}
+
+function scheduleFatalInboundExit(reason) {
+  if (fatalInboundExitScheduled) return;
+  fatalInboundExitScheduled = true;
+  console.error(
+    "photon-sidecar: fatal inbound stream error; exiting so Hermes can " +
+      "restart a clean sidecar: " +
+      String(reason || "unknown")
+  );
+  setTimeout(async () => {
+    await stopAppForFatalInboundExit();
+    process.exit(FATAL_INBOUND_EXIT_CODE);
+  }, 0).unref?.();
+}
+
+const originalConsoleError = console.error.bind(console);
+console.error = (...args) => {
+  originalConsoleError(...args);
+  if (isFatalInboundStreamError(args.join(" "))) {
+    scheduleFatalInboundExit(args.join(" "));
+  }
+};
 
 // ---------------------------------------------------------------------------
 // Inbound: forward `app.messages` (gRPC stream) to the Python consumer.
@@ -365,6 +401,9 @@ async function normalizeEvent(space, message) {
       }
       console.error("photon-sidecar: inbound stream ended — re-subscribing");
     } catch (e) {
+      if (isFatalInboundStreamError(e)) {
+        scheduleFatalInboundExit(e && e.message ? e.message : String(e));
+      }
       console.error(
         "photon-sidecar: inbound stream errored — restarting: " +
           (e && e.message ? e.message : String(e))
@@ -416,13 +455,16 @@ function badRequest(res, msg) {
   res.end(JSON.stringify({ ok: false, error: msg }));
 }
 
-function serverError(res) {
+function serverError(res, details = {}) {
   res.statusCode = 500;
   res.setHeader("Content-Type", "application/json");
   // Don't leak stack traces or raw exception text to the caller — even
-  // though we listen on loopback, the supervisor logs the real error
-  // and the client only needs a generic failure signal.
-  res.end(JSON.stringify({ ok: false, error: "internal sidecar error" }));
+  // though we listen on loopback, the supervisor logs the real error.
+  // We do return a tiny machine-readable code so the Python adapter can
+  // distinguish recoverable upstream transport drops from permanent failures.
+  res.end(
+    JSON.stringify({ ok: false, error: "internal sidecar error", ...details })
+  );
 }
 
 function ok(res, data) {
@@ -665,9 +707,10 @@ const server = http.createServer(async (req, res) => {
       "photon-sidecar: handler error: " +
         (e && e.stack ? e.stack : String(e))
     );
+    const recoverable = classifyRecoverableOutboundError(e);
     // serverError() intentionally returns a generic message — see its
     // body for the rationale.
-    return serverError(res);
+    return serverError(res, recoverable ? { error_code: recoverable } : {});
   }
 });
 

--- a/plugins/platforms/photon/sidecar/test/fatal-errors.test.mjs
+++ b/plugins/platforms/photon/sidecar/test/fatal-errors.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { errorToText, isFatalInboundStreamError, classifyRecoverableOutboundError } from "../fatal-errors.mjs";
+
+test("detects Photon catchUpEvents concurrency-limit errors", () => {
+  const error = {
+    message: "internalError",
+    grpcCode: 8,
+    cause: {
+      message:
+        "/photon.imessage.v1.EventService/CatchUpEvents RESOURCE_EXHAUSTED: [spectrum-imessage] catchUpEvents concurrency limit (16) reached",
+      details: "[spectrum-imessage] catchUpEvents concurrency limit (16) reached",
+    },
+  };
+
+  assert.equal(isFatalInboundStreamError(error), true);
+});
+
+test("detects fatal retry text emitted by spectrum-ts internal stream logger", () => {
+  assert.equal(
+    isFatalInboundStreamError(
+      "[spectrum.stream] stream persistently failing; still retrying RateLimitError: [spectrum-imessage] catchUpEvents concurrency limit (16) reached"
+    ),
+    true
+  );
+});
+
+test("does not treat outbound target authorization failures as fatal inbound stream errors", () => {
+  const error = new Error("AuthenticationError: [spectrum-imessage] Target not allowed for this project");
+
+  assert.equal(isFatalInboundStreamError(error), false);
+  assert.match(errorToText(error), /Target not allowed/);
+});
+
+test("classifies upstream connection drops as recoverable outbound send errors", () => {
+  const error = new Error("ConnectionError: [upstream] Connection dropped");
+
+  assert.equal(classifyRecoverableOutboundError(error), "upstream_connection_dropped");
+});

--- a/tests/plugins/test_photon_adapter_outbound_recovery.py
+++ b/tests/plugins/test_photon_adapter_outbound_recovery.py
@@ -1,0 +1,109 @@
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+@pytest.mark.asyncio
+async def test_direct_send_restarts_sidecar_after_recoverable_upstream_drop(monkeypatch):
+    adapter = PhotonAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"project_id": "pid", "project_secret": "secret"},
+        )
+    )
+
+    calls = {"send": 0, "restart": 0}
+
+    async def fake_sidecar_send(chat_id, text):
+        calls["send"] += 1
+        assert chat_id == "chat-1"
+        assert text == "hello"
+        if calls["send"] == 1:
+            return SendResult(
+                success=False,
+                error='Photon sidecar /send returned 500 error_code=upstream_connection_dropped: {"ok":false,"error":"internal sidecar error","error_code":"upstream_connection_dropped"}',
+            )
+        return SendResult(success=True, message_id="m-direct-recovered")
+
+    async def fake_restart(reason: str):
+        calls["restart"] += 1
+        assert "upstream_connection_dropped" in reason
+
+    monkeypatch.setattr(adapter, "_sidecar_send", fake_sidecar_send)
+    monkeypatch.setattr(adapter, "_restart_sidecar_for_outbound_error", fake_restart)
+
+    result = await adapter.send(chat_id="chat-1", content="hello")
+
+    assert result.success is True
+    assert result.message_id == "m-direct-recovered"
+    assert calls == {"send": 2, "restart": 1}
+
+
+@pytest.mark.asyncio
+async def test_direct_send_recovers_plain_upstream_drop_text(monkeypatch):
+    adapter = PhotonAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"project_id": "pid", "project_secret": "secret"},
+        )
+    )
+
+    calls = {"send": 0, "restart": 0}
+
+    async def fake_sidecar_send(chat_id, text):
+        calls["send"] += 1
+        if calls["send"] == 1:
+            return SendResult(
+                success=False,
+                error="Photon sidecar /send returned 500: ConnectionError: [upstream] Connection dropped",
+            )
+        return SendResult(success=True, message_id="m-plain-text-recovered")
+
+    async def fake_restart(reason: str):
+        calls["restart"] += 1
+        assert "upstream_connection_dropped" in reason
+
+    monkeypatch.setattr(adapter, "_sidecar_send", fake_sidecar_send)
+    monkeypatch.setattr(adapter, "_restart_sidecar_for_outbound_error", fake_restart)
+
+    result = await adapter.send(chat_id="chat-1", content="hello")
+
+    assert result.success is True
+    assert result.message_id == "m-plain-text-recovered"
+    assert calls == {"send": 2, "restart": 1}
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_restarts_sidecar_after_recoverable_upstream_drop(monkeypatch):
+    adapter = PhotonAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"project_id": "pid", "project_secret": "secret"},
+        )
+    )
+
+    calls = {"send": 0, "restart": 0}
+
+    async def fake_send(*, chat_id, content, reply_to=None, metadata=None):
+        calls["send"] += 1
+        if calls["send"] == 1:
+            return SendResult(
+                success=False,
+                error='Photon sidecar /send returned 500 error_code=upstream_connection_dropped: {"ok":false,"error":"internal sidecar error","error_code":"upstream_connection_dropped"}',
+            )
+        return SendResult(success=True, message_id="m-recovered")
+
+    async def fake_restart(reason: str):
+        calls["restart"] += 1
+        assert "upstream_connection_dropped" in reason
+
+    monkeypatch.setattr(adapter, "send", fake_send)
+    monkeypatch.setattr(adapter, "_restart_sidecar_for_outbound_error", fake_restart)
+
+    result = await adapter._send_with_retry("chat-1", "/new")
+
+    assert result.success is True
+    assert result.message_id == "m-recovered"
+    assert calls == {"send": 2, "restart": 1}

--- a/tests/plugins/test_photon_adapter_sidecar_restart.py
+++ b/tests/plugins/test_photon_adapter_sidecar_restart.py
@@ -1,0 +1,60 @@
+from typing import Any, cast
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+class _FakeProc:
+    def __init__(self, returncode=None):
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
+
+
+@pytest.mark.asyncio
+async def test_ensure_sidecar_running_restarts_exited_sidecar(monkeypatch):
+    adapter = PhotonAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"project_id": "pid", "project_secret": "secret"},
+        )
+    )
+    adapter._sidecar_proc = cast(Any, _FakeProc(returncode=75))
+    adapter._sidecar_supervisor_task = None
+    calls = []
+
+    async def fake_start_sidecar():
+        calls.append("start")
+        adapter._sidecar_proc = cast(Any, _FakeProc(returncode=None))
+
+    monkeypatch.setattr(adapter, "_start_sidecar", fake_start_sidecar)
+
+    await adapter._ensure_sidecar_running()
+
+    assert calls == ["start"]
+    assert adapter._sidecar_proc is not None
+    assert adapter._sidecar_proc.poll() is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_sidecar_running_keeps_live_sidecar(monkeypatch):
+    adapter = PhotonAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"project_id": "pid", "project_secret": "secret"},
+        )
+    )
+    adapter._sidecar_proc = cast(Any, _FakeProc(returncode=None))
+
+    async def fail_start_sidecar():  # pragma: no cover - should not be called
+        raise AssertionError("live sidecar should not restart")
+
+    monkeypatch.setattr(adapter, "_start_sidecar", fail_start_sidecar)
+
+    await adapter._ensure_sidecar_running()
+
+    assert adapter._sidecar_proc is not None
+    assert adapter._sidecar_proc.poll() is None


### PR DESCRIPTION
## Summary
- classify Photon sidecar/Spectrum transport drops as recoverable instead of fatal outbound authorization failures
- restart/recover the sidecar after upstream transport drops
- add sidecar fatal-error classification coverage and adapter recovery tests

## Tests
- `scripts/run_tests.sh tests/plugins/test_photon_adapter_outbound_recovery.py tests/plugins/test_photon_adapter_sidecar_restart.py`
- `node --test plugins/platforms/photon/sidecar/test/fatal-errors.test.mjs`
