### PR TITLE
feat(browser): parallel browser execution across multiple agents and profiles

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1309,6 +1309,19 @@ DEFAULT_CONFIG = {
         "cdp_url": "",  # Optional persistent CDP endpoint for attaching to an existing Chromium/Chrome
         "allow_unsafe_evaluate": False,  # Legacy override: when true, browser_console(expression=...) bypasses the restrict_evaluate denylist entirely
         "restrict_evaluate": False,  # Opt-in denylist blocking sensitive JS primitives (cookies/storage/clipboard/network/form values) in browser_console(expression=...)
+        # Named browser profiles for account / cookie-jar isolation.  Maps a
+        # profile name to a CDP endpoint, each typically a separate persistent
+        # Chrome with its own user-data-dir (cookies, logins, storage).  This
+        # lets the agent operate distinct identities — e.g. its own browser vs.
+        # the user's authenticated accounts — without cross-contaminating
+        # sessions.  ``browser_navigate(profile="<name>")`` selects one; calls
+        # with no profile use ``profiles["default"]``, which falls back to
+        # ``cdp_url`` above when unset (so existing single-endpoint configs keep
+        # working unchanged).  Example:
+        #   profiles:
+        #     default: http://localhost:9224
+        #     work:    http://localhost:9225
+        "profiles": {},
         # CDP supervisor — dialog + frame detection via a persistent WebSocket.
         # Active only when a CDP-capable backend is attached (Browserbase or
         # local Chrome via /browser connect). See

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -665,6 +665,18 @@ DEFAULT_CONFIG = {
         "real_profile_pin": "",
         "allow_unsafe_evaluate": False,  # Legacy override: when true, browser_console(expression=...) bypasses the restrict_evaluate denylist entirely
         "restrict_evaluate": False,  # Opt-in denylist blocking sensitive JS primitives (cookies/storage/clipboard/network/form values) in browser_console(expression=...)
+        # Named browser profiles for account / cookie-jar isolation.  Maps a
+        # profile name to a CDP endpoint, each typically a separate persistent
+        # Chrome.  Selecting a profile pins that session to its own endpoint, which
+        # lets the agent operate distinct identities — e.g. its own browser vs.
+        # a user's — and run different-profile sessions fully in parallel.  Calls
+        # with no profile use ``profiles["default"]``, which falls back to
+        # ``cdp_url`` above when unset (so existing single-endpoint configs keep
+        # working).  Example:
+        #   profiles:
+        #     default: http://localhost:9224
+        #     work:    http://localhost:9225
+        "profiles": {},
         # CDP supervisor — dialog + frame detection via a persistent WebSocket.
         # Active only when a CDP-capable backend is attached (Browserbase or
         # local Chrome via /browser connect). See

--- a/tests/tools/test_browser_profiles.py
+++ b/tests/tools/test_browser_profiles.py
@@ -1,0 +1,443 @@
+"""Tests for named browser profiles (account / cookie-jar isolation).
+
+``browser.profiles`` maps a profile name to a CDP endpoint, each typically a
+separate persistent Chrome with its own user-data-dir (cookies, logins). This
+lets the agent operate distinct identities — its own browser vs. the user's
+authenticated accounts — without cross-contaminating sessions.
+
+``browser_navigate(profile="<name>")`` binds the navigation, and every
+follow-up snapshot/click/type on the same task, to that profile's endpoint via
+a composite session key ``{task_id}::profile:{name}`` — mirroring the
+``::local`` hybrid-routing precedent.
+
+These tests cover the resolution layer (profiles map read, CDP resolution,
+legacy fallback, unknown-profile error), session-key composition/parsing,
+session creation routing, the navigate-level validation gate, and cleanup
+fan-out. They assert behavior contracts (how the pieces relate), not frozen
+snapshots.
+"""
+from unittest.mock import Mock
+
+import pytest
+
+import tools.browser_tool as browser_tool
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    """Clear module-level caches so each test starts clean."""
+    monkeypatch.setattr(browser_tool, "_active_sessions", {})
+    monkeypatch.setattr(browser_tool, "_last_active_session_key", {})
+    monkeypatch.setattr(browser_tool, "_start_browser_cleanup_thread", lambda: None)
+    monkeypatch.setattr(browser_tool, "_update_session_activity", lambda t: None)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    # No global override / cloud provider unless a test sets one.
+    monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "")
+    monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: None)
+    # Same-profile concurrency registries — reset so tests don't leak tabs/locks.
+    monkeypatch.setattr(browser_tool, "_endpoint_locks", {})
+    monkeypatch.setattr(browser_tool, "_session_owned_tab", {})
+    monkeypatch.setattr(browser_tool, "_session_endpoint", {})
+
+
+def _set_profiles(monkeypatch, mapping):
+    """Point _get_browser_profiles at a fixed mapping, identity CDP resolve."""
+    monkeypatch.setattr(browser_tool, "_get_browser_profiles", lambda: dict(mapping))
+    monkeypatch.setattr(browser_tool, "_resolve_cdp_override", lambda u: u)
+
+
+class TestProfilesMapRead:
+    """_get_browser_profiles reads browser.profiles, coercing/filtering."""
+
+    def test_reads_mapping_from_config(self, monkeypatch):
+        def fake_cfg():
+            return {"browser": {"profiles": {
+                "default": "http://localhost:9224",
+                "work": "http://localhost:9225",
+            }}}
+
+        import hermes_cli.config as cfg
+        monkeypatch.setattr(cfg, "read_raw_config", fake_cfg)
+        out = browser_tool._get_browser_profiles()
+        assert out == {
+            "default": "http://localhost:9224",
+            "work": "http://localhost:9225",
+        }
+
+    def test_missing_profiles_returns_empty(self, monkeypatch):
+        import hermes_cli.config as cfg
+        monkeypatch.setattr(cfg, "read_raw_config", lambda: {"browser": {}})
+        assert browser_tool._get_browser_profiles() == {}
+
+    def test_drops_empty_and_nonstring_values(self, monkeypatch):
+        import hermes_cli.config as cfg
+        monkeypatch.setattr(cfg, "read_raw_config", lambda: {"browser": {"profiles": {
+            "good": "http://localhost:9225",
+            "blank": "   ",
+            "nullish": None,
+            "": "http://localhost:9999",
+        }}})
+        assert browser_tool._get_browser_profiles() == {"good": "http://localhost:9225"}
+
+
+class TestProfileResolution:
+    """_resolve_profile_cdp maps a name to a concrete CDP URL or raises."""
+
+    def test_named_profile_resolves(self, monkeypatch):
+        _set_profiles(monkeypatch, {"work": "http://localhost:9225"})
+        assert browser_tool._resolve_profile_cdp("work") == "http://localhost:9225"
+
+    def test_default_falls_back_to_legacy_cdp_url(self, monkeypatch):
+        """default profile with no profiles entry uses legacy browser.cdp_url."""
+        monkeypatch.setattr(browser_tool, "_get_browser_profiles", lambda: {})
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://localhost:9224/x")
+        assert browser_tool._resolve_profile_cdp("default") == "ws://localhost:9224/x"
+
+    def test_default_explicit_entry_wins_over_legacy(self, monkeypatch):
+        _set_profiles(monkeypatch, {"default": "http://localhost:9230"})
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://localhost:9224/x")
+        assert browser_tool._resolve_profile_cdp("default") == "http://localhost:9230"
+
+    def test_default_with_nothing_configured_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(browser_tool, "_get_browser_profiles", lambda: {})
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "")
+        assert browser_tool._resolve_profile_cdp("default") == ""
+
+    def test_unknown_profile_raises_no_silent_fallback(self, monkeypatch):
+        """Crossing an account boundary by accident is the failure we prevent."""
+        _set_profiles(monkeypatch, {"work": "http://localhost:9225"})
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://localhost:9224/x")
+        with pytest.raises(ValueError) as ei:
+            browser_tool._resolve_profile_cdp("nonexistent")
+        # Error names the bad profile and lists configured ones.
+        assert "nonexistent" in str(ei.value)
+        assert "work" in str(ei.value)
+
+
+class TestSessionKeyComposition:
+    """Composite session-key build/parse round-trips and isolation invariants."""
+
+    def test_compose_and_parse_round_trip(self):
+        key = browser_tool._compose_profile_session_key("task-1", "work")
+        assert key == "task-1::profile:work"
+        assert browser_tool._profile_from_session_key(key) == "work"
+
+    def test_bare_key_has_no_profile(self):
+        assert browser_tool._profile_from_session_key("task-1") is None
+
+    def test_local_sidecar_key_has_no_profile(self):
+        assert browser_tool._profile_from_session_key("task-1::local") is None
+
+    def test_profile_key_is_not_a_local_sidecar(self):
+        """Profile keys must not be mistaken for ::local sidecars."""
+        key = browser_tool._compose_profile_session_key("task-1", "work")
+        assert not browser_tool._is_local_sidecar_key(key)
+
+    def test_distinct_profiles_yield_distinct_keys(self):
+        a = browser_tool._compose_profile_session_key("t", "alice")
+        b = browser_tool._compose_profile_session_key("t", "bob")
+        assert a != b  # isolation: two accounts never collide on one key
+
+
+class TestSessionCreationRouting:
+    """_get_session_info binds a profile key to that profile's CDP endpoint."""
+
+    def test_profile_key_creates_cdp_session_for_its_endpoint(self, monkeypatch):
+        _set_profiles(monkeypatch, {"work": "ws://localhost:9225/devtools/browser/abc"})
+        monkeypatch.setattr(browser_tool, "_ensure_cdp_supervisor", lambda t: None)
+
+        key = browser_tool._compose_profile_session_key("default", "work")
+        session = browser_tool._get_session_info(key)
+
+        assert session["cdp_url"] == "ws://localhost:9225/devtools/browser/abc"
+        assert session["features"].get("cdp_override") is True
+
+    def test_two_profiles_get_independent_sessions(self, monkeypatch):
+        _set_profiles(monkeypatch, {
+            "alice": "ws://localhost:9225/a",
+            "bob": "ws://localhost:9226/b",
+        })
+        monkeypatch.setattr(browser_tool, "_ensure_cdp_supervisor", lambda t: None)
+
+        ka = browser_tool._compose_profile_session_key("default", "alice")
+        kb = browser_tool._compose_profile_session_key("default", "bob")
+        sa = browser_tool._get_session_info(ka)
+        sb = browser_tool._get_session_info(kb)
+
+        # Distinct endpoints — no cookie-jar cross-contamination.
+        assert sa["cdp_url"] != sb["cdp_url"]
+        assert browser_tool._active_sessions[ka]["cdp_url"] == "ws://localhost:9225/a"
+        assert browser_tool._active_sessions[kb]["cdp_url"] == "ws://localhost:9226/b"
+
+    def test_profile_session_skips_cloud_provider(self, monkeypatch):
+        """A profile pins an explicit endpoint — cloud provider is bypassed."""
+        provider = Mock()
+        provider.create_session.return_value = {"session_name": "x", "cdp_url": "wss://cloud/ws"}
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: provider)
+        _set_profiles(monkeypatch, {"work": "ws://localhost:9225/w"})
+        monkeypatch.setattr(browser_tool, "_ensure_cdp_supervisor", lambda t: None)
+
+        key = browser_tool._compose_profile_session_key("default", "work")
+        session = browser_tool._get_session_info(key)
+
+        assert provider.create_session.call_count == 0
+        assert session["cdp_url"] == "ws://localhost:9225/w"
+
+
+class TestNavigateValidationGate:
+    """browser_navigate(profile=...) validates before doing any work."""
+
+    def test_unknown_profile_returns_error_not_raise(self, monkeypatch):
+        _set_profiles(monkeypatch, {"work": "ws://localhost:9225/w"})
+        out = browser_tool.browser_navigate("https://example.com", profile="ghost")
+        import json
+        data = json.loads(out)
+        assert data["success"] is False
+        assert "ghost" in data["error"]
+
+    def test_profile_resolving_to_empty_returns_error(self, monkeypatch):
+        """default profile with nothing configured → actionable error, no nav."""
+        monkeypatch.setattr(browser_tool, "_get_browser_profiles", lambda: {})
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "")
+        out = browser_tool.browser_navigate("https://example.com", profile="default")
+        import json
+        data = json.loads(out)
+        assert data["success"] is False
+        assert "default" in data["error"]
+
+
+class TestBackwardsCompat:
+    """No profile arg → byte-identical behavior to pre-profiles."""
+
+    def test_no_profile_does_not_compose_profile_key(self, monkeypatch):
+        """A nav without profile keeps the bare task_id (legacy behavior)."""
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: None)
+        key = browser_tool._navigation_session_key("default", "https://example.com")
+        assert browser_tool._profile_from_session_key(key) is None
+
+    def test_legacy_cdp_url_still_resolves_as_default(self, monkeypatch):
+        """Configs with only browser.cdp_url (no profiles) still work."""
+        monkeypatch.setattr(browser_tool, "_get_browser_profiles", lambda: {})
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://localhost:9224/legacy")
+        assert browser_tool._resolve_profile_cdp("default") == "ws://localhost:9224/legacy"
+
+
+class TestCleanupFanOut:
+    """cleanup_browser reaps profile sessions correctly."""
+
+    def test_bare_task_cleanup_reaps_profile_sessions(self, monkeypatch):
+        reaped = []
+        monkeypatch.setattr(browser_tool, "_cleanup_single_browser_session", lambda k: reaped.append(k))
+        monkeypatch.setattr(browser_tool, "_active_sessions", {
+            "default": {"session_name": "primary"},
+            "default::profile:work": {"session_name": "work_sess"},
+            "default::profile:home": {"session_name": "home_sess"},
+        })
+        monkeypatch.setattr(browser_tool, "_last_active_session_key",
+                            {"default": "default::profile:work"})
+
+        browser_tool.cleanup_browser("default")
+
+        assert set(reaped) == {"default", "default::profile:work", "default::profile:home"}
+        assert "default" not in browser_tool._last_active_session_key
+
+    def test_explicit_profile_key_reaps_only_itself(self, monkeypatch):
+        reaped = []
+        monkeypatch.setattr(browser_tool, "_cleanup_single_browser_session", lambda k: reaped.append(k))
+        monkeypatch.setattr(browser_tool, "_active_sessions", {
+            "default": {"session_name": "primary"},
+            "default::profile:work": {"session_name": "work_sess"},
+        })
+        monkeypatch.setattr(browser_tool, "_last_active_session_key",
+                            {"default": "default::profile:work"})
+
+        browser_tool.cleanup_browser("default::profile:work")
+
+        assert reaped == ["default::profile:work"]
+        # The last-active pointer named the exact session we just reaped, so it
+        # must be dropped — leaving it would let a follow-up click/snapshot
+        # resurrect a cleaned session on about:blank. A pointer at a *different*
+        # (still-live) session would be preserved; see below.
+        assert "default" not in browser_tool._last_active_session_key
+
+    def test_explicit_profile_key_preserves_unrelated_pointer(self, monkeypatch):
+        reaped = []
+        monkeypatch.setattr(browser_tool, "_cleanup_single_browser_session", lambda k: reaped.append(k))
+        monkeypatch.setattr(browser_tool, "_active_sessions", {
+            "default": {"session_name": "primary"},
+            "default::profile:work": {"session_name": "work_sess"},
+        })
+        # Pointer names the still-live primary session, not the one being reaped.
+        monkeypatch.setattr(browser_tool, "_last_active_session_key",
+                            {"default": "default"})
+
+        browser_tool.cleanup_browser("default::profile:work")
+
+        assert reaped == ["default::profile:work"]
+        # Reaping one profile session must not disturb a pointer at a live session.
+        assert browser_tool._last_active_session_key.get("default") == "default"
+
+
+class TestEndpointLock:
+    """Per-endpoint serialization: one lock per CDP url, shared across sessions."""
+
+    def test_same_endpoint_shares_one_lock(self):
+        l1 = browser_tool._endpoint_lock_for("http://localhost:9225")
+        l2 = browser_tool._endpoint_lock_for("http://localhost:9225")
+        assert l1 is l2  # same Chrome -> same lock -> commands serialize
+
+    def test_distinct_endpoints_get_distinct_locks(self):
+        l_work = browser_tool._endpoint_lock_for("http://localhost:9225")
+        l_home = browser_tool._endpoint_lock_for("http://localhost:9226")
+        assert l_work is not l_home  # different Chrome -> parallel, never block
+
+
+class TestOwnedTab:
+    """Each profile session acquires and caches its own labeled tab."""
+
+    def test_first_call_opens_tab_second_call_caches(self, monkeypatch):
+        calls = []
+
+        def fake_raw(session_name, cdp_url, argv, timeout=15):
+            calls.append(argv)
+            return {"success": True, "data": {"tabId": "t7"}}
+
+        monkeypatch.setattr(browser_tool, "_run_raw_agent_browser", fake_raw)
+
+        ref1 = browser_tool._ensure_owned_tab("s::profile:work", "cdp_abc", "http://x:9225")
+        ref2 = browser_tool._ensure_owned_tab("s::profile:work", "cdp_abc", "http://x:9225")
+
+        assert ref1 == "t7" and ref2 == "t7"
+        # Only ONE `tab new` — the second call is served from cache.
+        tab_new_calls = [c for c in calls if c[:2] == ["tab", "new"]]
+        assert len(tab_new_calls) == 1
+        assert browser_tool._session_owned_tab["s::profile:work"] == "t7"
+        assert browser_tool._session_endpoint["s::profile:work"] == "http://x:9225"
+
+    def test_acquire_failure_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            browser_tool, "_run_raw_agent_browser",
+            lambda *a, **k: {"success": False, "error": "endpoint down"},
+        )
+        ref = browser_tool._ensure_owned_tab("s::profile:work", "cdp_abc", "http://x:9225")
+        assert ref is None
+        assert "s::profile:work" not in browser_tool._session_owned_tab
+
+    def test_release_closes_and_forgets_tab(self, monkeypatch):
+        closed = []
+        monkeypatch.setattr(
+            browser_tool, "_run_raw_agent_browser",
+            lambda sn, url, argv, timeout=15: closed.append(argv) or {"success": True},
+        )
+        monkeypatch.setattr(browser_tool, "_active_sessions",
+                            {"s::profile:work": {"session_name": "cdp_abc"}})
+        browser_tool._session_owned_tab["s::profile:work"] = "t7"
+        browser_tool._session_endpoint["s::profile:work"] = "http://x:9225"
+
+        browser_tool._release_owned_tab("s::profile:work")
+
+        assert ["tab", "close", "t7"] in closed
+        assert "s::profile:work" not in browser_tool._session_owned_tab
+        assert "s::profile:work" not in browser_tool._session_endpoint
+
+
+class TestSameProfileCommandRouting:
+    """_run_browser_command activates the owned tab (under lock) for profile
+    sessions, and skips all of it for non-profile sessions."""
+
+    def _stub_command_env(self, monkeypatch):
+        """Stub out everything _run_browser_command needs except the profile path."""
+        monkeypatch.setattr(browser_tool, "_safe_command_timeout", lambda: 5)
+        monkeypatch.setattr(browser_tool, "_find_agent_browser", lambda: "agent-browser")
+        monkeypatch.setattr(browser_tool, "_requires_real_termux_browser_install", lambda c: False)
+        monkeypatch.setattr(browser_tool, "_is_local_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_get_browser_engine", lambda: "auto")
+        monkeypatch.setattr(browser_tool, "_build_browser_env", lambda: {})
+        monkeypatch.setattr(browser_tool, "_merge_browser_path", lambda p: p)
+        monkeypatch.setattr(browser_tool, "_socket_safe_tmpdir", lambda: "/tmp")
+        monkeypatch.setattr(browser_tool, "_write_owner_pid", lambda d, n: None)
+        monkeypatch.setattr(browser_tool, "_needs_chromium_sandbox_bypass", lambda: False)
+        monkeypatch.setattr(browser_tool, "_lightpanda_fallback_reason", lambda *a: None)
+        from tools import interrupt
+        monkeypatch.setattr(interrupt, "is_interrupted", lambda: False)
+
+    def test_profile_command_activates_owned_tab_before_running(self, monkeypatch):
+        self._stub_command_env(monkeypatch)
+        order = []
+
+        # Session bound to a profile endpoint.
+        monkeypatch.setattr(browser_tool, "_get_session_info",
+                            lambda tid: {"session_name": "cdp_abc",
+                                         "cdp_url": "http://x:9225"})
+
+        def fake_raw(session_name, cdp_url, argv, timeout=15):
+            order.append(("raw", tuple(argv)))
+            return {"success": True, "data": {"tabId": "t7"}}
+        monkeypatch.setattr(browser_tool, "_run_raw_agent_browser", fake_raw)
+
+        # Intercept the real subprocess spawn — record when the MAIN command runs.
+        class FakeProc:
+            returncode = 0
+            def wait(self, timeout=None): order.append(("main-command", "snapshot"))
+        monkeypatch.setattr(browser_tool.subprocess, "Popen", lambda *a, **k: FakeProc())
+        # File I/O around the spawn: make reads return a valid JSON result.
+        monkeypatch.setattr(browser_tool.os, "open", lambda *a, **k: 0)
+        monkeypatch.setattr(browser_tool.os, "close", lambda fd: None)
+        monkeypatch.setattr(browser_tool.os, "makedirs", lambda *a, **k: None)
+        monkeypatch.setattr(browser_tool.os, "unlink", lambda p: None)
+        import builtins, io
+        real_open = builtins.open
+        def fake_open(path, *a, **k):
+            if isinstance(path, str) and "_stdout_" in path:
+                return io.StringIO('{"success": true, "data": {}}')
+            if isinstance(path, str) and "_stderr_" in path:
+                return io.StringIO("")
+            return real_open(path, *a, **k)
+        monkeypatch.setattr(builtins, "open", fake_open)
+
+        browser_tool._run_browser_command("s::profile:work", "snapshot")
+
+        # The owned-tab activate (a raw `tab t7`) must appear BEFORE the main command.
+        activate_idx = next(i for i, e in enumerate(order)
+                            if e[0] == "raw" and e[1] == ("tab", "t7"))
+        main_idx = next(i for i, e in enumerate(order) if e[0] == "main-command")
+        assert activate_idx < main_idx
+        # And the lock must have been released (available to re-acquire).
+        lock = browser_tool._endpoint_lock_for("http://x:9225")
+        assert lock.acquire(blocking=False)
+        lock.release()
+
+    def test_non_profile_command_skips_tab_machinery(self, monkeypatch):
+        self._stub_command_env(monkeypatch)
+        raw_calls = []
+        monkeypatch.setattr(browser_tool, "_run_raw_agent_browser",
+                            lambda *a, **k: raw_calls.append(a) or {"success": True})
+        # Bare (non-profile) session on the global override endpoint.
+        monkeypatch.setattr(browser_tool, "_get_session_info",
+                            lambda tid: {"session_name": "cdp_abc",
+                                         "cdp_url": "http://x:9224"})
+
+        class FakeProc:
+            returncode = 0
+            def wait(self, timeout=None): pass
+        monkeypatch.setattr(browser_tool.subprocess, "Popen", lambda *a, **k: FakeProc())
+        monkeypatch.setattr(browser_tool.os, "open", lambda *a, **k: 0)
+        monkeypatch.setattr(browser_tool.os, "close", lambda fd: None)
+        monkeypatch.setattr(browser_tool.os, "makedirs", lambda *a, **k: None)
+        monkeypatch.setattr(browser_tool.os, "unlink", lambda p: None)
+        import builtins, io
+        real_open = builtins.open
+        def fake_open(path, *a, **k):
+            if isinstance(path, str) and "_stdout_" in path:
+                return io.StringIO('{"success": true, "data": {}}')
+            if isinstance(path, str) and "_stderr_" in path:
+                return io.StringIO("")
+            return real_open(path, *a, **k)
+        monkeypatch.setattr(builtins, "open", fake_open)
+
+        browser_tool._run_browser_command("bare-task", "snapshot")
+
+        # No tab machinery fired for a non-profile session.
+        assert raw_calls == []
+        assert browser_tool._session_owned_tab == {}
+

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -485,6 +485,78 @@ def _get_cdp_override() -> str:
     return ""
 
 
+# Composite session-key prefix for named browser profiles.  Mirrors
+# ``_LOCAL_SUFFIX`` ("::local") used by hybrid routing — a profile session key
+# is ``f"{task_id}::profile:{name}"``.  Both forms flow through the same
+# _active_sessions / _run_browser_command / cleanup paths; the key is opaque to
+# those internals.
+_PROFILE_PREFIX = "::profile:"
+
+
+def _get_browser_profiles() -> Dict[str, str]:
+    """Return the configured ``browser.profiles`` map (name -> CDP endpoint).
+
+    Read fresh from config on each call (like ``_get_cdp_override``) so a
+    config edit takes effect on the next browser call without a restart.
+    Returns an empty dict when unset or malformed.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {})
+        if isinstance(browser_cfg, dict):
+            profiles = browser_cfg.get("profiles", {})
+            if isinstance(profiles, dict):
+                # Coerce to str->str, dropping empty/invalid entries.
+                return {
+                    str(k): str(v)
+                    for k, v in profiles.items()
+                    if k and isinstance(v, (str,)) and v.strip()
+                }
+    except Exception as e:
+        logger.debug("Could not read browser.profiles from config: %s", e)
+    return {}
+
+
+def _resolve_profile_cdp(profile: str) -> str:
+    """Resolve a named browser profile to a concrete CDP URL.
+
+    Resolution order:
+      1. ``browser.profiles[profile]`` — explicit named endpoint.
+      2. For the implicit ``default`` profile only: fall back to the legacy
+         single-endpoint ``BROWSER_CDP_URL`` env / ``browser.cdp_url`` config
+         (so pre-profiles configs keep working with no ``profiles`` map).
+
+    Raises ``ValueError`` for an unknown non-default profile.  We deliberately
+    do NOT silently fall back to the default endpoint for an unknown name —
+    crossing an account boundary silently is exactly the failure profiles
+    exist to prevent.
+    """
+    profiles = _get_browser_profiles()
+    raw = profiles.get(profile, "")
+    if raw and raw.strip():
+        return _resolve_cdp_override(raw.strip())
+
+    if profile == _DEFAULT_PROFILE:
+        # Legacy fallback: a config with no profiles map but a bare cdp_url.
+        legacy = _get_cdp_override()
+        if legacy:
+            return legacy
+        return ""
+
+    # Unknown named profile — fail loud.
+    known = ", ".join(sorted(profiles)) or "(none configured)"
+    raise ValueError(
+        f"Unknown browser profile {profile!r}. "
+        f"Configured profiles: {known}. "
+        f"Add it under browser.profiles in config.yaml."
+    )
+
+
+_DEFAULT_PROFILE = "default"
+
+
 def _get_dialog_policy_config() -> Tuple[str, float]:
     """Read ``browser.dialog_policy`` + ``browser.dialog_timeout_s`` from config.
 
@@ -1297,11 +1369,194 @@ def _is_local_sidecar_key(session_key: str) -> bool:
     return session_key.endswith(_LOCAL_SUFFIX)
 
 
+def _profile_from_session_key(session_key: str) -> Optional[str]:
+    """Extract the browser-profile name from a composite session key.
+
+    Profile session keys look like ``f"{task_id}::profile:{name}"`` (see
+    ``_PROFILE_PREFIX``).  Returns the ``name`` portion, or ``None`` when the
+    key carries no profile (bare task_id or a ``::local`` sidecar key).
+    """
+    idx = session_key.find(_PROFILE_PREFIX)
+    if idx == -1:
+        return None
+    name = session_key[idx + len(_PROFILE_PREFIX):]
+    return name or None
+
+
+def _compose_profile_session_key(task_id: str, profile: str) -> str:
+    """Build the composite session key for ``task_id`` under ``profile``."""
+    return f"{task_id}{_PROFILE_PREFIX}{profile}"
+
+
 def _bare_task_id_for_session_key(session_key: str) -> str:
-    """Return the owning bare task id for an opaque browser session key."""
+    """Return the owning bare task id for an opaque browser session key.
+
+    Strips a ``::local`` sidecar suffix or a ``::profile:<name>`` suffix so
+    both composite forms map back to the task that owns them.
+    """
     if _is_local_sidecar_key(session_key):
         return session_key[: -len(_LOCAL_SUFFIX)]
+    if _profile_from_session_key(session_key) is not None:
+        return session_key.split(_PROFILE_PREFIX, 1)[0]
     return session_key
+
+
+# ---------------------------------------------------------------------------
+# Same-profile concurrency: per-endpoint serialization + per-session owned tab
+# ---------------------------------------------------------------------------
+# A named profile maps to ONE Chrome (one CDP endpoint).  agent-browser, when
+# attached over ``--cdp``, drives whatever tab is *currently active* in that
+# Chrome — it has no per-invocation "act on tab X" flag, and tab selection does
+# not persist across its stateless subprocess calls.  So two Hermes sessions
+# sharing one profile would fight over the single active tab (session B's
+# navigate steals session A's foreground page).
+#
+# Fix (verified live): give each session its own labeled tab in that Chrome and,
+# for every command, run ``tab <ownref>`` (activate my tab) immediately before
+# the real command, with the pair executed atomically under a per-endpoint lock
+# so no other session's activate can interleave.  Different profiles use
+# different endpoints and different locks, so they stay fully parallel — only
+# same-endpoint traffic serializes.
+#
+# The lock is acquired lazily and only actually contends when 2+ sessions share
+# an endpoint; a lone session pays a single un-contended lock acquire per call.
+_endpoint_locks: Dict[str, threading.Lock] = {}
+_endpoint_locks_guard = threading.Lock()
+# Maps a profile session key -> the agent-browser tab ref (e.g. "t7") it owns on
+# its endpoint.  Absent until the session opens its first tab.
+_session_owned_tab: Dict[str, str] = {}
+# Maps a profile session key -> the resolved CDP endpoint it is bound to, so
+# cleanup can find the right lock without re-resolving config.
+_session_endpoint: Dict[str, str] = {}
+
+
+def _endpoint_lock_for(cdp_url: str) -> threading.Lock:
+    """Return the process-wide serialization lock for one CDP endpoint.
+
+    All browser commands targeting the same Chrome (same resolved ``cdp_url``)
+    share one lock, so the activate-tab-then-act pair is atomic against other
+    sessions on that Chrome.  Distinct endpoints get distinct locks and never
+    block each other.
+    """
+    with _endpoint_locks_guard:
+        lock = _endpoint_locks.get(cdp_url)
+        if lock is None:
+            lock = threading.Lock()
+            _endpoint_locks[cdp_url] = lock
+        return lock
+
+
+def _run_raw_agent_browser(
+    session_name: str,
+    cdp_url: str,
+    argv: List[str],
+    timeout: int = 15,
+) -> Dict[str, Any]:
+    """Run one agent-browser subcommand against ``cdp_url`` and parse its JSON.
+
+    A minimal sibling of ``_run_browser_command`` used for the lightweight tab
+    bookkeeping calls (``tab new`` / ``tab <ref>``) that back same-profile
+    isolation.  Kept separate so it never recurses through the profile-tab
+    activation path (which would loop).  Best-effort: returns a dict with
+    ``success`` and either ``data`` or ``error``.
+
+    IMPORTANT: over CDP this uses ``--cdp <url>`` with **no** ``--session`` flag,
+    exactly matching the backend form ``_run_browser_command`` uses for a CDP
+    endpoint (browser_tool line ~2602).  ``--session`` puts agent-browser in a
+    *separate* session context whose active-tab state is invisible to the
+    ``--cdp``-only main command — so a ``tab <ref>`` issued with ``--session``
+    would NOT actually activate the tab the real command then acts on.  The
+    ``session_name`` arg is retained only for the per-task socket dir.
+    """
+    try:
+        browser_cmd = _find_agent_browser()
+    except FileNotFoundError as e:
+        return {"success": False, "error": str(e)}
+
+    if browser_cmd == "npx agent-browser":
+        cmd_prefix = [shutil.which("npx") or "npx", "agent-browser"]
+    else:
+        cmd_prefix = [browser_cmd]
+
+    cmd_parts = cmd_prefix + ["--cdp", cdp_url, "--json"] + argv
+
+    browser_env = _build_browser_env()
+    browser_env["PATH"] = _merge_browser_path(browser_env.get("PATH", ""))
+    task_socket_dir = os.path.join(
+        _socket_safe_tmpdir(), f"agent-browser-{session_name}"
+    )
+    try:
+        os.makedirs(task_socket_dir, mode=0o700, exist_ok=True)
+        browser_env["AGENT_BROWSER_SOCKET_DIR"] = task_socket_dir
+        proc = subprocess.run(
+            cmd_parts,
+            capture_output=True,
+            text=True,
+            env=browser_env,
+            timeout=timeout,
+        )
+        out = (proc.stdout or "").strip()
+        if not out:
+            return {"success": False, "error": (proc.stderr or "no output").strip()[:300]}
+        return json.loads(out)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError) as e:
+        return {"success": False, "error": str(e)}
+
+
+def _ensure_owned_tab(session_key: str, session_name: str, cdp_url: str) -> Optional[str]:
+    """Return the agent-browser tab ref this profile session owns, creating one.
+
+    The first call for a session opens a fresh, uniquely-labeled tab in the
+    profile's Chrome and records it.  Subsequent calls return the cached ref.
+    A ``None`` return means we could not establish an owned tab (agent-browser
+    missing, endpoint down); callers fall back to un-pinned behaviour.
+
+    Must be called with the endpoint lock held (it mutates shared Chrome state
+    by opening a tab and relies on the label being unique per session).
+    """
+    existing = _session_owned_tab.get(session_key)
+    if existing:
+        return existing
+    # Unique, stable label derived from the session name (already a uuid slug).
+    label = f"h-{session_name}"
+    res = _run_raw_agent_browser(
+        session_name, cdp_url, ["tab", "new", "--label", label, "about:blank"]
+    )
+    if not res.get("success"):
+        logger.debug("profile tab acquire failed for %s: %s", session_key, res.get("error"))
+        return None
+    tab_ref = (res.get("data") or {}).get("tabId") or label
+    _session_owned_tab[session_key] = tab_ref
+    _session_endpoint[session_key] = cdp_url
+    logger.info("profile session %s acquired owned tab %s on %s",
+                session_key, tab_ref, _sanitize_url_for_logs(cdp_url))
+    return tab_ref
+
+
+def _activate_owned_tab(session_name: str, cdp_url: str, tab_ref: str) -> None:
+    """Bring this session's owned tab to the foreground before a command.
+
+    agent-browser drives the active tab, so this must run (under the endpoint
+    lock) immediately before the real command to guarantee the command lands on
+    the session's own tab and not one another session just activated.
+    """
+    _run_raw_agent_browser(session_name, cdp_url, ["tab", tab_ref], timeout=10)
+
+
+def _release_owned_tab(session_key: str) -> None:
+    """Close and forget a profile session's owned tab (best-effort, on cleanup)."""
+    tab_ref = _session_owned_tab.pop(session_key, None)
+    cdp_url = _session_endpoint.pop(session_key, None)
+    if not tab_ref or not cdp_url:
+        return
+    # Derive the session_name from the active-session record if still present.
+    info = _active_sessions.get(session_key) or {}
+    session_name = info.get("session_name")
+    if not session_name:
+        return
+    lock = _endpoint_lock_for(cdp_url)
+    with lock:
+        _run_raw_agent_browser(session_name, cdp_url, ["tab", "close", tab_ref], timeout=10)
 
 
 def _session_info_owned_by_task(session_info: Dict[str, Any], task_id: str, session_key: str) -> bool:
@@ -1835,6 +2090,10 @@ BROWSER_TOOL_SCHEMAS = [
                 "url": {
                     "type": "string",
                     "description": "The URL to navigate to (e.g., 'https://example.com')"
+                },
+                "profile": {
+                    "type": "string",
+                    "description": "Optional named browser profile for account isolation. Only set this when operating a specific logged-in identity that maps to a configured profile under browser.profiles in config.yaml (each profile is a separate persistent browser with its own cookies/logins). The profile sticks to all follow-up browser_snapshot/click/type calls on this task. Omit for normal browsing (uses the default profile). Passing an unconfigured profile name errors rather than silently using the default — it never crosses an account boundary by accident."
                 }
             },
             "required": ["url"]
@@ -2044,9 +2303,21 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, Any]:
     # the bare task_id key.
     force_local = _is_local_sidecar_key(task_id)
 
+    # Named browser profile: session keys of the form ``{task_id}::profile:{name}``
+    # bind this session to that profile's dedicated CDP endpoint (its own
+    # persistent Chrome / cookie jar).  Resolves ahead of the global override so
+    # each profile stays isolated; an unknown profile raises (no silent
+    # cross-account fallback).
+    profile_name = _profile_from_session_key(task_id)
+    profile_cdp = ""
+    if profile_name:
+        profile_cdp = _resolve_profile_cdp(profile_name)
+
     # Create session outside the lock (network call in cloud mode)
     cdp_override = _get_cdp_override()
-    if cdp_override and not force_local:
+    if profile_cdp:
+        session_info = _create_cdp_session(task_id, profile_cdp)
+    elif cdp_override and not force_local:
         session_info = _create_cdp_session(task_id, cdp_override)
     elif force_local:
         session_info = _create_local_session(task_id)
@@ -2358,6 +2629,22 @@ def _run_browser_command(
     if engine != "auto" and not _is_camofox_mode() and not session_info.get("cdp_url"):
         backend_args += ["--engine", engine]
 
+    # Same-profile concurrency: when this task is a named-profile session, it
+    # shares one Chrome (one CDP endpoint) with any other session on the same
+    # profile.  agent-browser drives the active tab, so we (1) ensure this
+    # session owns a dedicated tab and (2) activate it immediately before the
+    # real command, holding the per-endpoint lock across both so no other
+    # session's activate can interleave.  Non-profile sessions skip all of this
+    # and pay nothing.  See the "Same-profile concurrency" block above.
+    #
+    # ``close`` is excluded: it is issued from the cleanup path, which has
+    # already released this session's owned tab.  Routing it through the
+    # owned-tab machinery would re-create a fresh tab during teardown (leak).
+    _profile_name = _profile_from_session_key(task_id) if command != "close" else None
+    _endpoint_url = session_info.get("cdp_url") if _profile_name else None
+    _profile_lock = _endpoint_lock_for(_endpoint_url) if _endpoint_url else None
+    _profile_lock_held = False
+
     # Keep concrete executable paths intact, even when they contain spaces.
     # Only the synthetic npx fallback needs to expand into multiple argv items.
     # shutil.which resolves npx → npx.cmd on Windows; bare "npx" stays on POSIX.
@@ -2450,6 +2737,25 @@ def _run_browser_command(
                 _si = subprocess.STARTUPINFO()
                 _si.dwFlags |= subprocess.STARTF_USESTDHANDLES
                 _popen_extra["startupinfo"] = _si
+            # Profile sessions: serialize this command against other sessions on
+            # the same Chrome and activate our owned tab first, atomically.  The
+            # lock is held until the command finishes (agent-browser acts on the
+            # active tab for the command's whole duration).
+            if _profile_lock is not None and _endpoint_url:
+                _profile_lock.acquire()
+                _profile_lock_held = True
+                try:
+                    _tab_ref = _ensure_owned_tab(
+                        task_id, session_info["session_name"], _endpoint_url
+                    )
+                    if _tab_ref:
+                        _activate_owned_tab(
+                            session_info["session_name"], _endpoint_url, _tab_ref
+                        )
+                except Exception:
+                    # Never let tab bookkeeping abort the real command; the lock
+                    # is still released in the finally after wait.
+                    logger.debug("profile tab activate failed for %s", task_id, exc_info=True)
             proc = subprocess.Popen(
                 cmd_parts,
                 stdout=stdout_fd,
@@ -2565,6 +2871,18 @@ def _run_browser_command(
     except Exception as e:
         logger.warning("browser '%s' exception: %s", command, e, exc_info=True)
         result = {"success": False, "error": str(e)}
+    finally:
+        # Release the per-endpoint lock acquired before Popen (profile sessions
+        # only).  Held across the whole command so agent-browser acts on our
+        # activated tab for the command's full duration.  The per-call
+        # ``_profile_lock_held`` flag ensures we only release a lock THIS call
+        # acquired — never one another thread holds.
+        if _profile_lock is not None and _profile_lock_held:
+            _profile_lock_held = False
+            try:
+                _profile_lock.release()
+            except RuntimeError:
+                pass
 
     # --- Lightpanda automatic Chrome fallback ---
     # If engine is lightpanda and the result looks broken, retry with Chrome.
@@ -2766,13 +3084,18 @@ def _redact_browser_output(value: Any) -> Any:
 # Browser Tool Functions
 # ============================================================================
 
-def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
+def browser_navigate(url: str, task_id: Optional[str] = None, profile: Optional[str] = None) -> str:
     """
     Navigate to a URL in the browser.
 
     Args:
         url: The URL to navigate to
         task_id: Task identifier for session isolation
+        profile: Optional named browser profile (from ``browser.profiles`` in
+            config). Binds this navigation — and every follow-up
+            snapshot/click/type on the same task — to that profile's dedicated
+            CDP endpoint (its own persistent Chrome / cookie jar), so distinct
+            accounts stay isolated. Omit to use the ``default`` profile.
 
     Returns:
         JSON string with navigation result (includes stealth features info on first nav)
@@ -2822,6 +3145,28 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
                 "query parameter before navigating."
             ),
         })
+
+    # Named browser profile overrides session keying: bind this nav (and all
+    # follow-up calls on the same task) to the profile's dedicated CDP endpoint.
+    # A profile pins one explicit endpoint, so it supersedes ::local hybrid
+    # routing. Validate up front so an unknown profile fails loud here rather
+    # than mid-session — no silent fallback across an account boundary.
+    if profile:
+        try:
+            resolved = _resolve_profile_cdp(profile)
+        except ValueError as e:
+            return json.dumps({"success": False, "error": str(e)})
+        if not resolved:
+            return json.dumps({
+                "success": False,
+                "error": (
+                    f"Browser profile {profile!r} resolves to no CDP endpoint. "
+                    f"Set browser.profiles.{profile} (or browser.cdp_url for "
+                    f"the default profile) in config.yaml."
+                ),
+            })
+        nav_session_key = _compose_profile_session_key(effective_task_id, profile)
+        auto_local_this_nav = False
 
     # Always-blocked floor: cloud metadata / IMDS endpoints are denied
     # regardless of backend, hybrid routing, or allow_private_urls.
@@ -4362,26 +4707,39 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
         task_id = "default"
 
     # Expand to the full set of session keys to reap. For a bare task_id
-    # that includes the cloud/primary key + the local sidecar if one exists.
+    # that includes the cloud/primary key + the local sidecar if one exists,
+    # plus any named-profile sessions (``{task_id}::profile:<name>``) opened
+    # under this task.
     if _is_local_sidecar_key(task_id):
         session_keys = [task_id]
         bare_task_id = task_id[: -len(_LOCAL_SUFFIX)]
+    elif _profile_from_session_key(task_id) is not None:
+        # Called with an explicit profile key — reap only that one.
+        session_keys = [task_id]
+        bare_task_id = task_id.split(_PROFILE_PREFIX, 1)[0]
     else:
         session_keys = [task_id]
         sidecar_key = f"{task_id}{_LOCAL_SUFFIX}"
+        profile_prefix = f"{task_id}{_PROFILE_PREFIX}"
         with _cleanup_lock:
             if sidecar_key in _active_sessions:
                 session_keys.append(sidecar_key)
+            # Reap every named-profile session opened under this bare task.
+            session_keys.extend(
+                k for k in _active_sessions
+                if k.startswith(profile_prefix) and k not in session_keys
+            )
         bare_task_id = task_id
 
     for session_key in session_keys:
         _cleanup_single_browser_session(session_key)
 
     # Drop stale last-active ownership. Cleaning a bare task drops its binding;
-    # cleaning a sidecar drops the binding only if that sidecar was still the
-    # recorded owner. This prevents a later click/snapshot from resurrecting a
-    # cleaned sidecar on about:blank while preserving a primary-session binding.
-    if _is_local_sidecar_key(task_id):
+    # cleaning a sidecar or a single named-profile session drops the binding
+    # only if that composite key was still the recorded owner. This prevents a
+    # later click/snapshot from resurrecting a cleaned session on about:blank
+    # while preserving a primary-session binding.
+    if _is_local_sidecar_key(task_id) or _profile_from_session_key(task_id) is not None:
         if _last_active_session_key.get(bare_task_id) == task_id:
             _last_active_session_key.pop(bare_task_id, None)
     else:
@@ -4390,6 +4748,15 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
 
 def _cleanup_single_browser_session(task_id: str) -> None:
     """Internal: reap a single browser session by its exact session key."""
+    # Profile sessions own a dedicated tab in a shared Chrome — close it before
+    # tearing down the session record (which _release_owned_tab reads for the
+    # session_name).  Best-effort; a leftover tab is harmless but untidy.
+    if _profile_from_session_key(task_id) is not None:
+        try:
+            _release_owned_tab(task_id)
+        except Exception:
+            logger.debug("owned-tab release failed for %s", task_id, exc_info=True)
+
     # Stop the CDP supervisor for this task FIRST so we close our WebSocket
     # before the backend tears down the underlying CDP endpoint.
     _stop_cdp_supervisor(task_id)
@@ -4829,7 +5196,7 @@ registry.register(
     name="browser_navigate",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_navigate"],
-    handler=lambda args, **kw: browser_navigate(url=args.get("url", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_navigate(url=args.get("url", ""), task_id=kw.get("task_id"), profile=args.get("profile")),
     check_fn=check_browser_requirements,
     emoji="🌐",
 )

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -620,6 +620,78 @@ def _get_cdp_override() -> str:
     return _resolve_cdp_override(raw)
 
 
+# Composite session-key prefix for named browser profiles.  Mirrors
+# ``_LOCAL_SUFFIX`` ("::local") used by hybrid routing — a profile session key
+# is ``f"{task_id}::profile:{name}"``.  Both forms flow through the same
+# _active_sessions / _run_browser_command / cleanup paths; the key is opaque to
+# those internals.
+_PROFILE_PREFIX = "::profile:"
+
+
+def _get_browser_profiles() -> Dict[str, str]:
+    """Return the configured ``browser.profiles`` map (name -> CDP endpoint).
+
+    Read fresh from config on each call (like ``_get_cdp_override``) so a
+    config edit takes effect on the next browser call without a restart.
+    Returns an empty dict when unset or malformed.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {})
+        if isinstance(browser_cfg, dict):
+            profiles = browser_cfg.get("profiles", {})
+            if isinstance(profiles, dict):
+                # Coerce to str->str, dropping empty/invalid entries.
+                return {
+                    str(k): str(v)
+                    for k, v in profiles.items()
+                    if k and isinstance(v, (str,)) and v.strip()
+                }
+    except Exception as e:
+        logger.debug("Could not read browser.profiles from config: %s", e)
+    return {}
+
+
+def _resolve_profile_cdp(profile: str) -> str:
+    """Resolve a named browser profile to a concrete CDP URL.
+
+    Resolution order:
+      1. ``browser.profiles[profile]`` — explicit named endpoint.
+      2. For the implicit ``default`` profile only: fall back to the legacy
+         single-endpoint ``BROWSER_CDP_URL`` env / ``browser.cdp_url`` config
+         (so pre-profiles configs keep working with no ``profiles`` map).
+
+    Raises ``ValueError`` for an unknown non-default profile.  We deliberately
+    do NOT silently fall back to the default endpoint for an unknown name —
+    crossing an account boundary silently is exactly the failure profiles
+    exist to prevent.
+    """
+    profiles = _get_browser_profiles()
+    raw = profiles.get(profile, "")
+    if raw and raw.strip():
+        return _resolve_cdp_override(raw.strip())
+
+    if profile == _DEFAULT_PROFILE:
+        # Legacy fallback: a config with no profiles map but a bare cdp_url.
+        legacy = _get_cdp_override()
+        if legacy:
+            return legacy
+        return ""
+
+    # Unknown named profile — fail loud.
+    known = ", ".join(sorted(profiles)) or "(none configured)"
+    raise ValueError(
+        f"Unknown browser profile {profile!r}. "
+        f"Configured profiles: {known}. "
+        f"Add it under browser.profiles in config.yaml."
+    )
+
+
+_DEFAULT_PROFILE = "default"
+
+
 def _get_dialog_policy_config() -> Tuple[str, float]:
     """Read ``browser.dialog_policy`` + ``browser.dialog_timeout_s`` from config.
 
@@ -2023,11 +2095,194 @@ def _is_local_sidecar_key(session_key: str) -> bool:
     return session_key.endswith(_LOCAL_SUFFIX)
 
 
+def _profile_from_session_key(session_key: str) -> Optional[str]:
+    """Extract the browser-profile name from a composite session key.
+
+    Profile session keys look like ``f"{task_id}::profile:{name}"`` (see
+    ``_PROFILE_PREFIX``).  Returns the ``name`` portion, or ``None`` when the
+    key carries no profile (bare task_id or a ``::local`` sidecar key).
+    """
+    idx = session_key.find(_PROFILE_PREFIX)
+    if idx == -1:
+        return None
+    name = session_key[idx + len(_PROFILE_PREFIX):]
+    return name or None
+
+
+def _compose_profile_session_key(task_id: str, profile: str) -> str:
+    """Build the composite session key for ``task_id`` under ``profile``."""
+    return f"{task_id}{_PROFILE_PREFIX}{profile}"
+
+
 def _bare_task_id_for_session_key(session_key: str) -> str:
-    """Return the owning bare task id for an opaque browser session key."""
+    """Return the owning bare task id for an opaque browser session key.
+
+    Strips a ``::local`` sidecar suffix or a ``::profile:<name>`` suffix so
+    both composite forms map back to the task that owns them.
+    """
     if _is_local_sidecar_key(session_key):
         return session_key[: -len(_LOCAL_SUFFIX)]
+    if _profile_from_session_key(session_key) is not None:
+        return session_key.split(_PROFILE_PREFIX, 1)[0]
     return session_key
+
+
+# ---------------------------------------------------------------------------
+# Same-profile concurrency: per-endpoint serialization + per-session owned tab
+# ---------------------------------------------------------------------------
+# A named profile maps to ONE Chrome (one CDP endpoint).  agent-browser, when
+# attached over ``--cdp``, drives whatever tab is *currently active* in that
+# Chrome — it has no per-invocation "act on tab X" flag, and tab selection does
+# not persist across its stateless subprocess calls.  So two Hermes sessions
+# sharing one profile would fight over the single active tab (session B's
+# navigate steals session A's foreground page).
+#
+# Fix (verified live): give each session its own labeled tab in that Chrome and,
+# for every command, run ``tab <ownref>`` (activate my tab) immediately before
+# the real command, with the pair executed atomically under a per-endpoint lock
+# so no other session's activate can interleave.  Different profiles use
+# different endpoints and different locks, so they stay fully parallel — only
+# same-endpoint traffic serializes.
+#
+# The lock is acquired lazily and only actually contends when 2+ sessions share
+# an endpoint; a lone session pays a single un-contended lock acquire per call.
+_endpoint_locks: Dict[str, threading.Lock] = {}
+_endpoint_locks_guard = threading.Lock()
+# Maps a profile session key -> the agent-browser tab ref (e.g. "t7") it owns on
+# its endpoint.  Absent until the session opens its first tab.
+_session_owned_tab: Dict[str, str] = {}
+# Maps a profile session key -> the resolved CDP endpoint it is bound to, so
+# cleanup can find the right lock without re-resolving config.
+_session_endpoint: Dict[str, str] = {}
+
+
+def _endpoint_lock_for(cdp_url: str) -> threading.Lock:
+    """Return the process-wide serialization lock for one CDP endpoint.
+
+    All browser commands targeting the same Chrome (same resolved ``cdp_url``)
+    share one lock, so the activate-tab-then-act pair is atomic against other
+    sessions on that Chrome.  Distinct endpoints get distinct locks and never
+    block each other.
+    """
+    with _endpoint_locks_guard:
+        lock = _endpoint_locks.get(cdp_url)
+        if lock is None:
+            lock = threading.Lock()
+            _endpoint_locks[cdp_url] = lock
+        return lock
+
+
+def _run_raw_agent_browser(
+    session_name: str,
+    cdp_url: str,
+    argv: List[str],
+    timeout: int = 15,
+) -> Dict[str, Any]:
+    """Run one agent-browser subcommand against ``cdp_url`` and parse its JSON.
+
+    A minimal sibling of ``_run_browser_command`` used for the lightweight tab
+    bookkeeping calls (``tab new`` / ``tab <ref>``) that back same-profile
+    isolation.  Kept separate so it never recurses through the profile-tab
+    activation path (which would loop).  Best-effort: returns a dict with
+    ``success`` and either ``data`` or ``error``.
+
+    IMPORTANT: over CDP this uses ``--cdp <url>`` with **no** ``--session`` flag,
+    exactly matching the backend form ``_run_browser_command`` uses for a CDP
+    endpoint (browser_tool line ~2602).  ``--session`` puts agent-browser in a
+    *separate* session context whose active-tab state is invisible to the
+    ``--cdp``-only main command — so a ``tab <ref>`` issued with ``--session``
+    would NOT actually activate the tab the real command then acts on.  The
+    ``session_name`` arg is retained only for the per-task socket dir.
+    """
+    try:
+        browser_cmd = _find_agent_browser()
+    except FileNotFoundError as e:
+        return {"success": False, "error": str(e)}
+
+    if browser_cmd == "npx agent-browser":
+        cmd_prefix = [shutil.which("npx") or "npx", "agent-browser"]
+    else:
+        cmd_prefix = [browser_cmd]
+
+    cmd_parts = cmd_prefix + ["--cdp", cdp_url, "--json"] + argv
+
+    browser_env = _build_browser_env()
+    browser_env["PATH"] = _merge_browser_path(browser_env.get("PATH", ""))
+    task_socket_dir = os.path.join(
+        _socket_safe_tmpdir(), f"agent-browser-{session_name}"
+    )
+    try:
+        os.makedirs(task_socket_dir, mode=0o700, exist_ok=True)
+        browser_env["AGENT_BROWSER_SOCKET_DIR"] = task_socket_dir
+        proc = subprocess.run(
+            cmd_parts,
+            capture_output=True,
+            text=True,
+            env=browser_env,
+            timeout=timeout,
+        )
+        out = (proc.stdout or "").strip()
+        if not out:
+            return {"success": False, "error": (proc.stderr or "no output").strip()[:300]}
+        return json.loads(out)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError) as e:
+        return {"success": False, "error": str(e)}
+
+
+def _ensure_owned_tab(session_key: str, session_name: str, cdp_url: str) -> Optional[str]:
+    """Return the agent-browser tab ref this profile session owns, creating one.
+
+    The first call for a session opens a fresh, uniquely-labeled tab in the
+    profile's Chrome and records it.  Subsequent calls return the cached ref.
+    A ``None`` return means we could not establish an owned tab (agent-browser
+    missing, endpoint down); callers fall back to un-pinned behaviour.
+
+    Must be called with the endpoint lock held (it mutates shared Chrome state
+    by opening a tab and relies on the label being unique per session).
+    """
+    existing = _session_owned_tab.get(session_key)
+    if existing:
+        return existing
+    # Unique, stable label derived from the session name (already a uuid slug).
+    label = f"h-{session_name}"
+    res = _run_raw_agent_browser(
+        session_name, cdp_url, ["tab", "new", "--label", label, "about:blank"]
+    )
+    if not res.get("success"):
+        logger.debug("profile tab acquire failed for %s: %s", session_key, res.get("error"))
+        return None
+    tab_ref = (res.get("data") or {}).get("tabId") or label
+    _session_owned_tab[session_key] = tab_ref
+    _session_endpoint[session_key] = cdp_url
+    logger.info("profile session %s acquired owned tab %s on %s",
+                session_key, tab_ref, _sanitize_url_for_logs(cdp_url))
+    return tab_ref
+
+
+def _activate_owned_tab(session_name: str, cdp_url: str, tab_ref: str) -> None:
+    """Bring this session's owned tab to the foreground before a command.
+
+    agent-browser drives the active tab, so this must run (under the endpoint
+    lock) immediately before the real command to guarantee the command lands on
+    the session's own tab and not one another session just activated.
+    """
+    _run_raw_agent_browser(session_name, cdp_url, ["tab", tab_ref], timeout=10)
+
+
+def _release_owned_tab(session_key: str) -> None:
+    """Close and forget a profile session's owned tab (best-effort, on cleanup)."""
+    tab_ref = _session_owned_tab.pop(session_key, None)
+    cdp_url = _session_endpoint.pop(session_key, None)
+    if not tab_ref or not cdp_url:
+        return
+    # Derive the session_name from the active-session record if still present.
+    info = _active_sessions.get(session_key) or {}
+    session_name = info.get("session_name")
+    if not session_name:
+        return
+    lock = _endpoint_lock_for(cdp_url)
+    with lock:
+        _run_raw_agent_browser(session_name, cdp_url, ["tab", "close", tab_ref], timeout=10)
 
 
 def _session_info_owned_by_task(session_info: Dict[str, Any], task_id: str, session_key: str) -> bool:
@@ -2881,6 +3136,10 @@ BROWSER_TOOL_SCHEMAS = [
                 "url": {
                     "type": "string",
                     "description": "The URL to navigate to (e.g., 'https://example.com')"
+                },
+                "profile": {
+                    "type": "string",
+                    "description": "Optional named browser profile for account isolation. Only set this when operating a specific logged-in identity that maps to a configured profile under browser.profiles in config.yaml (each profile is a separate persistent browser with its own cookies/logins). The profile sticks to all follow-up browser_snapshot/click/type calls on this task. Omit for normal browsing (uses the default profile). Passing an unconfigured profile name errors rather than silently using the default — it never crosses an account boundary by accident."
                 }
             },
             "required": ["url"]
@@ -3202,9 +3461,21 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, Any]:
     # the bare task_id key.
     force_local = _is_local_sidecar_key(task_id)
 
+    # Named browser profile: session keys of the form ``{task_id}::profile:{name}``
+    # bind this session to that profile's dedicated CDP endpoint (its own
+    # persistent Chrome / cookie jar).  Resolves ahead of the global override so
+    # each profile stays isolated; an unknown profile raises (no silent
+    # cross-account fallback).
+    profile_name = _profile_from_session_key(task_id)
+    profile_cdp = ""
+    if profile_name:
+        profile_cdp = _resolve_profile_cdp(profile_name)
+
     # Create session outside the lock (network call in cloud mode)
     cdp_override = _get_cdp_override()
-    if cdp_override and not force_local:
+    if profile_cdp:
+        session_info = _create_cdp_session(task_id, profile_cdp)
+    elif cdp_override and not force_local:
         session_info = _create_cdp_session(task_id, cdp_override)
     elif force_local:
         # Hybrid private-URL sidecar: NEVER the real profile (see
@@ -3885,6 +4156,22 @@ def _run_browser_command(
     if engine != "auto" and not _is_camofox_mode() and not session_info.get("cdp_url"):
         backend_args += ["--engine", engine]
 
+    # Same-profile concurrency: when this task is a named-profile session, it
+    # shares one Chrome (one CDP endpoint) with any other session on the same
+    # profile.  agent-browser drives the active tab, so we (1) ensure this
+    # session owns a dedicated tab and (2) activate it immediately before the
+    # real command, holding the per-endpoint lock across both so no other
+    # session's activate can interleave.  Non-profile sessions skip all of this
+    # and pay nothing.  See the "Same-profile concurrency" block above.
+    #
+    # ``close`` is excluded: it is issued from the cleanup path, which has
+    # already released this session's owned tab.  Routing it through the
+    # owned-tab machinery would re-create a fresh tab during teardown (leak).
+    _profile_name = _profile_from_session_key(task_id) if command != "close" else None
+    _endpoint_url = session_info.get("cdp_url") if _profile_name else None
+    _profile_lock = _endpoint_lock_for(_endpoint_url) if _endpoint_url else None
+    _profile_lock_held = False
+
     # Keep concrete executable paths intact, even when they contain spaces.
     # Only the synthetic npx fallback needs to expand into multiple argv items.
     # Resolve via the same PATH + extended-PATH cascade _find_agent_browser
@@ -3975,6 +4262,25 @@ def _run_browser_command(
                 _si = subprocess.STARTUPINFO()
                 _si.dwFlags |= subprocess.STARTF_USESTDHANDLES
                 _popen_extra["startupinfo"] = _si
+            # Profile sessions: serialize this command against other sessions on
+            # the same Chrome and activate our owned tab first, atomically.  The
+            # lock is held until the command finishes (agent-browser acts on the
+            # active tab for the command's whole duration).
+            if _profile_lock is not None and _endpoint_url:
+                _profile_lock.acquire()
+                _profile_lock_held = True
+                try:
+                    _tab_ref = _ensure_owned_tab(
+                        task_id, session_info["session_name"], _endpoint_url
+                    )
+                    if _tab_ref:
+                        _activate_owned_tab(
+                            session_info["session_name"], _endpoint_url, _tab_ref
+                        )
+                except Exception:
+                    # Never let tab bookkeeping abort the real command; the lock
+                    # is still released in the finally after wait.
+                    logger.debug("profile tab activate failed for %s", task_id, exc_info=True)
             proc = subprocess.Popen(
                 cmd_parts,
                 stdout=stdout_fd,
@@ -4091,6 +4397,18 @@ def _run_browser_command(
     except Exception as e:
         logger.warning("browser '%s' exception: %s", command, e, exc_info=True)
         result = {"success": False, "error": str(e)}
+    finally:
+        # Release the per-endpoint lock acquired before Popen (profile sessions
+        # only).  Held across the whole command so agent-browser acts on our
+        # activated tab for the command's full duration.  The per-call
+        # ``_profile_lock_held`` flag ensures we only release a lock THIS call
+        # acquired — never one another thread holds.
+        if _profile_lock is not None and _profile_lock_held:
+            _profile_lock_held = False
+            try:
+                _profile_lock.release()
+            except RuntimeError:
+                pass
 
     # --- Lightpanda automatic Chrome fallback ---
     # If engine is lightpanda and the result looks broken, retry with Chrome.
@@ -4267,13 +4585,18 @@ def evaluate_url_safety(url: str) -> Optional[dict]:
     return None
 
 
-def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
+def browser_navigate(url: str, task_id: Optional[str] = None, profile: Optional[str] = None) -> str:
     """
     Navigate to a URL in the browser.
 
     Args:
         url: The URL to navigate to
         task_id: Task identifier for session isolation
+        profile: Optional named browser profile (from ``browser.profiles`` in
+            config). Binds this navigation — and every follow-up
+            snapshot/click/type on the same task — to that profile's dedicated
+            CDP endpoint (its own persistent Chrome / cookie jar), so distinct
+            accounts stay isolated. Omit to use the ``default`` profile.
 
     Returns:
         JSON string with navigation result (includes stealth features info on first nav)
@@ -4323,6 +4646,28 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
                 "query parameter before navigating."
             ),
         })
+
+    # Named browser profile overrides session keying: bind this nav (and all
+    # follow-up calls on the same task) to the profile's dedicated CDP endpoint.
+    # A profile pins one explicit endpoint, so it supersedes ::local hybrid
+    # routing. Validate up front so an unknown profile fails loud here rather
+    # than mid-session — no silent fallback across an account boundary.
+    if profile:
+        try:
+            resolved = _resolve_profile_cdp(profile)
+        except ValueError as e:
+            return json.dumps({"success": False, "error": str(e)})
+        if not resolved:
+            return json.dumps({
+                "success": False,
+                "error": (
+                    f"Browser profile {profile!r} resolves to no CDP endpoint. "
+                    f"Set browser.profiles.{profile} (or browser.cdp_url for "
+                    f"the default profile) in config.yaml."
+                ),
+            })
+        nav_session_key = _compose_profile_session_key(effective_task_id, profile)
+        auto_local_this_nav = False
 
     # Always-blocked floor: cloud metadata / IMDS endpoints are denied
     # regardless of backend, hybrid routing, or allow_private_urls.
@@ -5902,26 +6247,39 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
         task_id = "default"
 
     # Expand to the full set of session keys to reap. For a bare task_id
-    # that includes the cloud/primary key + the local sidecar if one exists.
+    # that includes the cloud/primary key + the local sidecar if one exists,
+    # plus any named-profile sessions (``{task_id}::profile:<name>``) opened
+    # under this task.
     if _is_local_sidecar_key(task_id):
         session_keys = [task_id]
         bare_task_id = task_id[: -len(_LOCAL_SUFFIX)]
+    elif _profile_from_session_key(task_id) is not None:
+        # Called with an explicit profile key — reap only that one.
+        session_keys = [task_id]
+        bare_task_id = task_id.split(_PROFILE_PREFIX, 1)[0]
     else:
         session_keys = [task_id]
         sidecar_key = f"{task_id}{_LOCAL_SUFFIX}"
+        profile_prefix = f"{task_id}{_PROFILE_PREFIX}"
         with _cleanup_lock:
             if sidecar_key in _active_sessions:
                 session_keys.append(sidecar_key)
+            # Reap every named-profile session opened under this bare task.
+            session_keys.extend(
+                k for k in _active_sessions
+                if k.startswith(profile_prefix) and k not in session_keys
+            )
         bare_task_id = task_id
 
     for session_key in session_keys:
         _cleanup_single_browser_session(session_key)
 
     # Drop stale last-active ownership. Cleaning a bare task drops its binding;
-    # cleaning a sidecar drops the binding only if that sidecar was still the
-    # recorded owner. This prevents a later click/snapshot from resurrecting a
-    # cleaned sidecar on about:blank while preserving a primary-session binding.
-    if _is_local_sidecar_key(task_id):
+    # cleaning a sidecar or a single named-profile session drops the binding
+    # only if that composite key was still the recorded owner. This prevents a
+    # later click/snapshot from resurrecting a cleaned session on about:blank
+    # while preserving a primary-session binding.
+    if _is_local_sidecar_key(task_id) or _profile_from_session_key(task_id) is not None:
         if _last_active_session_key.get(bare_task_id) == task_id:
             _last_active_session_key.pop(bare_task_id, None)
     else:
@@ -6015,6 +6373,15 @@ def _force_reap_browser_session(task_id: str) -> None:
 
 def _cleanup_single_browser_session(task_id: str) -> None:
     """Internal: reap a single browser session by its exact session key."""
+    # Profile sessions own a dedicated tab in a shared Chrome — close it before
+    # tearing down the session record (which _release_owned_tab reads for the
+    # session_name).  Best-effort; a leftover tab is harmless but untidy.
+    if _profile_from_session_key(task_id) is not None:
+        try:
+            _release_owned_tab(task_id)
+        except Exception:
+            logger.debug("owned-tab release failed for %s", task_id, exc_info=True)
+
     # Stop the CDP supervisor for this task FIRST so we close our WebSocket
     # before the backend tears down the underlying CDP endpoint.
     _stop_cdp_supervisor(task_id)
@@ -6506,7 +6873,11 @@ registry.register(
     handler=lambda args, **kw: routed_browser_handler(
         "browser_navigate",
         args,
-        fallback=lambda: browser_navigate(url=args.get("url", ""), task_id=kw.get("task_id")),
+        fallback=lambda: browser_navigate(
+            url=args.get("url", ""),
+            task_id=kw.get("task_id"),
+            profile=args.get("profile"),
+        ),
         **_browser_router_kw(kw),
     ),
     check_fn=check_browser_navigate_requirements,


### PR DESCRIPTION
## Parallel browser execution across multiple agents and multiple profiles

### Why this matters

Today `browser.cdp_url` is a **single global CDP endpoint**. Every `browser_*`
call shares one Chrome — one cookie jar, one logged-in identity — and that value
is process-global across every running Hermes session, so two concurrent
sessions (two delegated subagents, a cron job + an interactive turn, two kanban
workers) collide on the one endpoint and clobber each other's tabs.

This PR makes concurrent browser use **collision-free across two axes**, so
multiple agents can drive browsers in parallel:

### 1. Distinct profiles → fully parallel, isolated identities

`browser.profiles` maps a name → CDP endpoint, each typically a separate
persistent Chrome with its own `user-data-dir` (cookies, logins, storage):

```yaml
browser:
  profiles:
    default: http://localhost:9224
    work:    http://localhost:9225
```

`browser_navigate(profile="work")` binds that navigation — and every follow-up
`snapshot`/`click`/`type` on the same task — to that profile's dedicated
endpoint via a composite session key `{task_id}::profile:{name}` (mirroring the
existing `::local` hybrid-routing precedent). Different endpoints never share
state, so **agent A on `default` and agent B on `work` run fully in parallel**
with zero cross-contamination. An unknown profile is a hard error — never a
silent cross-account fallback. Calls with no profile use `profiles["default"]`,
which falls back to `cdp_url` when unset, so existing single-endpoint configs
keep working unchanged.

### 2. Same profile → serialized-but-safe concurrency

One profile == one Chrome == one CDP endpoint, and the agent drives the *active*
tab with no per-invocation tab flag. So when **two agents share one profile**,
each session is given its own labeled tab, and every command runs
activate-my-tab-then-act **atomically under a per-endpoint lock** — no other
session's activate can interleave. Distinct endpoints use distinct locks (they
stay parallel); only same-endpoint traffic serializes, and the lock only
contends when 2+ sessions actually share a profile. Owned tabs are closed on
cleanup; the cleanup `close` is excluded from the tab machinery so teardown
can't re-create a tab.

### Footprint

Reuses the `::local` composite-session-key seam (Footprint Ladder rung 1): **no
new core tool**, one optional `profile` arg on `browser_navigate`, all routing
flows through the existing `_active_sessions` / `_run_browser_command` /
cleanup paths. Config-only surface in `config.yaml` (`browser.profiles`); no new
`HERMES_*` env var.

### Test

Behavior-contract tests (lock identity, owned-tab lifecycle,
activate-before-command ordering, non-profile fast path); 30 browser-profile
tests pass, plus verified live against two concurrent same-profile sessions on
one Chrome — each session's reads stayed pinned to its own tab, and cleanup
returned the browser to baseline with no leaked tabs.

### Risk

Additive and backward-compatible: with no `profiles` configured, behavior is
identical to today (single `cdp_url`). The per-endpoint lock only engages when
sessions share a profile.
