### PR TITLE
fix: scope gateway service PID detection by profile

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -78,8 +78,19 @@ class ProfileGatewayProcess:
     pid: int
 
 
-def _get_service_pids() -> set:
+def _gateway_service_unit_matches_current_profile(unit: str) -> bool:
+    """Return True when a systemd unit name belongs to this Hermes profile."""
+    return unit == f"{get_service_name()}.service"
+
+
+def _get_service_pids(all_profiles: bool = False) -> set:
     """Return PIDs currently managed by systemd or launchd gateway services.
+
+    By default this is scoped to the current Hermes profile's service unit so
+    ``gateway status`` and ``cron status`` do not count another profile's
+    service as the current profile's gateway.  Pass ``all_profiles=True`` for
+    global operations such as update/restart sweeps that intentionally need to
+    protect every service-managed gateway PID.
 
     Used to avoid killing freshly-restarted service processes when sweeping
     for stale manual gateway processes after a service restart.  Relies on the
@@ -110,6 +121,11 @@ def _get_service_pids() -> set:
                     if not parts or not parts[0].endswith(".service"):
                         continue
                     svc = parts[0]
+                    if (
+                        not all_profiles
+                        and not _gateway_service_unit_matches_current_profile(svc)
+                    ):
+                        continue
                     try:
                         show = subprocess.run(
                             scope_args + ["show", svc, "--property=MainPID", "--value"],
@@ -564,7 +580,7 @@ def find_gateway_pids(
             _append_unique_pid(pids, get_running_pid(), _exclude)
         except Exception:
             pass
-    for pid in _get_service_pids():
+    for pid in _get_service_pids(all_profiles=all_profiles):
         _append_unique_pid(pids, pid, _exclude)
     for pid in _scan_gateway_pids(_exclude, all_profiles=all_profiles):
         _append_unique_pid(pids, pid, _exclude)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9903,7 +9903,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # Kill any remaining gateway processes not managed by a service.
             # Exclude PIDs that belong to just-restarted services so we don't
             # immediately kill the process that systemd/launchd just spawned.
-            service_pids = _get_service_pids()
+            service_pids = _get_service_pids(all_profiles=True)
             manual_pids = find_gateway_pids(
                 exclude_pids=service_pids, all_profiles=True
             )
@@ -9987,7 +9987,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # manager can relaunch with fresh code.
             try:
                 _time.sleep(3.0)
-                _service_pids_after = _get_service_pids()
+                _service_pids_after = _get_service_pids(all_profiles=True)
                 _surviving = find_gateway_pids(
                     exclude_pids=_service_pids_after,
                     all_profiles=True,

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -794,7 +794,7 @@ def test_gateway_install_can_decline_start_now_and_startup(monkeypatch):
 
 
 def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkeypatch):
-    monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda all_profiles=False: set())
     monkeypatch.setattr(gateway, "is_windows", lambda: False)
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
 
@@ -819,6 +819,56 @@ def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkey
     monkeypatch.setattr(gateway.subprocess, "run", fake_run)
 
     assert gateway.find_gateway_pids() == [321]
+
+
+def _stub_systemd_gateway_services(monkeypatch, services: dict[str, int]) -> None:
+    """Make _get_service_pids see the given systemd unit -> MainPID map."""
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(gateway, "_scan_gateway_pids", lambda exclude_pids, all_profiles=False: [])
+
+    def fake_run(cmd, **kwargs):
+        if "list-units" in cmd:
+            stdout = "\n".join(
+                f"{unit} loaded active running Hermes Gateway" for unit in services
+            )
+            return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+        if "show" in cmd and "--property=MainPID" in cmd:
+            service = cmd[cmd.index("show") + 1]
+            return SimpleNamespace(returncode=0, stdout=f"{services[service]}\n", stderr="")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+
+def test_find_gateway_pids_scopes_default_systemd_service_to_current_profile(monkeypatch):
+    _stub_systemd_gateway_services(
+        monkeypatch,
+        {
+            "hermes-gateway.service": 111,
+            "hermes-gateway-hotline.service": 222,
+        },
+    )
+    monkeypatch.setattr(gateway, "get_service_name", lambda: "hermes-gateway")
+
+    assert gateway.find_gateway_pids() == [111]
+    assert set(gateway.find_gateway_pids(all_profiles=True)) == {111, 222}
+
+
+def test_find_gateway_pids_uses_named_profile_systemd_service_fallback(monkeypatch):
+    _stub_systemd_gateway_services(
+        monkeypatch,
+        {
+            "hermes-gateway.service": 111,
+            "hermes-gateway-administrator.service": 333,
+            "hermes-gateway-hotline.service": 222,
+        },
+    )
+    monkeypatch.setattr(gateway, "get_service_name", lambda: "hermes-gateway-administrator")
+
+    assert gateway.find_gateway_pids() == [333]
+    assert set(gateway.find_gateway_pids(all_profiles=True)) == {111, 333, 222}
 
 
 def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch):


### PR DESCRIPTION
## Summary
- Scope systemd gateway service PID fallback to the active Hermes profile when `all_profiles=false`
- Preserve global/all-profile discovery for dashboard/list views
- Add regression coverage for default and named-profile systemd fallback behavior

## Testing
- `uv run --extra dev python -m py_compile hermes_cli/gateway.py hermes_cli/main.py`
- `uv run --extra dev python -m pytest tests/hermes_cli/test_gateway.py::test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails tests/hermes_cli/test_gateway.py::test_find_gateway_pids_scopes_default_systemd_service_to_current_profile tests/hermes_cli/test_gateway.py::test_find_gateway_pids_uses_named_profile_systemd_service_fallback -q -o 'addopts='` -> 3 passed
- `uv run --extra dev python -m pytest tests/hermes_cli/test_gateway.py -q -o 'addopts='` -> 46 passed
- Broader check `tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_service.py` produced 207 passed / 2 failed; the failures are pre-existing root-environment system-service identity tests unrelated to this PID-scope change.

## Safety
- Only `hermes_cli/gateway.py`, `hermes_cli/main.py`, and `tests/hermes_cli/test_gateway.py` changed.
- `package-lock.json` and local divergent main state intentionally excluded.
- Added-line no-secrets scan passed.