### PR TITLE
feat(delegate): optional profile param so agent_profiles archetypes declare authoritative toolsets; MCP toolsets bypass parent intersection (non-MCP preserved)

### DIFF
--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -7,8 +7,14 @@ arbitrary toolsets.
 """
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
-from tools.delegate_tool import _strip_blocked_tools
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _build_child_agent,
+    _strip_blocked_tools,
+    delegate_task,
+)
 
 
 class TestToolsetIntersection:
@@ -63,3 +69,866 @@ class TestToolsetIntersection:
         scoped = [t for t in requested if t in parent_toolsets]
 
         assert scoped == []
+
+
+def _make_mcp_restricted_parent():
+    """Parent agent whose MCP context is empty (e.g. no_mcp orchestrator).
+
+    enabled_toolsets=[] means the parent loaded no toolsets at all — the
+    intersection against it would normally drop every requested toolset.
+    """
+    parent = MagicMock()
+    parent.enabled_toolsets = []
+    parent._delegate_depth = 0
+    parent._credential_pool = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._print_fn = None
+    return parent
+
+
+class TestProfileMcpToolsetBypass:
+    """MCP toolsets declared by a named agent_profile bypass parent intersection.
+
+    Regression coverage for NousResearch/hermes-agent#32668: an orchestrator
+    that restricts its own MCP servers must still be able to hand domain MCP
+    toolsets to a child via a named profile. Non-MCP toolsets keep going
+    through the parent intersection (the security boundary).
+    """
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_profile_mcp_toolsets_bypass_parent_intersection(self, _):
+        """profile_name set → MCP toolsets pass through even when parent has none."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Check mail",
+                context=None,
+                toolsets=["mcp-fastmail", "mcp-knowledge"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="mail",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-fastmail" in child_toolsets
+        assert "mcp-knowledge" in child_toolsets
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_no_profile_mcp_toolsets_still_intersected(self, _):
+        """No profile → MCP toolset request is dropped (intersection enforced)."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Check mail",
+                context=None,
+                toolsets=["mcp-fastmail"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name=None,
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-fastmail" not in child_toolsets
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_profile_non_mcp_toolsets_still_intersected(self, _):
+        """Even with a profile, non-MCP toolsets the parent lacks are dropped."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Browse the web",
+                context=None,
+                toolsets=["mcp-fastmail", "browser"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="mail",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        # MCP toolset bypasses intersection ...
+        assert "mcp-fastmail" in child_toolsets
+        # ... but the non-MCP toolset the parent never had is still dropped.
+        assert "browser" not in child_toolsets
+
+
+# ---------------------------------------------------------------------------
+# TestDelegateTaskProfileWiring
+# Regression guard for NousResearch/hermes-agent#32668 / #32727.
+# The full call chain from delegate_task() → _build_child_agent() must
+# thread the profile name and resolved toolsets through so MCP toolsets
+# bypass the no_mcp parent intersection at the _build_child_agent level.
+# ---------------------------------------------------------------------------
+
+_FAKE_AGENT_PROFILES = {
+    "documents": {
+        "toolsets": ["mcp-nextcloud-files", "mcp-knowledge"],
+    },
+    "mail": {
+        "toolsets": ["mcp-fastmail"],
+    },
+}
+
+# Minimal delegate_task config: no delegation-specific overrides.
+_BARE_DELEGATION_CFG = {}
+
+# A structurally valid result dict from _run_single_child (enough fields for
+# the post-run aggregation logic in delegate_task to not raise AttributeError).
+def _make_fake_child_result(task_index: int = 0) -> dict:
+    """Return a minimal _run_single_child result dict.
+
+    Why: delegate_task's post-run loop calls entry.pop('_child_role', None),
+    entry.get('api_calls', 0), etc. — mocking with a plain string raises
+    AttributeError.  This helper produces a dict with every field that the
+    post-run aggregation touches.
+    Test: Used internally by TestDelegateTaskProfileWiring patches.
+    """
+    return {
+        "task_index": task_index,
+        "status": "ok",
+        "summary": "done",
+        "error": None,
+        "exit_reason": "complete",
+        "api_calls": 0,
+        "duration_seconds": 0.1,
+        "_child_role": "leaf",
+        "diagnostic_path": None,
+    }
+
+
+def _make_no_mcp_parent():
+    """Parent agent that simulates a no_mcp orchestrator.
+
+    enabled_toolsets contains only the non-MCP platform toolsets.
+    No mcp-* names are present, so the intersection path in
+    _build_child_agent would strip every MCP toolset when profile_name=None.
+    """
+    parent = MagicMock()
+    parent.enabled_toolsets = ["delegation", "knowledge"]
+    parent._delegate_depth = 0
+    parent._credential_pool = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._print_fn = None
+    parent.api_key = None
+    parent._client_kwargs = {}
+    parent.model = "test-model"
+    parent._subagent_id = None
+    parent.valid_tool_names = []
+    return parent
+
+
+class TestDelegateTaskProfileWiring:
+    """delegate_task() wires profile → _build_child_agent(profile_name=...).
+
+    Key regression guard: MUST fail against pre-fix code (profile_name=None
+    hardcoded) and MUST pass after the fix (profile_name=resolved name).
+    """
+
+    @patch("tools.delegate_tool._load_profiles", return_value=_FAKE_AGENT_PROFILES)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_profile_forwarded_to_build_child_agent(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """delegate_task with profile='documents' calls _build_child_agent with
+        profile_name='documents' and the profile's toolsets.
+
+        This test FAILS on pre-fix code (profile_name=None hardcoded) and
+        PASSES after the fix (profile_name='documents' forwarded).
+
+        Why: Without this wiring the bypass branch at lines 972-976 of
+        _build_child_agent never activates, so mcp-nextcloud-files is stripped
+        from a no_mcp parent's child agent.
+        Test: Assert _build_child_agent is called with profile_name='documents'
+        and toolsets=['mcp-nextcloud-files', 'mcp-knowledge'].
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        # delegate_task needs _run_single_child; patch it out with a proper dict.
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Fetch the document",
+                context="Use the Nextcloud MCP server",
+                profile="documents",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        assert kwargs.get("profile_name") == "documents", (
+            f"profile_name should be 'documents', got {kwargs.get('profile_name')!r}. "
+            "Pre-fix code hardcodes profile_name=None — this is the regression guard."
+        )
+        assert "mcp-nextcloud-files" in (kwargs.get("toolsets") or []), (
+            f"Expected mcp-nextcloud-files in toolsets, got {kwargs.get('toolsets')!r}. "
+            "Profile toolsets must override the toolsets arg so the bypass activates."
+        )
+
+    @patch("tools.delegate_tool._load_profiles", return_value=_FAKE_AGENT_PROFILES)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_no_profile_leaves_profile_name_none(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """Without profile= arg, _build_child_agent is called with profile_name=None.
+
+        Preserves backward-compatible behavior: ad-hoc delegation without a
+        named profile still goes through the security intersection path.
+
+        Why: Must not accidentally enable the bypass for unprofiled calls.
+        Test: Call delegate_task without profile= and assert profile_name=None.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+        parent.enabled_toolsets = ["terminal", "file"]
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="List files",
+                toolsets=["terminal", "file"],
+                parent_agent=parent,
+            )
+
+        _, kwargs = mock_build.call_args
+        assert kwargs.get("profile_name") is None, (
+            f"Expected profile_name=None for unprofiled call, got {kwargs.get('profile_name')!r}"
+        )
+
+    @patch("tools.delegate_tool._load_profiles", return_value=_FAKE_AGENT_PROFILES)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_unknown_profile_returns_error(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """Unknown profile name HARD-FAILS: error JSON, delegation refused.
+
+        Why: An unknown profile must fail closed. Falling back to the caller's
+        raw toolsets would let a typo'd profile run with an unrestricted/unintended
+        toolset and silently bypass the profile's declared scope — the canonical,
+        security-correct behavior is to refuse the delegation entirely.
+        Test: Pass profile='nonexistent', assert the result is an
+        {"error": "Unknown agent profile ..."} JSON and _build_child_agent is
+        never called (no child constructed).
+        """
+        import json
+
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+        parent.enabled_toolsets = ["terminal"]
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            result = json.loads(
+                delegate_task(
+                    goal="Do something",
+                    toolsets=["terminal"],
+                    profile="nonexistent",
+                    parent_agent=parent,
+                )
+            )
+
+        assert "error" in result, (
+            f"Unknown profile must return an error JSON, got {result!r}"
+        )
+        assert "Unknown agent profile" in result["error"], (
+            f"Expected 'Unknown agent profile' in error, got {result['error']!r}"
+        )
+        mock_build.assert_not_called()
+
+
+class TestDelegateTaskSchemaProfile:
+    """DELEGATE_TASK_SCHEMA must formally declare the 'profile' property.
+
+    The model reliably emits only schema-declared fields. Without a formal
+    'profile' entry in the schema the model would silently omit it even when
+    the SOUL/orchestrator prompt instructs it to pass profile=.
+    """
+
+    def test_profile_field_in_schema(self):
+        """'profile' is a declared property in DELEGATE_TASK_SCHEMA.
+
+        Why: Without a formal schema entry the LLM strips the field before
+        calling the tool, making the orchestrator's profile= instruction
+        invisible to the handler.
+        Test: Assert 'profile' key exists in schema properties.
+        """
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        assert "profile" in props, (
+            "'profile' missing from DELEGATE_TASK_SCHEMA parameters.properties. "
+            "Add it so the model reliably emits the field."
+        )
+
+    def test_profile_field_is_string_type(self):
+        """'profile' schema property must be type=string.
+
+        Why: Any other type would cause schema validation failures at the
+        provider API boundary.
+        Test: Assert type == 'string' for the profile property.
+        """
+        prop = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["profile"]
+        assert prop.get("type") == "string", (
+            f"Expected profile schema type='string', got {prop.get('type')!r}"
+        )
+
+    def test_profile_field_not_required(self):
+        """'profile' must not be in the 'required' array (it is optional).
+
+        Why: Making it required would break all existing delegate_task calls
+        that don't specify a profile.
+        Test: Assert 'profile' absent from the required list.
+        """
+        required = DELEGATE_TASK_SCHEMA["parameters"].get("required", [])
+        assert "profile" not in required, (
+            "'profile' should not be in required — it is an optional field."
+        )
+
+
+class TestProfileMcpBypassEndToEnd:
+    """End-to-end bypass: no_mcp parent + profile → child keeps MCP toolsets.
+
+    This is the key regression guard from the PR description. It directly
+    tests _build_child_agent with profile_name set vs. None to confirm the
+    bypass branch activates/deactivates correctly.
+    """
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_no_mcp_parent_with_profile_retains_mcp_toolsets(self, _):
+        """CRITICAL: no_mcp parent + profile_name → child retains mcp-nextcloud-files.
+
+        This test FAILS against pre-fix code (profile_name=None hardcoded in
+        the _build_child_agent call site) because the bypass branch is never
+        entered — mcp-nextcloud-files gets stripped by the parent intersection.
+
+        After the fix (profile_name='documents' forwarded) the bypass branch
+        activates and mcp-nextcloud-files survives.
+
+        Why: The confirmed prod gap: fat sub-agents under no_mcp orchestrators
+        received 0 MCP tools. This verifies the fix at the _build_child_agent
+        level independent of the delegate_task wiring.
+        Test: Pass profile_name='documents' and assert mcp-nextcloud-files in
+        child enabled_toolsets. Then repeat with profile_name=None and assert
+        it IS stripped.
+        """
+        parent = _make_mcp_restricted_parent()
+
+        # --- With profile_name set (post-fix behavior) ---
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="File management",
+                context=None,
+                toolsets=["mcp-nextcloud-files", "knowledge"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="documents",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            "mcp-nextcloud-files should bypass no_mcp parent intersection when "
+            "profile_name is set. If this fails the fix is not working."
+        )
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_no_mcp_parent_without_profile_strips_mcp_toolsets(self, _):
+        """Confirm the pre-fix behavior: no profile → MCP stripped (security).
+
+        This must remain true to preserve the security boundary. Ad-hoc
+        delegation without a profile cannot bypass the intersection.
+
+        Why: The bypass is a deliberate whitelist; only named profiles whose
+        config explicitly declares MCP servers should get them through.
+        Test: profile_name=None → mcp-nextcloud-files absent from child.
+        """
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="File management",
+                context=None,
+                toolsets=["mcp-nextcloud-files"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name=None,
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-nextcloud-files" not in child_toolsets, (
+            "mcp-nextcloud-files must be stripped when profile_name=None (security boundary)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestBatchToolsetInjectionBlocked
+# Security regression guard for the batch-mode privilege-escalation hole:
+# a model that names a valid profile (activating the mcp-* bypass in
+# _build_child_agent) AND supplies per-task toolsets must NOT gain toolsets
+# beyond what the profile declares.
+# ---------------------------------------------------------------------------
+
+_PROFILES_WITH_NEXTCLOUD = {
+    "documents": {
+        "toolsets": ["mcp-nextcloud-files"],
+    },
+}
+
+_PROFILES_EMPTY_TOOLSETS = {
+    "bare-profile": {
+        # no 'toolsets' key → empty profile
+    },
+}
+
+
+class TestBatchToolsetInjectionBlocked:
+    """Batch-mode model-supplied toolsets cannot override a resolved profile.
+
+    The vulnerability: batch tasks=[{"goal":"x","toolsets":["mcp-evil"]}] with
+    profile="documents" previously let the model inject arbitrary mcp-* toolsets
+    because the batch loop used `t.get("toolsets") or toolsets`, overriding the
+    profile-resolved toolsets while resolved_profile_name stayed set (activating
+    the mcp-* bypass in _build_child_agent).
+
+    These tests FAIL on pre-fix code (mcp-injected-evil present in child) and
+    PASS after the fix (child toolsets match profile declaration only).
+    """
+
+    @patch("tools.delegate_tool._load_profiles", return_value=_PROFILES_WITH_NEXTCLOUD)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_batch_injection_blocked_model_cannot_inject_evil_mcp_toolset(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """CRITICAL security: batch per-task toolsets are ignored when a profile is set.
+
+        Why: Pre-fix, the batch loop used t.get("toolsets") or toolsets, so a
+        model could name profile="documents" (activating the mcp-* bypass) and
+        supply tasks=[{"goal":"x","toolsets":["mcp-injected-evil"]}] to gain
+        mcp-injected-evil — which the 'documents' profile never declared.
+        What: Assert _build_child_agent receives only the profile's toolsets
+        (mcp-nextcloud-files), and NOT the model-injected mcp-injected-evil.
+        Test: Compare the toolsets kwarg of the mock call against the profile
+        declaration; mcp-injected-evil must be absent, mcp-nextcloud-files present.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                # No top-level goal — use batch tasks path
+                tasks=[{"goal": "do something", "toolsets": ["mcp-injected-evil"]}],
+                profile="documents",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        child_toolsets = kwargs.get("toolsets") or []
+
+        assert "mcp-injected-evil" not in child_toolsets, (
+            f"SECURITY: mcp-injected-evil must be blocked but found in {child_toolsets!r}. "
+            "Pre-fix code lets batch per-task toolsets override the profile. "
+            "This test must FAIL before the fix and PASS after."
+        )
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            f"mcp-nextcloud-files (from profile 'documents') must be present, "
+            f"got {child_toolsets!r}"
+        )
+
+    @patch("tools.delegate_tool._load_profiles", return_value=_PROFILES_WITH_NEXTCLOUD)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_single_task_profile_toolsets_unchanged(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """Single-task profile path: child receives profile's declared toolsets.
+
+        Why: Regression guard — the batch fix must not break single-task profile
+        delegation, which already worked correctly pre-fix.
+        What: delegate_task(goal=..., profile="documents") → child gets
+        mcp-nextcloud-files (the profile's only declared toolset).
+        Test: Assert mcp-nextcloud-files in toolsets kwarg and profile_name set.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Manage my documents",
+                profile="documents",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        child_toolsets = kwargs.get("toolsets") or []
+
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            f"Single-task profile path must forward profile toolsets, got {child_toolsets!r}"
+        )
+        assert kwargs.get("profile_name") == "documents", (
+            f"profile_name must be 'documents', got {kwargs.get('profile_name')!r}"
+        )
+
+    @patch("tools.delegate_tool._load_profiles", return_value=_PROFILES_EMPTY_TOOLSETS)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_empty_profile_toolsets_bypass_not_activated(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """Profile with no toolsets does NOT activate the mcp-* bypass.
+
+        Why: Pre-fix, a profile with empty/missing toolsets still set
+        resolved_profile_name, activating the bypass with whatever caller-
+        supplied toolsets were present.  Any mcp-* name the model supplied
+        would bypass the parent intersection — a privilege-escalation vector.
+        What: Assert profile_name=None in the _build_child_agent call so the
+        intersection path (not bypass) is used, stripping mcp-x from a no_mcp
+        parent.
+        Test: Profile 'bare-profile' has no toolsets; caller passes
+        toolsets=['mcp-x']; assert profile_name=None in build call.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Do something restricted",
+                toolsets=["mcp-x"],
+                profile="bare-profile",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+
+        assert kwargs.get("profile_name") is None, (
+            f"Empty-toolsets profile must NOT set profile_name (bypass must be inactive), "
+            f"got profile_name={kwargs.get('profile_name')!r}. "
+            "Pre-fix: resolved_profile_name was set regardless of toolsets presence."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestProfileToolsetsAliasing
+# Regression guard for the config-aliasing vulnerability: toolsets must be
+# copied (list()) from the config dict, not assigned by reference.
+#
+# Without the copy, any in-place mutation of the working `toolsets` variable
+# (or of `profile_resolved_toolsets`, which is derived from it) silently
+# corrupts the agent_profiles config dict for the entire process lifetime.
+# On the next delegate_task call the now-mutated list would be used as the
+# authoritative profile declaration, bypassing the intended toolset scope.
+# ---------------------------------------------------------------------------
+
+class TestProfileToolsetsAliasing:
+    """Profile toolsets assignment must copy, not reference, the config list.
+
+    Why: profile_cfg["toolsets"] lives inside the dict returned by
+    _load_agent_profiles() and may be cached for the process lifetime.
+    Assigning it directly to the working variable means any in-place
+    mutation (e.g., .append(), .clear(), .pop()) of that variable would
+    corrupt the config — all subsequent delegate_task calls in the same
+    process would see the mutated toolsets as the 'official' profile
+    declaration.  This is a privilege-escalation / DoS vector.
+
+    The fix (list(profile_toolsets) at line ~2082 and
+    list(toolsets) at line ~2110) ensures the working variable and the
+    authoritative capture are independent copies.
+    """
+
+    @patch("tools.delegate_tool._load_profiles")
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_profile_toolsets_copy_prevents_config_corruption(
+        self, mock_build, _mock_cfg, mock_load_profiles
+    ):
+        """Mutating the toolsets list passed to _build_child_agent must NOT
+        corrupt the original agent_profiles config entry.
+
+        Why: Pre-fix code did ``toolsets = profile_toolsets`` (reference), so
+        mutating the kwarg received by _build_child_agent also mutated
+        profiles["documents"]["toolsets"] — corrupting it for every future call.
+        What: After delegate_task resolves a profile, capture the toolsets list
+        that was passed to _build_child_agent, mutate it in-place, then verify
+        profiles["documents"]["toolsets"] is unchanged.
+        Test: Assert that appending a sentinel to the captured child toolsets
+        list does NOT appear in the original config dict, proving list() copy.
+        """
+        # Hold a direct reference to the config list so we can inspect it after
+        # delegate_task has run and after we mutate the captured child toolsets.
+        original_toolsets_list = ["mcp-nextcloud-files", "mcp-knowledge"]
+        profiles_cfg = {
+            "documents": {
+                "toolsets": original_toolsets_list,
+            },
+        }
+        mock_load_profiles.return_value = profiles_cfg
+
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Fetch documents",
+                profile="documents",
+                parent_agent=parent,
+            )
+
+        # Retrieve the toolsets list that was handed to _build_child_agent.
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        child_toolsets_arg: list = kwargs.get("toolsets") or []
+
+        # Sanity: the profile toolsets made it through correctly.
+        assert "mcp-nextcloud-files" in child_toolsets_arg, (
+            f"Profile toolsets must be forwarded; got {child_toolsets_arg!r}"
+        )
+
+        # Now mutate the list that _build_child_agent received.
+        sentinel = "mcp-INJECTED-SENTINEL"
+        child_toolsets_arg.append(sentinel)
+        child_toolsets_arg.clear()
+
+        # CRITICAL ASSERTION: the original config list must be untouched.
+        # Pre-fix (reference): original_toolsets_list would now be empty.
+        # Post-fix (copy):     original_toolsets_list is still the original.
+        assert original_toolsets_list == ["mcp-nextcloud-files", "mcp-knowledge"], (
+            f"Config corruption detected: profiles['documents']['toolsets'] was mutated "
+            f"to {original_toolsets_list!r}. "
+            "The toolsets working variable must be a list() copy, not a reference to the "
+            "config dict's list. Pre-fix code assigns `toolsets = profile_toolsets` "
+            "(reference); the fix is `toolsets = list(profile_toolsets)`."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestInheritMcpToolsetsProfileGuard
+# Security hardening: _preserve_parent_mcp_toolsets must NOT run when a named
+# profile is in use.  The profile's declared toolsets are authoritative — the
+# parent's MCP toolsets must not bleed in via the inherit_mcp_toolsets path.
+#
+# Scenario: parent has mcp-nextcloud-files AND mcp-fastmail in its toolsets.
+# Profile "documents" declares only ["mcp-nextcloud-files"].
+# With inherit_mcp_toolsets=True (default), the pre-fix code calls
+# _preserve_parent_mcp_toolsets unconditionally, which appends mcp-fastmail
+# (a parent MCP toolset missing from the child list) to the resolved profile
+# toolsets — violating the invariant that the profile is authoritative.
+#
+# These tests FAIL on pre-fix code (mcp-fastmail bleeds in) and PASS after
+# the fix (guard `and not profile_name` prevents _preserve_parent_mcp_toolsets
+# from running when a profile is set).
+# ---------------------------------------------------------------------------
+
+_PROFILES_DOCUMENTS_NEXTCLOUD_ONLY = {
+    "documents": {
+        "toolsets": ["mcp-nextcloud-files"],
+    },
+}
+
+
+def _make_mcp_rich_parent():
+    """Parent agent that carries two MCP toolsets: nextcloud-files AND fastmail.
+
+    Why: Simulates an orchestrator that has loaded both domain MCP servers.
+    The profile "documents" only declares mcp-nextcloud-files, so mcp-fastmail
+    is the parent-only MCP toolset that must NOT bleed into the child when a
+    profile is named.
+
+    What: enabled_toolsets includes both mcp-nextcloud-files and mcp-fastmail
+    so that _preserve_parent_mcp_toolsets would normally append mcp-fastmail.
+
+    Test: Use as the parent arg in _build_child_agent calls below.
+    """
+    parent = MagicMock()
+    parent.enabled_toolsets = ["mcp-nextcloud-files", "mcp-fastmail", "delegation"]
+    parent._delegate_depth = 0
+    parent._credential_pool = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._print_fn = None
+    parent.api_key = None
+    parent._client_kwargs = {}
+    parent.model = "test-model"
+    parent._subagent_id = None
+    parent.valid_tool_names = []
+    return parent
+
+
+class TestInheritMcpToolsetsProfileGuard:
+    """inherit_mcp_toolsets=True must NOT add parent MCP toolsets when a profile is named.
+
+    The profile's declared toolsets are authoritative.  _preserve_parent_mcp_toolsets
+    must be skipped entirely when profile_name is set so that parent-only MCP toolsets
+    cannot bleed into the child.
+
+    FAIL before fix: mcp-fastmail (parent-only) appears in child toolsets.
+    PASS after fix:  child toolsets are EXACTLY the profile's (mcp-nextcloud-files only).
+    """
+
+    @patch("tools.delegate_tool._get_inherit_mcp_toolsets", return_value=True)
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_parent_mcp_bleed_blocked_under_profile(self, _mock_cfg, _mock_inherit):
+        """CRITICAL: profile toolsets are authoritative — parent MCP toolsets must not bleed.
+
+        Why: Pre-fix, _preserve_parent_mcp_toolsets runs unconditionally when
+        inherit_mcp_toolsets=True, appending every parent MCP toolset absent from
+        the child list.  With a profile that declares only mcp-nextcloud-files,
+        the parent's mcp-fastmail gets added — a silent scope expansion that
+        violates the "profile declares exactly which MCP servers the child needs"
+        invariant.
+
+        What: _build_child_agent with profile_name="documents" (declares only
+        mcp-nextcloud-files) and a parent that has BOTH mcp-nextcloud-files and
+        mcp-fastmail.  Child toolsets must be exactly ["mcp-nextcloud-files"]
+        (after stripping delegation); mcp-fastmail must NOT appear.
+
+        Test: Assert "mcp-nextcloud-files" in child toolsets and
+        "mcp-fastmail" NOT in child toolsets.  FAILS pre-fix (mcp-fastmail
+        bleeds in via _preserve_parent_mcp_toolsets), PASSES post-fix (guard
+        `and not profile_name` skips the bleed path).
+        """
+        parent = _make_mcp_rich_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Manage documents",
+                context=None,
+                toolsets=["mcp-nextcloud-files"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="documents",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            f"Profile-declared mcp-nextcloud-files must be present, got {child_toolsets!r}"
+        )
+        assert "mcp-fastmail" not in child_toolsets, (
+            f"SECURITY: mcp-fastmail (parent-only) must NOT bleed into the child when "
+            f"profile_name is set, but got {child_toolsets!r}. "
+            "Pre-fix: _preserve_parent_mcp_toolsets runs unconditionally, appending "
+            "every parent MCP toolset not in the child list. "
+            "Fix: add `and not profile_name` guard to the inherit_mcp_toolsets check "
+            "at line ~980 of delegate_tool.py."
+        )
+
+    @patch("tools.delegate_tool._get_inherit_mcp_toolsets", return_value=True)
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_non_profile_inheritance_unchanged(self, _mock_cfg, _mock_inherit):
+        """Non-profile delegation with inherit_mcp_toolsets=True still inherits parent MCP.
+
+        Why: Regression baseline — the profile guard must not break the existing
+        behavior for ad-hoc (no profile) delegation.  When no profile is named,
+        _preserve_parent_mcp_toolsets should still run and add parent MCP toolsets
+        to a narrowed child that requests only a subset.
+
+        What: parent has mcp-nextcloud-files + mcp-fastmail; child requests only
+        mcp-nextcloud-files with NO profile.  After the fix, mcp-fastmail must
+        still appear in child toolsets (non-profile path is unchanged).
+
+        Test: Assert BOTH mcp-nextcloud-files and mcp-fastmail are present in the
+        child toolsets, proving that the guard is scoped to the profile case only.
+        """
+        parent = _make_mcp_rich_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Ad-hoc file management",
+                context=None,
+                toolsets=["mcp-nextcloud-files"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name=None,  # no profile — inheritance must still work
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            f"Requested mcp-nextcloud-files must be present, got {child_toolsets!r}"
+        )
+        assert "mcp-fastmail" in child_toolsets, (
+            f"mcp-fastmail must be inherited from parent when no profile is named "
+            f"(non-profile inheritance must be unchanged), got {child_toolsets!r}. "
+            "If this fails the profile guard is too broad."
+        )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -16,6 +16,7 @@ The parent's context only sees the delegation call and the summary result,
 never the child's intermediate tool calls or reasoning.
 """
 
+import copy
 import enum
 import json
 import logging
@@ -990,6 +991,10 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Name of the resolved agent_profiles profile, if delegation used one.
+    # When set, MCP toolsets declared by the profile bypass parent
+    # intersection (see toolset resolution below).
+    profile_name: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -999,6 +1004,16 @@ def _build_child_agent(
     those credentials instead of inheriting from the parent.  This enables
     routing subagents to a different provider:model pair (e.g. cheap/fast
     model on OpenRouter while the parent runs on Nous Portal).
+
+    profile_name: when set (i.e. the delegation came from a named
+    agent_profiles entry), MCP toolsets in the requested toolset list bypass
+    the parent-intersection check and are resolved directly from the global
+    mcp_servers config.  This is intentional: a profile explicitly declares
+    which MCP servers its worker needs, and those servers should be available
+    regardless of whether the orchestrator itself loaded them (e.g. it
+    restricted its own context via no_mcp).  Non-MCP toolsets still go
+    through intersection — that security boundary is preserved for ad-hoc
+    delegation.  See NousResearch/hermes-agent#32668.
     """
     from run_agent import AIAgent
     import uuid as _uuid
@@ -1049,8 +1064,23 @@ def _build_child_agent(
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
-        if _get_inherit_mcp_toolsets():
+
+        # When toolsets come from a named agent_profile, MCP toolsets bypass the
+        # parent intersection. The profile declares exactly which MCP servers the
+        # child needs; resolving them against the parent's loaded tools would
+        # silently drop them whenever the orchestrator restricts its own MCP
+        # context (e.g. no_mcp, or simply not loading domain servers). Non-MCP
+        # toolsets still go through intersection — that security boundary is
+        # preserved. See NousResearch/hermes-agent#32668.
+        if profile_name:
+            child_toolsets = [
+                t for t in toolsets
+                if _is_mcp_toolset_name(t) or t in expanded_parent
+            ]
+        else:
+            child_toolsets = [t for t in toolsets if t in expanded_parent]
+
+        if _get_inherit_mcp_toolsets() and not profile_name:
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
             )
@@ -2071,6 +2101,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    profile: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
 ) -> str:
@@ -2085,6 +2116,16 @@ def delegate_task(
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The 'profile' parameter names an entry in the top-level
+    ``agent_profiles`` config mapping.  When set, the profile's declared
+    toolsets are used as the effective toolset list for the child, and
+    ``profile_name`` is forwarded to ``_build_child_agent`` so that
+    MCP toolsets declared by the profile bypass the parent's toolset
+    intersection.  This is the mechanism that lets fat sub-agents receive
+    their full MCP toolsets even when the orchestrator runs under a
+    ``no_mcp`` platform toolset.  See NousResearch/hermes-agent#32668 and
+    #32727.
 
     Returns JSON with results array, one entry per task.
     """
@@ -2102,6 +2143,19 @@ def delegate_task(
 
     # Normalise the top-level role once; per-task overrides re-normalise.
     top_role = _normalize_role(role)
+
+    # Resolve named profile (baseline values; explicit call params override profile)
+    _profile_overrides: dict = {}
+    if profile:
+        _all_profiles = _load_profiles()
+        try:
+            _profile_overrides = _resolve_profile(profile, _all_profiles)
+        except ValueError as exc:
+            return tool_error(str(exc))
+
+    # Apply profile baselines (explicit call params override profile values).
+    # toolsets baseline from profile when the caller didn't pass any.
+    toolsets = toolsets or _profile_overrides.get("toolsets")
 
     # Async (background) delegation is single-task only in v1. A batch carries
     # fan-out semantics (N handles, partial completion) that double the state
@@ -2148,6 +2202,13 @@ def delegate_task(
             max_iterations, default_max_iter,
         )
     effective_max_iter = default_max_iter
+    # Config max_iterations is authoritative; a top-level profile only supplies a
+    # baseline when the config default is still in effect. This mirrors the
+    # per-task path below (see task_max_iter / _profile_max_iter) so single-task
+    # calls honor a profile's max_iterations instead of silently discarding it.
+    _top_profile_max_iter = _profile_overrides.get("max_iterations")
+    if _top_profile_max_iter and effective_max_iter == default_max_iter:
+        effective_max_iter = _top_profile_max_iter
 
     # Resolve delegation credentials (provider:model pair).
     # When delegation.provider is configured, this resolves the full credential
@@ -2158,6 +2219,63 @@ def delegate_task(
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
+
+    # Profile model is a baseline: used only when delegation config did not
+    # set an explicit model (creds["model"]). The child still inherits the
+    # parent model when neither config nor profile specify one.
+    if not creds.get("model") and _profile_overrides.get("model"):
+        creds["model"] = _profile_overrides["model"]
+
+    # Named-profile resolution for the MCP-bypass / authoritative-toolset path.
+    #
+    # The profile name and per-task toolsets are threaded to _build_child_agent
+    # via ``_task_profile_names`` below (strict per-task resolution). An unknown
+    # profile already hard-failed above (``_resolve_profile`` raised → tool_error),
+    # so by here ``_profile_overrides`` reflects a VALID profile (or no profile).
+    # We do NOT re-read profiles via a second lenient loader: that older path
+    # warned-and-fell-back on an unknown name, contradicting the strict
+    # fail-closed resolver. Single strict path only. See #32668/#32727.
+    #
+    # ``resolved_profile_name`` activates two downstream behaviours when set:
+    #   1. the mcp-* parent-intersection bypass in _build_child_agent, and
+    #   2. authoritative profile toolsets for EVERY task in a batch (below),
+    #      so a model that names a valid profile cannot inject per-task toolsets
+    #      the profile never declared (batch-injection security fix).
+    # It is set ONLY when the resolved profile declares a non-empty toolsets
+    # list — an empty/toolset-less profile must not activate the bypass with
+    # caller-supplied toolsets (empty-profile bypass security fix).
+    resolved_profile_name: Optional[str] = None
+    if profile and _profile_overrides:
+        _resolved_profile_toolsets = _profile_overrides.get("toolsets")
+        if _resolved_profile_toolsets and isinstance(_resolved_profile_toolsets, list):
+            resolved_profile_name = profile
+            # Copy, not reference (config-aliasing hardening). _resolve_profile
+            # already deep-copies the profile dict, so this is belt-and-suspenders,
+            # but it also insulates the config from any later in-place mutation
+            # (.append()/.clear()) of the working ``toolsets`` variable below.
+            # list() is an independent shallow copy of the string items.
+            toolsets = list(_resolved_profile_toolsets)
+        else:
+            # Profile declares no toolsets — granting the bypass here would
+            # activate the mcp-* exception in _build_child_agent with whatever
+            # the caller/model supplied as toolsets, a privilege-escalation
+            # vector. Refuse to set the resolved name; fall back to intersection.
+            logger.warning(
+                "delegate_task: profile %r has no non-empty toolsets list; "
+                "bypass NOT activated (falling back to intersection path).",
+                profile,
+            )
+
+    # Capture the profile-resolved toolsets so the batch loop below can enforce
+    # them as authoritative, ignoring any per-task toolsets the model supplies.
+    # When no profile was resolved this is None and the batch loop falls through
+    # to the per-task / top-level toolsets (existing behaviour unchanged).
+    #
+    # Take an independent copy (list()) even though `toolsets` was already
+    # copied from profile_toolsets above.  This keeps profile_resolved_toolsets
+    # stable against any future code that mutates `toolsets` in-place between
+    # here and the batch loop — defence-in-depth.
+    profile_resolved_toolsets: Optional[list[str]] = list(toolsets) if resolved_profile_name else None
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -2196,6 +2314,48 @@ def delegate_task(
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
 
+    # Pre-resolve per-task profiles so an unknown profile name surfaces as a
+    # clean tool_error before any child is constructed (and we only load the
+    # profiles block once for the whole batch). Per-task profile beats the
+    # top-level profile; tasks without one inherit the top-level overrides.
+    _task_profile_overrides: List[dict] = []
+    # Effective profile name per task (per-task profile beats the top-level
+    # one). Passed to _build_child_agent so MCP toolsets declared by a named
+    # profile bypass the parent intersection. See NousResearch/hermes-agent#32668.
+    #
+    # Security: the name is carried ONLY when the resolved profile declares a
+    # non-empty toolsets list — the same guard used for ``resolved_profile_name``
+    # above. A toolset-less profile must not activate the mcp-* bypass in
+    # _build_child_agent with caller/model-supplied toolsets (empty-profile
+    # bypass fix). For tasks without a per-task profile we reuse the already
+    # toolset-gated ``resolved_profile_name`` so the top-level empty-profile
+    # case is handled consistently.
+    _task_profile_names: List[Optional[str]] = []
+    _profiles_cache: Optional[dict] = None
+    for t in task_list:
+        task_profile = t.get("profile")
+        if not task_profile:
+            _task_profile_overrides.append(_profile_overrides)
+            _task_profile_names.append(resolved_profile_name)
+            continue
+        if _profiles_cache is None:
+            _profiles_cache = _load_profiles()
+        try:
+            _task_override = _resolve_profile(task_profile, _profiles_cache)
+        except ValueError as exc:
+            return tool_error(str(exc))
+        _task_profile_overrides.append(_task_override)
+        _task_toolsets = _task_override.get("toolsets")
+        if _task_toolsets and isinstance(_task_toolsets, list):
+            _task_profile_names.append(task_profile)
+        else:
+            logger.warning(
+                "delegate_task: per-task profile %r has no non-empty toolsets "
+                "list; bypass NOT activated for this task.",
+                task_profile,
+            )
+            _task_profile_names.append(None)
+
     overall_start = time.monotonic()
     results = []
 
@@ -2220,13 +2380,49 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+
+            # Per-task profile (pre-resolved above) beats the top-level profile;
+            # tasks without one carry the top-level overrides.
+            task_overrides = _task_profile_overrides[i]
+            task_profile_name = _task_profile_names[i]
+
+            # Toolset resolution (security-ordered):
+            #  - If a per-task profile is authoritative (its name survived the
+            #    non-empty-toolsets gate in _task_profile_names), its declared
+            #    toolsets win — a model-supplied per-task `toolsets` must not
+            #    override a named profile and inject undeclared (mcp-*) toolsets.
+            #  - Otherwise: explicit per-task value > task profile baseline >
+            #    top-level toolsets baseline (backward-compatible behaviour).
+            if task_profile_name and task_overrides.get("toolsets"):
+                task_toolsets = task_overrides["toolsets"]
+            else:
+                task_toolsets = t.get("toolsets") or task_overrides.get("toolsets") or toolsets
+            # Config delegation.model wins; otherwise fall back to the task profile model.
+            task_model = creds["model"] or task_overrides.get("model")
+            # effective_max_iter already folds in any top-level profile baseline
+            # above (or the config default when no top-level profile applied). A
+            # per-task profile's max_iterations beats that inherited baseline.
+            task_max_iter = effective_max_iter
+            _profile_max_iter = task_overrides.get("max_iterations")
+            if _profile_max_iter:
+                task_max_iter = _profile_max_iter
+
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
-                max_iterations=effective_max_iter,
+                # Security: when a TOP-LEVEL named profile was resolved its
+                # toolsets are authoritative for every task in the batch. Using
+                # per-task model-supplied toolsets here would let the model name
+                # a valid profile (activating the mcp-* bypass in
+                # _build_child_agent) while injecting arbitrary toolsets the
+                # profile never declared — a privilege-escalation vector. When
+                # no top-level profile is authoritative, fall back to the local
+                # per-task resolution (per-task profile > per-task toolsets >
+                # top-level baseline) computed in ``task_toolsets`` above.
+                toolsets=profile_resolved_toolsets if resolved_profile_name else task_toolsets,
+                model=task_model,
+                max_iterations=task_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
                 override_provider=creds["provider"],
@@ -2242,7 +2438,15 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+                profile_name=task_profile_name,
             )
+            # Profile system prompt override: replace the child's ephemeral
+            # system prompt (read at runtime by the conversation loop) when the
+            # resolved profile supplies one. _build_child_agent's signature is
+            # intentionally left untouched — the override is applied here.
+            _profile_prompt = task_overrides.get("system_prompt_text")
+            if _profile_prompt:
+                setattr(child, "ephemeral_system_prompt", _profile_prompt)
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
             children.append((i, t, child))
@@ -2787,6 +2991,77 @@ def _load_config() -> dict:
         return {}
 
 
+def _load_profiles() -> dict:
+    """Read agent_profiles block from full config."""
+    try:
+        from hermes_cli.config import load_config
+        full_config = load_config()
+        return full_config.get("agent_profiles", {})
+    except Exception:
+        return {}
+
+
+def _load_agent_profiles() -> dict:
+    """Deprecated alias for :func:`_load_profiles` (single source of truth).
+
+    Why: Two loaders (`_load_profiles` strict + this lenient one) drifted apart
+    and let an unknown profile fall back to an unrestricted toolset on one path
+    while the other hard-failed — a security split. Collapsing to one loader
+    guarantees every `delegate_task` profile lookup goes through the same strict
+    resolver, so an unknown profile fails closed everywhere.
+
+    What: Returns the root ``agent_profiles`` mapping by delegating to
+    ``_load_profiles()``; retained only so external/legacy patch targets keep
+    resolving. New code must call ``_load_profiles`` directly.
+
+    Test: Patch ``hermes_cli.config.load_config`` to return
+    {"agent_profiles": {"docs": {...}}} and assert this returns the inner dict.
+    """
+    return _load_profiles()
+
+
+def _resolve_profile(name: str, profiles: dict) -> dict:
+    """Validate profile name and resolve system_prompt_file -> system_prompt_text.
+
+    Returns a dict with zero or more of: model, toolsets, max_iterations,
+    system_prompt_text. Unknown keys are preserved for forward-compatibility.
+    """
+    if name not in profiles:
+        available = list(profiles)
+        raise ValueError(
+            f"Unknown agent profile {name!r}. "
+            f"Available profiles: {available if available else '(none configured)'}"
+        )
+    # Deep copy so nested lists/dicts (e.g. toolsets) can never be mutated back
+    # into the cached profiles block by downstream callers.
+    raw = copy.deepcopy(profiles[name])
+    # Resolve system_prompt_file -> system_prompt_text
+    spf = raw.pop("system_prompt_file", None)
+    if spf:
+        import os
+        from pathlib import Path
+        path = Path(os.path.expanduser(os.path.expandvars(str(spf))))
+        try:
+            raw["system_prompt_text"] = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ValueError(
+                f"Cannot read system_prompt_file {spf!r} for profile {name!r}: {exc}"
+            ) from exc
+    elif "system_prompt" in raw:
+        raw["system_prompt_text"] = raw.pop("system_prompt")
+    # Coerce max_iterations to int so a YAML string (e.g. "30") or other
+    # non-int value fails fast here instead of corrupting the child budget.
+    if "max_iterations" in raw:
+        try:
+            raw["max_iterations"] = int(raw["max_iterations"])
+        except (ValueError, TypeError) as exc:
+            raise ValueError(
+                f"Profile {name!r}: max_iterations must be an integer, "
+                f"got {raw['max_iterations']!r}"
+            ) from exc
+    return raw
+
+
 # ---------------------------------------------------------------------------
 # OpenAI Function-Calling Schema
 # ---------------------------------------------------------------------------
@@ -3043,6 +3318,15 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "profile": {
+                            "type": "string",
+                            "description": (
+                                "Per-task profile override. Beats the top-level 'profile'. "
+                                "See top-level 'profile' for semantics, including the warning "
+                                "that a profile's system_prompt fully replaces the child's "
+                                "default prompt (dropping orchestrator delegation instructions)."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3055,6 +3339,20 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "profile": {
+                "type": "string",
+                "description": (
+                    "Name of a profile defined in agent_profiles config. "
+                    "Sets default model, toolsets, max_iterations, and system prompt "
+                    "for this delegation. Explicit call parameters override profile values. "
+                    "WARNING: a profile's system_prompt REPLACES the child's entire default "
+                    "system prompt (it does NOT append). This drops the orchestrator "
+                    "delegation instructions, so a child run under such a profile cannot "
+                    "spawn its own subagents unless its system_prompt re-includes those "
+                    "instructions. Use a system_prompt profile only for leaf workers, or "
+                    "include the delegation guidance yourself."
+                ),
             },
             "background": {
                 "type": "boolean",


### PR DESCRIPTION
# feat(delegate): optional `profile` param so agent_profiles archetypes declare authoritative toolsets; MCP toolsets bypass parent intersection (non-MCP preserved)

Closes/relates to: NousResearch/hermes-agent#32668 (also #32727)

## Summary

Adds an optional `profile` parameter to `delegate_task` (top-level and per-task in
`tasks=[...]`). A profile names an entry in the top-level `agent_profiles` config
mapping and supplies baseline `model`, `toolsets`, `max_iterations`, and
`system_prompt` for the spawned child. Explicit call parameters still override
profile values.

The motivating problem (#32668): an orchestrator that restricts its own context
via a `no_mcp` platform toolset (or simply never loaded a given domain MCP server)
cannot hand a fat sub-agent the MCP toolsets that sub-agent needs. Today
`_build_child_agent` intersects the child's requested toolsets against the
parent's loaded tools, which silently drops any MCP toolset the orchestrator
itself isn't carrying. The result: profile-driven workers come up missing exactly
the MCP servers their archetype declares.

This change lets a **named profile** act as the authoritative source of a child's
toolsets. When (and only when) a delegation resolves to a valid profile that
declares a non-empty `toolsets` list, MCP toolsets in that list **bypass the
parent-intersection check** and are resolved directly from the global
`mcp_servers` config. Non-MCP toolsets continue to go through intersection
unchanged.

## Why this is safe — the security boundary

The bypass is deliberately narrow. The privilege-escalation surface here is "a
model names a profile, then injects arbitrary toolsets the profile never
declared." Each of those vectors is closed:

1. **Only MCP toolsets bypass.** Non-MCP toolsets (`terminal`, `file`, `web`, …)
   still go through `expanded_parent` intersection in `_build_child_agent`. A
   profile cannot grant a child a non-MCP tool the parent lacks. (See
   `test_profile_non_mcp_toolsets_still_intersected`.)

2. **Empty/toolset-less profiles do NOT activate the bypass.** `profile_name` is
   carried into `_build_child_agent` only when the resolved profile declares a
   non-empty `toolsets` list. A profile with no toolsets falls back to the normal
   intersection path with a warning — so a caller cannot name an empty profile and
   then smuggle in `mcp-*` toolsets via the `toolsets` argument.
   (See `test_empty_profile_toolsets_bypass_not_activated`.)

3. **Batch-mode injection is blocked.** When a *top-level* profile is
   authoritative, its toolsets are used for **every** task in a `tasks=[...]`
   batch; per-task model-supplied `toolsets` are ignored. This stops a model from
   naming a valid profile (to activate the bypass) while injecting a per-task evil
   `mcp-*` toolset the profile never declared.
   (See `test_batch_injection_blocked_model_cannot_inject_evil_mcp_toolset`.)

4. **Unknown profiles fail closed.** `_resolve_profile` raises on an unknown name
   and `delegate_task` returns a `tool_error` before any child is built — there is
   a single strict resolver, no lenient "warn and fall back to unrestricted
   toolset" path. (See `test_unknown_profile_returns_error`.)

5. **Profile toolsets are deep-copied** (`_resolve_profile` deep-copies, and
   `delegate_task` takes an additional `list()` copy) so a child build can never
   mutate the cached config `agent_profiles` block.
   (See `test_profile_toolsets_copy_prevents_config_corruption`.)

6. **`inherit_mcp_toolsets` parent-bleed is suppressed under a profile.** When a
   profile is authoritative the `_preserve_parent_mcp_toolsets` step is skipped, so
   a profile-restricted child does not silently inherit the parent's MCP toolsets.
   (See `test_parent_mcp_bleed_blocked_under_profile`.)

The empty-toolset privilege-escalation guard and the existing parent-intersection
boundary for ad-hoc (profile-less) delegation are fully preserved.

## What changed

`tools/delegate_tool.py` (single production file):

- `delegate_task`: new optional `profile` param (top-level) + `profile` key in the
  per-task schema. Resolves the named profile, applies its `toolsets` / `model` /
  `max_iterations` / `system_prompt` as baselines (explicit args win), and computes
  `resolved_profile_name` / `profile_resolved_toolsets` under the non-empty-toolsets
  gate. Per-task profiles are pre-resolved (so an unknown name surfaces as a clean
  `tool_error` before any child is built) and beat the top-level profile.
- `_build_child_agent`: new optional `profile_name` param. When set, MCP toolsets
  in the requested list bypass parent intersection (`_is_mcp_toolset_name(t) or t in
  expanded_parent`); non-MCP toolsets still intersect. `_preserve_parent_mcp_toolsets`
  is skipped under a profile to prevent parent MCP bleed.
- New helpers: `_load_profiles()` (reads the `agent_profiles` config block),
  `_load_agent_profiles()` (deprecated alias → single strict source of truth), and
  `_resolve_profile(name, profiles)` (validates the name, deep-copies, resolves
  `system_prompt_file`/`system_prompt` → `system_prompt_text`, and coerces
  `max_iterations` to int).
- Schema: `profile` string property added to both the top-level params and the
  per-task `tasks[]` items, with a doc note that a profile's `system_prompt`
  *replaces* (not appends to) the child's default prompt.

No other production files are touched. The change is additive — `profile` defaults
to `None`, so existing profile-less delegation behaviour is byte-for-byte unchanged.

## Test summary

`tests/tools/test_delegate_toolset_scope.py` extends the existing
`TestToolsetIntersection` base cases (unchanged) with eight focused classes:

| Test class | Covers |
|---|---|
| `TestProfileMcpToolsetBypass` | MCP toolsets bypass intersection; non-MCP still intersected; profile-less still intersected |
| `TestDelegateTaskProfileWiring` | `profile_name` forwarded to `_build_child_agent`; profile-less leaves it `None`; unknown profile → `tool_error` |
| `TestDelegateTaskSchemaProfile` | `profile` present in schema, string-typed, not required |
| `TestProfileMcpBypassEndToEnd` | `no_mcp` parent + profile retains MCP toolsets; without profile strips them |
| `TestBatchToolsetInjectionBlocked` | batch per-task toolset injection blocked; single-task profile toolsets unchanged; empty-profile bypass not activated |
| `TestProfileToolsetsAliasing` | profile toolsets copied — child build can't corrupt config |
| `TestInheritMcpToolsetsProfileGuard` | parent MCP bleed blocked under profile; non-profile inheritance unchanged |

Result on a clean v0.17.0 + this patch:

```
tests/tools/test_delegate_toolset_scope.py ......................  [22 passed]
tests/tools/test_delegate.py (regression) ............... [140 passed]
162 passed
```

## Compatibility

- Purely additive; `profile=None` preserves all current behaviour.
- Builds on toolset-scoping primitives already present in v0.17.0
  (`_is_mcp_toolset_name`, `_preserve_parent_mcp_toolsets`,
  `_get_inherit_mcp_toolsets`), so no new cross-module dependencies are introduced.
- One stdlib import added (`import copy`) for the profile deep-copy.
