### PR TITLE
fix(desktop): avoid probing custom providers on model picker open

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -118,6 +118,7 @@ def build_models_payload(
     capabilities: bool = False,
     force_fresh_nous_tier: bool = False,
     refresh: bool = False,
+    probe_custom_providers: bool = True,
     max_models: int | None = None,
 ) -> dict:
     """Build the ``{providers, model, provider}`` shape every consumer
@@ -149,6 +150,11 @@ def build_models_payload(
       re-fetches its live catalog. Set only for an explicit user-triggered
       "refresh models" action; normal picker opens leave it false to stay
       snappy on the 1h cache.
+    - ``probe_custom_providers``: allow saved custom/provider endpoints to
+      run live ``/models`` discovery while building the payload. GUI picker
+      opens should leave this false unless the user explicitly refreshes; the
+      row can still render its configured model immediately, and slow/offline
+      local endpoints no longer block the dialog.
     """
     from hermes_cli.model_switch import list_authenticated_providers
 
@@ -161,6 +167,7 @@ def build_models_payload(
         force_fresh_nous_tier=force_fresh_nous_tier,
         max_models=max_models,
         refresh=refresh,
+        probe_custom_providers=probe_custom_providers,
     )
 
     # --- Deduplicate: remove models from aggregators that overlap with

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1250,6 +1250,7 @@ def list_authenticated_providers(
     max_models: int | None = None,
     current_model: str = "",
     refresh: bool = False,
+    probe_custom_providers: bool = True,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -1276,6 +1277,11 @@ def list_authenticated_providers(
     live catalog. Use for an explicit user-triggered "refresh models" action
     (e.g. the desktop picker's refresh control); leave false for normal picker
     opens so they stay snappy on the 1h cache.
+
+    ``probe_custom_providers`` controls live ``/models`` discovery for saved
+    custom OpenAI-compatible endpoints. Keep the default true for CLI parity;
+    GUI picker opens can pass false to show configured models immediately
+    without waiting on offline local endpoints.
     """
     import os
     from agent.models_dev import (
@@ -1812,7 +1818,7 @@ def list_authenticated_providers(
             if isinstance(discover, str):
                 discover = discover.lower() not in {"false", "no", "0"}
             has_explicit_models = bool(models_list)
-            should_probe = bool(api_url) and discover and (
+            should_probe = probe_custom_providers and bool(api_url) and discover and (
                 bool(api_key) or not has_explicit_models
             )
             if should_probe:
@@ -2057,7 +2063,8 @@ def list_authenticated_providers(
             #   full aggregator catalog via /models but only serve a subset
             #   (parity with section 3's user ``providers:`` behaviour).
             should_probe = (
-                bool(api_url)
+                probe_custom_providers
+                and bool(api_url)
                 and (bool(api_key) or not grp["models"])
                 and grp.get("discover_models", True)
             )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3559,6 +3559,7 @@ def get_model_options(profile: Optional[str] = None, refresh: bool = False):
                 pricing=True,
                 capabilities=True,
                 refresh=bool(refresh),
+                probe_custom_providers=bool(refresh),
             )
     except HTTPException:
         raise

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -217,6 +217,19 @@ def test_build_models_payload_can_force_fresh_nous_tier():
     assert mock_list.call_args.kwargs["force_fresh_nous_tier"] is True
 
 
+def test_build_models_payload_can_skip_custom_provider_probes():
+    ctx = _empty_ctx()
+    rows = []
+    with patch(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        return_value=rows,
+    ) as mock_list:
+        build_models_payload(ctx, probe_custom_providers=False)
+
+    mock_list.assert_called_once()
+    assert mock_list.call_args.kwargs["probe_custom_providers"] is False
+
+
 def test_list_authenticated_providers_force_fresh_is_keyword_only():
     """``force_fresh_nous_tier`` must be keyword-only on the public listing API.
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -45,6 +45,30 @@ def test_list_authenticated_providers_includes_custom_providers(monkeypatch):
     )
 
 
+def test_list_authenticated_providers_can_skip_custom_provider_live_probe(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    fetch = lambda *a, **k: (_ for _ in ()).throw(AssertionError("unexpected probe"))
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    providers = list_authenticated_providers(
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Slow Local",
+                "base_url": "http://127.0.0.1:8080/v1",
+                "api_key": "sk-local",
+                "model": "local-model",
+            }
+        ],
+        probe_custom_providers=False,
+    )
+
+    row = next(p for p in providers if p["slug"] == "custom:slow-local")
+    assert row["models"] == ["local-model"]
+    assert row["total_models"] == 1
+
+
 def test_resolve_provider_full_finds_named_custom_provider():
     """Explicit /model --provider should resolve saved custom_providers entries."""
     resolved = resolve_provider_full(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5516,6 +5516,7 @@ def test_model_options_does_not_overwrite_curated_models(monkeypatch):
     live_fetch.assert_not_called()
     # list_authenticated_providers is the single source.
     assert listing.call_count == 1
+    assert listing.call_args.kwargs["probe_custom_providers"] is False
 
 
 def test_model_options_propagates_list_exception(monkeypatch):
@@ -5539,6 +5540,22 @@ def test_model_options_propagates_list_exception(monkeypatch):
 # ---------------------------------------------------------------------------
 # prompt.submit — auto-title
 # ---------------------------------------------------------------------------
+
+
+def test_model_options_refresh_allows_custom_provider_probes(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"providers": {}, "custom_providers": []},
+    )
+    with patch(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        return_value=[],
+    ) as listing:
+        resp = server._methods["model.options"](78, {"session_id": "", "refresh": True})
+
+    assert "result" in resp, resp
+    assert listing.call_args.kwargs["probe_custom_providers"] is True
 
 
 class _ImmediateThread:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9561,6 +9561,7 @@ def _(rid, params: dict) -> dict:
             pricing=True,
             capabilities=True,
             refresh=bool(params.get("refresh")),
+            probe_custom_providers=bool(params.get("refresh")),
         )
         return _ok(rid, payload)
     except Exception as e:


### PR DESCRIPTION
﻿## What does this PR do?

Desktop/TUI model picker opens no longer synchronously probe saved custom OpenAI-compatible providers unless the user explicitly asks for a refresh.

The picker can render configured custom-provider models immediately from `config.yaml`; live `/models` discovery is still available through the existing `refresh` path. This prevents offline or slow local endpoints from blocking `model.options` and leaving the Desktop switch-model dialog on skeleton rows.

## Why

On Windows with three saved local custom providers pointing at `127.0.0.1:8080`, `:8081`, and `:8082`, the current `model.options` path spent roughly 23s building the picker payload. Each stopped local endpoint was probed serially through `fetch_api_models()`, even though each custom provider already had a configured `model` value that was enough to render/select the row.

Existing related PRs were checked before opening this:

- #44577 and #44598 both target #44560 with caching/timeout reductions, but in the reproduced Windows setup #44577 still took ~15.7s on the first open and ~13.2s on the second open.
- #39116 proposes a broader lazy probing flow across CLI/TUI. This PR is deliberately narrower: no new RPC or frontend flow, just make the existing GUI options payload avoid custom-provider live probes on normal opens while preserving explicit refresh.

## Changes

- Add `probe_custom_providers` to `build_models_payload()` and `list_authenticated_providers()`.
- Keep the default as `True` for CLI/backward compatibility.
- Pass `probe_custom_providers=bool(refresh)` from `tui_gateway model.options` and REST `/api/model/options`.
- Preserve configured custom-provider `model` entries when live probing is skipped.
- Add regression coverage for the skip flag, normal model.options behavior, and refresh behavior.

## Verification

- Reproduced baseline on this Windows machine: `build_models_payload(... pricing=True, capabilities=True)` took ~23.9s and probed the stopped local custom endpoints.
- Verified patched `model.options` RPC: ~5.6s, returned 40 providers, preserved the three custom model rows, and made zero `fetch_api_models()` calls.
- `python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py::test_list_authenticated_providers_can_skip_custom_provider_live_probe tests/hermes_cli/test_inventory.py::test_build_models_payload_can_skip_custom_provider_probes tests/test_tui_gateway_server.py::test_model_options_does_not_overwrite_curated_models tests/test_tui_gateway_server.py::test_model_options_refresh_allows_custom_provider_probes -q`
- `python -m pytest tests/hermes_cli/test_inventory.py tests/hermes_cli/test_model_switch_custom_providers.py tests/test_tui_gateway_server.py -q`
- `python -m pytest tests/hermes_cli/test_web_server.py -q -k "model_options or model_set or recommended_default"`
- `python -m ruff check hermes_cli/inventory.py hermes_cli/model_switch.py hermes_cli/web_server.py tui_gateway/server.py tests/hermes_cli/test_inventory.py tests/hermes_cli/test_model_switch_custom_providers.py tests/test_tui_gateway_server.py`
- `git diff --check`
