### PR TITLE
fix(hermes): detect Telegram transport-dead PID-alive gateway state

### DIFF
--- a/docs/plans/hardening/2026-06-20-hermes-telegram-paused-liveness.json
+++ b/docs/plans/hardening/2026-06-20-hermes-telegram-paused-liveness.json
@@ -1,0 +1,32 @@
+{
+  "id": "HARDENING-HERMES-TELEGRAM-PAUSED-LIVENESS-2026-06-20",
+  "source_finding": {
+    "status": "restored",
+    "severity": "operational_reliability_incident",
+    "root_cause_class": "gateway_transport_liveness_failure",
+    "symptom": "Hermes gateway process remained alive while Telegram polling paused after repeated reconnect failures, causing conductor silence."
+  },
+  "fix_packet": {
+    "runtime_classifier": "gateway.status.classify_gateway_transport_liveness",
+    "log_classifier": "gateway.status.classify_gateway_log_line",
+    "doctor_surface": "hermes doctor reports HERMES_TELEGRAM_PAUSED or HERMES_TELEGRAM_STALE as red failures",
+    "status_surface": "hermes gateway status reports behavior-level transport health even when PID exists",
+    "dashboard_surface": "/api/status returns gateway_liveness",
+    "repair": "Restart only the affected Hermes gateway profile."
+  },
+  "exit_criteria": [
+    "Paused Telegram runtime state fails red with code HERMES_TELEGRAM_PAUSED while PID metadata exists.",
+    "Stale Telegram last_successful_poll_at fails red with code HERMES_TELEGRAM_STALE.",
+    "Fresh connected Telegram state remains healthy.",
+    "Pause log signature classifies as HERMES_TELEGRAM_PAUSED.",
+    "Runbook separates Hermes transport health from Qwen/Ollama/Postgres/API health."
+  ],
+  "recheck": {
+    "commands": [
+      "scripts/run_tests.sh tests/gateway/test_status_transport_liveness.py tests/hermes_cli/test_gateway_runtime_health.py tests/gateway/test_telegram_network_reconnect.py",
+      ".venv/bin/python -m pytest tests/hermes_cli/test_doctor.py::test_check_gateway_transport_liveness_fails_paused_telegram -q",
+      "python -m py_compile gateway/status.py gateway/run.py gateway/platforms/telegram.py hermes_cli/gateway.py hermes_cli/doctor.py hermes_cli/web_server.py"
+    ],
+    "status": "rechecked_pass"
+  }
+}

--- a/docs/runbooks/hermes-gateway-transport-liveness.md
+++ b/docs/runbooks/hermes-gateway-transport-liveness.md
@@ -1,0 +1,80 @@
+# Hermes Gateway Transport Liveness
+
+Use this runbook when a gateway process is running but conductors are silent.
+This incident class is process-alive / transport-dead: the Hermes process can
+remain up while Telegram polling has paused after repeated reconnect failures.
+
+## First Response
+
+1. Check Hermes behavior-level health first:
+
+   ```bash
+   hermes gateway status
+   hermes doctor
+   ```
+
+2. Check the gateway log for the transport pause signature:
+
+   ```bash
+   tail -n 120 "${HERMES_HOME:-$HOME/.hermes}/logs/gateway.log"
+   ```
+
+   Classify this line as `HERMES_TELEGRAM_PAUSED`:
+
+   ```text
+   Telegram paused after 10 consecutive reconnect failures
+   ```
+
+3. Restart only the affected Hermes gateway profile:
+
+   ```bash
+   hermes gateway restart
+   ```
+
+   For a named profile:
+
+   ```bash
+   hermes --profile qwen-ops-runner-conductor gateway restart
+   ```
+
+4. Prove recovery:
+
+   ```bash
+   tail -n 80 "${HERMES_HOME:-$HOME/.hermes}/logs/gateway.log" | grep "Connected to Telegram (polling mode)"
+   hermes -z "Reply exactly: ok"
+   hermes --profile qwen-ops-runner-conductor -z "Reply exactly: ok"
+   ```
+
+## Do Not Chase First
+
+Do not start with Qwen, Ollama, Postgres, NeoEngine API, Cockpit, or the tunnel
+unless Hermes transport liveness is clean. Qwen tunnel health is separate from
+Hermes Telegram polling health.
+
+## Watchdog Rule
+
+Restart Hermes only when either condition is true:
+
+- `gateway_state.json` reports `platforms.telegram.state = "paused"` or
+  `platforms.telegram.transport_paused = true`.
+- `platforms.telegram.last_successful_poll_at` is older than the configured
+  stale threshold while Telegram is reported as connected.
+
+The default stale threshold is 15 minutes. Keep it above the Telegram polling
+heartbeat interval; `HERMES_TELEGRAM_POLLING_HEARTBEAT_SECONDS` is clamped to
+30-600 seconds.
+
+The repair is profile-scoped:
+
+```bash
+hermes gateway restart
+```
+
+or:
+
+```bash
+hermes --profile <profile> gateway restart
+```
+
+Leave Qwen tunnel, Ollama, Postgres, and NeoEngine API untouched unless their
+own independent checks fail after Hermes transport health is clean.

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -460,6 +460,14 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._polling_error_task: Optional[asyncio.Task] = None
+        self._polling_heartbeat_task: Optional[asyncio.Task] = None
+        self._polling_heartbeat_shutdown = False
+        self._polling_heartbeat_interval_seconds = self._env_float_clamped(
+            "HERMES_TELEGRAM_POLLING_HEARTBEAT_SECONDS",
+            60.0,
+            min_value=30.0,
+            max_value=600.0,
+        )
         self._polling_conflict_count: int = 0
         self._polling_network_error_count: int = 0
         self._polling_error_callback_ref = None
@@ -1431,6 +1439,80 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, exc_info=True,
             )
 
+    def _record_polling_heartbeat_success(self) -> None:
+        self._write_runtime_status_safe(
+            "polling_heartbeat",
+            platform_state="connected",
+            polling_state="connected",
+            error_code=None,
+            error_message=None,
+            reconnect_failure_count=0,
+            last_successful_poll_at=datetime.now(timezone.utc).isoformat(),
+            transport_paused=False,
+        )
+
+    def _start_polling_heartbeat_monitor(self) -> None:
+        if self._webhook_mode:
+            return
+        if self._polling_heartbeat_task and not self._polling_heartbeat_task.done():
+            return
+        self._polling_heartbeat_shutdown = False
+        task = asyncio.create_task(self._polling_heartbeat_monitor())
+        self._polling_heartbeat_task = task
+        self._background_tasks.add(task)
+        task.add_done_callback(self._clear_polling_heartbeat_task)
+
+    def _clear_polling_heartbeat_task(self, task: asyncio.Task) -> None:
+        self._background_tasks.discard(task)
+        if self._polling_heartbeat_task is task:
+            self._polling_heartbeat_task = None
+
+    async def _handle_polling_heartbeat_error(self, error: Exception) -> None:
+        try:
+            await self._handle_polling_network_error(error)
+        except Exception as reconnect_err:
+            # Intentionally let asyncio.CancelledError propagate; this guard
+            # only keeps unexpected reconnect failures from killing heartbeat.
+            logger.warning(
+                "[%s] Telegram polling heartbeat reconnect handler failed: %s",
+                self.name,
+                reconnect_err,
+                exc_info=True,
+            )
+
+    async def _polling_heartbeat_monitor(self) -> None:
+        """Refresh transport liveness and re-enter reconnect on polling wedges."""
+        while (
+            not self._polling_heartbeat_shutdown
+            and not self.has_fatal_error
+            and not self._webhook_mode
+        ):
+            await asyncio.sleep(self._polling_heartbeat_interval_seconds)
+            if self._polling_heartbeat_shutdown or self.has_fatal_error or self._webhook_mode:
+                return
+            if not (self._app and self._app.updater and self._app.updater.running):
+                logger.warning(
+                    "[%s] Telegram polling heartbeat found updater not running",
+                    self.name,
+                )
+                await self._handle_polling_heartbeat_error(
+                    RuntimeError("Updater not running during polling heartbeat")
+                )
+                continue
+
+            try:
+                await asyncio.wait_for(self._app.bot.get_me(), timeout=10)
+            except Exception as heartbeat_err:
+                logger.warning(
+                    "[%s] Telegram polling heartbeat failed: %s",
+                    self.name,
+                    heartbeat_err,
+                )
+                await self._handle_polling_heartbeat_error(heartbeat_err)
+                continue
+
+            self._record_polling_heartbeat_success()
+
     async def _handle_polling_network_error(self, error: Exception) -> None:
         """Reconnect polling after a transient network interruption.
 
@@ -1490,6 +1572,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, attempt,
             )
             self._polling_network_error_count = 0
+            self._record_polling_heartbeat_success()
+            self._start_polling_heartbeat_monitor()
             # start_polling() returning is necessary but not sufficient:
             # PTB's Updater can be left in a state where `running` is True
             # but the underlying long-poll task is wedged on a stale httpx
@@ -2261,6 +2345,9 @@ class TelegramAdapter(BasePlatformAdapter):
             self._mark_connected()
             mode = "webhook" if self._webhook_mode else "polling"
             logger.info("[%s] Connected to Telegram (%s mode)", self.name, mode)
+            if not self._webhook_mode:
+                self._record_polling_heartbeat_success()
+                self._start_polling_heartbeat_monitor()
 
             # Surface the gateway as "Online" in the bot's short description
             # (opt-in via extra.status_indicator). Non-fatal.
@@ -2329,6 +2416,19 @@ class TelegramAdapter(BasePlatformAdapter):
             await self._set_status_indicator(online=False)
         except Exception:
             pass
+
+        self._polling_heartbeat_shutdown = True
+        if self._polling_heartbeat_task and not self._polling_heartbeat_task.done():
+            heartbeat_task = self._polling_heartbeat_task
+            if heartbeat_task is not asyncio.current_task():
+                heartbeat_task.cancel()
+                try:
+                    await heartbeat_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    logger.debug("[%s] Polling heartbeat task failed during disconnect", self.name, exc_info=True)
+        self._polling_heartbeat_task = None
 
         pending_media_group_tasks = list(self._media_group_tasks.values())
         for task in pending_media_group_tasks:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -42,7 +42,7 @@ import sqlite3
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Optional, Any, List, Union
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
@@ -3623,15 +3623,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         platform_state: Optional[str] = None,
         error_code: Optional[str] = None,
         error_message: Optional[str] = None,
+        polling_state: Optional[str] = None,
+        reconnect_failure_count: Optional[int] = None,
+        last_successful_poll_at: Optional[str] = None,
+        transport_paused: Optional[bool] = None,
     ) -> None:
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(
-                platform=platform,
-                platform_state=platform_state,
-                error_code=error_code,
-                error_message=error_message,
-            )
+            kwargs = {
+                "platform": platform,
+                "platform_state": platform_state,
+                "error_code": error_code,
+                "error_message": error_message,
+            }
+            if polling_state is not None:
+                kwargs["polling_state"] = polling_state
+            if reconnect_failure_count is not None:
+                kwargs["reconnect_failure_count"] = reconnect_failure_count
+            if last_successful_poll_at is not None:
+                kwargs["last_successful_poll_at"] = last_successful_poll_at
+            if transport_paused is not None:
+                kwargs["transport_paused"] = transport_paused
+            write_runtime_status(**kwargs)
         except Exception:
             pass
 
@@ -3667,6 +3680,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 platform_state="paused",
                 error_code=None,
                 error_message=info["pause_reason"],
+                polling_state="paused",
+                reconnect_failure_count=info.get("attempts", 0),
+                transport_paused=True,
             )
         except Exception:
             pass
@@ -3698,6 +3714,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 platform_state="retrying",
                 error_code=None,
                 error_message=None,
+                polling_state="retrying",
+                reconnect_failure_count=0,
+                transport_paused=False,
             )
         except Exception:
             pass
@@ -6248,6 +6267,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             platform_state="connected",
                             error_code=None,
                             error_message=None,
+                            polling_state="connected",
+                            reconnect_failure_count=0,
+                            last_successful_poll_at=(
+                                datetime.now(timezone.utc).isoformat()
+                                if platform.value == "telegram"
+                                else None
+                            ),
+                            transport_paused=False,
                         )
                         logger.info("✓ %s reconnected successfully", platform.value)
 
@@ -6300,6 +6327,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             platform_state="retrying",
                             error_code=adapter.fatal_error_code,
                             error_message=adapter.fatal_error_message or "failed to reconnect",
+                            polling_state="retrying",
+                            reconnect_failure_count=attempt,
+                            transport_paused=False,
                         )
                         backoff = min(30 * (2 ** (attempt - 1)), _BACKOFF_CAP)
                         info["attempts"] = attempt
@@ -6338,6 +6368,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         platform_state="retrying",
                         error_code=None,
                         error_message=str(e),
+                        polling_state="retrying",
+                        reconnect_failure_count=attempt,
+                        transport_paused=False,
                     )
                     backoff = min(30 * (2 ** (attempt - 1)), _BACKOFF_CAP)
                     info["attempts"] = attempt

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -14,6 +14,7 @@ concurrently under distinct configurations).
 import hashlib
 import json
 import os
+import re
 import shlex
 import signal
 import subprocess
@@ -34,6 +35,11 @@ _RUNTIME_STATUS_FILE = "gateway_state.json"
 _LOCKS_DIRNAME = "gateway-locks"
 _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
+HERMES_TELEGRAM_PAUSED = "HERMES_TELEGRAM_PAUSED"
+HERMES_TELEGRAM_STALE = "HERMES_TELEGRAM_STALE"
+HERMES_RESTART_PROFILE_REPAIR = (
+    "Restart only this Hermes gateway profile: hermes gateway restart"
+)
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
 _gateway_lock_handle = None
 # Windows byte-range locks are mandatory for other readers. Lock a byte well
@@ -72,6 +78,170 @@ def _get_lock_dir() -> Path:
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _coerce_datetime(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    else:
+        return None
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _transport_issue(
+    *,
+    platform: str,
+    code: str,
+    summary: str,
+    state: Optional[str] = None,
+    reconnect_failure_count: Optional[int] = None,
+    last_successful_poll_at: Optional[str] = None,
+) -> dict[str, Any]:
+    return {
+        "platform": platform,
+        "healthy": False,
+        "code": code,
+        "summary": summary,
+        "state": state,
+        "reconnect_failure_count": reconnect_failure_count,
+        "last_successful_poll_at": last_successful_poll_at,
+        "recommended_repair": HERMES_RESTART_PROFILE_REPAIR,
+    }
+
+
+_TELEGRAM_PAUSED_RE = re.compile(
+    r"\btelegram\b.*\bpaused after\s+(\d+)\s+consecutive(?:\s+\w+)?\s+failures?\b",
+    re.IGNORECASE,
+)
+
+
+def classify_gateway_log_line(line: str) -> Optional[dict[str, Any]]:
+    """Classify gateway log lines that imply transport liveness failure."""
+    match = _TELEGRAM_PAUSED_RE.search(line or "")
+    if not match:
+        return None
+
+    count = _coerce_int(match.group(1))
+    summary = "Telegram polling paused"
+    if count is not None:
+        summary = f"{summary} after {count} reconnect failures"
+    return _transport_issue(
+        platform="telegram",
+        code=HERMES_TELEGRAM_PAUSED,
+        summary=summary,
+        state="paused",
+        reconnect_failure_count=count,
+    )
+
+
+def classify_gateway_transport_liveness(
+    state: Optional[dict[str, Any]],
+    *,
+    stale_after_seconds: int = 900,
+    now: Any = None,
+) -> dict[str, Any]:
+    """Classify behavior-level gateway transport health from runtime status.
+
+    PID/process checks answer "is the gateway process alive?" This answers
+    whether a messaging transport is still usable. A paused Telegram polling
+    transport is unhealthy even when the gateway process remains alive.
+    """
+    now_dt = _coerce_datetime(now) or datetime.now(timezone.utc)
+    issues: list[dict[str, Any]] = []
+
+    if isinstance(state, dict):
+        platforms = state.get("platforms") or {}
+        if isinstance(platforms, dict):
+            for platform, raw_platform_state in platforms.items():
+                if not isinstance(raw_platform_state, dict):
+                    continue
+                platform_name = str(platform)
+                platform_key = platform_name.lower()
+                transport_state = str(raw_platform_state.get("state") or "").lower()
+                polling_state = str(
+                    raw_platform_state.get("polling_state") or transport_state
+                ).lower()
+                reconnect_failure_count = _coerce_int(
+                    raw_platform_state.get("reconnect_failure_count")
+                )
+                last_successful_poll_at = raw_platform_state.get("last_successful_poll_at")
+                paused = (
+                    bool(raw_platform_state.get("transport_paused"))
+                    or transport_state == "paused"
+                    or polling_state == "paused"
+                )
+
+                if platform_key == "telegram" and paused:
+                    summary = "Telegram polling paused"
+                    if reconnect_failure_count is not None:
+                        summary += f" after {reconnect_failure_count} reconnect failures"
+                    error_message = raw_platform_state.get("error_message")
+                    if error_message:
+                        summary += f": {error_message}"
+                    issues.append(_transport_issue(
+                        platform=platform_name,
+                        code=HERMES_TELEGRAM_PAUSED,
+                        summary=summary,
+                        state=transport_state or polling_state or None,
+                        reconnect_failure_count=reconnect_failure_count,
+                        last_successful_poll_at=last_successful_poll_at,
+                    ))
+                    continue
+
+                last_poll_dt = _coerce_datetime(last_successful_poll_at)
+                if (
+                    platform_key == "telegram"
+                    and last_poll_dt is not None
+                    and (
+                        transport_state in {"connected", "running"}
+                        or polling_state in {"connected", "polling"}
+                    )
+                ):
+                    age_seconds = max(0, int((now_dt - last_poll_dt).total_seconds()))
+                    if age_seconds > int(stale_after_seconds):
+                        issues.append(_transport_issue(
+                            platform=platform_name,
+                            code=HERMES_TELEGRAM_STALE,
+                            summary=(
+                                "Telegram polling stale: last successful poll "
+                                f"{age_seconds}s ago"
+                            ),
+                            state=transport_state or polling_state or None,
+                            reconnect_failure_count=reconnect_failure_count,
+                            last_successful_poll_at=last_successful_poll_at,
+                        ))
+
+    first_issue = issues[0] if issues else None
+    return {
+        "healthy": not issues,
+        "status": "healthy" if not issues else "unhealthy",
+        "code": None if first_issue is None else first_issue["code"],
+        "summary": "Gateway transports healthy" if first_issue is None else first_issue["summary"],
+        "recommended_repair": None if first_issue is None else first_issue["recommended_repair"],
+        "platforms": issues,
+    }
 
 
 def terminate_pid(pid: int, *, force: bool = False) -> None:
@@ -576,17 +746,22 @@ def write_runtime_status(
     error_code: Any = _UNSET,
     error_message: Any = _UNSET,
     served_profiles: Any = _UNSET,
+    polling_state: Any = _UNSET,
+    reconnect_failure_count: Any = _UNSET,
+    last_successful_poll_at: Any = _UNSET,
+    transport_paused: Any = _UNSET,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
     current_record = _build_pid_record()
+    now_iso = _utc_now_iso()
     payload.setdefault("platforms", {})
     payload["kind"] = current_record["kind"]
     payload["pid"] = current_record["pid"]
     payload["argv"] = current_record["argv"]
     payload["start_time"] = current_record["start_time"]
-    payload["updated_at"] = _utc_now_iso()
+    payload["updated_at"] = now_iso
 
     if gateway_state is not _UNSET:
         payload["gateway_state"] = gateway_state
@@ -604,13 +779,51 @@ def write_runtime_status(
 
     if platform is not _UNSET:
         platform_payload = payload["platforms"].get(platform, {})
+        platform_key = str(platform).lower()
+        has_explicit_last_successful_poll = last_successful_poll_at is not _UNSET
         if platform_state is not _UNSET:
             platform_payload["state"] = platform_state
+            if platform_key == "telegram":
+                normalized_state = str(platform_state or "").lower()
+                if normalized_state == "connected":
+                    platform_payload["polling_state"] = "connected"
+                    platform_payload["transport_paused"] = False
+                    platform_payload["reconnect_failure_count"] = 0
+                    if not has_explicit_last_successful_poll:
+                        platform_payload.pop("last_successful_poll_at", None)
+                elif normalized_state == "paused":
+                    platform_payload["polling_state"] = "paused"
+                    platform_payload["transport_paused"] = True
+                elif normalized_state in {"connecting", "retrying"}:
+                    platform_payload["polling_state"] = normalized_state
+                    platform_payload["transport_paused"] = False
+                elif normalized_state in {"fatal", "disconnected"}:
+                    platform_payload["polling_state"] = normalized_state
+                    platform_payload["transport_paused"] = False
         if error_code is not _UNSET:
             platform_payload["error_code"] = error_code
         if error_message is not _UNSET:
             platform_payload["error_message"] = error_message
-        platform_payload["updated_at"] = _utc_now_iso()
+        if polling_state is not _UNSET:
+            platform_payload["polling_state"] = polling_state
+        if reconnect_failure_count is not _UNSET:
+            coerced_count = _coerce_int(reconnect_failure_count)
+            if coerced_count is None:
+                platform_payload.pop("reconnect_failure_count", None)
+            else:
+                platform_payload["reconnect_failure_count"] = max(0, coerced_count)
+        if last_successful_poll_at is not _UNSET:
+            if last_successful_poll_at is None:
+                platform_payload.pop("last_successful_poll_at", None)
+            elif isinstance(last_successful_poll_at, datetime):
+                platform_payload["last_successful_poll_at"] = (
+                    last_successful_poll_at.astimezone(timezone.utc).isoformat()
+                )
+            else:
+                platform_payload["last_successful_poll_at"] = str(last_successful_poll_at)
+        if transport_paused is not _UNSET:
+            platform_payload["transport_paused"] = bool(transport_paused)
+        platform_payload["updated_at"] = now_iso
         payload["platforms"][platform] = platform_payload
 
     _write_json_file(path, payload)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -367,6 +367,37 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
         check_warn("Could not verify systemd linger", f"({linger_detail})")
 
 
+def _check_gateway_transport_liveness(issues: list[str]) -> None:
+    """Fail doctor when the gateway process is alive but transport is wedged."""
+    try:
+        from gateway.status import (
+            classify_gateway_transport_liveness,
+            read_runtime_status,
+        )
+    except Exception as e:
+        check_warn("Gateway transport liveness", f"(could not import status helpers: {e})")
+        return
+
+    state = read_runtime_status()
+    if not state:
+        return
+
+    liveness = classify_gateway_transport_liveness(state)
+    if liveness.get("healthy"):
+        check_ok("Gateway transport liveness", "(runtime status healthy)")
+        return
+
+    _section("Gateway Transport")
+    for issue in liveness.get("platforms", []):
+        platform = issue.get("platform") or "gateway"
+        code = issue.get("code") or "transport_unhealthy"
+        summary = issue.get("summary") or "transport unhealthy"
+        repair = issue.get("recommended_repair") or "Restart the affected gateway profile"
+        check_fail(f"{platform}: {code}", f"({summary})")
+        check_info(repair)
+        issues.append(f"{code}: {summary}; {repair}")
+
+
 _APIKEY_PROVIDERS_CACHE: list | None = None
 
 
@@ -1300,6 +1331,7 @@ def run_doctor(args):
 
     _check_gateway_service_linger(issues)
     _check_s6_supervision(issues)
+    _check_gateway_transport_liveness(issues)
 
     if sys.platform != "win32":
         _section("Command Installation")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3804,6 +3804,13 @@ def launchd_status(deep: bool = False):
         print("  Service definition exists locally but launchd has not loaded it.")
         print("  Run: hermes gateway start")
 
+    runtime_lines = _runtime_health_lines()
+    if runtime_lines:
+        print()
+        print("Recent gateway health:")
+        for line in runtime_lines:
+            print(f"  {line}")
+
     if deep:
         log_file = get_hermes_home() / "logs" / "gateway.log"
         if log_file.exists():
@@ -4931,7 +4938,11 @@ def _platform_status(platform: dict) -> str:
 def _runtime_health_lines() -> list[str]:
     """Summarize the latest persisted gateway runtime health state."""
     try:
-        from gateway.status import read_runtime_status
+        from gateway.status import (
+            classify_gateway_log_line,
+            classify_gateway_transport_liveness,
+            read_runtime_status,
+        )
     except Exception:
         return []
 
@@ -4945,11 +4956,37 @@ def _runtime_health_lines() -> list[str]:
     active_agents = state.get("active_agents")
     restart_requested = state.get("restart_requested")
     platforms = state.get("platforms", {}) or {}
+    liveness = classify_gateway_transport_liveness(state)
+    seen_codes = set()
+
+    for issue in liveness.get("platforms", []):
+        platform = issue.get("platform") or "gateway"
+        code = issue.get("code") or "transport_unhealthy"
+        seen_codes.add(code)
+        summary = issue.get("summary") or "transport unhealthy"
+        repair = issue.get("recommended_repair")
+        detail = f"{summary} [{code}]"
+        if repair:
+            detail = f"{detail}; repair: {repair}"
+        lines.append(f"⚠ {platform}: {detail}")
 
     for platform, pdata in platforms.items():
         if pdata.get("state") == "fatal":
             message = pdata.get("error_message") or "unknown error"
             lines.append(f"⚠ {platform}: {message}")
+
+    for issue in _recent_gateway_log_transport_issues(classify_gateway_log_line):
+        code = issue.get("code") or "transport_unhealthy"
+        if code in seen_codes:
+            continue
+        seen_codes.add(code)
+        platform = issue.get("platform") or "gateway"
+        summary = issue.get("summary") or "transport unhealthy"
+        repair = issue.get("recommended_repair")
+        detail = f"{summary} [{code}]"
+        if repair:
+            detail = f"{detail}; repair: {repair}"
+        lines.append(f"⚠ {platform}: {detail}")
 
     if gateway_state == "startup_failed" and exit_reason:
         lines.append(f"⚠ Last startup issue: {exit_reason}")
@@ -4961,6 +4998,33 @@ def _runtime_health_lines() -> list[str]:
         lines.append(f"⚠ Last shutdown reason: {exit_reason}")
 
     return lines
+
+
+def _recent_gateway_log_transport_issues(classifier) -> list[dict]:
+    log_file = get_hermes_home() / "logs" / "gateway.log"
+    if not log_file.exists():
+        return []
+    try:
+        with log_file.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - 65536), os.SEEK_SET)
+            raw = handle.read()
+    except OSError:
+        return []
+
+    issues: list[dict] = []
+    seen_codes: set[str] = set()
+    for line in reversed(raw.decode("utf-8", errors="replace").splitlines()[-200:]):
+        issue = classifier(line)
+        if not issue:
+            continue
+        code = issue.get("code")
+        if code in seen_codes:
+            continue
+        seen_codes.add(code)
+        issues.append(issue)
+    return list(reversed(issues))
 
 
 def _setup_standard_platform(platform: dict):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -69,6 +69,7 @@ from hermes_cli.memory_providers import (
     get_memory_provider,
 )
 from gateway.status import (
+    classify_gateway_transport_liveness,
     get_running_pid,
     get_runtime_status_running_pid,
     read_runtime_status,
@@ -995,7 +996,6 @@ class ManagedFilesPolicy:
     locked_root: Path | None
     can_change_path: bool
 
-
 _FS_READDIR_HIDDEN = {
     ".git",
     ".hg",
@@ -1764,6 +1764,7 @@ async def get_status(profile: Optional[str] = None):
         gateway_platforms: dict = {}
         gateway_exit_reason = None
         gateway_updated_at = None
+        gateway_liveness = classify_gateway_transport_liveness(None)
         configured_gateway_platforms: set[str] | None = None
         try:
             from gateway.config import load_gateway_config
@@ -1812,6 +1813,10 @@ async def get_status(profile: Optional[str] = None):
                 # stopped/None state so the dashboard shows the correct badge.
                 if gateway_state in {None, "stopped"}:
                     gateway_state = "running"
+            gateway_liveness = classify_gateway_transport_liveness({
+                **runtime,
+                "platforms": gateway_platforms,
+            })
 
         # If there was no runtime info at all but the health probe confirmed alive,
         # ensure we still report the gateway as running (no shared volume scenario).
@@ -1863,6 +1868,7 @@ async def get_status(profile: Optional[str] = None):
             "gateway_platforms": gateway_platforms,
             "gateway_exit_reason": gateway_exit_reason,
             "gateway_updated_at": gateway_updated_at,
+            "gateway_liveness": gateway_liveness,
             "active_sessions": active_sessions,
             "auth_required": auth_required,
             "auth_providers": auth_providers,

--- a/tests/gateway/test_status_transport_liveness.py
+++ b/tests/gateway/test_status_transport_liveness.py
@@ -1,0 +1,153 @@
+"""Regression tests for gateway transport-liveness classification.
+
+Background: the gateway process can be alive (pid present, gateway_state=running)
+while a platform transport (e.g. Telegram long-poll) has been auto-paused after
+repeated reconnect failures. Without transport-level classification the
+operator sees "process healthy" and assumes messages flow - they don't.
+
+These tests pin the contract for two helpers under `gateway.status`:
+
+  - ``classify_gateway_transport_liveness(state, stale_after_seconds=900, now=...)``
+  - ``classify_gateway_log_line(line)``
+
+Tests are deterministic - no live gateway, no clock dependence.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from gateway import status as gateway_status
+
+
+def _state(platforms, **extra):
+    base = {
+        "pid": 12345,
+        "kind": "hermes-gateway",
+        "argv": ["python", "-m", "hermes_cli.main", "gateway"],
+        "start_time": 100,
+        "gateway_state": "running",
+        "exit_reason": None,
+        "restart_requested": False,
+        "active_agents": 1,
+        "platforms": platforms,
+        "updated_at": "2026-06-20T12:00:00+00:00",
+    }
+    base.update(extra)
+    return base
+
+
+class TestClassifyGatewayTransportLiveness:
+    def test_running_process_with_paused_telegram_fails_red(self):
+        """Process alive + telegram paused = red verdict with HERMES_TELEGRAM_PAUSED.
+
+        This is the incident shape: pid record present, gateway_state=running,
+        but the long-poll transport has been parked. Liveness must catch it.
+        """
+        state = _state({
+            "telegram": {
+                "state": "paused",
+                "error_code": None,
+                "error_message": "auto-paused after 10 consecutive reconnect failures",
+                "updated_at": "2026-06-20T12:00:00+00:00",
+            }
+        })
+
+        result = gateway_status.classify_gateway_transport_liveness(state)
+
+        assert result["healthy"] is False, result
+        assert result["code"] == "HERMES_TELEGRAM_PAUSED"
+        # platforms list must call out telegram specifically so operators
+        # don't have to grep the summary for what's broken.
+        platforms = result.get("platforms") or []
+        assert any(
+            (isinstance(p, str) and p == "telegram")
+            or (isinstance(p, dict) and p.get("platform") == "telegram")
+            for p in platforms
+        ), platforms
+
+    def test_connected_telegram_with_fresh_poll_is_healthy(self):
+        """state=connected + last_successful_poll_at within window = green."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state = _state({
+            "telegram": {
+                "state": "connected",
+                "error_code": None,
+                "error_message": None,
+                "last_successful_poll_at": (now - timedelta(seconds=10)).isoformat(),
+                "updated_at": (now - timedelta(seconds=10)).isoformat(),
+            }
+        })
+
+        result = gateway_status.classify_gateway_transport_liveness(
+            state, stale_after_seconds=300, now=now
+        )
+
+        assert result["healthy"] is True, result
+
+    def test_default_stale_threshold_allows_max_heartbeat_interval(self):
+        """Default stale threshold must stay above the heartbeat max clamp."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state = _state({
+            "telegram": {
+                "state": "connected",
+                "last_successful_poll_at": (now - timedelta(seconds=600)).isoformat(),
+            }
+        })
+
+        result = gateway_status.classify_gateway_transport_liveness(state, now=now)
+
+        assert result["healthy"] is True, result
+
+    def test_stale_telegram_poll_beyond_threshold_fails_red(self):
+        """Connected but last_successful_poll_at is stale -> red, telegram-stale code."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state = _state({
+            "telegram": {
+                "state": "connected",
+                "error_code": None,
+                "error_message": None,
+                "last_successful_poll_at": (now - timedelta(seconds=900)).isoformat(),
+                "updated_at": (now - timedelta(seconds=900)).isoformat(),
+            }
+        })
+
+        result = gateway_status.classify_gateway_transport_liveness(
+            state, stale_after_seconds=300, now=now
+        )
+
+        assert result["healthy"] is False, result
+        code = result["code"]
+        assert "TELEGRAM" in code.upper() and "STALE" in code.upper(), code
+
+
+class TestClassifyGatewayLogLine:
+    def test_recognizes_telegram_pause_phrase(self):
+        """The canonical pause phrase must classify as HERMES_TELEGRAM_PAUSED,
+        and the recommended repair must point at restarting the Hermes gateway
+        (or profile) ONLY - not Qwen, Ollama, Postgres, or any other healthy
+        subsystem."""
+        line = (
+            "2026-06-20T12:00:00 [WARNING] gateway: "
+            "Telegram paused after 10 consecutive reconnect failures"
+        )
+
+        result = gateway_status.classify_gateway_log_line(line)
+
+        assert result is not None, "pause phrase must classify, not return None"
+        assert result["code"] == "HERMES_TELEGRAM_PAUSED"
+
+        repair = (result.get("recommended_repair") or "").lower()
+        assert "hermes" in repair, repair
+        assert ("gateway" in repair) or ("profile" in repair), repair
+        # Repair MUST NOT recommend touching healthy subsystems.
+        for forbidden in ("qwen", "ollama", "postgres", "postgresql", "api server"):
+            assert forbidden not in repair, (
+                f"recommended_repair must not mention {forbidden!r}: {repair!r}"
+            )
+
+    def test_unrelated_line_returns_none(self):
+        """Liveness classifier should not pattern-match unrelated log lines."""
+        line = "2026-06-20T12:00:00 [INFO] gateway: telegram polling resumed"
+        result = gateway_status.classify_gateway_log_line(line)
+        assert result is None, result

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -118,12 +118,27 @@ async def test_reconnect_does_not_self_schedule_when_fatal_error_set():
 
 
 @pytest.mark.asyncio
-async def test_reconnect_success_resets_error_count():
+async def test_polling_heartbeat_reconnect_errors_are_contained():
+    adapter = _make_adapter()
+    adapter._handle_polling_network_error = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await adapter._handle_polling_heartbeat_error(RuntimeError("heartbeat failed"))
+
+    adapter._handle_polling_network_error.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_success_resets_error_count(monkeypatch):
     """
     When start_polling() succeeds, _polling_network_error_count should reset to 0.
     """
     adapter = _make_adapter()
     adapter._polling_network_error_count = 3
+    status_writes = []
+    monkeypatch.setattr(
+        "gateway.status.write_runtime_status",
+        lambda **kwargs: status_writes.append(kwargs),
+    )
 
     mock_updater = MagicMock()
     mock_updater.running = True
@@ -139,6 +154,11 @@ async def test_reconnect_success_resets_error_count():
         await adapter._handle_polling_network_error(Exception("Bad Gateway"))
 
     assert adapter._polling_network_error_count == 0
+    assert any(
+        write.get("polling_state") == "connected"
+        and write.get("last_successful_poll_at")
+        for write in status_writes
+    )
 
     # Clean up the heartbeat-probe task scheduled after a successful reconnect.
     pending = [t for t in adapter._background_tasks if not t.done()]

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -252,6 +252,35 @@ def test_check_gateway_service_linger_skips_when_service_not_installed(monkeypat
     assert out == ""
     assert issues == []
 
+def test_check_gateway_transport_liveness_fails_paused_telegram(monkeypatch, capsys):
+    from gateway import status as gateway_status
+
+    monkeypatch.setattr(
+        gateway_status,
+        "read_runtime_status",
+        lambda: {
+            "pid": 12345,
+            "kind": "hermes-gateway",
+            "gateway_state": "running",
+            "platforms": {
+                "telegram": {
+                    "state": "paused",
+                    "error_message": "auto-paused after 10 consecutive reconnect failures",
+                    "reconnect_failure_count": 10,
+                }
+            },
+        },
+    )
+
+    issues = []
+    doctor._check_gateway_transport_liveness(issues)
+
+    out = capsys.readouterr().out
+    assert "Gateway Transport" in out
+    assert "HERMES_TELEGRAM_PAUSED" in out
+    assert "hermes gateway restart" in out
+    assert any("HERMES_TELEGRAM_PAUSED" in issue for issue in issues)
+
 
 # ── Memory provider section (doctor should only check the *active* provider) ──
 

--- a/tests/hermes_cli/test_gateway_runtime_health.py
+++ b/tests/hermes_cli/test_gateway_runtime_health.py
@@ -1,7 +1,9 @@
+import hermes_cli.gateway as gateway_cli
 from hermes_cli.gateway import _runtime_health_lines
 
 
 def test_runtime_health_lines_include_fatal_platform_and_startup_reason(monkeypatch):
+    monkeypatch.setattr(gateway_cli, "_recent_gateway_log_transport_issues", lambda classifier: [])
     monkeypatch.setattr(
         "gateway.status.read_runtime_status",
         lambda: {
@@ -51,3 +53,83 @@ def test_runtime_status_running_pid_rejects_stopped_record(monkeypatch):
     monkeypatch.setattr(status_mod, "_pid_exists", lambda pid: True)
 
     assert status_mod.get_runtime_status_running_pid(runtime) is None
+
+
+def test_runtime_health_lines_surface_paused_telegram_transport(monkeypatch):
+    """Incident regression: gateway process alive, Telegram transport paused.
+
+    Before the fix, _runtime_health_lines only surfaced platforms in `fatal`
+    state. A `paused` platform after repeated reconnect failures was silent,
+    so operators saw a green gateway while conductors were unreachable.
+    """
+    monkeypatch.setattr(gateway_cli, "_recent_gateway_log_transport_issues", lambda classifier: [])
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "exit_reason": None,
+            "platforms": {
+                "telegram": {
+                    "state": "paused",
+                    "error_message": "auto-paused after 10 consecutive reconnect failures",
+                }
+            },
+        },
+    )
+
+    lines = _runtime_health_lines()
+
+    assert any(
+        "telegram" in line.lower() and "paused" in line.lower()
+        for line in lines
+    ), lines
+
+
+def test_runtime_health_lines_surface_stale_telegram_poll(monkeypatch):
+    """When the telegram transport hasn't polled successfully past the
+    staleness threshold, _runtime_health_lines must surface it even if
+    `state` is still nominally `connected`."""
+    monkeypatch.setattr(gateway_cli, "_recent_gateway_log_transport_issues", lambda classifier: [])
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "exit_reason": None,
+            "platforms": {
+                "telegram": {
+                    "state": "connected",
+                    "last_successful_poll_at": "2020-01-01T00:00:00+00:00",
+                }
+            },
+        },
+    )
+
+    lines = _runtime_health_lines()
+
+    assert any(
+        "telegram" in line.lower() and "stale" in line.lower()
+        for line in lines
+    ), lines
+
+
+def test_runtime_health_lines_surface_telegram_pause_log_signature(monkeypatch, tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "gateway.log").write_text(
+        "2026-06-20T12:00:00 [WARNING] gateway: "
+        "Telegram paused after 10 consecutive reconnect failures\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "exit_reason": None,
+            "platforms": {},
+        },
+    )
+
+    lines = _runtime_health_lines()
+
+    assert any("HERMES_TELEGRAM_PAUSED" in line for line in lines), lines


### PR DESCRIPTION
## Summary
- Detect PID-alive / Telegram transport-dead gateway states with explicit `HERMES_TELEGRAM_PAUSED` and `HERMES_TELEGRAM_STALE` classifications.
- Surface behavior-level gateway liveness in `hermes gateway status`, `hermes doctor`, and dashboard `/api/status`.
- Add Telegram polling heartbeat metadata, a pause-signature log classifier, operator runbook, and hardening receipt.

## Incident Pattern
- Telegram reconnect failures can pause polling while the Hermes process remains alive.
- In the observed incident, Qwen/Ollama tunnel, Postgres, NeoEngine API, and Cockpit were healthy; Hermes transport liveness was the failing layer.
- This PR is Wave 1: detection and diagnosis. Profile-scoped supervised recovery with flap protection should follow as a separate Wave 2.

## Tests
- `python -m py_compile gateway/status.py gateway/run.py gateway/platforms/telegram.py hermes_cli/gateway.py hermes_cli/doctor.py hermes_cli/web_server.py`
- `scripts/run_tests.sh tests/gateway/test_status_transport_liveness.py tests/hermes_cli/test_gateway_runtime_health.py tests/gateway/test_telegram_network_reconnect.py`
- `.venv/bin/python -m pytest tests/hermes_cli/test_doctor.py::test_check_gateway_transport_liveness_fails_paused_telegram -q`
- `git diff --check -- gateway/status.py gateway/run.py gateway/platforms/telegram.py hermes_cli/gateway.py hermes_cli/doctor.py hermes_cli/web_server.py tests/gateway/test_status_transport_liveness.py tests/gateway/test_telegram_network_reconnect.py tests/hermes_cli/test_gateway_runtime_health.py tests/hermes_cli/test_doctor.py docs/runbooks/hermes-gateway-transport-liveness.md docs/plans/hardening/2026-06-20-hermes-telegram-paused-liveness.json`

## Review
- Claude regression-test lane added focused tests for the liveness contract.
- Cross-review completed with final verdict: PASS.
