### PR TITLE
fix(windows): detect .venv and use sys.prefix for venv path resolution

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6034,7 +6034,7 @@ def _update_via_zip(args):
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        uv_env = {**os.environ, "VIRTUAL_ENV": sys.prefix}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -6759,7 +6759,7 @@ def _recover_from_interrupted_install() -> None:
 
             uv_bin = ensure_uv()
             if uv_bin:
-                uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+                uv_env = {**os.environ, "VIRTUAL_ENV": sys.prefix}
                 if _is_termux_env(uv_env):
                     uv_env.pop("PYTHONPATH", None)
                     uv_env.pop("PYTHONHOME", None)
@@ -6843,12 +6843,28 @@ def _is_windows() -> bool:
 
 
 def _venv_scripts_dir() -> Path | None:
-    """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
-    if not venv_dir.is_dir():
-        return None
-    scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
-    return scripts if scripts.is_dir() else None
+    """Return the venv Scripts directory if we're running inside the project venv.
+
+    Checks ``venv/`` first (the canonical Hermes install layout), then
+    ``.venv/`` (common when users create the venv manually with
+    ``python -m venv .venv``).  Falls back to ``sys.prefix`` so that any
+    non-standard venv location is covered when Hermes is actually running
+    inside it.
+    """
+    for candidate in (PROJECT_ROOT / "venv", PROJECT_ROOT / ".venv"):
+        if candidate.is_dir():
+            scripts = candidate / ("Scripts" if _is_windows() else "bin")
+            if scripts.is_dir():
+                return scripts
+    # Fall back to sys.prefix — covers venvs at non-standard paths and
+    # ensures quarantine / concurrent-instance detection works regardless
+    # of how the venv was named or placed.
+    sp = Path(sys.prefix)
+    if sp != Path("/") and sp.is_dir():
+        scripts = sp / ("Scripts" if _is_windows() else "bin")
+        if scripts.is_dir():
+            return scripts
+    return None
 
 
 def _hermes_exe_shims(scripts_dir: Path) -> list[Path]:
@@ -8946,7 +8962,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            uv_env = {**os.environ, "VIRTUAL_ENV": sys.prefix}
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6845,25 +6845,30 @@ def _is_windows() -> bool:
 def _venv_scripts_dir() -> Path | None:
     """Return the venv Scripts directory if we're running inside the project venv.
 
-    Checks ``venv/`` first (the canonical Hermes install layout), then
-    ``.venv/`` (common when users create the venv manually with
-    ``python -m venv .venv``).  Falls back to ``sys.prefix`` so that any
-    non-standard venv location is covered when Hermes is actually running
-    inside it.
+    Prefers ``sys.prefix`` first — when hermes.exe is running, it is the
+    authoritative answer for where the currently-loaded executable lives,
+    and it must agree with the ``VIRTUAL_ENV`` we pass to uv.  Falls back
+    to probing ``venv/`` then ``.venv/`` for call-sites where hermes is
+    not running (e.g. pip install orchestrated from outside the venv).
     """
+    # sys.prefix is the authoritative venv root when hermes is running
+    # inside it.  Only trust it when it is under PROJECT_ROOT — otherwise
+    # it may be a system Python that happens to have a Scripts/ dir.
+    sp = Path(sys.prefix)
+    try:
+        sp.relative_to(PROJECT_ROOT)
+    except ValueError:
+        pass  # sys.prefix is outside PROJECT_ROOT — probe directories instead
+    else:
+        scripts = sp / ("Scripts" if _is_windows() else "bin")
+        if scripts.is_dir():
+            return scripts
+
     for candidate in (PROJECT_ROOT / "venv", PROJECT_ROOT / ".venv"):
         if candidate.is_dir():
             scripts = candidate / ("Scripts" if _is_windows() else "bin")
             if scripts.is_dir():
                 return scripts
-    # Fall back to sys.prefix — covers venvs at non-standard paths and
-    # ensures quarantine / concurrent-instance detection works regardless
-    # of how the venv was named or placed.
-    sp = Path(sys.prefix)
-    if sp != Path("/") and sp.is_dir():
-        scripts = sp / ("Scripts" if _is_windows() else "bin")
-        if scripts.is_dir():
-            return scripts
     return None
 
 

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -622,3 +622,129 @@ def test_cmd_update_force_bypasses_concurrent_check(_winp, tmp_path):
 
     # When --force is set, we should not have even consulted psutil.
     detect.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _venv_scripts_dir
+# ---------------------------------------------------------------------------
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_venv_scripts_dir_sys_prefix_when_under_project_root(
+    _winp, tmp_path, monkeypatch
+):
+    """sys.prefix is authoritative when it is inside PROJECT_ROOT."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # sys.prefix points INSIDE repo (e.g. a venv at repo/.venv)
+    dot_venv = repo / ".venv"
+    scripts = dot_venv / "Scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "hermes.exe").write_bytes(b"")
+
+    monkeypatch.setattr(sys, "prefix", str(dot_venv))
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", repo)
+
+    result = cli_main._venv_scripts_dir()
+    assert result == scripts
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_venv_scripts_dir_dot_venv_when_venv_missing(
+    _winp, tmp_path, monkeypatch
+):
+    """When only .venv/ exists, return .venv/Scripts."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    dot_venv = repo / ".venv"
+    scripts = dot_venv / "Scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "hermes.exe").write_bytes(b"")
+    # venv/ does NOT exist
+
+    # sys.prefix points somewhere outside the repo so the
+    # relative_to(PROJECT_ROOT) check fails → falls through to probing.
+    monkeypatch.setattr(sys, "prefix", str(tmp_path / "somewhere_else"))
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", repo)
+
+    result = cli_main._venv_scripts_dir()
+    assert result == scripts
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_venv_scripts_dir_venv_first_when_no_sys_prefix_match(
+    _winp, tmp_path, monkeypatch
+):
+    """When sys.prefix is outside PROJECT_ROOT, probe venv/ first."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    venv_scripts = repo / "venv" / "Scripts"
+    venv_scripts.mkdir(parents=True)
+    (venv_scripts / "hermes.exe").write_bytes(b"")
+    dot_venv_scripts = repo / ".venv" / "Scripts"
+    dot_venv_scripts.mkdir(parents=True)
+    (dot_venv_scripts / "hermes.exe").write_bytes(b"")
+
+    monkeypatch.setattr(sys, "prefix", str(tmp_path / "outside"))
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", repo)
+
+    result = cli_main._venv_scripts_dir()
+    # Both exist; venv/ is probed first.
+    assert result == venv_scripts
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_venv_scripts_dir_sys_prefix_wins_over_probe(
+    _winp, tmp_path, monkeypatch
+):
+    """sys.prefix (pointing at .venv/) wins even when venv/ also exists."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Both directories exist
+    venv_scripts = repo / "venv" / "Scripts"
+    venv_scripts.mkdir(parents=True)
+    dot_venv = repo / ".venv"
+    dot_venv_scripts = dot_venv / "Scripts"
+    dot_venv_scripts.mkdir(parents=True)
+
+    # sys.prefix points at .venv (under PROJECT_ROOT)
+    monkeypatch.setattr(sys, "prefix", str(dot_venv))
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", repo)
+
+    result = cli_main._venv_scripts_dir()
+    # sys.prefix is authoritative — it must agree with the VIRTUAL_ENV
+    # we pass to uv, so it wins over directory probing.
+    assert result == dot_venv_scripts
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_venv_scripts_dir_returns_none_when_nothing_found(
+    _winp, tmp_path, monkeypatch
+):
+    """No venv, no .venv, sys.prefix outside PROJECT_ROOT → None."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    monkeypatch.setattr(sys, "prefix", str(tmp_path / "outside"))
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", repo)
+
+    result = cli_main._venv_scripts_dir()
+    assert result is None
+
+
+@patch.object(cli_main, "_is_windows", return_value=False)
+def test_venv_scripts_dir_still_works_off_windows(
+    _winp, tmp_path, monkeypatch
+):
+    """On non-Windows, bin/ is used instead of Scripts/."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    dot_venv = repo / ".venv"
+    scripts = dot_venv / "bin"
+    scripts.mkdir(parents=True)
+
+    monkeypatch.setattr(sys, "prefix", str(tmp_path / "outside"))
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", repo)
+
+    result = cli_main._venv_scripts_dir()
+    assert result == scripts


### PR DESCRIPTION
## What does this PR do?

`_venv_scripts_dir()` in `hermes_cli/main.py` hardcoded `PROJECT_ROOT / "venv"` and returned `None` when the venv directory was named `.venv` (extremely common — it is the default name suggested by Python docs for `python -m venv`). This silently disabled two critical Windows update safety mechanisms:

1. **`_quarantine_running_hermes_exe()`** — skipped because `scripts_dir` was `None`, so `uv pip install -e .` tried to overwrite the running `hermes.exe` directly → `Access is denied. (os error 5)`
2. **`_detect_concurrent_hermes_instances()`** — skipped because `scripts_dir` was `None`, so the pre-update concurrent-instance check never fired

The same hardcoded `PROJECT_ROOT / "venv"` was used in three `VIRTUAL_ENV` environment variable constructions, pointing `uv` at a non-existent directory.

This fix makes `_venv_scripts_dir()` prefer `sys.prefix` when under `PROJECT_ROOT` (authoritative when hermes is running), then fall back to probing `venv/` and `.venv/`. All three `VIRTUAL_ENV` assignments now use `sys.prefix`.

## Related Issue

Fixes #49665

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — `_venv_scripts_dir()` (L6798): prefer `sys.prefix` first (when under PROJECT_ROOT), then probe `venv/` and `.venv/` as fallbacks. Previously only checked `venv/`.
- `hermes_cli/main.py` — L5937, L6715, L8918: `VIRTUAL_ENV` now uses `sys.prefix` instead of `str(PROJECT_ROOT / "venv")`
- `tests/hermes_cli/test_update_concurrent_quarantine.py` — added 6 unit tests for `_venv_scripts_dir()`: sys.prefix priority, .venv-only, venv probe fallback, dual-dir sys.prefix wins, none-found → None, and non-Windows bin/ path

## How to Test

1. Install Hermes with venv at `.venv`: `python -m venv .venv && .venv\Scripts\pip install -e .`
2. Run `hermes update` while another `hermes.exe` is running
3. The concurrent-instance warning should now fire (previously silently skipped)
4. The quarantine rename should now run (previously silently skipped)
5. For users with `venv/` (not `.venv/`), behavior is unchanged — `venv/` is still checked first

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/hermes_cli/test_update_concurrent_quarantine.py -q` — all 26 tests pass
- [x] I have added tests for my changes (6 new tests for `_venv_scripts_dir()`)
- [x] I have tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] N/A — no docs or config keys affected
- [x] Cross-platform: the `sys.prefix` fallback is OS-agnostic; the `venv/` vs `.venv/` check runs on all platforms