### PR TITLE
docs(contributing): add "search first" guidance to cut duplicate PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,24 @@ We value contributions in this order:
 
 ---
 
+## Before You Start: Search First
+
+A quick search before you build saves your time and keeps the PR queue clean — duplicates are common here, so it's worth a minute up front.
+
+- **Search both open *and* merged PRs and issues** for your topic or error symptom — the duplicate-check in the PR template fires at review time, after you've already done the work:
+  ```bash
+  gh search issues --repo NousResearch/hermes-agent "<your terms>"
+  gh search prs --repo NousResearch/hermes-agent --state all "<your terms>"
+  ```
+  Or use the web UI: [issues](https://github.com/NousResearch/hermes-agent/issues?q=) · [PRs (all states)](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr).
+- **The issue tracker can lag the code.** Many requested features are already implemented in-tree, so also search the source (`search_files`, or your editor's grep) for the capability before proposing it.
+- **If an open PR already addresses it**, consider reviewing or improving that one instead of opening a competing duplicate.
+- **For larger work**, comment on the issue to signal you're working on it, so others don't start the same thing.
+
+Related: #38284 covers the agent-side analog — Hermes itself checking existing issues and PRs before deep self-troubleshooting. This section is the human-contributor complement.
+
+---
+
 ## Should it be a Skill or a Tool?
 
 This is the most common question for new contributors. The answer is almost always **skill**.


### PR DESCRIPTION
## What does this PR do?

Adds a short **Before You Start: Search First** subsection to `CONTRIBUTING.md`, placed near the top (right after Contribution Priorities, before the Skill/Tool and dev-setup sections) so contributors read it before they build.

**The gap:** the only existing duplicate-check is a checkbox in the PR template ("I searched for existing PRs to make sure this isn't a duplicate"). That fires at review-request time -- i.e. *after* a contributor has already built the change. There is currently no pre-work search step in the contributing guide, so contributors routinely build something that already has an open/merged PR, or that is already implemented in-tree (the issue tracker can lag the code).

**The fix** gives an actionable pre-work search step:

- Search both open and merged PRs and issues (`gh search issues` / `gh search prs --state all`, plus web UI links).
- Note that the issue tracker can lag the code, so search the source too before proposing a feature.
- If an open PR already addresses it, improve that one rather than opening a competing duplicate.
- For larger work, comment on the issue to signal you are working on it.

It is framed positively as saving the contributor's time and keeping the PR queue clean, and matches the guide's existing tone.

This is the human-contributor complement to #38284, which covers the agent-side analog (Hermes itself checking existing issues and PRs before deep self-troubleshooting) -- related, but a distinct concern, so no `Fixes`.

## Related Issue

Related (agent-side analog): #38284.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `CONTRIBUTING.md`: added a "Before You Start: Search First" subsection (18 lines) after "Contribution Priorities", before the Skill/Tool and Development Setup sections.

## How to Test

N/A -- docs-only change. Verify the new section renders correctly and reads well in `CONTRIBUTING.md`; the commands and links are valid.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (and I checked issues too -- found the related agent-side effort #38284, which is a distinct concern)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass -- N/A, docs-only change
- [ ] I've added tests for my changes -- N/A, docs-only change
- [x] I've tested on my platform: docs change, reviewed rendered Markdown

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- this PR *is* the documentation update
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- this PR updates `CONTRIBUTING.md`
- [x] I've considered cross-platform impact (Windows, macOS) -- N/A, docs-only
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

## Estimated impact

Rough and deliberately conservative, based on current repo counts (pulled 2026-06-20):

- 1,869 PRs already carry the `duplicate` label (~5% of all 37,315 PRs), plus 516 duplicate-labeled issues: roughly 2,385 explicitly-flagged duplicates. This is a floor, since many duplicates are closed without ever getting the label.
- The existing duplicate-check is a PR-template checkbox that fires at review time, after the work is already done. Moving a search prompt to "before you start" catches a duplicate at the cheapest possible point, before any contributor build time or reviewer triage time is spent on it.
- If pre-work search prevents even 10-20% of future duplicates, that is on the order of ~190-370 avoided duplicate PRs per comparable volume, plus the contributor hours spent building them and the maintainer cycles spent triaging and closing them.

Even a few-percent reduction compounds on a repo with a five-figure PR queue.
