### PR TITLE
feat(discord): add force_thread_channels to auto-thread free-response channels

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -732,6 +732,7 @@ platform_toolsets:
 #   require_mention: true            # Require @mention in server channels (default: true)
 #   auto_thread: true                # Auto-create thread on @mention (default: true)
 #   free_response_channels: ""       # Channel IDs where no mention is needed
+#   force_thread_channels: ""        # Free-response channel IDs that auto-thread anyway (inverse of no_thread_channels)
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5157,6 +5157,7 @@ class DiscordAdapter(BasePlatformAdapter):
         #   discord.ignored_channels: Channel IDs where bot NEVER responds (even when mentioned)
         #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
         #   discord.no_thread_channels: Channel IDs where bot responds directly without creating thread
+        #   discord.force_thread_channels: Free-response channel IDs that auto-thread anyway (inverse of no_thread_channels)
         #   discord.auto_thread: Auto-create thread on @mention in channels (default: true)
 
         thread_id = None
@@ -5243,11 +5244,26 @@ class DiscordAdapter(BasePlatformAdapter):
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
         # no_thread_channels: channels where bot responds directly without thread.
+        # force_thread_channels: channels that auto-thread even when they are
+        #   free-response. Free-response normally skips threading (so the channel
+        #   stays a lightweight inline chat); listing it here opts it back into
+        #   auto-threading, so a mention-free front-door channel (a /bug or
+        #   support intake, say) still spins each conversation into its own
+        #   thread. An explicit no_thread_channels listing always wins if a
+        #   channel appears in both. The independent voice-linked and reply-message
+        #   guards below still suppress threading regardless of this set.
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            force_thread_channels_raw = os.getenv("DISCORD_FORCE_THREAD_CHANNELS", "")
+            force_thread_channels = {ch.strip() for ch in force_thread_channels_raw.split(",") if ch.strip()}
+            force_thread = bool(channel_ids & force_thread_channels)
+            # A free-response channel normally skips auto-threading; force_thread
+            # opts it back in. An explicit no_thread_channels listing always wins.
+            skip_thread = bool(channel_ids & no_thread_channels) or (
+                is_free_channel and not force_thread
+            )
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
@@ -6968,7 +6984,8 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     ``DISCORD_REQUIRE_MENTION``, ``DISCORD_FREE_RESPONSE_CHANNELS``,
     ``DISCORD_AUTO_THREAD``, ``DISCORD_REACTIONS``,
     ``DISCORD_IGNORED_CHANNELS``, ``DISCORD_ALLOWED_CHANNELS``,
-    ``DISCORD_NO_THREAD_CHANNELS``, ``DISCORD_HISTORY_BACKFILL``,
+    ``DISCORD_NO_THREAD_CHANNELS``, ``DISCORD_FORCE_THREAD_CHANNELS``,
+    ``DISCORD_HISTORY_BACKFILL``,
     ``DISCORD_HISTORY_BACKFILL_LIMIT``, ``DISCORD_ALLOW_MENTION_*``,
     ``DISCORD_REPLY_TO_MODE``, ``DISCORD_THREAD_REQUIRE_MENTION``).
     Rather than rewrite ~50 call sites inside the adapter to read from
@@ -7028,6 +7045,14 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         if isinstance(ntc, list):
             ntc = ",".join(str(v) for v in ntc)
         os.environ["DISCORD_NO_THREAD_CHANNELS"] = str(ntc)
+    # force_thread_channels: free-response channels that auto-thread anyway
+    # (inverse of no_thread_channels — opts a mention-free channel back into
+    # auto-threading instead of inline replies)
+    ftc = discord_cfg.get("force_thread_channels")
+    if ftc is not None and not os.getenv("DISCORD_FORCE_THREAD_CHANNELS"):
+        if isinstance(ftc, list):
+            ftc = ",".join(str(v) for v in ftc)
+        os.environ["DISCORD_FORCE_THREAD_CHANNELS"] = str(ftc)
     # history_backfill: recover missed channel messages for shared sessions
     # when require_mention is active.  Fetches messages between bot turns
     # and prepends them to the user message for context.
@@ -7097,7 +7122,7 @@ def register(ctx) -> None:
         # YAML→env config bridge — owns the translation of ``config.yaml``
         # ``discord:`` keys (require_mention, free_response_channels,
         # auto_thread, reactions, ignored_channels, allowed_channels,
-        # no_thread_channels, allow_mentions.*, reply_to_mode,
+        # no_thread_channels, force_thread_channels, allow_mentions.*, reply_to_mode,
         # thread_require_mention) into ``DISCORD_*`` env vars that the
         # adapter reads via ``os.getenv()``.  Replaces the hardcoded block
         # that used to live in ``gateway/config.py``.  Hook contract: #24836.

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -281,6 +281,118 @@ async def test_no_thread_with_auto_thread_disabled_is_noop(adapter, monkeypatch)
     adapter.handle_message.assert_awaited_once()
 
 
+# ── force_thread_channels ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_force_thread_channel_threads_despite_free_response(adapter, monkeypatch):
+    """A free-response channel auto-threads when listed in force_thread_channels.
+
+    Free-response channels normally skip auto-threading (the bot replies
+    inline). force_thread_channels opts a channel back into threading while
+    keeping it mention-free — the regression this knob fixes: a /bug-style
+    intake channel that's both mention-free AND thread-per-conversation.
+    """
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "700")
+    monkeypatch.setenv("DISCORD_FORCE_THREAD_CHANNELS", "700")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    fake_thread = FakeThread(channel_id=999, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    # No @mention — proves the channel is still mention-free under force_thread.
+    message = make_message(channel=FakeTextChannel(channel_id=700), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_free_response_without_force_still_inline(adapter, monkeypatch):
+    """Regression guard: a free-response channel NOT in force_thread_channels
+    keeps the original inline (no-thread) behavior."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "700")
+    monkeypatch.setenv("DISCORD_FORCE_THREAD_CHANNELS", "701")  # different channel
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
+
+    message = make_message(channel=FakeTextChannel(channel_id=700), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_no_thread_channels_overrides_force_thread(adapter, monkeypatch):
+    """When a channel is in BOTH lists, no_thread_channels wins (no thread)."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "700")
+    monkeypatch.setenv("DISCORD_FORCE_THREAD_CHANNELS", "700")
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "700")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
+
+    message = make_message(channel=FakeTextChannel(channel_id=700), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_force_thread_noop_when_auto_thread_disabled(adapter, monkeypatch):
+    """force_thread_channels is a no-op when auto_thread is globally disabled."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "700")
+    monkeypatch.setenv("DISCORD_FORCE_THREAD_CHANNELS", "700")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(channel=FakeTextChannel(channel_id=700), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_force_thread_channels_csv_parsing(adapter, monkeypatch):
+    """Multiple force_thread channel IDs parsed from CSV; each threads."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "700, 800")
+    monkeypatch.setenv("DISCORD_FORCE_THREAD_CHANNELS", "700, 800")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
+
+    for ch_id in (700, 800):
+        adapter._auto_create_thread.reset_mock()
+        adapter.handle_message.reset_mock()
+        message = make_message(channel=FakeTextChannel(channel_id=ch_id), content="hello")
+        await adapter._handle_message(message)
+        adapter._auto_create_thread.assert_awaited_once()
+
+
 # ── config.py bridging ───────────────────────────────────────────────
 
 
@@ -322,6 +434,44 @@ def test_config_bridges_no_thread_channels(monkeypatch, tmp_path):
 
     import os
     assert os.getenv("DISCORD_NO_THREAD_CHANNELS") == "333"
+
+
+def test_config_bridges_force_thread_channels(monkeypatch, tmp_path):
+    """gateway/config.py bridges discord.force_thread_channels to env var."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "force_thread_channels": ["444"],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_FORCE_THREAD_CHANNELS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_FORCE_THREAD_CHANNELS") == "444"
+
+
+def test_config_bridges_force_thread_channels_csv(monkeypatch, tmp_path):
+    """force_thread_channels accepts a comma-separated string too."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "force_thread_channels": "444,555",
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_FORCE_THREAD_CHANNELS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_FORCE_THREAD_CHANNELS") == "444,555"
 
 
 def test_config_env_var_takes_precedence(monkeypatch, tmp_path):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -274,6 +274,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `DISCORD_REACTIONS` | Enable emoji reactions on messages during processing (default: `true`) |
 | `DISCORD_IGNORED_CHANNELS` | Comma-separated channel IDs where the bot never responds |
 | `DISCORD_NO_THREAD_CHANNELS` | Comma-separated channel IDs where bot responds without auto-threading |
+| `DISCORD_FORCE_THREAD_CHANNELS` | Comma-separated free-response channel IDs that auto-thread anyway (inverse of `DISCORD_NO_THREAD_CHANNELS`) |
 | `DISCORD_REPLY_TO_MODE` | Reply-reference behavior: `off`, `first` (default), or `all` |
 | `DISCORD_ALLOW_MENTION_EVERYONE` | Allow the bot to ping `@everyone`/`@here` (default: `false`). See [Mention Control](../user-guide/messaging/discord.md#mention-control). |
 | `DISCORD_ALLOW_MENTION_ROLES` | Allow the bot to ping `@role` mentions (default: `false`). |

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -286,6 +286,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
 | `DISCORD_NO_THREAD_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds directly in the channel instead of creating a thread. Only relevant when `DISCORD_AUTO_THREAD` is `true`. |
+| `DISCORD_FORCE_THREAD_CHANNELS` | No | — | Comma-separated channel IDs that auto-create a thread **even when the channel is free-response** (which normally skips threading). The inverse of `DISCORD_NO_THREAD_CHANNELS` — use it for a mention-free intake channel that should still thread each conversation. `DISCORD_NO_THREAD_CHANNELS` wins if a channel is in both. |
 | `DISCORD_HISTORY_BACKFILL` | No | `true` | When `true`, prepend recent channel scrollback (since the bot's last response) to the user message when the bot is mentioned. Recovers context the bot would otherwise miss with `require_mention`. Skipped in DMs and free-response channels. Set to `false` to disable. |
 | `DISCORD_HISTORY_BACKFILL_LIMIT` | No | `50` | Maximum number of messages to scan backwards when assembling the backfill block. In practice the scan usually stops earlier — at the bot's own last message in the channel. |
 | `DISCORD_REPLY_TO_MODE` | No | `"first"` | Controls reply-reference behavior: `"off"` — never reply to the original message, `"first"` — reply-reference on the first message chunk only (default), `"all"` — reply-reference on every chunk. |
@@ -313,6 +314,7 @@ discord:
   reactions: true                 # Add emoji reactions during processing
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
+  force_thread_channels: []       # Free-response channel IDs that auto-thread anyway
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
   history_backfill_limit: 50      # Max messages to scan backwards (default: 50)
   channel_prompts: {}             # Per-channel ephemeral system prompts
@@ -366,7 +368,7 @@ discord:
 
 If a thread's parent channel is in this list, the thread also becomes mention-free.
 
-Free-response channels also **skip auto-threading** — the bot replies inline rather than spinning off a new thread per message. This keeps the channel usable as a lightweight chat surface. If you want threading behavior, don't list the channel as free-response (use normal `@mention` flow instead).
+Free-response channels also **skip auto-threading** — the bot replies inline rather than spinning off a new thread per message. This keeps the channel usable as a lightweight chat surface. If you want a channel that is *both* mention-free **and** threads each conversation (for example a `/bug` or support-intake channel), add it to [`force_thread_channels`](#discordforce_thread_channels) as well.
 
 #### `discord.auto_thread`
 
@@ -374,7 +376,7 @@ Free-response channels also **skip auto-threading** — the bot replies inline r
 
 When enabled, every `@mention` in a regular text channel automatically creates a new thread for the conversation. This keeps the main channel clean and gives each conversation its own isolated session history. Once a thread is created, subsequent messages in that thread don't require `@mention` — the bot knows it's already participating. Set [`thread_require_mention`](#discordthread_require_mention) to `true` to disable this in-thread shortcut for multi-bot setups.
 
-Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead.
+Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead — unless a free-response channel is also listed in [`force_thread_channels`](#discordforce_thread_channels), which opts it back into threading.
 
 #### `discord.reactions`
 
@@ -420,6 +422,32 @@ discord:
 ```
 
 Useful for channels dedicated to bot interaction where threads would add unnecessary noise.
+
+#### `discord.force_thread_channels`
+
+**Type:** string or list — **Default:** `[]`
+
+Channel IDs that auto-create a thread **even when the channel is free-response**. This is the inverse of [`no_thread_channels`](#discordno_thread_channels), and it exists to resolve a specific tension:
+
+- [`free_response_channels`](#discordfree_response_channels) makes a channel **mention-free** — but as a side effect it also **skips auto-threading**, so replies land inline.
+- For an intake-style channel (a `/bug` reporter, a support desk, a help channel), you often want **both**: people post without `@mention`ing the bot, *and* each report gets its own thread so the conversation — and any agent progress posted back — stays isolated from the main channel.
+
+Listing a channel in **both** `free_response_channels` and `force_thread_channels` gives you exactly that: mention-free intake that still threads each conversation.
+
+```yaml
+discord:
+  free_response_channels:
+    - 1234567890   # #bugs — no @mention needed
+  force_thread_channels:
+    - 1234567890   # …and still thread each report
+```
+
+Precedence and interactions:
+
+- **`no_thread_channels` wins.** If a channel somehow appears in both `no_thread_channels` and `force_thread_channels`, it does **not** thread — the explicit "no thread" opt-out takes priority.
+- **Requires `auto_thread: true`** (the default). When auto-threading is globally disabled, `force_thread_channels` has no effect.
+- **Doesn't override the other thread-suppression guards.** Reply messages and voice-linked text channels still skip auto-threading regardless of this list.
+- **Only matters for free-response channels.** A normal (mention-gated) channel already auto-threads on `@mention`, so listing it here is a harmless no-op.
 
 #### `discord.channel_prompts`
 


### PR DESCRIPTION
## What does this PR do?

Adds a `force_thread_channels` Discord knob so a **free-response channel can also auto-thread**.

Today the two settings are mutually exclusive by construction:

- `free_response_channels` makes a channel **mention-free** (the bot replies without an `@mention`)…
- …but as a side effect it **skips auto-threading**, so replies land inline in the channel.

That's the right default for a lightweight chat surface, but it makes a common, useful setup impossible: an **intake-style channel** — a `/bug` reporter, a support desk, a help channel — that is *both* mention-free **and** spins each conversation into its own thread, so the discussion (and any agent progress posted back) stays isolated from the main channel. The current docs even spell out the limitation: *"If you want threading behavior, don't list the channel as free-response."*

`force_thread_channels` is the precise inverse of the existing `no_thread_channels` knob: it opts a free-response channel **back into** auto-threading. List a channel in both `free_response_channels` and `force_thread_channels` and you get mention-free intake that still threads each conversation.

This is the right approach because it (a) mirrors the existing `no_thread_channels` opt-out exactly (same env/YAML plumbing, same CSV-or-list parsing, same precedence story), (b) is fully backward-compatible — unset means today's behavior, and (c) changes a single boolean in the existing `skip_thread` decision rather than restructuring the threading path.

## Related Issue

No existing issue — happy to open one if preferred. The change is small, additive, and backward-compatible.

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`plugins/platforms/discord/adapter.py`**
  - `_handle_message`: read `DISCORD_FORCE_THREAD_CHANNELS`; a free-response channel listed there no longer sets `skip_thread`, so it auto-threads. `no_thread_channels` still wins; the independent voice-linked and reply-message guards are untouched.
  - `_apply_yaml_config`: bridge `discord.force_thread_channels` (CSV string or YAML list) → `DISCORD_FORCE_THREAD_CHANNELS`, env var wins over YAML — identical to the sibling channel-list keys.
  - Updated the inline config-doc comments + the two env-var enumeration docstrings.
- **`tests/gateway/test_discord_channel_controls.py`** — 9 new tests (see below).
- **`website/docs/user-guide/messaging/discord.md`** — config table, env table, a dedicated `force_thread_channels` section, and corrected the `auto_thread`/`free_response_channels` prose that previously said the two were mutually exclusive.
- **`website/docs/reference/environment-variables.md`** — `DISCORD_FORCE_THREAD_CHANNELS` row.
- **`cli-config.yaml.example`** — documented the new key in the `discord:` block.

## How to Test

Automated (CI-parity wrapper):

```bash
scripts/run_tests.sh tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_free_response.py
# 64 passed, 0 failed
```

The new tests cover:

1. **The fix** — a free-response channel also in `force_thread_channels` auto-threads, and is still mention-free (no `@mention` in the test message).
2. **Regression guard** — a free-response channel *not* in `force_thread_channels` still replies inline (`chat_type == "group"`).
3. **Precedence** — a channel in both `no_thread_channels` and `force_thread_channels` does **not** thread (the no-thread opt-out wins).
4. **Kill switch** — `force_thread_channels` is a no-op when `auto_thread` is globally `false`.
5. **CSV parsing** — multiple IDs from a comma-separated value each thread.
6. **YAML→env bridge** + env-precedence (list form and CSV form).

I also verified the behavioral tests are **non-vacuous**: reverting just the `skip_thread` line to the old logic makes `test_force_thread_channel_threads_despite_free_response` and `test_force_thread_channels_csv_parsing` fail (awaited 0 times), confirming the tests actually exercise the new path.

Manual:

```yaml
discord:
  free_response_channels:
    - 123456789012345678   # #bugs — no @mention needed
  force_thread_channels:
    - 123456789012345678   # …and thread each report
```

Post a plain message (no mention) in that channel → the bot opens a thread and responds there instead of inline.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(discord): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (closest is #41283 *pre-title auto-threads*, which touches auto-thread titling, not the `skip_thread`/free-response decision — no overlap)
- [x] My PR contains **only** changes related to this feature (single commit, 5 files)
- [x] I've run the test suite and all tests pass (`scripts/run_tests.sh`, 64 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/`, inline comments, docstrings)
- [x] I've updated `cli-config.yaml.example` (added the `force_thread_channels` key)
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` if I changed architecture or workflows — N/A (no architectural change)
- [x] Cross-platform impact — N/A (config-string parsing only, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (gateway adapter, not a tool)
