### PR TITLE
fix(status): accept GH_TOKEN as a GitHub credential

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -144,7 +144,7 @@ def show_status(args):
         "Browserbase": "BROWSERBASE_API_KEY",  # Optional — direct credentials only
         "FAL": "FAL_KEY",
         "ElevenLabs": "ELEVENLABS_API_KEY",
-        "GitHub": "GITHUB_TOKEN",
+        "GitHub": ("GITHUB_TOKEN", "GH_TOKEN"),
     }
 
     def _resolve_env(env_ref) -> str:

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -14,6 +14,22 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     assert "tvly...cdef" in output
 
 
+def test_show_status_includes_github_gh_token(monkeypatch, capsys, tmp_path):
+    # A user whose GitHub PAT lives in GH_TOKEN (the name the `gh` CLI exports)
+    # with GITHUB_TOKEN unset should still see GitHub as configured — matching
+    # `hermes doctor`, which resolves `GITHUB_TOKEN or GH_TOKEN`.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "ghp_testtoken1234567890")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    github_line = next(line for line in output.splitlines() if "GitHub" in line)
+    assert "(not set)" not in github_line
+    assert "ghp_...7890" in github_line
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## Sibling alignment — `hermes status` now matches `hermes doctor`

- `hermes doctor` (`hermes_cli/doctor.py`) already resolves the GitHub PAT as `GITHUB_TOKEN or GH_TOKEN`.
- `hermes status` (`hermes_cli/status.py`) only checked `GITHUB_TOKEN`, so a `GH_TOKEN`-only user saw a false `GitHub  ✗ (not set)`.
- This PR widens the status row to the same `(GITHUB_TOKEN, GH_TOKEN)` tuple that `_resolve_env` already supports (same shape as the existing Anthropic / Google rows).

Sibling code path that may want the same widen: `hermes_cli/dump.py` (`("GITHUB_TOKEN","github")`) has the identical single-alias gap. Left out to keep this diff atomic — happy to widen if preferred.

## What does this PR do?

The API-Keys table in `hermes status` resolved the GitHub credential from `GITHUB_TOKEN` only. The `gh` CLI itself exports the token as `GH_TOKEN`, and `tools/environments/local.py` passes that name through. A user whose PAT lives in `GH_TOKEN` with `GITHUB_TOKEN` unset therefore saw a false-negative `GitHub  ✗ (not set)` in `hermes status`, even though `hermes doctor` and the runtime consumers (`tools/skills_hub.py`, `optional-skills/devops/watchers/scripts/watch_github.py`) all treat that token as configured.

Root cause: the `keys` map at `hermes_cli/status.py` used a bare string `"GITHUB_TOKEN"` for the GitHub row while `_resolve_env` already supports a tuple of alternates (first non-empty wins) — the same mechanism the `Anthropic` and `Google / Gemini` rows use. GitHub was simply never widened to match the runtime/doctor precedence.

## Related Issue

No filed issue — code-originated fix. Aligns `status` with the existing `doctor` resolution (`hermes_cli/doctor.py`, `github_token = get_env_value("GITHUB_TOKEN") or get_env_value("GH_TOKEN")`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/status.py`: change the GitHub API-Keys row from `"GITHUB_TOKEN"` to `("GITHUB_TOKEN", "GH_TOKEN")`. No other change — `_resolve_env` and the render loop already handle tuples.
- `tests/hermes_cli/test_status.py`: add `test_show_status_includes_github_gh_token` (GITHUB_TOKEN unset, GH_TOKEN set → row shows the masked token, not `(not set)`).

## How to Test

1. `unset GITHUB_TOKEN; export GH_TOKEN=ghp_yourtoken`
2. `hermes status` → the GitHub API-Keys row shows a green check and masked token (previously `✗ (not set)`).
3. `pytest tests/hermes_cli/test_status.py -q`.

Regression guard (verified both directions): with the single-string row, `test_show_status_includes_github_gh_token` fails with `GitHub  ✗ (not set)`; with the tuple it passes and shows `ghp_...7890`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_status.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A