### PR TITLE
feat(skills): add Spraay x402 on-chain payments optional skill

### DIFF
--- a/optional-skills/blockchain/spraay-x402/SKILL.md
+++ b/optional-skills/blockchain/spraay-x402/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: spraay-x402
+description: On-chain batch payments and agent commerce via x402.
+version: 1.0.0
+author: LP (plagtech)
+license: MIT
+platforms: [macos, linux, windows]
+required_environment_variables:
+  - name: SPRAAY_GATEWAY_URL
+    prompt: Spraay gateway URL
+    help: Default is https://gateway.spraay.app — override only for self-hosted gateways
+    required_for: full functionality
+metadata:
+  hermes:
+    tags: [blockchain, payments, x402, batch, crypto, agent-commerce]
+    requires_toolsets: [terminal]
+---
+
+# Spraay x402 Payments Skill
+
+Send on-chain batch payments, escrow funds, bridge tokens, query gas prices, and access 150+ paid blockchain primitives through the Spraay x402 gateway — the payment rail built for AI agents.
+
+Spraay is not a wallet or exchange. It is a gateway that returns unsigned transactions for agent signing, charges per-call via the HTTP 402 protocol, and supports 13+ chains (Base, Ethereum, Solana, Polygon, Arbitrum, Optimism, Stacks, Stellar, XRP, Bitcoin, Canton, and more).
+
+## When to Use
+
+- The user asks to **send crypto payments** to one or more recipients
+- The user asks to **pay a batch** of addresses from a single transaction
+- The user needs to **escrow funds** for a contract or milestone
+- The user wants to **bridge tokens** between chains
+- The user asks for **gas estimates**, **token prices**, or **on-chain data**
+- The user wants to use the **x402 payment protocol** for agent-to-agent commerce
+- The user mentions **Spraay**, **x402 gateway**, or **machine payments**
+
+Do NOT use this skill for wallet creation, seed phrase management, or custodial key storage. Spraay is non-custodial — it returns unsigned transactions that the agent or user signs locally.
+
+## Prerequisites
+
+**Gateway URL (optional override):**
+
+The public gateway is `https://gateway.spraay.app`. No API key is required — Spraay uses the x402 protocol where each call includes a micro-payment header. Set `SPRAAY_GATEWAY_URL` in `~/.hermes/.env` only if you run a self-hosted instance.
+
+**MCP Server (alternative path):**
+
+Spraay also ships an MCP server with 161 tools on Smithery. If MCP is preferred over HTTP:
+
+```
+hermes mcp add spraay --url https://smithery.ai/servers/Plagtech/Spraay-x402-mcp
+```
+
+The skill and MCP server expose the same capabilities — use whichever fits your setup.
+
+**Wallet/Signer:**
+
+The agent needs access to a signing mechanism (private key, hardware wallet, or agent wallet) to submit the unsigned transactions Spraay returns. Spraay itself never touches private keys.
+
+## How to Run
+
+All interactions go through the `terminal` tool using `curl` against the gateway REST API.
+
+```bash
+# Scan available primitives
+curl -s https://gateway.spraay.app/scan | jq '.categories'
+
+# Get a quote for a batch payment on Base
+curl -s https://gateway.spraay.app/quote \
+  -H "Content-Type: application/json" \
+  -d '{
+    "primitive": "batch_payment",
+    "chain": "base",
+    "recipients": ["0xRecipient1", "0xRecipient2"],
+    "amounts": ["1000000", "2000000"],
+    "token": "USDC"
+  }' | jq .
+
+# Execute (returns unsigned tx for agent signing)
+curl -s https://gateway.spraay.app/execute \
+  -H "Content-Type: application/json" \
+  -H "X-402-Payment: <payment_header>" \
+  -d '{
+    "primitive": "batch_payment",
+    "chain": "base",
+    "recipients": ["0xRecipient1", "0xRecipient2"],
+    "amounts": ["1000000", "2000000"],
+    "token": "USDC",
+    "sender": "0xYourAddress"
+  }' | jq .
+```
+
+## Quick Reference
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/scan` | GET | List all 39 categories and 151+ paid primitives |
+| `/quote` | POST | Get price quote and gas estimate for a primitive |
+| `/execute` | POST | Execute primitive, returns unsigned tx |
+| `/health` | GET | Gateway health check |
+
+### Key Primitives by Category
+
+| Category | Primitives | Price Range |
+|----------|-----------|-------------|
+| Batch Payments | `batch_payment`, `batch_payment_erc20` | $0.01-0.05 |
+| Escrow | `create_escrow`, `release_escrow` | $0.05-0.25 |
+| Token Swaps | `swap_exact_tokens` | $0.01-0.05 |
+| Bridge | `bridge_tokens` | $0.05-0.25 |
+| RPC/Data | `get_balance`, `get_gas_price`, `get_block` | $0.001-0.005 |
+| AI Inference | `inference_request` (Bittensor SN64) | $0.03-0.05 |
+| Oracle | `get_price_feed` | $0.005-0.01 |
+
+### Supported Chains
+
+Base (primary), Ethereum, Solana, Polygon, Arbitrum, Optimism, Avalanche, BNB Chain, Stacks, Stellar, XRP, Bitcoin, Canton.
+
+## Procedure
+
+1. **Scan** — Call `/scan` via `terminal` to list available primitives and confirm the desired operation exists.
+
+2. **Quote** — Call `/quote` with the primitive name, chain, and parameters. The response includes the x402 payment amount (in USDC) and gas estimate.
+
+3. **Review** — Present the quote to the user. Show the total cost (gateway fee + estimated gas). Ask for confirmation before proceeding.
+
+4. **Execute** — Call `/execute` with the full parameters and the x402 payment header. The gateway returns an unsigned transaction object.
+
+5. **Sign & Submit** — The unsigned transaction must be signed by the user's wallet or agent wallet. Spraay does not handle signing. If the agent has a configured signer, sign and broadcast. Otherwise, present the unsigned tx to the user for manual signing.
+
+6. **Verify** — Check the transaction hash on the relevant block explorer. For Base: `https://basescan.org/tx/<hash>`.
+
+## Pitfalls
+
+- **Spraay is non-custodial.** It returns unsigned transactions. You need a signer. If no signer is configured, present the raw unsigned tx and guide the user to sign it manually.
+- **x402 payment required.** Each paid primitive requires a micro-payment via the `X-402-Payment` header. The `/quote` endpoint tells you the exact amount. Free primitives (health, scan, some reads) do not require payment.
+- **Batch contract address on Base is `0x1646452F98E36A3c9Cfc3eDD8868221E207B5eEC`.** Do not use any other address.
+- **Token amounts are in smallest units.** USDC on Base uses 6 decimals, so `1000000` = 1 USDC. ETH uses 18 decimals.
+- **Solana gateway** (`gateway-solana.spraay.app`) returns base64-encoded unsigned transactions, not EVM-style tx objects.
+- **Rate limits.** The public gateway is not rate-limited for normal usage, but sustained high-volume callers should reach out for dedicated access.
+- **Do not fabricate addresses.** Never generate or guess contract addresses. Use only the documented addresses from this skill or from the `/scan` response.
+
+## Verification
+
+```bash
+# Confirm gateway is live
+curl -s https://gateway.spraay.app/health | jq .
+
+# Confirm primitives are available
+curl -s https://gateway.spraay.app/scan | jq '.total_primitives'
+# Expected: 151 or higher
+```
+
+## Resources
+
+- Gateway: `https://gateway.spraay.app`
+- Solana Gateway: `https://gateway-solana.spraay.app`
+- Docs: `https://docs.spraay.app`
+- MCP Server: `https://smithery.ai/servers/Plagtech/Spraay-x402-mcp`
+- GitHub: `https://github.com/plagtech`
+- Batch Contract (Base): `0x1646452F98E36A3c9Cfc3eDD8868221E207B5eEC`
+- Pay Address: `0xAd62f03C7514bb8c51f1eA70C2b75C37404695c8`

--- a/optional-skills/blockchain/spraay-x402/SKILL.md
+++ b/optional-skills/blockchain/spraay-x402/SKILL.md
@@ -5,15 +5,14 @@ version: 1.0.0
 author: LP (plagtech)
 license: MIT
 platforms: [macos, linux, windows]
-required_environment_variables:
-  - name: SPRAAY_GATEWAY_URL
-    prompt: Spraay gateway URL
-    help: Default is https://gateway.spraay.app — override only for self-hosted gateways
-    required_for: full functionality
 metadata:
   hermes:
     tags: [blockchain, payments, x402, batch, crypto, agent-commerce]
     requires_toolsets: [terminal]
+    config:
+      SPRAAY_GATEWAY_URL:
+        default: "https://gateway.spraay.app"
+        help: "Spraay gateway URL. Override only for self-hosted gateways."
 ---
 
 # Spraay x402 Payments Skill
@@ -36,10 +35,6 @@ Do NOT use this skill for wallet creation, seed phrase management, or custodial 
 
 ## Prerequisites
 
-**Gateway URL (optional override):**
-
-The public gateway is `https://gateway.spraay.app`. No API key is required — Spraay uses the x402 protocol where each call includes a micro-payment header. Set `SPRAAY_GATEWAY_URL` in `~/.hermes/.env` only if you run a self-hosted instance.
-
 **MCP Server (alternative path):**
 
 Spraay also ships an MCP server with 161 tools on Smithery. If MCP is preferred over HTTP:
@@ -56,45 +51,36 @@ The agent needs access to a signing mechanism (private key, hardware wallet, or 
 
 ## How to Run
 
-All interactions go through the `terminal` tool using `curl` against the gateway REST API.
+All interactions go through the bundled helper script `scripts/spraay_gateway.py` via the `terminal` tool.
+
+### Helper script — `scripts/spraay_gateway.py`
 
 ```bash
-# Scan available primitives
-curl -s https://gateway.spraay.app/scan | jq '.categories'
+# Check gateway health
+python scripts/spraay_gateway.py health
 
-# Get a quote for a batch payment on Base
-curl -s https://gateway.spraay.app/quote \
-  -H "Content-Type: application/json" \
-  -d '{
-    "primitive": "batch_payment",
-    "chain": "base",
-    "recipients": ["0xRecipient1", "0xRecipient2"],
-    "amounts": ["1000000", "2000000"],
-    "token": "USDC"
-  }' | jq .
+# List all available primitives and categories
+python scripts/spraay_gateway.py scan
 
-# Execute (returns unsigned tx for agent signing)
-curl -s https://gateway.spraay.app/execute \
-  -H "Content-Type: application/json" \
-  -H "X-402-Payment: <payment_header>" \
-  -d '{
-    "primitive": "batch_payment",
-    "chain": "base",
-    "recipients": ["0xRecipient1", "0xRecipient2"],
-    "amounts": ["1000000", "2000000"],
-    "token": "USDC",
-    "sender": "0xYourAddress"
-  }' | jq .
+# Get a price quote for a primitive
+python scripts/spraay_gateway.py quote batch_payment base '{"recipientCount": 5}'
+
+# Execute a primitive (requires x402 payment header)
+python scripts/spraay_gateway.py execute batch_payment base 0xYourAddress \
+  --payment "<x402_payment_header>" \
+  '{"token": "USDC", "recipients": ["0xAddr1"], "amounts": ["1000000"]}'
 ```
+
+The `execute` command requires an `X-402-Payment` header obtained from the x402 payment flow. The `quote` endpoint returns the required payment amount; the agent's wallet signs the payment; then the signed payment header is passed via `--payment`.
 
 ## Quick Reference
 
-| Endpoint | Method | Purpose |
-|----------|--------|---------|
-| `/scan` | GET | List all 39 categories and 151+ paid primitives |
-| `/quote` | POST | Get price quote and gas estimate for a primitive |
-| `/execute` | POST | Execute primitive, returns unsigned tx |
-| `/health` | GET | Gateway health check |
+| Command | Purpose |
+|---------|---------|
+| `python scripts/spraay_gateway.py health` | Gateway health check |
+| `python scripts/spraay_gateway.py scan` | List all categories and primitives |
+| `python scripts/spraay_gateway.py quote <primitive> <chain> [params_json]` | Get price quote and gas estimate |
+| `python scripts/spraay_gateway.py execute <primitive> <chain> <sender> --payment <header> [params_json]` | Execute primitive with x402 payment |
 
 ### Key Primitives by Category
 
@@ -114,37 +100,39 @@ Base (primary), Ethereum, Solana, Polygon, Arbitrum, Optimism, Avalanche, BNB Ch
 
 ## Procedure
 
-1. **Scan** — Call `/scan` via `terminal` to list available primitives and confirm the desired operation exists.
+1. **Health check** — Run `python scripts/spraay_gateway.py health` via `terminal` to confirm the gateway is reachable.
 
-2. **Quote** — Call `/quote` with the primitive name, chain, and parameters. The response includes the x402 payment amount (in USDC) and gas estimate.
+2. **Scan** — Run `python scripts/spraay_gateway.py scan` to list available primitives and confirm the desired operation exists.
 
-3. **Review** — Present the quote to the user. Show the total cost (gateway fee + estimated gas). Ask for confirmation before proceeding.
+3. **Quote** — Run `python scripts/spraay_gateway.py quote <primitive> <chain> '<params_json>'`. The response includes the x402 payment amount (in USDC) and gas estimate.
 
-4. **Execute** — Call `/execute` with the full parameters and the x402 payment header. The gateway returns an unsigned transaction object.
+4. **Review** — Present the quote to the user. Show the total cost (gateway fee + estimated gas). Ask for confirmation before proceeding.
 
-5. **Sign & Submit** — The unsigned transaction must be signed by the user's wallet or agent wallet. Spraay does not handle signing. If the agent has a configured signer, sign and broadcast. Otherwise, present the unsigned tx to the user for manual signing.
+5. **Pay & Execute** — The agent's wallet signs the x402 payment for the quoted amount. Then run `python scripts/spraay_gateway.py execute <primitive> <chain> <sender> --payment "<signed_header>" '<params_json>'`. The gateway returns an unsigned transaction object.
 
-6. **Verify** — Check the transaction hash on the relevant block explorer. For Base: `https://basescan.org/tx/<hash>`.
+6. **Sign & Submit** — The unsigned transaction must be signed by the user's wallet or agent wallet. Spraay does not handle signing. If the agent has a configured signer, sign and broadcast. Otherwise, present the unsigned tx to the user for manual signing.
+
+7. **Verify** — Check the transaction hash on the relevant block explorer. For Base: `https://basescan.org/tx/<hash>`.
 
 ## Pitfalls
 
 - **Spraay is non-custodial.** It returns unsigned transactions. You need a signer. If no signer is configured, present the raw unsigned tx and guide the user to sign it manually.
-- **x402 payment required.** Each paid primitive requires a micro-payment via the `X-402-Payment` header. The `/quote` endpoint tells you the exact amount. Free primitives (health, scan, some reads) do not require payment.
+- **x402 payment required.** Each paid primitive requires a micro-payment via the `X-402-Payment` header. The `quote` command tells you the exact amount. Free primitives (health, scan, some reads) do not require payment.
 - **Batch contract address on Base is `0x1646452F98E36A3c9Cfc3eDD8868221E207B5eEC`.** Do not use any other address.
 - **Token amounts are in smallest units.** USDC on Base uses 6 decimals, so `1000000` = 1 USDC. ETH uses 18 decimals.
 - **Solana gateway** (`gateway-solana.spraay.app`) returns base64-encoded unsigned transactions, not EVM-style tx objects.
 - **Rate limits.** The public gateway is not rate-limited for normal usage, but sustained high-volume callers should reach out for dedicated access.
-- **Do not fabricate addresses.** Never generate or guess contract addresses. Use only the documented addresses from this skill or from the `/scan` response.
+- **Do not fabricate addresses.** Never generate or guess contract addresses. Use only the documented addresses from this skill or from the `scan` response.
 
 ## Verification
 
 ```bash
 # Confirm gateway is live
-curl -s https://gateway.spraay.app/health | jq .
+python scripts/spraay_gateway.py health
 
 # Confirm primitives are available
-curl -s https://gateway.spraay.app/scan | jq '.total_primitives'
-# Expected: 151 or higher
+python scripts/spraay_gateway.py scan
+# Expected: 151 or higher total primitives
 ```
 
 ## Resources

--- a/optional-skills/blockchain/spraay-x402/scripts/spraay_gateway.py
+++ b/optional-skills/blockchain/spraay-x402/scripts/spraay_gateway.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""spraay_gateway.py — Thin wrapper around the Spraay x402 gateway REST API.
+
+Usage:
+    python spraay_gateway.py scan                           # List categories and primitives
+    python spraay_gateway.py quote <primitive> <chain> [json_params]
+    python spraay_gateway.py execute <primitive> <chain> <sender> [json_params]
+    python spraay_gateway.py health                         # Check gateway status
+
+Designed to be invoked by Hermes Agent via the terminal tool.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+GATEWAY_URL = os.environ.get("SPRAAY_GATEWAY_URL", "https://gateway.spraay.app")
+
+
+def _request(method: str, path: str, data: dict | None = None, headers: dict | None = None) -> dict:
+    """Make an HTTP request to the gateway and return parsed JSON."""
+    url = f"{GATEWAY_URL}{path}"
+    req_headers = {"Content-Type": "application/json"}
+    if headers:
+        req_headers.update(headers)
+
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, headers=req_headers, method=method)
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode() if e.fp else ""
+        return {"error": True, "status": e.code, "message": error_body}
+    except urllib.error.URLError as e:
+        return {"error": True, "message": str(e.reason)}
+
+
+def cmd_health():
+    """Check gateway health."""
+    result = _request("GET", "/health")
+    print(json.dumps(result, indent=2))
+
+
+def cmd_scan():
+    """List all available categories and primitives."""
+    result = _request("GET", "/scan")
+    print(json.dumps(result, indent=2))
+
+
+def cmd_quote(primitive: str, chain: str, params_json: str = "{}"):
+    """Get a price quote for a primitive."""
+    params = json.loads(params_json)
+    params["primitive"] = primitive
+    params["chain"] = chain
+    result = _request("POST", "/quote", data=params)
+    print(json.dumps(result, indent=2))
+
+
+def cmd_execute(primitive: str, chain: str, sender: str, params_json: str = "{}"):
+    """Execute a primitive (returns unsigned transaction)."""
+    params = json.loads(params_json)
+    params["primitive"] = primitive
+    params["chain"] = chain
+    params["sender"] = sender
+    result = _request("POST", "/execute", data=params)
+    print(json.dumps(result, indent=2))
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    command = sys.argv[1].lower()
+
+    if command == "health":
+        cmd_health()
+    elif command == "scan":
+        cmd_scan()
+    elif command == "quote":
+        if len(sys.argv) < 4:
+            print("Usage: spraay_gateway.py quote <primitive> <chain> [json_params]")
+            sys.exit(1)
+        params_json = sys.argv[4] if len(sys.argv) > 4 else "{}"
+        cmd_quote(sys.argv[2], sys.argv[3], params_json)
+    elif command == "execute":
+        if len(sys.argv) < 5:
+            print("Usage: spraay_gateway.py execute <primitive> <chain> <sender> [json_params]")
+            sys.exit(1)
+        params_json = sys.argv[5] if len(sys.argv) > 5 else "{}"
+        cmd_execute(sys.argv[2], sys.argv[3], sys.argv[4], params_json)
+    else:
+        print(f"Unknown command: {command}")
+        print(__doc__)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/blockchain/spraay-x402/scripts/spraay_gateway.py
+++ b/optional-skills/blockchain/spraay-x402/scripts/spraay_gateway.py
@@ -2,10 +2,14 @@
 """spraay_gateway.py — Thin wrapper around the Spraay x402 gateway REST API.
 
 Usage:
+    python spraay_gateway.py health                         # Check gateway status
     python spraay_gateway.py scan                           # List categories and primitives
     python spraay_gateway.py quote <primitive> <chain> [json_params]
-    python spraay_gateway.py execute <primitive> <chain> <sender> [json_params]
-    python spraay_gateway.py health                         # Check gateway status
+    python spraay_gateway.py execute <primitive> <chain> <sender> --payment <header> [json_params]
+
+The execute command requires an X-402-Payment header. Obtain the payment amount
+from the quote command, sign it with the agent's wallet, and pass the signed
+header via --payment.
 
 Designed to be invoked by Hermes Agent via the terminal tool.
 """
@@ -16,10 +20,17 @@ import sys
 import urllib.request
 import urllib.error
 
-GATEWAY_URL = os.environ.get("SPRAAY_GATEWAY_URL", "https://gateway.spraay.app")
+GATEWAY_URL = os.environ.get(
+    "SPRAAY_GATEWAY_URL", "https://gateway.spraay.app"
+)
 
 
-def _request(method: str, path: str, data: dict | None = None, headers: dict | None = None) -> dict:
+def _request(
+    method: str,
+    path: str,
+    data: dict | None = None,
+    headers: dict | None = None,
+) -> dict:
     """Make an HTTP request to the gateway and return parsed JSON."""
     url = f"{GATEWAY_URL}{path}"
     req_headers = {"Content-Type": "application/json"}
@@ -27,7 +38,9 @@ def _request(method: str, path: str, data: dict | None = None, headers: dict | N
         req_headers.update(headers)
 
     body = json.dumps(data).encode() if data else None
-    req = urllib.request.Request(url, data=body, headers=req_headers, method=method)
+    req = urllib.request.Request(
+        url, data=body, headers=req_headers, method=method
+    )
 
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
@@ -60,13 +73,37 @@ def cmd_quote(primitive: str, chain: str, params_json: str = "{}"):
     print(json.dumps(result, indent=2))
 
 
-def cmd_execute(primitive: str, chain: str, sender: str, params_json: str = "{}"):
-    """Execute a primitive (returns unsigned transaction)."""
+def cmd_execute(
+    primitive: str,
+    chain: str,
+    sender: str,
+    payment_header: str,
+    params_json: str = "{}",
+):
+    """Execute a primitive with an x402 payment header.
+
+    The payment_header is the signed X-402-Payment value obtained after
+    quoting and signing the required micro-payment with the agent's wallet.
+    """
+    if not payment_header:
+        print(
+            "Error: --payment <header> is required for execute.\n"
+            "Run 'quote' first to get the payment amount, sign it with\n"
+            "the agent's wallet, then pass the signed header here."
+        )
+        sys.exit(1)
+
     params = json.loads(params_json)
     params["primitive"] = primitive
     params["chain"] = chain
     params["sender"] = sender
-    result = _request("POST", "/execute", data=params)
+
+    result = _request(
+        "POST",
+        "/execute",
+        data=params,
+        headers={"X-402-Payment": payment_header},
+    )
     print(json.dumps(result, indent=2))
 
 
@@ -79,20 +116,47 @@ def main():
 
     if command == "health":
         cmd_health()
+
     elif command == "scan":
         cmd_scan()
+
     elif command == "quote":
         if len(sys.argv) < 4:
-            print("Usage: spraay_gateway.py quote <primitive> <chain> [json_params]")
+            print(
+                "Usage: spraay_gateway.py quote <primitive> <chain>"
+                " [json_params]"
+            )
             sys.exit(1)
         params_json = sys.argv[4] if len(sys.argv) > 4 else "{}"
         cmd_quote(sys.argv[2], sys.argv[3], params_json)
+
     elif command == "execute":
         if len(sys.argv) < 5:
-            print("Usage: spraay_gateway.py execute <primitive> <chain> <sender> [json_params]")
+            print(
+                "Usage: spraay_gateway.py execute <primitive> <chain>"
+                " <sender> --payment <header> [json_params]"
+            )
             sys.exit(1)
-        params_json = sys.argv[5] if len(sys.argv) > 5 else "{}"
-        cmd_execute(sys.argv[2], sys.argv[3], sys.argv[4], params_json)
+
+        # Parse --payment flag
+        payment_header = ""
+        remaining_args = sys.argv[5:]
+        params_json = "{}"
+
+        i = 0
+        while i < len(remaining_args):
+            if remaining_args[i] == "--payment" and i + 1 < len(remaining_args):
+                payment_header = remaining_args[i + 1]
+                i += 2
+            else:
+                # Treat as params JSON
+                params_json = remaining_args[i]
+                i += 1
+
+        cmd_execute(
+            sys.argv[2], sys.argv[3], sys.argv[4], payment_header, params_json
+        )
+
     else:
         print(f"Unknown command: {command}")
         print(__doc__)

--- a/tests/skills/test_spraay_x402_skill.py
+++ b/tests/skills/test_spraay_x402_skill.py
@@ -1,0 +1,203 @@
+"""Tests for the spraay-x402 optional skill helper script."""
+
+import json
+import subprocess
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
+
+# Import the helper script
+sys.path.insert(
+    0, "optional-skills/blockchain/spraay-x402/scripts"
+)
+import spraay_gateway  # noqa: E402
+
+
+class TestSpraayGatewayHealth(unittest.TestCase):
+    """Tests for the health command."""
+
+    @patch("spraay_gateway.urllib.request.urlopen")
+    def test_health_success(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(
+            {"status": "ok", "version": "3.8.1"}
+        ).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        result = spraay_gateway._request("GET", "/health")
+        self.assertEqual(result["status"], "ok")
+
+    @patch("spraay_gateway.urllib.request.urlopen")
+    def test_health_url_error(self, mock_urlopen):
+        mock_urlopen.side_effect = URLError("Connection refused")
+
+        result = spraay_gateway._request("GET", "/health")
+        self.assertTrue(result["error"])
+        self.assertIn("Connection refused", result["message"])
+
+
+class TestSpraayGatewayScan(unittest.TestCase):
+    """Tests for the scan command."""
+
+    @patch("spraay_gateway.urllib.request.urlopen")
+    def test_scan_returns_categories(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(
+            {"categories": ["batch-payments", "escrow"], "total_primitives": 151}
+        ).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        result = spraay_gateway._request("GET", "/scan")
+        self.assertIn("categories", result)
+        self.assertGreaterEqual(result["total_primitives"], 1)
+
+
+class TestSpraayGatewayQuote(unittest.TestCase):
+    """Tests for the quote command."""
+
+    @patch("spraay_gateway.urllib.request.urlopen")
+    def test_quote_sends_correct_body(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(
+            {"amount": "0.02", "gas_estimate": "185000"}
+        ).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        result = spraay_gateway._request(
+            "POST",
+            "/quote",
+            data={
+                "primitive": "batch_payment",
+                "chain": "base",
+                "recipientCount": 5,
+            },
+        )
+        self.assertIn("amount", result)
+
+        # Verify the request was constructed correctly
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        self.assertEqual(req.method, "POST")
+        body = json.loads(req.data.decode())
+        self.assertEqual(body["primitive"], "batch_payment")
+        self.assertEqual(body["chain"], "base")
+
+
+class TestSpraayGatewayExecute(unittest.TestCase):
+    """Tests for the execute command with payment header."""
+
+    @patch("spraay_gateway.urllib.request.urlopen")
+    def test_execute_includes_payment_header(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(
+            {"transaction": {"to": "0x1646...", "data": "0x..."}}
+        ).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        payment_header = "x402_test_payment_header_abc123"
+
+        result = spraay_gateway._request(
+            "POST",
+            "/execute",
+            data={
+                "primitive": "batch_payment",
+                "chain": "base",
+                "sender": "0xTestSender",
+                "token": "USDC",
+                "recipients": ["0xAddr1"],
+                "amounts": ["1000000"],
+            },
+            headers={"X-402-Payment": payment_header},
+        )
+        self.assertIn("transaction", result)
+
+        # Verify the payment header was included
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        self.assertEqual(req.get_header("X-402-payment"), payment_header)
+
+    @patch("spraay_gateway.urllib.request.urlopen")
+    def test_execute_402_without_payment(self, mock_urlopen):
+        """Gateway returns 402 when payment header is missing."""
+        error_body = json.dumps(
+            {"error": "Payment required", "amount": "0.02"}
+        ).encode()
+        mock_fp = MagicMock()
+        mock_fp.read.return_value = error_body
+        mock_urlopen.side_effect = HTTPError(
+            url="https://gateway.spraay.app/execute",
+            code=402,
+            msg="Payment Required",
+            hdrs={},
+            fp=mock_fp,
+        )
+
+        result = spraay_gateway._request(
+            "POST",
+            "/execute",
+            data={"primitive": "batch_payment", "chain": "base"},
+        )
+        self.assertTrue(result["error"])
+        self.assertEqual(result["status"], 402)
+
+    def test_cmd_execute_rejects_missing_payment(self):
+        """cmd_execute exits when --payment is not provided."""
+        with self.assertRaises(SystemExit) as ctx:
+            spraay_gateway.cmd_execute(
+                "batch_payment", "base", "0xSender", "", "{}"
+            )
+        self.assertEqual(ctx.exception.code, 1)
+
+
+class TestSpraayGatewayConfig(unittest.TestCase):
+    """Tests for configuration handling."""
+
+    def test_default_gateway_url(self):
+        """Default gateway URL points to production."""
+        # Temporarily clear env override if present
+        original = spraay_gateway.GATEWAY_URL
+        spraay_gateway.GATEWAY_URL = "https://gateway.spraay.app"
+        self.assertEqual(
+            spraay_gateway.GATEWAY_URL, "https://gateway.spraay.app"
+        )
+        spraay_gateway.GATEWAY_URL = original
+
+    @patch.dict("os.environ", {"SPRAAY_GATEWAY_URL": "https://custom.example.com"})
+    def test_custom_gateway_url(self):
+        """SPRAAY_GATEWAY_URL env var overrides the default."""
+        url = os.environ.get("SPRAAY_GATEWAY_URL", "https://gateway.spraay.app")
+        self.assertEqual(url, "https://custom.example.com")
+
+
+class TestSpraayGatewayCLI(unittest.TestCase):
+    """Tests for CLI argument parsing."""
+
+    def test_no_args_prints_usage(self):
+        """Running with no arguments exits with usage info."""
+        with self.assertRaises(SystemExit) as ctx:
+            spraay_gateway.main()
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_unknown_command_exits(self):
+        """Unknown command exits with error."""
+        original_argv = sys.argv
+        sys.argv = ["spraay_gateway.py", "nonexistent"]
+        try:
+            with self.assertRaises(SystemExit) as ctx:
+                spraay_gateway.main()
+            self.assertEqual(ctx.exception.code, 1)
+        finally:
+            sys.argv = original_argv
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Adds an optional skill for the [Spraay x402 gateway](https://gateway.spraay.app) — the payment rail built for AI agents. This gives Hermes Agent native access to on-chain batch payments, escrow, token bridges, gas estimation, and 150+ blockchain primitives across 13+ chains via the HTTP 402 micropayment protocol.

Spraay is non-custodial — it returns unsigned transactions that the agent or user signs locally. No API keys required; each call is paid via x402 micropayment headers.

This complements the existing `blockchain/solana` optional skill by adding multi-chain payment capabilities and a structured gateway abstraction over raw RPC.

## Related Issue

N/A — new skill contribution.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/blockchain/spraay-x402/SKILL.md` — Full skill definition with frontmatter, quick reference tables, step-by-step procedure, pitfalls, and verification commands
- `optional-skills/blockchain/spraay-x402/scripts/spraay_gateway.py` — Stdlib-only Python helper wrapping the gateway REST API (scan, quote, execute, health)

## How to Test

1. Install the skill:
```bash
   hermes skills install official/blockchain/spraay-x402
```
2. Verify gateway connectivity:
```bash
   hermes chat -q "Use the spraay-x402 skill to check the gateway health"
```
3. List available primitives:
```bash
   hermes chat -q "Use spraay-x402 to scan all available payment categories"
```
4. Get a quote (read-only, no actual payment):
```bash
   hermes chat -q "Use spraay-x402 to get a quote for a batch payment of 1 USDC to 0x0000000000000000000000000000000000000001 on Base"
```

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, WSL2 Ubuntu

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

Gateway health check confirms live status:
```json
curl -s https://gateway.spraay.app/health | jq .
```

Primitive scan confirms 151+ paid primitives across 39 categories:
```json
curl -s https://gateway.spraay.app/scan | jq '.total_primitives'
```

## Additional Context

- **Gateway:** https://gateway.spraay.app
- **Docs:** https://docs.spraay.app
- **MCP Server (161 tools):** https://smithery.ai/servers/Plagtech/Spraay-x402-mcp
- **Batch Contract (Base):** `0x1646452F98E36A3c9Cfc3eDD8868221E207B5eEC`
- Spraay also ships an MCP server as an alternative integration path — documented in the skill's Prerequisites section via `hermes mcp add`.
