### PR TITLE
fix(kanban): migrate claim_lock/claim_expires on legacy DBs; init-lock failure degrades gracefully

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1278,6 +1278,86 @@ CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_
 
 
 # ---------------------------------------------------------------------------
+# SCHEMA_SQL column introspection (keeps the legacy-DB migration in sync)
+# ---------------------------------------------------------------------------
+
+# Table-level constraint keywords. A line inside ``CREATE TABLE`` that starts
+# with one of these is a constraint clause, NOT a column definition, and must
+# be excluded from the parsed column map.
+_TABLE_CONSTRAINT_KEYWORDS = (
+    "primary key",
+    "foreign key",
+    "unique",
+    "check",
+    "constraint",
+)
+
+
+def _parse_schema_columns(table: str, schema_sql: str = SCHEMA_SQL) -> "dict[str, str]":
+    """Parse ``CREATE TABLE <table>`` from SCHEMA_SQL into name -> column DDL.
+
+    Why: the legacy-DB migration historically hard-coded one ``ALTER TABLE``
+    per optional column, and any SCHEMA_SQL column forgotten in that list
+    silently broke legacy boards (5 incidents: claim_lock, claim_expires,
+    started_at, workspace_kind, workspace_path). Deriving the authoritative
+    column set directly from SCHEMA_SQL means no future column can be
+    forgotten — the generic reconcile picks it up automatically and the
+    drift-guard test fails loudly if the parse and SCHEMA_SQL disagree.
+    What: returns an ordered ``{column_name: "<name> <type/constraints>"}``
+    map for the named table, with SQL ``--`` comments stripped and
+    table-level constraint clauses (PRIMARY KEY (...), etc.) excluded. The
+    value is the exact DDL fragment usable as ``ALTER TABLE ADD COLUMN <ddl>``.
+    Test: ``_parse_schema_columns("tasks")`` includes ``started_at`` ->
+    "started_at INTEGER" and ``workspace_kind`` ->
+    "workspace_kind TEXT NOT NULL DEFAULT 'scratch'", and excludes ``id``'s
+    PRIMARY KEY from being treated as a separate constraint row.
+    """
+    # Isolate the body between the table's CREATE TABLE ... ( and its matching
+    # closing ");". SCHEMA_SQL has no nested parens at table scope, so the
+    # first ");" after the opening paren terminates the table body.
+    pattern = re.compile(
+        r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?" + re.escape(table) + r"\s*\((.*?)\n\)\s*;",
+        re.IGNORECASE | re.DOTALL,
+    )
+    match = pattern.search(schema_sql)
+    if not match:
+        raise ValueError(f"table {table!r} not found in SCHEMA_SQL")
+    body = match.group(1)
+
+    columns: "dict[str, str]" = {}
+    for raw_line in body.splitlines():
+        # Strip trailing ``--`` comments and surrounding whitespace.
+        line = raw_line.split("--", 1)[0].strip().rstrip(",").strip()
+        if not line:
+            continue
+        lowered = line.lower()
+        if any(lowered.startswith(kw) for kw in _TABLE_CONSTRAINT_KEYWORDS):
+            continue
+        name = line.split(None, 1)[0]
+        # Defensive: a bare keyword line with no following type is not a column.
+        if " " not in line:
+            continue
+        columns[name] = line
+    return columns
+
+
+def _is_not_null_without_default(column_ddl: str) -> bool:
+    """Return True when a column DDL is NOT NULL but declares no DEFAULT.
+
+    Why: SQLite ``ALTER TABLE ADD COLUMN`` rejects a NOT NULL column that has
+    no DEFAULT (it can't backfill existing rows). The generic reconcile must
+    skip such a column rather than crash. None currently exist in the
+    optional set (``workspace_kind`` carries ``DEFAULT 'scratch'``), but this
+    guards against a future SCHEMA_SQL change introducing one.
+    What: case-insensitive check for ``NOT NULL`` present and ``DEFAULT`` absent.
+    Test: True for "x INTEGER NOT NULL"; False for
+    "workspace_kind TEXT NOT NULL DEFAULT 'scratch'" and "y TEXT".
+    """
+    lowered = column_ddl.lower()
+    return "not null" in lowered and "default" not in lowered
+
+
+# ---------------------------------------------------------------------------
 # Connection helpers
 # ---------------------------------------------------------------------------
 
@@ -2074,22 +2154,37 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
             )
 
-    # ``claim_lock`` / ``claim_expires`` live in SCHEMA_SQL's CREATE TABLE for
-    # fresh DBs but were never added to this additive-migration list. Boards
-    # created before these columns existed therefore lack them, and the
-    # one-shot backfill SELECT below references both — so on a legacy/drifted
-    # board the dispatcher tick crashed with
-    # ``sqlite3.OperationalError: no such column: claim_lock`` (issue: legacy
-    # boards never self-heal). Add them here with the EXACT types from
-    # SCHEMA_SQL (``claim_lock TEXT`` / ``claim_expires INTEGER``) using the
-    # same presence-checked, race-tolerant pattern as every other optional
-    # column, then re-snapshot ``cols`` so the backfill SELECT sees them.
-    if "claim_lock" not in cols:
-        _add_column_if_missing(conn, "tasks", "claim_lock", "claim_lock TEXT")
-    if "claim_expires" not in cols:
-        _add_column_if_missing(
-            conn, "tasks", "claim_expires", "claim_expires INTEGER"
-        )
+    # Generic SCHEMA_SQL reconcile (the durable fix). The hand-maintained
+    # ALTER list above repeatedly drifted from SCHEMA_SQL's CREATE TABLE: a
+    # column added to SCHEMA_SQL for fresh DBs but forgotten here left legacy
+    # boards without it, and the one-shot backfill SELECT below (which reads
+    # claim_lock, claim_expires, started_at, ...) then crashed the dispatcher
+    # tick with ``sqlite3.OperationalError: no such column: <col>``. This bit
+    # 5 times (claim_lock, claim_expires, started_at, workspace_kind,
+    # workspace_path). Instead of chasing each column by hand, derive the
+    # authoritative column set straight from SCHEMA_SQL and ADD whatever the
+    # live table is missing, using the EXACT type/default SCHEMA_SQL declares.
+    # This runs BEFORE the backfill SELECT so every column it references
+    # exists. ``_add_column_if_missing`` is presence-checked and
+    # race-tolerant; we still gate on the live snapshot to avoid needless
+    # ALTERs. A column that is NOT NULL without a DEFAULT cannot be added by
+    # SQLite ALTER TABLE, so we skip+warn rather than crash (none exist in the
+    # set today — workspace_kind carries DEFAULT 'scratch' — but this guards
+    # future drift).
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    for name, ddl in _parse_schema_columns("tasks").items():
+        if name in cols:
+            continue
+        if _is_not_null_without_default(ddl):
+            _log.warning(
+                "kanban: SCHEMA_SQL column %r is NOT NULL without a DEFAULT and "
+                "cannot be added to a legacy 'tasks' table via ALTER TABLE; "
+                "skipping (DDL: %s)",
+                name,
+                ddl,
+            )
+            continue
+        _add_column_if_missing(conn, "tasks", name, ddl)
     cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
 
     # One-shot backfill: any task that is 'running' before runs existed

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1352,11 +1352,41 @@ def _cross_process_init_lock(path: Path):
     is redundant work, not corruption. A bounded "proceed anyway" beats an
     unbounded hang that silently stops the board.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_name(path.name + ".init.lock")
-    handle = lock_path.open("a+b")
-    acquired = False
+
+    # Open the advisory-lock sidecar, but DEGRADE GRACEFULLY if it can't be
+    # created/opened (e.g. a read-only mount, a lock file owned by another uid,
+    # or a filesystem that rejects the open). Previously any
+    # ``PermissionError``/``OSError`` here raised out of ``connect()`` and
+    # permanently blocked ALL migration on that board — the kanban DB could
+    # never self-heal. The advisory lock is only an optimization to serialize
+    # first-connect setup across processes; the in-process ``_INIT_LOCK`` still
+    # protects threads within this process and the additive migrations are
+    # idempotent and race-tolerant (``_add_column_if_missing`` swallows
+    # duplicate-column races). So on open failure we log once and proceed
+    # WITHOUT the cross-process lock rather than blocking kanban forever.
     try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = lock_path.open("a+b")
+    except (PermissionError, OSError) as exc:
+        _log.warning(
+            "kanban: cross-process init lock unavailable for %s (%s); "
+            "proceeding without advisory lock — in-process lock still applies "
+            "and additive migrations are idempotent",
+            lock_path,
+            exc,
+        )
+        yield
+        return
+
+    acquired = False
+    lock_degraded = False
+    try:
+        # Bounded, non-blocking acquire (#36644): retry ``LOCK_NB`` up to a
+        # deadline, then proceed WITHOUT the cross-process lock. This preserves
+        # main's bounded-loop behaviour — a wedged holder can no longer block
+        # this connect indefinitely — while the open-failure fallback above and
+        # the lock-error fallback below add graceful degradation on top of it.
         deadline = time.monotonic() + _INIT_LOCK_TIMEOUT_SECONDS
         if _IS_WINDOWS:
             import msvcrt
@@ -1381,11 +1411,27 @@ def _cross_process_init_lock(path: Path):
                     fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                     acquired = True
                     break
-                except (BlockingIOError, OSError):
+                except BlockingIOError:
+                    # Held by another process — keep polling until the deadline.
                     if time.monotonic() >= deadline:
                         break
                     time.sleep(_INIT_LOCK_POLL_SECONDS)
-        if not acquired:
+                except (PermissionError, OSError) as exc:
+                    # Structural inability to lock this sidecar (bad fd, a
+                    # filesystem without ``flock`` support, etc.) rather than
+                    # simple contention — polling would never succeed, so
+                    # degrade immediately instead of spinning to the deadline.
+                    _log.warning(
+                        "kanban: could not acquire cross-process init lock on "
+                        "%s (%s); proceeding without advisory lock — in-process "
+                        "lock still applies and additive migrations are "
+                        "idempotent",
+                        lock_path,
+                        exc,
+                    )
+                    lock_degraded = True
+                    break
+        if not acquired and not lock_degraded:
             _log.warning(
                 "kanban init lock for %s not acquired within %.0fs — proceeding "
                 "without the cross-process lock (in-process lock + idempotent "
@@ -2027,6 +2073,24 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
             )
+
+    # ``claim_lock`` / ``claim_expires`` live in SCHEMA_SQL's CREATE TABLE for
+    # fresh DBs but were never added to this additive-migration list. Boards
+    # created before these columns existed therefore lack them, and the
+    # one-shot backfill SELECT below references both — so on a legacy/drifted
+    # board the dispatcher tick crashed with
+    # ``sqlite3.OperationalError: no such column: claim_lock`` (issue: legacy
+    # boards never self-heal). Add them here with the EXACT types from
+    # SCHEMA_SQL (``claim_lock TEXT`` / ``claim_expires INTEGER``) using the
+    # same presence-checked, race-tolerant pattern as every other optional
+    # column, then re-snapshot ``cols`` so the backfill SELECT sees them.
+    if "claim_lock" not in cols:
+        _add_column_if_missing(conn, "tasks", "claim_lock", "claim_lock TEXT")
+    if "claim_expires" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "claim_expires", "claim_expires INTEGER"
+        )
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
 
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.

--- a/tests/test_kanban_migration_claim_lock.py
+++ b/tests/test_kanban_migration_claim_lock.py
@@ -1,0 +1,218 @@
+"""Regression tests for the kanban legacy-DB migration self-heal.
+
+Covers two defects fixed together:
+
+* **Defect A** — ``_migrate_add_optional_columns`` ALTERed in the other
+  ~18 optional columns for legacy DBs but OMITTED ``claim_lock`` /
+  ``claim_expires`` (those only existed in ``SCHEMA_SQL`` for fresh DBs).
+  The one-shot backfill SELECT references ``claim_lock`` *before* any step
+  guaranteed it existed, so a board predating the claim_lock columns
+  crashed the dispatcher tick with
+  ``sqlite3.OperationalError: no such column: claim_lock``.
+
+* **Defect B** — ``_cross_process_init_lock`` HARD-RAISED on a
+  ``PermissionError`` when the ``.init.lock`` sidecar wasn't writable,
+  silently blocking ALL migration on that board forever. It must now log a
+  warning and degrade (proceed without the advisory lock).
+
+Why: legacy/drifted boards must self-heal on the next ``connect()`` with
+the patched code — no manual DB surgery, and an unwritable lock sidecar
+must not wedge kanban on the board indefinitely.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+# Minimal legacy ``tasks`` shape: the v1 NOT NULL columns plus the columns
+# the backfill SELECT reads, but DELIBERATELY missing ``claim_lock`` /
+# ``claim_expires`` (and the other post-v1 additive columns) to simulate a
+# board created before those columns were introduced.
+_LEGACY_TASKS_DDL = """
+CREATE TABLE tasks (
+    id              TEXT PRIMARY KEY,
+    title           TEXT NOT NULL,
+    body            TEXT,
+    assignee        TEXT,
+    status          TEXT NOT NULL,
+    created_at      INTEGER NOT NULL,
+    started_at      INTEGER
+)
+"""
+
+# ``task_runs`` must exist for the backfill branch to run; reuse the same
+# shape as the live schema for the columns the backfill INSERTs into.
+_TASK_RUNS_DDL = """
+CREATE TABLE task_runs (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id             TEXT NOT NULL,
+    profile             TEXT,
+    step_key            TEXT,
+    status              TEXT NOT NULL,
+    claim_lock          TEXT,
+    claim_expires       INTEGER,
+    worker_pid          INTEGER,
+    max_runtime_seconds INTEGER,
+    last_heartbeat_at   INTEGER,
+    started_at          INTEGER NOT NULL,
+    ended_at            INTEGER,
+    outcome             TEXT,
+    summary             TEXT,
+    metadata            TEXT,
+    error               TEXT
+)
+"""
+
+
+# ``task_events`` gets an additive ``run_id`` column in the same migration;
+# it must exist for the pass to complete.
+_TASK_EVENTS_DDL = """
+CREATE TABLE task_events (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id    TEXT NOT NULL,
+    kind       TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+)
+"""
+
+
+def _legacy_conn() -> sqlite3.Connection:
+    """Build an in-memory connection shaped like a pre-claim_lock board.
+
+    Why: isolates the migration function from the full schema/WAL/connect
+    machinery so the assertion targets exactly the column-omission defect.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        _LEGACY_TASKS_DDL + ";" + _TASK_RUNS_DDL + ";" + _TASK_EVENTS_DDL
+    )
+    return conn
+
+
+def test_migration_self_heals_missing_claim_lock_columns():
+    """Defect A: legacy board with a running task migrates without crashing.
+
+    Why: a board predating ``claim_lock`` must self-heal on connect.
+    What: seeds a 'running' task, runs the migration, asserts no exception,
+    the columns now exist, and the backfill produced a matching run row.
+    Test: this test — it fails on unpatched code with OperationalError:
+    no such column: claim_lock.
+    """
+    conn = _legacy_conn()
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at, started_at) "
+        "VALUES (?, ?, 'running', ?, ?)",
+        ("t-legacy-1", "legacy running task", now, now),
+    )
+    conn.commit()
+
+    # Sanity: the columns really are absent before migration.
+    pre = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+    assert "claim_lock" not in pre
+    assert "claim_expires" not in pre
+
+    # (a) no exception — the crux of Defect A.
+    kb._migrate_add_optional_columns(conn)
+
+    # (b) the columns now exist.
+    post = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+    assert "claim_lock" in post
+    assert "claim_expires" in post
+
+    # (c) the backfill ran: the in-flight 'running' task got a task_runs row
+    #     and a current_run_id pointer.
+    run = conn.execute(
+        "SELECT task_id, status FROM task_runs WHERE task_id = ?",
+        ("t-legacy-1",),
+    ).fetchone()
+    assert run is not None
+    assert run["status"] == "running"
+    ptr = conn.execute(
+        "SELECT current_run_id FROM tasks WHERE id = ?", ("t-legacy-1",)
+    ).fetchone()
+    assert ptr["current_run_id"] is not None
+    conn.close()
+
+
+def test_migration_is_idempotent_on_second_run():
+    """Defect A guard: running the migration twice stays clean.
+
+    Why: ``connect()``/``init_db`` may re-run the pass; it must not crash or
+    double-backfill.
+    What: runs the migration twice; asserts no exception and exactly one run
+    row for the in-flight task.
+    Test: this test — a non-idempotent ALTER or backfill would raise or
+    duplicate.
+    """
+    conn = _legacy_conn()
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at, started_at) "
+        "VALUES (?, ?, 'running', ?, ?)",
+        ("t-legacy-2", "legacy running task", now, now),
+    )
+    conn.commit()
+
+    kb._migrate_add_optional_columns(conn)
+    # Real re-migration (init_db) re-runs against a freshly-opened
+    # connection; commit any pending implicit DDL txn so the second pass
+    # starts clean, mirroring that.
+    conn.commit()
+    kb._migrate_add_optional_columns(conn)
+
+    rows = conn.execute(
+        "SELECT COUNT(*) AS n FROM task_runs WHERE task_id = ?",
+        ("t-legacy-2",),
+    ).fetchone()
+    assert rows["n"] == 1
+    conn.close()
+
+
+def test_init_lock_degrades_when_sidecar_unwritable(tmp_path, monkeypatch, caplog):
+    """Defect B: an unwritable ``.init.lock`` must not block migration.
+
+    Why: a non-writable lock sidecar previously raised and wedged ALL
+    migration on the board forever.
+    What: forces the sidecar ``open`` to raise PermissionError, then runs a
+    full ``connect()``; asserts it still returns a usable, fully-migrated DB
+    and that a warning was logged (not raised).
+    Test: this test — on unpatched code ``connect()`` propagates
+    PermissionError instead of returning.
+    """
+    db_path = tmp_path / "kanban.db"
+    lock_name = db_path.name + ".init.lock"
+
+    real_open = Path.open
+
+    def fake_open(self, *args, **kwargs):
+        if self.name == lock_name:
+            raise PermissionError(f"simulated unwritable lock: {self}")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+    with caplog.at_level("WARNING"):
+        # Must NOT raise even though the advisory lock can't be taken.
+        conn = kb.connect(db_path=db_path)
+
+    try:
+        # The board is fully usable: the migrated schema is present.
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+        assert "claim_lock" in cols
+        assert "claim_expires" in cols
+    finally:
+        conn.close()
+
+    # Degraded gracefully with a warning, not a raise.
+    assert any(
+        "init lock" in rec.message.lower() for rec in caplog.records
+    ), [rec.message for rec in caplog.records]

--- a/tests/test_kanban_migration_claim_lock.py
+++ b/tests/test_kanban_migration_claim_lock.py
@@ -1,6 +1,6 @@
 """Regression tests for the kanban legacy-DB migration self-heal.
 
-Covers two defects fixed together:
+Covers two defects fixed together, plus the generalized durable fix:
 
 * **Defect A** — ``_migrate_add_optional_columns`` ALTERed in the other
   ~18 optional columns for legacy DBs but OMITTED ``claim_lock`` /
@@ -15,9 +15,21 @@ Covers two defects fixed together:
   silently blocking ALL migration on that board forever. It must now log a
   warning and degrade (proceed without the advisory lock).
 
+* **Defect A (generalized)** — fixing only ``claim_lock`` / ``claim_expires``
+  was insufficient: a live stopgap on a real legacy board proved the SAME
+  class of omission also dropped ``started_at``, ``workspace_kind``
+  (``TEXT NOT NULL DEFAULT 'scratch'``), and ``workspace_path`` — all in
+  SCHEMA_SQL's CREATE TABLE but absent from the hand-maintained ALTER list,
+  and all read by the backfill SELECT. This bit 5 times. The migration now
+  derives the authoritative column set directly from SCHEMA_SQL and
+  reconciles ALL missing ``tasks`` columns generically, so no future column
+  can be forgotten. The drift-guard test below fails loudly if the parsed
+  reconcile set and SCHEMA_SQL ever disagree.
+
 Why: legacy/drifted boards must self-heal on the next ``connect()`` with
-the patched code — no manual DB surgery, and an unwritable lock sidecar
-must not wedge kanban on the board indefinitely.
+the patched code — no manual DB surgery, an unwritable lock sidecar must
+not wedge kanban on the board indefinitely, and a future SCHEMA_SQL column
+must never silently break legacy boards again.
 """
 
 from __future__ import annotations
@@ -216,3 +228,260 @@ def test_init_lock_degrades_when_sidecar_unwritable(tmp_path, monkeypatch, caplo
     assert any(
         "init lock" in rec.message.lower() for rec in caplog.records
     ), [rec.message for rec in caplog.records]
+
+
+# The maximally-drifted legacy shape: ONLY the original v1 NOT NULL columns,
+# missing every post-v1 SCHEMA_SQL column INCLUDING the five the live stopgap
+# proved get dropped (claim_lock, claim_expires, started_at, workspace_kind,
+# workspace_path). ``started_at`` is intentionally absent here (unlike
+# ``_LEGACY_TASKS_DDL``) so the test exercises the generic reconcile adding it
+# before the backfill SELECT reads it.
+_FULLY_DRIFTED_TASKS_DDL = """
+CREATE TABLE tasks (
+    id              TEXT PRIMARY KEY,
+    title           TEXT NOT NULL,
+    body            TEXT,
+    assignee        TEXT,
+    status          TEXT NOT NULL,
+    created_at      INTEGER NOT NULL
+)
+"""
+
+# Columns the generic reconcile must SKIP on a legacy table: NOT NULL with no
+# DEFAULT. These are the v1 base columns that always exist on a real board, so
+# the skip path is never hit in practice — but the guard must classify them so
+# a future NOT-NULL-without-default optional column degrades instead of
+# crashing ``ALTER TABLE ADD COLUMN``.
+_NOT_NULL_NO_DEFAULT_BASE = {"title", "status", "created_at"}
+
+
+def _fully_drifted_conn() -> sqlite3.Connection:
+    """Build an in-memory connection shaped like a maximally-drifted board.
+
+    Why: isolates the generic SCHEMA_SQL reconcile from connect/WAL machinery
+    while reproducing the worst-case legacy shape (every post-v1 column gone,
+    including ``started_at`` which the backfill SELECT reads).
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        _FULLY_DRIFTED_TASKS_DDL + ";" + _TASK_RUNS_DDL + ";" + _TASK_EVENTS_DDL
+    )
+    return conn
+
+
+def test_migration_self_heals_fully_drifted_board():
+    """Generalized Defect A: a board missing ALL 5 proven-dropped columns heals.
+
+    Why: a live stopgap proved ``started_at``/``workspace_kind``/
+    ``workspace_path`` are dropped alongside ``claim_lock``/``claim_expires``
+    on legacy boards; patching only the claim_* pair would still crash on
+    ``started_at`` (next in the backfill SELECT). The generic reconcile must
+    add every missing SCHEMA_SQL ``tasks`` column.
+    What: seeds a 'running' task on a table missing all 5 (and every other
+    post-v1 column), runs the migration, asserts no exception, all 5 columns
+    now exist with their SCHEMA_SQL defaults, and the backfill produced a
+    matching run row.
+    Test: this test — on the hardcoded-pair PR it raises
+    ``OperationalError: no such column: started_at``.
+    """
+    conn = _fully_drifted_conn()
+    now = int(time.time())
+    # NOTE: no started_at column to write — it doesn't exist yet on this board.
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) "
+        "VALUES (?, ?, 'running', ?)",
+        ("t-drift-1", "fully drifted running task", now),
+    )
+    conn.commit()
+
+    # Sanity: every proven-dropped column really is absent before migration.
+    pre = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+    for col in (
+        "claim_lock",
+        "claim_expires",
+        "started_at",
+        "workspace_kind",
+        "workspace_path",
+    ):
+        assert col not in pre, col
+
+    # (a) no exception — the crux of the generalized defect.
+    kb._migrate_add_optional_columns(conn)
+
+    # (b) all five proven-dropped columns now exist.
+    post = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+    for col in (
+        "claim_lock",
+        "claim_expires",
+        "started_at",
+        "workspace_kind",
+        "workspace_path",
+    ):
+        assert col in post, col
+
+    # (c) defaults from SCHEMA_SQL were preserved: the NOT NULL DEFAULT
+    #     'scratch' column backfilled existing rows with 'scratch'.
+    wk = conn.execute(
+        "SELECT workspace_kind FROM tasks WHERE id = ?", ("t-drift-1",)
+    ).fetchone()
+    assert wk["workspace_kind"] == "scratch"
+
+    # (d) the backfill ran end-to-end despite started_at having been absent
+    #     at INSERT time (it is NULL, so the backfill substitutes now()).
+    run = conn.execute(
+        "SELECT task_id, status FROM task_runs WHERE task_id = ?",
+        ("t-drift-1",),
+    ).fetchone()
+    assert run is not None
+    assert run["status"] == "running"
+    ptr = conn.execute(
+        "SELECT current_run_id FROM tasks WHERE id = ?", ("t-drift-1",)
+    ).fetchone()
+    assert ptr["current_run_id"] is not None
+    conn.close()
+
+
+def _write_legacy_disk_db(path: Path) -> None:
+    """Materialize a pre-claim_lock kanban board as a real on-disk sqlite file.
+
+    Why: the migration helper tests above call ``_migrate_add_optional_columns``
+    directly, but production reaches it only through ``connect()`` — which first
+    runs ``executescript(SCHEMA_SQL)`` (``CREATE TABLE IF NOT EXISTS`` preserves
+    the drifted ``tasks``) and THEN ``_migrate_add_optional_columns``. This
+    builds only the maximally-drifted ``tasks`` table (missing every post-v1
+    column, including the five proven-dropped ones) plus one in-flight
+    ``running`` row; ``connect()`` creates ``task_runs``/``task_events``/indexes
+    from SCHEMA_SQL. A hand-built sqlite file has a valid header so the
+    connect-time integrity guards pass.
+    What: writes ``path`` with a legacy ``tasks`` table and a seeded running row.
+    Test: exercised by ``test_connect_self_heals_legacy_disk_db`` below.
+    """
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.executescript(_FULLY_DRIFTED_TASKS_DDL)
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, created_at) "
+            "VALUES (?, ?, 'running', ?)",
+            ("t-disk-legacy-1", "legacy on-disk running task", now),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_connect_self_heals_legacy_disk_db(tmp_path, monkeypatch):
+    """END-TO-END: a legacy on-disk board self-heals through real ``connect()``.
+
+    Why (maintainer ask): the direct ``_migrate_add_optional_columns`` tests
+    don't prove the self-heal fires on the PRODUCTION path. Production invokes
+    the migration via ``connect()`` after ``SCHEMA_SQL`` (kanban_db.py connect()
+    init block), so the claimed connect-time self-heal needs a disk-backed,
+    real-``connect()`` regression — not a helper call.
+    What: writes a real on-disk legacy board MISSING ``claim_lock`` /
+    ``claim_expires`` (and the rest of the drifted set), points the production
+    path resolver at it via ``HERMES_KANBAN_DB`` under a temp ``HERMES_HOME``,
+    calls ``kb.connect()``, and asserts the missing columns now exist AND the
+    backfill produced the matching ``task_runs`` row + pointer.
+    Test: this test — on code whose ``_migrate_add_optional_columns`` omits the
+    claim columns, ``connect()`` raises ``OperationalError: no such column:
+    claim_lock`` from the backfill SELECT (see the fail-without-fix demo).
+    """
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    db_path = tmp_path / "kanban.db"
+    _write_legacy_disk_db(db_path)
+
+    # Route the real path resolver at our on-disk legacy file and isolate
+    # HERMES_HOME so nothing touches a real board.
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+
+    # Never let a stale per-process cache skip the connect-time init/migration.
+    resolved = str(db_path.resolve())
+    kb._INITIALIZED_PATHS.discard(resolved)
+
+    # Sanity: the on-disk board really lacks the claim columns pre-connect.
+    pre_conn = sqlite3.connect(str(db_path))
+    try:
+        pre = {r[1] for r in pre_conn.execute("PRAGMA table_info(tasks)")}
+    finally:
+        pre_conn.close()
+    assert "claim_lock" not in pre
+    assert "claim_expires" not in pre
+
+    # Real production entrypoint: SCHEMA_SQL (IF NOT EXISTS) then the migration.
+    conn = kb.connect()
+    try:
+        post = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+        # (a) the self-heal added the previously-missing claim columns.
+        assert "claim_lock" in post
+        assert "claim_expires" in post
+        # (b) and the rest of the proven-dropped set, via the generic reconcile.
+        for col in ("started_at", "workspace_kind", "workspace_path"):
+            assert col in post, col
+
+        # (c) the backfill SELECT (which reads claim_lock/claim_expires/
+        #     started_at) ran to completion: the in-flight running task got a
+        #     task_runs row and a current_run_id pointer.
+        run = conn.execute(
+            "SELECT status FROM task_runs WHERE task_id = ?",
+            ("t-disk-legacy-1",),
+        ).fetchone()
+        assert run is not None
+        assert run["status"] == "running"
+        ptr = conn.execute(
+            "SELECT current_run_id FROM tasks WHERE id = ?",
+            ("t-disk-legacy-1",),
+        ).fetchone()
+        assert ptr["current_run_id"] is not None
+    finally:
+        conn.close()
+        kb._INITIALIZED_PATHS.discard(resolved)
+
+
+def test_no_schema_sql_tasks_column_is_unmigratable():
+    """Drift guard: the reconcile set must equal the SCHEMA_SQL tasks columns.
+
+    Why: every prior incident was a SCHEMA_SQL ``tasks`` column that existed
+    for fresh DBs but was forgotten in the migration, so legacy boards never
+    got it. This test makes that class of bug fail at test time: if a future
+    column is added to SCHEMA_SQL it MUST be reachable by the generic
+    reconcile (which derives its set from SCHEMA_SQL), and any column the
+    reconcile would skip MUST be only a NOT-NULL-without-default base column.
+    What: asserts the parsed reconcile map exactly equals the live fresh-DB
+    ``tasks`` columns, and that the only skip-classified columns are the
+    known v1 NOT-NULL-without-default base columns.
+    Test: this test — adding a column to SCHEMA_SQL's CREATE TABLE without it
+    being parseable, or a new NOT-NULL-without-default optional column,
+    fails this assertion.
+    """
+    # The authoritative reconcile set: exactly what the migration iterates.
+    reconcile = kb._parse_schema_columns("tasks")
+
+    # Ground truth: the columns SQLite reports for a freshly-created board.
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(kb.SCHEMA_SQL)
+    kb._migrate_add_optional_columns(conn)
+    live = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+    conn.close()
+
+    # The reconcile set is exactly the SCHEMA_SQL/fresh-DB column set — no
+    # column SCHEMA_SQL declares is unreachable by the migration, and the
+    # migration never invents a column SCHEMA_SQL doesn't have.
+    assert set(reconcile) == live, {
+        "missing_from_reconcile": live - set(reconcile),
+        "extra_in_reconcile": set(reconcile) - live,
+    }
+
+    # The only columns the generic reconcile would SKIP (NOT NULL, no DEFAULT)
+    # are the known v1 base columns — every post-v1 optional column is either
+    # nullable or carries a DEFAULT and is therefore migratable.
+    skipped = {
+        name
+        for name, ddl in reconcile.items()
+        if kb._is_not_null_without_default(ddl)
+    }
+    assert skipped == _NOT_NULL_NO_DEFAULT_BASE, skipped


### PR DESCRIPTION
## Summary

Two defects in `hermes_cli/kanban_db.py` could permanently wedge kanban migration on a legacy/drifted board: the dispatcher tick crashed on every `connect()` and the board never self-healed. Rebased onto current `main`; the init-lock change is now layered **on top of** the bounded non-blocking acquire from #50353 rather than replacing it.

### Defect A (root cause) — legacy DBs miss additive `tasks` columns the backfill reads

`_migrate_add_optional_columns()` hand-maintained one `ALTER TABLE` per optional column and repeatedly **drifted** from `SCHEMA_SQL`'s `CREATE TABLE tasks`. Columns present only in `SCHEMA_SQL` (fresh DBs) were forgotten for legacy boards, and the one-shot backfill `SELECT id, assignee, claim_lock, claim_expires, worker_pid, …, started_at FROM tasks WHERE status='running' …` referenced them **before** any step guaranteed they exist.

**Symptom** on a board predating those columns:

```
sqlite3.OperationalError: no such column: claim_lock
```

and the board never migrated/self-healed. This bit **5 times** (`claim_lock`, `claim_expires`, `started_at`, `workspace_kind`, `workspace_path`).

**Fix (durable):** before the backfill, derive the authoritative column set **directly from `SCHEMA_SQL`** (`_parse_schema_columns("tasks")`) and `ADD` whatever the live `tasks` table is missing, using the exact `SCHEMA_SQL` type/default. Uses the presence-checked, race-tolerant `_add_column_if_missing`; a `NOT NULL`-without-`DEFAULT` column (none exist today) is skipped+warned instead of crashing `ALTER TABLE`. `cols` is re-snapshotted so the backfill `SELECT` sees the new columns. No future `SCHEMA_SQL` column can be forgotten again — a drift-guard test fails loudly if the parsed set and `SCHEMA_SQL` disagree.

This is a **connect()-time self-heal**: production invokes the migration via `connect()` after `executescript(SCHEMA_SQL)` (which preserves the drifted table via `CREATE TABLE IF NOT EXISTS`), so legacy/drifted boards heal on the next `connect()` — no manual DB surgery.

### Defect B (secondary) — init-lock/sidecar failure must not block migration, **while preserving #50353's bounded acquire**

`main`'s `_cross_process_init_lock` (#50353) does a **bounded non-blocking** acquire: retry `flock(LOCK_EX | LOCK_NB)` up to a deadline, then proceed unlocked. This PR **keeps that bounded loop unchanged** and layers graceful degradation on top:

- if the `.init.lock` sidecar can't be created/opened (`mkdir`/`open` raises `PermissionError`/`OSError` — read-only mount, foreign-uid lock file, fs without `flock`), log once and proceed **without** the advisory lock instead of raising out of `connect()`;
- if the lock call itself raises a structural `PermissionError`/`OSError` (not simple `BlockingIOError` contention), degrade immediately rather than spinning to the deadline.

The advisory lock is only an optimization to serialize first-connect setup across processes; the in-process `_INIT_LOCK` still serializes threads and the additive migrations are idempotent, so the board degrades safely. The bounded-wait, proceed-unlocked-on-timeout, and unlock-only-if-acquired semantics from #50353 are all preserved.

## Test coverage — `tests/test_kanban_migration_claim_lock.py`

- **End-to-end disk-backed `connect()` self-heal (maintainer ask):** writes a real on-disk legacy board MISSING `claim_lock`/`claim_expires` (and the rest of the drifted set), points the production path resolver at it via `HERMES_KANBAN_DB` under a temp `HERMES_HOME`, calls the real `kb.connect()` (SCHEMA_SQL → migration), and asserts the columns now exist AND the backfill produced the matching `task_runs` row + pointer. Demonstrated to **fail without the fix** (`OperationalError: no such column: claim_lock` from the backfill `SELECT`) and **pass with it**.
- **Direct helper regressions:** legacy + fully-drifted `tasks` tables self-heal; migration is idempotent on a second run.
- **Drift guard:** the reconcile set equals the live `SCHEMA_SQL` `tasks` columns; the only skip-classified columns are the known v1 `NOT NULL`-without-`DEFAULT` base columns.
- **Defect B degrade:** an unwritable `.init.lock` → full `connect()` still returns a usable, fully-migrated DB and logs a warning instead of raising.

`main`'s bounded-loop coverage (`tests/hermes_cli/test_kanban_init_lock_bounded.py`) still passes, confirming #50353 behavior is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
