### PR TITLE
fix(model): omit custom max_tokens default for vLLM (#49686)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -513,6 +513,13 @@ class ChatCompletionsTransport(ProviderTransport):
         # they front several backends with different completion-token limits
         # (e.g. opencode-go: mimo-v2.5-pro = 131072).
         profile_max = profile.get_max_tokens(model)
+        if getattr(profile, "name", "") == "custom" and not params.get("ollama_num_ctx"):
+            # Generic OpenAI-compatible custom endpoints (vLLM, llama.cpp,
+            # user proxies) should choose their own output budget unless the
+            # user set model.max_tokens explicitly. The custom profile keeps a
+            # large default only for Ollama-style calls, where omitting it
+            # falls back to a tiny num_predict and truncates responses.
+            profile_max = None
 
         if ephemeral is not None and max_tokens_fn:
             api_kwargs.update(max_tokens_fn(ephemeral))

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -458,6 +458,73 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["max_tokens"] == 4096
 
+    def test_custom_openai_endpoint_omits_profile_max_tokens_default(self, transport):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemma4-31b",
+            messages=msgs,
+            provider_profile=profile,
+            provider_name="custom",
+            base_url="http://vllm.example.test:11435/v1",
+            max_tokens=None,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert "max_tokens" not in kw
+
+    def test_custom_openai_endpoint_keeps_explicit_max_tokens(self, transport):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemma4-31b",
+            messages=msgs,
+            provider_profile=profile,
+            provider_name="custom",
+            base_url="http://vllm.example.test:11435/v1",
+            max_tokens=4096,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["max_tokens"] == 4096
+
+    def test_custom_openai_endpoint_keeps_ephemeral_max_tokens(self, transport):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemma4-31b",
+            messages=msgs,
+            provider_profile=profile,
+            provider_name="custom",
+            base_url="http://vllm.example.test:11435/v1",
+            max_tokens=None,
+            ephemeral_max_output_tokens=2048,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["max_tokens"] == 2048
+
+    def test_custom_ollama_num_ctx_keeps_profile_max_tokens_default(self, transport):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="llama3",
+            messages=msgs,
+            provider_profile=profile,
+            provider_name="custom",
+            base_url="http://localhost:11434/v1",
+            ollama_num_ctx=32768,
+            max_tokens=None,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["max_tokens"] == 65536
+        assert kw["extra_body"]["options"]["num_ctx"] == 32768
+
     def test_ephemeral_overrides_max_tokens(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(


### PR DESCRIPTION
## Summary
- Omit the custom provider profile's default `max_tokens` for generic OpenAI-compatible custom endpoints such as vLLM/llama.cpp/user proxies.
- Preserve explicit user/per-call output caps, so configured `model.max_tokens` and ephemeral caps are still sent.
- Preserve the existing Ollama protection when `ollama_num_ctx` is used, so Ollama does not fall back to its tiny `num_predict` default.

## Verification
- RED proof captured in `.automation/runs/20260620T160540Z/49686/fail-without-fix.txt`: `test_custom_openai_endpoint_omits_profile_max_tokens_default` failed on upstream/main with `max_tokens: 65536` still present.
- Re-ran focused/nearby suite before publish:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/agent/transports/test_chat_completions.py -v -o "addopts=" --tb=short`
  - Result: 85 passed.
- Branch verified exactly one commit ahead of upstream/main: `0 1`.

## Duplicate / competitor check
- Same-author issue search for `49686 in:title,body`: no open PRs.
- Same-author branch search for `Tranquil-Flow:fix/49686*`: no open PRs.
- Open PR search for issue `49686`: no competitors.
- Topic searches for `vLLM max_tokens custom endpoint` and `custom max_tokens context_length`: no competitors.

Auto-published by Moonsong via Path B automated pipeline.
