### PR TITLE
feat(delegate): unbounded task queue + per-task model routing

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1917,8 +1917,19 @@ DEFAULT_CONFIG = {
                                      # (floor 30s) to enforce a hard cap.
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
                                  # "low", "minimal", "none" (empty = inherit parent's level)
-        "max_concurrent_children": 3,  # max parallel children per batch; floor of 1 enforced, no ceiling
+        "max_concurrent_children": 3,  # max parallel children per batch; floor of 1 enforced, no ceiling.
+                                       # Tasks beyond this are queued and start as workers free up —
+                                       # the limit caps concurrency, NOT total task count.
         "max_async_children": 3,  # max concurrent background (background=true) subagents; new dispatches rejected at capacity
+        # Per-task model routing: map task kinds to different provider:model pairs
+        # so coding tasks use one model, research another, PM another — all in
+        # a single delegate_task batch call. When absent, all children inherit
+        # delegation.model/provider.
+        # task_routing:
+        #   coding:     {provider: zai,           model: "glm-5.2:cloud"}
+        #   research:   {provider: kimi-coding,   model: "kimi-k2.7-code:cloud"}
+        #   pm:         {provider: minimax,       model: "minimax-m3:cloud"}
+        #   default:    {provider: openrouter,    model: "google/gemini-3-flash-preview"}
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —
         # raise deliberately, each level multiplies API cost.

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -99,7 +99,7 @@ class TestDelegateRequirements(unittest.TestCase):
         # Top-level description names the user's spawn-depth limit explicitly.
         self.assertIn(f"max_spawn_depth={max_depth}", desc)
         # tasks parameter description repeats the concurrency cap.
-        self.assertIn(f"up to {max_children}", tasks_desc)
+        self.assertIn(f"Up to {max_children}", tasks_desc)
         # role parameter description names the spawn-depth limit.
         self.assertIn(f"max_spawn_depth={max_depth}", role_desc)
         # The misleading "default 3" / "default 2" wording is gone from
@@ -273,20 +273,28 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("could not be parsed as JSON", result["error"])
         mock_run.assert_not_called()
 
+    @patch("tools.delegate_tool._get_max_concurrent_children", return_value=2)
     @patch("tools.delegate_tool._run_single_child")
-    def test_batch_capped_at_3(self, mock_run):
-        mock_run.return_value = {
-            "task_index": 0, "status": "completed",
-            "summary": "Done", "api_calls": 1, "duration_seconds": 1.0
-        }
+    def test_batch_queues_tasks_beyond_concurrency_limit(self, mock_run, _mock_limit):
+        def fake_run(task_index, goal, child, parent_agent):
+            return {
+                "task_index": task_index,
+                "status": "completed",
+                "summary": f"Done {goal}",
+                "api_calls": 1,
+                "duration_seconds": 1.0,
+            }
+
+        mock_run.side_effect = fake_run
         parent = _make_mock_parent()
-        limit = _get_max_concurrent_children()
-        tasks = [{"goal": f"Task {i}"} for i in range(limit + 2)]
+        tasks = [{"goal": f"Task {i}"} for i in range(5)]
+
         result = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
-        # Should return an error instead of silently truncating
-        self.assertIn("error", result)
-        self.assertIn("Too many tasks", result["error"])
-        mock_run.assert_not_called()
+
+        self.assertNotIn("error", result)
+        self.assertEqual(len(result["results"]), 5)
+        self.assertEqual([r["task_index"] for r in result["results"]], [0, 1, 2, 3, 4])
+        self.assertEqual(mock_run.call_count, 5)
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_ignores_toplevel_goal(self, mock_run):
@@ -1395,6 +1403,80 @@ class TestDelegationProviderIntegration(unittest.TestCase):
                 self.assertEqual(call.kwargs.get("override_base_url"), "https://openrouter.ai/api/v1")
                 self.assertEqual(call.kwargs.get("override_api_key"), "sk-or-batch")
                 self.assertEqual(call.kwargs.get("override_api_mode"), "chat_completions")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_batch_mode_routes_children_by_task_kind(self, mock_creds, mock_cfg):
+        """Tasks can be routed to different provider:model pairs by goal/toolsets."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "fallback-model",
+            "provider": "fallback-provider",
+            "task_routing": {
+                "coding": {"provider": "zai", "model": "glm-5.2:cloud"},
+                "research": {"provider": "kimi-coding", "model": "kimi-k2.7-code:cloud"},
+                "pm": {"provider": "minimax", "model": "minimax-m3:cloud"},
+            },
+        }
+        mock_creds.side_effect = [
+            {
+                "model": "fallback-model",
+                "provider": "fallback-provider",
+                "base_url": "https://fallback.example/v1",
+                "api_key": "fallback-key",
+                "api_mode": "chat_completions",
+            },
+            {
+                "model": "glm-5.2:cloud",
+                "provider": "zai",
+                "base_url": "https://glm.example/v1",
+                "api_key": "glm-key",
+                "api_mode": "chat_completions",
+            },
+            {
+                "model": "kimi-k2.7-code:cloud",
+                "provider": "kimi-coding",
+                "base_url": "https://kimi.example/v1",
+                "api_key": "kimi-key",
+                "api_mode": "anthropic_messages",
+            },
+            {
+                "model": "minimax-m3:cloud",
+                "provider": "minimax",
+                "base_url": "https://minimax.example/v1",
+                "api_key": "minimax-key",
+                "api_mode": "chat_completions",
+            },
+        ]
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.side_effect = [MagicMock(), MagicMock(), MagicMock()]
+            mock_run.side_effect = [
+                {"task_index": 0, "status": "completed", "summary": "code", "api_calls": 1, "duration_seconds": 1.0},
+                {"task_index": 1, "status": "completed", "summary": "research", "api_calls": 1, "duration_seconds": 1.0},
+                {"task_index": 2, "status": "completed", "summary": "pm", "api_calls": 1, "duration_seconds": 1.0},
+            ]
+
+            tasks = [
+                {"goal": "Fix the failing Python tests", "toolsets": ["terminal", "file"]},
+                {"goal": "Research current provider docs", "toolsets": ["web"]},
+                {"goal": "Create a release plan and prioritize scope"},
+            ]
+            result = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+
+            self.assertEqual(len(result["results"]), 3)
+            self.assertEqual([c.kwargs.get("model") for c in mock_build.call_args_list], [
+                "glm-5.2:cloud",
+                "kimi-k2.7-code:cloud",
+                "minimax-m3:cloud",
+            ])
+            self.assertEqual([c.kwargs.get("override_provider") for c in mock_build.call_args_list], [
+                "zai",
+                "kimi-coding",
+                "minimax",
+            ])
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2039,27 +2039,74 @@ def _run_single_child(
             logger.debug("Failed to close child agent after delegation")
 
 
-def _recover_tasks_from_json_string(
-    tasks: Any,
-) -> tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+def _recover_tasks_from_json_string(tasks: Any) -> tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+    """Accept accidental JSON-stringified tasks arrays from model/tool adapters."""
     if not isinstance(tasks, str):
         return None, None
     raw = tasks.strip()
     if not raw:
-        return None, "Provide either 'goal' (single task) or 'tasks' (batch)."
+        return None, None
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as exc:
         return None, (
-            "tasks must be a JSON array of task objects; received a string "
-            f"that could not be parsed as JSON ({exc.msg})."
+            "The 'tasks' argument was a string that could not be parsed as JSON. "
+            f"Pass an array of task objects instead. JSON error: {exc.msg}."
         )
     if not isinstance(parsed, list):
         return None, (
-            f"tasks must be a JSON array of task objects; parsed "
-            f"{type(parsed).__name__} instead."
+            "The 'tasks' argument was a JSON string, but it decoded to "
+            f"{type(parsed).__name__} instead of a list."
         )
     return parsed, None
+
+
+def _infer_task_route_key(task: Dict[str, Any]) -> Optional[str]:
+    """Infer a coarse routing bucket for a delegated task.
+
+    The router is deterministic and local: it never calls an LLM, and a task
+    may override it explicitly with ``route``/``kind``/``type``.
+    """
+    for key in ("route", "kind", "type", "category"):
+        value = str(task.get(key) or "").strip().lower()
+        if value:
+            return value
+
+    text = " ".join(
+        str(part or "").lower()
+        for part in (
+            task.get("goal"),
+            task.get("context"),
+            " ".join(task.get("toolsets") or []),
+        )
+    )
+    if any(word in text for word in ("research", "search", "look up", "lookup", "docs", "web")):
+        return "research"
+    if any(word in text for word in ("plan", "roadmap", "prioritize", "priority", "release", "pm")):
+        return "pm"
+    if any(word in text for word in ("code", "coding", "implement", "fix", "test", "debug", "refactor", "terminal", "file")):
+        return "coding"
+    if any(word in text for word in ("architecture", "design", "system", "infra", "structure")):
+        return "engineering"
+    return None
+
+
+def _route_task_config(base_cfg: dict, task: Dict[str, Any]) -> dict:
+    """Return delegation config overrides for one task, if task_routing matches."""
+    routing = base_cfg.get("task_routing") or base_cfg.get("routes") or {}
+    if not isinstance(routing, dict):
+        return base_cfg
+
+    route_key = _infer_task_route_key(task)
+    route_cfg = routing.get(route_key or "") or routing.get("default")
+    if not isinstance(route_cfg, dict):
+        return base_cfg
+
+    merged = dict(base_cfg)
+    for key in ("model", "provider", "base_url", "api_key", "api_mode"):
+        if key in route_cfg:
+            merged[key] = route_cfg.get(key)
+    return merged
 
 
 def delegate_task(
@@ -2168,14 +2215,11 @@ def delegate_task(
         tasks = recovered_tasks
 
     if tasks and isinstance(tasks, list):
-        if len(tasks) > max_children:
-            return tool_error(
-                f"Too many tasks: {len(tasks)} provided, but "
-                f"max_concurrent_children is {max_children}. "
-                f"Either reduce the task count, split into multiple "
-                f"delegate_task calls, or increase "
-                f"delegation.max_concurrent_children in config.yaml."
-            )
+        # Accept any number of tasks. max_concurrent_children is a concurrency
+        # limit, not a total task-count limit: ThreadPoolExecutor queues the
+        # remainder and starts them as workers free up. This lets models hand
+        # over large decompositions in one call without creating unbounded
+        # parallelism or forcing manual multi-call chunking.
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
@@ -2220,26 +2264,37 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task routing: when delegation.task_routing is configured,
+            # resolve credentials per task based on goal/toolsets heuristics.
+            # Falls back to the batch-level creds when no route matches.
+            task_cfg = _route_task_config(cfg, t)
+            if task_cfg is not cfg:
+                try:
+                    task_creds = _resolve_delegation_credentials(task_cfg, parent_agent)
+                except ValueError:
+                    task_creds = creds
+            else:
+                task_creds = creds
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or task_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else task_creds.get("args"))
                 ),
                 role=effective_role,
             )
@@ -2843,10 +2898,9 @@ def _build_top_level_description() -> str:
         "never enter your context window.\n\n"
         "TWO MODES (one of 'goal' or 'tasks' is required):\n"
         "1. Single task: provide 'goal' (+ optional context, toolsets)\n"
-        f"2. Batch (parallel): provide 'tasks' array with up to {max_children} "
-        f"items concurrently for this user (configured via "
-        f"delegation.max_concurrent_children in config.yaml). "
-        f"All run in parallel and results are returned together. {nesting_clause}\n\n"
+        f"2. Batch (parallel): provide 'tasks' array — up to {max_children} "
+        f"run concurrently (delegation.max_concurrent_children); extra tasks "
+        f"queue automatically with no total cap. {nesting_clause}\n\n"
         "WHEN TO USE delegate_task:\n"
         "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
         "- Tasks that would flood your context with intermediate data\n"
@@ -2898,9 +2952,10 @@ def _build_tasks_param_description() -> str:
     except Exception:
         max_children = _DEFAULT_MAX_CONCURRENT_CHILDREN
     return (
-        f"Batch mode: tasks to run in parallel (up to {max_children} for this "
-        f"user, set via delegation.max_concurrent_children). Each gets "
-        "its own subagent with isolated context and terminal session. "
+        f"Batch mode: tasks to run. Up to {max_children} run concurrently "
+        f"(set via delegation.max_concurrent_children); additional tasks are "
+        f"queued and start as workers free up — there is NO total task limit. "
+        "Each gets its own subagent with isolated context and terminal session. "
         "When provided, top-level goal/context/toolsets are ignored."
     )
 


### PR DESCRIPTION
## Summary
- Remove total task-count limit from `delegate_task`: `max_concurrent_children` now caps **concurrency** only, not batch size. Extra tasks queue automatically via `ThreadPoolExecutor`'s internal queue — no unbounded parallelism, just sequential batch processing.
- Add `delegation.task_routing` config for per-task provider:model routing. Each task in a batch can use a different model based on goal/toolsets heuristics (deterministic, no LLM call).
- Update schema descriptions to advertise unbounded batch size.

## Example config
```yaml
delegation:
  task_routing:
    coding:     {provider: zai,         model: "glm-5.2:cloud"}
    research:   {provider: kimi-coding, model: "kimi-k2.7-code:cloud"}
    pm:         {provider: minimax,     model: "minimax-m3:cloud"}
    default:    {provider: openrouter,  model: "google/gemini-3-flash-preview"}
```

## Test Plan
- [x] `uv run --extra dev python -m pytest tests/tools/test_delegate.py -q --tb=short -o 'addopts='`
- [x] `uv run --extra dev ruff check tools/delegate_tool.py tests/tools/test_delegate.py hermes_cli/config.py`
- [x] `git diff --check`

## Verification
- Focused pytest: **141 passed** in 29s
- Ruff: **All checks passed!**
- Diff hygiene: clean
- 8/8 independent verification agents passed (safety, logic, config, schema, overlap, release)

## Notes
- `ThreadPoolExecutor(max_workers=N)` already has an unbounded internal queue; this PR simply stops rejecting tasks beyond `max_concurrent_children` and lets the executor queue them naturally.
- Task routing is deterministic: `_infer_task_route_key` uses keyword matching on goal/context/toolsets, never calls an LLM. Tasks can override via `route`/`kind`/`type` fields.
- No overlap with PR #49585 (security contracts) or #49675 (self-learning contracts).