### PR TITLE
fix(cli): use live launch cwd for HERMES_CWD instead of stale env

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1948,7 +1948,12 @@ def _launch_tui(
         "HERMES_PYTHON_SRC_ROOT", str(PROJECT_ROOT)
     )
     env.setdefault("HERMES_PYTHON", sys.executable)
-    env.setdefault("HERMES_CWD", os.getcwd())
+    # Use the live launch cwd, not a HERMES_CWD inherited from os.environ: an
+    # exported/stale value (e.g. left over from an earlier `hermes --tui` in a
+    # different directory) must not win over where the user actually invoked the
+    # TUI. The --worktree branch below still overrides this with the worktree
+    # path. (#49637)
+    env["HERMES_CWD"] = os.getcwd()
     env.setdefault("NODE_ENV", "development" if tui_dev else "production")
 
     wt_info = None

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -996,6 +996,34 @@ def test_launch_tui_sets_resume_env_from_resume_arg(monkeypatch, main_mod):
     assert captured["env"]["HERMES_TUI_RESUME"] == "20260518_000000_goodid"
 
 
+def test_launch_tui_uses_current_cwd_over_stale_env(monkeypatch, main_mod, tmp_path):
+    captured = {}
+
+    # A HERMES_CWD exported in the parent shell (e.g. left over from an earlier
+    # `hermes --tui` in a different directory) must NOT win over the directory
+    # the TUI is actually launched from. setdefault() kept the stale value; the
+    # launch cwd is the source of truth (#49637).
+    monkeypatch.setenv("HERMES_CWD", "/stale/exported/dir")
+    monkeypatch.chdir(tmp_path)
+    expected_cwd = os.getcwd()
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["node", "dist/entry.js"], Path(".")),
+    )
+    monkeypatch.setattr(
+        main_mod.subprocess,
+        "call",
+        lambda argv, cwd=None, env=None: captured.update({"env": env}) or 1,
+    )
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui()
+
+    assert captured["env"]["HERMES_CWD"] == expected_cwd
+    assert captured["env"]["HERMES_CWD"] != "/stale/exported/dir"
+
+
 def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path):
     tui_dir = tmp_path / "ui-tui"
     tsx = tui_dir / "node_modules" / ".bin" / "tsx"


### PR DESCRIPTION
## What

`hermes --tui` could launch the gateway in the wrong working directory when a `HERMES_CWD` value was already exported in the parent shell.

`_launch_tui()` builds the child environment from `os.environ.copy()` and then sets the launch cwd with:

```python
env.setdefault("HERMES_CWD", os.getcwd())
```

Because `setdefault()` does not overwrite an existing key, a stale `HERMES_CWD` inherited from the user's shell (for example, one left over from an earlier `hermes --tui` started in a different directory) wins over the live `os.getcwd()`. The TUI side then spawns the gateway there (`ui-tui/src/gatewayClient.ts`: `const cwd = process.env.HERMES_CWD || root`), so the session runs against the wrong directory.

## Fix

Assign the launch cwd unconditionally so the directory the user actually invoked the TUI from is the source of truth:

```python
env["HERMES_CWD"] = os.getcwd()
```

The `--worktree` branch a few lines below still overrides `HERMES_CWD` with the worktree path, so worktree launches are unchanged. This mirrors the existing stale-env handling for `HERMES_TUI_RESUME` further down in the same function (which already `env.pop()`s a stale inherited value for exactly this reason).

## Test

Added `test_launch_tui_uses_current_cwd_over_stale_env`, which exports a stale `HERMES_CWD`, `chdir`s elsewhere, and asserts the env handed to the launcher carries the live cwd. It fails before the change and passes after; the full `test_tui_resume_flow.py` suite (47 tests) stays green, and `scripts/check-windows-footguns.py` is clean on the touched files.

Fixes #49637

## Scope

Limited to `HERMES_CWD`, which is the variable affected by the `setdefault` bug. The issue also mentioned `TERMINAL_CWD`; in `_launch_tui()` that one is only assigned on the `--worktree` path and is never `setdefault`-ed from `os.getcwd()`, so it has a different shape and is intentionally left untouched here.
