### PR TITLE
fix(telegram): don't italicize whitespace-flanked asterisks in MarkdownV2

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5148,11 +5148,15 @@ class TelegramAdapter(BasePlatformAdapter):
             text,
         )
 
-        # 6) Convert italic: *text* (single asterisk) → _text_ (MarkdownV2 italic)
-        #    [^*\n]+ prevents matching across newlines (which would corrupt
-        #    bullet lists using * markers and multi-line content).
+        # 6) Convert italic: *text* (single asterisk) → _text_ (MarkdownV2 italic).
+        #    The flanking guard mirrors the Slack converter (slack.py):
+        #    an emphasis run must touch non-whitespace on both sides, so
+        #    whitespace-flanked literals like "2 * 3 * 4" or "apples * 5"
+        #    are NOT italicized (they fall through and are escaped as literal
+        #    \*). [^*\n] keeps the run on a single line so bullet lists using
+        #    * markers are not merged.
         text = re.sub(
-            r'\*([^*\n]+)\*',
+            r'(?<!\*)\*(\S(?:[^*\n]*?\S)?)\*(?!\*)',
             lambda m: _ph(f'_{_escape_mdv2(m.group(1))}_'),
             text,
         )

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -210,6 +210,20 @@ class TestFormatMessageBoldItalic:
         assert "*bold*" in result
         assert "_italic_" in result
 
+    def test_whitespace_flanked_asterisks_not_italicized(self, adapter):
+        # Multiplication / glob asterisks are flanked by whitespace, so they
+        # are NOT emphasis runs (CommonMark flanking rule). They must be
+        # escaped as literal \* rather than converted to italic markers.
+        result = adapter.format_message("Multiply: 2 * 3 * 4 = 24")
+        assert "_" not in result
+        assert "2 \\* 3 \\* 4" in result
+
+    def test_real_italic_still_works_with_flanking_guard(self, adapter):
+        # Regression guard: genuine *italic* (non-whitespace on both sides)
+        # still converts after the flanking fix.
+        assert "_italic_" in adapter.format_message("This is *italic* text")
+        assert "_hello\\.world_" in adapter.format_message("*hello.world*")
+
     def test_reload_mcp_summary_escapes_dynamic_server_names(self, adapter):
         content = (
             "🔄 **MCP Servers Reloaded**\n"


### PR DESCRIPTION
## Sibling follow-up — aligns Telegram with the Slack converter

- Slack's `_format_markdown_for_slack` (`gateway/platforms/slack.py`) already uses a flanking-aware italic pattern.
- Telegram's step-6 italic regex (`gateway/platforms/telegram.py`) used the naive `\*([^*\n]+)\*`, so whitespace-flanked asterisks (multiplication, globs) were wrongly italicized and the surrounding text corrupted.
- This PR adopts the same flanking guard `(?<!\*)\*(\S(?:[^*\n]*?\S)?)\*(?!\*)`.

Audited siblings: bold (step 5) uses paired `**...**` (non-greedy) and is not affected; strikethrough/spoiler are paired-delimiter and not affected.

## What does this PR do?

The single-asterisk italic conversion in `TelegramAdapter.format_message` matched any `*...*` pair on a line, ignoring the CommonMark flanking rule (an emphasis opener must not be followed by whitespace, and a closer must not be preceded by whitespace). As a result, literal asterisks used for multiplication or globs were converted to MarkdownV2 italic markers, corrupting the message:

```
"Multiply: 2 * 3 * 4 = 24"  ->  "Multiply: 2 _ 3 _ 4 \= 24"
"apples * 5, oranges * 3"   ->  "apples _ 5, oranges _ 3"
```

Root cause: the step-6 regex `\*([^*\n]+)\*` has no flanking guard. The merged fix #204 only addressed the cross-newline case (`[^*]` -> `[^*\n]`); whitespace-flanked literals on a single line were still mis-converted.

The Slack converter already solved this with a flanking-aware pattern. This PR adopts the same pattern in the Telegram path so real `*italic*` still converts while whitespace-flanked asterisks fall through and are escaped as literal `\*` (correct MarkdownV2).

## Related Issue

No filed issue — code-originated fix mirroring the established Slack pattern (`gateway/platforms/slack.py`, `(?<!\*)\*(\S(?:[^*\n]*?\S)?)\*(?!\*)`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: replace the step-6 italic regex `\*([^*\n]+)\*` with the flanking-aware `(?<!\*)\*(\S(?:[^*\n]*?\S)?)\*(?!\*)` (matching slack.py).
- `tests/gateway/test_telegram_format.py`: add `test_whitespace_flanked_asterisks_not_italicized` (multiplication asterisks escaped, no `_`) and `test_real_italic_still_works_with_flanking_guard` (genuine italic still converts).

## How to Test

1. Send a Telegram message containing `Multiply: 2 * 3 * 4 = 24` -> renders with literal asterisks, not italic (previously `2 _ 3 _ 4`).
2. Send `This is *italic* text` -> still renders italic.
3. `pytest tests/gateway/test_telegram_format.py -q`.

Regression guard (verified both directions): with the naive regex `test_whitespace_flanked_asterisks_not_italicized` fails (`Multiply: 2 _ 3 _ 4 \= 24`); with the flanking pattern it passes and the existing italic / newline-bug tests stay green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_telegram_format.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A