### PR TITLE
fix(oauth): correct claude-code Accounts hint to `claude logout`

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5703,7 +5703,7 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "id": "claude-code",
         "name": "Anthropic OAuth: Required Extra Usage Credits to Use Subscription",
         "flow": "external",
-        "cli_command": "claude setup-token",
+        "cli_command": "claude logout",
         "docs_url": "https://docs.claude.com/en/docs/claude-code",
         "status_fn": _claude_code_only_status,
     },


### PR DESCRIPTION
## Summary

The `claude-code` entry in `_OAUTH_PROVIDER_CATALOG`
(`hermes_cli/web_server.py`) carries `cli_command="claude setup-token"`.
Hermes Desktop renders that field as the "manage / remove" hint on the
Accounts tab, producing:

> Anthropic OAuth: Required Extra Usage Credits to Use Subscription is
> managed outside Hermes. Remove it with `claude setup-token`.

`claude setup-token` issues a long-lived OAuth token for CI / BYOK use —
it does **not** log out, revoke, or otherwise remove an existing OAuth
connection. Users following the hint find their connection unchanged
and may assume the disconnect silently failed.

The correct disconnect path inside the Claude Code CLI is:

- `claude logout` from the terminal, or
- `/logout` inside an interactive Claude Code session, or
- delete `~/.claude/.credentials.json`
  (`%USERPROFILE%\.claude\.credentials.json` on Windows) as a fallback.

The backend `_oauth_provider_disconnect_command()` already returns the
correct shell command for this provider (clearing
`~/.claude/.credentials.json` and, on macOS, the keychain entry), so the
terminal disconnect flow is already right — only the user-facing
**hint** string was wrong. This PR fixes that one field.

## Changes

- `hermes_cli/web_server.py`: change `cli_command` for the `claude-code`
  catalog entry from `"claude setup-token"` to `"claude logout"`.

One-line change, no behaviour change beyond the displayed hint.

## Test plan

- [ ] Open Hermes Desktop → Settings → Connect an account
- [ ] Locate the "Anthropic OAuth: Required Extra Usage Credits to Use
      Subscription" card
- [ ] Confirm the hint now reads `… Remove it with claude logout.`
- [ ] Run `claude logout` and verify the connection state in Hermes
      reflects the logout (existing `_claude_code_only_status` probe)

## Credits

Thanks to @maxmilian for tracing the misleading string from the
downstream `hermes-desktop` UI back to this catalog entry in
`hermes-agent` (the desktop repo only consumes the gateway's OAuth
provider list and doesn't own the hint text), which is why the fix
belongs here rather than there.

## References

- Downstream issue that triggered this:
  https://github.com/fathah/hermes-desktop/issues/678
- `claude setup-token` and `claude logout` are documented side-by-side
  in the Claude Code CLI reference, making the contrast clear:
  https://docs.claude.com/en/docs/claude-code/cli-reference
- Related upstream context (long-lived OAuth tokens are issued, not
  consumed, by `setup-token`):
  https://github.com/anthropics/claude-code/issues/8938