### PR TITLE
fix(desktop): add tooltips to right sidebar header buttons

### DIFF
--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -173,7 +173,7 @@ function FilesystemTab({
           disabled={!hasCwd || loading}
           onClick={onRefresh}
           size="icon-xs"
-		  title={r.refreshTree}
+          title={r.refreshTree}
           variant="ghost"
         >
           <Codicon name="refresh" size="0.8125rem" spinning={loading} />
@@ -183,7 +183,7 @@ function FilesystemTab({
           className={HEADER_ACTION_CLASS}
           onClick={() => void onChangeFolder()}
           size="icon-xs"
-		  title={r.openFolder}
+          title={r.openFolder}
           variant="ghost"
         >
           <Codicon name="folder-opened" size="0.8125rem" />
@@ -194,7 +194,7 @@ function FilesystemTab({
           disabled={!hasCwd || !canCollapse}
           onClick={onCollapseAll}
           size="icon-xs"
-		  title={r.collapseAll}
+          title={r.collapseAll}
           variant="ghost"
         >
           <Codicon name="collapse-all" size="0.8125rem" />

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -173,6 +173,7 @@ function FilesystemTab({
           disabled={!hasCwd || loading}
           onClick={onRefresh}
           size="icon-xs"
+		  title={r.refreshTree}
           variant="ghost"
         >
           <Codicon name="refresh" size="0.8125rem" spinning={loading} />
@@ -182,6 +183,7 @@ function FilesystemTab({
           className={HEADER_ACTION_CLASS}
           onClick={() => void onChangeFolder()}
           size="icon-xs"
+		  title={r.openFolder}
           variant="ghost"
         >
           <Codicon name="folder-opened" size="0.8125rem" />
@@ -192,6 +194,7 @@ function FilesystemTab({
           disabled={!hasCwd || !canCollapse}
           onClick={onCollapseAll}
           size="icon-xs"
+		  title={r.collapseAll}
           variant="ghost"
         >
           <Codicon name="collapse-all" size="0.8125rem" />

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -178,6 +178,7 @@ AUTHOR_MAP = {
     "scubamount@users.noreply.github.com": "scubamount",
     "251514042+youngstar-eth@users.noreply.github.com": "youngstar-eth",
     "155192176+alelpoan@users.noreply.github.com": "alelpoan",
+    "alelpoan@proton.me": "alelpoan",
     "aman@abacus.ai": "Aman113114-IITD",
     "octavio.turra@gmail.com": "octavioturra",
     "524706+Twanislas@users.noreply.github.com": "Twanislas",


### PR DESCRIPTION
## Summary
The three right-sidebar header icon buttons (Refresh, Open Folder, Collapse All) now show a hover tooltip — previously they only had `aria-label` (screen-reader only), so newcomers got no visible hint of what each button does.

Salvages #49697 by @alelpoan onto current `main`.

## Changes
- `apps/desktop/src/app/right-sidebar/index.tsx`: add `title={r.refreshTree/openFolder/collapseAll}` to the three header buttons (i18n keys already existed).
- `scripts/release.py`: map `alelpoan@proton.me` in the author map.

## Follow-up over the original PR
- Re-indented the contributor's three lines from tabs to spaces via prettier so `prettier --check` passes.

## Validation
| | Before | After |
|---|---|---|
| Hover tooltip on the 3 buttons | none | shows localized label |
| `prettier --check` on the file | fails (tabs) | passes |

Original PR: #49697

## Infographic

![tooltips-for-the-sidebar](https://v3b.fal.media/files/b/0a9f144f/c_Lmjid3nQR97iXm8y3lq_VK1pNMkB.png)
