### PR TITLE
fix(matrix,simplex): tolerate malformed HERMES_*_TEXT_BATCH_* delay env vars

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -131,6 +131,7 @@ from gateway.platforms.base import (
     _ssrf_redirect_guard,
 )
 from gateway.platforms.helpers import ThreadParticipationTracker
+from utils import env_float
 
 logger = logging.getLogger(__name__)
 
@@ -946,11 +947,13 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # Matrix clients split long messages around 4000 chars.
-        self._text_batch_delay_seconds = float(
-            os.getenv("HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS", "0.6")
-        )
-        self._text_batch_split_delay_seconds = float(
-            os.getenv("HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0")
+        # env_float tolerates a malformed value (e.g. a "0.6s" unit-suffix typo)
+        # instead of raising ValueError out of __init__ and crashing gateway
+        # boot — matching how the sibling adapters (Feishu/WeCom/Discord/Telegram)
+        # read this same HERMES_<PLATFORM>_TEXT_BATCH_* family.
+        self._text_batch_delay_seconds = env_float("HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS", 0.6)
+        self._text_batch_split_delay_seconds = env_float(
+            "HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS", 2.0
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -66,6 +66,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
 )
+from utils import env_float
 
 logger = logging.getLogger(__name__)
 
@@ -191,9 +192,9 @@ class SimplexAdapter(BasePlatformAdapter):
 
         # Text message batching — concatenate rapid-fire messages into one
         # event before dispatching, mirroring Telegram's batching.
-        self._text_batch_delay = float(
-            os.getenv("HERMES_SIMPLEX_TEXT_BATCH_DELAY", "0.8")
-        )
+        # env_float tolerates a malformed value instead of raising out of
+        # __init__ (mirrors the other text-batch adapters).
+        self._text_batch_delay = env_float("HERMES_SIMPLEX_TEXT_BATCH_DELAY", 0.8)
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -5309,3 +5309,37 @@ class TestMatrixDispatchSyncIsolation:
 
         assert ran["ok"] is True  # the sibling handler still ran
         assert "event handler failed" in caplog.text  # failure surfaced, not swallowed
+class TestMatrixTextBatchEnvParsing:
+    """A malformed HERMES_MATRIX_TEXT_BATCH_* value must not crash adapter init.
+
+    The env-cast sweep (a7dd98c86) routed these casts through utils.env_float for
+    Feishu/WeCom/Discord/Telegram but missed Matrix. A non-numeric value (e.g. a
+    ``0.6s`` unit-suffix typo) previously raised ValueError out of __init__,
+    which propagates through the gateway platform-init loop and aborts boot.
+    """
+
+    def _build(self):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        return MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="tok",
+                extra={"homeserver": "https://matrix.example.org"},
+            )
+        )
+
+    def test_malformed_delay_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS", "0.6s")
+        adapter = self._build()  # must not raise ValueError
+        assert adapter._text_batch_delay_seconds == 0.6
+
+    def test_malformed_split_delay_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS", "abc")
+        adapter = self._build()  # must not raise ValueError
+        assert adapter._text_batch_split_delay_seconds == 2.0
+
+    def test_valid_delay_is_honored(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS", "1.5")
+        adapter = self._build()
+        assert adapter._text_batch_delay_seconds == 1.5


### PR DESCRIPTION
## Summary

Follow-up to `a7dd98c86` ("guard remaining malformed int/float env var casts with utils helpers").

That sweep routed the `HERMES_<PLATFORM>_TEXT_BATCH_*` delay casts through the safe `utils.env_float` helper for **Feishu, WeCom, Discord, and Telegram** — but missed the identical sibling sites in the **Matrix** and **SimpleX** adapters, which still do a raw `float(os.getenv(...))`:

```python
# gateway/platforms/matrix.py (MatrixAdapter.__init__)
self._text_batch_delay_seconds = float(os.getenv("HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS", "0.6"))
self._text_batch_split_delay_seconds = float(os.getenv("HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
# plugins/platforms/simplex/adapter.py
self._text_batch_delay = float(os.getenv("HERMES_SIMPLEX_TEXT_BATCH_DELAY", "0.8"))
```

A non-numeric value — e.g. a realistic unit-suffix typo `HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS=0.6s` — makes `float("0.6s")` raise an uncaught `ValueError` inside `MatrixAdapter.__init__`. That propagates through `GatewayRunner._create_adapter` and the **unguarded** platform-init loop in `GatewayRunner.start()`, so **the whole gateway fails to boot** when Matrix is enabled.

This is an overlooked miss, not an intentional fail-fast:
- the same `__init__` already guards `MATRIX_ROOM_IDENTITY_TTL_SECONDS` with `try/except` + fallback;
- the sweep's own commit message states only sites *already* guarded by try/except or helpers were left untouched;
- the four sibling text-batch adapters were all converted — Matrix/SimpleX are simply the ones the sweep didn't reach.

## Fix

Route both adapters' casts through `env_float` (returns the default on `ValueError`/`TypeError`), exactly as the four siblings were converted. No behavior change for valid values; the empty-string case also degrades to the default instead of raising.

## Tests

`tests/gateway/test_matrix.py::TestMatrixTextBatchEnvParsing` — constructs `MatrixAdapter` with a malformed `HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS` / `..._SPLIT_DELAY_SECONDS` and asserts init no longer raises and falls back to the default; plus a valid-value case. The two malformed cases **fail without the fix** (`ValueError` out of `__init__`).