### PR TITLE
fix(packaging): ship optional-mcps/unreal-engine manifest in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,6 +323,7 @@ locales = ["locales/*.yaml"]
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
+"optional-mcps/unreal-engine" = ["optional-mcps/unreal-engine/manifest.yaml"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -265,3 +265,38 @@ def test_locale_catalogs_ship_in_both_wheel_and_sdist():
     on_disk = list((REPO_ROOT / "locales").glob("*.yaml"))
     assert on_disk, "expected locales/*.yaml catalogs on disk"
 
+
+def test_optional_mcps_catalog_entries_ship_in_wheel():
+    """Every on-disk optional-mcps/<name> must ship in the wheel + sdist.
+
+    optional-mcps/ is a bare data directory (no __init__.py), so each catalog
+    entry is shipped ONLY via a hand-maintained [tool.setuptools.data-files]
+    target (wheel) plus `graft optional-mcps` in MANIFEST.in (sdist). A new
+    catalog manifest that lands without its data-files target ships in the
+    sdist but is dropped from the wheel, so `hermes mcp catalog`/`install`
+    silently omit it on pip/Docker/Nix installs. This guards that recurring
+    gap (e.g. the unreal-engine entry added in 5ffbfed19 without a target).
+    """
+    on_disk = sorted(p.parent.name for p in (REPO_ROOT / "optional-mcps").glob("*/manifest.yaml"))
+    assert on_disk, "expected optional-mcps/*/manifest.yaml entries on disk"
+
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    data_files = data["tool"]["setuptools"].get("data-files", {})
+
+    missing = []
+    for name in on_disk:
+        key = f"optional-mcps/{name}"
+        expected = [f"optional-mcps/{name}/manifest.yaml"]
+        if data_files.get(key) != expected:
+            missing.append(key)
+    assert not missing, (
+        "pyproject [tool.setuptools.data-files] is missing a wheel target for "
+        f"each on-disk optional-mcps entry (so it would be dropped from the "
+        f"wheel): {missing}"
+    )
+
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    assert "graft optional-mcps" in manifest, (
+        "MANIFEST.in must `graft optional-mcps` so the sdist ships the catalog"
+    )
+

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -286,13 +286,18 @@ def test_optional_mcps_catalog_entries_ship_in_wheel():
     missing = []
     for name in on_disk:
         key = f"optional-mcps/{name}"
-        expected = [f"optional-mcps/{name}/manifest.yaml"]
-        if data_files.get(key) != expected:
+        manifest_path = f"optional-mcps/{name}/manifest.yaml"
+        # Assert the target EXISTS and INCLUDES the manifest — not that it
+        # equals exactly one path. An entry may legitimately ship additional
+        # files (README, assets) under the same target; the guard we care
+        # about is that the manifest itself is never dropped from the wheel.
+        targets = data_files.get(key)
+        if not targets or manifest_path not in targets:
             missing.append(key)
     assert not missing, (
-        "pyproject [tool.setuptools.data-files] is missing a wheel target for "
-        f"each on-disk optional-mcps entry (so it would be dropped from the "
-        f"wheel): {missing}"
+        "pyproject [tool.setuptools.data-files] is missing a wheel target "
+        "shipping the manifest for each on-disk optional-mcps entry (so it "
+        f"would be dropped from the wheel): {missing}"
     )
 
     manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")


### PR DESCRIPTION
## Follow-up to 5ffbfed19 (Unreal Engine MCP catalog entry)

- `5ffbfed19` added `optional-mcps/unreal-engine/manifest.yaml` to the repo.
- It did NOT add the matching `[tool.setuptools.data-files]` target, so the entry ships in the sdist (`graft optional-mcps`) but is dropped from the wheel — invisible/uninstallable on pip/Docker/Nix installs.
- This PR adds the missing data-files target and a completeness test that asserts every on-disk `optional-mcps/<name>` has a wheel target. Same bug class as the locales wheel-completeness fixes #27632 / #35374.

Audited siblings: `locales/` already has both a data-files entry and a wheel/sdist test; this brings optional-mcps to parity.

## What does this PR do?

`optional-mcps/` is a bare data directory (no `__init__.py`), so it is invisible to `packages.find` and to package-data. Each catalog entry is shipped in the wheel ONLY via a hand-maintained `[tool.setuptools.data-files]` target (one per entry, because data-files flattens globs into a single target dir). The `data-files` block declared `linear` and `n8n` but not `unreal-engine`, which was added on main by `5ffbfed19` (teknium1, 2026-06-18).

Result: on wheel / Docker / Nix installs, `hermes_cli/mcp_catalog.py::list_catalog()` iterates the packaged dir and silently omits unreal-engine, so `hermes mcp catalog` / picker / dashboard don't list it and `hermes mcp install unreal-engine` fails. The sdist channel is unaffected (`MANIFEST.in` `graft optional-mcps`).

The comment in the `data-files` block already claimed `tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>` — but no such test existed (only a locales test), so nothing caught the omission. This PR adds the missing target and makes that comment true.

## Related Issue

No filed issue — code-originated follow-up to commit `5ffbfed19`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `pyproject.toml`: add `"optional-mcps/unreal-engine" = ["optional-mcps/unreal-engine/manifest.yaml"]` to `[tool.setuptools.data-files]`.
- `tests/test_packaging_metadata.py`: add `test_optional_mcps_catalog_entries_ship_in_wheel` — globs on-disk `optional-mcps/*/manifest.yaml` and asserts each has a matching data-files target and that `MANIFEST.in` grafts the dir.

## How to Test

1. `pytest tests/test_packaging_metadata.py -q` (requires setuptools in the env).
2. Build a wheel (`python -m build --wheel`) and confirm `optional-mcps/unreal-engine/manifest.yaml` is present in the archive.

Regression guard (verified both directions): removing the `unreal-engine` data-files target makes `test_optional_mcps_catalog_entries_ship_in_wheel` fail with `missing: ['optional-mcps/unreal-engine']`; with the target it passes. The new test also guards every future catalog-entry PR (e.g. open MCP-catalog additions) against re-introducing the wheel-drop.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_packaging_metadata.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A