### PR TITLE
fix(goals): keep gateway goals alive across streaming and compression

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -613,6 +613,25 @@ def compress_context(
             # refresh the stored system prompt and reset the flush cursor so the
             # next turn re-bases its append diff.
             agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+
+            # Goal state is keyed by ``goal:<session_id>``.  When compression
+            # rotates the physical session id, copy unfinished /goal state so the
+            # child session keeps judging and /goal status remains accurate.  In
+            # in-place compaction there is no new key to migrate to.  See #33618.
+            try:
+                _goal_old_sid = locals().get("old_session_id")
+                if _goal_old_sid:
+                    from hermes_cli.goals import migrate_goal
+
+                    if migrate_goal(_goal_old_sid, agent.session_id):
+                        logger.info(
+                            "Migrated /goal state after compression: %s -> %s",
+                            _goal_old_sid,
+                            agent.session_id,
+                        )
+            except Exception as goal_err:
+                logger.debug("goal migration on compression failed: %s", goal_err)
+
             agent._last_flushed_db_idx = 0
         except Exception as e:
             logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9838,6 +9838,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                         )
+                    # The normal post-turn /goal hook lives in the caller and
+                    # only sees this method's return value.  For streamed turns
+                    # we return None below to avoid duplicate delivery, so run
+                    # the hook here while the final response text is still
+                    # available.  Without this, streamed gateway sessions keep
+                    # showing an active goal at 0/N turns but never enqueue the
+                    # next continuation.
+                    try:
+                        await self._post_turn_goal_continuation(
+                            session_entry=session_entry,
+                            source=source,
+                            final_response=response,
+                        )
+                    except Exception as _goal_exc:
+                        logger.debug("goal continuation hook failed after streamed delivery: %s", _goal_exc)
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
                 # Send it now as a small trailing message so Telegram/Discord/etc.

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -279,6 +279,46 @@ def clear_goal(session_id: str) -> None:
     save_goal(session_id, state)
 
 
+def migrate_goal(old_session_id: str, new_session_id: str) -> bool:
+    """Copy unfinished /goal state across a compression session rotation.
+
+    Goal state is keyed by ``goal:<session_id>``.  Context compression ends
+    the physical parent session and continues the same logical conversation on
+    a child ``session_id``.  Without copying this row, ``GoalManager`` bound to
+    the child sees no active goal and the continuation loop silently stops.
+
+    This helper is deliberately conservative and fail-soft:
+    - only active/paused goals migrate;
+    - an existing non-cleared destination goal is never overwritten;
+    - missing/empty/identical ids are no-ops;
+    - persistence errors are logged and reported as ``False``.
+    """
+    old_session_id = (old_session_id or "").strip()
+    new_session_id = (new_session_id or "").strip()
+    if not old_session_id or not new_session_id or old_session_id == new_session_id:
+        return False
+
+    try:
+        state = load_goal(old_session_id)
+        if state is None or state.status not in {"active", "paused"}:
+            return False
+
+        existing = load_goal(new_session_id)
+        if existing is not None and existing.status != "cleared":
+            return False
+
+        save_goal(new_session_id, state)
+        return True
+    except Exception as exc:
+        logger.debug(
+            "GoalManager: migrate_goal(%s -> %s) failed: %s",
+            old_session_id,
+            new_session_id,
+            exc,
+        )
+        return False
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Judge
 # ──────────────────────────────────────────────────────────────────────
@@ -907,6 +947,7 @@ __all__ = [
     "load_goal",
     "save_goal",
     "clear_goal",
+    "migrate_goal",
     "judge_goal",
     "run_kanban_goal_loop",
 ]

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -252,6 +252,48 @@ class TestGoalManager:
         assert mgr2.state.goal == "do the thing"
         assert mgr2.is_active()
 
+    def test_migrate_goal_preserves_unfinished_goal_after_compression_split(self, hermes_home):
+        """Regression guard for #33618: /goal survives session_id rotation."""
+        from hermes_cli.goals import GoalManager, migrate_goal
+
+        old_sid = "compress-parent-sid"
+        new_sid = "compress-child-sid"
+
+        old_mgr = GoalManager(session_id=old_sid, default_max_turns=99)
+        old_mgr.set("ship the feature")
+        old_mgr.evaluate_after_turn("progress", user_initiated=True)
+        old_mgr.pause(reason="waiting for input")
+
+        assert migrate_goal(old_sid, new_sid) is True
+
+        new_mgr = GoalManager(session_id=new_sid)
+        assert new_mgr.state is not None
+        assert new_mgr.state.goal == "ship the feature"
+        assert new_mgr.state.status == "paused"
+        assert new_mgr.state.turns_used == 1
+        assert new_mgr.state.max_turns == 99
+        assert new_mgr.state.paused_reason == "waiting for input"
+        assert new_mgr.has_goal()
+
+    def test_migrate_goal_noops_for_terminal_or_existing_destination(self, hermes_home):
+        from hermes_cli.goals import GoalManager, migrate_goal
+
+        done_mgr = GoalManager(session_id="done-parent")
+        done_mgr.set("already done")
+        done_mgr.mark_done("finished")
+        assert migrate_goal("done-parent", "done-child") is False
+        assert GoalManager(session_id="done-child").state is None
+
+        source_mgr = GoalManager(session_id="source-parent")
+        source_mgr.set("source goal")
+        dest_mgr = GoalManager(session_id="existing-child")
+        dest_mgr.set("existing goal")
+
+        assert migrate_goal("source-parent", "existing-child") is False
+        preserved = GoalManager(session_id="existing-child").state
+        assert preserved is not None
+        assert preserved.goal == "existing goal"
+
     def test_evaluate_after_turn_done(self, hermes_home):
         """Judge says done → status=done, no continuation."""
         from hermes_cli import goals


### PR DESCRIPTION
## Summary
- add a conservative `migrate_goal(old_session_id, new_session_id)` helper for active/paused `/goal` state
- call it when context compression rotates the physical session id, while leaving in-place compaction unchanged
- run the post-turn goal continuation hook before returning from already-streamed gateway replies, so Telegram/streamed sessions do not stay stuck at `0/N turns`
- do not overwrite an existing child-session goal and no-op for terminal goals

Fixes #33618. Related to #48956, #45059, and #18467.

## Test plan
- `PYTHONPATH=. /opt/homebrew/bin/pytest tests/hermes_cli/test_goals.py::TestGoalManager::test_migrate_goal_preserves_unfinished_goal_after_compression_split tests/hermes_cli/test_goals.py::TestGoalManager::test_migrate_goal_noops_for_terminal_or_existing_destination -q -o 'addopts='`
- `PYTHONPATH=. /opt/homebrew/bin/pytest tests/hermes_cli/test_goals.py -q -o 'addopts='`
- `PYTHONPATH=. /opt/homebrew/bin/pytest tests/run_agent/test_compression_persistence.py tests/run_agent/test_compression_boundary.py tests/gateway/test_compression_session_id_persistence.py -q -o 'addopts='`
- `PYTHONPATH=. python -m py_compile gateway/run.py`
- `PYTHONPATH=. /opt/homebrew/bin/pytest tests/hermes_cli/test_goals.py tests/gateway/test_goal_verdict_send.py tests/gateway/test_goal_max_turns_config.py -q -o 'addopts='` (async gateway tests skipped locally because pytest-asyncio is not installed)
