### PR TITLE
test: lock xAI Composer model picker payload

### DIFF
--- a/tests/hermes_cli/test_xai_curated_models.py
+++ b/tests/hermes_cli/test_xai_curated_models.py
@@ -1,5 +1,6 @@
 """Regression tests for xAI curated model list (OAuth picker)."""
 
+from hermes_cli.inventory import ConfigContext, build_models_payload
 from hermes_cli.models import _PROVIDER_MODELS, provider_model_ids
 
 
@@ -12,3 +13,34 @@ def test_grok_composer_slots_after_grok_build():
     models = _PROVIDER_MODELS["xai-oauth"]
     assert models[0] == "grok-build-0.1"
     assert models[1] == "grok-composer-2.5-fast"
+
+
+def test_grok_composer_surfaces_in_shared_model_payload(monkeypatch):
+    """Dashboard, TUI, and web pickers share build_models_payload.
+
+    xAI OAuth Composer must survive that shared inventory layer, not just the
+    low-level provider_model_ids() helper.
+    """
+
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_auth_store",
+        lambda: {"providers": {"xai-oauth": {"tokens": {"access_token": "token"}}}},
+    )
+
+    payload = build_models_payload(
+        ConfigContext(
+            current_provider="xai-oauth",
+            current_model="",
+            current_base_url="",
+            user_providers={},
+            custom_providers=[],
+        ),
+        include_unconfigured=True,
+        picker_hints=True,
+        canonical_order=True,
+    )
+
+    xai = next(p for p in payload["providers"] if p["slug"] == "xai-oauth")
+    assert xai["authenticated"] is True
+    assert "grok-composer-2.5-fast" in xai["models"]


### PR DESCRIPTION
Closes #49650.

## Summary
- adds a regression test that verifies `grok-composer-2.5-fast` survives the shared `build_models_payload` inventory layer
- covers the substrate used by dashboard/TUI/web/REST model picker surfaces, not only the low-level `provider_model_ids("xai-oauth")` helper

## Validation
- `python -m pytest tests/hermes_cli/test_xai_curated_models.py tests/test_tui_gateway_server.py::test_model_options_does_not_overwrite_curated_models -q -o 'addopts='` → `4 passed in 3.68s`\n- `npm --workspace web run typecheck` → pass\n- `npm --workspace apps/desktop run typecheck` → pass after `npm ci` restored workspace deps\n- `npm --workspace apps/desktop run test:ui -- src/store/model-visibility.test.ts` → `7 passed`\n- Live Neo profile payload validation: `provider_model_ids`, canonical provider list, `build_models_payload`, TUI `model.options`, and REST `/api/model/options` all include `grok-composer-2.5-fast` at index 1 under authenticated `xai-oauth`\n- Fresh-context QA agent re-ran the targeted pytest command and live payload checks: PASS\n\n## Notes\nUpstream main already contains the actual Composer entry; this PR locks the cross-surface picker invariant so the fleet update has a hard regression check before restart.