### PR TITLE
fix(desktop): add tooltips to right sidebar header buttons

### DIFF
--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -173,6 +173,7 @@ function FilesystemTab({
           disabled={!hasCwd || loading}
           onClick={onRefresh}
           size="icon-xs"
+		  title={r.refreshTree}
           variant="ghost"
         >
           <Codicon name="refresh" size="0.8125rem" spinning={loading} />
@@ -182,6 +183,7 @@ function FilesystemTab({
           className={HEADER_ACTION_CLASS}
           onClick={() => void onChangeFolder()}
           size="icon-xs"
+		  title={r.openFolder}
           variant="ghost"
         >
           <Codicon name="folder-opened" size="0.8125rem" />
@@ -192,6 +194,7 @@ function FilesystemTab({
           disabled={!hasCwd || !canCollapse}
           onClick={onCollapseAll}
           size="icon-xs"
+		  title={r.collapseAll}
           variant="ghost"
         >
           <Codicon name="collapse-all" size="0.8125rem" />


### PR DESCRIPTION
## What does this PR do?
Three icon buttons in the right sidebar header (Refresh, Open Folder, Collapse All) had no tooltips on hover, making them hard to discover for new users. Added native `title` attributes to each button to match the existing tooltip pattern used throughout the titlebar controls.

## Related Issue
Fixes #

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `apps/desktop/src/app/right-sidebar/index.tsx` — added `title={r.refreshTree}`, `title={r.openFolder}`, `title={r.collapseAll}` to the three header icon buttons in `FilesystemTab`

## How to Test
1. Open the app and click "Show right sidebar" button in the titlebar
2. Hover over the Refresh button (top right of sidebar header) — tooltip should appear
3. Hover over the Open Folder and Collapse All buttons — tooltips should appear for each

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills
N/A

## Screenshots / Logs

**Before**

<img width="272" height="186" alt="image" src="https://github.com/user-attachments/assets/e5f69c9d-3df7-47aa-a437-a4cbbbeb3a3e" />

**After**

<img width="343" height="193" alt="image" src="https://github.com/user-attachments/assets/3783c0d5-60c6-4d07-9b2a-767e99573553" />
