### PR TITLE
fix(cron): log async job exceptions and catch BaseException in ticker

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2308,6 +2308,12 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
             def _on_done(_f: concurrent.futures.Future) -> None:
                 _remaining[0] -= 1
+                try:
+                    _exc = _f.exception()
+                    if _exc is not None:
+                        logger.error("Cron job future failed in async mode: %s", _exc, exc_info=(type(_exc), _exc, _exc.__traceback__))
+                except Exception:
+                    pass
                 if _remaining[0] <= 0:
                     _sweep_mcp_orphans()
 

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -172,6 +172,6 @@ class InProcessCronScheduler(CronScheduler):
         while not stop_event.is_set():
             try:
                 cron_tick(verbose=False, adapters=adapters, loop=loop, sync=False)
-            except Exception as e:
-                logger.debug("Cron tick error: %s", e)
+            except BaseException as e:
+                logger.error("Cron tick error: %s", e, exc_info=True)
             stop_event.wait(interval)


### PR DESCRIPTION
## Summary

Two bugs in cron exception handling that cause silent failures and potential gateway crashes.

### Bug 1: Async cron futures silently swallow exceptions (cron/scheduler.py)

In async mode (gateway ticker), `tick()` dispatches futures via `ThreadPoolExecutor` and adds an `_on_done` callback. But the callback only decrements a counter and runs orphan sweep -- it never calls `_f.exception()`. When a cron job fails, the exception is stored in the future but never logged.

Sync mode (tests/manual) correctly calls `f.result()` which re-raises the exception. Async mode silently drops it.

Fix: Check `_f.exception()` in the done callback and log with `logger.error(exc_info=True)`.

### Bug 2: Cron ticker catches only Exception, misses SystemExit (cron/scheduler_provider.py)

`InProcessCronScheduler.start()` catches `except Exception` around `cron_tick()`. Provider SDKs can raise `SystemExit` (a `BaseException` subclass) after retry exhaustion, which bypasses `except Exception` and crashes the ticker thread.

Additionally, errors were logged at `logger.debug`, making them invisible in production.

Fix: Widen to `except BaseException` and promote to `logger.error` with `exc_info=True`.

## Test Plan

- [x] All cron tests pass
- [x] Lint passes on both files
