### PR TITLE
fix(state): use COALESCE(?, model) so mid-session model switches are persisted

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1626,7 +1626,7 @@ class SessionDB:
                    billing_provider = COALESCE(billing_provider, ?),
                    billing_base_url = COALESCE(billing_base_url, ?),
                    billing_mode = COALESCE(billing_mode, ?),
-                   model = COALESCE(model, ?),
+                   model = COALESCE(?, model),
                    api_call_count = ?
                    WHERE id = ?"""
         else:
@@ -1647,7 +1647,7 @@ class SessionDB:
                    billing_provider = COALESCE(billing_provider, ?),
                    billing_base_url = COALESCE(billing_base_url, ?),
                    billing_mode = COALESCE(billing_mode, ?),
-                   model = COALESCE(model, ?),
+                   model = COALESCE(?, model),
                    api_call_count = COALESCE(api_call_count, 0) + ?
                    WHERE id = ?"""
         params = (


### PR DESCRIPTION
Fixes #34850

## Problem
`update_token_counts()` uses `model = COALESCE(model, ?)` in both the
`absolute=True` and `absolute=False` SQL paths. Once a session's model
column is set at creation, any subsequent call with a new model value is
silently discarded — `/model` switches never reach the database.

## Fix
Swap argument order to `COALESCE(?, model)`: the provided value takes
priority when non-NULL; falls back to the existing column value otherwise.

## Test
```python
db.update_token_counts(session_id, model="gpt-4o")
db.update_token_counts(session_id, model="claude-opus-4-8")
session = db.get_session(session_id)
assert session["model"] == "claude-opus-4-8"  # previously returned "gpt-4o"
```