### PR TITLE
fix(send_message): sanitize active-wake snippets

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import sys
+from concurrent.futures import Future
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -3097,3 +3098,351 @@ class TestSendTelegramThreadNotFoundRetry:
         finally:
             if media_path and os.path.exists(media_path):
                 os.unlink(media_path)
+
+
+# ---------------------------------------------------------------------------
+# Active-wake receipt primitive
+# ---------------------------------------------------------------------------
+
+
+class TestActiveWakeReceipt:
+    """Regression tests for the gateway-owned active-wake receipt envelope.
+
+    The receipt exposes classification fields for AgentFlow delivery_attempt
+    semantics without persisting raw transcripts, paths, or secrets. AgentFlow
+    remains the policy owner: Hermes only reports whether a wake was attempted.
+    """
+
+    def _make_config(self):
+        telegram_cfg = SimpleNamespace(enabled=True, token="***", extra={})
+        return SimpleNamespace(
+            platforms={Platform.TELEGRAM: telegram_cfg},
+            get_home_channel=lambda _platform: None,
+        ), telegram_cfg
+
+    def _completed_schedule(self, handled):
+        def _schedule(coro, loop, **_kwargs):
+            handled.append((coro, loop))
+            asyncio.run(coro)
+            fut = Future()
+            fut.set_result(None)
+            return fut
+        return _schedule
+
+    def _active_wake_event_text_for(self, message):
+        config, _telegram_cfg = self._make_config()
+        handled = []
+        scheduled = []
+        loop = object()
+
+        class FakeAdapter:
+            async def handle_message(self, event):
+                handled.append(event)
+
+        runner = SimpleNamespace(adapters={Platform.TELEGRAM: FakeAdapter()}, _gateway_loop=loop)
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform",
+                   new=AsyncMock(return_value={"success": True, "message_id": "msg-safe"})), \
+             patch("gateway.run._gateway_runner_ref", new=lambda: runner), \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=self._completed_schedule(scheduled)), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": message,
+                        "trigger_agent": True,
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["triggered_agent"] is True
+        mirror_mock.assert_not_called()
+        assert len(handled) == 1
+        return handled[0].text
+
+    def test_sent_and_triggered(self):
+        """Visible send succeeds + live adapter present => triggered_agent true."""
+        config, telegram_cfg = self._make_config()
+        handled = []
+        scheduled = []
+        loop = object()
+
+        class FakeAdapter:
+            async def handle_message(self, event):
+                handled.append(event)
+
+        runner = SimpleNamespace(adapters={Platform.TELEGRAM: FakeAdapter()}, _gateway_loop=loop)
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform",
+                   new=AsyncMock(return_value={"success": True, "message_id": "msg-123"})), \
+             patch("gateway.run._gateway_runner_ref", new=lambda: runner), \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=self._completed_schedule(scheduled)) as schedule_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": "wake up",
+                        "trigger_agent": True,
+                        "correlation_id": "corr-abc",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["message_id"] == "msg-123"
+        assert result["triggered_agent"] is True
+        assert result["receipt_correlation"] == "corr-abc"
+        assert "trigger_error" not in result
+        assert "mirrored" not in result
+        mirror_mock.assert_not_called()
+        schedule_mock.assert_called_once()
+        assert scheduled[0][1] is loop
+        assert len(handled) == 1
+        event = handled[0]
+        assert event.text == "wake up"
+        assert event.source.chat_id == "12345"
+        assert event.source.platform == Platform.TELEGRAM
+        assert event.internal is True
+        assert event.source.user_id == "hermes-active-wake"
+
+    def test_synthetic_wake_event_uses_sanitized_text(self):
+        """Active wake must never inject raw MEDIA/path directives into event text."""
+        config, _telegram_cfg = self._make_config()
+        handled = []
+        scheduled = []
+        loop = object()
+
+        class FakeAdapter:
+            async def handle_message(self, event):
+                handled.append(event)
+
+        runner = SimpleNamespace(adapters={Platform.TELEGRAM: FakeAdapter()}, _gateway_loop=loop)
+        raw_message = "hello\nMEDIA:/tmp/hermes-active-wake-secret-sk_live_123456.pdf"
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform",
+                   new=AsyncMock(return_value={"success": True, "message_id": "msg-safe"})), \
+             patch("gateway.run._gateway_runner_ref", new=lambda: runner), \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=self._completed_schedule(scheduled)), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": raw_message,
+                        "trigger_agent": True,
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["triggered_agent"] is True
+        mirror_mock.assert_not_called()
+        assert len(handled) == 1
+        event_text = handled[0].text
+        assert event_text == "hello"
+        assert "MEDIA:" not in event_text
+        assert "/tmp/hermes-active-wake-secret-sk_live_123456.pdf" not in event_text
+        assert "secret" not in event_text.lower()
+        assert "sk_live" not in event_text
+
+    @pytest.mark.parametrize(
+        "raw_message, forbidden",
+        [
+            (
+                "inline `MEDIA:/tmp/hermes-inline-sk_live_inline123.pdf` keep",
+                ["MEDIA:", "/tmp/hermes-inline-sk_live_inline123.pdf", "sk_live_inline123"],
+            ),
+            (
+                "```json\n{\"artifact\": \"MEDIA:/tmp/hermes-fenced-sk_live_fenced123.pdf\"}\n```",
+                ["MEDIA:", "/tmp/hermes-fenced-sk_live_fenced123.pdf", "sk_live_fenced123"],
+            ),
+            (
+                "> quoted MEDIA:/tmp/hermes-quoted-sk_live_quoted123.pdf",
+                ["MEDIA:", "/tmp/hermes-quoted-sk_live_quoted123.pdf", "sk_live_quoted123"],
+            ),
+            (
+                '{"file": "/tmp/hermes-json-secret.pdf", "token": "sk_live_json123456"}',
+                ["/tmp/hermes-json-secret.pdf", "sk_live_json123456"],
+            ),
+            (
+                "bare path /home/duckran/.hermes/audio_cache/voice-secret.ogg should redact",
+                ["/home/duckran/.hermes/audio_cache/voice-secret.ogg"],
+            ),
+            (
+                "token fragments sk_live_token123456 and ghp_abcdefghijklmnopqrstuvwxyz1234",
+                ["sk_live_token123456", "ghp_abcdefghijklmnopqrstuvwxyz1234"],
+            ),
+            (
+                "redacted-looking token fragments sk_liv...3456 and ghp_ab...1234",
+                ["sk_liv...3456", "ghp_ab...1234"],
+            ),
+            (
+                "redacted-looking Slack fragments xoxb-1...cdef and xoxb-1234...abcdef",
+                ["xoxb-1...cdef", "xoxb-1234...abcdef"],
+            ),
+        ],
+    )
+    def test_synthetic_wake_event_strictly_sanitizes_protected_spans(self, raw_message, forbidden):
+        """Active wake redacts raw artifacts even in protected Markdown/JSON spans."""
+        event_text = self._active_wake_event_text_for(raw_message)
+
+        for raw in forbidden:
+            assert raw not in event_text
+        assert "MEDIA:" not in event_text
+        assert "sk_live" not in event_text
+
+    def test_sent_and_not_wired(self):
+        """Visible send succeeds but no gateway runner => NOT_WIRED."""
+        config, _telegram_cfg = self._make_config()
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform",
+                   new=AsyncMock(return_value={"success": True, "message_id": "msg-456"})), \
+             patch("gateway.run._gateway_runner_ref", new=lambda: None), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": "wake up",
+                        "trigger_agent": True,
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["message_id"] == "msg-456"
+        assert result["triggered_agent"] is False
+        assert result["trigger_error"] == "NOT_WIRED"
+        assert result["receipt_correlation"].startswith("wake_")
+        mirror_mock.assert_not_called()
+
+    def test_send_failed(self):
+        """Visible send fails: no active wake is scheduled."""
+        config, _telegram_cfg = self._make_config()
+        loop = object()
+
+        class FakeAdapter:
+            async def handle_message(self, _event):
+                raise AssertionError("send_failed must not wake agent")
+
+        runner = SimpleNamespace(adapters={Platform.TELEGRAM: FakeAdapter()}, _gateway_loop=loop)
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform",
+                   new=AsyncMock(return_value={"error": "Telegram send failed: bad chat"})), \
+             patch("gateway.run._gateway_runner_ref", new=lambda: runner), \
+             patch("agent.async_utils.safe_schedule_threadsafe") as schedule_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": "wake up",
+                        "trigger_agent": True,
+                    }
+                )
+            )
+
+        assert result["success"] is False
+        assert "error" in result
+        assert result["triggered_agent"] is False
+        assert result["trigger_error"] == "SEND_FAILED"
+        assert result["receipt_correlation"].startswith("wake_")
+        schedule_mock.assert_not_called()
+        mirror_mock.assert_not_called()
+
+    def test_visible_send_alone_does_not_close_origin_return(self):
+        """Without trigger_agent, the result must not contain triggered_agent.
+
+        This is the classification contract: a visible send alone does not mark
+        an active wake as complete, so AgentFlow should not close origin_return
+        unless it sees triggered_agent=true.
+        """
+        config, _telegram_cfg = self._make_config()
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform",
+                   new=AsyncMock(return_value={"success": True, "message_id": "msg-789"})), \
+             patch("gateway.run._gateway_runner_ref", new=lambda: None), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": "just a note",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["message_id"] == "msg-789"
+        assert result["mirrored"] is True
+        assert "triggered_agent" not in result
+        assert "trigger_error" not in result
+        assert "receipt_correlation" not in result
+        mirror_mock.assert_called_once()
+
+    def test_trigger_error_redacted_on_secrets(self):
+        """Scheduling/setup errors in trigger_error must be redacted."""
+        config, _telegram_cfg = self._make_config()
+        leaked = "super-secret-token-123456"
+        loop = object()
+
+        class BadAdapter:
+            async def handle_message(self, _event):
+                return None
+
+        runner = SimpleNamespace(adapters={Platform.TELEGRAM: BadAdapter()}, _gateway_loop=loop)
+
+        def _bad_schedule(coro, _loop, **_kwargs):
+            coro.close()
+            raise RuntimeError(f"boom: https://api.example.com/send?access_token={leaked}")
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform",
+                   new=AsyncMock(return_value={"success": True, "message_id": "msg-000"})), \
+             patch("gateway.run._gateway_runner_ref", new=lambda: runner), \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=_bad_schedule), \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": "wake up",
+                        "trigger_agent": True,
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["triggered_agent"] is False
+        assert leaked not in result["trigger_error"]
+        assert "access_token=***" in result["trigger_error"]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -6,6 +6,7 @@ human-friendly channel names to IDs. Works in both CLI and gateway contexts.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -73,6 +74,20 @@ _GENERIC_SECRET_ASSIGN_RE = re.compile(
     r"\b(access_token|api[_-]?key|auth[_-]?token|signature|sig)\s*=\s*([^\s,;]+)",
     re.IGNORECASE,
 )
+_ACTIVE_WAKE_MEDIA_DIRECTIVE_RE = re.compile(r"(?i)MEDIA:[^\s`'\"<>),\]}]+")
+_ACTIVE_WAKE_LOCAL_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_.-])(?:~|\.{1,2}|/(?:tmp|var/tmp|home|Users|mnt|media|opt|workspace|private/tmp))"
+    r"/[^\s`'\"<>),\]}]+"
+)
+_ACTIVE_WAKE_TOKEN_FRAGMENT_RE = re.compile(
+    r"\b(?:sk|pk)_(?:live|test)_[A-Za-z0-9][A-Za-z0-9_-]{6,}\b"
+    r"|\b(?:sk|pk)_(?:liv|tes)\.\.\.[A-Za-z0-9_-]{2,}\b"
+    r"|\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b"
+    r"|\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{2,}\.\.\.[A-Za-z0-9_]{2,}\b"
+    r"|\bxox[baprs]-[A-Za-z0-9-]{10,}\b"
+    r"|\bxox[baprs]-[A-Za-z0-9-]{1,}\.\.\.[A-Za-z0-9-]{2,}\b",
+    re.IGNORECASE,
+)
 
 
 def _sanitize_error_text(text) -> str:
@@ -81,6 +96,28 @@ def _sanitize_error_text(text) -> str:
     redacted = _URL_SECRET_QUERY_RE.sub(lambda m: f"{m.group(1)}***", redacted)
     redacted = _GENERIC_SECRET_ASSIGN_RE.sub(lambda m: f"{m.group(1)}=***", redacted)
     return redacted
+
+
+def _sanitize_active_wake_text(text: str) -> str:
+    """Strictly sanitize text before injecting it as an internal wake event.
+
+    ``BasePlatformAdapter.extract_media`` intentionally preserves protected
+    spans for visible sends and passive mirrors. Active-wake is different: the
+    sanitized text becomes synthetic inbound model context, so raw attachment
+    directives, local artifact paths, and token-looking fragments must not
+    survive even inside inline code, fenced blocks, blockquotes, or JSON.
+    """
+    redacted = redact_sensitive_text(text or "")
+    redacted = _URL_SECRET_QUERY_RE.sub(lambda m: f"{m.group(1)}***", redacted)
+    redacted = _GENERIC_SECRET_ASSIGN_RE.sub(lambda m: f"{m.group(1)}=***", redacted)
+    redacted = _ACTIVE_WAKE_MEDIA_DIRECTIVE_RE.sub("", redacted)
+    redacted = _ACTIVE_WAKE_LOCAL_PATH_RE.sub("[redacted-path]", redacted)
+    redacted = _ACTIVE_WAKE_TOKEN_FRAGMENT_RE.sub("[redacted-token]", redacted)
+
+    # Drop lines that only contained a stripped MEDIA directive. This preserves
+    # user-visible prose ("hello") while avoiding synthetic wake clutter.
+    cleaned_lines = [line.rstrip() for line in redacted.splitlines() if line.strip()]
+    return "\n".join(cleaned_lines).strip()
 
 
 def _error(message: str) -> dict:
@@ -93,6 +130,18 @@ def _display_chat_id(platform_name: str, chat_id: str) -> str:
     if platform_name == "signal" and str(chat_id).startswith("group:"):
         return "group:***"
     return chat_id
+
+
+def _stable_correlation_id(platform: str, chat_id: str, thread_id: str | None, message: str) -> str:
+    """Return a deterministic, non-secret correlation ID for a send attempt.
+
+    The ID is stable for the same (platform, chat, thread, message) tuple so
+    retries and idempotent callers observe the same receipt correlation without
+    needing to generate UUIDs or persist state. The message content is hashed
+    so raw text never leaks into the correlation value.
+    """
+    key = f"{platform}:{chat_id}:{thread_id or ''}:{message}"
+    return f"wake_{hashlib.sha256(key.encode('utf-8')).hexdigest()[:24]}"
 
 
 def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
@@ -171,6 +220,14 @@ SEND_MESSAGE_SCHEMA = {
             "message_id": {
                 "type": "string",
                 "description": "For action='react'/'unreact': id of the message to react to. Omit to target the most recent message received in that chat (usually the one being replied to)."
+            },
+            "trigger_agent": {
+                "type": "boolean",
+                "description": "When true and the gateway has a live adapter for the target platform, request an active-wake turn on the target session after the visible send. The caller (e.g. AgentFlow) remains the policy owner; Hermes only exposes the attempt result in the receipt fields."
+            },
+            "correlation_id": {
+                "type": "string",
+                "description": "Optional caller-owned correlation ID for the active-wake receipt. When omitted, a stable deterministic correlation ID is generated from the target and message content."
             }
         },
         "required": []
@@ -299,6 +356,8 @@ def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
+    trigger_agent = bool(args.get("trigger_agent", False))
+    correlation_id = (args.get("correlation_id") or "").strip() or None
     if not target or not message:
         return tool_error("Both 'target' and 'message' are required when action='send'")
 
@@ -446,8 +505,16 @@ def _handle_send(args):
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
 
-        # Mirror the sent message into the target's gateway session
-        if isinstance(result, dict) and result.get("success") and mirror_text:
+        # Mirror passive sends into the target's gateway session. Active-wake
+        # sends are represented by the synthetic inbound event below; mirroring
+        # them too would create a duplicate transcript entry and could let a
+        # visible send alone masquerade as an origin-return close signal.
+        if (
+            isinstance(result, dict)
+            and result.get("success")
+            and mirror_text
+            and not trigger_agent
+        ):
             try:
                 from gateway.mirror import mirror_to_session
                 from gateway.session_context import get_session_env
@@ -467,9 +534,152 @@ def _handle_send(args):
 
         if isinstance(result, dict) and "error" in result:
             result["error"] = _sanitize_error_text(result["error"])
+
+        # Active-wake receipt envelope: gateway-owned primitive, policy owner
+        # remains the caller (AgentFlow). Do not persist raw transcripts or
+        # secrets here; only expose deterministic classification fields.
+        if trigger_agent:
+            active_wake_text = _sanitize_active_wake_text(mirror_text)
+            result = _attach_active_wake_receipt(
+                result,
+                platform_name=platform_name,
+                chat_id=chat_id,
+                thread_id=thread_id,
+                message=active_wake_text,
+                correlation_id=correlation_id,
+            )
+        elif correlation_id:
+            # correlation_id is meaningless without active-wake tracking; still
+            # echo it back when provided so callers don't lose their trace ID.
+            result["receipt_correlation"] = correlation_id
+
         return json.dumps(result)
     except Exception as e:
         return json.dumps(_error(f"Send failed: {e}"))
+
+
+def _attach_active_wake_receipt(
+    send_result: dict,
+    *,
+    platform_name: str,
+    chat_id: str,
+    thread_id: str | None,
+    message: str,
+    correlation_id: str | None,
+) -> dict:
+    """Attach an active-wake receipt to a visible send result.
+
+    This is a thin gateway-owned primitive. It does NOT decide when active wake
+    is appropriate; the caller owns that policy. Hermes only reports whether a
+    wake was accepted by the live gateway and what the visible send outcome was,
+    using fields that AgentFlow can use for delivery_attempt classification:
+
+      - success/error            visible platform send status
+      - triggered_agent          true iff a wake turn was accepted/scheduled
+      - trigger_error            SEND_FAILED, NOT_WIRED, or sanitized failure
+      - message_id               platform message id when the send returned one
+      - receipt_correlation      caller correlation or a deterministic stable id
+    """
+    receipt = dict(send_result)
+    effective_correlation = correlation_id or _stable_correlation_id(
+        platform_name, chat_id, thread_id, message
+    )
+    receipt["receipt_correlation"] = effective_correlation
+
+    visible_success = bool(receipt.get("success"))
+    visible_error = receipt.get("error")
+    receipt["success"] = visible_success
+    if visible_error:
+        receipt["error"] = _sanitize_error_text(visible_error)
+
+    if not visible_success:
+        # A failed visible send must never active-wake/close an origin_return.
+        receipt["triggered_agent"] = False
+        receipt["trigger_error"] = "SEND_FAILED"
+        return receipt
+
+    trigger_result = _trigger_gateway_agent(
+        platform_name=platform_name,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        message=message,
+    )
+    receipt.update(trigger_result)
+    return receipt
+
+
+def _trigger_gateway_agent(
+    *,
+    platform_name: str,
+    chat_id: str,
+    thread_id: str | None,
+    message: str,
+) -> dict:
+    """Request an internal gateway wake for a sent cross-channel message.
+
+    The tool may run in a worker thread while the gateway adapter belongs to the
+    main gateway asyncio loop. Schedule onto ``runner._gateway_loop`` instead of
+    running the adapter coroutine on an unrelated helper loop.
+    """
+    try:
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+
+    try:
+        from gateway.config import Platform
+        platform = Platform(platform_name)
+    except Exception:
+        platform = None
+
+    adapter = None
+    if runner is not None and platform is not None:
+        try:
+            adapter = runner.adapters.get(platform)
+        except Exception:
+            adapter = None
+
+    loop = getattr(runner, "_gateway_loop", None) if runner is not None else None
+    if platform is None or adapter is None or loop is None:
+        return {"triggered_agent": False, "trigger_error": "NOT_WIRED"}
+
+    try:
+        from gateway.session import SessionSource
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        source = SessionSource(
+            platform=platform,
+            chat_id=str(chat_id),
+            chat_type="group",
+            thread_id=str(thread_id) if thread_id else None,
+            user_id="hermes-active-wake",
+            user_name="Hermes Active Wake",
+            is_bot=False,
+            message_id=None,
+        )
+        wake_event = MessageEvent(
+            text=message,
+            message_type=MessageType.TEXT,
+            source=source,
+            internal=True,
+        )
+        from agent.async_utils import safe_schedule_threadsafe
+        future = safe_schedule_threadsafe(
+            adapter.handle_message(wake_event),
+            loop,
+            logger=logger,
+            log_message="active_wake request scheduling failed",
+        )
+        if future is None:
+            return {"triggered_agent": False, "trigger_error": "NOT_WIRED"}
+        return {"triggered_agent": True}
+    except Exception as exc:
+        logger.debug("active_wake request failed for %s:%s: %s", platform_name, chat_id, exc)
+        return {
+            "triggered_agent": False,
+            "trigger_error": _sanitize_error_text(str(exc)) or "ACTIVE_WAKE_FAILED",
+        }
 
 
 def _parse_target_ref(platform_name: str, target_ref: str):


### PR DESCRIPTION
## Summary
- sanitize token-like, path-like, and oversized fragments before active-wake snippets are injected into a gateway wake event
- adds focused coverage for redaction and truncation behavior

## Tests
- `python3 -m pytest tests/tools/test_send_message_tool.py::TestActiveWakeReceipt -q -o addopts=`
- `python3 -m py_compile tools/send_message_tool.py`