### PR TITLE
fix(agent): allow suppressing file tool diffs

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1235,6 +1235,18 @@ DEFAULT_CONFIG = {
         "max_lines": 2000,
         "max_line_length": 2000,
     },
+    # Structured tool-result shaping before results are appended back into
+    # the agent conversation. This is separate from display.inline_diffs
+    # (human-facing UI only) and tool_output (terminal/read_file caps).
+    "tool_result": {
+        # When true, remove large unified diffs from file-edit tool results
+        # before they enter the model context. Success/error metadata,
+        # touched files, lint, and diagnostics are left intact.
+        "suppress_diff": False,
+        # Optional line cap for retained diffs. 0 is equivalent to
+        # suppress_diff=true. None/unset preserves full diffs.
+        "max_diff_lines": None,
+    },
 
     # Tool loop guardrails nudge models when they repeat failed or
     # non-progressing tool calls. Soft warnings are always-on by default;

--- a/model_tools.py
+++ b/model_tools.py
@@ -612,6 +612,75 @@ def _sanitize_tool_error(error_msg: str) -> str:
     return f"[TOOL_ERROR] {sanitized}"
 
 
+_FILE_EDIT_TOOLS_WITH_DIFF = {"patch", "write_file"}
+
+
+def _coerce_optional_int(value: Any) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _apply_tool_result_diff_config(function_name: str, result: str) -> str:
+    """Apply tool_result diff shaping to JSON file-edit tool results.
+
+    This runs after tool execution and plugin transforms, just before the
+    result string is returned to the agent loop and injected as tool-message
+    content. The default config preserves byte-for-byte behavior.
+    """
+    if function_name not in _FILE_EDIT_TOOLS_WITH_DIFF:
+        return result
+    if not isinstance(result, str) or '"diff"' not in result:
+        return result
+
+    try:
+        from hermes_cli.config import load_config
+        tool_result_config = (load_config().get("tool_result") or {})
+    except Exception as exc:
+        logger.debug("tool_result diff config unavailable: %s", exc)
+        return result
+
+    suppress_diff = bool(tool_result_config.get("suppress_diff", False))
+    max_diff_lines = _coerce_optional_int(tool_result_config.get("max_diff_lines"))
+    if max_diff_lines == 0:
+        suppress_diff = True
+
+    if not suppress_diff and (max_diff_lines is None or max_diff_lines < 0):
+        return result
+
+    try:
+        payload = json.loads(result)
+    except Exception:
+        return result
+    if not isinstance(payload, dict):
+        return result
+
+    diff = payload.get("diff")
+    if not isinstance(diff, str) or not diff:
+        return result
+
+    if suppress_diff:
+        payload.pop("diff", None)
+        payload["diff_suppressed"] = True
+        return json.dumps(payload, ensure_ascii=False)
+
+    lines = diff.splitlines()
+    if max_diff_lines is not None and len(lines) > max_diff_lines:
+        shown = max(max_diff_lines, 0)
+        payload["diff"] = "\n".join(lines[:shown])
+        payload["diff_truncated"] = {
+            "shown_lines": shown,
+            "total_lines": len(lines),
+        }
+        return json.dumps(payload, ensure_ascii=False)
+    return result
+
+
 # =========================================================================
 # Tool argument type coercion
 # =========================================================================
@@ -1194,7 +1263,7 @@ def handle_function_call(
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
 
-        return result
+        return _apply_tool_result_diff_config(function_name, result)
 
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -201,6 +201,61 @@ class TestHandleFunctionCall:
         assert pre_call[1]["middleware_trace"] == expected_trace
         assert post_call[1]["middleware_trace"] == expected_trace
 
+    def test_tool_result_diff_config_preserves_diff_by_default(self, monkeypatch):
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *a, **kw: json.dumps({"success": True, "diff": "a\nb"}),
+        )
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"tool_result": {}})
+
+        result = json.loads(handle_function_call("patch", {"mode": "patch", "patch": "x"}))
+
+        assert result["diff"] == "a\nb"
+        assert "diff_suppressed" not in result
+        assert "diff_truncated" not in result
+
+    def test_tool_result_diff_config_suppresses_patch_diff(self, monkeypatch):
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *a, **kw: json.dumps({
+                "success": True,
+                "diff": "--- a\n+++ b\n@@\n-old\n+new",
+                "files_modified": ["a.py"],
+                "lint": {"status": "ok"},
+            }),
+        )
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"tool_result": {"suppress_diff": True}},
+        )
+
+        result = json.loads(handle_function_call("patch", {"mode": "patch", "patch": "x"}))
+
+        assert "diff" not in result
+        assert result["diff_suppressed"] is True
+        assert result["success"] is True
+        assert result["files_modified"] == ["a.py"]
+        assert result["lint"] == {"status": "ok"}
+
+    def test_tool_result_diff_config_truncates_write_file_diff(self, monkeypatch):
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *a, **kw: json.dumps({"bytes_written": 4, "diff": "1\n2\n3\n4"}),
+        )
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"tool_result": {"max_diff_lines": 2}},
+        )
+
+        result = json.loads(handle_function_call("write_file", {"path": "a.py", "content": "x"}))
+
+        assert result["diff"] == "1\n2"
+        assert result["diff_truncated"] == {"shown_lines": 2, "total_lines": 4}
+        assert result["bytes_written"] == 4
+
 
 # =========================================================================
 # Agent loop tools


### PR DESCRIPTION
## Summary
- Add a `tool_result` config section for shaping structured tool results before they enter agent context.
- Support suppressing or truncating `patch` / `write_file` diffs while preserving success metadata, touched files, lint, and diagnostics.
- Add regression coverage for default behavior, suppression, and truncation.

## Test Plan
- [x] `python -m pytest tests/test_model_tools.py -q -o 'addopts='`\n\nCloses #49316