### PR TITLE
fix(desktop): index messagingSessions in sessionByAnyId for pinned section (#49667)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -430,10 +430,10 @@ export function ChatSidebar({
   const sessionByAnyId = useMemo(() => {
     const map = new Map<string, SessionInfo>()
 
-    // Cron sessions are listed separately but can still be pinned, so index
-    // them too — otherwise a pinned cron job can't resolve into the Pinned
+    // Cron sessions and messaging sessions are listed separately but can still be pinned, so index
+    // them too — otherwise a pinned cron/messaging job/session can't resolve into the Pinned
     // section. Recents take precedence on id collisions (set last).
-    for (const s of [...cronSessions, ...visibleSessions]) {
+    for (const s of [...cronSessions, ...messagingSessions, ...visibleSessions]) {
       map.set(s.id, s)
 
       if (s._lineage_root_id && !map.has(s._lineage_root_id)) {
@@ -442,7 +442,7 @@ export function ChatSidebar({
     }
 
     return map
-  }, [visibleSessions, cronSessions])
+  }, [visibleSessions, cronSessions, messagingSessions])
 
   const pinnedSessions = useMemo(() => {
     const seen = new Set<string>()


### PR DESCRIPTION
Fixes #49667

### Description
This PR resolves the issue where messaging-platform sessions (such as Telegram or Discord) pinned by the user do not render in the "Pinned" section of the Desktop sidebar. 

### Root Cause
In PR #42537, external messaging platform sessions were isolated from the main recents list into their own separately-fetched array (`messagingSessions`) to prevent them from crowding out the interactive local recents pagination.

However, the Desktop sidebar relies on a React `useMemo` map called `sessionByAnyId` to resolve the stored pin IDs (stable lineage-root IDs) into the live UI session objects. This map only iterated over `cronSessions` and `visibleSessions` (which contains `$sessions` filtered by profile):

```typescript
const sessionByAnyId = useMemo(() => {
  const map = new Map<string, SessionInfo>()

  for (const s of [...cronSessions, ...visibleSessions]) {
    map.set(s.id, s)
    // ...
  }
  return map
}, [visibleSessions, cronSessions])
```

Because `messagingSessions` was omitted from this loop, any pinned session ID from Telegram or other messaging sources returned `undefined` during resolution:
```typescript
const session = sessionByAnyId.get(pinId) // Returned undefined for messaging sessions
```
This caused the renderer to skip rendering these rows entirely.

### Solution
This PR adds `messagingSessions` to the loop inside `sessionByAnyId` and registers it in the `useMemo` dependencies list. This ensures that pinned messaging platform sessions are correctly resolved and render in the sidebar.

```typescript
  const sessionByAnyId = useMemo(() => {
    const map = new Map<string, SessionInfo>()

    // Cron sessions and messaging sessions are listed separately but can still be pinned, so index
    // them too — otherwise a pinned cron/messaging job/session can't resolve into the Pinned
    // section. Recents take precedence on id collisions (set last).
    for (const s of [...cronSessions, ...messagingSessions, ...visibleSessions]) {
      map.set(s.id, s)

      if (s._lineage_root_id && !map.has(s._lineage_root_id)) {
        map.set(s._lineage_root_id, s)
      }
    }

    return map
  }, [visibleSessions, cronSessions, messagingSessions])
```

### Verification & Testing
- Resolved dependencies using `bun install`
- Ran frontend tests in the `jsdom` environment:
  ```bash
  bunx vitest run --environment jsdom src/store/session.test.ts
  ```
- **Result**: All 20 tests passed successfully.
