### PR TITLE
fix(desktop): cap save image buffer payloads

### DIFF
--- a/apps/desktop/electron/hardening.cjs
+++ b/apps/desktop/electron/hardening.cjs
@@ -6,6 +6,7 @@ const { fileURLToPath } = require('node:url')
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000
 const DATA_URL_READ_MAX_BYTES = 16 * 1024 * 1024
 const TEXT_PREVIEW_SOURCE_MAX_BYTES = 64 * 1024 * 1024
+const COMPOSER_IMAGE_MAX_BYTES = 16 * 1024 * 1024
 
 const SAFE_ENV_SUFFIXES = new Set(['dist', 'example', 'sample', 'template'])
 const SENSITIVE_EXTENSIONS = new Set(['.kdbx', '.p12', '.pem', '.pfx'])
@@ -111,6 +112,61 @@ function ipcPathError(code, message) {
   const error = new Error(message)
   error.code = code
   return error
+}
+
+function assertComposerImageByteLength(byteLength, maxBytes = COMPOSER_IMAGE_MAX_BYTES) {
+  const limit = Number.isFinite(maxBytes) && Number(maxBytes) > 0 ? Number(maxBytes) : COMPOSER_IMAGE_MAX_BYTES
+  const size = Number(byteLength)
+
+  if (!Number.isFinite(size) || size <= 0) {
+    throw ipcPathError('invalid-image-data', 'saveImageBuffer failed: image data is required.')
+  }
+
+  if (size > limit) {
+    throw ipcPathError('EFBIG', `saveImageBuffer failed: image data is too large (${size} bytes; limit ${limit} bytes).`)
+  }
+}
+
+function composerImageBufferFromPayloadData(data, options = {}) {
+  const maxBytes = options.maxBytes
+
+  if (!data) {
+    throw ipcPathError('invalid-image-data', 'saveImageBuffer failed: image data is required.')
+  }
+
+  if (Buffer.isBuffer(data)) {
+    assertComposerImageByteLength(data.byteLength, maxBytes)
+    return data
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    assertComposerImageByteLength(data.byteLength, maxBytes)
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+  }
+
+  if (data instanceof ArrayBuffer) {
+    assertComposerImageByteLength(data.byteLength, maxBytes)
+    return Buffer.from(data)
+  }
+
+  if (Array.isArray(data)) {
+    assertComposerImageByteLength(data.length, maxBytes)
+    return Buffer.from(data)
+  }
+
+  if (typeof data === 'string') {
+    const byteLength = Buffer.byteLength(data)
+    assertComposerImageByteLength(byteLength, maxBytes)
+    return Buffer.from(data)
+  }
+
+  try {
+    const buffer = Buffer.from(data)
+    assertComposerImageByteLength(buffer.byteLength, maxBytes)
+    return buffer
+  } catch {
+    throw ipcPathError('invalid-image-data', 'saveImageBuffer failed: image data must be bytes.')
+  }
 }
 
 function rejectUnsafePathSyntax(filePath, purpose = 'File read') {
@@ -266,9 +322,11 @@ async function resolveReadableFileForIpc(filePath, options = {}) {
 }
 
 module.exports = {
+  COMPOSER_IMAGE_MAX_BYTES,
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
   TEXT_PREVIEW_SOURCE_MAX_BYTES,
+  composerImageBufferFromPayloadData,
   encryptDesktopSecret,
   rejectUnsafePathSyntax,
   resolveDirectoryForIpc,

--- a/apps/desktop/electron/hardening.test.cjs
+++ b/apps/desktop/electron/hardening.test.cjs
@@ -6,7 +6,9 @@ const test = require('node:test')
 const { pathToFileURL } = require('node:url')
 
 const {
+  COMPOSER_IMAGE_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
+  composerImageBufferFromPayloadData,
   encryptDesktopSecret,
   resolveDirectoryForIpc,
   resolveReadableFileForIpc,
@@ -51,6 +53,31 @@ test('encryptDesktopSecret stores safeStorage base64 payload', () => {
     encoding: 'safeStorage',
     value: Buffer.from('enc:token-123', 'utf8').toString('base64')
   })
+})
+
+test('composerImageBufferFromPayloadData accepts normal byte payloads', () => {
+  const source = Uint8Array.from([137, 80, 78, 71])
+  const buffer = composerImageBufferFromPayloadData(source)
+
+  assert.ok(Buffer.isBuffer(buffer))
+  assert.deepEqual([...buffer], [137, 80, 78, 71])
+})
+
+test('composerImageBufferFromPayloadData rejects missing empty and oversized payloads', () => {
+  assert.throws(() => composerImageBufferFromPayloadData(null), error => {
+    assert.equal(error?.code, 'invalid-image-data')
+    return true
+  })
+  assert.throws(() => composerImageBufferFromPayloadData(Buffer.alloc(0)), error => {
+    assert.equal(error?.code, 'invalid-image-data')
+    return true
+  })
+  assert.throws(() => composerImageBufferFromPayloadData(Buffer.alloc(5), { maxBytes: 4 }), error => {
+    assert.equal(error?.code, 'EFBIG')
+    assert.match(error.message, /limit 4 bytes/)
+    return true
+  })
+  assert.equal(COMPOSER_IMAGE_MAX_BYTES, 16 * 1024 * 1024)
 })
 
 test('sensitiveFileBlockReason blocks obvious secret file patterns', () => {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -73,9 +73,11 @@ const {
   tokenPreview
 } = require('./connection-config.cjs')
 const {
+  COMPOSER_IMAGE_MAX_BYTES,
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
   TEXT_PREVIEW_SOURCE_MAX_BYTES,
+  composerImageBufferFromPayloadData,
   encryptDesktopSecret: encryptDesktopSecretStrict,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
@@ -3103,6 +3105,14 @@ async function saveImageFromUrl(rawUrl) {
 }
 
 async function writeComposerImage(buffer, ext = '.png') {
+  if (buffer.byteLength > COMPOSER_IMAGE_MAX_BYTES) {
+    const error = new Error(
+      `saveImageBuffer failed: image data is too large (${buffer.byteLength} bytes; limit ${COMPOSER_IMAGE_MAX_BYTES} bytes).`
+    )
+    error.code = 'EFBIG'
+    throw error
+  }
+
   const rawExt = String(ext || '.png')
     .trim()
     .toLowerCase()
@@ -5728,10 +5738,7 @@ ipcMain.handle('hermes:writeClipboard', (_event, text) => {
 ipcMain.handle('hermes:saveImageFromUrl', (_event, url) => saveImageFromUrl(String(url || '')))
 
 ipcMain.handle('hermes:saveImageBuffer', async (_event, payload) => {
-  const data = payload?.data
-  if (!data) throw new Error('saveImageBuffer: missing data')
-
-  const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data)
+  const buffer = composerImageBufferFromPayloadData(payload?.data)
   return writeComposerImage(buffer, payload?.ext || '.png')
 })
 


### PR DESCRIPTION
## Summary
- Add an explicit 16 MiB cap for desktop `hermes:saveImageBuffer` payloads.
- Validate IPC byte payloads before converting/writing them and return clear `invalid-image-data` / `EFBIG` errors.
- Keep a defensive write-time cap in `writeComposerImage` and add hardening regression coverage.

## Test Plan
- [x] `node --test apps/desktop/electron/hardening.test.cjs`
- [x] `node --check apps/desktop/electron/main.cjs`
- [x] `node --check apps/desktop/electron/hardening.cjs`

Closes #49457