### PR TITLE
fix(hermes): add supervised recovery for stale or paused Telegram gateway polling

### DIFF
--- a/docs/plans/hardening/2026-06-20-hermes-telegram-paused-liveness.json
+++ b/docs/plans/hardening/2026-06-20-hermes-telegram-paused-liveness.json
@@ -1,0 +1,32 @@
+{
+  "id": "HARDENING-HERMES-TELEGRAM-PAUSED-LIVENESS-2026-06-20",
+  "source_finding": {
+    "status": "restored",
+    "severity": "operational_reliability_incident",
+    "root_cause_class": "gateway_transport_liveness_failure",
+    "symptom": "Hermes gateway process remained alive while Telegram polling paused after repeated reconnect failures, causing conductor silence."
+  },
+  "fix_packet": {
+    "runtime_classifier": "gateway.status.classify_gateway_transport_liveness",
+    "log_classifier": "gateway.status.classify_gateway_log_line",
+    "doctor_surface": "hermes doctor reports HERMES_TELEGRAM_PAUSED or HERMES_TELEGRAM_STALE as red failures",
+    "status_surface": "hermes gateway status reports behavior-level transport health even when PID exists",
+    "dashboard_surface": "/api/status returns gateway_liveness",
+    "repair": "Restart only the affected Hermes gateway profile."
+  },
+  "exit_criteria": [
+    "Paused Telegram runtime state fails red with code HERMES_TELEGRAM_PAUSED while PID metadata exists.",
+    "Stale Telegram last_successful_poll_at fails red with code HERMES_TELEGRAM_STALE.",
+    "Fresh connected Telegram state remains healthy.",
+    "Pause log signature classifies as HERMES_TELEGRAM_PAUSED.",
+    "Runbook separates Hermes transport health from Qwen/Ollama/Postgres/API health."
+  ],
+  "recheck": {
+    "commands": [
+      "scripts/run_tests.sh tests/gateway/test_status_transport_liveness.py tests/hermes_cli/test_gateway_runtime_health.py tests/gateway/test_telegram_network_reconnect.py",
+      ".venv/bin/python -m pytest tests/hermes_cli/test_doctor.py::test_check_gateway_transport_liveness_fails_paused_telegram -q",
+      "python -m py_compile gateway/status.py gateway/run.py gateway/platforms/telegram.py hermes_cli/gateway.py hermes_cli/doctor.py hermes_cli/web_server.py"
+    ],
+    "status": "rechecked_pass"
+  }
+}

--- a/docs/plans/hardening/2026-06-20-hermes-telegram-supervised-recovery.json
+++ b/docs/plans/hardening/2026-06-20-hermes-telegram-supervised-recovery.json
@@ -1,0 +1,60 @@
+{
+  "id": "HARDENING-HERMES-TELEGRAM-SUPERVISED-RECOVERY-2026-06-20",
+  "depends_on": [
+    "HARDENING-HERMES-TELEGRAM-PAUSED-LIVENESS-2026-06-20"
+  ],
+  "source_finding": {
+    "status": "restored",
+    "severity": "operational_reliability_incident",
+    "root_cause_class": "gateway_transport_liveness_failure",
+    "incident_pattern": [
+      "Telegram reconnect failures accumulated until polling paused.",
+      "Hermes process and PID metadata remained alive.",
+      "Qwen tunnel, Ollama, Postgres, NeoEngine API, Cockpit, and tunnel health were separate from the failing Hermes transport.",
+      "Affected Hermes oneshot failed before restart and passed after a profile-scoped Hermes gateway restart.",
+      "Fresh logs showed Connected to Telegram (polling mode) after restart."
+    ]
+  },
+  "fix_packet": {
+    "recovery_module": "gateway.recovery",
+    "cli_surface": "hermes gateway recover",
+    "dashboard_surface": "/api/gateway/recover plus /api/status.gateway_recovery",
+    "action_scope": "restart only the affected Hermes gateway profile",
+    "profile_awareness": "default profile uses hermes gateway recover/restart; named profiles use hermes --profile <name> gateway recover/restart",
+    "cooldown_guard": {
+      "max_restarts": 3,
+      "window_seconds": 900,
+      "scope": "per_profile",
+      "blocked_action": "operator_intervention_required"
+    },
+    "forbidden_targets": [
+      "qwen_tunnel",
+      "ollama",
+      "postgres",
+      "neoengine_api",
+      "cockpit",
+      "unrelated_hermes_profiles"
+    ]
+  },
+  "exit_criteria": [
+    "HERMES_TELEGRAM_PAUSED and HERMES_TELEGRAM_STALE produce restart_profile decisions when cooldown permits.",
+    "Default and qwen-ops-runner-conductor profiles produce distinct command shapes.",
+    "Cooldown blocks a fourth supervised restart within 15 minutes for the affected profile only.",
+    "Corrupt or unreadable recovery-state ledger blocks supervised restart and routes to operator intervention.",
+    "Failed restart attempts are recorded in the cooldown ledger so broken restarts cannot loop unbounded.",
+    "Old restart events are pruned across all profiles to keep the cooldown ledger bounded.",
+    "Dashboard status exposes unhealthy process-alive / transport-dead severity and gateway_recovery.",
+    "Dashboard recovery endpoint supports dry-run decision rendering and profile-scoped background recovery.",
+    "Runbook includes status, doctor, PID lookup, profile-specific recovery, manual fallback, and post-restart oneshot verification commands."
+  ],
+  "recheck": {
+    "commands": [
+      "python -m py_compile gateway/recovery.py gateway/status.py hermes_cli/gateway.py hermes_cli/main.py hermes_cli/web_server.py",
+      "scripts/run_tests.sh tests/gateway/test_recovery_decision.py tests/gateway/test_status_transport_liveness.py tests/docs/test_transport_liveness_runbook.py tests/hermes_cli/test_gateway_runtime_health.py tests/gateway/test_telegram_network_reconnect.py",
+      ".venv/bin/python -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_gateway_recover_dry_run_uses_profile_scoped_cli tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_gateway_recover_spawns_profile_scoped_background_action tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_status -q",
+      ".venv/bin/python -m pytest tests/hermes_cli/test_doctor.py::test_check_gateway_transport_liveness_fails_paused_telegram -q"
+    ],
+    "status": "rechecked_pass",
+    "note": "Full tests/hermes_cli/test_web_server.py was not used as Wave 2 acceptance because TestPtyWebSocket websocket PTY tests fail in isolation in this environment; the new gateway recovery and status endpoint nodeids pass."
+  }
+}

--- a/docs/runbooks/hermes-gateway-transport-liveness.md
+++ b/docs/runbooks/hermes-gateway-transport-liveness.md
@@ -1,0 +1,80 @@
+# Hermes Gateway Transport Liveness
+
+Use this runbook when a gateway process is running but conductors are silent.
+This incident class is process-alive / transport-dead: the Hermes process can
+remain up while Telegram polling has paused after repeated reconnect failures.
+
+## First Response
+
+1. Check Hermes behavior-level health first:
+
+   ```bash
+   hermes gateway status
+   hermes doctor
+   ```
+
+2. Check the gateway log for the transport pause signature:
+
+   ```bash
+   tail -n 120 "${HERMES_HOME:-$HOME/.hermes}/logs/gateway.log"
+   ```
+
+   Classify this line as `HERMES_TELEGRAM_PAUSED`:
+
+   ```text
+   Telegram paused after 10 consecutive reconnect failures
+   ```
+
+3. Restart only the affected Hermes gateway profile:
+
+   ```bash
+   hermes gateway restart
+   ```
+
+   For a named profile:
+
+   ```bash
+   hermes --profile qwen-ops-runner-conductor gateway restart
+   ```
+
+4. Prove recovery:
+
+   ```bash
+   tail -n 80 "${HERMES_HOME:-$HOME/.hermes}/logs/gateway.log" | grep "Connected to Telegram (polling mode)"
+   hermes -z "Reply exactly: ok"
+   hermes --profile qwen-ops-runner-conductor -z "Reply exactly: ok"
+   ```
+
+## Do Not Chase First
+
+Do not start with Qwen, Ollama, Postgres, NeoEngine API, Cockpit, or the tunnel
+unless Hermes transport liveness is clean. Qwen tunnel health is separate from
+Hermes Telegram polling health.
+
+## Watchdog Rule
+
+Restart Hermes only when either condition is true:
+
+- `gateway_state.json` reports `platforms.telegram.state = "paused"` or
+  `platforms.telegram.transport_paused = true`.
+- `platforms.telegram.last_successful_poll_at` is older than the configured
+  stale threshold while Telegram is reported as connected.
+
+The default stale threshold is 15 minutes. Keep it above the Telegram polling
+heartbeat interval; `HERMES_TELEGRAM_POLLING_HEARTBEAT_SECONDS` is clamped to
+30-600 seconds.
+
+The repair is profile-scoped:
+
+```bash
+hermes gateway restart
+```
+
+or:
+
+```bash
+hermes --profile <profile> gateway restart
+```
+
+Leave Qwen tunnel, Ollama, Postgres, and NeoEngine API untouched unless their
+own independent checks fail after Hermes transport health is clean.

--- a/docs/runbooks/hermes-gateway-transport-liveness.md
+++ b/docs/runbooks/hermes-gateway-transport-liveness.md
@@ -3,6 +3,9 @@
 Use this runbook when a gateway process is running but conductors are silent.
 This incident class is process-alive / transport-dead: the Hermes process can
 remain up while Telegram polling has paused after repeated reconnect failures.
+Liveness codes are `HERMES_TELEGRAM_PAUSED` (auto-paused after reconnect
+failures) and `HERMES_TELEGRAM_STALE` (no successful poll within the stale
+threshold despite the transport reporting connected).
 
 ## First Response
 
@@ -13,7 +16,18 @@ remain up while Telegram polling has paused after repeated reconnect failures.
    hermes doctor
    ```
 
-2. Check the gateway log for the transport pause signature:
+2. Confirm the gateway process is alive (transport-dead vs process-dead is the
+   discriminator here):
+
+   ```bash
+   hermes gateway pid
+   ```
+
+   A non-empty PID with a red `hermes gateway status` is the signature of this
+   incident class — the process is up but the Telegram transport is paused or
+   stale.
+
+3. Check the gateway log for the transport pause signature:
 
    ```bash
    tail -n 120 "${HERMES_HOME:-$HOME/.hermes}/logs/gateway.log"
@@ -25,19 +39,65 @@ remain up while Telegram polling has paused after repeated reconnect failures.
    Telegram paused after 10 consecutive reconnect failures
    ```
 
-3. Restart only the affected Hermes gateway profile:
+4. Ask the supervised recovery path what it would do.
+
+   Default profile:
+
+   ```bash
+   hermes gateway recover --dry-run
+   ```
+
+   Named profile:
+
+   ```bash
+   hermes --profile qwen-ops-runner-conductor gateway recover --dry-run
+   ```
+
+   A recoverable decision must name only the affected Hermes profile and must
+   not mention Qwen, Ollama, Postgres, NeoEngine API, Cockpit, the tunnel, or
+   unrelated Hermes profiles as restart targets.
+
+5. Let the supervisor restart only the affected Hermes gateway profile when
+   the dry-run decision is `restart_profile`.
+
+   Default profile:
+
+   ```bash
+   hermes gateway recover
+   ```
+
+   Named profile:
+
+   ```bash
+   hermes --profile qwen-ops-runner-conductor gateway recover
+   ```
+
+   The supervisor enforces the per-profile cooldown: max 3 supervised restarts
+   in 15 minutes. If it returns `operator_intervention_required`, stop here and
+   investigate the underlying Telegram/network/auth failure.
+
+6. If supervised recovery is unavailable, restart only the affected Hermes
+   gateway profile manually.
+
+   Default profile (no profile flag):
 
    ```bash
    hermes gateway restart
    ```
 
-   For a named profile:
+   Named profile (qwen-ops-runner-conductor or any other named profile):
 
    ```bash
    hermes --profile qwen-ops-runner-conductor gateway restart
    ```
 
-4. Prove recovery:
+   The two commands are distinct on purpose — the supervisor decides which
+   profile is affected based on the `gateway_state.json` it owns, then
+   emits the matching command shape. Default profile uses the bare
+   command; named profiles use `--profile <name>` so operators reading the
+   log can tell which slot the supervisor touched.
+
+7. Prove recovery:
 
    ```bash
    tail -n 80 "${HERMES_HOME:-$HOME/.hermes}/logs/gateway.log" | grep "Connected to Telegram (polling mode)"
@@ -45,20 +105,78 @@ remain up while Telegram polling has paused after repeated reconnect failures.
    hermes --profile qwen-ops-runner-conductor -z "Reply exactly: ok"
    ```
 
+   Either oneshot succeeding is the post-restart verification signal. The
+   pre-restart oneshot fails or times out because the transport is paused;
+   the post-restart oneshot succeeds because polling resumed.
+
 ## Do Not Chase First
 
 Do not start with Qwen, Ollama, Postgres, NeoEngine API, Cockpit, or the tunnel
 unless Hermes transport liveness is clean. Qwen tunnel health is separate from
-Hermes Telegram polling health.
+Hermes Telegram polling health. The supervisor is **profile-scoped** — it will
+only restart the affected Hermes profile and will not touch Qwen, Ollama,
+Postgres, the NeoEngine API, or any unrelated Hermes profile.
 
-## Watchdog Rule
+## Supervised Recovery Decision
+
+The supervisor uses `gateway.recovery.evaluate_gateway_recovery(...)` to turn a
+transport-liveness verdict into a bounded action:
+
+- Liveness healthy → `no_action`.
+- `HERMES_TELEGRAM_PAUSED` or `HERMES_TELEGRAM_STALE` and the profile is under
+  the cooldown bound → `restart_profile`; restart only the affected Hermes
+  profile via the profile-aware command shape above.
+- Profile has hit the cooldown bound → no restart; the decision returns
+  `operator_intervention_required` and the runbook routes to a human.
+
+### Cooldown / Flap Guard
+
+Maximum **3 restarts in 15 minutes** per profile. After the third in-window
+restart, the supervisor stops restarting and reports
+`operator_intervention_required` until enough of the in-window restart history
+ages out. The bound is per-profile — a saturated qwen-ops-runner-conductor
+profile does not block recovery on the default profile, and vice versa.
+
+When the supervisor stops restarting, treat it as a hard escalation. The
+underlying transport failure is probably not a transient reconnect — common
+root causes:
+
+- Bot token revoked or rotated; Telegram returns 401 forever.
+- Network partition between the host and `api.telegram.org`.
+- Another poller (different `HERMES_HOME`, container, or laptop) is holding
+  the long-poll session, causing the local profile to get kicked.
+
+In every case, the fix is a human action (rotate token, restore connectivity,
+identify and stop the rogue poller) — looping restarts will not heal it.
+
+If the supervisor returns `recovery_state_corrupt`, inspect and move aside the
+cooldown ledger before retrying supervised recovery:
+
+```bash
+RECOVERY_STATE="${HERMES_HOME:-$HOME/.hermes}/gateway_recovery_state.json"
+python -m json.tool "$RECOVERY_STATE"
+mv "$RECOVERY_STATE" "$RECOVERY_STATE.corrupt.$(date +%Y%m%d%H%M%S)"
+hermes gateway recover --dry-run
+```
+
+For a named profile, let Hermes resolve the profile home; do not guess an
+ad-hoc `HERMES_HOME`. Confirm the profile-scoped gateway state, inspect the
+ledger under that profile's real home, then retry the profile-scoped dry-run:
+
+```bash
+hermes --profile qwen-ops-runner-conductor gateway status
+hermes --profile qwen-ops-runner-conductor gateway recover --dry-run
+```
+
+### Watchdog Rule
 
 Restart Hermes only when either condition is true:
 
 - `gateway_state.json` reports `platforms.telegram.state = "paused"` or
-  `platforms.telegram.transport_paused = true`.
+  `platforms.telegram.transport_paused = true` (`HERMES_TELEGRAM_PAUSED`).
 - `platforms.telegram.last_successful_poll_at` is older than the configured
-  stale threshold while Telegram is reported as connected.
+  stale threshold while Telegram is reported as connected
+  (`HERMES_TELEGRAM_STALE`).
 
 The default stale threshold is 15 minutes. Keep it above the Telegram polling
 heartbeat interval; `HERMES_TELEGRAM_POLLING_HEARTBEAT_SECONDS` is clamped to
@@ -78,3 +196,18 @@ hermes --profile <profile> gateway restart
 
 Leave Qwen tunnel, Ollama, Postgres, and NeoEngine API untouched unless their
 own independent checks fail after Hermes transport health is clean.
+
+## Incident Pattern (reference)
+
+Original incident:
+
+- Telegram reconnect failures accumulated on the qwen-ops-runner-conductor
+  profile until polling auto-paused.
+- Qwen tunnel was healthy throughout — no need to bounce.
+- `hermes -z` oneshot failed against the affected profile (transport dead).
+- Profile-scoped `hermes --profile qwen-ops-runner-conductor gateway restart`
+  resumed polling.
+- Post-restart `hermes -z` oneshot succeeded; conductor traffic resumed.
+
+The supervisor's job is to make that exact sequence happen automatically while
+the cooldown/flap guard prevents it from masking a deeper failure.

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -460,6 +460,14 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._polling_error_task: Optional[asyncio.Task] = None
+        self._polling_heartbeat_task: Optional[asyncio.Task] = None
+        self._polling_heartbeat_shutdown = False
+        self._polling_heartbeat_interval_seconds = self._env_float_clamped(
+            "HERMES_TELEGRAM_POLLING_HEARTBEAT_SECONDS",
+            60.0,
+            min_value=30.0,
+            max_value=600.0,
+        )
         self._polling_conflict_count: int = 0
         self._polling_network_error_count: int = 0
         self._polling_error_callback_ref = None
@@ -1431,6 +1439,80 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, exc_info=True,
             )
 
+    def _record_polling_heartbeat_success(self) -> None:
+        self._write_runtime_status_safe(
+            "polling_heartbeat",
+            platform_state="connected",
+            polling_state="connected",
+            error_code=None,
+            error_message=None,
+            reconnect_failure_count=0,
+            last_successful_poll_at=datetime.now(timezone.utc).isoformat(),
+            transport_paused=False,
+        )
+
+    def _start_polling_heartbeat_monitor(self) -> None:
+        if self._webhook_mode:
+            return
+        if self._polling_heartbeat_task and not self._polling_heartbeat_task.done():
+            return
+        self._polling_heartbeat_shutdown = False
+        task = asyncio.create_task(self._polling_heartbeat_monitor())
+        self._polling_heartbeat_task = task
+        self._background_tasks.add(task)
+        task.add_done_callback(self._clear_polling_heartbeat_task)
+
+    def _clear_polling_heartbeat_task(self, task: asyncio.Task) -> None:
+        self._background_tasks.discard(task)
+        if self._polling_heartbeat_task is task:
+            self._polling_heartbeat_task = None
+
+    async def _handle_polling_heartbeat_error(self, error: Exception) -> None:
+        try:
+            await self._handle_polling_network_error(error)
+        except Exception as reconnect_err:
+            # Intentionally let asyncio.CancelledError propagate; this guard
+            # only keeps unexpected reconnect failures from killing heartbeat.
+            logger.warning(
+                "[%s] Telegram polling heartbeat reconnect handler failed: %s",
+                self.name,
+                reconnect_err,
+                exc_info=True,
+            )
+
+    async def _polling_heartbeat_monitor(self) -> None:
+        """Refresh transport liveness and re-enter reconnect on polling wedges."""
+        while (
+            not self._polling_heartbeat_shutdown
+            and not self.has_fatal_error
+            and not self._webhook_mode
+        ):
+            await asyncio.sleep(self._polling_heartbeat_interval_seconds)
+            if self._polling_heartbeat_shutdown or self.has_fatal_error or self._webhook_mode:
+                return
+            if not (self._app and self._app.updater and self._app.updater.running):
+                logger.warning(
+                    "[%s] Telegram polling heartbeat found updater not running",
+                    self.name,
+                )
+                await self._handle_polling_heartbeat_error(
+                    RuntimeError("Updater not running during polling heartbeat")
+                )
+                continue
+
+            try:
+                await asyncio.wait_for(self._app.bot.get_me(), timeout=10)
+            except Exception as heartbeat_err:
+                logger.warning(
+                    "[%s] Telegram polling heartbeat failed: %s",
+                    self.name,
+                    heartbeat_err,
+                )
+                await self._handle_polling_heartbeat_error(heartbeat_err)
+                continue
+
+            self._record_polling_heartbeat_success()
+
     async def _handle_polling_network_error(self, error: Exception) -> None:
         """Reconnect polling after a transient network interruption.
 
@@ -1490,6 +1572,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, attempt,
             )
             self._polling_network_error_count = 0
+            self._record_polling_heartbeat_success()
+            self._start_polling_heartbeat_monitor()
             # start_polling() returning is necessary but not sufficient:
             # PTB's Updater can be left in a state where `running` is True
             # but the underlying long-poll task is wedged on a stale httpx
@@ -2261,6 +2345,9 @@ class TelegramAdapter(BasePlatformAdapter):
             self._mark_connected()
             mode = "webhook" if self._webhook_mode else "polling"
             logger.info("[%s] Connected to Telegram (%s mode)", self.name, mode)
+            if not self._webhook_mode:
+                self._record_polling_heartbeat_success()
+                self._start_polling_heartbeat_monitor()
 
             # Surface the gateway as "Online" in the bot's short description
             # (opt-in via extra.status_indicator). Non-fatal.
@@ -2329,6 +2416,19 @@ class TelegramAdapter(BasePlatformAdapter):
             await self._set_status_indicator(online=False)
         except Exception:
             pass
+
+        self._polling_heartbeat_shutdown = True
+        if self._polling_heartbeat_task and not self._polling_heartbeat_task.done():
+            heartbeat_task = self._polling_heartbeat_task
+            if heartbeat_task is not asyncio.current_task():
+                heartbeat_task.cancel()
+                try:
+                    await heartbeat_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    logger.debug("[%s] Polling heartbeat task failed during disconnect", self.name, exc_info=True)
+        self._polling_heartbeat_task = None
 
         pending_media_group_tasks = list(self._media_group_tasks.values())
         for task in pending_media_group_tasks:

--- a/gateway/recovery.py
+++ b/gateway/recovery.py
@@ -1,0 +1,442 @@
+"""Profile-scoped gateway transport recovery helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from gateway.status import (
+    HERMES_TELEGRAM_PAUSED,
+    HERMES_TELEGRAM_STALE,
+    classify_gateway_transport_liveness,
+    read_runtime_status,
+)
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
+
+_log = logging.getLogger(__name__)
+
+RECOVERABLE_CODES = {HERMES_TELEGRAM_PAUSED, HERMES_TELEGRAM_STALE}
+DEFAULT_MAX_RESTARTS = 3
+DEFAULT_WINDOW_SECONDS = 15 * 60
+RECOVERY_STATE_FILE = "gateway_recovery_state.json"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _coerce_datetime(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    else:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def recovery_state_path(profile_home: Optional[Path] = None) -> Path:
+    return (profile_home or get_hermes_home()) / RECOVERY_STATE_FILE
+
+
+def load_recovery_state(path: Optional[Path] = None) -> dict[str, Any]:
+    state_path = path or recovery_state_path()
+    if not state_path.exists():
+        return {"restart_events": []}
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _log.warning("Gateway recovery state is unreadable: %s", state_path, exc_info=True)
+        return {
+            "restart_events": [],
+            "state_corrupt": True,
+            "state_path": str(state_path),
+            "state_error": str(exc),
+        }
+    if not isinstance(data, dict):
+        return {
+            "restart_events": [],
+            "state_corrupt": True,
+            "state_path": str(state_path),
+            "state_error": "state root is not an object",
+        }
+    events = data.get("restart_events")
+    if not isinstance(events, list):
+        data["restart_events"] = []
+        data["state_corrupt"] = True
+        data["state_path"] = str(state_path)
+        data["state_error"] = "restart_events is not a list"
+        return data
+    for event in events:
+        if not isinstance(event, dict) or _coerce_datetime(event.get("at")) is None:
+            data["state_corrupt"] = True
+            data["state_path"] = str(state_path)
+            data["state_error"] = "restart_events contains an invalid event"
+            break
+    return data
+
+
+def save_recovery_state(state: dict[str, Any], path: Optional[Path] = None) -> None:
+    state_path = path or recovery_state_path()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_json_write(state_path, state)
+
+
+def recent_restart_events(
+    state: dict[str, Any],
+    *,
+    profile: str,
+    now: Optional[datetime] = None,
+    window_seconds: int = DEFAULT_WINDOW_SECONDS,
+) -> list[dict[str, Any]]:
+    now_dt = now or _utc_now()
+    cutoff = now_dt - timedelta(seconds=max(0, int(window_seconds)))
+    recent: list[dict[str, Any]] = []
+    for event in state.get("restart_events", []) or []:
+        if not isinstance(event, dict):
+            continue
+        if str(event.get("profile") or "default") != profile:
+            continue
+        at = _coerce_datetime(event.get("at"))
+        if at is not None and at >= cutoff:
+            recent.append(event)
+    return recent
+
+
+def pruned_restart_events(
+    state: dict[str, Any],
+    *,
+    now: Optional[datetime] = None,
+    window_seconds: int = DEFAULT_WINDOW_SECONDS,
+) -> list[dict[str, Any]]:
+    now_dt = now or _utc_now()
+    cutoff = now_dt - timedelta(seconds=max(0, int(window_seconds)))
+    pruned: list[dict[str, Any]] = []
+    for event in state.get("restart_events", []) or []:
+        if not isinstance(event, dict):
+            continue
+        at = _coerce_datetime(event.get("at"))
+        if at is not None and at >= cutoff:
+            pruned.append(event)
+    return pruned
+
+
+def _state_from_restart_history(
+    *,
+    profile: str,
+    restart_history: Optional[list[Any]],
+) -> Optional[dict[str, Any]]:
+    if restart_history is None:
+        return None
+    events: list[dict[str, Any]] = []
+    for value in restart_history:
+        if isinstance(value, dict):
+            event = dict(value)
+            event["profile"] = str(event.get("profile") or profile)
+            if "at" not in event and "timestamp" in event:
+                event["at"] = event.get("timestamp")
+        else:
+            event = {"profile": profile, "at": value}
+        events.append(event)
+    return {"restart_events": events}
+
+
+def _cooldown_remaining_seconds(
+    events: list[dict[str, Any]],
+    *,
+    now: datetime,
+    window_seconds: int,
+) -> int:
+    oldest: Optional[datetime] = None
+    for event in events:
+        at = _coerce_datetime(event.get("at"))
+        if at is None:
+            continue
+        if oldest is None or at < oldest:
+            oldest = at
+    if oldest is None:
+        return 0
+    age = max(0, int((now - oldest).total_seconds()))
+    return max(0, int(window_seconds) - age)
+
+
+def record_recovery_attempt(
+    *,
+    profile: str,
+    code: str,
+    outcome: str,
+    returncode: Optional[int] = None,
+    state_path: Optional[Path] = None,
+    now: Optional[datetime] = None,
+    window_seconds: int = DEFAULT_WINDOW_SECONDS,
+) -> dict[str, Any]:
+    now_dt = now or _utc_now()
+    state = load_recovery_state(state_path)
+    kept = pruned_restart_events(
+        state,
+        now=now_dt,
+        window_seconds=window_seconds,
+    )
+    event = {
+        "at": _iso(now_dt),
+        "profile": profile,
+        "code": code,
+        "outcome": outcome,
+    }
+    if returncode is not None:
+        event["returncode"] = returncode
+    kept.append(event)
+    state["restart_events"] = kept
+    state.pop("state_corrupt", None)
+    state.pop("state_error", None)
+    state.pop("state_path", None)
+    state["updated_at"] = _iso(now_dt)
+    save_recovery_state(state, state_path)
+    return state
+
+
+def record_recovery_restart(
+    *,
+    profile: str,
+    code: str,
+    state_path: Optional[Path] = None,
+    now: Optional[datetime] = None,
+    window_seconds: int = DEFAULT_WINDOW_SECONDS,
+) -> dict[str, Any]:
+    return record_recovery_attempt(
+        profile=profile,
+        code=code,
+        outcome="success",
+        state_path=state_path,
+        now=now,
+        window_seconds=window_seconds,
+    )
+
+
+def profile_restart_command(profile: str, *, python_executable: Optional[str] = None) -> list[str]:
+    command = [python_executable or sys.executable, "-m", "hermes_cli.main"]
+    if profile and profile != "default":
+        command.extend(["--profile", profile])
+    command.extend(["gateway", "restart"])
+    return command
+
+
+def profile_restart_display(profile: str) -> str:
+    if profile and profile != "default":
+        return f"hermes --profile {profile} gateway restart"
+    return "hermes gateway restart"
+
+
+def _first_recoverable_issue(liveness: dict[str, Any]) -> Optional[dict[str, Any]]:
+    for issue in liveness.get("platforms", []) or []:
+        if isinstance(issue, dict) and issue.get("code") in RECOVERABLE_CODES:
+            return issue
+    return None
+
+
+def evaluate_gateway_recovery(
+    liveness: dict[str, Any],
+    *,
+    profile: str = "default",
+    state: Optional[dict[str, Any]] = None,
+    restart_history: Optional[list[Any]] = None,
+    now: Optional[datetime] = None,
+    max_restarts: int = DEFAULT_MAX_RESTARTS,
+    window_seconds: int = DEFAULT_WINDOW_SECONDS,
+) -> dict[str, Any]:
+    """Return a restart/noop/intervention decision for one Hermes profile."""
+    now_dt = now or _utc_now()
+    profile = profile or "default"
+    issue = _first_recoverable_issue(liveness or {})
+    history_state = _state_from_restart_history(
+        profile=profile,
+        restart_history=restart_history,
+    )
+    decision_state = history_state if history_state is not None else state
+    state_corrupt = bool((decision_state or {}).get("state_corrupt"))
+    recent = recent_restart_events(
+        decision_state or {"restart_events": []},
+        profile=profile,
+        now=now_dt,
+        window_seconds=window_seconds,
+    )
+    restart_command = profile_restart_command(profile)
+    restart_command_display = profile_restart_display(profile)
+
+    base = {
+        "profile": profile,
+        "restart_scope": "hermes_gateway_profile",
+        "restart_command": restart_command,
+        "restart_command_display": restart_command_display,
+        "restart_count_in_window": len(recent),
+        "cooldown": {
+            "max_restarts": int(max_restarts),
+            "window_seconds": int(window_seconds),
+            "recent_restarts": len(recent),
+        },
+        "state_corrupt": state_corrupt,
+        "state_path": (
+            (decision_state or {}).get("state_path") if state_corrupt else None
+        ),
+        "state_error": (
+            (decision_state or {}).get("state_error") if state_corrupt else None
+        ),
+        "forbidden_targets": [
+            "qwen_tunnel",
+            "ollama",
+            "postgres",
+            "neoengine_api",
+            "cockpit",
+            "unrelated_hermes_profiles",
+        ],
+    }
+
+    if issue is None:
+        return {
+            **base,
+            "action": "no_action",
+            "command": None,
+            "should_restart": False,
+            "operator_intervention_required": False,
+            "reason": "no_recoverable_transport_failure",
+            "cooldown_remaining_seconds": 0,
+        }
+
+    code = str(issue.get("code") or "")
+    if state_corrupt:
+        return {
+            **base,
+            "action": "operator_intervention_required",
+            "command": None,
+            "should_restart": False,
+            "operator_intervention_required": True,
+            "reason": "recovery_state_corrupt",
+            "code": code,
+            "summary": issue.get("summary"),
+            "details": (
+                "Gateway recovery cooldown ledger is unreadable; "
+                "operator must inspect or clear it before supervised restart"
+            ),
+            "cooldown_remaining_seconds": 0,
+        }
+
+    if len(recent) >= int(max_restarts):
+        return {
+            **base,
+            "action": "operator_intervention_required",
+            "command": None,
+            "should_restart": False,
+            "operator_intervention_required": True,
+            "reason": "cooldown_exceeded",
+            "code": code,
+            "summary": issue.get("summary"),
+            "details": f"{code}: restart cooldown exceeded",
+            "cooldown_remaining_seconds": _cooldown_remaining_seconds(
+                recent,
+                now=now_dt,
+                window_seconds=window_seconds,
+            ),
+        }
+
+    return {
+        **base,
+        "action": "restart_profile",
+        "command": restart_command_display,
+        "should_restart": True,
+        "operator_intervention_required": False,
+        "reason": "recoverable_transport_failure",
+        "code": code,
+        "summary": issue.get("summary"),
+        "details": f"{code}: restart affected Hermes gateway profile only",
+        "cooldown_remaining_seconds": 0,
+    }
+
+
+def evaluate_current_gateway_recovery(
+    *,
+    profile: str = "default",
+    state_path: Optional[Path] = None,
+    now: Optional[datetime] = None,
+    max_restarts: int = DEFAULT_MAX_RESTARTS,
+    window_seconds: int = DEFAULT_WINDOW_SECONDS,
+) -> dict[str, Any]:
+    liveness = classify_gateway_transport_liveness(read_runtime_status())
+    recovery_state = load_recovery_state(state_path)
+    return evaluate_gateway_recovery(
+        liveness,
+        profile=profile,
+        state=recovery_state,
+        now=now,
+        max_restarts=max_restarts,
+        window_seconds=window_seconds,
+    )
+
+
+def execute_gateway_recovery(
+    *,
+    profile: str = "default",
+    state_path: Optional[Path] = None,
+    dry_run: bool = False,
+    runner: Optional[Callable[..., Any]] = None,
+    now: Optional[datetime] = None,
+    max_restarts: int = DEFAULT_MAX_RESTARTS,
+    window_seconds: int = DEFAULT_WINDOW_SECONDS,
+) -> dict[str, Any]:
+    """Apply a profile-scoped recovery decision.
+
+    ``runner`` exists for tests and embedding surfaces; production uses
+    ``subprocess.run`` and never touches unrelated services.
+    """
+    liveness = classify_gateway_transport_liveness(read_runtime_status())
+    recovery_state = load_recovery_state(state_path)
+    decision = evaluate_gateway_recovery(
+        liveness,
+        profile=profile,
+        state=recovery_state,
+        now=now,
+        max_restarts=max_restarts,
+        window_seconds=window_seconds,
+    )
+    if not decision.get("should_restart") or dry_run:
+        return {**decision, "executed": False, "dry_run": bool(dry_run)}
+
+    command = list(decision["restart_command"])
+    run = runner or subprocess.run
+    result = run(command, check=False)
+    returncode = getattr(result, "returncode", 0)
+    record_recovery_attempt(
+        profile=profile,
+        code=str(decision.get("code") or "unknown"),
+        outcome="success" if returncode == 0 else "failure",
+        returncode=returncode,
+        state_path=state_path,
+        now=now,
+        window_seconds=window_seconds,
+    )
+    return {
+        **decision,
+        "executed": True,
+        "dry_run": False,
+        "returncode": returncode,
+        "ok": returncode == 0,
+    }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -42,7 +42,7 @@ import sqlite3
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Optional, Any, List, Union
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
@@ -3623,15 +3623,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         platform_state: Optional[str] = None,
         error_code: Optional[str] = None,
         error_message: Optional[str] = None,
+        polling_state: Optional[str] = None,
+        reconnect_failure_count: Optional[int] = None,
+        last_successful_poll_at: Optional[str] = None,
+        transport_paused: Optional[bool] = None,
     ) -> None:
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(
-                platform=platform,
-                platform_state=platform_state,
-                error_code=error_code,
-                error_message=error_message,
-            )
+            kwargs = {
+                "platform": platform,
+                "platform_state": platform_state,
+                "error_code": error_code,
+                "error_message": error_message,
+            }
+            if polling_state is not None:
+                kwargs["polling_state"] = polling_state
+            if reconnect_failure_count is not None:
+                kwargs["reconnect_failure_count"] = reconnect_failure_count
+            if last_successful_poll_at is not None:
+                kwargs["last_successful_poll_at"] = last_successful_poll_at
+            if transport_paused is not None:
+                kwargs["transport_paused"] = transport_paused
+            write_runtime_status(**kwargs)
         except Exception:
             pass
 
@@ -3667,6 +3680,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 platform_state="paused",
                 error_code=None,
                 error_message=info["pause_reason"],
+                polling_state="paused",
+                reconnect_failure_count=info.get("attempts", 0),
+                transport_paused=True,
             )
         except Exception:
             pass
@@ -3698,6 +3714,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 platform_state="retrying",
                 error_code=None,
                 error_message=None,
+                polling_state="retrying",
+                reconnect_failure_count=0,
+                transport_paused=False,
             )
         except Exception:
             pass
@@ -6248,6 +6267,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             platform_state="connected",
                             error_code=None,
                             error_message=None,
+                            polling_state="connected",
+                            reconnect_failure_count=0,
+                            last_successful_poll_at=(
+                                datetime.now(timezone.utc).isoformat()
+                                if platform.value == "telegram"
+                                else None
+                            ),
+                            transport_paused=False,
                         )
                         logger.info("✓ %s reconnected successfully", platform.value)
 
@@ -6300,6 +6327,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             platform_state="retrying",
                             error_code=adapter.fatal_error_code,
                             error_message=adapter.fatal_error_message or "failed to reconnect",
+                            polling_state="retrying",
+                            reconnect_failure_count=attempt,
+                            transport_paused=False,
                         )
                         backoff = min(30 * (2 ** (attempt - 1)), _BACKOFF_CAP)
                         info["attempts"] = attempt
@@ -6338,6 +6368,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         platform_state="retrying",
                         error_code=None,
                         error_message=str(e),
+                        polling_state="retrying",
+                        reconnect_failure_count=attempt,
+                        transport_paused=False,
                     )
                     backoff = min(30 * (2 ** (attempt - 1)), _BACKOFF_CAP)
                     info["attempts"] = attempt

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -14,6 +14,7 @@ concurrently under distinct configurations).
 import hashlib
 import json
 import os
+import re
 import shlex
 import signal
 import subprocess
@@ -34,6 +35,11 @@ _RUNTIME_STATUS_FILE = "gateway_state.json"
 _LOCKS_DIRNAME = "gateway-locks"
 _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
+HERMES_TELEGRAM_PAUSED = "HERMES_TELEGRAM_PAUSED"
+HERMES_TELEGRAM_STALE = "HERMES_TELEGRAM_STALE"
+HERMES_RESTART_PROFILE_REPAIR = (
+    "Restart only this Hermes gateway profile: hermes gateway restart"
+)
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
 _gateway_lock_handle = None
 # Windows byte-range locks are mandatory for other readers. Lock a byte well
@@ -72,6 +78,170 @@ def _get_lock_dir() -> Path:
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _coerce_datetime(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    else:
+        return None
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _transport_issue(
+    *,
+    platform: str,
+    code: str,
+    summary: str,
+    state: Optional[str] = None,
+    reconnect_failure_count: Optional[int] = None,
+    last_successful_poll_at: Optional[str] = None,
+) -> dict[str, Any]:
+    return {
+        "platform": platform,
+        "healthy": False,
+        "code": code,
+        "summary": summary,
+        "state": state,
+        "reconnect_failure_count": reconnect_failure_count,
+        "last_successful_poll_at": last_successful_poll_at,
+        "recommended_repair": HERMES_RESTART_PROFILE_REPAIR,
+    }
+
+
+_TELEGRAM_PAUSED_RE = re.compile(
+    r"\btelegram\b.*\bpaused after\s+(\d+)\s+consecutive(?:\s+\w+)?\s+failures?\b",
+    re.IGNORECASE,
+)
+
+
+def classify_gateway_log_line(line: str) -> Optional[dict[str, Any]]:
+    """Classify gateway log lines that imply transport liveness failure."""
+    match = _TELEGRAM_PAUSED_RE.search(line or "")
+    if not match:
+        return None
+
+    count = _coerce_int(match.group(1))
+    summary = "Telegram polling paused"
+    if count is not None:
+        summary = f"{summary} after {count} reconnect failures"
+    return _transport_issue(
+        platform="telegram",
+        code=HERMES_TELEGRAM_PAUSED,
+        summary=summary,
+        state="paused",
+        reconnect_failure_count=count,
+    )
+
+
+def classify_gateway_transport_liveness(
+    state: Optional[dict[str, Any]],
+    *,
+    stale_after_seconds: int = 900,
+    now: Any = None,
+) -> dict[str, Any]:
+    """Classify behavior-level gateway transport health from runtime status.
+
+    PID/process checks answer "is the gateway process alive?" This answers
+    whether a messaging transport is still usable. A paused Telegram polling
+    transport is unhealthy even when the gateway process remains alive.
+    """
+    now_dt = _coerce_datetime(now) or datetime.now(timezone.utc)
+    issues: list[dict[str, Any]] = []
+
+    if isinstance(state, dict):
+        platforms = state.get("platforms") or {}
+        if isinstance(platforms, dict):
+            for platform, raw_platform_state in platforms.items():
+                if not isinstance(raw_platform_state, dict):
+                    continue
+                platform_name = str(platform)
+                platform_key = platform_name.lower()
+                transport_state = str(raw_platform_state.get("state") or "").lower()
+                polling_state = str(
+                    raw_platform_state.get("polling_state") or transport_state
+                ).lower()
+                reconnect_failure_count = _coerce_int(
+                    raw_platform_state.get("reconnect_failure_count")
+                )
+                last_successful_poll_at = raw_platform_state.get("last_successful_poll_at")
+                paused = (
+                    bool(raw_platform_state.get("transport_paused"))
+                    or transport_state == "paused"
+                    or polling_state == "paused"
+                )
+
+                if platform_key == "telegram" and paused:
+                    summary = "Telegram polling paused"
+                    if reconnect_failure_count is not None:
+                        summary += f" after {reconnect_failure_count} reconnect failures"
+                    error_message = raw_platform_state.get("error_message")
+                    if error_message:
+                        summary += f": {error_message}"
+                    issues.append(_transport_issue(
+                        platform=platform_name,
+                        code=HERMES_TELEGRAM_PAUSED,
+                        summary=summary,
+                        state=transport_state or polling_state or None,
+                        reconnect_failure_count=reconnect_failure_count,
+                        last_successful_poll_at=last_successful_poll_at,
+                    ))
+                    continue
+
+                last_poll_dt = _coerce_datetime(last_successful_poll_at)
+                if (
+                    platform_key == "telegram"
+                    and last_poll_dt is not None
+                    and (
+                        transport_state in {"connected", "running"}
+                        or polling_state in {"connected", "polling"}
+                    )
+                ):
+                    age_seconds = max(0, int((now_dt - last_poll_dt).total_seconds()))
+                    if age_seconds > int(stale_after_seconds):
+                        issues.append(_transport_issue(
+                            platform=platform_name,
+                            code=HERMES_TELEGRAM_STALE,
+                            summary=(
+                                "Telegram polling stale: last successful poll "
+                                f"{age_seconds}s ago"
+                            ),
+                            state=transport_state or polling_state or None,
+                            reconnect_failure_count=reconnect_failure_count,
+                            last_successful_poll_at=last_successful_poll_at,
+                        ))
+
+    first_issue = issues[0] if issues else None
+    return {
+        "healthy": not issues,
+        "status": "healthy" if not issues else "unhealthy",
+        "code": None if first_issue is None else first_issue["code"],
+        "summary": "Gateway transports healthy" if first_issue is None else first_issue["summary"],
+        "recommended_repair": None if first_issue is None else first_issue["recommended_repair"],
+        "platforms": issues,
+    }
 
 
 def terminate_pid(pid: int, *, force: bool = False) -> None:
@@ -576,17 +746,22 @@ def write_runtime_status(
     error_code: Any = _UNSET,
     error_message: Any = _UNSET,
     served_profiles: Any = _UNSET,
+    polling_state: Any = _UNSET,
+    reconnect_failure_count: Any = _UNSET,
+    last_successful_poll_at: Any = _UNSET,
+    transport_paused: Any = _UNSET,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
     current_record = _build_pid_record()
+    now_iso = _utc_now_iso()
     payload.setdefault("platforms", {})
     payload["kind"] = current_record["kind"]
     payload["pid"] = current_record["pid"]
     payload["argv"] = current_record["argv"]
     payload["start_time"] = current_record["start_time"]
-    payload["updated_at"] = _utc_now_iso()
+    payload["updated_at"] = now_iso
 
     if gateway_state is not _UNSET:
         payload["gateway_state"] = gateway_state
@@ -604,13 +779,51 @@ def write_runtime_status(
 
     if platform is not _UNSET:
         platform_payload = payload["platforms"].get(platform, {})
+        platform_key = str(platform).lower()
+        has_explicit_last_successful_poll = last_successful_poll_at is not _UNSET
         if platform_state is not _UNSET:
             platform_payload["state"] = platform_state
+            if platform_key == "telegram":
+                normalized_state = str(platform_state or "").lower()
+                if normalized_state == "connected":
+                    platform_payload["polling_state"] = "connected"
+                    platform_payload["transport_paused"] = False
+                    platform_payload["reconnect_failure_count"] = 0
+                    if not has_explicit_last_successful_poll:
+                        platform_payload.pop("last_successful_poll_at", None)
+                elif normalized_state == "paused":
+                    platform_payload["polling_state"] = "paused"
+                    platform_payload["transport_paused"] = True
+                elif normalized_state in {"connecting", "retrying"}:
+                    platform_payload["polling_state"] = normalized_state
+                    platform_payload["transport_paused"] = False
+                elif normalized_state in {"fatal", "disconnected"}:
+                    platform_payload["polling_state"] = normalized_state
+                    platform_payload["transport_paused"] = False
         if error_code is not _UNSET:
             platform_payload["error_code"] = error_code
         if error_message is not _UNSET:
             platform_payload["error_message"] = error_message
-        platform_payload["updated_at"] = _utc_now_iso()
+        if polling_state is not _UNSET:
+            platform_payload["polling_state"] = polling_state
+        if reconnect_failure_count is not _UNSET:
+            coerced_count = _coerce_int(reconnect_failure_count)
+            if coerced_count is None:
+                platform_payload.pop("reconnect_failure_count", None)
+            else:
+                platform_payload["reconnect_failure_count"] = max(0, coerced_count)
+        if last_successful_poll_at is not _UNSET:
+            if last_successful_poll_at is None:
+                platform_payload.pop("last_successful_poll_at", None)
+            elif isinstance(last_successful_poll_at, datetime):
+                platform_payload["last_successful_poll_at"] = (
+                    last_successful_poll_at.astimezone(timezone.utc).isoformat()
+                )
+            else:
+                platform_payload["last_successful_poll_at"] = str(last_successful_poll_at)
+        if transport_paused is not _UNSET:
+            platform_payload["transport_paused"] = bool(transport_paused)
+        platform_payload["updated_at"] = now_iso
         payload["platforms"][platform] = platform_payload
 
     _write_json_file(path, payload)

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -234,9 +234,25 @@ def classify_gateway_transport_liveness(
                         ))
 
     first_issue = issues[0] if issues else None
+    process_alive = False
+    if isinstance(state, dict):
+        process_alive = bool(state.get("pid")) or state.get("gateway_state") in {
+            "running",
+            "degraded",
+        }
+    headline = "Gateway transports healthy"
+    if first_issue is not None:
+        headline = (
+            "transport dead / process alive"
+            if process_alive
+            else "gateway transport unhealthy"
+        )
     return {
         "healthy": not issues,
         "status": "healthy" if not issues else "unhealthy",
+        "severity": "healthy" if not issues else "unhealthy",
+        "headline": headline,
+        "process_alive": process_alive,
         "code": None if first_issue is None else first_issue["code"],
         "summary": "Gateway transports healthy" if first_issue is None else first_issue["summary"],
         "recommended_repair": None if first_issue is None else first_issue["recommended_repair"],

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -367,6 +367,37 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
         check_warn("Could not verify systemd linger", f"({linger_detail})")
 
 
+def _check_gateway_transport_liveness(issues: list[str]) -> None:
+    """Fail doctor when the gateway process is alive but transport is wedged."""
+    try:
+        from gateway.status import (
+            classify_gateway_transport_liveness,
+            read_runtime_status,
+        )
+    except Exception as e:
+        check_warn("Gateway transport liveness", f"(could not import status helpers: {e})")
+        return
+
+    state = read_runtime_status()
+    if not state:
+        return
+
+    liveness = classify_gateway_transport_liveness(state)
+    if liveness.get("healthy"):
+        check_ok("Gateway transport liveness", "(runtime status healthy)")
+        return
+
+    _section("Gateway Transport")
+    for issue in liveness.get("platforms", []):
+        platform = issue.get("platform") or "gateway"
+        code = issue.get("code") or "transport_unhealthy"
+        summary = issue.get("summary") or "transport unhealthy"
+        repair = issue.get("recommended_repair") or "Restart the affected gateway profile"
+        check_fail(f"{platform}: {code}", f"({summary})")
+        check_info(repair)
+        issues.append(f"{code}: {summary}; {repair}")
+
+
 _APIKEY_PROVIDERS_CACHE: list | None = None
 
 
@@ -1300,6 +1331,7 @@ def run_doctor(args):
 
     _check_gateway_service_linger(issues)
     _check_s6_supervision(issues)
+    _check_gateway_transport_liveness(issues)
 
     if sys.platform != "win32":
         _section("Command Installation")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3804,6 +3804,13 @@ def launchd_status(deep: bool = False):
         print("  Service definition exists locally but launchd has not loaded it.")
         print("  Run: hermes gateway start")
 
+    runtime_lines = _runtime_health_lines()
+    if runtime_lines:
+        print()
+        print("Recent gateway health:")
+        for line in runtime_lines:
+            print(f"  {line}")
+
     if deep:
         log_file = get_hermes_home() / "logs" / "gateway.log"
         if log_file.exists():
@@ -4931,7 +4938,11 @@ def _platform_status(platform: dict) -> str:
 def _runtime_health_lines() -> list[str]:
     """Summarize the latest persisted gateway runtime health state."""
     try:
-        from gateway.status import read_runtime_status
+        from gateway.status import (
+            classify_gateway_log_line,
+            classify_gateway_transport_liveness,
+            read_runtime_status,
+        )
     except Exception:
         return []
 
@@ -4945,11 +4956,37 @@ def _runtime_health_lines() -> list[str]:
     active_agents = state.get("active_agents")
     restart_requested = state.get("restart_requested")
     platforms = state.get("platforms", {}) or {}
+    liveness = classify_gateway_transport_liveness(state)
+    seen_codes = set()
+
+    for issue in liveness.get("platforms", []):
+        platform = issue.get("platform") or "gateway"
+        code = issue.get("code") or "transport_unhealthy"
+        seen_codes.add(code)
+        summary = issue.get("summary") or "transport unhealthy"
+        repair = issue.get("recommended_repair")
+        detail = f"{summary} [{code}]"
+        if repair:
+            detail = f"{detail}; repair: {repair}"
+        lines.append(f"⚠ {platform}: {detail}")
 
     for platform, pdata in platforms.items():
         if pdata.get("state") == "fatal":
             message = pdata.get("error_message") or "unknown error"
             lines.append(f"⚠ {platform}: {message}")
+
+    for issue in _recent_gateway_log_transport_issues(classify_gateway_log_line):
+        code = issue.get("code") or "transport_unhealthy"
+        if code in seen_codes:
+            continue
+        seen_codes.add(code)
+        platform = issue.get("platform") or "gateway"
+        summary = issue.get("summary") or "transport unhealthy"
+        repair = issue.get("recommended_repair")
+        detail = f"{summary} [{code}]"
+        if repair:
+            detail = f"{detail}; repair: {repair}"
+        lines.append(f"⚠ {platform}: {detail}")
 
     if gateway_state == "startup_failed" and exit_reason:
         lines.append(f"⚠ Last startup issue: {exit_reason}")
@@ -4961,6 +4998,33 @@ def _runtime_health_lines() -> list[str]:
         lines.append(f"⚠ Last shutdown reason: {exit_reason}")
 
     return lines
+
+
+def _recent_gateway_log_transport_issues(classifier) -> list[dict]:
+    log_file = get_hermes_home() / "logs" / "gateway.log"
+    if not log_file.exists():
+        return []
+    try:
+        with log_file.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - 65536), os.SEEK_SET)
+            raw = handle.read()
+    except OSError:
+        return []
+
+    issues: list[dict] = []
+    seen_codes: set[str] = set()
+    for line in reversed(raw.decode("utf-8", errors="replace").splitlines()[-200:]):
+        issue = classifier(line)
+        if not issue:
+            continue
+        code = issue.get("code")
+        if code in seen_codes:
+            continue
+        seen_codes.add(code)
+        issues.append(issue)
+    return list(reversed(issues))
 
 
 def _setup_standard_platform(platform: dict):

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5,6 +5,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 """
 
 import asyncio
+import json
 import logging
 import os
 import shlex
@@ -7116,6 +7117,41 @@ def _gateway_command_inner(args):
             # Start fresh
             print("Starting gateway...")
             run_gateway(verbose=0)
+
+    elif subcmd == "recover":
+        from gateway.recovery import execute_gateway_recovery
+        from hermes_cli.profiles import get_active_profile_name
+
+        result = execute_gateway_recovery(
+            profile=get_active_profile_name(),
+            dry_run=getattr(args, "dry_run", False),
+            max_restarts=max(1, int(getattr(args, "max_restarts", 3) or 3)),
+            window_seconds=max(1, int(getattr(args, "window_seconds", 900) or 900)),
+        )
+        if getattr(args, "json", False):
+            print(json.dumps(result, indent=2))
+        else:
+            action = result.get("action")
+            profile = result.get("profile")
+            if action == "restart_profile":
+                if result.get("executed"):
+                    print(f"✓ Restarted Hermes gateway profile '{profile}'")
+                else:
+                    print(f"↻ Would restart Hermes gateway profile '{profile}'")
+                print(f"  Command: {result.get('restart_command_display')}")
+            elif action == "operator_intervention_required":
+                print("✗ Gateway recovery cooldown exceeded")
+                print(f"  Profile: {profile}")
+                print(f"  Code: {result.get('code')}")
+                if result.get("cooldown_remaining_seconds"):
+                    print(f"  Retry after: {result.get('cooldown_remaining_seconds')}s")
+                print("  Operator intervention required before another restart.")
+            else:
+                print("✓ No supervised gateway recovery needed")
+        if result.get("operator_intervention_required") or (
+            result.get("executed") and not result.get("ok", False)
+        ):
+            sys.exit(1)
 
     elif subcmd == "status":
         deep = getattr(args, "deep", False)

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -133,6 +133,34 @@ def build_gateway_parser(
     )
     _add_compat_platform_flag(gateway_restart)
 
+    # gateway recover
+    gateway_recover = gateway_subparsers.add_parser(
+        "recover",
+        help="Restart this profile's gateway only when transport liveness is failed",
+    )
+    gateway_recover.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the recovery decision without running the restart command",
+    )
+    gateway_recover.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the recovery decision as JSON",
+    )
+    gateway_recover.add_argument(
+        "--max-restarts",
+        type=int,
+        default=3,
+        help="Maximum supervised restarts allowed in the cooldown window",
+    )
+    gateway_recover.add_argument(
+        "--window-seconds",
+        type=int,
+        default=900,
+        help="Cooldown window in seconds (default: 900)",
+    )
+
     # gateway status
     gateway_status = gateway_subparsers.add_parser("status", help="Show gateway status")
     gateway_status.add_argument("--deep", action="store_true", help="Deep status check")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -69,6 +69,7 @@ from hermes_cli.memory_providers import (
     get_memory_provider,
 )
 from gateway.status import (
+    classify_gateway_transport_liveness,
     get_running_pid,
     get_runtime_status_running_pid,
     read_runtime_status,
@@ -995,7 +996,6 @@ class ManagedFilesPolicy:
     locked_root: Path | None
     can_change_path: bool
 
-
 _FS_READDIR_HIDDEN = {
     ".git",
     ".hg",
@@ -1764,6 +1764,7 @@ async def get_status(profile: Optional[str] = None):
         gateway_platforms: dict = {}
         gateway_exit_reason = None
         gateway_updated_at = None
+        gateway_liveness = classify_gateway_transport_liveness(None)
         configured_gateway_platforms: set[str] | None = None
         try:
             from gateway.config import load_gateway_config
@@ -1812,6 +1813,10 @@ async def get_status(profile: Optional[str] = None):
                 # stopped/None state so the dashboard shows the correct badge.
                 if gateway_state in {None, "stopped"}:
                     gateway_state = "running"
+            gateway_liveness = classify_gateway_transport_liveness({
+                **runtime,
+                "platforms": gateway_platforms,
+            })
 
         # If there was no runtime info at all but the health probe confirmed alive,
         # ensure we still report the gateway as running (no shared volume scenario).
@@ -1863,6 +1868,7 @@ async def get_status(profile: Optional[str] = None):
             "gateway_platforms": gateway_platforms,
             "gateway_exit_reason": gateway_exit_reason,
             "gateway_updated_at": gateway_updated_at,
+            "gateway_liveness": gateway_liveness,
             "active_sessions": active_sessions,
             "auth_required": auth_required,
             "auth_providers": auth_providers,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -996,6 +996,7 @@ class ManagedFilesPolicy:
     locked_root: Path | None
     can_change_path: bool
 
+
 _FS_READDIR_HIDDEN = {
     ".git",
     ".hg",
@@ -1765,6 +1766,7 @@ async def get_status(profile: Optional[str] = None):
         gateway_exit_reason = None
         gateway_updated_at = None
         gateway_liveness = classify_gateway_transport_liveness(None)
+        gateway_recovery: dict[str, Any] | None = None
         configured_gateway_platforms: set[str] | None = None
         try:
             from gateway.config import load_gateway_config
@@ -1817,6 +1819,23 @@ async def get_status(profile: Optional[str] = None):
                 **runtime,
                 "platforms": gateway_platforms,
             })
+            try:
+                from gateway.recovery import evaluate_gateway_recovery, load_recovery_state
+                from hermes_cli.profiles import get_active_profile_name
+
+                recovery_profile = (
+                    requested_profile
+                    if requested_profile and requested_profile.lower() != "current"
+                    else get_active_profile_name()
+                )
+                gateway_recovery = evaluate_gateway_recovery(
+                    gateway_liveness,
+                    profile=recovery_profile,
+                    state=load_recovery_state(),
+                )
+            except Exception:
+                _log.warning("Failed to evaluate gateway recovery state", exc_info=True)
+                gateway_recovery = None
 
         # If there was no runtime info at all but the health probe confirmed alive,
         # ensure we still report the gateway as running (no shared volume scenario).
@@ -1869,6 +1888,9 @@ async def get_status(profile: Optional[str] = None):
             "gateway_exit_reason": gateway_exit_reason,
             "gateway_updated_at": gateway_updated_at,
             "gateway_liveness": gateway_liveness,
+            "gateway_liveness_severity": gateway_liveness.get("severity"),
+            "gateway_liveness_headline": gateway_liveness.get("headline"),
+            "gateway_recovery": gateway_recovery,
             "active_sessions": active_sessions,
             "auth_required": auth_required,
             "auth_providers": auth_providers,
@@ -2222,6 +2244,7 @@ _ACTION_LOG_DIR: Path = get_hermes_home() / "logs"
 
 # Short ``name`` (from the URL) → absolute log file path.
 _ACTION_LOG_FILES: Dict[str, str] = {
+    "gateway-recover": "gateway-recover.log",
     "gateway-restart": "gateway-restart.log",
     "gateway-start": "gateway-start.log",
     "gateway-stop": "gateway-stop.log",
@@ -2266,6 +2289,17 @@ def _record_completed_action(name: str, message: str, exit_code: int = 1) -> Non
     _ACTION_PROCS.pop(name, None)
     _ACTION_COMMANDS.pop(name, None)
     _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": None}
+
+
+class GatewayRecoverBody(BaseModel):
+    dry_run: bool = False
+    profile: Optional[str] = None
+    max_restarts: int = 3
+    window_seconds: int = 900
+
+
+_GATEWAY_RECOVER_DASHBOARD_MAX_RESTARTS = 3
+_GATEWAY_RECOVER_DASHBOARD_MIN_WINDOW_SECONDS = 15 * 60
 
 
 def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
@@ -2426,6 +2460,121 @@ async def restart_gateway(profile: Optional[str] = None):
         "ok": True,
         "pid": proc.pid,
         "name": "gateway-restart",
+    }
+
+
+def _gateway_recover_profile(profile: Optional[str]) -> str:
+    requested = (profile or "").strip()
+    if requested and requested.lower() != "current":
+        return requested
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Could not resolve active dashboard profile for gateway recovery",
+        ) from exc
+
+
+def _gateway_recover_max_restarts(value: int) -> int:
+    return min(
+        _GATEWAY_RECOVER_DASHBOARD_MAX_RESTARTS,
+        max(1, int(value or _GATEWAY_RECOVER_DASHBOARD_MAX_RESTARTS)),
+    )
+
+
+def _gateway_recover_window_seconds(value: int) -> int:
+    return max(
+        _GATEWAY_RECOVER_DASHBOARD_MIN_WINDOW_SECONDS,
+        int(value or _GATEWAY_RECOVER_DASHBOARD_MIN_WINDOW_SECONDS),
+    )
+
+
+def _gateway_recover_subcommand(body: GatewayRecoverBody, *, dry_run: bool) -> List[str]:
+    profile = _gateway_recover_profile(body.profile)
+    subcommand: List[str] = []
+    if profile and profile != "default":
+        subcommand.extend(["--profile", profile])
+    subcommand.extend([
+        "gateway",
+        "recover",
+        "--max-restarts",
+        str(_gateway_recover_max_restarts(body.max_restarts)),
+        "--window-seconds",
+        str(_gateway_recover_window_seconds(body.window_seconds)),
+    ])
+    if dry_run:
+        subcommand.extend(["--dry-run", "--json"])
+    return subcommand
+
+
+@app.post("/api/gateway/recover")
+async def recover_gateway(body: GatewayRecoverBody):
+    """Run supervised, profile-scoped gateway recovery.
+
+    Dry-run returns the decision payload immediately. Non-dry-run is spawned
+    in the background so a dashboard request cannot hang while the gateway
+    restarts itself.
+    """
+    if body.dry_run:
+        cmd = [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            *_gateway_recover_subcommand(body, dry_run=True),
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=str(PROJECT_ROOT),
+                env={**os.environ, "HERMES_NONINTERACTIVE": "1"},
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=15,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise HTTPException(
+                status_code=504,
+                detail=f"Gateway recovery dry-run timed out: {exc}",
+            )
+        except Exception as exc:
+            _log.exception("Failed to run gateway recovery dry-run")
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to evaluate gateway recovery: {exc}",
+            )
+        # The CLI exits 1 for operator-intervention decisions (cooldown/corrupt
+        # state). Those are valid decision payloads for a dashboard dry-run.
+        if result.returncode not in {0, 1}:
+            detail = (result.stderr or result.stdout or "").strip()
+            raise HTTPException(
+                status_code=500,
+                detail=f"Gateway recovery dry-run failed: {detail or result.returncode}",
+            )
+        try:
+            decision = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            raise HTTPException(
+                status_code=500,
+                detail="Gateway recovery dry-run did not return JSON",
+            )
+        return {"ok": True, "dry_run": True, "decision": decision}
+
+    try:
+        proc = _spawn_hermes_action(
+            _gateway_recover_subcommand(body, dry_run=False),
+            "gateway-recover",
+        )
+    except Exception as exc:
+        _log.exception("Failed to spawn gateway recovery")
+        raise HTTPException(status_code=500, detail=f"Failed to recover gateway: {exc}")
+    return {
+        "ok": True,
+        "pid": proc.pid,
+        "name": "gateway-recover",
     }
 
 

--- a/tests/docs/test_transport_liveness_runbook.py
+++ b/tests/docs/test_transport_liveness_runbook.py
@@ -1,0 +1,112 @@
+"""Acceptance tests for the gateway transport-liveness runbook.
+
+The runbook is the operator-facing surface that documents the supervised
+recovery decision. These tests pin the load-bearing content so a future
+edit cannot silently drop the exact-command block, the cooldown / flap
+rule, or the profile-specific commands an operator pastes during an
+incident.
+
+We intentionally do NOT assert the prose verbatim — only the structural
+signals that prove the runbook still covers:
+
+  1. Status + doctor first-response commands.
+  2. PID-lookup command (for confirming the gateway process is alive).
+  3. Profile-specific restart commands (default and named profile).
+  4. Post-restart verification block (oneshot + log grep).
+  5. Cooldown / flap rule (max 3 restarts in 15 minutes; then operator).
+  6. Liveness codes HERMES_TELEGRAM_PAUSED and HERMES_TELEGRAM_STALE.
+  7. The "do not chase Qwen / Ollama / Postgres / API" non-claim.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+RUNBOOK = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "runbooks"
+    / "hermes-gateway-transport-liveness.md"
+)
+
+
+@pytest.fixture(scope="module")
+def runbook_text() -> str:
+    assert RUNBOOK.exists(), f"missing runbook at {RUNBOOK}"
+    return RUNBOOK.read_text(encoding="utf-8")
+
+
+def test_runbook_lists_status_and_doctor_commands(runbook_text: str) -> None:
+    assert "hermes gateway status" in runbook_text
+    assert "hermes doctor" in runbook_text
+
+
+def test_runbook_includes_pid_lookup_command(runbook_text: str) -> None:
+    """Operators need a single command to confirm the gateway process is
+    alive even when the transport is dead. ``hermes gateway pid`` is the
+    canonical zero-noise lookup (returns PID or empty)."""
+    assert re.search(
+        r"hermes\s+gateway\s+(pid|status\s+--pid|status\s+-p)", runbook_text
+    ), runbook_text
+
+
+def test_runbook_documents_default_and_named_profile_restart(runbook_text: str) -> None:
+    """Default profile uses the bare command; named profile uses
+    ``--profile <name>`` so the operator can tell which slot they touched."""
+    assert "hermes gateway restart" in runbook_text
+    assert "--profile qwen-ops-runner-conductor" in runbook_text
+    assert "hermes --profile qwen-ops-runner-conductor gateway restart" in runbook_text
+
+
+def test_runbook_documents_post_restart_verification(runbook_text: str) -> None:
+    """After a restart, the operator must verify the transport reconnected
+    and the agent oneshot succeeds. Both checks are load-bearing."""
+    assert "Connected to Telegram" in runbook_text
+    assert re.search(r"hermes\s+-z", runbook_text), "expected hermes -z oneshot verification"
+
+
+def test_runbook_documents_cooldown_and_flap_rule(runbook_text: str) -> None:
+    """Cooldown / flap guard prose is canon. Pin the numbers so a casual
+    edit cannot drop them — they're load-bearing for incident response."""
+    lowered = runbook_text.lower()
+    assert "3" in runbook_text and "15" in runbook_text, runbook_text
+    assert "operator" in lowered, runbook_text
+    # The runbook must explicitly say the supervisor stops restarting
+    # after the bound is reached.
+    assert re.search(
+        r"(max(imum)?\s+\w*\s*3\s+restart|3\s+restart.*15|three\s+restart)",
+        lowered,
+    ), runbook_text
+
+
+def test_runbook_documents_corrupt_recovery_state_path(runbook_text: str) -> None:
+    """A corrupt cooldown ledger blocks supervised restart. The runbook must
+    preserve the non-destructive archive-and-retry path."""
+    lowered = runbook_text.lower()
+    assert "recovery_state_corrupt" in runbook_text
+    assert "gateway_recovery_state.json" in runbook_text
+    assert re.search(r"\bmv\s+", runbook_text), runbook_text
+    assert "corrupt.$(date" in runbook_text
+    assert "let Hermes resolve the profile home" in runbook_text
+    assert "do not guess an\nad-hoc `HERMES_HOME`" in runbook_text
+    assert "gateway recover --dry-run" in lowered
+
+
+def test_runbook_documents_liveness_codes(runbook_text: str) -> None:
+    assert "HERMES_TELEGRAM_PAUSED" in runbook_text
+    assert "HERMES_TELEGRAM_STALE" in runbook_text
+
+
+def test_runbook_does_not_chase_unrelated_subsystems(runbook_text: str) -> None:
+    """The runbook must include the explicit non-claim that Qwen tunnel,
+    Ollama, Postgres, and the NeoEngine API are *not* in scope for the
+    Telegram-paused recovery path. Without this, operators routinely bounce
+    healthy infrastructure during transport incidents."""
+    lowered = runbook_text.lower()
+    assert "qwen" in lowered
+    assert "ollama" in lowered
+    assert "postgres" in lowered
+    assert "neoengine" in lowered or "api" in lowered

--- a/tests/gateway/test_recovery_decision.py
+++ b/tests/gateway/test_recovery_decision.py
@@ -1,0 +1,689 @@
+"""Deterministic tests for supervised Hermes gateway transport recovery.
+
+Wave 1 added behavior-level classification for HERMES_TELEGRAM_PAUSED and
+HERMES_TELEGRAM_STALE. Wave 2 adds a *decision* layer on top of that
+classification: when classification fails red, what (if anything) should the
+supervisor do, and which Hermes profile is affected?
+
+These tests pin the contract for ``gateway.recovery.evaluate_gateway_recovery``:
+
+  * Recovery is profile-scoped — touching the affected Hermes profile only.
+  * Recovery never touches Qwen, Ollama, Postgres, the NeoEngine API, or
+    other Hermes profiles, regardless of how unhealthy the affected profile
+    looks.
+  * Cooldown / flap protection bounds restart attempts to a small number
+    within a rolling window (default: 3 restarts per 15 minutes). After
+    that bound is reached the supervisor stops restarting and surfaces an
+    operator-intervention requirement instead of looping forever.
+  * The decision payload exposes the affected profile, the exact restart
+    command (list + display string), the upstream liveness code, and the
+    current restart pressure so dashboards and operators can act without
+    re-deriving any of it.
+
+No live services. No subprocesses. No clock dependence — every test pins
+``now`` and ``restart_events`` explicitly.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from gateway import recovery as gateway_recovery
+from gateway import status as gateway_status
+
+evaluate_gateway_recovery = gateway_recovery.evaluate_gateway_recovery
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _liveness_healthy() -> dict[str, Any]:
+    return gateway_status.classify_gateway_transport_liveness(None)
+
+
+def _liveness_paused_telegram() -> dict[str, Any]:
+    state = {
+        "pid": 12345,
+        "gateway_state": "running",
+        "platforms": {
+            "telegram": {
+                "state": "paused",
+                "error_message": "auto-paused after 10 consecutive reconnect failures",
+                "reconnect_failure_count": 10,
+            }
+        },
+    }
+    return gateway_status.classify_gateway_transport_liveness(state)
+
+
+def _liveness_stale_telegram(now: datetime) -> dict[str, Any]:
+    state = {
+        "pid": 12345,
+        "gateway_state": "running",
+        "platforms": {
+            "telegram": {
+                "state": "connected",
+                "last_successful_poll_at": (now - timedelta(seconds=1800)).isoformat(),
+            }
+        },
+    }
+    return gateway_status.classify_gateway_transport_liveness(
+        state, stale_after_seconds=900, now=now
+    )
+
+
+def _restart_state(*events: tuple[datetime, str]) -> dict[str, Any]:
+    """Build the ``state`` dict shape expected by evaluate_gateway_recovery."""
+    return {
+        "restart_events": [
+            {
+                "at": ts.astimezone(timezone.utc).isoformat(),
+                "profile": profile,
+                "code": "HERMES_TELEGRAM_PAUSED",
+            }
+            for ts, profile in events
+        ]
+    }
+
+
+def _flat_command(decision: dict[str, Any]) -> str:
+    """Return a single string covering both the argv-list command and the
+    operator-display command. Tests use this for substring assertions."""
+    parts: list[str] = []
+    cmd = decision.get("restart_command")
+    if isinstance(cmd, (list, tuple)):
+        parts.append(" ".join(str(p) for p in cmd))
+    elif isinstance(cmd, str):
+        parts.append(cmd)
+    display = decision.get("restart_command_display")
+    if display:
+        parts.append(str(display))
+    return " ".join(parts)
+
+
+# ── action / no-action contract ────────────────────────────────────────────
+
+
+class TestHealthyLivenessRequiresNoAction:
+    def test_healthy_liveness_returns_no_action(self):
+        """A green liveness verdict must not trigger any restart."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        decision = evaluate_gateway_recovery(
+            _liveness_healthy(),
+            profile="default",
+            state=_restart_state(),
+            now=now,
+        )
+
+        assert decision["action"] == "no_action", decision
+        assert decision["should_restart"] is False, decision
+        assert decision["operator_intervention_required"] is False, decision
+
+    def test_healthy_liveness_no_action_even_with_recent_history(self):
+        """A successful recent restart that healed the transport must not
+        keep flapping — once liveness reports healthy, do nothing."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        decision = evaluate_gateway_recovery(
+            _liveness_healthy(),
+            profile="default",
+            state=_restart_state((now - timedelta(seconds=60), "default")),
+            now=now,
+        )
+
+        assert decision["action"] == "no_action", decision
+        assert decision["should_restart"] is False, decision
+
+    def test_healthy_liveness_still_surfaces_corrupt_recovery_state(self, tmp_path):
+        """No restart is needed while transports are healthy, but dashboards
+        should still see a corrupt ledger before the next incident."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state_path = tmp_path / "gateway_recovery_state.json"
+        state_path.write_text("{not-json", encoding="utf-8")
+
+        decision = evaluate_gateway_recovery(
+            _liveness_healthy(),
+            profile="default",
+            state=gateway_recovery.load_recovery_state(state_path),
+            now=now,
+        )
+
+        assert decision["action"] == "no_action", decision
+        assert decision["should_restart"] is False, decision
+        assert decision["state_corrupt"] is True, decision
+        assert decision["state_path"] == str(state_path), decision
+
+
+# ── restart-affected-profile contract ─────────────────────────────────────
+
+
+class TestProfileScopedRestart:
+    def test_paused_telegram_recommends_restart_of_affected_profile(self):
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="default",
+            state=_restart_state(),
+            now=now,
+        )
+
+        assert decision["action"] == "restart_profile", decision
+        assert decision["should_restart"] is True, decision
+        assert decision["profile"] == "default", decision
+        # restart_command is the argv form; restart_command_display is the
+        # operator-display form. Both must reference the canonical hermes
+        # gateway restart surface.
+        command_text = _flat_command(decision)
+        assert "gateway" in command_text and "restart" in command_text, command_text
+        assert decision["restart_command_display"] == "hermes gateway restart", decision
+
+    def test_stale_telegram_recommends_restart_of_affected_profile(self):
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        decision = evaluate_gateway_recovery(
+            _liveness_stale_telegram(now),
+            profile="default",
+            state=_restart_state(),
+            now=now,
+        )
+
+        assert decision["action"] == "restart_profile", decision
+        assert decision["should_restart"] is True, decision
+        assert decision["code"] == "HERMES_TELEGRAM_STALE", decision
+
+    def test_named_profile_emits_profile_scoped_command(self):
+        """The qwen-ops-runner-conductor profile must NOT trigger the default
+        restart command — it must scope to ``--profile qwen-ops-runner-conductor``.
+        Without this the supervisor would bounce the wrong profile when only
+        the qwen-ops runner is sick."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="qwen-ops-runner-conductor",
+            state=_restart_state(),
+            now=now,
+        )
+
+        assert decision["action"] == "restart_profile", decision
+        assert decision["profile"] == "qwen-ops-runner-conductor", decision
+
+        command_text = _flat_command(decision)
+        # Profile must appear in the command and it must use the canonical
+        # ``--profile <name>`` argument shape rather than positional.
+        assert "qwen-ops-runner-conductor" in command_text, command_text
+        assert "--profile" in command_text, command_text
+        assert (
+            decision["restart_command_display"]
+            == "hermes --profile qwen-ops-runner-conductor gateway restart"
+        ), decision
+
+    def test_default_profile_does_not_inject_profile_flag(self):
+        """The default profile uses the bare ``hermes gateway restart`` form,
+        not ``hermes --profile default gateway restart`` — keep the two
+        surfaces distinct so operators reading logs can tell which profile
+        the supervisor touched."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="default",
+            state=_restart_state(),
+            now=now,
+        )
+
+        command_text = _flat_command(decision)
+        assert "--profile" not in command_text, command_text
+
+    def test_profile_restart_argv_scopes_profile_before_gateway_command(self):
+        """The executable argv must put ``--profile <name>`` before
+        ``gateway restart`` so Hermes' early profile parser selects the
+        affected profile's HERMES_HOME before any gateway modules import."""
+        command = gateway_recovery.profile_restart_command(
+            "qwen-ops-runner-conductor",
+            python_executable="python",
+        )
+
+        assert command == [
+            "python",
+            "-m",
+            "hermes_cli.main",
+            "--profile",
+            "qwen-ops-runner-conductor",
+            "gateway",
+            "restart",
+        ]
+
+
+# ── never-touch-unrelated-systems contract ────────────────────────────────
+
+
+class TestRecoveryDoesNotTouchUnrelatedSystems:
+    """The supervisor's authority is limited to the affected Hermes profile.
+
+    A paused Telegram transport on profile A must NEVER produce a decision
+    that targets Qwen, Ollama, Postgres, the NeoEngine API, or any other
+    Hermes profile. This is the core safety property of the supervised
+    recovery layer — without it, transport classification could cascade
+    into infrastructure-wide bounces.
+    """
+
+    FORBIDDEN_SUBSTRINGS = (
+        "qwen",
+        "ollama",
+        "postgres",
+        "postgresql",
+        "neoengine api",
+        "api server",
+        "tunnel",
+    )
+
+    def test_restart_command_does_not_mention_unrelated_systems(self):
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="default",
+            state=_restart_state(),
+            now=now,
+        )
+
+        # The argv-form command and the operator-display string are what
+        # actually get executed / shown — they must not name Qwen, Ollama,
+        # Postgres, the NeoEngine API, the tunnel, etc.
+        command_text = _flat_command(decision).lower()
+        for needle in self.FORBIDDEN_SUBSTRINGS:
+            assert needle not in command_text, (
+                f"recovery command must not mention {needle!r}: {command_text!r}"
+            )
+
+    def test_decision_surfaces_forbidden_targets_explicitly(self):
+        """The decision payload exposes ``forbidden_targets`` so downstream
+        consumers (dashboard, operator runbook) can show the operator what
+        the supervisor will NOT touch even when the transport is fully red."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="default",
+            state=_restart_state(),
+            now=now,
+        )
+
+        forbidden = decision.get("forbidden_targets") or []
+        forbidden_text = " ".join(str(t).lower() for t in forbidden)
+        for needle in ("qwen", "ollama", "postgres", "neoengine_api"):
+            assert needle in forbidden_text, (
+                f"forbidden_targets must include {needle!r}: {forbidden!r}"
+            )
+
+    def test_restart_scope_is_profile_only(self):
+        """The decision payload pins ``restart_scope`` to a per-profile
+        Hermes gateway scope so a dashboard cannot confuse it with a
+        broader infra-level recovery."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="qwen-ops-runner-conductor",
+            state=_restart_state(),
+            now=now,
+        )
+
+        assert decision.get("restart_scope") == "hermes_gateway_profile", decision
+
+
+# ── cooldown / flap-guard contract ────────────────────────────────────────
+
+
+class TestCooldownFlapGuard:
+    """Recovery is bounded: max 3 restarts per 15 minutes per profile.
+
+    The fourth attempt within the window must NOT restart. It must surface
+    an operator-intervention requirement so a human can investigate the
+    underlying transport failure (e.g. revoked token, network partition).
+    """
+
+    def test_three_restarts_in_fifteen_minutes_blocks_fourth(self):
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state = _restart_state(
+            (now - timedelta(minutes=14), "default"),
+            (now - timedelta(minutes=9), "default"),
+            (now - timedelta(minutes=4), "default"),
+        )
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="default",
+            state=state,
+            now=now,
+        )
+
+        assert decision["action"] == "operator_intervention_required", decision
+        assert decision["should_restart"] is False, decision
+        assert decision["operator_intervention_required"] is True, decision
+        # Affected profile must still be surfaced so the operator knows
+        # which slot to investigate.
+        assert decision.get("profile") == "default", decision
+        # Cooldown remaining must be > 0 when blocked — the dashboard uses
+        # this to schedule a follow-up check rather than spinning. The
+        # oldest in-window restart was 14 minutes ago against a 15-minute
+        # window, so ~60s should remain; allow generous tolerance.
+        cooldown_remaining = decision.get("cooldown_remaining_seconds")
+        assert cooldown_remaining is not None and cooldown_remaining > 0, decision
+        assert cooldown_remaining <= 15 * 60, decision
+
+    def test_two_restarts_in_window_still_allows_third(self):
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state = _restart_state(
+            (now - timedelta(minutes=12), "default"),
+            (now - timedelta(minutes=6), "default"),
+        )
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="default",
+            state=state,
+            now=now,
+        )
+
+        assert decision["action"] == "restart_profile", decision
+        assert decision["cooldown"]["recent_restarts"] == 2, decision
+
+    def test_old_restarts_outside_window_do_not_count(self):
+        """Restarts older than the window must not block recovery — the
+        supervisor uses a *rolling* count, not a lifetime count."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state = _restart_state(
+            (now - timedelta(minutes=60), "default"),
+            (now - timedelta(minutes=45), "default"),
+            (now - timedelta(minutes=30), "default"),
+            (now - timedelta(minutes=16), "default"),  # just outside default 15-min window
+        )
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="default",
+            state=state,
+            now=now,
+        )
+
+        assert decision["action"] == "restart_profile", decision
+        assert decision["cooldown"]["recent_restarts"] == 0, decision
+
+    def test_cooldown_window_and_max_restarts_round_trip(self):
+        """The decision payload must expose the cooldown configuration the
+        supervisor used. Operators consume this to verify the active
+        thresholds match the runbook's 3/15min bound."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="default",
+            state=_restart_state(),
+            now=now,
+        )
+
+        cooldown = decision.get("cooldown") or {}
+        assert cooldown.get("max_restarts") == 3, decision
+        assert cooldown.get("window_seconds") == 15 * 60, decision
+
+    def test_cooldown_is_per_profile(self):
+        """One profile flapping must not block recovery on a sibling profile.
+
+        Conductor profile saturates its cooldown; default profile still has
+        zero history and must be allowed to restart on its own liveness
+        failure. Without this property, a single broken profile would
+        silence supervised recovery for the whole fleet."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        shared_state = _restart_state(
+            (now - timedelta(minutes=12), "qwen-ops-runner-conductor"),
+            (now - timedelta(minutes=8), "qwen-ops-runner-conductor"),
+            (now - timedelta(minutes=2), "qwen-ops-runner-conductor"),
+        )
+
+        # qwen-ops-runner-conductor is saturated — must block.
+        blocked = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="qwen-ops-runner-conductor",
+            state=shared_state,
+            now=now,
+        )
+        assert blocked["action"] == "operator_intervention_required", blocked
+
+        # default profile is independent — must restart even though the
+        # ledger has plenty of conductor entries.
+        allowed = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="default",
+            state=shared_state,
+            now=now,
+        )
+        assert allowed["action"] == "restart_profile", allowed
+        assert allowed["cooldown"]["recent_restarts"] == 0, allowed
+
+    def test_corrupt_recovery_state_blocks_supervised_restart(self, tmp_path):
+        """A corrupt cooldown ledger must not reset restart pressure to zero.
+        Block and route to an operator until the file is inspected or cleared."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state_path = tmp_path / "gateway_recovery_state.json"
+        state_path.write_text("{not-json", encoding="utf-8")
+
+        state = gateway_recovery.load_recovery_state(state_path)
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="default",
+            state=state,
+            now=now,
+        )
+
+        assert decision["action"] == "operator_intervention_required", decision
+        assert decision["should_restart"] is False, decision
+        assert decision["reason"] == "recovery_state_corrupt", decision
+        assert decision["state_path"] == str(state_path), decision
+
+    def test_recording_attempt_prunes_old_events_for_all_profiles(self, tmp_path):
+        """Pruning is global to the ledger, not only the current profile, so
+        long-lived multi-profile supervisors do not accumulate stale history."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state_path = tmp_path / "gateway_recovery_state.json"
+        state_path.write_text(
+            json.dumps({
+                "restart_events": [
+                    {
+                        "at": (now - timedelta(hours=2)).isoformat(),
+                        "profile": "default",
+                        "code": "HERMES_TELEGRAM_PAUSED",
+                    },
+                    {
+                        "at": (now - timedelta(hours=3)).isoformat(),
+                        "profile": "qwen-ops-runner-conductor",
+                        "code": "HERMES_TELEGRAM_PAUSED",
+                    },
+                    {
+                        "at": (now - timedelta(minutes=5)).isoformat(),
+                        "profile": "qwen-ops-runner-conductor",
+                        "code": "HERMES_TELEGRAM_PAUSED",
+                    },
+                ],
+            }),
+            encoding="utf-8",
+        )
+
+        state = gateway_recovery.record_recovery_attempt(
+            profile="default",
+            code="HERMES_TELEGRAM_PAUSED",
+            outcome="success",
+            state_path=state_path,
+            now=now,
+        )
+
+        events = state["restart_events"]
+        assert len(events) == 2, state
+        assert {event["profile"] for event in events} == {
+            "default",
+            "qwen-ops-runner-conductor",
+        }
+        assert all(
+            datetime.fromisoformat(event["at"]) >= now - timedelta(minutes=15)
+            for event in events
+        ), state
+
+
+# ── decision-payload shape ────────────────────────────────────────────────
+
+
+class TestDecisionPayloadShape:
+    def test_decision_payload_includes_restart_count(self):
+        """The decision must expose how many restarts the supervisor has seen
+        in the current window — operators and dashboards consume this to
+        plot flap pressure."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state = _restart_state(
+            (now - timedelta(minutes=10), "default"),
+            (now - timedelta(minutes=5), "default"),
+        )
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="default",
+            state=state,
+            now=now,
+        )
+
+        cooldown = decision.get("cooldown") or {}
+        assert cooldown.get("recent_restarts") == 2, decision
+
+    def test_decision_payload_records_liveness_code(self):
+        """Reason / details must round-trip the upstream liveness code so a
+        dashboard reading only the decision payload can still classify the
+        incident as HERMES_TELEGRAM_PAUSED vs HERMES_TELEGRAM_STALE."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        decision = evaluate_gateway_recovery(
+            _liveness_paused_telegram(),
+            profile="default",
+            state=_restart_state(),
+            now=now,
+        )
+
+        assert decision.get("code") == "HERMES_TELEGRAM_PAUSED", decision
+        summary = decision.get("summary") or ""
+        assert "telegram" in summary.lower(), decision
+
+
+class TestExecuteGatewayRecovery:
+    def test_successful_restart_records_profile_cooldown_event(self, monkeypatch, tmp_path):
+        """The action path records a restart only after the profile-scoped
+        restart command succeeds. This is the durable flap guard ledger."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state_path = tmp_path / "gateway_recovery_state.json"
+        runtime_state = {
+            "pid": 12345,
+            "gateway_state": "running",
+            "platforms": {
+                "telegram": {
+                    "state": "paused",
+                    "error_message": "auto-paused after 10 consecutive reconnect failures",
+                    "reconnect_failure_count": 10,
+                }
+            },
+        }
+        calls: list[list[str]] = []
+
+        class _Result:
+            returncode = 0
+
+        def _runner(command, check=False):
+            calls.append(list(command))
+            assert check is False
+            return _Result()
+
+        monkeypatch.setattr(gateway_recovery, "read_runtime_status", lambda: runtime_state)
+
+        result = gateway_recovery.execute_gateway_recovery(
+            profile="qwen-ops-runner-conductor",
+            state_path=state_path,
+            runner=_runner,
+            now=now,
+        )
+
+        assert result["executed"] is True, result
+        assert result["ok"] is True, result
+        assert calls and "--profile" in calls[0], calls
+        assert "qwen-ops-runner-conductor" in calls[0], calls
+
+        recorded = json.loads(state_path.read_text(encoding="utf-8"))
+        events = recorded.get("restart_events") or []
+        assert len(events) == 1, recorded
+        assert events[0]["profile"] == "qwen-ops-runner-conductor", recorded
+        assert events[0]["code"] == "HERMES_TELEGRAM_PAUSED", recorded
+        assert events[0]["outcome"] == "success", recorded
+
+    def test_failed_restart_attempt_counts_toward_cooldown(self, monkeypatch, tmp_path):
+        """A failed restart attempt can flap just as hard as a successful one;
+        record it so a broken service manager cannot be hammered forever."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state_path = tmp_path / "gateway_recovery_state.json"
+        runtime_state = {
+            "pid": 12345,
+            "gateway_state": "running",
+            "platforms": {
+                "telegram": {
+                    "state": "paused",
+                    "error_message": "auto-paused after 10 consecutive reconnect failures",
+                    "reconnect_failure_count": 10,
+                }
+            },
+        }
+
+        class _Result:
+            returncode = 7
+
+        monkeypatch.setattr(gateway_recovery, "read_runtime_status", lambda: runtime_state)
+
+        result = gateway_recovery.execute_gateway_recovery(
+            profile="default",
+            state_path=state_path,
+            runner=lambda command, check=False: _Result(),
+            now=now,
+        )
+
+        assert result["executed"] is True, result
+        assert result["ok"] is False, result
+        assert result["returncode"] == 7, result
+
+        recorded = json.loads(state_path.read_text(encoding="utf-8"))
+        events = recorded.get("restart_events") or []
+        assert len(events) == 1, recorded
+        assert events[0]["profile"] == "default", recorded
+        assert events[0]["outcome"] == "failure", recorded
+        assert events[0]["returncode"] == 7, recorded
+
+
+# ── liveness payload severity / process-alive contract ───────────────────
+
+
+class TestLivenessSeverityForDashboard:
+    """The dashboard ``/api/status`` payload needs structured severity for a
+    process-alive / transport-dead gateway. Wave 1 added the classification;
+    Wave 2 adds the severity + headline that the dashboard consumes so the
+    UI can render an unhealthy badge without re-deriving the verdict."""
+
+    def test_process_alive_transport_dead_payload_is_visible(self):
+        state = {
+            "pid": 12345,
+            "gateway_state": "running",
+            "platforms": {
+                "telegram": {
+                    "state": "paused",
+                    "error_message": "auto-paused after 10 consecutive reconnect failures",
+                }
+            },
+        }
+        liveness = gateway_status.classify_gateway_transport_liveness(state)
+
+        # Severity must be unhealthy; the dashboard reads this directly.
+        assert liveness.get("severity") == "unhealthy", liveness
+        # The process_alive bit is the discriminator that gives the
+        # incident its "transport dead / process alive" shape.
+        assert liveness.get("process_alive") is True, liveness
+        headline = (liveness.get("headline") or "").lower()
+        assert "transport dead" in headline and "process alive" in headline, liveness
+
+    def test_healthy_liveness_payload_reports_healthy_severity(self):
+        liveness = gateway_status.classify_gateway_transport_liveness(None)
+
+        assert liveness.get("severity") == "healthy", liveness
+        assert liveness.get("process_alive") is False, liveness

--- a/tests/gateway/test_status_transport_liveness.py
+++ b/tests/gateway/test_status_transport_liveness.py
@@ -1,0 +1,153 @@
+"""Regression tests for gateway transport-liveness classification.
+
+Background: the gateway process can be alive (pid present, gateway_state=running)
+while a platform transport (e.g. Telegram long-poll) has been auto-paused after
+repeated reconnect failures. Without transport-level classification the
+operator sees "process healthy" and assumes messages flow - they don't.
+
+These tests pin the contract for two helpers under `gateway.status`:
+
+  - ``classify_gateway_transport_liveness(state, stale_after_seconds=900, now=...)``
+  - ``classify_gateway_log_line(line)``
+
+Tests are deterministic - no live gateway, no clock dependence.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from gateway import status as gateway_status
+
+
+def _state(platforms, **extra):
+    base = {
+        "pid": 12345,
+        "kind": "hermes-gateway",
+        "argv": ["python", "-m", "hermes_cli.main", "gateway"],
+        "start_time": 100,
+        "gateway_state": "running",
+        "exit_reason": None,
+        "restart_requested": False,
+        "active_agents": 1,
+        "platforms": platforms,
+        "updated_at": "2026-06-20T12:00:00+00:00",
+    }
+    base.update(extra)
+    return base
+
+
+class TestClassifyGatewayTransportLiveness:
+    def test_running_process_with_paused_telegram_fails_red(self):
+        """Process alive + telegram paused = red verdict with HERMES_TELEGRAM_PAUSED.
+
+        This is the incident shape: pid record present, gateway_state=running,
+        but the long-poll transport has been parked. Liveness must catch it.
+        """
+        state = _state({
+            "telegram": {
+                "state": "paused",
+                "error_code": None,
+                "error_message": "auto-paused after 10 consecutive reconnect failures",
+                "updated_at": "2026-06-20T12:00:00+00:00",
+            }
+        })
+
+        result = gateway_status.classify_gateway_transport_liveness(state)
+
+        assert result["healthy"] is False, result
+        assert result["code"] == "HERMES_TELEGRAM_PAUSED"
+        # platforms list must call out telegram specifically so operators
+        # don't have to grep the summary for what's broken.
+        platforms = result.get("platforms") or []
+        assert any(
+            (isinstance(p, str) and p == "telegram")
+            or (isinstance(p, dict) and p.get("platform") == "telegram")
+            for p in platforms
+        ), platforms
+
+    def test_connected_telegram_with_fresh_poll_is_healthy(self):
+        """state=connected + last_successful_poll_at within window = green."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state = _state({
+            "telegram": {
+                "state": "connected",
+                "error_code": None,
+                "error_message": None,
+                "last_successful_poll_at": (now - timedelta(seconds=10)).isoformat(),
+                "updated_at": (now - timedelta(seconds=10)).isoformat(),
+            }
+        })
+
+        result = gateway_status.classify_gateway_transport_liveness(
+            state, stale_after_seconds=300, now=now
+        )
+
+        assert result["healthy"] is True, result
+
+    def test_default_stale_threshold_allows_max_heartbeat_interval(self):
+        """Default stale threshold must stay above the heartbeat max clamp."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state = _state({
+            "telegram": {
+                "state": "connected",
+                "last_successful_poll_at": (now - timedelta(seconds=600)).isoformat(),
+            }
+        })
+
+        result = gateway_status.classify_gateway_transport_liveness(state, now=now)
+
+        assert result["healthy"] is True, result
+
+    def test_stale_telegram_poll_beyond_threshold_fails_red(self):
+        """Connected but last_successful_poll_at is stale -> red, telegram-stale code."""
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        state = _state({
+            "telegram": {
+                "state": "connected",
+                "error_code": None,
+                "error_message": None,
+                "last_successful_poll_at": (now - timedelta(seconds=900)).isoformat(),
+                "updated_at": (now - timedelta(seconds=900)).isoformat(),
+            }
+        })
+
+        result = gateway_status.classify_gateway_transport_liveness(
+            state, stale_after_seconds=300, now=now
+        )
+
+        assert result["healthy"] is False, result
+        code = result["code"]
+        assert "TELEGRAM" in code.upper() and "STALE" in code.upper(), code
+
+
+class TestClassifyGatewayLogLine:
+    def test_recognizes_telegram_pause_phrase(self):
+        """The canonical pause phrase must classify as HERMES_TELEGRAM_PAUSED,
+        and the recommended repair must point at restarting the Hermes gateway
+        (or profile) ONLY - not Qwen, Ollama, Postgres, or any other healthy
+        subsystem."""
+        line = (
+            "2026-06-20T12:00:00 [WARNING] gateway: "
+            "Telegram paused after 10 consecutive reconnect failures"
+        )
+
+        result = gateway_status.classify_gateway_log_line(line)
+
+        assert result is not None, "pause phrase must classify, not return None"
+        assert result["code"] == "HERMES_TELEGRAM_PAUSED"
+
+        repair = (result.get("recommended_repair") or "").lower()
+        assert "hermes" in repair, repair
+        assert ("gateway" in repair) or ("profile" in repair), repair
+        # Repair MUST NOT recommend touching healthy subsystems.
+        for forbidden in ("qwen", "ollama", "postgres", "postgresql", "api server"):
+            assert forbidden not in repair, (
+                f"recommended_repair must not mention {forbidden!r}: {repair!r}"
+            )
+
+    def test_unrelated_line_returns_none(self):
+        """Liveness classifier should not pattern-match unrelated log lines."""
+        line = "2026-06-20T12:00:00 [INFO] gateway: telegram polling resumed"
+        result = gateway_status.classify_gateway_log_line(line)
+        assert result is None, result

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -118,12 +118,27 @@ async def test_reconnect_does_not_self_schedule_when_fatal_error_set():
 
 
 @pytest.mark.asyncio
-async def test_reconnect_success_resets_error_count():
+async def test_polling_heartbeat_reconnect_errors_are_contained():
+    adapter = _make_adapter()
+    adapter._handle_polling_network_error = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await adapter._handle_polling_heartbeat_error(RuntimeError("heartbeat failed"))
+
+    adapter._handle_polling_network_error.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_success_resets_error_count(monkeypatch):
     """
     When start_polling() succeeds, _polling_network_error_count should reset to 0.
     """
     adapter = _make_adapter()
     adapter._polling_network_error_count = 3
+    status_writes = []
+    monkeypatch.setattr(
+        "gateway.status.write_runtime_status",
+        lambda **kwargs: status_writes.append(kwargs),
+    )
 
     mock_updater = MagicMock()
     mock_updater.running = True
@@ -139,6 +154,11 @@ async def test_reconnect_success_resets_error_count():
         await adapter._handle_polling_network_error(Exception("Bad Gateway"))
 
     assert adapter._polling_network_error_count == 0
+    assert any(
+        write.get("polling_state") == "connected"
+        and write.get("last_successful_poll_at")
+        for write in status_writes
+    )
 
     # Clean up the heartbeat-probe task scheduled after a successful reconnect.
     pending = [t for t in adapter._background_tasks if not t.done()]

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -252,6 +252,35 @@ def test_check_gateway_service_linger_skips_when_service_not_installed(monkeypat
     assert out == ""
     assert issues == []
 
+def test_check_gateway_transport_liveness_fails_paused_telegram(monkeypatch, capsys):
+    from gateway import status as gateway_status
+
+    monkeypatch.setattr(
+        gateway_status,
+        "read_runtime_status",
+        lambda: {
+            "pid": 12345,
+            "kind": "hermes-gateway",
+            "gateway_state": "running",
+            "platforms": {
+                "telegram": {
+                    "state": "paused",
+                    "error_message": "auto-paused after 10 consecutive reconnect failures",
+                    "reconnect_failure_count": 10,
+                }
+            },
+        },
+    )
+
+    issues = []
+    doctor._check_gateway_transport_liveness(issues)
+
+    out = capsys.readouterr().out
+    assert "Gateway Transport" in out
+    assert "HERMES_TELEGRAM_PAUSED" in out
+    assert "hermes gateway restart" in out
+    assert any("HERMES_TELEGRAM_PAUSED" in issue for issue in issues)
+
 
 # ── Memory provider section (doctor should only check the *active* provider) ──
 

--- a/tests/hermes_cli/test_gateway_runtime_health.py
+++ b/tests/hermes_cli/test_gateway_runtime_health.py
@@ -1,7 +1,9 @@
+import hermes_cli.gateway as gateway_cli
 from hermes_cli.gateway import _runtime_health_lines
 
 
 def test_runtime_health_lines_include_fatal_platform_and_startup_reason(monkeypatch):
+    monkeypatch.setattr(gateway_cli, "_recent_gateway_log_transport_issues", lambda classifier: [])
     monkeypatch.setattr(
         "gateway.status.read_runtime_status",
         lambda: {
@@ -51,3 +53,83 @@ def test_runtime_status_running_pid_rejects_stopped_record(monkeypatch):
     monkeypatch.setattr(status_mod, "_pid_exists", lambda pid: True)
 
     assert status_mod.get_runtime_status_running_pid(runtime) is None
+
+
+def test_runtime_health_lines_surface_paused_telegram_transport(monkeypatch):
+    """Incident regression: gateway process alive, Telegram transport paused.
+
+    Before the fix, _runtime_health_lines only surfaced platforms in `fatal`
+    state. A `paused` platform after repeated reconnect failures was silent,
+    so operators saw a green gateway while conductors were unreachable.
+    """
+    monkeypatch.setattr(gateway_cli, "_recent_gateway_log_transport_issues", lambda classifier: [])
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "exit_reason": None,
+            "platforms": {
+                "telegram": {
+                    "state": "paused",
+                    "error_message": "auto-paused after 10 consecutive reconnect failures",
+                }
+            },
+        },
+    )
+
+    lines = _runtime_health_lines()
+
+    assert any(
+        "telegram" in line.lower() and "paused" in line.lower()
+        for line in lines
+    ), lines
+
+
+def test_runtime_health_lines_surface_stale_telegram_poll(monkeypatch):
+    """When the telegram transport hasn't polled successfully past the
+    staleness threshold, _runtime_health_lines must surface it even if
+    `state` is still nominally `connected`."""
+    monkeypatch.setattr(gateway_cli, "_recent_gateway_log_transport_issues", lambda classifier: [])
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "exit_reason": None,
+            "platforms": {
+                "telegram": {
+                    "state": "connected",
+                    "last_successful_poll_at": "2020-01-01T00:00:00+00:00",
+                }
+            },
+        },
+    )
+
+    lines = _runtime_health_lines()
+
+    assert any(
+        "telegram" in line.lower() and "stale" in line.lower()
+        for line in lines
+    ), lines
+
+
+def test_runtime_health_lines_surface_telegram_pause_log_signature(monkeypatch, tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "gateway.log").write_text(
+        "2026-06-20T12:00:00 [WARNING] gateway: "
+        "Telegram paused after 10 consecutive reconnect failures\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "exit_reason": None,
+            "platforms": {},
+        },
+    )
+
+    lines = _runtime_health_lines()
+
+    assert any("HERMES_TELEGRAM_PAUSED" in line for line in lines), lines

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1231,6 +1231,58 @@ class TestWebServerEndpoints:
         assert resp.json()["gateway_state"] == "startup_failed"
         assert resp.json()["gateway_platforms"] == {}
 
+    def test_get_status_recovery_uses_requested_profile(self, monkeypatch):
+        import contextlib
+
+        import gateway.config as gateway_config
+        from gateway import recovery as gateway_recovery
+        from hermes_cli import profiles as profiles_mod
+        import hermes_cli.web_server as web_server
+
+        class _Platform:
+            value = "telegram"
+
+        class _GatewayConfig:
+            def get_connected_platforms(self):
+                return [_Platform()]
+
+        seen = {}
+
+        def fake_evaluate(liveness, *, profile, state):
+            seen["profile"] = profile
+            return {"action": "restart_profile", "profile": profile}
+
+        monkeypatch.setattr(web_server, "_config_profile_scope", lambda profile: contextlib.nullcontext())
+        monkeypatch.setattr(web_server, "get_running_pid", lambda: 12345)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda: {
+                "gateway_state": "running",
+                "platforms": {
+                    "telegram": {
+                        "state": "paused",
+                        "error_message": "auto-paused after 10 consecutive reconnect failures",
+                    }
+                },
+            },
+        )
+        monkeypatch.setattr(web_server, "check_config_version", lambda: (1, 1))
+        monkeypatch.setattr(gateway_config, "load_gateway_config", lambda: _GatewayConfig())
+        monkeypatch.setattr(gateway_recovery, "load_recovery_state", lambda: {"profiles": {}})
+        monkeypatch.setattr(gateway_recovery, "evaluate_gateway_recovery", fake_evaluate)
+        monkeypatch.setattr(
+            profiles_mod,
+            "get_active_profile_name",
+            lambda: pytest.fail("requested profile should be used"),
+        )
+
+        resp = self.client.get("/api/status?profile=qwen-ops-runner-conductor")
+
+        assert resp.status_code == 200
+        assert seen["profile"] == "qwen-ops-runner-conductor"
+        assert resp.json()["gateway_recovery"]["profile"] == "qwen-ops-runner-conductor"
+
     def test_cron_delivery_targets_lists_configured_platforms(self, monkeypatch):
         """The cron dropdown endpoint returns Local + configured platforms dynamically."""
         import gateway.config as gateway_config
@@ -1258,6 +1310,132 @@ class TestWebServerEndpoints:
         assert targets["matrix"]["home_target_set"] is True
         # No hardcoded telegram/discord/slack/email when they aren't configured.
         assert "telegram" not in targets
+
+    def test_gateway_recover_dry_run_uses_profile_scoped_cli(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        calls = []
+
+        class _Result:
+            returncode = 0
+            stdout = json.dumps({
+                "action": "restart_profile",
+                "profile": "qwen-ops-runner-conductor",
+            })
+            stderr = ""
+
+        def fake_run(command, **kwargs):
+            calls.append((list(command), kwargs))
+            return _Result()
+
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.post(
+            "/api/gateway/recover",
+            json={
+                "dry_run": True,
+                "profile": "qwen-ops-runner-conductor",
+                "max_restarts": 3,
+                "window_seconds": 900,
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["decision"]["profile"] == "qwen-ops-runner-conductor"
+        command = calls[0][0]
+        assert "--profile" in command, command
+        assert "qwen-ops-runner-conductor" in command, command
+        assert command[-2:] == ["--dry-run", "--json"], command
+        assert "gateway" in command and "recover" in command, command
+
+    def test_gateway_recover_dry_run_resolves_current_profile(self, monkeypatch):
+        from hermes_cli import profiles as profiles_mod
+        import hermes_cli.web_server as web_server
+
+        calls = []
+
+        class _Result:
+            returncode = 0
+            stdout = json.dumps({
+                "action": "restart_profile",
+                "profile": "qwen-ops-runner-conductor",
+            })
+            stderr = ""
+
+        def fake_run(command, **kwargs):
+            calls.append((list(command), kwargs))
+            return _Result()
+
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "qwen-ops-runner-conductor")
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.post(
+            "/api/gateway/recover",
+            json={
+                "dry_run": True,
+                "max_restarts": 10000,
+                "window_seconds": 1,
+            },
+        )
+
+        assert resp.status_code == 200
+        command = calls[0][0]
+        assert command[3:5] == ["--profile", "qwen-ops-runner-conductor"], command
+        assert command[7:9] == ["--max-restarts", "3"], command
+        assert command[9:11] == ["--window-seconds", "900"], command
+        assert command[-2:] == ["--dry-run", "--json"], command
+
+    def test_gateway_recover_fails_closed_when_current_profile_unresolved(self, monkeypatch):
+        from hermes_cli import profiles as profiles_mod
+
+        def fail_active_profile():
+            raise RuntimeError("profile context unavailable")
+
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", fail_active_profile)
+
+        resp = self.client.post(
+            "/api/gateway/recover",
+            json={
+                "dry_run": True,
+                "max_restarts": 3,
+                "window_seconds": 900,
+            },
+        )
+
+        assert resp.status_code == 500
+        assert "Could not resolve active dashboard profile" in resp.json()["detail"]
+
+    def test_gateway_recover_spawns_profile_scoped_background_action(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        calls = []
+
+        class _Proc:
+            pid = 4321
+
+        def fake_spawn(subcommand, name):
+            calls.append((list(subcommand), name))
+            return _Proc()
+
+        monkeypatch.setattr(web_server, "_spawn_hermes_action", fake_spawn)
+
+        resp = self.client.post(
+            "/api/gateway/recover",
+            json={
+                "dry_run": False,
+                "profile": "qwen-ops-runner-conductor",
+                "max_restarts": 3,
+                "window_seconds": 900,
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "pid": 4321, "name": "gateway-recover"}
+        subcommand, action_name = calls[0]
+        assert action_name == "gateway-recover"
+        assert subcommand[:2] == ["--profile", "qwen-ops-runner-conductor"], subcommand
+        assert subcommand[2:4] == ["gateway", "recover"], subcommand
+        assert "--max-restarts" in subcommand and "--window-seconds" in subcommand
 
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")


### PR DESCRIPTION
## What does this PR do?

Adds Wave 2 supervised recovery for Hermes Telegram transport liveness failures detected in #49681.

This closes the process-alive / transport-dead recurrence path by adding a profile-scoped recovery decision/action layer for `HERMES_TELEGRAM_PAUSED` and `HERMES_TELEGRAM_STALE`. The recovery path restarts only the affected Hermes gateway profile, keeps Qwen/Ollama/Postgres/API/Cockpit/tunnel out of scope, and enforces a per-profile cooldown / flap guard.

Stack note: depends on #49681 (`fix(hermes): detect Telegram transport-dead PID-alive gateway state`). This PR is Wave 2 on top of that branch.

## Related Issue

Depends on #49681.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added `gateway/recovery.py` for supervised recovery decisions and execution.
- Added `hermes gateway recover` with `--dry-run`, `--json`, `--max-restarts`, and `--window-seconds`.
- Added dashboard `/api/gateway/recover` and `/api/status.gateway_recovery` surfaces.
- Added per-profile cooldown ledger: max 3 restart attempts in 15 minutes.
- Counted failed restart attempts toward cooldown and blocked corrupt/unreadable ledgers with `operator_intervention_required`.
- Extended transport liveness payload with severity/headline/process-alive fields for dashboard rendering.
- Updated `docs/runbooks/hermes-gateway-transport-liveness.md` with exact status, doctor, PID, recovery, manual fallback, corrupt-ledger, and post-restart verification commands.
- Added durable Wave 2 hardening receipt.
- Added focused tests for recovery decisions, runbook acceptance, dashboard recovery endpoints, and execution ledger behavior.

## How to Test

1. `python -m py_compile gateway/recovery.py gateway/status.py hermes_cli/gateway.py hermes_cli/main.py hermes_cli/web_server.py`
2. `scripts/run_tests.sh tests/gateway/test_recovery_decision.py tests/gateway/test_status_transport_liveness.py tests/docs/test_transport_liveness_runbook.py tests/hermes_cli/test_gateway_runtime_health.py tests/gateway/test_telegram_network_reconnect.py`
3. `.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_gateway_recover_dry_run_uses_profile_scoped_cli tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_gateway_recover_spawns_profile_scoped_background_action tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_status -q`
4. `.venv/bin/python -m pytest tests/hermes_cli/test_doctor.py::test_check_gateway_transport_liveness_fails_paused_telegram -q`
5. `scripts/run_tests.sh tests/docs/test_transport_liveness_runbook.py`

Note: full `tests/hermes_cli/test_web_server.py` has three PTY WebSocket failures that reproduce in isolation in this environment and are unrelated to this recovery diff. The new dashboard/status nodeids pass.

## Risk, Complexity, Review, and CI Classification

- Risk class: R2
- Complexity class: C3
- Impacted surfaces: runtime_backend, api_route, CLI gateway management, dashboard status/action API, operator runbook
- RuntimePayloadContract present: yes
- protected_surface: false
- runtime_authority_change: true
- customer_data_or_finance_impact: false
- governance_or_merge_authority_change: false
- model_tier_required: 3
- cc_review_required: true
- opposite_frontier_required: false
- escalation_reason: bounded_complex_engineering
- Blocker exemption, if any: none
- Secondary review required: yes
- Adversarial review required: no
- Opposite-provider adversarial required: no
- Human/protected review required: no
- Founder review required: no
- Required CI lanes: unit, targeted_runtime_tests, backend_runtime, runtime-contract, docs_impact
- Skipped CI lanes and rationale: full `tests/hermes_cli/test_web_server.py` not used as Wave 2 evidence because unrelated `TestPtyWebSocket` tests fail in isolation locally; targeted dashboard recovery/status nodeids pass.
- Token class: L
- Expected state change: no live service mutation from this PR by itself; operators/dashboard may invoke profile-scoped recovery after deployment.
- Stop condition: `operator_intervention_required` on cooldown exhaustion or corrupt recovery ledger.

## Policy decision output

```json
{
  "policy_version": "0.1.0",
  "ruleset_hash": "sha256:447010f4fc71c86e6a8ee93b17004d13430cea95d547afb1dedec650450312eb",
  "risk_class": "R0",
  "complexity_class": "C0",
  "required_ci_lanes": [
    "runtime-contract",
    "unit"
  ],
  "required_reviews": [
    "owner"
  ],
  "required_non_claims": [],
  "requires_runtime_payload_contract": false,
  "requires_contract_tests": false,
  "requires_generated_artifact_check": false,
  "requires_artifact_pointer_check": false,
  "requires_repo_hygiene_check": false,
  "requires_adversarial_review": false,
  "merge_blockers": [],
  "warnings": [
    {
      "rule_id": "policy.no-specialized-rule-matched",
      "message": "No specialized org-rails rule matched; owner review and unit lane still required."
    }
  ],
  "matched_rules": []
}
```

Manual declaration above is intentionally stronger than the classifier output because this changes gateway recovery runtime behavior and a dashboard action route.

## Non-claims

- This PR does not claim production readiness.
- This PR does not claim launch readiness.
- This PR does not claim live-bank readiness.
- This PR does not claim customer-data readiness.
- This PR does not claim money-movement authority.
- This PR does not claim protected approval.
- This PR does not bypass branch protection.
- This PR does not add live OAuth/banking/account-connection behavior unless explicitly scoped and gated.
- This PR does not rewrite history.

## Review Receipt

- review_type: secondary
- provider: Anthropic
- model: Claude Opus via cc-companion
- provider_family: Anthropic
- reviewer_family: Anthropic
- primary_builder_family: OpenAI
- family_relation: opposite_frontier
- reviewer_identity: cc-review
- same_provider_fallback: no
- fallback_reason: none
- pr_reviewed: local staged/working-tree diff for branch `codex/hermes-telegram-supervised-recovery`
- head_sha_reviewed: 825ad028eabe6e8423f7356103bd8fa59a31dcae
- base_sha_reviewed: 98a70906f6530b1714c9035dd86cdae3ecdfc9bd
- verdict: PASS_WITH_CAVEATS
- material_findings: Prior major findings resolved: corrupt ledger blocks restart, failed restart attempts count toward cooldown, all-profile ledger pruning, exact profile argv ordering, profile-scoped dashboard recovery.
- unresolved_blockers: none
- protected_claims_checked: no Qwen/Ollama/Postgres/API/Cockpit/tunnel restart target; no unrelated Hermes profile restart; no live service restart during development.
- review_timestamp: 2026-06-20T16:02:47Z
- evidence_url_or_path: local `cc-companion review --scope working-tree` output in Codex session

## RuntimePayloadContract

- user_or_operator_visible_outcome: operators can run `hermes gateway recover --dry-run` / `hermes gateway recover`; dashboard exposes recovery decision and can spawn profile-scoped recovery.
- runtime_surface_touched: Hermes gateway recovery CLI, dashboard `/api/status`, dashboard `/api/gateway/recover`.
- product_or_platform_capability_advanced: silent conductor outage from Telegram paused/stale polling can now be diagnosed and remediated without bouncing Qwen/Ollama/Postgres/API/tunnel.
- why_this_is_not_only_docs_or_scaffolding: adds executable recovery logic, CLI parser/handler, dashboard API route, cooldown ledger persistence, and runtime liveness fields.
- tests_that_prove_runtime_behavior: `tests/gateway/test_recovery_decision.py`, `tests/hermes_cli/test_web_server.py` targeted nodeids, `tests/hermes_cli/test_gateway_runtime_health.py`, `tests/gateway/test_status_transport_liveness.py`.
- acceptance_gate: focused tests and cc-review pass; no live gateway restart during development.
- rollback: revert this commit to remove `gateway recover`, dashboard recovery endpoint, and recovery ledger logic; Wave 1 detection remains separately revertible via #49681.
- protected_non_claims: no production readiness, no protected approval, no branch-protection bypass, no customer-data or money-movement authority.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local development environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## For New Skills

N/A.

## Screenshots / Logs

Focused local evidence:

```text
scripts/run_tests.sh ... -> 57 tests passed
web_server recovery/status nodeids -> 3 passed
paused-transport doctor nodeid -> 1 passed
py_compile -> pass
```
