### PR TITLE
fix(tui): always capture current CWD instead of inheriting stale HERMES_CWD

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2265,6 +2265,15 @@ def _launch_tui(
     )
     os.close(active_session_fd)
     env["HERMES_TUI_ACTIVE_SESSION_FILE"] = active_session_file
+    env["HERMES_PYTHON_SRC_ROOT"] = os.environ.get(
+        "HERMES_PYTHON_SRC_ROOT", str(PROJECT_ROOT)
+    )
+    env.setdefault("HERMES_PYTHON", sys.executable)
+    # Always capture the current working directory — never inherit a stale
+    # HERMES_CWD from a previous TUI session in the parent environment.
+    # `os.environ.copy()` picks up every env var, including one left behind
+    # by a prior TUI launch, and `setdefault` would keep the stale value.
+    env["HERMES_CWD"] = os.getcwd()
     env.setdefault("NODE_ENV", "development" if tui_dev else "production")
 
     wt_info = None

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1914,3 +1914,31 @@ def test_print_tui_exit_summary_prefers_actual_active_session_file(
     assert seen == ["actual_session"]
     assert "hermes --tui --resume actual_session" in out
     assert "startup_resume" not in out
+
+
+def test_launch_tui_uses_current_cwd_over_stale_env(monkeypatch, main_mod, tmp_path):
+    captured = {}
+
+    # A HERMES_CWD exported in the parent shell (e.g. left over from an earlier
+    # `hermes --tui` in a different directory) must NOT win over the directory
+    # the TUI is actually launched from.  setdefault() kept the stale value; the
+    # launch cwd is the source of truth (#49637).
+    monkeypatch.setenv("HERMES_CWD", "/stale/exported/dir")
+    monkeypatch.chdir(tmp_path)
+    expected_cwd = os.getcwd()
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["node", "dist/entry.js"], Path(".")),
+    )
+    monkeypatch.setattr(
+        main_mod.subprocess,
+        "call",
+        lambda argv, cwd=None, env=None: captured.update({"env": env}) or 1,
+    )
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui()
+
+    assert captured["env"]["HERMES_CWD"] == expected_cwd
+    assert captured["env"]["HERMES_CWD"] != "/stale/exported/dir"


### PR DESCRIPTION
## Summary

Fixes TUI sessions starting with stale working directory from a previous session instead of the shell's current directory.

## Root Cause

`_launch_tui()` builds the TUI process environment with `os.environ.copy()`, which picks up every env var — including a `HERMES_CWD` left behind by a prior TUI launch. It then used `env.setdefault("HERMES_CWD", os.getcwd())` which preserves any existing value instead of capturing the current directory.

The TUI frontend reads `HERMES_CWD` directly (in `ui-tui/src/app/useMainApp.ts:1088` and `ui-tui/src/gatewayClient.ts:342`), so a stale value causes every new session to start in the wrong directory.

## Fix

One-line change: `env.setdefault(...)` → `env["HERMES_CWD"] = os.getcwd()` — always captures the current working directory, never inherits a stale one.

## Why the old CLI didn't have this bug

The classic CLI mode uses `os.getcwd()` directly via `resolve_agent_cwd()` in `agent/runtime_cwd.py` — it doesn't read `HERMES_CWD` from the environment at all. The TUI path was the only codepath affected.

Fixes #49637