### PR TITLE
test(agent): close SessionDB before TemporaryDirectory teardown (fixes WinError 32)

### DIFF
--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -285,19 +285,26 @@ def test_review_fork_disables_compression_to_prevent_stale_parent_fork() -> None
 
     with tempfile.TemporaryDirectory() as td:
         db = SessionDB(db_path=Path(td) / "state.db")
-        db.create_session(parent_sid, source="discord")
-        parent = _build_agent_with_db(db, parent_sid)
+        try:
+            db.create_session(parent_sid, source="discord")
+            parent = _build_agent_with_db(db, parent_sid)
 
-        # The worker does a local ``from run_agent import AIAgent``; patching
-        # the class method covers that import path.
-        from run_agent import AIAgent
+            # The worker does a local ``from run_agent import AIAgent``; patching
+            # the class method covers that import path.
+            from run_agent import AIAgent
 
-        with patch.object(AIAgent, "run_conversation", _fake_run_conversation):
-            br._run_review_in_thread(
-                parent,
-                [{"role": "user", "content": "hi"}],
-                "review this conversation",
-            )
+            with patch.object(AIAgent, "run_conversation", _fake_run_conversation):
+                br._run_review_in_thread(
+                    parent,
+                    [{"role": "user", "content": "hi"}],
+                    "review this conversation",
+                )
+        finally:
+            # Release the SQLite connection before the TemporaryDirectory is
+            # torn down. On Windows an open handle to state.db makes the
+            # directory undeletable (PermissionError [WinError 32]); on POSIX
+            # the unlink succeeds anyway and hides the leak.
+            db.close()
 
     assert captured, (
         "_run_review_in_thread never reached run_conversation — the spawn path "


### PR DESCRIPTION
## What

Fixes `tests/agent/test_compression_concurrent_fork.py::test_review_fork_disables_compression_to_prevent_stale_parent_fork`, which fails on Windows with:

```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: '...\state.db'
```

The test opened a `SessionDB` inside a `tempfile.TemporaryDirectory()` but never released the SQLite connection. The fix wraps the body in `try/finally` and calls `db.close()` before the temp directory is torn down.

## Why

`tempfile.TemporaryDirectory().__exit__` deletes the directory immediately. On Windows the OS refuses to unlink `state.db` while the SQLite connection handle is still open, so cleanup raises `WinError 32` and the test fails before its assertions even run. On POSIX the unlink succeeds despite the open handle, which is why the leak was invisible on Linux/macOS CI.

This is a test-fixture resource leak, not a production bug: `SessionDB.close()` already exists and is the canonical lifecycle method, and every other `SessionDB`-owning test in the repo closes it (usually via a fixture finalizer). This test was the only one using a strict `TemporaryDirectory()` instead of pytest's lenient `tmp_path`, so it was the only one to surface the leak on Windows.

## How to test

```
python -m pytest tests/agent/test_compression_concurrent_fork.py -q
```

- Before: target test fails on Windows with `PermissionError [WinError 32]` during temp-dir cleanup.
- After: all 4 tests pass on Windows; the temp directory is actually deletable now (the fix releases the handle rather than masking the cleanup error).

## Affected platforms

Windows (native). POSIX behavior is unchanged — the connection is now closed deterministically on all platforms.

Part of #48986
