### PR TITLE
test(acp): seed write_file fixture with explicit LF so byte count is deterministic on Windows

### DIFF
--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -62,7 +62,12 @@ def test_write_file_rejection_does_not_mutate_existing_file(tmp_path):
 
 def test_write_file_approval_mutates_and_request_includes_diff(tmp_path):
     target = tmp_path / "sample.txt"
-    target.write_text("before\n", encoding="utf-8")
+    # Seed with explicit LF (newline="") so the on-disk fixture is byte-identical
+    # across platforms. Path.write_text() uses text mode, which translates "\n"
+    # to os.linesep on Windows -> the seed file would hold CRLF, and write_file's
+    # line-ending-preservation then correctly keeps CRLF, making bytes_written 7
+    # ("after\r\n") instead of the 6 this test asserts.
+    target.write_text("before\n", encoding="utf-8", newline="")
     proposals = []
 
     def approve(proposal):


### PR DESCRIPTION
## What

Make the Windows-native byte-count fixture deterministic by seeding its existing file with explicit LF bytes:

```python
target.write_text("before\n", encoding="utf-8", newline="")
```

## Why

The root cause is in the test fixture, not production code. On Windows, text-mode `Path.write_text("before\n")` writes CRLF. `write_file` then correctly preserves that existing line-ending style, so `"after\n"` becomes `"after\r\n"` and reports 7 bytes while the test expects 6.

Using `newline=""` makes this fixture's on-disk bytes identical on every platform. Production line-ending preservation remains unchanged and still has its own coverage.

## Current-main A/B proof

Fresh native-Windows verification on CPython 3.12.11 after rebasing onto `main` at `9f384783e`:

- Current `main`, target test: **fails** with `AssertionError: assert 7 == 6`.
- This branch (`ab2966df3`), full test file: **10 passed**.
- Canonical per-file runner with the pending Windows wrapper environment fix from #67387: **10 passed, 0 failed**.
- `ruff`/diff check: clean.

## Scope

One test file, one behavioral line plus its root-cause comment. No production behavior, dependency, or lockfile changes. The two other `write_text("before\n")` fixtures in this file assert decoded text rather than a byte count, so they are intentionally unchanged.

Part of #48986.