### PR TITLE
fix(photon): verify and tolerate sidecar spectrum-ts drift

### DIFF
--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import getpass
+import json
 import os
 import shutil
 import subprocess
@@ -396,7 +397,23 @@ def _install_sidecar() -> int:
         )
     if proc.returncode != 0:
         print("npm install failed", file=sys.stderr)
-    return proc.returncode
+        return proc.returncode
+
+    issues = _sidecar_spectrum_drift_messages()
+    if issues:
+        print("sidecar install verification failed:", file=sys.stderr)
+        for issue in issues:
+            print(f"  - {issue}", file=sys.stderr)
+        print(
+            "Re-run `hermes photon install-sidecar` after removing the drifted "
+            "`node_modules/spectrum-ts`, or restore the committed lockfile.",
+            file=sys.stderr,
+        )
+        return 1
+
+    expected = _sidecar_spectrum_versions().get("expected") or "unknown"
+    print(f"  ✓ sidecar deps verified (spectrum-ts {expected})")
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -422,6 +439,103 @@ def gateway_setup() -> None:
         skip_sidecar_install=False,
     )
     _cmd_setup(args)
+
+
+def _read_json_file(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _sidecar_spectrum_versions(sidecar_dir: Path | None = None) -> dict[str, str]:
+    if sidecar_dir is None:
+        sidecar_dir = _SIDECAR_DIR
+    pkg = _read_json_file(sidecar_dir / "package.json")
+    lock = _read_json_file(sidecar_dir / "package-lock.json")
+    installed = _read_json_file(
+        sidecar_dir / "node_modules" / "spectrum-ts" / "package.json"
+    )
+
+    expected = ""
+    deps = pkg.get("dependencies")
+    if isinstance(deps, dict):
+        raw_expected = deps.get("spectrum-ts")
+        if isinstance(raw_expected, str):
+            expected = raw_expected.strip()
+
+    lock_spec = ""
+    lock_version = ""
+    packages = lock.get("packages")
+    if isinstance(packages, dict):
+        root_meta = packages.get("")
+        if isinstance(root_meta, dict):
+            root_deps = root_meta.get("dependencies")
+            if isinstance(root_deps, dict):
+                raw_lock_spec = root_deps.get("spectrum-ts")
+                if isinstance(raw_lock_spec, str):
+                    lock_spec = raw_lock_spec.strip()
+        installed_meta = packages.get("node_modules/spectrum-ts")
+        if isinstance(installed_meta, dict):
+            raw_lock_version = installed_meta.get("version")
+            if isinstance(raw_lock_version, str):
+                lock_version = raw_lock_version.strip()
+
+    if not lock_spec or not lock_version:
+        top_level_deps = lock.get("dependencies")
+        if isinstance(top_level_deps, dict):
+            dep_meta = top_level_deps.get("spectrum-ts")
+            if isinstance(dep_meta, dict):
+                if not lock_spec:
+                    raw_lock_spec = dep_meta.get("version")
+                    if isinstance(raw_lock_spec, str):
+                        lock_spec = raw_lock_spec.strip()
+                if not lock_version:
+                    raw_lock_version = dep_meta.get("version")
+                    if isinstance(raw_lock_version, str):
+                        lock_version = raw_lock_version.strip()
+
+    installed_version = ""
+    raw_installed = installed.get("version")
+    if isinstance(raw_installed, str):
+        installed_version = raw_installed.strip()
+
+    return {
+        "expected": expected,
+        "lock_spec": lock_spec,
+        "lock_version": lock_version,
+        "installed": installed_version,
+    }
+
+
+def _sidecar_spectrum_drift_messages(
+    sidecar_dir: Path | None = None,
+) -> list[str]:
+    if sidecar_dir is None:
+        sidecar_dir = _SIDECAR_DIR
+    versions = _sidecar_spectrum_versions(sidecar_dir)
+    expected = versions["expected"]
+    lock_spec = versions["lock_spec"]
+    lock_version = versions["lock_version"]
+    installed = versions["installed"]
+    issues: list[str] = []
+
+    if not installed:
+        issues.append("node_modules/spectrum-ts is missing after install")
+    if expected and lock_spec and lock_spec != expected:
+        issues.append(
+            f"package-lock pins spectrum-ts as {lock_spec}, but package.json pins {expected}"
+        )
+    if expected and installed and installed != expected:
+        issues.append(
+            f"installed spectrum-ts@{installed}, but package.json pins {expected}"
+        )
+    if lock_version and installed and installed != lock_version:
+        issues.append(
+            f"installed spectrum-ts@{installed}, but package-lock resolves {lock_version}"
+        )
+    return issues
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -56,6 +56,7 @@
 
 import http from "node:http";
 import crypto from "node:crypto";
+import fs from "node:fs";
 import { once } from "node:events";
 import { patchSpectrumTs } from "./patch-spectrum-mixed-attachments.mjs";
 
@@ -80,6 +81,8 @@ const E164_RE = /^\+\d{6,}$/;
 const MAX_KNOWN_SPACES = 2048;
 const MAX_KNOWN_MESSAGES = 1024;
 const MAX_REACTION_HANDLES = 512;
+const PINNED_SPECTRUM_VERSION = "3.1.0";
+const compatWarnings = new Set();
 
 if (!projectId || !projectSecret || !sharedToken) {
   console.error(
@@ -88,6 +91,29 @@ if (!projectId || !projectSecret || !sharedToken) {
   );
   process.exit(2);
 }
+
+function readInstalledSpectrumVersion() {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(
+        new URL("./node_modules/spectrum-ts/package.json", import.meta.url),
+        "utf8"
+      )
+    );
+    return typeof pkg?.version === "string" ? pkg.version : "";
+  } catch {
+    return "";
+  }
+}
+
+function logCompatWarning(key, message) {
+  if (compatWarnings.has(key)) return;
+  compatWarnings.add(key);
+  console.error(message);
+}
+
+const installedSpectrumVersion = readInstalledSpectrumVersion();
+const installedSpectrumLabel = installedSpectrumVersion || "unknown";
 
 // Lazy-load spectrum-ts so a missing install fails with a clear message
 // instead of a cryptic module-resolution error during import. Apply Hermes'
@@ -134,6 +160,56 @@ try {
       (e && e.stack ? e.stack : String(e))
   );
   process.exit(3);
+}
+
+if (
+  typeof Spectrum !== "function" ||
+  typeof attachment !== "function" ||
+  typeof voice !== "function" ||
+  typeof spectrumText !== "function"
+) {
+  console.error(
+    "photon-sidecar: incompatible spectrum-ts@" +
+      installedSpectrumLabel +
+      " loaded; required builders are missing. " +
+      `Expected pinned spectrum-ts@${PINNED_SPECTRUM_VERSION}. ` +
+      "Run `hermes photon install-sidecar`."
+  );
+  process.exit(3);
+}
+
+if (
+  installedSpectrumVersion &&
+  installedSpectrumVersion !== PINNED_SPECTRUM_VERSION
+) {
+  logCompatWarning(
+    "version-drift",
+    "photon-sidecar: loaded spectrum-ts@" +
+      installedSpectrumVersion +
+      ` but the committed pin is ${PINNED_SPECTRUM_VERSION}. ` +
+      "Compatibility fallbacks are enabled where possible; " +
+      "run `hermes photon install-sidecar`."
+  );
+}
+
+if (typeof spectrumMarkdown !== "function") {
+  logCompatWarning(
+    "missing-markdown-builder",
+    "photon-sidecar: spectrum-ts@" +
+      installedSpectrumLabel +
+      " is missing markdown(); outbound markdown will fall back to text(). " +
+      "Run `hermes photon install-sidecar`."
+  );
+}
+
+if (typeof spectrumTyping !== "function") {
+  logCompatWarning(
+    "missing-typing-builder",
+    "photon-sidecar: spectrum-ts@" +
+      installedSpectrumLabel +
+      " is missing typing(); typing indicators will be skipped. " +
+      "Run `hermes photon install-sidecar`."
+  );
 }
 
 const app = await Spectrum({
@@ -431,6 +507,13 @@ function ok(res, data) {
   res.end(JSON.stringify({ ok: true, ...data }));
 }
 
+function buildOutboundText(text, format) {
+  if (format === "markdown" && typeof spectrumMarkdown === "function") {
+    return spectrumMarkdown(text);
+  }
+  return spectrumText(text);
+}
+
 function handleInbound(req, res) {
   res.statusCode = 200;
   res.setHeader("Content-Type", "application/x-ndjson");
@@ -547,10 +630,10 @@ const server = http.createServer(async (req, res) => {
         return badRequest(res, "format must be text or markdown");
       }
       const space = await resolveSpace(spaceId);
-      // iMessage renders markdown natively; spectrum-ts degrades it to
-      // readable plain text on platforms that don't.
-      const builder =
-        format === "markdown" ? spectrumMarkdown(text) : spectrumText(text);
+      // iMessage renders markdown natively when the SDK exposes markdown();
+      // older/newer SDK lines may not, so we degrade to text() instead of
+      // crashing every outbound send on a drifted install.
+      const builder = buildOutboundText(text, format);
       const result = await space.send(builder);
       return ok(res, { messageId: result?.id || null });
     }
@@ -652,6 +735,9 @@ const server = http.createServer(async (req, res) => {
       if (!spaceId) return badRequest(res, "spaceId is required");
       if (state !== "start" && state !== "stop") {
         return badRequest(res, "state must be start or stop");
+      }
+      if (typeof spectrumTyping !== "function") {
+        return ok(res, { skipped: true });
       }
       const space = await resolveSpace(spaceId);
       await space.send(spectrumTyping(state));

--- a/tests/plugins/platforms/photon/test_sidecar_compat.py
+++ b/tests/plugins/platforms/photon/test_sidecar_compat.py
@@ -1,0 +1,338 @@
+"""Compatibility regression tests for Photon sidecar spectrum-ts drift.
+
+These exercise the real Node sidecar against a tiny fake ``spectrum-ts``
+package that intentionally omits the v3-only ``markdown()`` / ``typing()``
+builders. The sidecar must keep outbound delivery working (markdown falls back
+to ``text()``) and skip typing indicators without turning either path into a
+500.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import textwrap
+import time
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import pytest
+
+
+NODE_BIN = shutil.which("node")
+
+
+_PATCHABLE_SPECTRUM_CHUNK = textwrap.dedent(
+    """
+    var rebuildFromAppleMessage = async (client, message, phone, chatGuidHint) => {
+      const messageGuidStr = message.guid;
+      const timestamp = message.dateCreated ?? /* @__PURE__ */ new Date();
+      const base = buildMessageBase(message, chatGuidHint, timestamp, phone);
+      const attachments = messageAttachments(message);
+      if (attachments.length === 1) {
+        const info = attachments[0];
+        if (!info) {
+          throw new Error("Unreachable: attachments.length === 1 but no element");
+        }
+        return buildAttachmentMessage(client, base, info, messageGuidStr, 0);
+      }
+      if (attachments.length > 1) {
+        const items = [];
+        for (let i = 0; i < attachments.length; i++) {
+          const info = attachments[i];
+          if (!info) {
+            continue;
+          }
+          items.push(
+            await buildAttachmentMessage(
+              client,
+              base,
+              info,
+              formatChildId(i, messageGuidStr),
+              i,
+              messageGuidStr
+            )
+          );
+        }
+        return {
+          ...base,
+          id: messageGuidStr,
+          content: asProviderGroup(items)
+        };
+      }
+      if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) {
+        return toRichlinkMessage(message, base, messageGuidStr);
+      }
+      const text2 = message.content.text;
+      return {
+        ...base,
+        id: messageGuidStr,
+        content: text2 ? asText(text2) : asCustom(message)
+      };
+    };
+    var toInboundMessages = async (client, cache, event, phone) => {
+      const base = buildMessageBase(
+        event.message,
+        event.chatGuid,
+        event.occurredAt,
+        phone
+      );
+      const messageGuidStr = event.message.guid;
+      if (getBalloonBundleId(event.message) === URL_BALLOON_BUNDLE_ID) {
+        const msg2 = toRichlinkMessage(event.message, base, messageGuidStr);
+        cacheMessage(cache, msg2);
+        return [msg2];
+      }
+      const attachments = messageAttachments(event.message);
+      if (attachments.length === 1) {
+        const info = attachments[0];
+        if (!info) {
+          throw new Error("Unreachable: attachments.length === 1 but no element");
+        }
+        const msg2 = await buildAttachmentMessage(
+          client,
+          base,
+          info,
+          messageGuidStr,
+          0
+        );
+        cacheMessage(cache, msg2);
+        return [msg2];
+      }
+      if (attachments.length > 1) {
+        const items = [];
+        for (let i = 0; i < attachments.length; i++) {
+          const info = attachments[i];
+          if (!info) {
+            continue;
+          }
+          items.push(
+            await buildAttachmentMessage(
+              client,
+              base,
+              info,
+              formatChildId(i, messageGuidStr),
+              i,
+              messageGuidStr
+            )
+          );
+        }
+        const parent = {
+          ...base,
+          id: messageGuidStr,
+          content: asProviderGroup(items)
+        };
+        cacheMessage(cache, parent);
+        return [parent];
+      }
+      const text2 = event.message.content.text;
+      const msg = {
+        ...base,
+        id: messageGuidStr,
+        content: text2 ? asText(text2) : asCustom(event.message)
+      };
+      cacheMessage(cache, msg);
+      return [msg];
+    };
+    """
+)
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _post_json(base_url: str, token: str, path: str, body: dict) -> dict:
+    req = Request(
+        f"{base_url}{path}",
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "X-Hermes-Sidecar-Token": token,
+        },
+        method="POST",
+    )
+    with urlopen(req, timeout=5) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _write_fake_spectrum(sidecar_dir: Path) -> None:
+    spectrum_dir = sidecar_dir / "node_modules" / "spectrum-ts"
+    providers_dir = spectrum_dir / "providers"
+    dist_dir = spectrum_dir / "dist"
+    providers_dir.mkdir(parents=True)
+    dist_dir.mkdir(parents=True)
+
+    (spectrum_dir / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "spectrum-ts",
+                "version": "2.0.0",
+                "type": "module",
+                "exports": {
+                    ".": "./index.js",
+                    "./providers/imessage": "./providers/imessage.js",
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (spectrum_dir / "index.js").write_text(
+        textwrap.dedent(
+            """
+            export async function Spectrum() {
+              return {
+                messages: (async function* () {
+                  await new Promise(() => {});
+                })(),
+                async stop() {},
+              };
+            }
+
+            export const text = (value) => ({ kind: "text", value });
+            export const attachment = (value, options) => ({ kind: "attachment", value, options });
+            export const voice = (value, options) => ({ kind: "voice", value, options });
+            """
+        ),
+        encoding="utf-8",
+    )
+    (providers_dir / "imessage.js").write_text(
+        textwrap.dedent(
+            """
+            function makeReactionHandle() {
+              return {
+                id: "reaction-1",
+                async unsend() {},
+              };
+            }
+
+            function makeMessage(id) {
+              return {
+                id,
+                async react() {
+                  return makeReactionHandle();
+                },
+              };
+            }
+
+            function makeSpace(id) {
+              return {
+                id,
+                async send(builder) {
+                  return { id: `${builder.kind || "message"}-1` };
+                },
+                async getMessage(id) {
+                  return makeMessage(id);
+                },
+                async unsend() {},
+              };
+            }
+
+            export function imessage(app) {
+              return {
+                space: {
+                  async create(id) {
+                    return makeSpace(id);
+                  },
+                  async get(id) {
+                    return makeSpace(id);
+                  },
+                },
+              };
+            }
+
+            imessage.config = () => ({ provider: "imessage" });
+            """
+        ),
+        encoding="utf-8",
+    )
+    (dist_dir / "chunk-test.js").write_text(
+        _PATCHABLE_SPECTRUM_CHUNK,
+        encoding="utf-8",
+    )
+
+
+def _copy_sidecar_sources(tmp_path: Path) -> Path:
+    src_dir = Path("plugins/platforms/photon/sidecar")
+    sidecar_dir = tmp_path / "sidecar"
+    sidecar_dir.mkdir()
+    shutil.copy2(src_dir / "index.mjs", sidecar_dir / "index.mjs")
+    shutil.copy2(
+        src_dir / "patch-spectrum-mixed-attachments.mjs",
+        sidecar_dir / "patch-spectrum-mixed-attachments.mjs",
+    )
+    _write_fake_spectrum(sidecar_dir)
+    return sidecar_dir
+
+
+@pytest.mark.skipif(NODE_BIN is None, reason="node is required for Photon sidecar tests")
+def test_sidecar_degrades_builder_drift_without_dropping_replies(tmp_path: Path) -> None:
+    sidecar_dir = _copy_sidecar_sources(tmp_path)
+    port = _free_port()
+    token = "test-sidecar-token"
+    proc = subprocess.Popen(
+        [NODE_BIN, "index.mjs"],
+        cwd=sidecar_dir,
+        env={
+            **os.environ,
+            "PHOTON_PROJECT_ID": "proj-test",
+            "PHOTON_PROJECT_SECRET": "secret-test",
+            "PHOTON_SIDECAR_PORT": str(port),
+            "PHOTON_SIDECAR_TOKEN": token,
+        },
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    base_url = f"http://127.0.0.1:{port}"
+
+    try:
+        deadline = time.time() + 10
+        while True:
+            try:
+                health = _post_json(base_url, token, "/healthz", {})
+                if health.get("ok") is True:
+                    break
+            except (HTTPError, URLError, OSError):
+                if time.time() >= deadline:
+                    raise
+                time.sleep(0.1)
+
+        sent = _post_json(
+            base_url,
+            token,
+            "/send",
+            {
+                "spaceId": "+15551234567",
+                "text": "**hello**",
+                "format": "markdown",
+            },
+        )
+        typing = _post_json(
+            base_url,
+            token,
+            "/typing",
+            {"spaceId": "+15551234567", "state": "start"},
+        )
+
+        assert sent["ok"] is True
+        assert sent["messageId"] == "text-1"
+        assert typing == {"ok": True, "skipped": True}
+    finally:
+        try:
+            _post_json(base_url, token, "/shutdown", {})
+        except Exception:
+            proc.terminate()
+        proc.wait(timeout=10)
+
+    stderr = (proc.stderr.read() if proc.stderr else "") or ""
+    assert "loaded spectrum-ts@2.0.0" in stderr
+    assert "missing markdown()" in stderr
+    assert "missing typing()" in stderr

--- a/tests/plugins/platforms/photon/test_sidecar_install.py
+++ b/tests/plugins/platforms/photon/test_sidecar_install.py
@@ -1,0 +1,107 @@
+"""Tests for Photon sidecar install verification.
+
+The sidecar pin is exact because ``spectrum-ts`` ships breaking majors. After
+``npm ci`` / ``npm install`` completes, Hermes should verify that
+``node_modules`` really matches the committed pin instead of silently
+continuing with a drifted tree that will break outbound iMessage sends.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from plugins.platforms.photon import cli
+
+
+def _write_sidecar_tree(
+    root: Path,
+    *,
+    expected: str = "3.1.0",
+    lock_spec: str = "3.1.0",
+    lock_version: str = "3.1.0",
+    installed: str = "3.1.0",
+) -> Path:
+    sidecar_dir = root / "sidecar"
+    (sidecar_dir / "node_modules" / "spectrum-ts").mkdir(parents=True)
+    (sidecar_dir / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "@hermes-agent/photon-sidecar",
+                "private": True,
+                "dependencies": {"spectrum-ts": expected},
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (sidecar_dir / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "name": "@hermes-agent/photon-sidecar",
+                "lockfileVersion": 3,
+                "packages": {
+                    "": {"dependencies": {"spectrum-ts": lock_spec}},
+                    "node_modules/spectrum-ts": {"version": lock_version},
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (sidecar_dir / "node_modules" / "spectrum-ts" / "package.json").write_text(
+        json.dumps({"name": "spectrum-ts", "version": installed}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return sidecar_dir
+
+
+def test_spectrum_drift_messages_detect_installed_mismatch(tmp_path: Path) -> None:
+    sidecar_dir = _write_sidecar_tree(tmp_path, installed="2.0.0")
+
+    issues = cli._sidecar_spectrum_drift_messages(sidecar_dir)
+
+    assert any("installed spectrum-ts@2.0.0" in issue for issue in issues)
+
+
+def test_install_sidecar_fails_when_verification_detects_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    sidecar_dir = _write_sidecar_tree(tmp_path, installed="2.0.0")
+    monkeypatch.setattr(cli, "_SIDECAR_DIR", sidecar_dir)
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/bin/npm")
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0),
+    )
+
+    rc = cli._install_sidecar()
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "sidecar install verification failed" in err
+    assert "installed spectrum-ts@2.0.0" in err
+
+
+def test_install_sidecar_succeeds_when_versions_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    sidecar_dir = _write_sidecar_tree(tmp_path)
+    monkeypatch.setattr(cli, "_SIDECAR_DIR", sidecar_dir)
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/bin/npm")
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0),
+    )
+
+    rc = cli._install_sidecar()
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "sidecar deps verified" in out


### PR DESCRIPTION
## What does this PR do?

Fixes a Photon sidecar failure mode where outbound iMessage replies crash when the installed `spectrum-ts` under `plugins/platforms/photon/sidecar/node_modules` drifts away from the committed `3.1.0` pin.

This change addresses the problem in two places:
- the sidecar now feature-detects optional builders and keeps outbound delivery working when `markdown()` or `typing()` are missing
- `hermes photon install-sidecar` now verifies that `package.json`, `package-lock.json`, and the installed `node_modules/spectrum-ts` version all agree before reporting success

That turns the previous cryptic runtime `TypeError` into an actionable install warning while preserving outbound delivery on the cheap compatibility path.

## Related Issue

Fixes #49640

Related: #48992

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add sidecar startup compatibility warnings for version drift and missing optional builders in `plugins/platforms/photon/sidecar/index.mjs`
- keep `/send` working by falling back from `markdown()` to `text()` when the installed SDK line does not export `markdown()`
- keep `/typing` from 500ing by returning `{\"ok\": true, \"skipped\": true}` when `typing()` is unavailable
- hard-fail sidecar startup if required builders like `Spectrum`, `text`, `attachment`, or `voice` are missing entirely
- verify `spectrum-ts` pin / lock / installed version consistency after `npm ci` / fallback `npm install` in `plugins/platforms/photon/cli.py`
- add regression coverage for drifted installs and the compatibility fallback path in `tests/plugins/platforms/photon/test_sidecar_install.py` and `tests/plugins/platforms/photon/test_sidecar_compat.py`

## How to Test

1. Run `uv run pytest tests/plugins/platforms/photon/test_sidecar_install.py tests/plugins/platforms/photon/test_sidecar_compat.py -q`
2. Run `uv run pytest tests/plugins/platforms/photon/test_markdown.py tests/plugins/platforms/photon/test_sidecar_lifecycle.py tests/plugins/platforms/photon/test_setup_access.py -q`
3. Run `uv run pytest tests/plugins/platforms/photon/test_spectrum_patch.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no docs changes needed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.
