### PR TITLE
Fix/mcp multiplexer stability

### DIFF
--- a/0001-feat-windows-native-PowerShell-support-for-file-ops-.patch
+++ b/0001-feat-windows-native-PowerShell-support-for-file-ops-.patch
@@ -1,0 +1,1514 @@
+From 1a3f742b00439b63324a2fc0afed4bef7c7dcef7 Mon Sep 17 00:00:00 2001
+From: kosecom <kosecom1@gmail.com>
+Date: Fri, 19 Jun 2026 05:11:42 +0200
+Subject: [PATCH] feat(windows): native PowerShell support for file ops,
+ process registry, and shell detection
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Make Hermes Agent work natively with PowerShell on Windows by detecting the
+configured shell type and routing all shell-specific operations through
+PowerShell-compatible alternatives.
+
+Key changes:
+
+- environments/base.py: Add shell_type='bash' class attribute to BaseEnvironment
+  so all backends have a default. PowerShellEnvironment overrides to 'powershell'.
+
+- environments/powershell.py: New PowerShellEnvironment with shell_type='powershell',
+  init_session() using Get-ChildItem/Set-Location/Get-Location, _wrap_command()
+  with PowerShell-native command wrapping, _find_powershell() for pwsh 7+/5.1.
+
+- environments/local.py: _find_shell() now returns pwsh when terminal.shell is
+  'powershell' in config.yaml, falling back to bash otherwise.
+
+- file_operations.py: ShellFileOperations detects shell_type and uses python -c
+  snippets for ALL file operations on PowerShell (read, write, patch, search,
+  delete, move, mkdir, stat, line-ending detection, BOM handling, binary
+  detection). Bash commands preserved for non-PowerShell backends. New methods:
+  _atomic_write_python, _read_file_python, _read_file_raw_python,
+  _search_files_python, _search_content_python.
+
+- process_registry.py: spawn_local() uses pwsh -NoProfile -Command instead of
+  bash -lic 'set +m; ...' when PowerShell is configured. spawn_via_env() uses
+  Start-Process/Set-Content instead of nohup/bash for PowerShell backends.
+  _env_temp_dir() accepts Windows paths (C:\\...) instead of only POSIX /tmp.
+  New helpers: _is_powershell_shell(), _find_configured_shell().
+
+- terminal_tool.py: Dynamic terminal tool description based on configured shell.
+  Fix NameError from function ordering of _get_terminal_shell_config().
+
+- prompt_builder.py: Dynamic shell hint in system prompt — PowerShell hint when
+  terminal.shell is 'powershell', bash hint otherwise.
+
+- transcription_tools.py: Use _quote_command_stt_placeholder() and
+  subprocess.list2cmdline() on Windows instead of shlex.quote for STT commands.
+
+- code_execution_tool.py: shell_quote() uses PowerShell single-quote escaping
+  on Windows instead of shlex.quote (bash-only).
+---
+ agent/prompt_builder.py          |  28 +-
+ tools/code_execution_tool.py     |   5 +
+ tools/environments/base.py       |   4 +
+ tools/environments/local.py      |  17 +-
+ tools/environments/powershell.py | 267 +++++++++++++++
+ tools/file_operations.py         | 547 ++++++++++++++++++++++++++++---
+ tools/process_registry.py        | 109 ++++--
+ tools/terminal_tool.py           |  72 +++-
+ tools/transcription_tools.py     |  19 +-
+ 9 files changed, 990 insertions(+), 78 deletions(-)
+ create mode 100644 tools/environments/powershell.py
+
+diff --git a/agent/prompt_builder.py b/agent/prompt_builder.py
+index 97836f27b..bf1c9beac 100644
+--- a/agent/prompt_builder.py
++++ b/agent/prompt_builder.py
+@@ -790,6 +790,18 @@ _WINDOWS_BASH_SHELL_HINT = (
+ )
+ 
+ 
++_WINDOWS_POWERSHELL_SHELL_HINT = (
++    "Shell: on this Windows host your `terminal` tool runs commands through "
++    "PowerShell 7+ (pwsh), NOT bash or cmd.exe. Use PowerShell cmdlets and "
++    "syntax inside terminal calls: `Get-ChildItem` (alias: ls), "
++    "`Get-Content` (alias: cat), `Select-String` (alias: sls) for search, "
++    "`$env:VAR_NAME` for environment variables, `;` instead of `&&`/`||` "
++    "for command chaining, `$LASTEXITCODE` for exit codes of external "
++    "programs. Use native Windows paths like `C:\\Users\\<user>\\...`. "
++    "Bash syntax (`$FOO`, `&&`, `||`, `grep`, `sed`) will NOT work."
++)
++
++
+ def _probe_remote_backend(env_type: str) -> str | None:
+     """Run a tiny introspection command inside the active terminal backend.
+ 
+@@ -923,10 +935,20 @@ def build_environment_hints() -> str:
+             )
+         hints.append("\n".join(host_lines))
+ 
+-        # Windows-local terminal runs bash, not PowerShell — the model must
+-        # know this or it will issue PowerShell syntax and fail.
++        # Windows-local terminal: tell the model which shell it has.
++        # When terminal.shell=powershell is configured, emit the PowerShell
++        # hint; otherwise default to the historical bash (git-bash/MSYS) hint.
+         if sys.platform == "win32" and not is_wsl():
+-            hints.append(_WINDOWS_BASH_SHELL_HINT)
++            _shell_hint = _WINDOWS_BASH_SHELL_HINT
++            try:
++                from hermes_cli.config import load_config as _lc
++                _cfg = _lc() or {}
++                _shell = str((_cfg.get("terminal") or {}).get("shell", "")).lower().strip()
++                if _shell in ("powershell", "pwsh"):
++                    _shell_hint = _WINDOWS_POWERSHELL_SHELL_HINT
++            except Exception:
++                pass
++            hints.append(_shell_hint)
+     else:
+         # --- Remote backend block (host info suppressed) ---
+         probe = _probe_remote_backend(backend)
+diff --git a/tools/code_execution_tool.py b/tools/code_execution_tool.py
+index 5514f63b9..2daae36d5 100644
+--- a/tools/code_execution_tool.py
++++ b/tools/code_execution_tool.py
+@@ -311,6 +311,11 @@ def shell_quote(s: str) -> str:
+     Use this when inserting dynamic content into terminal() commands:
+         terminal(f"echo {shell_quote(user_input)}")
+     """
++    import platform as _pf
++    if _pf.system() == "Windows":
++        # PowerShell: wrap in single quotes, escape embedded single quotes
++        # by doubling them ('' → '').
++        return "'" + s.replace("'", "''") + "'"
+     return shlex.quote(s)
+ 
+ 
+diff --git a/tools/environments/base.py b/tools/environments/base.py
+index 251bb18f1..2f7312940 100644
+--- a/tools/environments/base.py
++++ b/tools/environments/base.py
+@@ -299,6 +299,10 @@ class BaseEnvironment(ABC):
+     # Snapshot creation timeout (override for slow cold-starts).
+     _snapshot_timeout: int = 30
+ 
++    # Shell type: "bash" (default) or "powershell".  ShellFileOperations
++    # uses this to select between bash commands and Python snippets.
++    shell_type: str = "bash"
++
+     def get_temp_dir(self) -> str:
+         """Return the backend temp directory used for session artifacts.
+ 
+diff --git a/tools/environments/local.py b/tools/environments/local.py
+index b808816ef..6ada23cc8 100644
+--- a/tools/environments/local.py
++++ b/tools/environments/local.py
+@@ -286,8 +286,19 @@ def _find_bash() -> str:
+     )
+ 
+ 
+-# Backward compat — process_registry.py imports this name
+-_find_shell = _find_bash
++# Backward compat — process_registry.py imports this name.
++# When PowerShell is configured as the terminal shell, return pwsh instead
++# of bash so background processes are spawned with the correct shell.
++def _find_shell() -> str:
++    """Return the path to the configured shell (pwsh or bash)."""
++    try:
++        from tools.terminal_tool import _get_terminal_shell_config
++        if _get_terminal_shell_config() == "powershell":
++            from tools.environments.powershell import _find_powershell
++            return _find_powershell()
++    except Exception:
++        pass
++    return _find_bash()
+ 
+ 
+ # Standard PATH entries for environments with minimal PATH.
+@@ -492,6 +503,8 @@ class LocalEnvironment(BaseEnvironment):
+     CWD persists via file-based read after each command.
+     """
+ 
++    shell_type = "bash"
++
+     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
+         if cwd:
+             cwd = os.path.expanduser(cwd)
+diff --git a/tools/environments/powershell.py b/tools/environments/powershell.py
+new file mode 100644
+index 000000000..7289de6c2
+--- /dev/null
++++ b/tools/environments/powershell.py
+@@ -0,0 +1,267 @@
++"""PowerShell execution environment for Windows — spawn-per-call with session snapshot.
++
++Mirrors LocalEnvironment but uses pwsh (PowerShell 7+) instead of Git Bash.
++Activated via ``terminal.shell: powershell`` in config.yaml.
++"""
++
++import logging
++import os
++import platform
++import subprocess
++import tempfile
++import time
++from pathlib import Path
++
++from tools.environments.base import BaseEnvironment, _pipe_stdin
++from tools.environments.local import _make_run_env, _sanitize_subprocess_env
++from hermes_cli._subprocess_compat import windows_hide_flags
++
++_IS_WINDOWS = platform.system() == "Windows"
++
++logger = logging.getLogger(__name__)
++
++
++def _find_powershell() -> str:
++    """Find PowerShell 7+ (pwsh) or fall back to Windows PowerShell 5.1."""
++    import shutil
++
++    pwsh = shutil.which("pwsh")
++    if pwsh:
++        return pwsh
++
++    for candidate in (
++        os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "PowerShell", "7", "pwsh.exe"),
++        os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "PowerShell", "7-preview", "pwsh.exe"),
++    ):
++        if candidate and os.path.isfile(candidate):
++            return candidate
++
++    powershell = shutil.which("powershell")
++    if powershell:
++        return powershell
++
++    for candidate in (
++        os.path.join(os.environ.get("SystemRoot", r"C:\Windows"), "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
++    ):
++        if candidate and os.path.isfile(candidate):
++            return candidate
++
++    raise RuntimeError(
++        "PowerShell not found. Install PowerShell 7+ from: "
++        "https://github.com/PowerShell/PowerShell/releases"
++    )
++
++
++class PowerShellEnvironment(BaseEnvironment):
++    """Run commands via PowerShell on Windows.
++
++    Spawn-per-call: every execute() spawns a fresh pwsh process.
++    Session snapshot preserves env vars across calls via a .ps1 file.
++    CWD persists via file-based read after each command.
++    """
++
++    _stdin_mode = "pipe"
++    shell_type = "powershell"
++
++    def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
++        if cwd:
++            cwd = os.path.expanduser(cwd)
++        super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
++        self.init_session()
++
++    def get_temp_dir(self) -> str:
++        if _IS_WINDOWS:
++            try:
++                from hermes_constants import get_hermes_home
++                cache_dir = get_hermes_home() / "cache" / "terminal"
++            except Exception:
++                cache_dir = Path(tempfile.gettempdir()) / "hermes_terminal"
++            cache_dir.mkdir(parents=True, exist_ok=True)
++            return str(cache_dir).replace("\\", "/")
++        return "/tmp"
++
++    def _run_bash(self, cmd_string: str, *, login: bool = False,
++                  timeout: int = 120,
++                  stdin_data: str | None = None) -> subprocess.Popen:
++        """Spawn a PowerShell process to run *cmd_string*.
++
++        Despite the name (kept for BaseEnvironment compatibility), this
++        runs pwsh, not bash.
++        """
++        pwsh = _find_powershell()
++        args = [pwsh, "-NoProfile", "-NoLogo", "-Command", cmd_string]
++        run_env = _make_run_env(self.env)
++
++        safe_cwd = self.cwd
++        if _IS_WINDOWS and not os.path.isdir(safe_cwd):
++            parent = os.path.dirname(safe_cwd)
++            while parent:
++                if os.path.isdir(parent):
++                    safe_cwd = parent
++                    break
++                next_parent = os.path.dirname(parent)
++                if next_parent == parent:
++                    break
++                parent = next_parent
++            else:
++                safe_cwd = tempfile.gettempdir()
++
++        _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
++
++        proc = subprocess.Popen(
++            args,
++            text=True,
++            env=run_env,
++            encoding="utf-8",
++            errors="replace",
++            stdout=subprocess.PIPE,
++            stderr=subprocess.STDOUT,
++            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
++            preexec_fn=None if _IS_WINDOWS else os.setsid,
++            cwd=safe_cwd,
++            **_popen_kwargs,
++        )
++        if not _IS_WINDOWS:
++            try:
++                proc._hermes_pgid = os.getpgid(proc.pid)
++            except ProcessLookupError:
++                pass
++
++        if stdin_data is not None:
++            _pipe_stdin(proc, stdin_data)
++
++        return proc
++
++    def init_session(self):
++        """Capture PowerShell environment into a snapshot file."""
++        snap_path = self._snapshot_path.replace("/", "\\")
++        cwd_file = self._cwd_file.replace("/", "\\")
++        cwd_escaped = self.cwd.replace("'", "''")
++        marker = self._cwd_marker
++
++        bootstrap = (
++            f"$ErrorActionPreference = 'Continue'\n"
++            f"Get-ChildItem Env: | ForEach-Object {{ "
++            f"  \"$($_.Name)=$($_.Value)\" "
++            f"}} | Set-Content -Path '{snap_path}' -Encoding UTF8\n"
++            f"Set-Location -LiteralPath '{cwd_escaped}' -ErrorAction SilentlyContinue\n"
++            f"(Get-Location).Path | Set-Content -Path '{cwd_file}' -Encoding UTF8\n"
++            f"Write-Output \"`n{marker}$((Get-Location).Path){marker}`n\"\n"
++        )
++        try:
++            proc = self._run_bash(bootstrap, login=False, timeout=self._snapshot_timeout)
++            result = self._wait_for_process(proc, timeout=self._snapshot_timeout)
++            self._snapshot_ready = True
++            self._update_cwd(result)
++            logger.info(
++                "PowerShell session snapshot created (session=%s, cwd=%s)",
++                self._session_id,
++                self.cwd,
++            )
++        except Exception as exc:
++            logger.warning(
++                "PowerShell init_session failed (session=%s): %s — "
++                "falling back to per-command execution",
++                self._session_id,
++                exc,
++            )
++            self._snapshot_ready = False
++
++    def _wrap_command(self, command: str, cwd: str) -> str:
++        """Build a PowerShell script that sources snapshot, cd's, runs command,
++        re-dumps env vars, and emits CWD markers."""
++        snap_path = self._snapshot_path.replace("/", "\\")
++        cwd_file = self._cwd_file.replace("/", "\\")
++        cwd_escaped = cwd.replace("'", "''")
++        marker = self._cwd_marker
++        command_escaped = command.replace("'", "''")
++
++        parts = [
++            f"$ErrorActionPreference = 'Continue'",
++        ]
++
++        if self._snapshot_ready:
++            parts.append(
++                f"if (Test-Path -LiteralPath '{snap_path}') {{ "
++                f"  Get-Content -LiteralPath '{snap_path}' | ForEach-Object {{ "
++                f"    $idx = $_.IndexOf('='); "
++                f"    if ($idx -gt 0) {{ "
++                f"      [Environment]::SetEnvironmentVariable("
++                f"        $_.Substring(0, $idx), $_.Substring($idx + 1), 'Process') "
++                f"    }} "
++                f"  }} "
++                f"}}"
++            )
++
++        parts.append(f"Set-Location -LiteralPath '{cwd_escaped}' -ErrorAction SilentlyContinue")
++
++        parts.append(
++            f"try {{ & {{ {command_escaped} }}; $__hermes_ec = $LASTEXITCODE }} "
++            f"catch {{ Write-Error $_.Exception.Message; $__hermes_ec = 1 }}; "
++            f"if ($__hermes_ec -eq $null) {{ $__hermes_ec = 0 }}"
++        )
++
++        if self._snapshot_ready:
++            parts.append(
++                f"Get-ChildItem Env: | ForEach-Object {{ "
++                f"  \"$($_.Name)=$($_.Value)\" "
++                f"}} | Set-Content -Path '{snap_path}' -Encoding UTF8 -ErrorAction SilentlyContinue"
++            )
++
++        parts.append(
++            f"(Get-Location).Path | Set-Content -Path '{cwd_file}' -Encoding UTF8 -ErrorAction SilentlyContinue"
++        )
++        parts.append(
++            f"Write-Output \"`n{marker}$((Get-Location).Path){marker}`n\""
++        )
++        parts.append(f"exit $__hermes_ec")
++
++        return "\n".join(parts)
++
++    def _update_cwd(self, result: dict):
++        """Read CWD from temp file (PowerShell writes native Windows paths)."""
++        try:
++            with open(self._cwd_file, encoding="utf-8") as f:
++                cwd_path = f.read().strip()
++            if cwd_path and os.path.isdir(cwd_path):
++                self.cwd = cwd_path
++        except (OSError, FileNotFoundError):
++            pass
++
++        self._extract_cwd_from_output(result)
++
++    def _kill_process(self, proc):
++        """Kill the process (Windows: terminate, POSIX: process group)."""
++        try:
++            if _IS_WINDOWS:
++                proc.terminate()
++            else:
++                try:
++                    pgid = os.getpgid(proc.pid)
++                except ProcessLookupError:
++                    pgid = getattr(proc, "_hermes_pgid", None)
++                    if pgid is None:
++                        raise
++                import signal as _signal
++                try:
++                    os.killpg(pgid, _signal.SIGTERM)
++                except ProcessLookupError:
++                    return
++                time.sleep(1.0)
++                try:
++                    os.killpg(pgid, _signal.SIGKILL)
++                except ProcessLookupError:
++                    return
++        except (ProcessLookupError, PermissionError, OSError):
++            try:
++                proc.kill()
++            except Exception:
++                pass
++
++    def cleanup(self):
++        """Clean up temp files."""
++        for f in (self._snapshot_path, self._cwd_file):
++            try:
++                os.unlink(f)
++            except OSError:
++                pass
+diff --git a/tools/file_operations.py b/tools/file_operations.py
+index c9374a4ef..b184593c4 100644
+--- a/tools/file_operations.py
++++ b/tools/file_operations.py
+@@ -725,6 +725,11 @@ class ShellFileOperations(FileOperations):
+     
+     Works with ANY terminal backend that has execute(command, cwd) method.
+     This includes local, docker, singularity, ssh, modal, and daytona environments.
++
++    When the backend's ``shell_type`` is ``"powershell"``, all file operations
++    use Python snippets (``python -c``) instead of bash commands so they work
++    correctly on Windows PowerShell where ``cat``, ``sed``, ``wc``, ``head``,
++    ``mktemp``, ``trap``, etc. are unavailable.
+     """
+     
+     def __init__(self, terminal_env, cwd: str = None):
+@@ -761,7 +766,11 @@ class ShellFileOperations(FileOperations):
+ 
+         # Cache for command availability checks
+         self._command_cache: Dict[str, bool] = {}
+-    
++
++        # Detect PowerShell backends — when true, we use Python-based
++        # operations instead of bash/POSIX commands.
++        self._is_powershell = getattr(terminal_env, 'shell_type', 'bash') == 'powershell'
++
+     def _exec(self, command: str, cwd: str = None, timeout: int = None,
+               stdin_data: str = None) -> ExecuteResult:
+         """Execute command via terminal backend.
+@@ -797,7 +806,10 @@ class ShellFileOperations(FileOperations):
+     def _has_command(self, cmd: str) -> bool:
+         """Check if a command exists in the environment (cached)."""
+         if cmd not in self._command_cache:
+-            result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
++            if self._is_powershell:
++                result = self._exec(f"Get-Command {cmd} -ErrorAction SilentlyContinue | Out-Null; if ($?) {{ echo 'yes' }}")
++            else:
++                result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
+             self._command_cache[cmd] = result.stdout.strip() == 'yes'
+         return self._command_cache[cmd]
+     
+@@ -863,7 +875,10 @@ class ShellFileOperations(FileOperations):
+         # Handle ~ and ~user
+         if path.startswith('~'):
+             # Get home directory via the terminal environment
+-            result = self._exec("echo $HOME")
++            if self._is_powershell:
++                result = self._exec("echo $env:USERPROFILE")
++            else:
++                result = self._exec("echo $HOME")
+             if result.exit_code == 0 and result.stdout.strip():
+                 home = result.stdout.strip()
+                 if path == '~':
+@@ -879,7 +894,10 @@ class ShellFileOperations(FileOperations):
+                 if username and re.fullmatch(r'[a-zA-Z0-9._-]+', username):
+                     # Only expand ~username (not the full path) to avoid shell
+                     # injection via path suffixes like "~user/$(malicious)".
+-                    expand_result = self._exec(f"echo ~{username}")
++                    if self._is_powershell:
++                        expand_result = self._exec(f"echo (Resolve-Path ~{username}).Path")
++                    else:
++                        expand_result = self._exec(f"echo ~{username}")
+                     if expand_result.exit_code == 0 and expand_result.stdout.strip():
+                         user_home = expand_result.stdout.strip()
+                         suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
+@@ -889,7 +907,10 @@ class ShellFileOperations(FileOperations):
+     
+     def _escape_shell_arg(self, arg: str) -> str:
+         """Escape a string for safe use in shell commands."""
+-        # Use single quotes and escape any single quotes in the string
++        if self._is_powershell:
++            # PowerShell single-quote escaping: double embedded single quotes
++            return "'" + arg.replace("'", "''") + "'"
++        # bash single-quote escaping
+         return "'" + arg.replace("'", "'\"'\"'") + "'"
+ 
+     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
+@@ -907,6 +928,9 @@ class ShellFileOperations(FileOperations):
+         was swapped into place atomically. A non-zero exit means nothing was
+         renamed and the original (if any) is intact.
+         """
++        if self._is_powershell:
++            return self._atomic_write_python(path, content)
++
+         q_path = self._escape_shell_arg(path)
+         parent = os.path.dirname(path) or "."
+         q_parent = self._escape_shell_arg(parent)
+@@ -946,6 +970,36 @@ class ShellFileOperations(FileOperations):
+         )
+         return self._exec(script, stdin_data=content)
+ 
++    def _atomic_write_python(self, path: str, content: str) -> "ExecuteResult":
++        """Atomic write via Python snippet — used on PowerShell backends.
++
++        Uses ``python -c`` with stdin piping so it works on any shell that
++        has Python available (which Hermes always does via its venv).
++        Creates a temp file in the same directory, writes stdin to it,
++        then atomically replaces the target.
++        """
++        snippet = (
++            "import sys, os, tempfile, pathlib\n"
++            f"target = pathlib.Path({path!r})\n"
++            "parent = target.parent if target.parent else pathlib.Path('.')\n"
++            "parent.mkdir(parents=True, exist_ok=True)\n"
++            "fd, tmp = tempfile.mkstemp(dir=str(parent), prefix='.hermes-tmp.')\n"
++            "try:\n"
++            "    with os.fdopen(fd, 'w', encoding='utf-8', newline='') as f:\n"
++            "        f.write(sys.stdin.read())\n"
++            "    if target.exists():\n"
++            "        try:\n"
++            "            os.chmod(tmp, os.stat(str(target)).st_mode & 0o7777)\n"
++            "        except Exception:\n"
++            "            pass\n"
++            "    os.replace(tmp, str(target))\n"
++            "except Exception:\n"
++            "    try: os.unlink(tmp)\n"
++            "    except Exception: pass\n"
++            "    raise\n"
++        )
++        return self._exec(f"python -c {self._escape_shell_arg(snippet)}", stdin_data=content)
++
+     def _detect_file_line_ending(self, path: str, pre_content: Optional[str] = None) -> Optional[str]:
+         """Detect the dominant line ending of a file on disk.
+ 
+@@ -959,10 +1013,20 @@ class ShellFileOperations(FileOperations):
+         """
+         if pre_content:
+             return _detect_line_ending(pre_content)
+-        # File may not exist (new write) — `head` exits 0 with empty
+-        # stdout in that case which yields None below.  Cheap probe.
+-        head_cmd = f"head -c 4096 {self._escape_shell_arg(path)} 2>/dev/null"
+-        head_result = self._exec(head_cmd)
++        # File may not exist (new write) — probe returns empty in that case.
++        if self._is_powershell:
++            snippet = (
++                "import sys\n"
++                f"p = {path!r}\n"
++                "try:\n"
++                "    with open(p, 'rb') as f: data = f.read(4096)\n"
++                "    sys.stdout.buffer.write(data)\n"
++                "except Exception: pass\n"
++            )
++            head_result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
++        else:
++            head_cmd = f"head -c 4096 {self._escape_shell_arg(path)} 2>/dev/null"
++            head_result = self._exec(head_cmd)
+         if head_result.exit_code != 0 or not head_result.stdout:
+             return None
+         return _detect_line_ending(head_result.stdout)
+@@ -977,8 +1041,19 @@ class ShellFileOperations(FileOperations):
+         """
+         if pre_content is not None:
+             return _has_bom(pre_content)
+-        head_cmd = f"head -c 3 {self._escape_shell_arg(path)} 2>/dev/null"
+-        head_result = self._exec(head_cmd)
++        if self._is_powershell:
++            snippet = (
++                "import sys\n"
++                f"p = {path!r}\n"
++                "try:\n"
++                "    with open(p, 'rb') as f: data = f.read(3)\n"
++                "    sys.stdout.buffer.write(data)\n"
++                "except Exception: pass\n"
++            )
++            head_result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
++        else:
++            head_cmd = f"head -c 3 {self._escape_shell_arg(path)} 2>/dev/null"
++            head_result = self._exec(head_cmd)
+         if head_result.exit_code != 0 or not head_result.stdout:
+             return False
+         return _has_bom(head_result.stdout)
+@@ -1015,7 +1090,10 @@ class ShellFileOperations(FileOperations):
+         path = self._expand_path(path)
+         
+         offset, limit = normalize_read_pagination(offset, limit)
+-        
++
++        if self._is_powershell:
++            return self._read_file_python(path, offset, limit)
++
+         # Check if file exists and get size (wc -c is POSIX, works on Linux + macOS)
+         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
+         stat_result = self._exec(stat_cmd)
+@@ -1096,6 +1174,87 @@ class ShellFileOperations(FileOperations):
+             hint=hint
+         )
+     
++    def _read_file_python(self, path: str, offset: int, limit: int) -> ReadResult:
++        """Read file via Python snippet — used on PowerShell backends."""
++        snippet = (
++            "import sys, os\n"
++            f"p = {path!r}\n"
++            "if not os.path.isfile(p):\n"
++            "    sys.exit(1)\n"
++            "st = os.stat(p)\n"
++            f"print(st.st_size)\n"
++            "with open(p, 'rb') as f:\n"
++            "    data = f.read(1000)\n"
++            "sys.stdout.buffer.write(data)\n"
++        )
++        result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
++        if result.exit_code != 0:
++            return self._suggest_similar_files(path)
++        lines = result.stdout.split('\n', 1)
++        try:
++            file_size = int(lines[0].strip())
++        except (ValueError, IndexError):
++            file_size = 0
++        sample_output = lines[1] if len(lines) > 1 else ""
++        sample_output = _strip_terminal_fence_leaks(sample_output)
++
++        if self._is_image(path):
++            return ReadResult(
++                is_image=True, is_binary=True, file_size=file_size,
++                hint="Image file detected. Use vision_analyze with this file path."
++            )
++        if self._is_likely_binary(path, sample_output):
++            return ReadResult(
++                is_binary=True, file_size=file_size,
++                error="Binary file - cannot display as text."
++            )
++
++        end_line = offset + limit - 1
++        read_snippet = (
++            "import sys\n"
++            f"p = {path!r}\n"
++            "with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
++            "    for i, line in enumerate(f, 1):\n"
++            f"        if i < {offset}: continue\n"
++            f"        if i > {end_line}: break\n"
++            "        sys.stdout.write(line)\n"
++        )
++        read_result = self._exec(f"python -c {self._escape_shell_arg(read_snippet)}")
++        if read_result.exit_code != 0:
++            return ReadResult(error=f"Failed to read file: {read_result.stdout}")
++        read_output = _strip_terminal_fence_leaks(read_result.stdout)
++        if offset == 1:
++            read_output, _ = _strip_bom(read_output)
++
++        count_snippet = (
++            "import sys\n"
++            f"p = {path!r}\n"
++            "try:\n"
++            "    with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
++            "        print(sum(1 for _ in f))\n"
++            "except Exception:\n"
++            "    print(0)\n"
++        )
++        wc_result = self._exec(f"python -c {self._escape_shell_arg(count_snippet)}")
++        wc_output = _strip_terminal_fence_leaks(wc_result.stdout)
++        try:
++            total_lines = int(wc_output.strip())
++        except ValueError:
++            total_lines = 0
++
++        truncated = total_lines > end_line
++        hint = None
++        if truncated:
++            hint = f"Use offset={end_line + 1} to continue reading (showing {offset}-{end_line} of {total_lines} lines)"
++
++        return ReadResult(
++            content=self._add_line_numbers(read_output, offset),
++            total_lines=total_lines,
++            file_size=file_size,
++            truncated=truncated,
++            hint=hint
++        )
++
+     def _suggest_similar_files(self, path: str) -> ReadResult:
+         """Suggest similar files when the requested file is not found."""
+         dir_path = os.path.dirname(path) or "."
+@@ -1105,8 +1264,19 @@ class ShellFileOperations(FileOperations):
+         lower_name = filename.lower()
+ 
+         # List files in the target directory
+-        ls_cmd = f"ls -1 {self._escape_shell_arg(dir_path)} 2>/dev/null | head -50"
+-        ls_result = self._exec(ls_cmd)
++        if self._is_powershell:
++            list_snippet = (
++                "import os, sys\n"
++                f"d = {dir_path!r}\n"
++                "try:\n"
++                "    for f in sorted(os.listdir(d))[:50]:\n"
++                "        print(f)\n"
++                "except Exception: pass\n"
++            )
++            ls_result = self._exec(f"python -c {self._escape_shell_arg(list_snippet)}")
++        else:
++            ls_cmd = f"ls -1 {self._escape_shell_arg(dir_path)} 2>/dev/null | head -50"
++            ls_result = self._exec(ls_cmd)
+ 
+         scored: list = []  # (score, filepath) — higher is better
+         if ls_result.exit_code == 0 and ls_result.stdout.strip():
+@@ -1155,6 +1325,8 @@ class ShellFileOperations(FileOperations):
+         Uses cat so the full file is returned regardless of size.
+         """
+         path = self._expand_path(path)
++        if self._is_powershell:
++            return self._read_file_raw_python(path)
+         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
+         stat_result = self._exec(stat_cmd)
+         if stat_result.exit_code != 0:
+@@ -1187,6 +1359,50 @@ class ShellFileOperations(FileOperations):
+             file_size=file_size,
+         )
+ 
++    def _read_file_raw_python(self, path: str) -> ReadResult:
++        """Read full file content via Python snippet — used on PowerShell backends."""
++        stat_snippet = (
++            "import sys, os\n"
++            f"p = {path!r}\n"
++            "if not os.path.isfile(p):\n"
++            "    sys.exit(1)\n"
++            f"print(os.stat(p).st_size)\n"
++            "with open(p, 'rb') as f:\n"
++            "    data = f.read(1000)\n"
++            "sys.stdout.buffer.write(data)\n"
++        )
++        stat_result = self._exec(f"python -c {self._escape_shell_arg(stat_snippet)}")
++        if stat_result.exit_code != 0:
++            return self._suggest_similar_files(path)
++        lines_out = stat_result.stdout.split('\n', 1)
++        try:
++            file_size = int(lines_out[0].strip())
++        except (ValueError, IndexError):
++            file_size = 0
++        sample_output = lines_out[1] if len(lines_out) > 1 else ""
++        sample_output = _strip_terminal_fence_leaks(sample_output)
++        if self._is_image(path):
++            return ReadResult(is_image=True, is_binary=True, file_size=file_size)
++        if self._is_likely_binary(path, sample_output):
++            return ReadResult(
++                is_binary=True, file_size=file_size,
++                error="Binary file — cannot display as text."
++            )
++        read_snippet = (
++            "import sys\n"
++            f"p = {path!r}\n"
++            "with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
++            "    sys.stdout.write(f.read())\n"
++        )
++        read_result = self._exec(f"python -c {self._escape_shell_arg(read_snippet)}")
++        if read_result.exit_code != 0:
++            return ReadResult(error=f"Failed to read file: {read_result.stdout}")
++        raw_content, _ = _strip_bom(_strip_terminal_fence_leaks(read_result.stdout))
++        return ReadResult(
++            content=raw_content,
++            file_size=file_size,
++        )
++
+     def delete_file(self, path: str) -> WriteResult:
+         """Delete a single file.
+ 
+@@ -1236,12 +1452,15 @@ class ShellFileOperations(FileOperations):
+             "    print(str(exc), file=sys.stderr); sys.exit(1)\n"
+         )
+ 
+-        result = self._exec(f"python3 -c {self._escape_shell_arg(snippet)}")
+-
+-        # Fall back to ``python`` (Windows / older systems where there's no
+-        # ``python3`` symlink but a ``python`` binary is on PATH).
+-        if result.exit_code != 0 and "python3" in (result.stdout or ""):
++        if self._is_powershell:
+             result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
++        else:
++            result = self._exec(f"python3 -c {self._escape_shell_arg(snippet)}")
++
++            # Fall back to ``python`` (Windows / older systems where there's no
++            # ``python3`` symlink but a ``python`` binary is on PATH).
++            if result.exit_code != 0 and "python3" in (result.stdout or ""):
++                result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
+ 
+         if result.exit_code != 0:
+             return WriteResult(error=f"Failed to delete {path}: {(result.stdout or '').strip() or 'unknown error'}")
+@@ -1249,15 +1468,27 @@ class ShellFileOperations(FileOperations):
+         return WriteResult()
+ 
+     def move_file(self, src: str, dst: str) -> WriteResult:
+-        """Move a file via mv."""
++        """Move a file via mv (bash) or Python snippet (PowerShell)."""
+         src = self._expand_path(src)
+         dst = self._expand_path(dst)
+         for p in (src, dst):
+             if _is_write_denied(p):
+                 return WriteResult(error=f"Move denied: {p} is a protected path")
+-        result = self._exec(
+-            f"mv {self._escape_shell_arg(src)} {self._escape_shell_arg(dst)}"
+-        )
++        if self._is_powershell:
++            snippet = (
++                "import shutil, sys\n"
++                f"src = {src!r}\n"
++                f"dst = {dst!r}\n"
++                "try:\n"
++                "    shutil.move(src, dst)\n"
++                "except Exception as exc:\n"
++                "    print(str(exc), file=sys.stderr); sys.exit(1)\n"
++            )
++            result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
++        else:
++            result = self._exec(
++                f"mv {self._escape_shell_arg(src)} {self._escape_shell_arg(dst)}"
++            )
+         if result.exit_code != 0:
+             return WriteResult(error=f"Failed to move {src} -> {dst}: {result.stdout}")
+         return WriteResult()
+@@ -1318,8 +1549,19 @@ class ShellFileOperations(FileOperations):
+             # pre_content as None which makes both downstream consumers
+             # degrade gracefully (lint reports all errors; LSP skips the
+             # shift map).
+-            read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+-            read_result = self._exec(read_cmd)
++            if self._is_powershell:
++                pre_snippet = (
++                    "import sys\n"
++                    f"p = {path!r}\n"
++                    "try:\n"
++                    "    with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
++                    "        sys.stdout.write(f.read())\n"
++                    "except Exception: sys.exit(1)\n"
++                )
++                read_result = self._exec(f"python -c {self._escape_shell_arg(pre_snippet)}")
++            else:
++                read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
++                read_result = self._exec(read_cmd)
+             if read_result.exit_code == 0 and read_result.stdout:
+                 pre_content = read_result.stdout
+ 
+@@ -1358,8 +1600,19 @@ class ShellFileOperations(FileOperations):
+         dirs_created = False
+ 
+         if parent:
+-            mkdir_cmd = f"mkdir -p {self._escape_shell_arg(parent)}"
+-            mkdir_result = self._exec(mkdir_cmd)
++            if self._is_powershell:
++                mkdir_snippet = (
++                    "import pathlib, sys\n"
++                    f"p = pathlib.Path({parent!r})\n"
++                    "try:\n"
++                    "    p.mkdir(parents=True, exist_ok=True)\n"
++                    "except Exception as exc:\n"
++                    "    print(str(exc), file=sys.stderr); sys.exit(1)\n"
++                )
++                mkdir_result = self._exec(f"python -c {self._escape_shell_arg(mkdir_snippet)}")
++            else:
++                mkdir_cmd = f"mkdir -p {self._escape_shell_arg(parent)}"
++                mkdir_result = self._exec(mkdir_cmd)
+             if mkdir_result.exit_code == 0:
+                 dirs_created = True
+ 
+@@ -1383,9 +1636,19 @@ class ShellFileOperations(FileOperations):
+         if write_result.exit_code != 0:
+             return WriteResult(error=f"Failed to write file: {write_result.stdout}")
+ 
+-        # Get bytes written (wc -c is POSIX, works on Linux + macOS)
+-        stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
+-        stat_result = self._exec(stat_cmd)
++        # Get bytes written
++        if self._is_powershell:
++            size_snippet = (
++                "import os, sys\n"
++                f"p = {path!r}\n"
++                "try:\n"
++                "    print(os.path.getsize(p))\n"
++                "except Exception: sys.exit(1)\n"
++            )
++            stat_result = self._exec(f"python -c {self._escape_shell_arg(size_snippet)}")
++        else:
++            stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
++            stat_result = self._exec(stat_cmd)
+ 
+         try:
+             bytes_written = int(stat_result.stdout.strip())
+@@ -1442,8 +1705,19 @@ class ShellFileOperations(FileOperations):
+             return PatchResult(error=f"Write denied: '{path}' is a protected system/credential file.")
+ 
+         # Read current content
+-        read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+-        read_result = self._exec(read_cmd)
++        if self._is_powershell:
++            patch_read_snippet = (
++                "import sys\n"
++                f"p = {path!r}\n"
++                "try:\n"
++                "    with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
++                "        sys.stdout.write(f.read())\n"
++                "except Exception: sys.exit(1)\n"
++            )
++            read_result = self._exec(f"python -c {self._escape_shell_arg(patch_read_snippet)}")
++        else:
++            read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
++            read_result = self._exec(read_cmd)
+         
+         if read_result.exit_code != 0:
+             return PatchResult(error=f"Failed to read file: {path}")
+@@ -1495,7 +1769,19 @@ class ShellFileOperations(FileOperations):
+         # pipe, etc.) that would otherwise return success-with-diff while the
+         # file is unchanged on disk.
+         verify_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+-        verify_result = self._exec(verify_cmd)
++        if self._is_powershell:
++            verify_snippet = (
++                "import sys\n"
++                f"p = {path!r}\n"
++                "try:\n"
++                "    with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
++                "        sys.stdout.write(f.read())\n"
++                "except Exception: sys.exit(1)\n"
++            )
++            verify_result = self._exec(f"python -c {self._escape_shell_arg(verify_snippet)}")
++        else:
++            verify_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
++            verify_result = self._exec(verify_cmd)
+         if verify_result.exit_code != 0:
+             return PatchResult(error=f"Post-write verification failed: could not re-read {path}")
+         # Normalize line endings before comparing.  On Windows, Python's
+@@ -1600,8 +1886,19 @@ class ShellFileOperations(FileOperations):
+         if inproc is not None:
+             # Need content — either passed in or read from disk.
+             if content is None:
+-                read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+-                read_result = self._exec(read_cmd)
++                if self._is_powershell:
++                    lint_read_snippet = (
++                        "import sys\n"
++                        f"p = {path!r}\n"
++                        "try:\n"
++                        "    with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
++                        "        sys.stdout.write(f.read())\n"
++                        "except Exception: sys.exit(1)\n"
++                    )
++                    read_result = self._exec(f"python -c {self._escape_shell_arg(lint_read_snippet)}")
++                else:
++                    read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
++                    read_result = self._exec(read_cmd)
+                 if read_result.exit_code != 0:
+                     return LintResult(skipped=True, message=f"Failed to read {path} for lint")
+                 content = read_result.stdout
+@@ -1942,20 +2239,47 @@ class ShellFileOperations(FileOperations):
+         path = self._expand_path(path)
+         
+         # Validate that the path exists before searching
+-        check = self._exec(f"test -e {self._escape_shell_arg(path)} && echo exists || echo not_found")
++        if self._is_powershell:
++            check_snippet = (
++                "import os, sys\n"
++                f"p = {path!r}\n"
++                "print('exists' if os.path.exists(p) else 'not_found')\n"
++            )
++            check = self._exec(f"python -c {self._escape_shell_arg(check_snippet)}")
++        else:
++            check = self._exec(f"test -e {self._escape_shell_arg(path)} && echo exists || echo not_found")
+         if "not_found" in check.stdout:
+             # Try to suggest nearby paths
+             parent = os.path.dirname(path) or "."
+             basename_query = os.path.basename(path)
+             hint_parts = [f"Path not found: {path}"]
+             # Check if parent directory exists and list similar entries
+-            parent_check = self._exec(
+-                f"test -d {self._escape_shell_arg(parent)} && echo yes || echo no"
+-            )
+-            if "yes" in parent_check.stdout and basename_query:
+-                ls_result = self._exec(
+-                    f"ls -1 {self._escape_shell_arg(parent)} 2>/dev/null | head -20"
++            if self._is_powershell:
++                parent_snippet = (
++                    "import os, sys\n"
++                    f"p = {parent!r}\n"
++                    "print('yes' if os.path.isdir(p) else 'no')\n"
++                )
++                parent_check = self._exec(f"python -c {self._escape_shell_arg(parent_snippet)}")
++            else:
++                parent_check = self._exec(
++                    f"test -d {self._escape_shell_arg(parent)} && echo yes || echo no"
+                 )
++            if "yes" in parent_check.stdout and basename_query:
++                if self._is_powershell:
++                    ls_snippet = (
++                        "import os, sys\n"
++                        f"d = {parent!r}\n"
++                        "try:\n"
++                        "    for f in sorted(os.listdir(d))[:20]:\n"
++                        "        print(f)\n"
++                        "except Exception: pass\n"
++                    )
++                    ls_result = self._exec(f"python -c {self._escape_shell_arg(ls_snippet)}")
++                else:
++                    ls_result = self._exec(
++                        f"ls -1 {self._escape_shell_arg(parent)} 2>/dev/null | head -20"
++                    )
+                 if ls_result.exit_code == 0 and ls_result.stdout.strip():
+                     lower_q = basename_query.lower()
+                     candidates = []
+@@ -1994,6 +2318,11 @@ class ShellFileOperations(FileOperations):
+             for part in search_root.parts
+         )
+ 
++        # On PowerShell, use Python-based search instead of find/rg
++        if self._is_powershell:
++            return self._search_files_python(search_pattern, path, limit, offset,
++                                              has_hidden_path_ancestor, search_root)
++
+         # Prefer ripgrep: respects .gitignore, excludes hidden dirs by
+         # default, and has parallel directory traversal (~200x faster than
+         # find on wide trees).  Mirrors _search_content which already uses rg.
+@@ -2111,10 +2440,45 @@ class ShellFileOperations(FileOperations):
+             truncated=len(all_files) >= fetch_limit or bool(limit_reason),
+             limit_reason=limit_reason,
+         )
+-    
++
++    def _search_files_python(self, pattern: str, path: str, limit: int, offset: int,
++                             has_hidden_ancestor: bool, search_root: Path) -> SearchResult:
++        """File search via Python snippet — used on PowerShell backends."""
++        snippet = (
++            "import os, fnmatch, sys, time\n"
++            f"root = {path!r}\n"
++            f"pattern = {pattern!r}\n"
++            f"skip_hidden = {not has_hidden_ancestor!r}\n"
++            "results = []\n"
++            "for dirpath, dirnames, filenames in os.walk(root):\n"
++            "    if skip_hidden:\n"
++            "        dirnames[:] = [d for d in dirnames if not d.startswith('.')]\n"
++            "    for fn in filenames:\n"
++            "        if fnmatch.fnmatch(fn, pattern):\n"
++            "            fp = os.path.join(dirpath, fn)\n"
++            "            try: mt = os.path.getmtime(fp)\n"
++            "            except Exception: mt = 0\n"
++            "            results.append((mt, fp))\n"
++            "results.sort(key=lambda x: -x[0])\n"
++            "for mt, fp in results:\n"
++            "    print(fp)\n"
++        )
++        result = self._exec(f"python -c {self._escape_shell_arg(snippet)}", timeout=60)
++        all_files = [f for f in result.stdout.strip().split('\n') if f]
++        page = all_files[offset:offset + limit]
++        return SearchResult(
++            files=page,
++            total_count=len(all_files),
++            truncated=len(all_files) > offset + limit,
++        )
++
+     def _search_content(self, pattern: str, path: str, file_glob: Optional[str],
+                         limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+         """Search for content inside files (grep-like)."""
++        # On PowerShell, use Python-based search to avoid bash pipe syntax
++        if self._is_powershell:
++            return self._search_content_python(pattern, path, file_glob, limit, offset,
++                                                output_mode, context)
+         # Try ripgrep first (fast), fallback to grep (slower but works)
+         if self._has_command('rg'):
+             return self._search_with_rg(pattern, path, file_glob, limit, offset, 
+@@ -2128,7 +2492,102 @@ class ShellFileOperations(FileOperations):
+                 error="Content search requires ripgrep (rg) or grep. "
+                       "Install ripgrep: https://github.com/BurntSushi/ripgrep#installation"
+             )
+-    
++
++    def _search_content_python(self, pattern: str, path: str, file_glob: Optional[str],
++                               limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
++        """Content search via Python snippet — used on PowerShell backends."""
++        snippet = (
++            "import os, re, sys, fnmatch\n"
++            f"root = {path!r}\n"
++            f"pattern = {pattern!r}\n"
++            f"file_glob = {file_glob!r}\n"
++            f"output_mode = {output_mode!r}\n"
++            f"context = {context!r}\n"
++            f"limit = {limit + offset + 50!r}\n"
++            "try:\n"
++            "    regex = re.compile(pattern)\n"
++            "except re.error as e:\n"
++            "    print(f'Regex error: {e}', file=sys.stderr); sys.exit(1)\n"
++            "matches = []\n"
++            "if os.path.isfile(root):\n"
++            "    files_to_search = [root]\n"
++            "else:\n"
++            "    files_to_search = []\n"
++            "    for dirpath, dirnames, filenames in os.walk(root):\n"
++            "        dirnames[:] = [d for d in dirnames if not d.startswith('.')]\n"
++            "        for fn in filenames:\n"
++            "            if file_glob and not fnmatch.fnmatch(fn, file_glob):\n"
++            "                continue\n"
++            "            files_to_search.append(os.path.join(dirpath, fn))\n"
++            "for fp in files_to_search:\n"
++            "    try:\n"
++            "        with open(fp, 'r', encoding='utf-8', errors='replace') as f:\n"
++            "            lines = f.readlines()\n"
++            "    except Exception:\n"
++            "        continue\n"
++            "    for i, line in enumerate(lines, 1):\n"
++            "        if regex.search(line):\n"
++            "            if output_mode == 'files_only':\n"
++            "                print(fp)\n"
++            "                break\n"
++            "            elif output_mode == 'count':\n"
++            "                pass\n"
++            "            else:\n"
++            "                start = max(0, i - 1 - context)\n"
++            "                end = min(len(lines), i + context)\n"
++            "                for j in range(start, end):\n"
++            "                    prefix = '>>' if j == i - 1 else '  '\n"
++            "                    print(f'{fp}:{j+1}:{prefix} {lines[j].rstrip()}')\n"
++            "                if context > 0 and i < len(lines):\n"
++            "                    print('--')\n"
++            "    if output_mode == 'count':\n"
++            "        cnt = sum(1 for line in lines if regex.search(line))\n"
++            "        if cnt > 0:\n"
++            "            print(f'{fp}:{cnt}')\n"
++            "    if len(matches) >= limit:\n"
++            "        break\n"
++        )
++        result = self._exec(f"python -c {self._escape_shell_arg(snippet)}", timeout=60)
++        if result.exit_code != 0:
++            return SearchResult(error=f"Search failed: {result.stdout.strip()}")
++
++        stdout = result.stdout
++        if output_mode == "files_only":
++            all_files = [f for f in stdout.strip().split('\n') if f and f != '--']
++            page = all_files[offset:offset + limit]
++            return SearchResult(files=page, total_count=len(all_files))
++        elif output_mode == "count":
++            counts = {}
++            for line in stdout.strip().split('\n'):
++                if ':' in line:
++                    parts = line.rsplit(':', 1)
++                    if len(parts) == 2:
++                        try:
++                            counts[parts[0]] = int(parts[1])
++                        except ValueError:
++                            pass
++            return SearchResult(counts=counts, total_count=sum(counts.values()))
++
++        # content mode
++        matches = []
++        current_path = None
++        for line in stdout.split('\n'):
++            if not line or line == '--':
++                continue
++            parts = line.split(':', 2)
++            if len(parts) >= 3:
++                try:
++                    ln = int(parts[1])
++                except ValueError:
++                    continue
++                matches.append(SearchMatch(path=parts[0], line_number=ln, content=parts[2]))
++        page = matches[offset:offset + limit]
++        return SearchResult(
++            matches=page,
++            total_count=len(matches),
++            truncated=len(matches) > offset + limit,
++        )
++
+     def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],
+                         limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+         """Search using ripgrep."""
+diff --git a/tools/process_registry.py b/tools/process_registry.py
+index e9f3276ff..23a5335a2 100644
+--- a/tools/process_registry.py
++++ b/tools/process_registry.py
+@@ -51,6 +51,24 @@ from hermes_cli.config import get_hermes_home
+ logger = logging.getLogger(__name__)
+ 
+ 
++def _is_powershell_shell() -> bool:
++    """Return True if the configured terminal shell is PowerShell."""
++    try:
++        from tools.terminal_tool import _get_terminal_shell_config
++        return _get_terminal_shell_config() == "powershell"
++    except Exception:
++        return False
++
++
++def _find_configured_shell() -> str:
++    """Return the path to the configured shell (pwsh or bash).
++
++    Delegates to _find_shell() which now handles PowerShell detection
++    internally via _get_terminal_shell_config().
++    """
++    return _find_shell()
++
++
+ # Checkpoint file for crash recovery (gateway only)
+ CHECKPOINT_PATH = get_hermes_home() / "processes.json"
+ 
+@@ -510,10 +528,18 @@ class ProcessRegistry:
+         if callable(get_temp_dir):
+             try:
+                 temp_dir = get_temp_dir()
+-                if isinstance(temp_dir, str) and temp_dir.startswith("/"):
+-                    return temp_dir.rstrip("/") or "/"
++                if isinstance(temp_dir, str) and temp_dir:
++                    # Accept both POSIX (/tmp) and Windows (C:\...) paths.
++                    # Normalise backslashes to forward slashes for consistent
++                    # path joining downstream.
++                    normalised = temp_dir.replace("\\", "/").rstrip("/") or "/"
++                    return normalised
+             except Exception as exc:
+                 logger.debug("Could not resolve environment temp dir: %s", exc)
++        # Platform-appropriate fallback
++        if _IS_WINDOWS:
++            import tempfile as _tmpmod
++            return _tmpmod.gettempdir().replace("\\", "/")
+         return "/tmp"
+ 
+     def spawn_local(
+@@ -551,15 +577,26 @@ class ProcessRegistry:
+                     from winpty import PtyProcess as _PtyProcessCls
+                 else:
+                     from ptyprocess import PtyProcess as _PtyProcessCls
+-                user_shell = _find_shell()
++                user_shell = _find_configured_shell()
+                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
+                 pty_env["PYTHONUNBUFFERED"] = "1"
+-                pty_proc = _PtyProcessCls.spawn(
+-                    [user_shell, "-lic", f"set +m; {command}"],
+-                    cwd=session.cwd,
+-                    env=pty_env,
+-                    dimensions=(30, 120),
+-                )
++                # Detect PowerShell: use pwsh -NoProfile -Command instead of
++                # bash -lic "set +m; ..."
++                is_powershell = _is_powershell_shell()
++                if is_powershell:
++                    pty_proc = _PtyProcessCls.spawn(
++                        [user_shell, "-NoProfile", "-NoLogo", "-Command", command],
++                        cwd=session.cwd,
++                        env=pty_env,
++                        dimensions=(30, 120),
++                    )
++                else:
++                    pty_proc = _PtyProcessCls.spawn(
++                        [user_shell, "-lic", f"set +m; {command}"],
++                        cwd=session.cwd,
++                        env=pty_env,
++                        dimensions=(30, 120),
++                    )
+                 session.pid = pty_proc.pid
+                 # Store the pty handle on the session for read/write
+                 session._pty = pty_proc
+@@ -589,7 +626,7 @@ class ProcessRegistry:
+         # Standard Popen path (non-PTY or PTY fallback)
+         # Use the user's login shell for consistency with LocalEnvironment --
+         # ensures rc files are sourced and user tools are available.
+-        user_shell = _find_shell()
++        user_shell = _find_configured_shell()
+         # Force unbuffered output for Python scripts so progress is visible
+         # during background execution (libraries like tqdm/datasets buffer when
+         # stdout is a pipe, hiding output from process(action="poll")).
+@@ -597,8 +634,15 @@ class ProcessRegistry:
+         bg_env["PYTHONUNBUFFERED"] = "1"
+         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
+ 
++        # Detect PowerShell: use pwsh -NoProfile -Command instead of bash -lic
++        is_powershell = _is_powershell_shell()
++        if is_powershell:
++            shell_args = [user_shell, "-NoProfile", "-NoLogo", "-Command", command]
++        else:
++            shell_args = [user_shell, "-lic", f"set +m; {command}"]
++
+         proc = subprocess.Popen(
+-            [user_shell, "-lic", f"set +m; {command}"],
++            shell_args,
+             text=True,
+             cwd=session.cwd,
+             env=bg_env,
+@@ -689,17 +733,38 @@ class ProcessRegistry:
+         log_path = f"{temp_dir}/hermes_bg_{session.id}.log"
+         pid_path = f"{temp_dir}/hermes_bg_{session.id}.pid"
+         exit_path = f"{temp_dir}/hermes_bg_{session.id}.exit"
+-        quoted_command = shlex.quote(command)
+-        quoted_temp_dir = shlex.quote(temp_dir)
+-        quoted_log_path = shlex.quote(log_path)
+-        quoted_pid_path = shlex.quote(pid_path)
+-        quoted_exit_path = shlex.quote(exit_path)
+-        bg_command = (
+-            f"mkdir -p {quoted_temp_dir} && "
+-            f"( nohup bash -lc {quoted_command} > {quoted_log_path} 2>&1; "
+-            f"rc=$?; printf '%s\\n' \"$rc\" > {quoted_exit_path} ) & "
+-            f"echo $! > {quoted_pid_path} && cat {quoted_pid_path}"
+-        )
++
++        # Detect PowerShell backends — use PowerShell job syntax instead of
++        # nohup/bash.  Falls back to the original bash path for all others.
++        is_powershell = getattr(env, 'shell_type', 'bash') == 'powershell'
++
++        if is_powershell:
++            # PowerShell: use Start-Job / Start-Process for background execution.
++            # Paths use Windows-style backslashes inside the sandbox.
++            win_log = log_path.replace("/", "\\")
++            win_pid = pid_path.replace("/", "\\")
++            win_exit = exit_path.replace("/", "\\")
++            win_temp = temp_dir.replace("/", "\\")
++            cmd_escaped = command.replace("'", "''")
++            bg_command = (
++                f"if (-not (Test-Path '{win_temp}')) {{ New-Item -ItemType Directory -Path '{win_temp}' -Force | Out-Null }}; "
++                f"$proc = Start-Process -FilePath 'pwsh' -ArgumentList '-NoProfile','-NoLogo','-Command','{cmd_escaped}' "
++                f"  -RedirectStandardOutput '{win_log}' -RedirectStandardError '{win_log}' -PassThru -NoNewWindow; "
++                f"$proc.Id | Set-Content -Path '{win_pid}' -Encoding UTF8; "
++                f"Get-Content '{win_pid}'"
++            )
++        else:
++            quoted_command = shlex.quote(command)
++            quoted_temp_dir = shlex.quote(temp_dir)
++            quoted_log_path = shlex.quote(log_path)
++            quoted_pid_path = shlex.quote(pid_path)
++            quoted_exit_path = shlex.quote(exit_path)
++            bg_command = (
++                f"mkdir -p {quoted_temp_dir} && "
++                f"( nohup bash -lc {quoted_command} > {quoted_log_path} 2>&1; "
++                f"rc=$?; printf '%s\\n' \"$rc\" > {quoted_exit_path} ) & "
++                f"echo $! > {quoted_pid_path} && cat {quoted_pid_path}"
++            )
+ 
+         try:
+             result = env.execute(
+diff --git a/tools/terminal_tool.py b/tools/terminal_tool.py
+index 71907a3a3..9d81d6bd4 100644
+--- a/tools/terminal_tool.py
++++ b/tools/terminal_tool.py
+@@ -824,6 +824,7 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
+ 
+ # Environment classes now live in tools/environments/
+ from tools.environments.local import LocalEnvironment as _LocalEnvironment
++from tools.environments.powershell import PowerShellEnvironment as _PowerShellEnvironment
+ from tools.environments.singularity import SingularityEnvironment as _SingularityEnvironment
+ from tools.environments.ssh import SSHEnvironment as _SSHEnvironment
+ from tools.environments.docker import DockerEnvironment as _DockerEnvironment
+@@ -834,7 +835,45 @@ import sys
+ 
+ 
+ # Tool description for LLM
+-TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
++_POWERSHELL_TOOL_DESCRIPTION = """Execute commands in a PowerShell environment on Windows. Filesystem, current working directory, and environment variables persist between calls.
++
++You are running on Windows with PowerShell 7+ (pwsh). Use PowerShell cmdlets and syntax:
++- List files: Get-ChildItem (alias: ls, dir, gci)
++- Read file content: Get-Content (alias: cat, gc) — but prefer read_file tool
++- Search text: Select-String (alias: sls) — but prefer search_files tool
++- Environment variables: $env:VAR_NAME (e.g. $env:PATH, $env:USERPROFILE)
++- Set env var: $env:VAR_NAME = "value"
++- Current dir: Get-Location (alias: pwd, gl)
++- Change dir: Set-Location (alias: cd, sl)
++- Pipe: | (works like bash but passes objects, not text)
++- Variables: $var = "value" (no $ needed on assignment, $ on read)
++- String interpolation: "Hello $name" (double quotes interpolate, single quotes don't)
++- Exit code: $LASTEXITCODE (for external programs), $? (True/False for cmdlets)
++- Run exe: & "C:\\path\\to.exe" arg1 arg2
++- Multi-statement: use ; between commands (not &&). Use ; instead of && and ||
++
++Do NOT use cat/head/tail to read files — use read_file instead.
++Do NOT use grep/rg/find to search — use search_files instead.
++Do NOT use ls to list directories — use search_files(target='files') instead.
++Do NOT use sed/awk to edit files — use patch instead.
++Do NOT use Set-Content/Out-File to create files — use write_file instead.
++Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
++Because environment state persists, activate a virtualenv or set up variables once per session; do not re-set the same environment before every command unless a command proves the shell state was reset.
++
++Foreground (default): Commands return INSTANTLY when done, even if the timeout is high. Set timeout=300 for long builds/scripts — you'll still get the result in seconds if it's fast. Prefer foreground for short commands.
++Background: Set background=true to get a session_id. Almost always pair with notify_on_complete=true — bg without notify runs SILENTLY and you have no way to learn it finished short of calling process(action='poll') yourself. Two legitimate uses:
++  (1) Long-lived processes that never exit (servers, watchers, daemons) — silent is correct, there's no exit to notify on.
++  (2) Long-running bounded tasks (tests, builds, deploys, CI pollers, batch jobs) — MUST set notify_on_complete=true. Without it you'll either forget to poll or sit blocked waiting for the user to surface the result.
++For servers/watchers, do NOT use shell-level background wrappers (Start-Process -NoNewWindow / trailing '&') in foreground mode. Use background=true so Hermes can track lifecycle and output.
++After starting a server, verify readiness with a health check or log signal, then run tests in a separate terminal() call. Avoid blind sleep loops.
++Use process(action="poll") for progress checks, process(action="wait") to block until done.
++Working directory: Use 'workdir' for per-command cwd.
++PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REPL).
++
++Do NOT use vim/nano/interactive tools without pty=true — they hang without a pseudo-terminal. Pipe git output to Out-Host or cat if it might page.
++"""
++
++_BASH_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
+ 
+ Do NOT use cat/head/tail to read files — use read_file instead.
+ Do NOT use grep/rg/find to search — use search_files instead.
+@@ -857,6 +896,34 @@ PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REP
+ Do NOT use vim/nano/interactive tools without pty=true — they hang without a pseudo-terminal. Pipe git output to cat if it might page.
+ """
+ 
++
++def _get_terminal_shell_config() -> str:
++    """Return the configured shell type for local terminal: 'powershell' or 'bash'.
++
++    Reads ``terminal.shell`` from config.yaml. Defaults to 'bash' (the
++    historical Hermes behaviour on Windows via Git Bash).
++    """
++    try:
++        from hermes_cli.config import load_config
++        cfg = load_config() or {}
++        terminal_cfg = cfg.get("terminal") or {}
++        shell = str(terminal_cfg.get("shell", "")).lower().strip()
++        if shell in ("powershell", "pwsh"):
++            return "powershell"
++        return "bash"
++    except Exception:
++        return "bash"
++
++
++def _get_terminal_tool_description() -> str:
++    """Return the terminal tool description matching the configured shell."""
++    if _get_terminal_shell_config() == "powershell":
++        return _POWERSHELL_TOOL_DESCRIPTION
++    return _BASH_TOOL_DESCRIPTION
++
++
++TERMINAL_TOOL_DESCRIPTION = _get_terminal_tool_description()
++
+ # Global state for environment lifecycle management
+ _active_environments: Dict[str, Any] = {}
+ _last_activity: Dict[str, float] = {}
+@@ -1255,6 +1322,9 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
+     docker_extra_args = cc.get("docker_extra_args", [])
+ 
+     if env_type == "local":
++        shell_type = _get_terminal_shell_config()
++        if shell_type == "powershell":
++            return _PowerShellEnvironment(cwd=cwd, timeout=timeout)
+         return _LocalEnvironment(cwd=cwd, timeout=timeout)
+     
+     elif env_type == "docker":
+diff --git a/tools/transcription_tools.py b/tools/transcription_tools.py
+index d0712c81e..f02e87d7e 100644
+--- a/tools/transcription_tools.py
++++ b/tools/transcription_tools.py
+@@ -167,7 +167,10 @@ def _get_local_command_template() -> Optional[str]:
+ 
+     whisper_binary = _find_whisper_binary()
+     if whisper_binary:
+-        quoted_binary = shlex.quote(whisper_binary)
++        if os.name == "nt":
++            quoted_binary = subprocess.list2cmdline([whisper_binary])
++        else:
++            quoted_binary = shlex.quote(whisper_binary)
+         return (
+             f"{quoted_binary} {{input_path}} --model {{model}} --output_format txt "
+             "--output_dir {output_dir} --language {language}"
+@@ -1225,17 +1228,21 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
+                 return {"success": False, "transcript": "", "error": prep_error}
+ 
+             command = command_template.format(
+-                input_path=shlex.quote(prepared_input),
+-                output_dir=shlex.quote(output_dir),
+-                language=shlex.quote(language),
+-                model=shlex.quote(normalized_model),
++                input_path=_quote_command_stt_placeholder(prepared_input, None),
++                output_dir=_quote_command_stt_placeholder(output_dir, None),
++                language=_quote_command_stt_placeholder(language, None),
++                model=_quote_command_stt_placeholder(normalized_model, None),
+             )
+             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
+             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
+             if use_shell:
+                 subprocess.run(command, shell=True, check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
+             else:
+-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
++                if os.name == "nt":
++                    # On Windows, use list2cmdline for proper argument splitting
++                    subprocess.run(subprocess.list2cmdline(shlex.split(command)), check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
++                else:
++                    subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
+             
+ 
+             txt_files = sorted(Path(output_dir).glob("*.txt"))
+-- 
+2.53.0.windows.1
+

--- a/MULTIPLEXER_PATCH.diff
+++ b/MULTIPLEXER_PATCH.diff
@@ -1,0 +1,478 @@
+diff --git a/gateway/config.py b/gateway/config.py
+--- a/gateway/config.py
++++ b/gateway/config.py
+@@ -550,6 +550,12 @@
+     # profile on the host: profiles are stamped into session keys and (in later
+     # phases) per-profile adapters/credentials are resolved. When False, the
+     # gateway behaves exactly as before — single HERMES_HOME, no profile stamping.
++    multiplex_profiles: bool = False
++
+     # Unauthorized DM policy
+     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
+ 
+@@ -657,6 +663,7 @@
+             "group_sessions_per_user": self.group_sessions_per_user,
+             "thread_sessions_per_user": self.thread_sessions_per_user,
+             "max_concurrent_sessions": self.max_concurrent_sessions,
++            "multiplex_profiles": self.multiplex_profiles,
+             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
+             "streaming": self.streaming.to_dict(),
+             "session_store_max_age_days": self.session_store_max_age_days,
+@@ -703,6 +710,16 @@
+         group_sessions_per_user = data.get("group_sessions_per_user")
+         thread_sessions_per_user = data.get("thread_sessions_per_user")
++        multiplex_profiles = data.get("multiplex_profiles")
+         nested_gateway = data.get("gateway") if isinstance(data.get("gateway"), dict) else {}
++        if multiplex_profiles is None and isinstance(nested_gateway, dict):
++            # Also honor gateway.multiplex_profiles written by
++            # ``hermes config set gateway.multiplex_profiles true``.
++            multiplex_profiles = nested_gateway.get("multiplex_profiles")
+         if "max_concurrent_sessions" in data:
+             max_concurrent_sessions_raw = data.get("max_concurrent_sessions")
+             max_concurrent_key = "max_concurrent_sessions"
+@@ -745,6 +762,7 @@
+             stt_enabled=_coerce_bool(stt_enabled, True),
+             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
+             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
++            multiplex_profiles=_coerce_bool(multiplex_profiles, False),
+             max_concurrent_sessions=max_concurrent_sessions,
+             unauthorized_dm_behavior=unauthorized_dm_behavior,
+             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+@@ -846,6 +864,12 @@
+                 gw_data["thread_sessions_per_user"] = yaml_cfg["thread_sessions_per_user"]
+ 
++            # Multiplexing flag: accept both the top-level key and the nested
++            # gateway.multiplex_profiles form (from_dict resolves the nested
++            # fallback, but surface the top-level key here for parity with the
++            # other session-scope flags above).
++            if "multiplex_profiles" in yaml_cfg:
++                gw_data["multiplex_profiles"] = yaml_cfg["multiplex_profiles"]
++
+             gateway_section = yaml_cfg.get("gateway")
+             if isinstance(gateway_section, dict) and "max_concurrent_sessions" in gateway_section:
+
+diff --git a/gateway/session.py b/gateway/session.py
+--- a/gateway/session.py
++++ b/gateway/session.py
+@@ -92,6 +92,12 @@
+     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
+     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
+     role_authorized: bool = False  # True when adapter granted access via role (not user ID)
++    # Profile this inbound message is routed to in a multiplexing gateway
++    # (from the /p/<profile>/ URL prefix or per-credential adapter ownership).
++    # None => the gateway's active/default profile. Drives both session-key
++    # namespacing and the per-turn config/credential scope.
++    profile: Optional[str] = None
+ 
+     @property
+     def description(self) -> str:
+@@ -140,6 +146,8 @@
+             d["parent_chat_id"] = self.parent_chat_id
+         if self.message_id:
+             d["message_id"] = self.message_id
++        if self.profile:
++            d["profile"] = self.profile
+         return d
+ 
+     @classmethod
+@@ -160,6 +168,7 @@
+             guild_id=data.get("guild_id"),
+             parent_chat_id=data.get("parent_chat_id"),
+             message_id=data.get("message_id"),
++            profile=data.get("profile"),
+         )
+ 
+@@ -623,6 +632,44 @@
++def _session_key_namespace(profile: Optional[str]) -> str:
++    """Return the ``agent:<ns>`` namespace prefix for a session key.
++
++    The historical key format is ``agent:main:<platform>:<chat_type>:...`` where
++    ``main`` is a static namespace literal (NOT a branch name — branching keys
++    off ``session_id``, not this slot). Multi-profile multiplexing reuses this
++    slot to carry the profile:
++
++    - default profile (or ``None``/``""``/``"default"``) → ``agent:main`` —
++      BYTE-IDENTICAL to every key ever generated, so existing sessions and all
++      positional parsers (``parts[2]`` == platform, etc.) are unaffected.
++    - named profile ``coder`` → ``agent:coder`` — keeps the same positional
++      layout, just a different namespace, so two profiles serving the same
++      platform/chat never collide.
++    """
++    if not profile or profile == "default":
++        return "agent:main"
++    return f"agent:{profile}"
++
+ 
+ def build_session_key(
+     source: SessionSource,
+     group_sessions_per_user: bool = True,
+     thread_sessions_per_user: bool = False,
++    profile: Optional[str] = None,
+ ) -> str:
+     """Build a deterministic session key from a message source.
+ 
++    ``profile`` selects the key namespace (see :func:`_session_key_namespace`).
++    It defaults to ``None`` ⇒ the legacy ``agent:main`` namespace, so callers
++    that don't multiplex produce byte-identical keys to before. Only the
++    multiplexing gateway passes a non-default profile.
++
+     DM rules:
+       - DMs include chat_id when present, so each private conversation is isolated.
+@@ -680,6 +717,7 @@
+         shared session per chat.
+       - Without identifiers, messages fall back to one session per platform/chat_type.
+     """
++    ns = _session_key_namespace(profile)
+     platform = source.platform.value
+     if source.chat_type == "dm":
+         dm_chat_id = source.chat_id
+@@ -810,6 +848,36 @@
++    def _resolve_profile_for_key(self, source: Optional[SessionSource] = None) -> Optional[str]:
++        """Return the profile namespace for session keys, or None when off.
++
++        When ``multiplex_profiles`` is disabled (default), returns ``None`` so
++        keys stay in the legacy ``agent:main`` namespace — byte-identical to
++        before. When enabled, prefers the profile the inbound source was routed
++        to (``source.profile`` — set by the /p/<profile>/ URL prefix or
++        per-credential adapter), falling back to the active profile name.
++        """
++        if not getattr(self.config, "multiplex_profiles", False):
++            return None
++        if source is not None and source.profile:
++            return source.profile
++        try:
++            from hermes_cli.profiles import get_active_profile_name
++            return get_active_profile_name() or "default"
++        except Exception:
++            return None
+ 
+     def _generate_session_key(self, source: SessionSource) -> str:
+         return build_session_key(
+             source,
+             group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
+             thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
++            profile=self._resolve_profile_for_key(source),
+         )
+
+diff --git a/gateway/delivery.py b/gateway/delivery.py
+--- a/gateway/delivery.py
++++ b/gateway/delivery.py
+@@ -185,8 +185,16 @@
+     def __init__(self, config: GatewayConfig, adapters: Dict[Platform, Any] = None,
++                 profile_adapters: Dict[str, Dict[Platform, Any]] = None):
+         """Initialize the delivery router."""
+         self.config = config
+         self.adapters = adapters or {}
++        self.profile_adapters = profile_adapters or {}
+         self.output_dir = get_hermes_home() / "cron" / "output"
+ 
+@@ -316,6 +324,16 @@
+         """Deliver content to a messaging platform."""
+         adapter = None
+         target_profile = getattr(target, "profile", None)
++        if target_profile and getattr(self.config, "multiplex_profiles", False):
++            profile_map = self.profile_adapters.get(target_profile, {})
++            adapter = profile_map.get(target.platform)
+         if adapter is None:
+             adapter = self.adapters.get(target.platform)
+
+diff --git a/gateway/run.py b/gateway/run.py
+--- a/gateway/run.py
++++ b/gateway/run.py
+@@ -2387,6 +2387,20 @@
+         self.config = config or load_gateway_config()
++        # Mark the process as a profile multiplexer when configured. This flips
++        # agent.secret_scope.get_secret() to fail-closed on any unscoped
++        # credential read, so a missed migration crashes loudly instead of
++        # leaking a cross-profile value (Workstream A). Inert when off.
++        try:
++            from agent.secret_scope import set_multiplex_active
++            set_multiplex_active(bool(getattr(self.config, "multiplex_profiles", False)))
++        except Exception:
++            logger.debug("could not set multiplex-active flag", exc_info=True)
+         self.adapters: Dict[Platform, BasePlatformAdapter] = {}
++        # Multi-profile multiplexing: adapters for NON-default profiles live
++        # here, keyed by profile name then Platform. self.adapters stays the
++        # default/active profile's map so the ~93 existing self.adapters[...]
++        # sites are untouched when multiplexing is off (this dict is empty).
++        # Populated by _start_secondary_profile_adapters().
++        self._profile_adapters: Dict[str, Dict[Platform, BasePlatformAdapter]] = {}
+         self._warn_if_docker_media_delivery_is_risky()
+         _gateway_runner_ref = _weakref.ref(self)
+@@ -2425,6 +2439,7 @@
+         self.delivery_router = DeliveryRouter(
+             self.config,
++            profile_adapters=self._profile_adapters,
+         )
+         self._running = False
+
+@@ -2955,6 +2970,80 @@
++    def _adapter_for_source(self, source) -> "BasePlatformAdapter | None":
++        """Resolve the correct outbound adapter for a source.
++        
++        In multiplex mode, routes through the profile-specific adapter
++        (self._profile_adapters[profile][platform]) so responses go back
++        through the correct bot token. Falls back to self.adapters for
++        default profile or when multiplexing is off.
++        """
++        profile = getattr(source, "profile", None)
++        platform = getattr(source, "platform", None)
++        if profile and platform and getattr(self.config, "multiplex_profiles", False):
++            profile_adapters = self._profile_adapters.get(profile, {})
++            adapter = profile_adapters.get(platform)
++            if adapter is not None:
++                return adapter
++        # Default profile or multiplexing off or profile adapter not found
++        if platform:
++            return self.adapters.get(platform)
++        return None
++
++    def _all_adapters(self):
++        """Yield (platform, adapter) for ALL adapters — default + multiplexed profiles.
++
++        In multiplex mode this iterates default profile adapters first, then
++        every secondary profile's adapters. In single-profile mode it's
++        identical to self.adapters.items().
++        """
++        yield from self.adapters.items()
++        if getattr(self.config, "multiplex_profiles", False):
++            for profile_name, plat_map in self._profile_adapters.items():
++                for platform, adapter in plat_map.items():
++                    yield platform, adapter
++
++    def _all_adapters_with_profile(self):
++        """Yield (platform, adapter, profile_name) for ALL adapters.
++
++        Default profile adapters get profile_name=None (or the active profile).
++        Secondary profile adapters get their profile name.
++        """
++        for platform, adapter in self.adapters.items():
++            yield platform, adapter, None
++        if getattr(self.config, "multiplex_profiles", False):
++            for profile_name, plat_map in self._profile_adapters.items():
++                for platform, adapter in plat_map.items():
++                    yield platform, adapter, profile_name
++
++    def _adapter_for_platform_name(self, platform_name: str, source=None):
++        """Resolve adapter by platform name string, with optional profile routing."""
++        profile = getattr(source, "profile", None) if source else None
++        if profile and getattr(self.config, "multiplex_profiles", False):
++            plat_map = self._profile_adapters.get(profile, {})
++            for p, a in plat_map.items():
++                if p.value == platform_name:
++                    return a
++        for p, a in self.adapters.items():
++            if p.value == platform_name:
++                return a
++        return None
++
++    def _adapter_for_platform(self, platform, source=None):
++        """Resolve adapter by Platform enum, with optional profile routing."""
++        profile = getattr(source, "profile", None) if source else None
++        if profile and getattr(self.config, "multiplex_profiles", False):
++            plat_map = self._profile_adapters.get(profile, {})
++            adapter = plat_map.get(platform)
++            if adapter is not None:
++                return adapter
++        return self.adapters.get(platform)
+
+ # Replace all self.adapters.get(event.source.platform) call sites with
+ # self._adapter_for_source(event.source) for correct profile routing:
+@@ -4112 +4191 @@
+-        adapter = self.adapters.get(event.source.platform)
++        adapter = self._adapter_for_source(event.source)
+@@ -4169 +4248 @@
+-        adapter = self.adapters.get(event.source.platform)
++        adapter = self._adapter_for_source(event.source)
+@@ -4196 +4275 @@
+-        adapter = self.adapters.get(event.source.platform)
++        adapter = self._adapter_for_source(event.source)
+@@ -4499 +4578 @@
+-        adapter = self.adapters.get(platform)
++        adapter = self._adapter_for_source(source) if source else self.adapters.get(platform)
+@@ -4561 +4640 @@
+-        for platform, adapter in list(self.adapters.items()):
++        for platform, adapter in list(self._all_adapters()):
+@@ -5047 +5126 @@
+-        adapter = self.adapters.get(source.platform) if source is not None else None
++        adapter = self._adapter_for_source(source) if source is not None else None
+@@ -5131 +5210 @@
+-        adapter = self.adapters.get(source.platform)
++        adapter = self._adapter_for_source(source)
+@@ -5669 +5748 @@
+         self.delivery_router.adapters = self.adapters
++        self.delivery_router.profile_adapters = self._profile_adapters
+@@ -5681 +5761 @@
+-            "platforms": [p.value for p in self.adapters.keys()],
++            "platforms": [p.value for p in self.adapters.keys()] + [p.value for _prof, pm in getattr(self, "_profile_adapters", {}).items() for p in pm.keys()],
+@@ -5596 +5676 @@
++        try:
++            _secondary_connected = await self._start_secondary_profile_adapters()
++            connected_count += _secondary_connected
++        except MultiplexConfigError as e:
++            # Invalid multiplexer config — abort startup cleanly
++            raise
+
+@@ -6807 +6887,140 new methods:
++    async def _start_secondary_profile_adapters(self) -> int:
++        """Bring up adapters for every non-active profile this gateway serves.
++
++        Returns the number of secondary adapters that connected. No-op (returns
++        0) unless ``gateway.multiplex_profiles`` is on.
++
++        Each profile's adapters are created and connected under that profile's
++        HERMES_HOME + secret scope, stored in ``self._profile_adapters[profile]``,
++        and given a message handler that stamps ``source.profile`` before
++        delegating to the shared ``_handle_message`` — so the agent turn resolves
++        that profile's config, skills, and credentials. Same-platform credential
++        collisions (two profiles polling the same bot token) are detected and
++        refused here.
++        """
++        if not getattr(self.config, "multiplex_profiles", False):
++            return 0
++        try:
++            from hermes_cli.profiles import profiles_to_serve, get_active_profile_name
++        except Exception:
++            return 0
++        active = get_active_profile_name() or "default"
++        connected = 0
++        claimed: Dict[tuple, str] = {}
++        for _plat, _ad in self.adapters.items():
++            fp = self._adapter_credential_fingerprint(_ad)
++            if fp is not None:
++                claimed[(_plat, fp)] = active
++        for profile_name, profile_home in profiles_to_serve(multiplex=True):
++            if profile_name == active:
++                continue
++            try:
++                connected += await self._start_one_profile_adapters(
++                    profile_name, profile_home, claimed
++                )
++            except MultiplexConfigError:
++                raise
++            except Exception as e:
++                logger.error(
++                    "Failed to start adapters for profile '%s': %s",
++                    profile_name, e, exc_info=True,
++                )
++        try:
++            from gateway.status import write_runtime_status
++            served = [active] + sorted(self._profile_adapters.keys())
++            write_runtime_status(served_profiles=served)
++        except Exception:
++            logger.debug("could not record served_profiles", exc_info=True)
++        return connected
++
++    async def _start_one_profile_adapters(
++        self, profile_name: str, profile_home: "Path", claimed: Dict[tuple, str]
++    ) -> int:
++        """Create+connect one profile's adapters under its runtime scope."""
++        from gateway.config import load_gateway_config
++        with _profile_runtime_scope(profile_home):
++            profile_cfg = load_gateway_config()
++        profile_map = self._profile_adapters.setdefault(profile_name, {})
++        connected = 0
++        for platform, platform_config in profile_cfg.platforms.items():
++            if not platform_config.enabled:
++                continue
++            if platform.value in _PORT_BINDING_PLATFORM_VALUES:
++                raise MultiplexConfigError(
++                    f"Profile '{profile_name}' enables the port-binding platform "
++                    f"'{platform.value}', but gateway.multiplex_profiles is on. "
++                    f"Remove platforms.{platform.value} from profile "
++                    f"'{profile_name}'s config.yaml."
++                )
++            with _profile_runtime_scope(profile_home):
++                adapter = self._create_adapter(platform, platform_config)
++            if not adapter:
++                continue
++            fp = self._adapter_credential_fingerprint(adapter)
++            if fp is not None:
++                owner = claimed.get((platform, fp))
++                if owner is not None:
++                    logger.error(
++                        "Profile '%s' and '%s' both configure %s with the same "
++                        "credential — refusing to start the duplicate.",
++                        owner, profile_name, platform.value,
++                    )
++                    await self._safe_adapter_disconnect(adapter, platform)
++                    continue
++                claimed[(platform, fp)] = profile_name
++            adapter.set_message_handler(
++                self._make_profile_message_handler(profile_name)
++            )
++            adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
++            adapter.set_session_store(self.session_store)
++            adapter.set_busy_session_handler(self._handle_active_session_busy_message)
++            adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
++            adapter._busy_text_mode = self._busy_text_mode
++            try:
++                with _profile_runtime_scope(profile_home):
++                    success = await self._connect_adapter_with_timeout(adapter, platform)
++                if success:
++                    profile_map[platform] = adapter
++                    connected += 1
++                    logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
++                else:
++                    logger.warning("✗ %s failed to connect (profile: %s)", platform.value, profile_name)
++                    await self._safe_adapter_disconnect(adapter, platform)
++            except Exception as e:
++                logger.error("✗ %s error (profile: %s): %s", platform.value, profile_name, e)
++                await self._safe_adapter_disconnect(adapter, platform)
++        return connected
++
++    def _make_profile_message_handler(self, profile_name: str):
++        """Return a message handler that stamps source.profile then delegates."""
++        async def _handler(event):
++            try:
++                if getattr(event, "source", None) is not None and not event.source.profile:
++                    event.source.profile = profile_name
++            except Exception:
++                pass
++            return await self._handle_message(event)
++        return _handler
++
++    @staticmethod
++    def _adapter_credential_fingerprint(adapter: Any) -> Optional[str]:
++        """Return a stable, log-safe fingerprint of an adapter's credential."""
++        token = None
++        for attr in ("token", "bot_token", "_token", "api_token", "_bot_token"):
++            val = getattr(adapter, attr, None)
++            if isinstance(val, str) and val.strip():
++                token = val.strip()
++                break
++        if not token:
++            return None
++        import hashlib
++        return hashlib.sha256(("hermes-mux:" + token).encode("utf-8")).hexdigest()[:16]
+
+diff --git a/plugins/memory/hindsight/__init__.py b/plugins/memory/hindsight/__init__.py
+--- a/plugins/memory/hindsight/__init__.py
++++ b/plugins/memory/hindsight/__init__.py
+@@ -1851,6 +1851,18 @@
++        if self._client is not None:
++            try:
++                if self._mode == "local_embedded":
++                    # Multiplexed gateway fix: when idle_timeout=0, the daemon is
++                    # configured to persist. Closing the embedded client here causes
++                    # a cleanup lock timeout (daemon busy serving other profiles),
++                    # which marks the client as _closed=True. Subsequent background
++                    # tasks (memory writes from other profiles) then fail silently.
++                    # Skip the close when the daemon is configured to persist.
++                    if self._idle_timeout == 0:
++                        logger.debug(
++                            "Hindsight shutdown: skipping embedded client close "
++                            "(idle_timeout=0, daemon persists for multiplexed profiles)"
++                        )
++                    else:
+                         inner_client = getattr(self._client, "_client", None)
+
+diff --git a/tools/mcp_tool.py b/tools/mcp_tool.py
+--- a/tools/mcp_tool.py
++++ b/tools/mcp_tool.py
+@@ -279,5 +279,5 @@
+-_MAX_RECONNECT_RETRIES = 5
++_MAX_RECONNECT_RETRIES = 20
+@@ -281,5 +281,5 @@
+-_MAX_BACKOFF_SECONDS = 60
++_MAX_BACKOFF_SECONDS = 30

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,206 @@
+# Hermes Multiplexer Patches
+
+Patches applied to the Hermes agent codebase to enable **stable multi-profile multiplexing with separate Telegram channels**.
+
+## Context
+
+Hermes runs as a single systemd gateway serving multiple agent profiles. Each profile has its own `config.yaml`, `SOUL.md`, and MCP server definitions, and **its own Telegram channel** — allowing multiple independent bots to run simultaneously on one gateway instance. All profiles share the same underlying MCP tool servers (gbrain, hindsight, instantly, transcriptor, open-design).
+
+Without these patches, multiplexed profiles experienced frequent MCP server disconnects, orphaned subprocesses on restart, and broken Hindsight daemon connections — making separate Telegram channels unreliable and unusable for production use.
+
+The following patches fix these issues and enable bug-free operation of multiple independent agent profiles on a single Hermes gateway.
+
+---
+
+## 1. MCP Reconnect Resilience (`mcp_tool.py`)
+
+**File:** `$HERMES_HOME/hermes-agent/tools/mcp_tool.py`
+**Lines:** 279, 281
+
+### Problem
+The default reconnect logic gave up after only 5 retries with exponential backoff capped at 60s. When an SSE stream broke (e.g. gbrain TaskGroup errors), the MCP client would permanently lose the server after ~31 seconds of attempts, leaving all 81 gbrain tools unavailable for the rest of the session.
+
+### Patch
+
+```diff
+-_MAX_RECONNECT_RETRIES = 5
+-_MAX_BACKOFF_SECONDS = 60
++_MAX_RECONNECT_RETRIES = 20
++_MAX_BACKOFF_SECONDS = 30
+```
+
+### Rationale
+- **20 retries** gives the server ~8 minutes to recover (enough for transient SSE drops, Ollama model loads, or network blips).
+- **30s backoff cap** (down from 60s) ensures retries happen frequently enough to catch a quick recovery, without the exponential tail making waits absurdly long.
+
+---
+
+## 2. MCP Keepalive & Timeout Tuning (all profiles)
+
+**Files:**
+- `$HERMES_HOME/config.yaml` (main profile)
+- `$HERMES_HOME/profiles/<profile-a>/config.yaml`
+- `$HERMES_HOME/profiles/<profile-b>/config.yaml`
+
+### Problem
+The default keepalive interval for HTTP MCP servers is 180s (code default in `mcp_tool.py:288`). gbrain and hindsight servers have shorter SSE session TTLs. With 180s keepalive, idle sessions would expire between pings, causing `TaskGroup` errors and connection drops. The tool-call timeout of 60s was also too short for gbrain operations like `mcp_gbrain_think` or `mcp_gbrain_submit_job`.
+
+### Patch
+
+For **gbrain** and **hindsight** in all profile configs:
+
+```diff
+ mcp_servers:
+   gbrain:
+     url: http://localhost:7777/mcp
++    keepalive_interval: 60
+     # ... auth headers ...
+     connect_timeout: 30
+-    timeout: 60
++    timeout: 120
+   hindsight:
+     url: http://localhost:8888/mcp
++    keepalive_interval: 60
+     connect_timeout: 30
+-    timeout: 60
++    timeout: 120
+```
+
+### Rationale
+- **60s keepalive** (down from 180s default) ensures SSE sessions stay alive before any reasonable server-side TTL expires.
+- **120s timeout** (up from 60s) accommodates long-running gbrain tool calls (graph traversal, job submission, schema operations).
+- Applied to **all profiles** so multiplexed agents share the same stability guarantees.
+
+---
+
+## 3. Hindsight Ollama Endpoint Fix
+
+**Files:**
+- `$HERMES_HOME/.env`
+- `$HINDSIGHT_HOME/profiles/<profile>.env` (one per profile)
+
+### Problem
+The Hindsight embedded daemon uses `dotenv` with `find_dotenv(usecwd=True, override=True)` in `hindsight_api/config.py:23`. Since the gateway's `WorkingDirectory` is `~/.hermes`, the daemon picks up `~/.hermes/.env` and **overrides** any environment variables set by the embedded manager. The URL was set to the WSL Windows-host IP, which is unreachable from within WSL when Ollama runs natively on Linux.
+
+### Patch
+
+```diff
+ # $HERMES_HOME/.env
+-HINDSIGHT_API_LLM_BASE_URL=http://<host-ip>:11434/v1
++HINDSIGHT_API_LLM_BASE_URL=http://localhost:11434/v1
+
+ # $HINDSIGHT_HOME/profiles/<profile>.env  (repeat for each profile)
+-HINDSIGHT_API_LLM_BASE_URL=http://<host-ip>:11434/v1
++HINDSIGHT_API_LLM_BASE_URL=http://localhost:11434/v1
+```
+
+### Rationale
+- Ollama runs natively on `localhost:11434` inside WSL.
+- The Windows-host IP is only reachable via WSL's mirrored networking, which is unreliable and adds latency.
+- All env files must be patched because `dotenv(override=True)` in the daemon process will overwrite any env vars set by the embedded manager from the profile `.env`.
+
+---
+
+## 4. Orphaned stdio MCP Process Cleanup
+
+**File:** `$HERMES_HOME/scripts/kill-mcp-orphans.sh` (new)
+
+### Problem
+When the gateway restarts, stdio MCP subprocesses (transcriptor, open-design) are not always killed cleanly. `KillMode=mixed` in the systemd service sends SIGTERM to the main process but leaves orphaned stdio subprocesses consuming memory and holding ports.
+
+### Patch
+
+Created `$HERMES_HOME/scripts/kill-mcp-orphans.sh`:
+
+```bash
+#!/bin/bash
+# Kill orphaned stdio MCP subprocesses from previous gateway runs
+# Only targets transcriptor wrapper and open-design MCP stdio clients (not the daemon)
+
+pkill -f 'transcriptor-mcp-wrapper.sh' 2>/dev/null || true
+pkill -f 'open-design.*cli.js.*mcp.*daemon-url' 2>/dev/null || true
+
+exit 0
+```
+
+### Rationale
+- Targets only the specific stdio MCP wrapper processes, not all child processes.
+- Safe to run before gateway startup (`ExecStartPre`) or manually.
+- The `|| true` ensures the script doesn't fail if no orphans exist.
+
+### Note
+The `ExecStartPre` directive was prepared but is **not yet wired** into the systemd service file. To activate, add to `hermes-gateway.service`:
+
+```ini
+[Service]
+ExecStartPre=$HERMES_HOME/scripts/kill-mcp-orphans.sh
+```
+
+---
+
+## 5. systemd Service Hardening (drop-in)
+
+**Files:**
+- `~/.config/systemd/user/hermes-gateway.service.d/autostart.conf`
+- `~/.config/systemd/user/hermes-gateway.service.d/hardening.conf`
+
+*(Paths use `~` for user home. Replace `$HERMES_HOME` with your Hermes installation path.)*
+
+### autostart.conf
+Ensures the gateway starts after Ollama is available:
+
+```ini
+[Unit]
+After=network-online.target ollama.service
+Wants=network-online.target
+```
+
+### hardening.conf
+Prevents crash loops and ensures clean process group kills:
+
+```ini
+[Unit]
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+Restart=on-failure
+RestartSec=15
+KillMode=control-group
+RuntimeMaxSec=43200
+```
+
+### Rationale
+- `After=ollama.service` ensures Ollama is up before the gateway tries to connect MCP servers that depend on it.
+- `KillMode=control-group` (overriding the main service's `mixed`) ensures all child processes including stdio MCP subprocesses are killed on stop.
+- `StartLimitBurst=5` prevents infinite restart loops if the gateway crashes on startup.
+- `RuntimeMaxSec=43200` (12h) forces a periodic clean restart to prevent memory leaks in long-running sessions.
+
+---
+
+## Summary Table
+
+| # | File | Change | Impact |
+|---|------|--------|--------|
+| 1 | `tools/mcp_tool.py:279,281` | Reconnect retries 5→20, backoff cap 60→30s | MCP servers survive transient SSE drops |
+| 2 | `config.yaml` (all profiles) | keepalive 180→60s, timeout 60→120s for gbrain/hindsight | No more idle-session expiry; long tool calls don't timeout |
+| 3 | `.env` (per profile + main) | Ollama URL `<host-ip>`→`localhost` | Hindsight daemon can reach Ollama for LLM verification |
+| 4 | `scripts/kill-mcp-orphans.sh` | New orphan cleanup script | Prevents zombie stdio MCP processes after restarts |
+| 5 | systemd drop-ins | After=ollama, KillMode=control-group, StartLimitBurst | Clean startup ordering, no crash loops, no orphans |
+
+## Verification
+
+After applying all patches and restarting the gateway:
+
+```
+MCP: registered 190 tool(s) from 5 server(s)
+  gbrain (HTTP):     81 tools
+  hindsight (HTTP):  36 tools
+  instantly (HTTP):  42 tools
+  open-design (stdio): 20 tools
+  transcriptor (stdio): 11 tools
+```
+
+- No gbrain connection drops in logs post-restart
+- No hindsight MCP connection drops in logs post-restart
+- All profiles have identical keepalive/timeout settings

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -12,6 +12,89 @@ The following patches fix these issues and enable bug-free operation of multiple
 
 ---
 
+## 0. Multi-Profile Multiplexer Core (`gateway/run.py`, `gateway/config.py`, `gateway/session.py`, `gateway/delivery.py`)
+
+**Files:** `$HERMES_HOME/hermes-agent/gateway/run.py`, `gateway/config.py`, `gateway/session.py`, `gateway/delivery.py`
+**Full diff:** See `MULTIPLEXER_PATCH.diff` in this repository.
+
+### Problem
+Hermes supported only a single active profile per gateway. Running multiple profiles (each with its own Telegram bot token, SOUL.md, and config) required separate gateway processes — one per profile. This wasted resources, complicated systemd management, and prevented shared MCP tool servers from being reused across profiles.
+
+### Patch
+
+**`gateway/config.py`** — New `multiplex_profiles` config flag:
+```diff
++    multiplex_profiles: bool = False
+```
+When enabled, the gateway serves all profiles defined under `$HERMES_HOME/profiles/` from a single process. Each profile gets its own adapters, credentials, and session namespace.
+
+**`gateway/session.py`** — Profile-aware session keys + `SessionSource.profile` field:
+```diff
++    profile: Optional[str] = None  # Profile this inbound message is routed to
++
++def _session_key_namespace(profile: Optional[str]) -> str:
++    if not profile or profile == "default":
++        return "agent:main"
++    return f"agent:{profile}"
+```
+Session keys are namespaced per-profile (`agent:<profile>:<platform>:...`) so two profiles serving the same platform/chat never collide. Default profile produces byte-identical keys to before.
+
+**`gateway/run.py`** — Profile routing + secondary adapter startup:
+```diff
++self._profile_adapters: Dict[str, Dict[Platform, BasePlatformAdapter]] = {}
++
++def _adapter_for_source(self, source):
++    """Route outbound responses through the correct profile's bot token."""
++    if profile and multiplex_profiles:
++        return self._profile_adapters[profile][platform]
++    return self.adapters.get(platform)
++
++async def _start_secondary_profile_adapters(self) -> int:
++    """Bring up adapters for every non-active profile."""
++    # Creates+connects each profile's adapters under its HERMES_HOME scope
++    # Detects same-token conflicts (two profiles polling the same bot)
++    # Stamps source.profile on every inbound event
+```
+
+**`gateway/delivery.py`** — Profile-aware delivery routing:
+```diff
++    def __init__(self, config, adapters=None, profile_adapters=None):
++        self.profile_adapters = profile_adapters or {}
++
++    async def deliver(self, target, ...):
++        if target_profile and multiplex_profiles:
++            adapter = self.profile_adapters[target_profile][platform]
+```
+
+### Rationale
+- **Single gateway, multiple bots:** One systemd service serves N profiles, each with its own Telegram bot token and channel.
+- **No session collisions:** Per-profile namespace (`agent:<profile>`) keeps sessions isolated.
+- **Correct response routing:** `_adapter_for_source()` ensures responses go back through the profile's own bot token, not the default profile's.
+- **Credential conflict detection:** Same-token conflicts are caught at startup with a clear error message.
+- **Zero overhead when off:** `multiplex_profiles=False` (default) → all new code paths are no-ops, `_profile_adapters` stays empty, keys are byte-identical to before.
+
+### Affected call sites in `gateway/run.py`
+All `self.adapters.get(event.source.platform)` calls replaced with `self._adapter_for_source(event.source)`:
+- `_queue_or_replace_pending_event`
+- `_handle_active_session_busy_message`
+- `_drain_pending_events`
+- `_send_home_channel_startup_notifications`
+- `_restore_queued_startup_events`
+- `_auto_resume_sessions`
+- `_handle_slash_command` (platform resolution)
+- `gateway:startup` hook (platforms list includes secondary profiles)
+
+### Hindsight multiplexed daemon fix (`plugins/memory/hindsight/__init__.py`)
+```diff
++    if self._mode == "local_embedded" and self._idle_timeout == 0:
++        # Skip close — daemon persists for multiplexed profiles
++        logger.debug("Hindsight shutdown: skipping embedded client close "
++                     "(idle_timeout=0, daemon persists for multiplexed profiles)")
+```
+When `idle_timeout=0`, the embedded Hindsight daemon is configured to persist. Closing the client during one profile's shutdown causes a cleanup lock timeout (daemon busy serving other profiles). The fix skips the close when the daemon is configured to persist.
+
+---
+
 ## 1. MCP Reconnect Resilience (`mcp_tool.py`)
 
 **File:** `$HERMES_HOME/hermes-agent/tools/mcp_tool.py`
@@ -182,6 +265,8 @@ RuntimeMaxSec=43200
 
 | # | File | Change | Impact |
 |---|------|--------|--------|
+| 0 | `gateway/run.py`, `config.py`, `session.py`, `delivery.py` | Multi-profile multiplexer core: `multiplex_profiles` flag, `_profile_adapters`, `_adapter_for_source()`, profile-aware session keys | Single gateway serves N profiles with separate Telegram channels |
+| 0 | `plugins/memory/hindsight/__init__.py` | Skip embedded client close when `idle_timeout=0` | Hindsight daemon persists for multiplexed profiles |
 | 1 | `tools/mcp_tool.py:279,281` | Reconnect retries 5→20, backoff cap 60→30s | MCP servers survive transient SSE drops |
 | 2 | `config.yaml` (all profiles) | keepalive 180→60s, timeout 60→120s for gbrain/hindsight | No more idle-session expiry; long tool calls don't timeout |
 | 3 | `.env` (per profile + main) | Ollama URL `<host-ip>`→`localhost` | Hindsight daemon can reach Ollama for LLM verification |
@@ -200,7 +285,3 @@ MCP: registered 190 tool(s) from 5 server(s)
   open-design (stdio): 20 tools
   transcriptor (stdio): 11 tools
 ```
-
-- No gbrain connection drops in logs post-restart
-- No hindsight MCP connection drops in logs post-restart
-- All profiles have identical keepalive/timeout settings

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,92 @@
+# feat(windows): native PowerShell support for file ops, process registry, and shell detection
+
+## Summary
+
+This patch adds full native PowerShell support to Hermes Agent on Windows. Previously, all file operations, background process spawning, and shell quoting used Bash-specific commands (`cat`, `sed`, `wc`, `head`, `mkdir -p`, `nohup bash -lc`, `shlex.quote`, `set -o pipefail`, etc.) that fail on PowerShell. This patch detects the configured shell type (`terminal.shell: powershell` in `config.yaml`) and routes all shell-specific operations through PowerShell-compatible alternatives.
+
+## Motivation
+
+Hermes Agent on Windows required Git Bash (MSYS) as the terminal backend. While this works, many Windows users prefer PowerShell 7+ as their primary shell. Without this patch:
+
+- `write_file` fails — uses `cat`, `mkdir -p`, `wc -c`, `mktemp`, `trap`, `mv`
+- `read_file` fails — uses `cat`, `head -c`, `sed -n`, `wc -l`
+- `patch_replace` fails — uses `cat` for pre-read and post-write verification
+- `search` fails — uses `find`, `rg | head`, `set -o pipefail`, `ls -1 | head`
+- Background processes fail — `spawn_local` uses `bash -lic "set +m; ..."`, `spawn_via_env` uses `nohup bash -lc`
+- `shell_quote()` in the agent's code execution tool produces bash quoting on Windows
+- System prompt hardcodes "Shell: on this Windows host your terminal tool runs commands through bash"
+
+## Changes
+
+### New file: `tools/environments/powershell.py`
+- `PowerShellEnvironment` class with `shell_type = "powershell"`
+- `init_session()` — captures env vars via `Get-ChildItem Env:`, CWD via `Get-Location`
+- `_wrap_command()` — PowerShell-native command wrapping (`Set-Location`, `& { ... }`, `$LASTEXITCODE`)
+- `_find_powershell()` — locates pwsh 7+ or falls back to Windows PowerShell 5.1
+- `_kill_process()` — `proc.terminate()` on Windows (no process groups)
+
+### `tools/environments/base.py`
+- Added `shell_type: str = "bash"` class attribute to `BaseEnvironment` as default
+
+### `tools/environments/local.py`
+- `_find_shell()` changed from a static alias (`_find_shell = _find_bash`) to a function that returns `pwsh` when `terminal.shell: powershell` is configured, otherwise `bash`
+- Added `shell_type = "bash"` to `LocalEnvironment`
+
+### `tools/file_operations.py` (+547/-78 lines)
+- `ShellFileOperations.__init__` detects `shell_type` from terminal env, sets `self._is_powershell`
+- `_escape_shell_arg` — PowerShell single-quote escaping (`''` doubling) vs bash escaping
+- `_has_command` — `Get-Command` on PowerShell, `command -v` on bash
+- `_expand_path` — `$env:USERPROFILE` on PowerShell, `$HOME` on bash
+- New Python-snippet methods for PowerShell:
+  - `_atomic_write_python` — `tempfile.mkstemp` + `os.replace`
+  - `_read_file_python` — paginated read with `open()` + `readlines()`
+  - `_read_file_raw_python` — full file read
+  - `_search_files_python` — `os.walk` + `fnmatch`
+  - `_search_content_python` — `re.compile` + file iteration (replaces `rg`/`grep`)
+- All existing methods (`write_file`, `read_file`, `read_file_raw`, `patch_replace`, `_check_lint`, `search`, `_suggest_similar_files`, `move_file`, `_python_delete`, `_detect_file_line_ending`, `_file_has_bom`) now branch on `self._is_powershell` and use Python snippets instead of bash commands
+- Original bash behavior preserved for all non-PowerShell backends
+
+### `tools/process_registry.py` (+109 lines)
+- New `_is_powershell_shell()` — detects PowerShell config
+- New `_find_configured_shell()` — returns pwsh or bash path
+- `_env_temp_dir()` — accepts Windows paths (`C:\...`), falls back to `tempfile.gettempdir()` on Windows instead of `/tmp`
+- `spawn_local()` — uses `pwsh -NoProfile -NoLogo -Command` instead of `bash -lic "set +m; ..."` when PowerShell is configured (both PTY and Popen paths)
+- `spawn_via_env()` — uses `Start-Process` + `Set-Content` instead of `nohup bash -lc` for PowerShell backends
+
+### `tools/terminal_tool.py` (+72 lines)
+- `_get_terminal_shell_config()` — reads `terminal.shell` from `config.yaml`, returns `"powershell"` or `"bash"`
+- `_get_terminal_tool_description()` — returns PowerShell or Bash tool description dynamically
+- Fixed `NameError` caused by function definition ordering
+
+### `agent/prompt_builder.py` (+28 lines)
+- `_WINDOWS_POWERSHELL_SHELL_HINT` — system prompt hint for PowerShell
+- `build_environment_hints()` — dynamically selects between Bash and PowerShell hints based on config
+
+### `tools/transcription_tools.py` (+19 lines)
+- `_get_local_command_template()` — uses `subprocess.list2cmdline()` on Windows instead of `shlex.quote`
+- `_transcribe_local_command()` — uses `_quote_command_stt_placeholder()` for Windows-compatible quoting
+
+### `tools/code_execution_tool.py` (+5 lines)
+- `shell_quote()` — uses PowerShell single-quote escaping (`''` doubling) on Windows instead of `shlex.quote`
+
+## Configuration
+
+Add to `config.yaml`:
+```yaml
+terminal:
+  shell: powershell
+```
+
+This activates the PowerShell backend. Without this setting (or with `shell: bash`), all existing behavior is unchanged.
+
+## Testing
+
+- All files compile cleanly (`py_compile` verified)
+- Original bash behavior is preserved for all non-PowerShell backends (every change is guarded by `self._is_powershell` or `_is_powershell_shell()`)
+- No new dependencies required — Python snippets use stdlib only (`os`, `re`, `fnmatch`, `tempfile`, `shutil`, `pathlib`)
+
+## Backward Compatibility
+
+- **Fully backward compatible.** No changes to behavior when `terminal.shell` is `bash` or unset.
+- All new code paths are guarded by shell-type detection.
+- `shell_type` defaults to `"bash"` in `BaseEnvironment`, so Docker/SSH/Modal/Daytona/Singularity backends are unaffected.

--- a/README-PATCH.md
+++ b/README-PATCH.md
@@ -1,0 +1,94 @@
+# Hermes Agent — Native PowerShell Support for Windows
+
+A patch that adds full native PowerShell 7+ support to [Hermes Agent](https://github.com/NousResearch/hermes-agent) on Windows.
+
+## What This Fixes
+
+Without this patch, Hermes Agent on Windows requires Git Bash (MSYS) as the terminal backend. All file operations, background process spawning, and shell quoting use Bash-specific commands that fail on PowerShell:
+
+- `write_file` — uses `cat`, `mkdir -p`, `wc -c`, `mktemp`, `trap`, `mv`
+- `read_file` — uses `cat`, `head -c`, `sed -n`, `wc -l`
+- `patch_replace` — uses `cat` for pre-read and post-write verification
+- `search` — uses `find`, `rg | head`, `set -o pipefail`, `ls -1 | head`
+- Background processes — `spawn_local` uses `bash -lic "set +m; ..."`, `spawn_via_env` uses `nohup bash -lc`
+- `shell_quote()` produces bash quoting on Windows
+- System prompt hardcodes bash as the shell
+
+## What This Patch Does
+
+Detects the configured shell type (`terminal.shell: powershell` in `config.yaml`) and routes all shell-specific operations through PowerShell-compatible alternatives:
+
+- **File operations** — Uses `python -c` snippets (stdlib only: `os`, `re`, `fnmatch`, `tempfile`, `shutil`, `pathlib`) instead of bash commands
+- **Process spawning** — Uses `pwsh -NoProfile -Command` instead of `bash -lic`
+- **Background tasks** — Uses `Start-Process` + `Set-Content` instead of `nohup bash -lc`
+- **Shell quoting** — PowerShell single-quote escaping (`''` doubling) instead of `shlex.quote`
+- **System prompts** — Dynamic shell hints that reflect the actual configured shell
+- **Temp directories** — Windows paths (`C:\...`) instead of POSIX-only `/tmp`
+
+## Installation
+
+### Option A: Apply as Git Patch
+
+```bash
+git clone https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+git am 0001-feat-windows-native-PowerShell-support-for-file-ops-.patch
+```
+
+### Option B: Clone This Repo
+
+```bash
+git clone https://github.com/kosecom/hermes-agent-native-shell.git
+cd hermes-agent-native-shell
+git checkout feat/windows-powershell-support
+```
+
+## Configuration
+
+Add to `config.yaml`:
+
+```yaml
+terminal:
+  shell: powershell
+```
+
+Without this setting (or with `shell: bash`), all existing behavior is unchanged — **fully backward compatible**.
+
+## Files Changed
+
+```
+ 9 files changed, 990 insertions(+), 78 deletions(-)
+ create mode 100644 tools/environments/powershell.py
+```
+
+| File | Changes |
+|------|---------|
+| `tools/environments/powershell.py` | **New** — `PowerShellEnvironment` class with session snapshot, command wrapping, pwsh detection |
+| `tools/environments/base.py` | `shell_type = "bash"` default in `BaseEnvironment` |
+| `tools/environments/local.py` | `_find_shell()` returns pwsh when PowerShell configured |
+| `tools/file_operations.py` | All file ops shell-aware: Python snippets for PowerShell, bash preserved |
+| `tools/process_registry.py` | Shell-aware `spawn_local`, `spawn_via_env`, `_env_temp_dir` |
+| `tools/terminal_tool.py` | Dynamic tool descriptions, shell config detection, NameError fix |
+| `agent/prompt_builder.py` | Dynamic shell hints in system prompt |
+| `tools/transcription_tools.py` | Windows-compatible quoting for STT commands |
+| `tools/code_execution_tool.py` | `shell_quote()` uses PowerShell escaping on Windows |
+
+## Requirements
+
+- PowerShell 7+ (`pwsh`) recommended, or Windows PowerShell 5.1 (`powershell.exe`) as fallback
+- Python 3.8+ (for `python -c` snippets — already required by Hermes)
+
+## Backward Compatibility
+
+- **Fully backward compatible.** No changes to behavior when `terminal.shell` is `bash` or unset.
+- All new code paths are guarded by shell-type detection.
+- `shell_type` defaults to `"bash"` in `BaseEnvironment`, so Docker/SSH/Modal/Daytona/Singularity backends are unaffected.
+- No new dependencies — Python snippets use stdlib only.
+
+## Pull Request
+
+PR opened against upstream: [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent/pull/new/kosecom:feat/windows-powershell-support)
+
+---
+
+Built by a Windows user, for Windows users.

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -790,6 +790,18 @@ _WINDOWS_BASH_SHELL_HINT = (
 )
 
 
+_WINDOWS_POWERSHELL_SHELL_HINT = (
+    "Shell: on this Windows host your `terminal` tool runs commands through "
+    "PowerShell 7+ (pwsh), NOT bash or cmd.exe. Use PowerShell cmdlets and "
+    "syntax inside terminal calls: `Get-ChildItem` (alias: ls), "
+    "`Get-Content` (alias: cat), `Select-String` (alias: sls) for search, "
+    "`$env:VAR_NAME` for environment variables, `;` instead of `&&`/`||` "
+    "for command chaining, `$LASTEXITCODE` for exit codes of external "
+    "programs. Use native Windows paths like `C:\\Users\\<user>\\...`. "
+    "Bash syntax (`$FOO`, `&&`, `||`, `grep`, `sed`) will NOT work."
+)
+
+
 def _probe_remote_backend(env_type: str) -> str | None:
     """Run a tiny introspection command inside the active terminal backend.
 
@@ -923,10 +935,20 @@ def build_environment_hints() -> str:
             )
         hints.append("\n".join(host_lines))
 
-        # Windows-local terminal runs bash, not PowerShell — the model must
-        # know this or it will issue PowerShell syntax and fail.
+        # Windows-local terminal: tell the model which shell it has.
+        # When terminal.shell=powershell is configured, emit the PowerShell
+        # hint; otherwise default to the historical bash (git-bash/MSYS) hint.
         if sys.platform == "win32" and not is_wsl():
-            hints.append(_WINDOWS_BASH_SHELL_HINT)
+            _shell_hint = _WINDOWS_BASH_SHELL_HINT
+            try:
+                from hermes_cli.config import load_config as _lc
+                _cfg = _lc() or {}
+                _shell = str((_cfg.get("terminal") or {}).get("shell", "")).lower().strip()
+                if _shell in ("powershell", "pwsh"):
+                    _shell_hint = _WINDOWS_POWERSHELL_SHELL_HINT
+            except Exception:
+                pass
+            hints.append(_shell_hint)
     else:
         # --- Remote backend block (host info suppressed) ---
         probe = _probe_remote_backend(backend)

--- a/scripts/kill-mcp-orphans.sh
+++ b/scripts/kill-mcp-orphans.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Kill orphaned stdio MCP subprocesses from previous gateway runs
+# Only targets transcriptor wrapper and open-design MCP stdio clients (not the daemon)
+
+pkill -f 'transcriptor-mcp-wrapper.sh' 2>/dev/null || true
+pkill -f 'open-design.*cli.js.*mcp.*daemon-url' 2>/dev/null || true
+
+exit 0

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -311,6 +311,11 @@ def shell_quote(s: str) -> str:
     Use this when inserting dynamic content into terminal() commands:
         terminal(f"echo {shell_quote(user_input)}")
     """
+    import platform as _pf
+    if _pf.system() == "Windows":
+        # PowerShell: wrap in single quotes, escape embedded single quotes
+        # by doubling them ('' → '').
+        return "'" + s.replace("'", "''") + "'"
     return shlex.quote(s)
 
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -299,6 +299,10 @@ class BaseEnvironment(ABC):
     # Snapshot creation timeout (override for slow cold-starts).
     _snapshot_timeout: int = 30
 
+    # Shell type: "bash" (default) or "powershell".  ShellFileOperations
+    # uses this to select between bash commands and Python snippets.
+    shell_type: str = "bash"
+
     def get_temp_dir(self) -> str:
         """Return the backend temp directory used for session artifacts.
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -286,8 +286,19 @@ def _find_bash() -> str:
     )
 
 
-# Backward compat — process_registry.py imports this name
-_find_shell = _find_bash
+# Backward compat — process_registry.py imports this name.
+# When PowerShell is configured as the terminal shell, return pwsh instead
+# of bash so background processes are spawned with the correct shell.
+def _find_shell() -> str:
+    """Return the path to the configured shell (pwsh or bash)."""
+    try:
+        from tools.terminal_tool import _get_terminal_shell_config
+        if _get_terminal_shell_config() == "powershell":
+            from tools.environments.powershell import _find_powershell
+            return _find_powershell()
+    except Exception:
+        pass
+    return _find_bash()
 
 
 # Standard PATH entries for environments with minimal PATH.
@@ -491,6 +502,8 @@ class LocalEnvironment(BaseEnvironment):
     Session snapshot preserves env vars across calls.
     CWD persists via file-based read after each command.
     """
+
+    shell_type = "bash"
 
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         if cwd:

--- a/tools/environments/powershell.py
+++ b/tools/environments/powershell.py
@@ -1,0 +1,267 @@
+"""PowerShell execution environment for Windows — spawn-per-call with session snapshot.
+
+Mirrors LocalEnvironment but uses pwsh (PowerShell 7+) instead of Git Bash.
+Activated via ``terminal.shell: powershell`` in config.yaml.
+"""
+
+import logging
+import os
+import platform
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+from tools.environments.base import BaseEnvironment, _pipe_stdin
+from tools.environments.local import _make_run_env, _sanitize_subprocess_env
+from hermes_cli._subprocess_compat import windows_hide_flags
+
+_IS_WINDOWS = platform.system() == "Windows"
+
+logger = logging.getLogger(__name__)
+
+
+def _find_powershell() -> str:
+    """Find PowerShell 7+ (pwsh) or fall back to Windows PowerShell 5.1."""
+    import shutil
+
+    pwsh = shutil.which("pwsh")
+    if pwsh:
+        return pwsh
+
+    for candidate in (
+        os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "PowerShell", "7", "pwsh.exe"),
+        os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "PowerShell", "7-preview", "pwsh.exe"),
+    ):
+        if candidate and os.path.isfile(candidate):
+            return candidate
+
+    powershell = shutil.which("powershell")
+    if powershell:
+        return powershell
+
+    for candidate in (
+        os.path.join(os.environ.get("SystemRoot", r"C:\Windows"), "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+    ):
+        if candidate and os.path.isfile(candidate):
+            return candidate
+
+    raise RuntimeError(
+        "PowerShell not found. Install PowerShell 7+ from: "
+        "https://github.com/PowerShell/PowerShell/releases"
+    )
+
+
+class PowerShellEnvironment(BaseEnvironment):
+    """Run commands via PowerShell on Windows.
+
+    Spawn-per-call: every execute() spawns a fresh pwsh process.
+    Session snapshot preserves env vars across calls via a .ps1 file.
+    CWD persists via file-based read after each command.
+    """
+
+    _stdin_mode = "pipe"
+    shell_type = "powershell"
+
+    def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
+        if cwd:
+            cwd = os.path.expanduser(cwd)
+        super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        self.init_session()
+
+    def get_temp_dir(self) -> str:
+        if _IS_WINDOWS:
+            try:
+                from hermes_constants import get_hermes_home
+                cache_dir = get_hermes_home() / "cache" / "terminal"
+            except Exception:
+                cache_dir = Path(tempfile.gettempdir()) / "hermes_terminal"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            return str(cache_dir).replace("\\", "/")
+        return "/tmp"
+
+    def _run_bash(self, cmd_string: str, *, login: bool = False,
+                  timeout: int = 120,
+                  stdin_data: str | None = None) -> subprocess.Popen:
+        """Spawn a PowerShell process to run *cmd_string*.
+
+        Despite the name (kept for BaseEnvironment compatibility), this
+        runs pwsh, not bash.
+        """
+        pwsh = _find_powershell()
+        args = [pwsh, "-NoProfile", "-NoLogo", "-Command", cmd_string]
+        run_env = _make_run_env(self.env)
+
+        safe_cwd = self.cwd
+        if _IS_WINDOWS and not os.path.isdir(safe_cwd):
+            parent = os.path.dirname(safe_cwd)
+            while parent:
+                if os.path.isdir(parent):
+                    safe_cwd = parent
+                    break
+                next_parent = os.path.dirname(parent)
+                if next_parent == parent:
+                    break
+                parent = next_parent
+            else:
+                safe_cwd = tempfile.gettempdir()
+
+        _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
+
+        proc = subprocess.Popen(
+            args,
+            text=True,
+            env=run_env,
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            cwd=safe_cwd,
+            **_popen_kwargs,
+        )
+        if not _IS_WINDOWS:
+            try:
+                proc._hermes_pgid = os.getpgid(proc.pid)
+            except ProcessLookupError:
+                pass
+
+        if stdin_data is not None:
+            _pipe_stdin(proc, stdin_data)
+
+        return proc
+
+    def init_session(self):
+        """Capture PowerShell environment into a snapshot file."""
+        snap_path = self._snapshot_path.replace("/", "\\")
+        cwd_file = self._cwd_file.replace("/", "\\")
+        cwd_escaped = self.cwd.replace("'", "''")
+        marker = self._cwd_marker
+
+        bootstrap = (
+            f"$ErrorActionPreference = 'Continue'\n"
+            f"Get-ChildItem Env: | ForEach-Object {{ "
+            f"  \"$($_.Name)=$($_.Value)\" "
+            f"}} | Set-Content -Path '{snap_path}' -Encoding UTF8\n"
+            f"Set-Location -LiteralPath '{cwd_escaped}' -ErrorAction SilentlyContinue\n"
+            f"(Get-Location).Path | Set-Content -Path '{cwd_file}' -Encoding UTF8\n"
+            f"Write-Output \"`n{marker}$((Get-Location).Path){marker}`n\"\n"
+        )
+        try:
+            proc = self._run_bash(bootstrap, login=False, timeout=self._snapshot_timeout)
+            result = self._wait_for_process(proc, timeout=self._snapshot_timeout)
+            self._snapshot_ready = True
+            self._update_cwd(result)
+            logger.info(
+                "PowerShell session snapshot created (session=%s, cwd=%s)",
+                self._session_id,
+                self.cwd,
+            )
+        except Exception as exc:
+            logger.warning(
+                "PowerShell init_session failed (session=%s): %s — "
+                "falling back to per-command execution",
+                self._session_id,
+                exc,
+            )
+            self._snapshot_ready = False
+
+    def _wrap_command(self, command: str, cwd: str) -> str:
+        """Build a PowerShell script that sources snapshot, cd's, runs command,
+        re-dumps env vars, and emits CWD markers."""
+        snap_path = self._snapshot_path.replace("/", "\\")
+        cwd_file = self._cwd_file.replace("/", "\\")
+        cwd_escaped = cwd.replace("'", "''")
+        marker = self._cwd_marker
+        command_escaped = command.replace("'", "''")
+
+        parts = [
+            f"$ErrorActionPreference = 'Continue'",
+        ]
+
+        if self._snapshot_ready:
+            parts.append(
+                f"if (Test-Path -LiteralPath '{snap_path}') {{ "
+                f"  Get-Content -LiteralPath '{snap_path}' | ForEach-Object {{ "
+                f"    $idx = $_.IndexOf('='); "
+                f"    if ($idx -gt 0) {{ "
+                f"      [Environment]::SetEnvironmentVariable("
+                f"        $_.Substring(0, $idx), $_.Substring($idx + 1), 'Process') "
+                f"    }} "
+                f"  }} "
+                f"}}"
+            )
+
+        parts.append(f"Set-Location -LiteralPath '{cwd_escaped}' -ErrorAction SilentlyContinue")
+
+        parts.append(
+            f"try {{ & {{ {command_escaped} }}; $__hermes_ec = $LASTEXITCODE }} "
+            f"catch {{ Write-Error $_.Exception.Message; $__hermes_ec = 1 }}; "
+            f"if ($__hermes_ec -eq $null) {{ $__hermes_ec = 0 }}"
+        )
+
+        if self._snapshot_ready:
+            parts.append(
+                f"Get-ChildItem Env: | ForEach-Object {{ "
+                f"  \"$($_.Name)=$($_.Value)\" "
+                f"}} | Set-Content -Path '{snap_path}' -Encoding UTF8 -ErrorAction SilentlyContinue"
+            )
+
+        parts.append(
+            f"(Get-Location).Path | Set-Content -Path '{cwd_file}' -Encoding UTF8 -ErrorAction SilentlyContinue"
+        )
+        parts.append(
+            f"Write-Output \"`n{marker}$((Get-Location).Path){marker}`n\""
+        )
+        parts.append(f"exit $__hermes_ec")
+
+        return "\n".join(parts)
+
+    def _update_cwd(self, result: dict):
+        """Read CWD from temp file (PowerShell writes native Windows paths)."""
+        try:
+            with open(self._cwd_file, encoding="utf-8") as f:
+                cwd_path = f.read().strip()
+            if cwd_path and os.path.isdir(cwd_path):
+                self.cwd = cwd_path
+        except (OSError, FileNotFoundError):
+            pass
+
+        self._extract_cwd_from_output(result)
+
+    def _kill_process(self, proc):
+        """Kill the process (Windows: terminate, POSIX: process group)."""
+        try:
+            if _IS_WINDOWS:
+                proc.terminate()
+            else:
+                try:
+                    pgid = os.getpgid(proc.pid)
+                except ProcessLookupError:
+                    pgid = getattr(proc, "_hermes_pgid", None)
+                    if pgid is None:
+                        raise
+                import signal as _signal
+                try:
+                    os.killpg(pgid, _signal.SIGTERM)
+                except ProcessLookupError:
+                    return
+                time.sleep(1.0)
+                try:
+                    os.killpg(pgid, _signal.SIGKILL)
+                except ProcessLookupError:
+                    return
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def cleanup(self):
+        """Clean up temp files."""
+        for f in (self._snapshot_path, self._cwd_file):
+            try:
+                os.unlink(f)
+            except OSError:
+                pass

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -725,6 +725,11 @@ class ShellFileOperations(FileOperations):
     
     Works with ANY terminal backend that has execute(command, cwd) method.
     This includes local, docker, singularity, ssh, modal, and daytona environments.
+
+    When the backend's ``shell_type`` is ``"powershell"``, all file operations
+    use Python snippets (``python -c``) instead of bash commands so they work
+    correctly on Windows PowerShell where ``cat``, ``sed``, ``wc``, ``head``,
+    ``mktemp``, ``trap``, etc. are unavailable.
     """
     
     def __init__(self, terminal_env, cwd: str = None):
@@ -761,7 +766,11 @@ class ShellFileOperations(FileOperations):
 
         # Cache for command availability checks
         self._command_cache: Dict[str, bool] = {}
-    
+
+        # Detect PowerShell backends — when true, we use Python-based
+        # operations instead of bash/POSIX commands.
+        self._is_powershell = getattr(terminal_env, 'shell_type', 'bash') == 'powershell'
+
     def _exec(self, command: str, cwd: str = None, timeout: int = None,
               stdin_data: str = None) -> ExecuteResult:
         """Execute command via terminal backend.
@@ -797,7 +806,10 @@ class ShellFileOperations(FileOperations):
     def _has_command(self, cmd: str) -> bool:
         """Check if a command exists in the environment (cached)."""
         if cmd not in self._command_cache:
-            result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
+            if self._is_powershell:
+                result = self._exec(f"Get-Command {cmd} -ErrorAction SilentlyContinue | Out-Null; if ($?) {{ echo 'yes' }}")
+            else:
+                result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
     
@@ -863,7 +875,10 @@ class ShellFileOperations(FileOperations):
         # Handle ~ and ~user
         if path.startswith('~'):
             # Get home directory via the terminal environment
-            result = self._exec("echo $HOME")
+            if self._is_powershell:
+                result = self._exec("echo $env:USERPROFILE")
+            else:
+                result = self._exec("echo $HOME")
             if result.exit_code == 0 and result.stdout.strip():
                 home = result.stdout.strip()
                 if path == '~':
@@ -879,7 +894,10 @@ class ShellFileOperations(FileOperations):
                 if username and re.fullmatch(r'[a-zA-Z0-9._-]+', username):
                     # Only expand ~username (not the full path) to avoid shell
                     # injection via path suffixes like "~user/$(malicious)".
-                    expand_result = self._exec(f"echo ~{username}")
+                    if self._is_powershell:
+                        expand_result = self._exec(f"echo (Resolve-Path ~{username}).Path")
+                    else:
+                        expand_result = self._exec(f"echo ~{username}")
                     if expand_result.exit_code == 0 and expand_result.stdout.strip():
                         user_home = expand_result.stdout.strip()
                         suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
@@ -889,7 +907,10 @@ class ShellFileOperations(FileOperations):
     
     def _escape_shell_arg(self, arg: str) -> str:
         """Escape a string for safe use in shell commands."""
-        # Use single quotes and escape any single quotes in the string
+        if self._is_powershell:
+            # PowerShell single-quote escaping: double embedded single quotes
+            return "'" + arg.replace("'", "''") + "'"
+        # bash single-quote escaping
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
@@ -907,6 +928,9 @@ class ShellFileOperations(FileOperations):
         was swapped into place atomically. A non-zero exit means nothing was
         renamed and the original (if any) is intact.
         """
+        if self._is_powershell:
+            return self._atomic_write_python(path, content)
+
         q_path = self._escape_shell_arg(path)
         parent = os.path.dirname(path) or "."
         q_parent = self._escape_shell_arg(parent)
@@ -946,6 +970,36 @@ class ShellFileOperations(FileOperations):
         )
         return self._exec(script, stdin_data=content)
 
+    def _atomic_write_python(self, path: str, content: str) -> "ExecuteResult":
+        """Atomic write via Python snippet — used on PowerShell backends.
+
+        Uses ``python -c`` with stdin piping so it works on any shell that
+        has Python available (which Hermes always does via its venv).
+        Creates a temp file in the same directory, writes stdin to it,
+        then atomically replaces the target.
+        """
+        snippet = (
+            "import sys, os, tempfile, pathlib\n"
+            f"target = pathlib.Path({path!r})\n"
+            "parent = target.parent if target.parent else pathlib.Path('.')\n"
+            "parent.mkdir(parents=True, exist_ok=True)\n"
+            "fd, tmp = tempfile.mkstemp(dir=str(parent), prefix='.hermes-tmp.')\n"
+            "try:\n"
+            "    with os.fdopen(fd, 'w', encoding='utf-8', newline='') as f:\n"
+            "        f.write(sys.stdin.read())\n"
+            "    if target.exists():\n"
+            "        try:\n"
+            "            os.chmod(tmp, os.stat(str(target)).st_mode & 0o7777)\n"
+            "        except Exception:\n"
+            "            pass\n"
+            "    os.replace(tmp, str(target))\n"
+            "except Exception:\n"
+            "    try: os.unlink(tmp)\n"
+            "    except Exception: pass\n"
+            "    raise\n"
+        )
+        return self._exec(f"python -c {self._escape_shell_arg(snippet)}", stdin_data=content)
+
     def _detect_file_line_ending(self, path: str, pre_content: Optional[str] = None) -> Optional[str]:
         """Detect the dominant line ending of a file on disk.
 
@@ -959,10 +1013,20 @@ class ShellFileOperations(FileOperations):
         """
         if pre_content:
             return _detect_line_ending(pre_content)
-        # File may not exist (new write) — `head` exits 0 with empty
-        # stdout in that case which yields None below.  Cheap probe.
-        head_cmd = f"head -c 4096 {self._escape_shell_arg(path)} 2>/dev/null"
-        head_result = self._exec(head_cmd)
+        # File may not exist (new write) — probe returns empty in that case.
+        if self._is_powershell:
+            snippet = (
+                "import sys\n"
+                f"p = {path!r}\n"
+                "try:\n"
+                "    with open(p, 'rb') as f: data = f.read(4096)\n"
+                "    sys.stdout.buffer.write(data)\n"
+                "except Exception: pass\n"
+            )
+            head_result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
+        else:
+            head_cmd = f"head -c 4096 {self._escape_shell_arg(path)} 2>/dev/null"
+            head_result = self._exec(head_cmd)
         if head_result.exit_code != 0 or not head_result.stdout:
             return None
         return _detect_line_ending(head_result.stdout)
@@ -977,8 +1041,19 @@ class ShellFileOperations(FileOperations):
         """
         if pre_content is not None:
             return _has_bom(pre_content)
-        head_cmd = f"head -c 3 {self._escape_shell_arg(path)} 2>/dev/null"
-        head_result = self._exec(head_cmd)
+        if self._is_powershell:
+            snippet = (
+                "import sys\n"
+                f"p = {path!r}\n"
+                "try:\n"
+                "    with open(p, 'rb') as f: data = f.read(3)\n"
+                "    sys.stdout.buffer.write(data)\n"
+                "except Exception: pass\n"
+            )
+            head_result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
+        else:
+            head_cmd = f"head -c 3 {self._escape_shell_arg(path)} 2>/dev/null"
+            head_result = self._exec(head_cmd)
         if head_result.exit_code != 0 or not head_result.stdout:
             return False
         return _has_bom(head_result.stdout)
@@ -1015,7 +1090,10 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
         
         offset, limit = normalize_read_pagination(offset, limit)
-        
+
+        if self._is_powershell:
+            return self._read_file_python(path, offset, limit)
+
         # Check if file exists and get size (wc -c is POSIX, works on Linux + macOS)
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
         stat_result = self._exec(stat_cmd)
@@ -1096,6 +1174,87 @@ class ShellFileOperations(FileOperations):
             hint=hint
         )
     
+    def _read_file_python(self, path: str, offset: int, limit: int) -> ReadResult:
+        """Read file via Python snippet — used on PowerShell backends."""
+        snippet = (
+            "import sys, os\n"
+            f"p = {path!r}\n"
+            "if not os.path.isfile(p):\n"
+            "    sys.exit(1)\n"
+            "st = os.stat(p)\n"
+            f"print(st.st_size)\n"
+            "with open(p, 'rb') as f:\n"
+            "    data = f.read(1000)\n"
+            "sys.stdout.buffer.write(data)\n"
+        )
+        result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
+        if result.exit_code != 0:
+            return self._suggest_similar_files(path)
+        lines = result.stdout.split('\n', 1)
+        try:
+            file_size = int(lines[0].strip())
+        except (ValueError, IndexError):
+            file_size = 0
+        sample_output = lines[1] if len(lines) > 1 else ""
+        sample_output = _strip_terminal_fence_leaks(sample_output)
+
+        if self._is_image(path):
+            return ReadResult(
+                is_image=True, is_binary=True, file_size=file_size,
+                hint="Image file detected. Use vision_analyze with this file path."
+            )
+        if self._is_likely_binary(path, sample_output):
+            return ReadResult(
+                is_binary=True, file_size=file_size,
+                error="Binary file - cannot display as text."
+            )
+
+        end_line = offset + limit - 1
+        read_snippet = (
+            "import sys\n"
+            f"p = {path!r}\n"
+            "with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
+            "    for i, line in enumerate(f, 1):\n"
+            f"        if i < {offset}: continue\n"
+            f"        if i > {end_line}: break\n"
+            "        sys.stdout.write(line)\n"
+        )
+        read_result = self._exec(f"python -c {self._escape_shell_arg(read_snippet)}")
+        if read_result.exit_code != 0:
+            return ReadResult(error=f"Failed to read file: {read_result.stdout}")
+        read_output = _strip_terminal_fence_leaks(read_result.stdout)
+        if offset == 1:
+            read_output, _ = _strip_bom(read_output)
+
+        count_snippet = (
+            "import sys\n"
+            f"p = {path!r}\n"
+            "try:\n"
+            "    with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
+            "        print(sum(1 for _ in f))\n"
+            "except Exception:\n"
+            "    print(0)\n"
+        )
+        wc_result = self._exec(f"python -c {self._escape_shell_arg(count_snippet)}")
+        wc_output = _strip_terminal_fence_leaks(wc_result.stdout)
+        try:
+            total_lines = int(wc_output.strip())
+        except ValueError:
+            total_lines = 0
+
+        truncated = total_lines > end_line
+        hint = None
+        if truncated:
+            hint = f"Use offset={end_line + 1} to continue reading (showing {offset}-{end_line} of {total_lines} lines)"
+
+        return ReadResult(
+            content=self._add_line_numbers(read_output, offset),
+            total_lines=total_lines,
+            file_size=file_size,
+            truncated=truncated,
+            hint=hint
+        )
+
     def _suggest_similar_files(self, path: str) -> ReadResult:
         """Suggest similar files when the requested file is not found."""
         dir_path = os.path.dirname(path) or "."
@@ -1105,8 +1264,19 @@ class ShellFileOperations(FileOperations):
         lower_name = filename.lower()
 
         # List files in the target directory
-        ls_cmd = f"ls -1 {self._escape_shell_arg(dir_path)} 2>/dev/null | head -50"
-        ls_result = self._exec(ls_cmd)
+        if self._is_powershell:
+            list_snippet = (
+                "import os, sys\n"
+                f"d = {dir_path!r}\n"
+                "try:\n"
+                "    for f in sorted(os.listdir(d))[:50]:\n"
+                "        print(f)\n"
+                "except Exception: pass\n"
+            )
+            ls_result = self._exec(f"python -c {self._escape_shell_arg(list_snippet)}")
+        else:
+            ls_cmd = f"ls -1 {self._escape_shell_arg(dir_path)} 2>/dev/null | head -50"
+            ls_result = self._exec(ls_cmd)
 
         scored: list = []  # (score, filepath) — higher is better
         if ls_result.exit_code == 0 and ls_result.stdout.strip():
@@ -1155,6 +1325,8 @@ class ShellFileOperations(FileOperations):
         Uses cat so the full file is returned regardless of size.
         """
         path = self._expand_path(path)
+        if self._is_powershell:
+            return self._read_file_raw_python(path)
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
         stat_result = self._exec(stat_cmd)
         if stat_result.exit_code != 0:
@@ -1182,6 +1354,50 @@ class ShellFileOperations(FileOperations):
         # back out — it re-probes the on-disk file, which still has the
         # marker — so the round-trip preserves it.
         raw_content, _ = _strip_bom(_strip_terminal_fence_leaks(cat_result.stdout))
+        return ReadResult(
+            content=raw_content,
+            file_size=file_size,
+        )
+
+    def _read_file_raw_python(self, path: str) -> ReadResult:
+        """Read full file content via Python snippet — used on PowerShell backends."""
+        stat_snippet = (
+            "import sys, os\n"
+            f"p = {path!r}\n"
+            "if not os.path.isfile(p):\n"
+            "    sys.exit(1)\n"
+            f"print(os.stat(p).st_size)\n"
+            "with open(p, 'rb') as f:\n"
+            "    data = f.read(1000)\n"
+            "sys.stdout.buffer.write(data)\n"
+        )
+        stat_result = self._exec(f"python -c {self._escape_shell_arg(stat_snippet)}")
+        if stat_result.exit_code != 0:
+            return self._suggest_similar_files(path)
+        lines_out = stat_result.stdout.split('\n', 1)
+        try:
+            file_size = int(lines_out[0].strip())
+        except (ValueError, IndexError):
+            file_size = 0
+        sample_output = lines_out[1] if len(lines_out) > 1 else ""
+        sample_output = _strip_terminal_fence_leaks(sample_output)
+        if self._is_image(path):
+            return ReadResult(is_image=True, is_binary=True, file_size=file_size)
+        if self._is_likely_binary(path, sample_output):
+            return ReadResult(
+                is_binary=True, file_size=file_size,
+                error="Binary file — cannot display as text."
+            )
+        read_snippet = (
+            "import sys\n"
+            f"p = {path!r}\n"
+            "with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
+            "    sys.stdout.write(f.read())\n"
+        )
+        read_result = self._exec(f"python -c {self._escape_shell_arg(read_snippet)}")
+        if read_result.exit_code != 0:
+            return ReadResult(error=f"Failed to read file: {read_result.stdout}")
+        raw_content, _ = _strip_bom(_strip_terminal_fence_leaks(read_result.stdout))
         return ReadResult(
             content=raw_content,
             file_size=file_size,
@@ -1236,12 +1452,15 @@ class ShellFileOperations(FileOperations):
             "    print(str(exc), file=sys.stderr); sys.exit(1)\n"
         )
 
-        result = self._exec(f"python3 -c {self._escape_shell_arg(snippet)}")
-
-        # Fall back to ``python`` (Windows / older systems where there's no
-        # ``python3`` symlink but a ``python`` binary is on PATH).
-        if result.exit_code != 0 and "python3" in (result.stdout or ""):
+        if self._is_powershell:
             result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
+        else:
+            result = self._exec(f"python3 -c {self._escape_shell_arg(snippet)}")
+
+            # Fall back to ``python`` (Windows / older systems where there's no
+            # ``python3`` symlink but a ``python`` binary is on PATH).
+            if result.exit_code != 0 and "python3" in (result.stdout or ""):
+                result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
 
         if result.exit_code != 0:
             return WriteResult(error=f"Failed to delete {path}: {(result.stdout or '').strip() or 'unknown error'}")
@@ -1249,15 +1468,27 @@ class ShellFileOperations(FileOperations):
         return WriteResult()
 
     def move_file(self, src: str, dst: str) -> WriteResult:
-        """Move a file via mv."""
+        """Move a file via mv (bash) or Python snippet (PowerShell)."""
         src = self._expand_path(src)
         dst = self._expand_path(dst)
         for p in (src, dst):
             if _is_write_denied(p):
                 return WriteResult(error=f"Move denied: {p} is a protected path")
-        result = self._exec(
-            f"mv {self._escape_shell_arg(src)} {self._escape_shell_arg(dst)}"
-        )
+        if self._is_powershell:
+            snippet = (
+                "import shutil, sys\n"
+                f"src = {src!r}\n"
+                f"dst = {dst!r}\n"
+                "try:\n"
+                "    shutil.move(src, dst)\n"
+                "except Exception as exc:\n"
+                "    print(str(exc), file=sys.stderr); sys.exit(1)\n"
+            )
+            result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
+        else:
+            result = self._exec(
+                f"mv {self._escape_shell_arg(src)} {self._escape_shell_arg(dst)}"
+            )
         if result.exit_code != 0:
             return WriteResult(error=f"Failed to move {src} -> {dst}: {result.stdout}")
         return WriteResult()
@@ -1318,8 +1549,19 @@ class ShellFileOperations(FileOperations):
             # pre_content as None which makes both downstream consumers
             # degrade gracefully (lint reports all errors; LSP skips the
             # shift map).
-            read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
-            read_result = self._exec(read_cmd)
+            if self._is_powershell:
+                pre_snippet = (
+                    "import sys\n"
+                    f"p = {path!r}\n"
+                    "try:\n"
+                    "    with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
+                    "        sys.stdout.write(f.read())\n"
+                    "except Exception: sys.exit(1)\n"
+                )
+                read_result = self._exec(f"python -c {self._escape_shell_arg(pre_snippet)}")
+            else:
+                read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+                read_result = self._exec(read_cmd)
             if read_result.exit_code == 0 and read_result.stdout:
                 pre_content = read_result.stdout
 
@@ -1358,8 +1600,19 @@ class ShellFileOperations(FileOperations):
         dirs_created = False
 
         if parent:
-            mkdir_cmd = f"mkdir -p {self._escape_shell_arg(parent)}"
-            mkdir_result = self._exec(mkdir_cmd)
+            if self._is_powershell:
+                mkdir_snippet = (
+                    "import pathlib, sys\n"
+                    f"p = pathlib.Path({parent!r})\n"
+                    "try:\n"
+                    "    p.mkdir(parents=True, exist_ok=True)\n"
+                    "except Exception as exc:\n"
+                    "    print(str(exc), file=sys.stderr); sys.exit(1)\n"
+                )
+                mkdir_result = self._exec(f"python -c {self._escape_shell_arg(mkdir_snippet)}")
+            else:
+                mkdir_cmd = f"mkdir -p {self._escape_shell_arg(parent)}"
+                mkdir_result = self._exec(mkdir_cmd)
             if mkdir_result.exit_code == 0:
                 dirs_created = True
 
@@ -1383,9 +1636,19 @@ class ShellFileOperations(FileOperations):
         if write_result.exit_code != 0:
             return WriteResult(error=f"Failed to write file: {write_result.stdout}")
 
-        # Get bytes written (wc -c is POSIX, works on Linux + macOS)
-        stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
-        stat_result = self._exec(stat_cmd)
+        # Get bytes written
+        if self._is_powershell:
+            size_snippet = (
+                "import os, sys\n"
+                f"p = {path!r}\n"
+                "try:\n"
+                "    print(os.path.getsize(p))\n"
+                "except Exception: sys.exit(1)\n"
+            )
+            stat_result = self._exec(f"python -c {self._escape_shell_arg(size_snippet)}")
+        else:
+            stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
+            stat_result = self._exec(stat_cmd)
 
         try:
             bytes_written = int(stat_result.stdout.strip())
@@ -1442,8 +1705,19 @@ class ShellFileOperations(FileOperations):
             return PatchResult(error=f"Write denied: '{path}' is a protected system/credential file.")
 
         # Read current content
-        read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
-        read_result = self._exec(read_cmd)
+        if self._is_powershell:
+            patch_read_snippet = (
+                "import sys\n"
+                f"p = {path!r}\n"
+                "try:\n"
+                "    with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
+                "        sys.stdout.write(f.read())\n"
+                "except Exception: sys.exit(1)\n"
+            )
+            read_result = self._exec(f"python -c {self._escape_shell_arg(patch_read_snippet)}")
+        else:
+            read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+            read_result = self._exec(read_cmd)
         
         if read_result.exit_code != 0:
             return PatchResult(error=f"Failed to read file: {path}")
@@ -1495,7 +1769,19 @@ class ShellFileOperations(FileOperations):
         # pipe, etc.) that would otherwise return success-with-diff while the
         # file is unchanged on disk.
         verify_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
-        verify_result = self._exec(verify_cmd)
+        if self._is_powershell:
+            verify_snippet = (
+                "import sys\n"
+                f"p = {path!r}\n"
+                "try:\n"
+                "    with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
+                "        sys.stdout.write(f.read())\n"
+                "except Exception: sys.exit(1)\n"
+            )
+            verify_result = self._exec(f"python -c {self._escape_shell_arg(verify_snippet)}")
+        else:
+            verify_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+            verify_result = self._exec(verify_cmd)
         if verify_result.exit_code != 0:
             return PatchResult(error=f"Post-write verification failed: could not re-read {path}")
         # Normalize line endings before comparing.  On Windows, Python's
@@ -1600,8 +1886,19 @@ class ShellFileOperations(FileOperations):
         if inproc is not None:
             # Need content — either passed in or read from disk.
             if content is None:
-                read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
-                read_result = self._exec(read_cmd)
+                if self._is_powershell:
+                    lint_read_snippet = (
+                        "import sys\n"
+                        f"p = {path!r}\n"
+                        "try:\n"
+                        "    with open(p, 'r', encoding='utf-8', errors='replace') as f:\n"
+                        "        sys.stdout.write(f.read())\n"
+                        "except Exception: sys.exit(1)\n"
+                    )
+                    read_result = self._exec(f"python -c {self._escape_shell_arg(lint_read_snippet)}")
+                else:
+                    read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+                    read_result = self._exec(read_cmd)
                 if read_result.exit_code != 0:
                     return LintResult(skipped=True, message=f"Failed to read {path} for lint")
                 content = read_result.stdout
@@ -1942,20 +2239,47 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
         
         # Validate that the path exists before searching
-        check = self._exec(f"test -e {self._escape_shell_arg(path)} && echo exists || echo not_found")
+        if self._is_powershell:
+            check_snippet = (
+                "import os, sys\n"
+                f"p = {path!r}\n"
+                "print('exists' if os.path.exists(p) else 'not_found')\n"
+            )
+            check = self._exec(f"python -c {self._escape_shell_arg(check_snippet)}")
+        else:
+            check = self._exec(f"test -e {self._escape_shell_arg(path)} && echo exists || echo not_found")
         if "not_found" in check.stdout:
             # Try to suggest nearby paths
             parent = os.path.dirname(path) or "."
             basename_query = os.path.basename(path)
             hint_parts = [f"Path not found: {path}"]
             # Check if parent directory exists and list similar entries
-            parent_check = self._exec(
-                f"test -d {self._escape_shell_arg(parent)} && echo yes || echo no"
-            )
-            if "yes" in parent_check.stdout and basename_query:
-                ls_result = self._exec(
-                    f"ls -1 {self._escape_shell_arg(parent)} 2>/dev/null | head -20"
+            if self._is_powershell:
+                parent_snippet = (
+                    "import os, sys\n"
+                    f"p = {parent!r}\n"
+                    "print('yes' if os.path.isdir(p) else 'no')\n"
                 )
+                parent_check = self._exec(f"python -c {self._escape_shell_arg(parent_snippet)}")
+            else:
+                parent_check = self._exec(
+                    f"test -d {self._escape_shell_arg(parent)} && echo yes || echo no"
+                )
+            if "yes" in parent_check.stdout and basename_query:
+                if self._is_powershell:
+                    ls_snippet = (
+                        "import os, sys\n"
+                        f"d = {parent!r}\n"
+                        "try:\n"
+                        "    for f in sorted(os.listdir(d))[:20]:\n"
+                        "        print(f)\n"
+                        "except Exception: pass\n"
+                    )
+                    ls_result = self._exec(f"python -c {self._escape_shell_arg(ls_snippet)}")
+                else:
+                    ls_result = self._exec(
+                        f"ls -1 {self._escape_shell_arg(parent)} 2>/dev/null | head -20"
+                    )
                 if ls_result.exit_code == 0 and ls_result.stdout.strip():
                     lower_q = basename_query.lower()
                     candidates = []
@@ -1993,6 +2317,11 @@ class ShellFileOperations(FileOperations):
             part not in {".", ".."} and part.startswith(".")
             for part in search_root.parts
         )
+
+        # On PowerShell, use Python-based search instead of find/rg
+        if self._is_powershell:
+            return self._search_files_python(search_pattern, path, limit, offset,
+                                              has_hidden_path_ancestor, search_root)
 
         # Prefer ripgrep: respects .gitignore, excludes hidden dirs by
         # default, and has parallel directory traversal (~200x faster than
@@ -2111,10 +2440,45 @@ class ShellFileOperations(FileOperations):
             truncated=len(all_files) >= fetch_limit or bool(limit_reason),
             limit_reason=limit_reason,
         )
-    
+
+    def _search_files_python(self, pattern: str, path: str, limit: int, offset: int,
+                             has_hidden_ancestor: bool, search_root: Path) -> SearchResult:
+        """File search via Python snippet — used on PowerShell backends."""
+        snippet = (
+            "import os, fnmatch, sys, time\n"
+            f"root = {path!r}\n"
+            f"pattern = {pattern!r}\n"
+            f"skip_hidden = {not has_hidden_ancestor!r}\n"
+            "results = []\n"
+            "for dirpath, dirnames, filenames in os.walk(root):\n"
+            "    if skip_hidden:\n"
+            "        dirnames[:] = [d for d in dirnames if not d.startswith('.')]\n"
+            "    for fn in filenames:\n"
+            "        if fnmatch.fnmatch(fn, pattern):\n"
+            "            fp = os.path.join(dirpath, fn)\n"
+            "            try: mt = os.path.getmtime(fp)\n"
+            "            except Exception: mt = 0\n"
+            "            results.append((mt, fp))\n"
+            "results.sort(key=lambda x: -x[0])\n"
+            "for mt, fp in results:\n"
+            "    print(fp)\n"
+        )
+        result = self._exec(f"python -c {self._escape_shell_arg(snippet)}", timeout=60)
+        all_files = [f for f in result.stdout.strip().split('\n') if f]
+        page = all_files[offset:offset + limit]
+        return SearchResult(
+            files=page,
+            total_count=len(all_files),
+            truncated=len(all_files) > offset + limit,
+        )
+
     def _search_content(self, pattern: str, path: str, file_glob: Optional[str],
                         limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Search for content inside files (grep-like)."""
+        # On PowerShell, use Python-based search to avoid bash pipe syntax
+        if self._is_powershell:
+            return self._search_content_python(pattern, path, file_glob, limit, offset,
+                                                output_mode, context)
         # Try ripgrep first (fast), fallback to grep (slower but works)
         if self._has_command('rg'):
             return self._search_with_rg(pattern, path, file_glob, limit, offset, 
@@ -2128,7 +2492,102 @@ class ShellFileOperations(FileOperations):
                 error="Content search requires ripgrep (rg) or grep. "
                       "Install ripgrep: https://github.com/BurntSushi/ripgrep#installation"
             )
-    
+
+    def _search_content_python(self, pattern: str, path: str, file_glob: Optional[str],
+                               limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+        """Content search via Python snippet — used on PowerShell backends."""
+        snippet = (
+            "import os, re, sys, fnmatch\n"
+            f"root = {path!r}\n"
+            f"pattern = {pattern!r}\n"
+            f"file_glob = {file_glob!r}\n"
+            f"output_mode = {output_mode!r}\n"
+            f"context = {context!r}\n"
+            f"limit = {limit + offset + 50!r}\n"
+            "try:\n"
+            "    regex = re.compile(pattern)\n"
+            "except re.error as e:\n"
+            "    print(f'Regex error: {e}', file=sys.stderr); sys.exit(1)\n"
+            "matches = []\n"
+            "if os.path.isfile(root):\n"
+            "    files_to_search = [root]\n"
+            "else:\n"
+            "    files_to_search = []\n"
+            "    for dirpath, dirnames, filenames in os.walk(root):\n"
+            "        dirnames[:] = [d for d in dirnames if not d.startswith('.')]\n"
+            "        for fn in filenames:\n"
+            "            if file_glob and not fnmatch.fnmatch(fn, file_glob):\n"
+            "                continue\n"
+            "            files_to_search.append(os.path.join(dirpath, fn))\n"
+            "for fp in files_to_search:\n"
+            "    try:\n"
+            "        with open(fp, 'r', encoding='utf-8', errors='replace') as f:\n"
+            "            lines = f.readlines()\n"
+            "    except Exception:\n"
+            "        continue\n"
+            "    for i, line in enumerate(lines, 1):\n"
+            "        if regex.search(line):\n"
+            "            if output_mode == 'files_only':\n"
+            "                print(fp)\n"
+            "                break\n"
+            "            elif output_mode == 'count':\n"
+            "                pass\n"
+            "            else:\n"
+            "                start = max(0, i - 1 - context)\n"
+            "                end = min(len(lines), i + context)\n"
+            "                for j in range(start, end):\n"
+            "                    prefix = '>>' if j == i - 1 else '  '\n"
+            "                    print(f'{fp}:{j+1}:{prefix} {lines[j].rstrip()}')\n"
+            "                if context > 0 and i < len(lines):\n"
+            "                    print('--')\n"
+            "    if output_mode == 'count':\n"
+            "        cnt = sum(1 for line in lines if regex.search(line))\n"
+            "        if cnt > 0:\n"
+            "            print(f'{fp}:{cnt}')\n"
+            "    if len(matches) >= limit:\n"
+            "        break\n"
+        )
+        result = self._exec(f"python -c {self._escape_shell_arg(snippet)}", timeout=60)
+        if result.exit_code != 0:
+            return SearchResult(error=f"Search failed: {result.stdout.strip()}")
+
+        stdout = result.stdout
+        if output_mode == "files_only":
+            all_files = [f for f in stdout.strip().split('\n') if f and f != '--']
+            page = all_files[offset:offset + limit]
+            return SearchResult(files=page, total_count=len(all_files))
+        elif output_mode == "count":
+            counts = {}
+            for line in stdout.strip().split('\n'):
+                if ':' in line:
+                    parts = line.rsplit(':', 1)
+                    if len(parts) == 2:
+                        try:
+                            counts[parts[0]] = int(parts[1])
+                        except ValueError:
+                            pass
+            return SearchResult(counts=counts, total_count=sum(counts.values()))
+
+        # content mode
+        matches = []
+        current_path = None
+        for line in stdout.split('\n'):
+            if not line or line == '--':
+                continue
+            parts = line.split(':', 2)
+            if len(parts) >= 3:
+                try:
+                    ln = int(parts[1])
+                except ValueError:
+                    continue
+                matches.append(SearchMatch(path=parts[0], line_number=ln, content=parts[2]))
+        page = matches[offset:offset + limit]
+        return SearchResult(
+            matches=page,
+            total_count=len(matches),
+            truncated=len(matches) > offset + limit,
+        )
+
     def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],
                         limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Search using ripgrep."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -260,9 +260,9 @@ if _MCP_AVAILABLE and not _MCP_MESSAGE_HANDLER_SUPPORTED:
 
 _DEFAULT_TOOL_TIMEOUT = 300      # seconds for tool calls
 _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
-_MAX_RECONNECT_RETRIES = 5
+_MAX_RECONNECT_RETRIES = 20
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
-_MAX_BACKOFF_SECONDS = 60
+_MAX_BACKOFF_SECONDS = 30
 
 # Environment variables that are safe to pass to stdio subprocesses
 _SAFE_ENV_KEYS = frozenset({

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -51,6 +51,24 @@ from hermes_cli.config import get_hermes_home
 logger = logging.getLogger(__name__)
 
 
+def _is_powershell_shell() -> bool:
+    """Return True if the configured terminal shell is PowerShell."""
+    try:
+        from tools.terminal_tool import _get_terminal_shell_config
+        return _get_terminal_shell_config() == "powershell"
+    except Exception:
+        return False
+
+
+def _find_configured_shell() -> str:
+    """Return the path to the configured shell (pwsh or bash).
+
+    Delegates to _find_shell() which now handles PowerShell detection
+    internally via _get_terminal_shell_config().
+    """
+    return _find_shell()
+
+
 # Checkpoint file for crash recovery (gateway only)
 CHECKPOINT_PATH = get_hermes_home() / "processes.json"
 
@@ -510,10 +528,18 @@ class ProcessRegistry:
         if callable(get_temp_dir):
             try:
                 temp_dir = get_temp_dir()
-                if isinstance(temp_dir, str) and temp_dir.startswith("/"):
-                    return temp_dir.rstrip("/") or "/"
+                if isinstance(temp_dir, str) and temp_dir:
+                    # Accept both POSIX (/tmp) and Windows (C:\...) paths.
+                    # Normalise backslashes to forward slashes for consistent
+                    # path joining downstream.
+                    normalised = temp_dir.replace("\\", "/").rstrip("/") or "/"
+                    return normalised
             except Exception as exc:
                 logger.debug("Could not resolve environment temp dir: %s", exc)
+        # Platform-appropriate fallback
+        if _IS_WINDOWS:
+            import tempfile as _tmpmod
+            return _tmpmod.gettempdir().replace("\\", "/")
         return "/tmp"
 
     def spawn_local(
@@ -551,15 +577,26 @@ class ProcessRegistry:
                     from winpty import PtyProcess as _PtyProcessCls
                 else:
                     from ptyprocess import PtyProcess as _PtyProcessCls
-                user_shell = _find_shell()
+                user_shell = _find_configured_shell()
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
-                pty_proc = _PtyProcessCls.spawn(
-                    [user_shell, "-lic", f"set +m; {command}"],
-                    cwd=session.cwd,
-                    env=pty_env,
-                    dimensions=(30, 120),
-                )
+                # Detect PowerShell: use pwsh -NoProfile -Command instead of
+                # bash -lic "set +m; ..."
+                is_powershell = _is_powershell_shell()
+                if is_powershell:
+                    pty_proc = _PtyProcessCls.spawn(
+                        [user_shell, "-NoProfile", "-NoLogo", "-Command", command],
+                        cwd=session.cwd,
+                        env=pty_env,
+                        dimensions=(30, 120),
+                    )
+                else:
+                    pty_proc = _PtyProcessCls.spawn(
+                        [user_shell, "-lic", f"set +m; {command}"],
+                        cwd=session.cwd,
+                        env=pty_env,
+                        dimensions=(30, 120),
+                    )
                 session.pid = pty_proc.pid
                 # Store the pty handle on the session for read/write
                 session._pty = pty_proc
@@ -589,7 +626,7 @@ class ProcessRegistry:
         # Standard Popen path (non-PTY or PTY fallback)
         # Use the user's login shell for consistency with LocalEnvironment --
         # ensures rc files are sourced and user tools are available.
-        user_shell = _find_shell()
+        user_shell = _find_configured_shell()
         # Force unbuffered output for Python scripts so progress is visible
         # during background execution (libraries like tqdm/datasets buffer when
         # stdout is a pipe, hiding output from process(action="poll")).
@@ -597,8 +634,15 @@ class ProcessRegistry:
         bg_env["PYTHONUNBUFFERED"] = "1"
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
+        # Detect PowerShell: use pwsh -NoProfile -Command instead of bash -lic
+        is_powershell = _is_powershell_shell()
+        if is_powershell:
+            shell_args = [user_shell, "-NoProfile", "-NoLogo", "-Command", command]
+        else:
+            shell_args = [user_shell, "-lic", f"set +m; {command}"]
+
         proc = subprocess.Popen(
-            [user_shell, "-lic", f"set +m; {command}"],
+            shell_args,
             text=True,
             cwd=session.cwd,
             env=bg_env,
@@ -689,17 +733,38 @@ class ProcessRegistry:
         log_path = f"{temp_dir}/hermes_bg_{session.id}.log"
         pid_path = f"{temp_dir}/hermes_bg_{session.id}.pid"
         exit_path = f"{temp_dir}/hermes_bg_{session.id}.exit"
-        quoted_command = shlex.quote(command)
-        quoted_temp_dir = shlex.quote(temp_dir)
-        quoted_log_path = shlex.quote(log_path)
-        quoted_pid_path = shlex.quote(pid_path)
-        quoted_exit_path = shlex.quote(exit_path)
-        bg_command = (
-            f"mkdir -p {quoted_temp_dir} && "
-            f"( nohup bash -lc {quoted_command} > {quoted_log_path} 2>&1; "
-            f"rc=$?; printf '%s\\n' \"$rc\" > {quoted_exit_path} ) & "
-            f"echo $! > {quoted_pid_path} && cat {quoted_pid_path}"
-        )
+
+        # Detect PowerShell backends — use PowerShell job syntax instead of
+        # nohup/bash.  Falls back to the original bash path for all others.
+        is_powershell = getattr(env, 'shell_type', 'bash') == 'powershell'
+
+        if is_powershell:
+            # PowerShell: use Start-Job / Start-Process for background execution.
+            # Paths use Windows-style backslashes inside the sandbox.
+            win_log = log_path.replace("/", "\\")
+            win_pid = pid_path.replace("/", "\\")
+            win_exit = exit_path.replace("/", "\\")
+            win_temp = temp_dir.replace("/", "\\")
+            cmd_escaped = command.replace("'", "''")
+            bg_command = (
+                f"if (-not (Test-Path '{win_temp}')) {{ New-Item -ItemType Directory -Path '{win_temp}' -Force | Out-Null }}; "
+                f"$proc = Start-Process -FilePath 'pwsh' -ArgumentList '-NoProfile','-NoLogo','-Command','{cmd_escaped}' "
+                f"  -RedirectStandardOutput '{win_log}' -RedirectStandardError '{win_log}' -PassThru -NoNewWindow; "
+                f"$proc.Id | Set-Content -Path '{win_pid}' -Encoding UTF8; "
+                f"Get-Content '{win_pid}'"
+            )
+        else:
+            quoted_command = shlex.quote(command)
+            quoted_temp_dir = shlex.quote(temp_dir)
+            quoted_log_path = shlex.quote(log_path)
+            quoted_pid_path = shlex.quote(pid_path)
+            quoted_exit_path = shlex.quote(exit_path)
+            bg_command = (
+                f"mkdir -p {quoted_temp_dir} && "
+                f"( nohup bash -lc {quoted_command} > {quoted_log_path} 2>&1; "
+                f"rc=$?; printf '%s\\n' \"$rc\" > {quoted_exit_path} ) & "
+                f"echo $! > {quoted_pid_path} && cat {quoted_pid_path}"
+            )
 
         try:
             result = env.execute(

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -824,6 +824,7 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
 
 # Environment classes now live in tools/environments/
 from tools.environments.local import LocalEnvironment as _LocalEnvironment
+from tools.environments.powershell import PowerShellEnvironment as _PowerShellEnvironment
 from tools.environments.singularity import SingularityEnvironment as _SingularityEnvironment
 from tools.environments.ssh import SSHEnvironment as _SSHEnvironment
 from tools.environments.docker import DockerEnvironment as _DockerEnvironment
@@ -834,7 +835,45 @@ import sys
 
 
 # Tool description for LLM
-TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
+_POWERSHELL_TOOL_DESCRIPTION = """Execute commands in a PowerShell environment on Windows. Filesystem, current working directory, and environment variables persist between calls.
+
+You are running on Windows with PowerShell 7+ (pwsh). Use PowerShell cmdlets and syntax:
+- List files: Get-ChildItem (alias: ls, dir, gci)
+- Read file content: Get-Content (alias: cat, gc) — but prefer read_file tool
+- Search text: Select-String (alias: sls) — but prefer search_files tool
+- Environment variables: $env:VAR_NAME (e.g. $env:PATH, $env:USERPROFILE)
+- Set env var: $env:VAR_NAME = "value"
+- Current dir: Get-Location (alias: pwd, gl)
+- Change dir: Set-Location (alias: cd, sl)
+- Pipe: | (works like bash but passes objects, not text)
+- Variables: $var = "value" (no $ needed on assignment, $ on read)
+- String interpolation: "Hello $name" (double quotes interpolate, single quotes don't)
+- Exit code: $LASTEXITCODE (for external programs), $? (True/False for cmdlets)
+- Run exe: & "C:\\path\\to.exe" arg1 arg2
+- Multi-statement: use ; between commands (not &&). Use ; instead of && and ||
+
+Do NOT use cat/head/tail to read files — use read_file instead.
+Do NOT use grep/rg/find to search — use search_files instead.
+Do NOT use ls to list directories — use search_files(target='files') instead.
+Do NOT use sed/awk to edit files — use patch instead.
+Do NOT use Set-Content/Out-File to create files — use write_file instead.
+Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
+Because environment state persists, activate a virtualenv or set up variables once per session; do not re-set the same environment before every command unless a command proves the shell state was reset.
+
+Foreground (default): Commands return INSTANTLY when done, even if the timeout is high. Set timeout=300 for long builds/scripts — you'll still get the result in seconds if it's fast. Prefer foreground for short commands.
+Background: Set background=true to get a session_id. Almost always pair with notify_on_complete=true — bg without notify runs SILENTLY and you have no way to learn it finished short of calling process(action='poll') yourself. Two legitimate uses:
+  (1) Long-lived processes that never exit (servers, watchers, daemons) — silent is correct, there's no exit to notify on.
+  (2) Long-running bounded tasks (tests, builds, deploys, CI pollers, batch jobs) — MUST set notify_on_complete=true. Without it you'll either forget to poll or sit blocked waiting for the user to surface the result.
+For servers/watchers, do NOT use shell-level background wrappers (Start-Process -NoNewWindow / trailing '&') in foreground mode. Use background=true so Hermes can track lifecycle and output.
+After starting a server, verify readiness with a health check or log signal, then run tests in a separate terminal() call. Avoid blind sleep loops.
+Use process(action="poll") for progress checks, process(action="wait") to block until done.
+Working directory: Use 'workdir' for per-command cwd.
+PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REPL).
+
+Do NOT use vim/nano/interactive tools without pty=true — they hang without a pseudo-terminal. Pipe git output to Out-Host or cat if it might page.
+"""
+
+_BASH_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
 
 Do NOT use cat/head/tail to read files — use read_file instead.
 Do NOT use grep/rg/find to search — use search_files instead.
@@ -856,6 +895,34 @@ PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REP
 
 Do NOT use vim/nano/interactive tools without pty=true — they hang without a pseudo-terminal. Pipe git output to cat if it might page.
 """
+
+
+def _get_terminal_shell_config() -> str:
+    """Return the configured shell type for local terminal: 'powershell' or 'bash'.
+
+    Reads ``terminal.shell`` from config.yaml. Defaults to 'bash' (the
+    historical Hermes behaviour on Windows via Git Bash).
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        terminal_cfg = cfg.get("terminal") or {}
+        shell = str(terminal_cfg.get("shell", "")).lower().strip()
+        if shell in ("powershell", "pwsh"):
+            return "powershell"
+        return "bash"
+    except Exception:
+        return "bash"
+
+
+def _get_terminal_tool_description() -> str:
+    """Return the terminal tool description matching the configured shell."""
+    if _get_terminal_shell_config() == "powershell":
+        return _POWERSHELL_TOOL_DESCRIPTION
+    return _BASH_TOOL_DESCRIPTION
+
+
+TERMINAL_TOOL_DESCRIPTION = _get_terminal_tool_description()
 
 # Global state for environment lifecycle management
 _active_environments: Dict[str, Any] = {}
@@ -1255,6 +1322,9 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     docker_extra_args = cc.get("docker_extra_args", [])
 
     if env_type == "local":
+        shell_type = _get_terminal_shell_config()
+        if shell_type == "powershell":
+            return _PowerShellEnvironment(cwd=cwd, timeout=timeout)
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
     
     elif env_type == "docker":

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -167,7 +167,10 @@ def _get_local_command_template() -> Optional[str]:
 
     whisper_binary = _find_whisper_binary()
     if whisper_binary:
-        quoted_binary = shlex.quote(whisper_binary)
+        if os.name == "nt":
+            quoted_binary = subprocess.list2cmdline([whisper_binary])
+        else:
+            quoted_binary = shlex.quote(whisper_binary)
         return (
             f"{quoted_binary} {{input_path}} --model {{model}} --output_format txt "
             "--output_dir {output_dir} --language {language}"
@@ -1225,17 +1228,21 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
                 return {"success": False, "transcript": "", "error": prep_error}
 
             command = command_template.format(
-                input_path=shlex.quote(prepared_input),
-                output_dir=shlex.quote(output_dir),
-                language=shlex.quote(language),
-                model=shlex.quote(normalized_model),
+                input_path=_quote_command_stt_placeholder(prepared_input, None),
+                output_dir=_quote_command_stt_placeholder(output_dir, None),
+                language=_quote_command_stt_placeholder(language, None),
+                model=_quote_command_stt_placeholder(normalized_model, None),
             )
             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
             if use_shell:
                 subprocess.run(command, shell=True, check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
             else:
-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
+                if os.name == "nt":
+                    # On Windows, use list2cmdline for proper argument splitting
+                    subprocess.run(subprocess.list2cmdline(shlex.split(command)), check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
+                else:
+                    subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
             
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))


### PR DESCRIPTION
# Hermes Multiplexer Patches

Patches applied to the Hermes agent codebase to enable stable multi-profile multiplexing with shared MCP tool servers.

## Context

Hermes runs as a single systemd gateway serving multiple agent profiles. Each profile has its own `config.yaml`, `SOUL.md`, and MCP server definitions, but shares the same underlying MCP tool servers (gbrain, hindsight, instantly, transcriptor, open-design). The following patches address connection instability, orphaned processes, and misconfigured endpoints that prevented reliable multiplexed operation.

---

## 1. MCP Reconnect Resilience (`mcp_tool.py`)

**File:** `$HERMES_HOME/hermes-agent/tools/mcp_tool.py`
**Lines:** 279, 281

### Problem
The default reconnect logic gave up after only 5 retries with exponential backoff capped at 60s. When an SSE stream broke (e.g. gbrain TaskGroup errors), the MCP client would permanently lose the server after ~31 seconds of attempts, leaving all 81 gbrain tools unavailable for the rest of the session.

### Patch

```diff
-_MAX_RECONNECT_RETRIES = 5
-_MAX_BACKOFF_SECONDS = 60
+_MAX_RECONNECT_RETRIES = 20
+_MAX_BACKOFF_SECONDS = 30
```

### Rationale
- **20 retries** gives the server ~8 minutes to recover (enough for transient SSE drops, Ollama model loads, or network blips).
- **30s backoff cap** (down from 60s) ensures retries happen frequently enough to catch a quick recovery, without the exponential tail making waits absurdly long.

---

## 2. MCP Keepalive & Timeout Tuning (all profiles)

**Files:**
- `$HERMES_HOME/config.yaml` (main profile)
- `$HERMES_HOME/profiles/<profile-a>/config.yaml`
- `$HERMES_HOME/profiles/<profile-b>/config.yaml`

### Problem
The default keepalive interval for HTTP MCP servers is 180s (code default in `mcp_tool.py:288`). gbrain and hindsight servers have shorter SSE session TTLs. With 180s keepalive, idle sessions would expire between pings, causing `TaskGroup` errors and connection drops. The tool-call timeout of 60s was also too short for gbrain operations like `mcp_gbrain_think` or `mcp_gbrain_submit_job`.

### Patch

For **gbrain** and **hindsight** in all profile configs:

```diff
 mcp_servers:
   gbrain:
     url: http://localhost:7777/mcp
+    keepalive_interval: 60
     headers:
       Authorization: Bearer gbrain_...
     connect_timeout: 30
-    timeout: 60
+    timeout: 120
   hindsight:
     url: http://localhost:8888/mcp
+    keepalive_interval: 60
     connect_timeout: 30
-    timeout: 60
+    timeout: 120
```

### Rationale
- **60s keepalive** (down from 180s default) ensures SSE sessions stay alive before any reasonable server-side TTL expires.
- **120s timeout** (up from 60s) accommodates long-running gbrain tool calls (graph traversal, job submission, schema operations).
- Applied to **all profiles** so multiplexed agents share the same stability guarantees.

---

## 3. Hindsight Ollama Endpoint Fix

**Files:**
- `$HERMES_HOME/.env`
- `$HINDSIGHT_HOME/profiles/<profile>.env` (one per profile)

### Problem
The Hindsight embedded daemon uses `dotenv` with `find_dotenv(usecwd=True, override=True)` in `hindsight_api/config.py:23`. Since the gateway's `WorkingDirectory` is `~/.hermes`, the daemon picks up `~/.hermes/.env` and **overrides** any environment variables set by the embedded manager. The URL was set to the WSL Windows-host IP, which is unreachable from within WSL when Ollama runs natively on Linux.

### Patch

```diff
 # $HERMES_HOME/.env
-HINDSIGHT_API_LLM_BASE_URL=http://<host-ip>:11434/v1
+HINDSIGHT_API_LLM_BASE_URL=http://localhost:11434/v1

 # $HINDSIGHT_HOME/profiles/<profile>.env  (repeat for each profile)
-HINDSIGHT_API_LLM_BASE_URL=http://<host-ip>:11434/v1
+HINDSIGHT_API_LLM_BASE_URL=http://localhost:11434/v1
```

### Rationale
- Ollama runs natively on `localhost:11434` inside WSL.
- The Windows-host IP is only reachable via WSL's mirrored networking, which is unreliable and adds latency.
- All env files must be patched because `dotenv(override=True)` in the daemon process will overwrite any env vars set by the embedded manager from the profile `.env`.

---

## 4. Orphaned stdio MCP Process Cleanup

**File:** `$HERMES_HOME/scripts/kill-mcp-orphans.sh` (new)

### Problem
When the gateway restarts, stdio MCP subprocesses (transcriptor, open-design) are not always killed cleanly. `KillMode=mixed` in the systemd service sends SIGTERM to the main process but leaves orphaned stdio subprocesses consuming memory and holding ports.

### Patch

Created `$HERMES_HOME/scripts/kill-mcp-orphans.sh`:

```bash
#!/bin/bash
# Kill orphaned stdio MCP subprocesses from previous gateway runs
# Only targets transcriptor wrapper and open-design MCP stdio clients (not the daemon)

pkill -f 'transcriptor-mcp-wrapper.sh' 2>/dev/null || true
pkill -f 'open-design.*cli.js.*mcp.*daemon-url' 2>/dev/null || true

exit 0
```

### Rationale
- Targets only the specific stdio MCP wrapper processes, not all child processes.
- Safe to run before gateway startup (`ExecStartPre`) or manually.
- The `|| true` ensures the script doesn't fail if no orphans exist.

### Note
The `ExecStartPre` directive was prepared but is **not yet wired** into the systemd service file. To activate, add to `hermes-gateway.service`:

```ini
[Service]
ExecStartPre=$HERMES_HOME/scripts/kill-mcp-orphans.sh
```

---

## 5. systemd Service Hardening (drop-in)

**Files:**
- `~/.config/systemd/user/hermes-gateway.service.d/autostart.conf`
- `~/.config/systemd/user/hermes-gateway.service.d/hardening.conf`

*(Paths use `~` for user home. Replace `$HERMES_HOME` with your Hermes installation path.)*

### autostart.conf
Ensures the gateway starts after Ollama is available:

```ini
[Unit]
After=network-online.target ollama.service
Wants=network-online.target
```

### hardening.conf
Prevents crash loops and ensures clean process group kills:

```ini
[Unit]
StartLimitIntervalSec=300
StartLimitBurst=5

[Service]
Restart=on-failure
RestartSec=15
KillMode=control-group
RuntimeMaxSec=43200
```

### Rationale
- `After=ollama.service` ensures Ollama is up before the gateway tries to connect MCP servers that depend on it.
- `KillMode=control-group` (overriding the main service's `mixed`) ensures all child processes including stdio MCP subprocesses are killed on stop.
- `StartLimitBurst=5` prevents infinite restart loops if the gateway crashes on startup.
- `RuntimeMaxSec=43200` (12h) forces a periodic clean restart to prevent memory leaks in long-running sessions.

---

## Summary Table

| # | File | Change | Impact |
|---|------|--------|--------|
| 1 | `tools/mcp_tool.py:279,281` | Reconnect retries 5→20, backoff cap 60→30s | MCP servers survive transient SSE drops |
| 2 | `config.yaml` (all profiles) | keepalive 180→60s, timeout 60→120s for gbrain/hindsight | No more idle-session expiry; long tool calls don't timeout |
| 3 | `.env` (per profile + main) | Ollama URL `<host-ip>`→`localhost` | Hindsight daemon can reach Ollama for LLM verification |
| 4 | `scripts/kill-mcp-orphans.sh` | New orphan cleanup script | Prevents zombie stdio MCP processes after restarts |
| 5 | systemd drop-ins | After=ollama, KillMode=control-group, StartLimitBurst | Clean startup ordering, no crash loops, no orphans |

## Verification

After applying all patches and restarting the gateway:

```
MCP: registered 190 tool(s) from 5 server(s)
  gbrain (HTTP):     81 tools
  hindsight (HTTP):  36 tools
  instantly (HTTP):  42 tools
  open-design (stdio): 20 tools
  transcriptor (stdio): 11 tools
```