### PR TITLE
fix(tools): preserve canonical Windows location env var names in _build_safe_env

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1278,16 +1278,19 @@ class TestBuildSafeEnv:
 
         fake_env = {
             "PATH": r"C:\Windows\System32",
-            "ProgramFiles": r"C:\Program Files",
-            "ProgramData": r"C:\ProgramData",
-            "ProgramW6432": r"C:\Program Files",
+            "PROGRAMFILES": r"C:\Program Files",
+            "PROGRAMDATA": r"C:\ProgramData",
+            "PROGRAMW6432": r"C:\Program Files",
             "LOCALAPPDATA": r"C:\Users\alice\AppData\Local",
             "APPDATA": r"C:\Users\alice\AppData\Roaming",
             "USERPROFILE": r"C:\Users\alice",
             "GITHUB_TOKEN": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
             "OPENAI_API_KEY": "sk-proj-abc123",
         }
-        with patch.dict("os.environ", fake_env, clear=True):
+        with (
+            patch("tools.mcp_tool.os.name", "nt"),
+            patch.dict("os.environ", fake_env, clear=True),
+        ):
             result = _build_safe_env(None)
 
         assert result["ProgramFiles"] == r"C:\Program Files"
@@ -1298,6 +1301,20 @@ class TestBuildSafeEnv:
         assert result["USERPROFILE"] == r"C:\Users\alice"
         assert "GITHUB_TOKEN" not in result
         assert "OPENAI_API_KEY" not in result
+
+    def test_posix_preserves_uppercase_windows_location_var_spelling(self):
+        """POSIX environments retain source case for allowed Windows names."""
+        from tools.mcp_tool import _build_safe_env
+
+        fake_env = {"PROGRAMFILES": "/opt/windows-program-files"}
+        with (
+            patch("tools.mcp_tool.os.name", "posix"),
+            patch.dict("os.environ", fake_env, clear=True),
+        ):
+            result = _build_safe_env(None)
+
+        assert result["PROGRAMFILES"] == "/opt/windows-program-files"
+        assert "ProgramFiles" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1126,16 +1126,19 @@ class TestBuildSafeEnv:
 
         fake_env = {
             "PATH": r"C:\Windows\System32",
-            "ProgramFiles": r"C:\Program Files",
-            "ProgramData": r"C:\ProgramData",
-            "ProgramW6432": r"C:\Program Files",
+            "PROGRAMFILES": r"C:\Program Files",
+            "PROGRAMDATA": r"C:\ProgramData",
+            "PROGRAMW6432": r"C:\Program Files",
             "LOCALAPPDATA": r"C:\Users\alice\AppData\Local",
             "APPDATA": r"C:\Users\alice\AppData\Roaming",
             "USERPROFILE": r"C:\Users\alice",
             "GITHUB_TOKEN": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
             "OPENAI_API_KEY": "sk-proj-abc123",
         }
-        with patch.dict("os.environ", fake_env, clear=True):
+        with (
+            patch("tools.mcp_tool.os.name", "nt"),
+            patch.dict("os.environ", fake_env, clear=True),
+        ):
             result = _build_safe_env(None)
 
         assert result["ProgramFiles"] == r"C:\Program Files"
@@ -1146,6 +1149,20 @@ class TestBuildSafeEnv:
         assert result["USERPROFILE"] == r"C:\Users\alice"
         assert "GITHUB_TOKEN" not in result
         assert "OPENAI_API_KEY" not in result
+
+    def test_posix_preserves_uppercase_windows_location_var_spelling(self):
+        """POSIX environments retain source case for allowed Windows names."""
+        from tools.mcp_tool import _build_safe_env
+
+        fake_env = {"PROGRAMFILES": "/opt/windows-program-files"}
+        with (
+            patch("tools.mcp_tool.os.name", "posix"),
+            patch.dict("os.environ", fake_env, clear=True),
+        ):
+            result = _build_safe_env(None)
+
+        assert result["PROGRAMFILES"] == "/opt/windows-program-files"
+        assert "ProgramFiles" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -652,6 +652,24 @@ _SAFE_ENV_KEYS_CASE_INSENSITIVE = frozenset({
     "WINDIR",
 })
 
+# Canonical (mixed-case) spellings for the Windows location vars whose
+# documented names are not all-uppercase. CPython normalizes every key in
+# ``os.environ`` to UPPERCASE on Windows (``os.name == "nt"``), so iterating it
+# yields e.g. ``"PROGRAMFILES"`` even though the variable is documented and
+# consumed as ``"ProgramFiles"``. Launcher-style tools (and the test contract)
+# expect the canonical spelling, so map the upper-cased key back to it on
+# Windows only. Keys not in this map keep their original spelling
+# (all-uppercase vars like ``APPDATA`` are already canonical).
+_WINDOWS_CANONICAL_ENV_KEYS = {
+    "PROGRAMFILES": "ProgramFiles",
+    "PROGRAMFILES(X86)": "ProgramFiles(x86)",
+    "PROGRAMW6432": "ProgramW6432",
+    "PROGRAMDATA": "ProgramData",
+    "COMMONPROGRAMFILES": "CommonProgramFiles",
+    "COMMONPROGRAMFILES(X86)": "CommonProgramFiles(x86)",
+    "COMMONPROGRAMW6432": "CommonProgramW6432",
+}
+
 # Regex for credential patterns to strip from error messages
 _CREDENTIAL_PATTERN = re.compile(
     r"(?:"
@@ -759,7 +777,14 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
             or key.startswith("XDG_")
             or (get_secret_source is not None and get_secret_source(key))
         ):
-            env[key] = value
+            # Restore mixed-case Windows location names only where CPython
+            # normalizes os.environ keys. POSIX must retain the source spelling.
+            canonical_key = (
+                _WINDOWS_CANONICAL_ENV_KEYS.get(key.upper(), key)
+                if os.name == "nt"
+                else key
+            )
+            env[canonical_key] = value
     if user_env:
         env.update(user_env)
     return env

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -405,6 +405,24 @@ _SAFE_ENV_KEYS_CASE_INSENSITIVE = frozenset({
     "WINDIR",
 })
 
+# Canonical (mixed-case) spellings for the Windows location vars whose
+# documented names are not all-uppercase. CPython normalizes every key in
+# ``os.environ`` to UPPERCASE on Windows (``os.name == "nt"``), so iterating it
+# yields e.g. ``"PROGRAMFILES"`` even though the variable is documented and
+# consumed as ``"ProgramFiles"``. Launcher-style tools (and the test contract)
+# expect the canonical spelling, so map the upper-cased key back to it on
+# Windows only. Keys not in this map keep their original spelling
+# (all-uppercase vars like ``APPDATA`` are already canonical).
+_WINDOWS_CANONICAL_ENV_KEYS = {
+    "PROGRAMFILES": "ProgramFiles",
+    "PROGRAMFILES(X86)": "ProgramFiles(x86)",
+    "PROGRAMW6432": "ProgramW6432",
+    "PROGRAMDATA": "ProgramData",
+    "COMMONPROGRAMFILES": "CommonProgramFiles",
+    "COMMONPROGRAMFILES(X86)": "CommonProgramFiles(x86)",
+    "COMMONPROGRAMW6432": "CommonProgramW6432",
+}
+
 # Regex for credential patterns to strip from error messages
 _CREDENTIAL_PATTERN = re.compile(
     r"(?:"
@@ -470,7 +488,14 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
             or key.startswith("XDG_")
             or (get_secret_source is not None and get_secret_source(key))
         ):
-            env[key] = value
+            # Restore mixed-case Windows location names only where CPython
+            # normalizes os.environ keys. POSIX must retain the source spelling.
+            canonical_key = (
+                _WINDOWS_CANONICAL_ENV_KEYS.get(key.upper(), key)
+                if os.name == "nt"
+                else key
+            )
+            env[canonical_key] = value
     if user_env:
         env.update(user_env)
     return env


### PR DESCRIPTION
## What

Preserve canonical mixed-case Windows location variable names (`ProgramFiles`, `ProgramData`, `ProgramW6432`, and the `CommonProgram*` family) in the filtered environment passed to stdio MCP subprocesses.

## Why

The earlier #49486 fix allowlisted these variables, but current `main` still emits each source key verbatim. CPython normalizes `os.environ` keys to uppercase on Windows, so launcher-style MCP servers receive `PROGRAMFILES` instead of the documented `ProgramFiles` spelling they query.

This follow-up maps only those known location keys back to canonical spelling, and only when `os.name == "nt"`. Secret filtering and explicit user-env precedence are unchanged. POSIX environments retain the exact source spelling.

## Review feedback addressed

- Canonical-name rewriting is now gated to Windows.
- The Windows test uses uppercase source keys and forces the Windows branch, so it is platform-independent.
- A forced-POSIX regression verifies `PROGRAMFILES` remains `PROGRAMFILES` rather than being rewritten.

## Current-main A/B proof

Fresh verification after rebasing onto `main` at `9f384783e`:

- Current `main`, existing Windows-location test: **fails** with `KeyError: 'ProgramFiles'`.
- This branch (`fdbe3ca81`), `TestBuildSafeEnv`: **9 passed**.
- Full `tests/tools/test_mcp_tool.py`: **217 passed**.
- Canonical per-file runner with the pending #67387 Windows wrapper environment fix: **217 passed, 0 failed**.
- `ruff check tools/mcp_tool.py tests/tools/test_mcp_tool.py`: clean.
- `git diff --check`: clean.

## Scope

Two files: the runtime mapping and focused behavioral regression tests. No dependency, lockfile, or unrelated MCP changes.

Follow-up to #49486.