### PR TITLE
fix(kanban): surface terminal ACK relay failures

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -416,6 +416,15 @@ class GatewayKanbanWatchersMixin:
                             await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )
+                            await asyncio.to_thread(
+                                self._kanban_record_notify_delivery,
+                                sub,
+                                board_slug,
+                                outcome="delivered",
+                                event_kind=kind,
+                                failure_count=0,
+                                max_failures=MAX_SEND_FAILURES,
+                            )
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
@@ -448,6 +457,16 @@ class GatewayKanbanWatchersMixin:
                         except Exception as exc:
                             fails = sub_fail_counts.get(sub_key, 0) + 1
                             sub_fail_counts[sub_key] = fails
+                            outcome = "terminal_failure" if fails >= MAX_SEND_FAILURES else "retry_failure"
+                            await asyncio.to_thread(
+                                self._kanban_record_notify_delivery,
+                                sub,
+                                board_slug,
+                                outcome=outcome,
+                                event_kind=kind,
+                                failure_count=fails,
+                                max_failures=MAX_SEND_FAILURES,
+                            )
                             logger.warning(
                                 "kanban notifier: send failed for %s on %s "
                                 "(attempt %d/%d): %s",
@@ -459,6 +478,15 @@ class GatewayKanbanWatchersMixin:
                                     "kanban notifier: dropping subscription "
                                     "%s on %s after %d consecutive send failures",
                                     sub["task_id"], platform_str, fails,
+                                )
+                                await asyncio.to_thread(
+                                    self._kanban_record_notify_delivery,
+                                    sub,
+                                    board_slug,
+                                    outcome="subscription_dropped",
+                                    event_kind=kind,
+                                    failure_count=fails,
+                                    max_failures=MAX_SEND_FAILURES,
                                 )
                                 await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
                                 sub_fail_counts.pop(sub_key, None)
@@ -628,6 +656,52 @@ class GatewayKanbanWatchersMixin:
                 thread_id=sub.get("thread_id") or "",
                 claimed_cursor=claimed_cursor,
                 old_cursor=old_cursor,
+            )
+        finally:
+            conn.close()
+
+    def _kanban_record_notify_delivery(
+        self,
+        sub: dict,
+        board: Optional[str],
+        *,
+        outcome: str,
+        event_kind: Optional[str] = None,
+        failure_count: int = 0,
+        max_failures: int = 0,
+    ) -> None:
+        """Sync helper: persist sanitized notifier delivery outcomes.
+
+        This runs exactly at the gateway ``adapter.send`` boundary. It is
+        intentionally separate from task completion because only the gateway
+        can know whether a requested notification target actually delivered,
+        retried, or was dropped after terminal failure.
+        """
+        from hermes_cli import kanban_db as _kb
+        try:
+            conn = _kb.connect(board=board)
+        except Exception as exc:
+            logger.warning(
+                "kanban notifier: could not persist %s delivery outcome for %s: %s",
+                outcome, sub.get("task_id"), exc,
+            )
+            return
+        try:
+            _kb.append_notify_delivery_status(
+                conn,
+                sub["task_id"],
+                outcome=outcome,
+                platform=sub.get("platform"),
+                chat_id=sub.get("chat_id"),
+                thread_id=sub.get("thread_id") or "",
+                event_kind=event_kind,
+                failure_count=failure_count,
+                max_failures=max_failures,
+            )
+        except Exception as exc:
+            logger.warning(
+                "kanban notifier: could not persist %s delivery outcome for %s: %s",
+                outcome, sub.get("task_id"), exc,
             )
         finally:
             conn.close()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3958,6 +3958,96 @@ def _scan_prose_for_phantom_ids(
     return [m for m in unique if m not in existing]
 
 
+# Substrings that, when present in a terminal task's summary / result /
+# metadata, mean the origin wake/ACK relay did NOT reach a live target even
+# though the task itself reached a terminal verdict. Worker CLI sessions
+# frequently cannot send messages, so the gateway relay path is the only way
+# the origin learns the task finished — when that path emits one of these
+# strings the completion is durable but the ACK is missing. Matched
+# case-insensitively. See :func:`classify_ack_relay`.
+ACK_RELAY_FAILURE_PATTERNS: tuple[str, ...] = (
+    "no messaging targets",
+    "origin relay could not be sent",
+    "no live gateway runner",
+)
+
+
+def _parse_task_verdict(text: str) -> Optional[str]:
+    """Extract a ``Verdict: <X>`` token from terminal handoff text.
+
+    Review / fan-in tasks encode their work decision as a ``Verdict:``
+    line (e.g. ``Verdict: GO`` / ``Verdict: BLOCK``). Returns the
+    normalised upper-case token (``-`` folded to ``_``) or ``None`` when
+    no verdict line is present. Deliberately verdict-only: it says
+    nothing about whether the origin was woken — that is ``ack_status``.
+    """
+    if not text:
+        return None
+    m = re.search(r"verdict\s*[:=]\s*([A-Za-z][A-Za-z_-]*)", text, re.IGNORECASE)
+    if not m:
+        return None
+    return m.group(1).strip().upper().replace("-", "_")
+
+
+def classify_ack_relay(
+    summary: Optional[str] = None,
+    result: Optional[str] = None,
+    metadata: Optional[dict] = None,
+    *,
+    notify_subs: Optional[list] = None,
+) -> dict:
+    """Classify a terminal task's handoff into separate verdict + ack signals.
+
+    Returns a dict with:
+
+    * ``task_verdict`` — the work decision (``"GO"`` / ``"BLOCK"`` / …) parsed
+      from a ``Verdict:`` line, or ``None``.
+    * ``ack_status`` — one of:
+        - ``"failed"``: a relay-failure pattern was found in the text/metadata
+          (the origin ACK demonstrably could not be delivered).
+        - ``"ambiguous"``: no failure string, but a verdict is present and
+          ``notify_subs`` was supplied and empty — the origin relay had no
+          target at terminal time (could be delivered-then-removed, or never
+          subscribed; we cannot prove the wake happened).
+        - ``"unknown"``: no positive or negative ACK signal.
+    * ``relay_failure`` — ``True`` iff a failure pattern matched.
+    * ``matched`` — the failure substrings found (lower-cased), in pattern order.
+
+    ``task_verdict`` and ``ack_status`` are intentionally independent so a
+    done BLOCK/GO task is never treated as proof the origin was woken.
+    """
+    haystack_parts: list[str] = []
+    for part in (summary, result):
+        if part:
+            haystack_parts.append(str(part))
+    if isinstance(metadata, dict):
+        try:
+            haystack_parts.append(json.dumps(metadata, ensure_ascii=False))
+        except Exception:
+            haystack_parts.append(str(metadata))
+    haystack = "\n".join(haystack_parts)
+    hay_lower = haystack.lower()
+
+    matched = [p for p in ACK_RELAY_FAILURE_PATTERNS if p in hay_lower]
+    relay_failure = bool(matched)
+
+    verdict = _parse_task_verdict(haystack)
+
+    if relay_failure:
+        ack_status = "failed"
+    elif verdict is not None and notify_subs is not None and len(notify_subs) == 0:
+        ack_status = "ambiguous"
+    else:
+        ack_status = "unknown"
+
+    return {
+        "task_verdict": verdict,
+        "ack_status": ack_status,
+        "relay_failure": relay_failure,
+        "matched": matched,
+    }
+
+
 class HallucinatedCardsError(ValueError):
     """Raised by ``complete_task`` when ``created_cards`` contains ids
     that don't exist or weren't created by the completing worker.
@@ -4169,6 +4259,34 @@ def complete_task(
                     },
                     run_id=run_id,
                 )
+    # Durable ACK/relay classification. The work verdict can be terminal
+    # (done, BLOCK/GO) while the origin wake/ACK relay never reached a
+    # target — worker CLI sessions often cannot send messages, so a relay
+    # failure string in the handoff (or an empty notify list at terminal
+    # time) means the origin may be silently waiting. Record a durable
+    # ``ack_relay_status`` event so diagnostics can surface it; keep
+    # ``task_verdict`` and ``ack_status`` as distinct payload fields so a
+    # done verdict is never mistaken for a delivered ACK. Emitted at most
+    # once per terminal transition (this block only runs when the status
+    # update above flipped exactly one row), so it cannot storm.
+    ack = classify_ack_relay(
+        summary=summary,
+        result=result,
+        metadata=metadata,
+        notify_subs=list_notify_subs(conn, task_id),
+    )
+    if ack["ack_status"] in ("failed", "ambiguous"):
+        with write_txn(conn):
+            _append_event(
+                conn, task_id, "ack_relay_status",
+                {
+                    "ack_status": ack["ack_status"],
+                    "task_verdict": ack["task_verdict"],
+                    "matched": ack["matched"],
+                    "source": "completion",
+                },
+                run_id=run_id,
+            )
     # Successful completion — wipe the consecutive-failures counter.
     # Failure history stays on the event log for audit; the counter
     # just tracks "is there a current pathology the breaker should

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3958,94 +3958,76 @@ def _scan_prose_for_phantom_ids(
     return [m for m in unique if m not in existing]
 
 
-# Substrings that, when present in a terminal task's summary / result /
-# metadata, mean the origin wake/ACK relay did NOT reach a live target even
-# though the task itself reached a terminal verdict. Worker CLI sessions
-# frequently cannot send messages, so the gateway relay path is the only way
-# the origin learns the task finished — when that path emits one of these
-# strings the completion is durable but the ACK is missing. Matched
-# case-insensitively. See :func:`classify_ack_relay`.
-ACK_RELAY_FAILURE_PATTERNS: tuple[str, ...] = (
-    "no messaging targets",
-    "origin relay could not be sent",
-    "no live gateway runner",
+# Outcomes recorded by the gateway notifier at the *actual* delivery
+# boundary (gateway/kanban_watchers.py). These are the only trustworthy
+# signal that an origin ACK/relay was or was not delivered — the worker's
+# completion prose says nothing about whether ``adapter.send`` reached a
+# live chat. See :func:`append_notify_delivery_status`.
+NOTIFY_DELIVERY_OUTCOMES: tuple[str, ...] = (
+    "delivered",
+    "retry_failure",
+    "terminal_failure",
+    "subscription_dropped",
 )
 
+# Event kind for the sanitized notify-delivery outcome rows.
+NOTIFY_DELIVERY_EVENT_KIND = "notify_delivery_status"
 
-def _parse_task_verdict(text: str) -> Optional[str]:
-    """Extract a ``Verdict: <X>`` token from terminal handoff text.
 
-    Review / fan-in tasks encode their work decision as a ``Verdict:``
-    line (e.g. ``Verdict: GO`` / ``Verdict: BLOCK``). Returns the
-    normalised upper-case token (``-`` folded to ``_``) or ``None`` when
-    no verdict line is present. Deliberately verdict-only: it says
-    nothing about whether the origin was woken — that is ``ack_status``.
+def _notify_target_hash(platform: Optional[str], chat_id: Optional[str]) -> str:
+    """Stable, non-reversible fingerprint for a delivery target.
+
+    We deliberately never persist the raw ``chat_id`` (it can be a phone
+    number, DM id, or other PII) in a diagnostic event. Hash the
+    ``platform:chat_id`` pair so repeated failures against the same target
+    coalesce while the identifier itself stays out of the durable log.
     """
-    if not text:
-        return None
-    m = re.search(r"verdict\s*[:=]\s*([A-Za-z][A-Za-z_-]*)", text, re.IGNORECASE)
-    if not m:
-        return None
-    return m.group(1).strip().upper().replace("-", "_")
+    material = f"{platform or ''}:{chat_id or ''}".encode("utf-8", "replace")
+    return hashlib.sha256(material).hexdigest()[:16]
 
 
-def classify_ack_relay(
-    summary: Optional[str] = None,
-    result: Optional[str] = None,
-    metadata: Optional[dict] = None,
+def append_notify_delivery_status(
+    conn: sqlite3.Connection,
+    task_id: str,
     *,
-    notify_subs: Optional[list] = None,
-) -> dict:
-    """Classify a terminal task's handoff into separate verdict + ack signals.
+    outcome: str,
+    platform: Optional[str] = None,
+    chat_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    event_kind: Optional[str] = None,
+    failure_count: int = 0,
+    max_failures: int = 0,
+    run_id: Optional[int] = None,
+) -> None:
+    """Durably record a notify-delivery outcome observed at the gateway
+    ``adapter.send`` boundary.
 
-    Returns a dict with:
+    This is the *only* place origin ACK/relay delivery is classified: the
+    gateway notifier knows whether ``adapter.send`` actually raised, retried,
+    or exhausted its retry budget. ``outcome`` is one of
+    :data:`NOTIFY_DELIVERY_OUTCOMES`.
 
-    * ``task_verdict`` — the work decision (``"GO"`` / ``"BLOCK"`` / …) parsed
-      from a ``Verdict:`` line, or ``None``.
-    * ``ack_status`` — one of:
-        - ``"failed"``: a relay-failure pattern was found in the text/metadata
-          (the origin ACK demonstrably could not be delivered).
-        - ``"ambiguous"``: no failure string, but a verdict is present and
-          ``notify_subs`` was supplied and empty — the origin relay had no
-          target at terminal time (could be delivered-then-removed, or never
-          subscribed; we cannot prove the wake happened).
-        - ``"unknown"``: no positive or negative ACK signal.
-    * ``relay_failure`` — ``True`` iff a failure pattern matched.
-    * ``matched`` — the failure substrings found (lower-cased), in pattern order.
-
-    ``task_verdict`` and ``ack_status`` are intentionally independent so a
-    done BLOCK/GO task is never treated as proof the origin was woken.
+    The payload is intentionally sanitized — it carries a hashed
+    ``target_hash`` and a ``thread_present`` boolean instead of the raw
+    ``chat_id`` / ``thread_id``, and never stores summary, result, or
+    exception text. Downstream diagnostics only need the outcome, platform,
+    and failure counters.
     """
-    haystack_parts: list[str] = []
-    for part in (summary, result):
-        if part:
-            haystack_parts.append(str(part))
-    if isinstance(metadata, dict):
-        try:
-            haystack_parts.append(json.dumps(metadata, ensure_ascii=False))
-        except Exception:
-            haystack_parts.append(str(metadata))
-    haystack = "\n".join(haystack_parts)
-    hay_lower = haystack.lower()
-
-    matched = [p for p in ACK_RELAY_FAILURE_PATTERNS if p in hay_lower]
-    relay_failure = bool(matched)
-
-    verdict = _parse_task_verdict(haystack)
-
-    if relay_failure:
-        ack_status = "failed"
-    elif verdict is not None and notify_subs is not None and len(notify_subs) == 0:
-        ack_status = "ambiguous"
-    else:
-        ack_status = "unknown"
-
-    return {
-        "task_verdict": verdict,
-        "ack_status": ack_status,
-        "relay_failure": relay_failure,
-        "matched": matched,
+    if outcome not in NOTIFY_DELIVERY_OUTCOMES:
+        raise ValueError(f"unknown notify delivery outcome: {outcome!r}")
+    payload = {
+        "outcome": outcome,
+        "platform": (platform or "").lower() or None,
+        "target_hash": _notify_target_hash(platform, chat_id),
+        "thread_present": bool(thread_id),
+        "event_kind": event_kind,
+        "failure_count": int(failure_count or 0),
+        "max_failures": int(max_failures or 0),
     }
+    with write_txn(conn):
+        _append_event(
+            conn, task_id, NOTIFY_DELIVERY_EVENT_KIND, payload, run_id=run_id,
+        )
 
 
 class HallucinatedCardsError(ValueError):
@@ -4259,34 +4241,6 @@ def complete_task(
                     },
                     run_id=run_id,
                 )
-    # Durable ACK/relay classification. The work verdict can be terminal
-    # (done, BLOCK/GO) while the origin wake/ACK relay never reached a
-    # target — worker CLI sessions often cannot send messages, so a relay
-    # failure string in the handoff (or an empty notify list at terminal
-    # time) means the origin may be silently waiting. Record a durable
-    # ``ack_relay_status`` event so diagnostics can surface it; keep
-    # ``task_verdict`` and ``ack_status`` as distinct payload fields so a
-    # done verdict is never mistaken for a delivered ACK. Emitted at most
-    # once per terminal transition (this block only runs when the status
-    # update above flipped exactly one row), so it cannot storm.
-    ack = classify_ack_relay(
-        summary=summary,
-        result=result,
-        metadata=metadata,
-        notify_subs=list_notify_subs(conn, task_id),
-    )
-    if ack["ack_status"] in ("failed", "ambiguous"):
-        with write_txn(conn):
-            _append_event(
-                conn, task_id, "ack_relay_status",
-                {
-                    "ack_status": ack["ack_status"],
-                    "task_verdict": ack["task_verdict"],
-                    "matched": ack["matched"],
-                    "source": "completion",
-                },
-                run_id=run_id,
-            )
     # Successful completion — wipe the consecutive-failures counter.
     # Failure history stays on the event log for audit; the counter
     # just tracks "is there a current pathology the breaker should

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -1000,6 +1000,90 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     )]
 
 
+def _rule_missing_ack_relay(task, events, runs, now, cfg) -> list[Diagnostic]:
+    """A terminal task reached a work verdict but the origin ACK/relay
+    could not be delivered (or had no target).
+
+    Fires on active ``ack_relay_status`` events — those not superseded by a
+    later clean ``completed`` / ``edited`` (a retry that relayed fine clears
+    the stale signal). ``ack_status="failed"`` is an error (the relay
+    demonstrably failed); ``ack_status="ambiguous"`` is a warning (no target
+    at terminal time — could be delivered-then-removed or never subscribed).
+
+    Keeps ``task_verdict`` and ``ack_status`` separate so a done BLOCK/GO
+    task is not silently treated as fully delivered. The recovery hint is
+    deliberately conservative: surface the gap and let the operator relay /
+    re-trigger, rather than auto-firing a wake.
+    """
+    hits = _active_hallucination_events(events, "ack_relay_status")
+    if not hits:
+        return []
+    # The latest active event wins for status/verdict; "failed" anywhere in
+    # the active run dominates "ambiguous".
+    statuses = [(_parse_payload(ev).get("ack_status") or "") for ev in hits]
+    failed = "failed" in statuses
+    ack_status = "failed" if failed else (statuses[-1] or "ambiguous")
+    matched: list[str] = []
+    task_verdict = None
+    for ev in hits:
+        p = _parse_payload(ev)
+        if p.get("task_verdict"):
+            task_verdict = p.get("task_verdict")
+        for m in p.get("matched", []) or []:
+            if m not in matched:
+                matched.append(m)
+    severity = "error" if failed else "warning"
+    task_id = _task_field(task, "id")
+    actions: list[DiagnosticAction] = [
+        DiagnosticAction(
+            kind="comment",
+            label="Relay the verdict to the origin and comment NEED_ACK_RELAY",
+            suggested=True,
+        ),
+    ]
+    if task_id:
+        actions.append(DiagnosticAction(
+            kind="cli_hint",
+            label=f"Inspect relay context: hermes kanban show {task_id}",
+            payload={"command": f"hermes kanban show {task_id}"},
+        ))
+    verdict_str = task_verdict or "(none)"
+    if failed:
+        detail = (
+            f"This task reached a terminal work verdict ({verdict_str}) but the "
+            f"origin ACK/relay could not be delivered "
+            f"({', '.join(matched) or 'relay failure'}). The worker could not "
+            f"message the origin and the gateway relay had no live target, so "
+            f"the origin may be silently waiting. The task is done, but the "
+            f"ACK is not — relay the result or re-trigger the origin wake."
+        )
+    else:
+        detail = (
+            f"This task reached a terminal work verdict ({verdict_str}) but no "
+            f"notify target was registered at completion time, so whether the "
+            f"origin was woken is ambiguous. Confirm the origin received the "
+            f"verdict; relay it manually if not."
+        )
+    return [Diagnostic(
+        kind="missing_ack_relay",
+        severity=severity,
+        title=(
+            f"Verdict {verdict_str} done but origin ACK "
+            f"{'failed' if failed else 'unconfirmed'}"
+        ),
+        detail=detail,
+        actions=actions,
+        first_seen_at=_event_ts(hits[0]),
+        last_seen_at=_event_ts(hits[-1]),
+        count=len(hits),
+        data={
+            "task_verdict": task_verdict,
+            "ack_status": ack_status,
+            "matched": matched,
+        },
+    )]
+
+
 # Registry — order matters: rules higher on the list render first when
 # severity ties. Add new rules here.
 _RULES: list[RuleFn] = [
@@ -1011,6 +1095,7 @@ _RULES: list[RuleFn] = [
     _rule_stuck_in_blocked,
     _rule_block_unblock_cycling,
     _rule_stranded_in_ready,
+    _rule_missing_ack_relay,
 ]
 
 
@@ -1025,6 +1110,7 @@ DIAGNOSTIC_KINDS = (
     "stuck_in_blocked",
     "block_unblock_cycling",
     "stranded_in_ready",
+    "missing_ack_relay",
 )
 
 

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -1001,38 +1001,34 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
 
 
 def _rule_missing_ack_relay(task, events, runs, now, cfg) -> list[Diagnostic]:
-    """A terminal task reached a work verdict but the origin ACK/relay
-    could not be delivered (or had no target).
+    """A requested origin notification target hit terminal send failure.
 
-    Fires on active ``ack_relay_status`` events — those not superseded by a
-    later clean ``completed`` / ``edited`` (a retry that relayed fine clears
-    the stale signal). ``ack_status="failed"`` is an error (the relay
-    demonstrably failed); ``ack_status="ambiguous"`` is a warning (no target
-    at terminal time — could be delivered-then-removed or never subscribed).
-
-    Keeps ``task_verdict`` and ``ack_status`` separate so a done BLOCK/GO
-    task is not silently treated as fully delivered. The recovery hint is
-    deliberately conservative: surface the gap and let the operator relay /
-    re-trigger, rather than auto-firing a wake.
+    This rule deliberately keys only off sanitized ``notify_delivery_status``
+    rows written by the gateway notifier around ``adapter.send``. It does not
+    infer failure from completion prose, missing optional subscriptions, or a
+    worker-side summary, because none of those can observe actual delivery.
     """
-    hits = _active_hallucination_events(events, "ack_relay_status")
-    if not hits:
+    delivery_events = [ev for ev in events if _event_kind(ev) == "notify_delivery_status"]
+    terminal_failures = [
+        ev for ev in delivery_events
+        if _parse_payload(ev).get("outcome") == "terminal_failure"
+    ]
+    if not terminal_failures:
         return []
-    # The latest active event wins for status/verdict; "failed" anywhere in
-    # the active run dominates "ambiguous".
-    statuses = [(_parse_payload(ev).get("ack_status") or "") for ev in hits]
-    failed = "failed" in statuses
-    ack_status = "failed" if failed else (statuses[-1] or "ambiguous")
-    matched: list[str] = []
-    task_verdict = None
-    for ev in hits:
+    latest_by_target: dict[str, str] = {}
+    for ev in delivery_events:
         p = _parse_payload(ev)
-        if p.get("task_verdict"):
-            task_verdict = p.get("task_verdict")
-        for m in p.get("matched", []) or []:
-            if m not in matched:
-                matched.append(m)
-    severity = "error" if failed else "warning"
+        target = str(p.get("target_hash") or "")
+        if target:
+            latest_by_target[target] = str(p.get("outcome") or "")
+    active_failures = []
+    for ev in terminal_failures:
+        p = _parse_payload(ev)
+        target = str(p.get("target_hash") or "")
+        if not target or latest_by_target.get(target) in {"terminal_failure", "subscription_dropped"}:
+            active_failures.append(ev)
+    if not active_failures:
+        return []
     task_id = _task_field(task, "id")
     actions: list[DiagnosticAction] = [
         DiagnosticAction(
@@ -1047,39 +1043,33 @@ def _rule_missing_ack_relay(task, events, runs, now, cfg) -> list[Diagnostic]:
             label=f"Inspect relay context: hermes kanban show {task_id}",
             payload={"command": f"hermes kanban show {task_id}"},
         ))
-    verdict_str = task_verdict or "(none)"
-    if failed:
-        detail = (
-            f"This task reached a terminal work verdict ({verdict_str}) but the "
-            f"origin ACK/relay could not be delivered "
-            f"({', '.join(matched) or 'relay failure'}). The worker could not "
-            f"message the origin and the gateway relay had no live target, so "
-            f"the origin may be silently waiting. The task is done, but the "
-            f"ACK is not — relay the result or re-trigger the origin wake."
-        )
-    else:
-        detail = (
-            f"This task reached a terminal work verdict ({verdict_str}) but no "
-            f"notify target was registered at completion time, so whether the "
-            f"origin was woken is ambiguous. Confirm the origin received the "
-            f"verdict; relay it manually if not."
-        )
+    latest = _parse_payload(active_failures[-1])
+    platform = latest.get("platform") or "unknown"
+    detail = (
+        f"The gateway notifier retried delivery to an explicitly requested "
+        f"{platform} notification target and reached terminal send failure "
+        f"({latest.get('failure_count')}/{latest.get('max_failures')}). The "
+        f"subscription was dropped to stop a dead-chat retry loop, so the "
+        f"origin may not have received the Kanban verdict. Relay the result "
+        f"manually or re-subscribe a valid target."
+    )
     return [Diagnostic(
         kind="missing_ack_relay",
-        severity=severity,
-        title=(
-            f"Verdict {verdict_str} done but origin ACK "
-            f"{'failed' if failed else 'unconfirmed'}"
-        ),
+        severity="error",
+        title="Kanban notification delivery failed at gateway boundary",
         detail=detail,
         actions=actions,
-        first_seen_at=_event_ts(hits[0]),
-        last_seen_at=_event_ts(hits[-1]),
-        count=len(hits),
+        first_seen_at=_event_ts(active_failures[0]),
+        last_seen_at=_event_ts(active_failures[-1]),
+        count=len(active_failures),
         data={
-            "task_verdict": task_verdict,
-            "ack_status": ack_status,
-            "matched": matched,
+            "ack_status": "failed",
+            "outcome": "terminal_failure",
+            "platform": platform,
+            "target_hash": latest.get("target_hash"),
+            "event_kind": latest.get("event_kind"),
+            "failure_count": latest.get("failure_count"),
+            "max_failures": latest.get("max_failures"),
         },
     )]
 

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -776,66 +776,71 @@ def test_severity_at_or_above_uses_threshold_semantics():
 
 
 # ---------------------------------------------------------------------------
-# missing_ack_relay — origin ACK/relay failed even though the work verdict
-# is terminal. task_verdict and ack_status are tracked separately so a
-# done BLOCK/GO task does not silently look fully delivered.
+# missing_ack_relay — origin ACK/relay failed at the actual gateway notifier
+# adapter.send boundary. Missing optional subscriptions and completion prose are
+# not evidence of failure.
 # ---------------------------------------------------------------------------
 
 
-def test_missing_ack_relay_fires_on_failed_event():
+def test_missing_ack_relay_fires_on_terminal_delivery_failure():
     task = _task(status="done")
     events = [
         _event("completed", ts=100, summary="Verdict: BLOCK"),
-        _event("ack_relay_status", ts=101, ack_status="failed",
-               task_verdict="BLOCK", matched=["no messaging targets"]),
+        _event("notify_delivery_status", ts=101, outcome="retry_failure",
+               platform="telegram", target_hash="abc", event_kind="completed",
+               failure_count=1, max_failures=3),
+        _event("notify_delivery_status", ts=102, outcome="terminal_failure",
+               platform="telegram", target_hash="abc", event_kind="completed",
+               failure_count=3, max_failures=3),
+        _event("notify_delivery_status", ts=103, outcome="subscription_dropped",
+               platform="telegram", target_hash="abc", event_kind="completed",
+               failure_count=3, max_failures=3),
     ]
     diags = kd.compute_task_diagnostics(task, events, [], now=300)
     hits = [d for d in diags if d.kind == "missing_ack_relay"]
     assert len(hits) == 1
     d = hits[0]
     assert d.severity == "error"
-    # Verdict is reported but kept distinct from the ack status.
-    assert d.data["task_verdict"] == "BLOCK"
     assert d.data["ack_status"] == "failed"
-    assert "no messaging targets" in d.data["matched"]
+    assert d.data["outcome"] == "terminal_failure"
+    assert d.data["platform"] == "telegram"
+    assert d.data["target_hash"] == "abc"
 
 
-def test_missing_ack_relay_ambiguous_is_warning():
+def test_missing_ack_relay_ignores_missing_optional_subscription_prose():
     task = _task(status="done")
     events = [
-        _event("completed", ts=100, summary="Verdict: GO"),
-        _event("ack_relay_status", ts=101, ack_status="ambiguous",
-               task_verdict="GO", matched=[]),
-    ]
-    diags = kd.compute_task_diagnostics(task, events, [], now=300)
-    hits = [d for d in diags if d.kind == "missing_ack_relay"]
-    assert len(hits) == 1
-    assert hits[0].severity == "warning"
-    assert hits[0].data["ack_status"] == "ambiguous"
-
-
-def test_missing_ack_relay_clears_after_clean_recompletion():
-    task = _task(status="done")
-    events = [
-        _event("completed", ts=100, summary="Verdict: BLOCK"),
-        _event("ack_relay_status", ts=101, ack_status="failed",
-               task_verdict="BLOCK", matched=["origin relay could not be sent"]),
-        # A later clean completion (e.g. after a reclaim+retry that relayed
-        # fine) supersedes the stale failure.
-        _event("completed", ts=200, summary="Verdict: GO"),
+        _event("completed", ts=100, summary="Verdict: GO no messaging targets"),
     ]
     diags = kd.compute_task_diagnostics(task, events, [], now=300)
     assert [d for d in diags if d.kind == "missing_ack_relay"] == []
 
 
-def test_missing_ack_relay_does_not_storm_on_repeated_events():
+def test_missing_ack_relay_ignores_retry_failure_when_later_delivered():
     task = _task(status="done")
     events = [
         _event("completed", ts=100, summary="Verdict: BLOCK"),
-        _event("ack_relay_status", ts=101, ack_status="failed",
-               task_verdict="BLOCK", matched=["no live gateway runner"]),
-        _event("ack_relay_status", ts=102, ack_status="failed",
-               task_verdict="BLOCK", matched=["no live gateway runner"]),
+        _event("notify_delivery_status", ts=101, outcome="retry_failure",
+               platform="discord", target_hash="target1", event_kind="completed",
+               failure_count=1, max_failures=3),
+        _event("notify_delivery_status", ts=102, outcome="delivered",
+               platform="discord", target_hash="target1", event_kind="completed",
+               failure_count=0, max_failures=3),
+    ]
+    diags = kd.compute_task_diagnostics(task, events, [], now=300)
+    assert [d for d in diags if d.kind == "missing_ack_relay"] == []
+
+
+def test_missing_ack_relay_does_not_storm_on_repeated_terminal_failures():
+    task = _task(status="done")
+    events = [
+        _event("completed", ts=100, summary="Verdict: BLOCK"),
+        _event("notify_delivery_status", ts=101, outcome="terminal_failure",
+               platform="telegram", target_hash="a", event_kind="completed",
+               failure_count=3, max_failures=3),
+        _event("notify_delivery_status", ts=102, outcome="terminal_failure",
+               platform="telegram", target_hash="b", event_kind="completed",
+               failure_count=3, max_failures=3),
     ]
     diags = kd.compute_task_diagnostics(task, events, [], now=300)
     hits = [d for d in diags if d.kind == "missing_ack_relay"]

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -773,3 +773,72 @@ def test_severity_at_or_above_uses_threshold_semantics():
     assert kd.severity_at_or_above("error", "critical") is False
     assert kd.severity_at_or_above("mystery", "warning") is False
     assert kd.severity_at_or_above("warning", None) is True
+
+
+# ---------------------------------------------------------------------------
+# missing_ack_relay — origin ACK/relay failed even though the work verdict
+# is terminal. task_verdict and ack_status are tracked separately so a
+# done BLOCK/GO task does not silently look fully delivered.
+# ---------------------------------------------------------------------------
+
+
+def test_missing_ack_relay_fires_on_failed_event():
+    task = _task(status="done")
+    events = [
+        _event("completed", ts=100, summary="Verdict: BLOCK"),
+        _event("ack_relay_status", ts=101, ack_status="failed",
+               task_verdict="BLOCK", matched=["no messaging targets"]),
+    ]
+    diags = kd.compute_task_diagnostics(task, events, [], now=300)
+    hits = [d for d in diags if d.kind == "missing_ack_relay"]
+    assert len(hits) == 1
+    d = hits[0]
+    assert d.severity == "error"
+    # Verdict is reported but kept distinct from the ack status.
+    assert d.data["task_verdict"] == "BLOCK"
+    assert d.data["ack_status"] == "failed"
+    assert "no messaging targets" in d.data["matched"]
+
+
+def test_missing_ack_relay_ambiguous_is_warning():
+    task = _task(status="done")
+    events = [
+        _event("completed", ts=100, summary="Verdict: GO"),
+        _event("ack_relay_status", ts=101, ack_status="ambiguous",
+               task_verdict="GO", matched=[]),
+    ]
+    diags = kd.compute_task_diagnostics(task, events, [], now=300)
+    hits = [d for d in diags if d.kind == "missing_ack_relay"]
+    assert len(hits) == 1
+    assert hits[0].severity == "warning"
+    assert hits[0].data["ack_status"] == "ambiguous"
+
+
+def test_missing_ack_relay_clears_after_clean_recompletion():
+    task = _task(status="done")
+    events = [
+        _event("completed", ts=100, summary="Verdict: BLOCK"),
+        _event("ack_relay_status", ts=101, ack_status="failed",
+               task_verdict="BLOCK", matched=["origin relay could not be sent"]),
+        # A later clean completion (e.g. after a reclaim+retry that relayed
+        # fine) supersedes the stale failure.
+        _event("completed", ts=200, summary="Verdict: GO"),
+    ]
+    diags = kd.compute_task_diagnostics(task, events, [], now=300)
+    assert [d for d in diags if d.kind == "missing_ack_relay"] == []
+
+
+def test_missing_ack_relay_does_not_storm_on_repeated_events():
+    task = _task(status="done")
+    events = [
+        _event("completed", ts=100, summary="Verdict: BLOCK"),
+        _event("ack_relay_status", ts=101, ack_status="failed",
+               task_verdict="BLOCK", matched=["no live gateway runner"]),
+        _event("ack_relay_status", ts=102, ack_status="failed",
+               task_verdict="BLOCK", matched=["no live gateway runner"]),
+    ]
+    diags = kd.compute_task_diagnostics(task, events, [], now=300)
+    hits = [d for d in diags if d.kind == "missing_ack_relay"]
+    # Coalesced into a single diagnostic, not one per event.
+    assert len(hits) == 1
+    assert hits[0].count == 2

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -660,90 +660,156 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
 
 
 # ---------------------------------------------------------------------------
-# ACK/relay status classification + durable event on terminal completion.
-# task_verdict (the work decision) is tracked separately from ack_status
-# (whether the origin wake/ACK relay actually reached a target).
+# ACK/relay status is recorded only at the gateway adapter.send boundary.
+# Completion prose and missing optional subscriptions are not evidence of a
+# failed ACK.
 # ---------------------------------------------------------------------------
 
 
-def test_classify_ack_relay_detects_no_messaging_targets():
-    res = kb.classify_ack_relay(
-        summary="Verdict: BLOCK\nReview failed. no messaging targets",
-    )
-    assert res["task_verdict"] == "BLOCK"
-    assert res["ack_status"] == "failed"
-    assert res["relay_failure"] is True
-    assert "no messaging targets" in res["matched"]
+async def _run_notifier_until_stopped(runner):
+    _orig_sleep = asyncio.sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
 
 
-def test_classify_ack_relay_parses_go_verdict_without_relay_failure():
-    res = kb.classify_ack_relay(summary="Verdict: GO\nAll good, merged.")
-    assert res["task_verdict"] == "GO"
-    # No relay-failure string and no notify context -> not a hard failure.
-    assert res["relay_failure"] is False
-    assert res["ack_status"] == "unknown"
+@pytest.mark.asyncio
+async def test_notifier_persists_retry_failures_then_success_without_diagnostic(kanban_home):
+    import hermes_cli.kanban_db as kb
+    from hermes_cli import kanban_diagnostics as kd
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
 
-
-def test_classify_ack_relay_empty_notify_after_terminal_is_ambiguous():
-    # A done task carrying a verdict but with zero notify subscriptions is
-    # ambiguous: the subs may have been delivered+removed, or there may
-    # never have been an origin target. Not a confirmed failure.
-    res = kb.classify_ack_relay(summary="Verdict: GO", notify_subs=[])
-    assert res["task_verdict"] == "GO"
-    assert res["relay_failure"] is False
-    assert res["ack_status"] == "ambiguous"
-
-
-def test_classify_ack_relay_scans_result_and_metadata():
-    res = kb.classify_ack_relay(
-        result="done",
-        metadata={"relay": "trigger_error no live gateway runner"},
-    )
-    assert res["relay_failure"] is True
-    assert res["ack_status"] == "failed"
-
-
-def test_complete_task_emits_ack_relay_status_event_on_relay_failure(kanban_home):
     conn = kb.connect()
     try:
-        tid = kb.create_task(conn, title="review task", assignee="reviewer")
-        kb.complete_task(
-            conn, tid,
-            summary="Verdict: BLOCK\norigin relay could not be sent",
-        )
-        events = kb.list_events(conn, tid)
+        tid = kb.create_task(conn, title="retry task", assignee="worker1")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
+        kb.complete_task(conn, tid, summary="Verdict: GO\nshipped")
     finally:
         conn.close()
-    ack = [e for e in events if e.kind == "ack_relay_status"]
-    assert len(ack) == 1, "exactly one durable ack_relay_status event"
-    payload = ack[0].payload
-    assert payload["ack_status"] == "failed"
-    assert payload["task_verdict"] == "BLOCK"
-    assert "origin relay could not be sent" in payload["matched"]
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+
+    attempts = 0
+
+    async def _send(chat_id, msg, metadata=None):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise RuntimeError("transient network failure with secret-like text")
+        runner._running = False
+
+    fake_adapter = MagicMock()
+    fake_adapter.send = AsyncMock(side_effect=_send)
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+
+    await _run_notifier_until_stopped(runner)
+
+    conn = kb.connect()
+    try:
+        events = kb.list_events(conn, tid)
+        subs = kb.list_notify_subs(conn, tid)
+        task = kb.get_task(conn, tid)
+    finally:
+        conn.close()
+
+    outcomes = [(e.payload or {})["outcome"] for e in events if e.kind == "notify_delivery_status"]
+    assert outcomes == ["retry_failure", "retry_failure", "delivered"]
+    assert subs == []
+    assert kd.compute_task_diagnostics(task, events, [], now=300) == []
+    assert all("chat1" not in str(e.payload) for e in events if e.kind == "notify_delivery_status")
+    assert all("secret-like" not in str(e.payload) for e in events if e.kind == "notify_delivery_status")
 
 
-def test_complete_task_clean_summary_emits_no_ack_relay_event(kanban_home):
+@pytest.mark.asyncio
+async def test_notifier_persists_terminal_failure_and_drops_subscription(kanban_home):
+    import hermes_cli.kanban_db as kb
+    from hermes_cli import kanban_diagnostics as kd
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="dead chat", assignee="worker1")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="dead-chat")
+        kb.complete_task(conn, tid, summary="Verdict: GO\nshipped")
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+
+    tick_count = 0
+    _orig_sleep = asyncio.sleep
+
+    async def _fast_sleep(_):
+        nonlocal tick_count
+        await _orig_sleep(0)
+        tick_count += 1
+        if tick_count >= 6:
+            runner._running = False
+
+    fake_adapter = MagicMock()
+    fake_adapter.send = AsyncMock(side_effect=RuntimeError("bot kicked from dead-chat"))
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    conn = kb.connect()
+    try:
+        events = kb.list_events(conn, tid)
+        subs = kb.list_notify_subs(conn, tid)
+        task = kb.get_task(conn, tid)
+    finally:
+        conn.close()
+
+    outcomes = [(e.payload or {})["outcome"] for e in events if e.kind == "notify_delivery_status"]
+    assert outcomes == [
+        "retry_failure",
+        "retry_failure",
+        "terminal_failure",
+        "subscription_dropped",
+    ]
+    assert subs == []
+    diags = kd.compute_task_diagnostics(task, events, [], now=300)
+    hits = [d for d in diags if d.kind == "missing_ack_relay"]
+    assert len(hits) == 1
+    assert hits[0].data["outcome"] == "terminal_failure"
+    assert hits[0].data["platform"] == "telegram"
+    assert all("dead-chat" not in str(e.payload) for e in events if e.kind == "notify_delivery_status")
+    assert all("bot kicked" not in str(e.payload) for e in events if e.kind == "notify_delivery_status")
+
+
+def test_complete_task_without_requested_target_has_no_ack_diagnostic(kanban_home):
+    from hermes_cli import kanban_diagnostics as kd
+
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="leaf task", assignee="worker")
-        # Has a live notify sub, so the empty-notify ambiguity does not apply.
-        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="c1")
-        kb.complete_task(conn, tid, summary="Verdict: GO\nshipped.")
+        kb.complete_task(
+            conn,
+            tid,
+            summary="Verdict: BLOCK\nno messaging targets / origin relay could not be sent",
+            metadata={"relay": "no live gateway runner"},
+        )
         events = kb.list_events(conn, tid)
+        task = kb.get_task(conn, tid)
     finally:
         conn.close()
+
     assert [e for e in events if e.kind == "ack_relay_status"] == []
-
-
-def test_complete_task_ack_relay_event_emitted_once_no_storm(kanban_home):
-    conn = kb.connect()
-    try:
-        tid = kb.create_task(conn, title="fanin task", assignee="reviewer")
-        kb.complete_task(conn, tid, summary="Verdict: BLOCK no messaging targets")
-        # A second completion call on an already-done task is a no-op and
-        # must not append another ack_relay_status event.
-        kb.complete_task(conn, tid, summary="Verdict: BLOCK no messaging targets")
-        events = kb.list_events(conn, tid)
-    finally:
-        conn.close()
-    assert len([e for e in events if e.kind == "ack_relay_status"]) == 1
+    assert [e for e in events if e.kind == "notify_delivery_status"] == []
+    assert [d for d in kd.compute_task_diagnostics(task, events, [], now=300) if d.kind == "missing_ack_relay"] == []

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -657,3 +657,93 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
     # Only the real file was uploaded.
     assert len(documents_uploaded) == 1
     assert "real.pdf" in documents_uploaded[0]
+
+
+# ---------------------------------------------------------------------------
+# ACK/relay status classification + durable event on terminal completion.
+# task_verdict (the work decision) is tracked separately from ack_status
+# (whether the origin wake/ACK relay actually reached a target).
+# ---------------------------------------------------------------------------
+
+
+def test_classify_ack_relay_detects_no_messaging_targets():
+    res = kb.classify_ack_relay(
+        summary="Verdict: BLOCK\nReview failed. no messaging targets",
+    )
+    assert res["task_verdict"] == "BLOCK"
+    assert res["ack_status"] == "failed"
+    assert res["relay_failure"] is True
+    assert "no messaging targets" in res["matched"]
+
+
+def test_classify_ack_relay_parses_go_verdict_without_relay_failure():
+    res = kb.classify_ack_relay(summary="Verdict: GO\nAll good, merged.")
+    assert res["task_verdict"] == "GO"
+    # No relay-failure string and no notify context -> not a hard failure.
+    assert res["relay_failure"] is False
+    assert res["ack_status"] == "unknown"
+
+
+def test_classify_ack_relay_empty_notify_after_terminal_is_ambiguous():
+    # A done task carrying a verdict but with zero notify subscriptions is
+    # ambiguous: the subs may have been delivered+removed, or there may
+    # never have been an origin target. Not a confirmed failure.
+    res = kb.classify_ack_relay(summary="Verdict: GO", notify_subs=[])
+    assert res["task_verdict"] == "GO"
+    assert res["relay_failure"] is False
+    assert res["ack_status"] == "ambiguous"
+
+
+def test_classify_ack_relay_scans_result_and_metadata():
+    res = kb.classify_ack_relay(
+        result="done",
+        metadata={"relay": "trigger_error no live gateway runner"},
+    )
+    assert res["relay_failure"] is True
+    assert res["ack_status"] == "failed"
+
+
+def test_complete_task_emits_ack_relay_status_event_on_relay_failure(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="review task", assignee="reviewer")
+        kb.complete_task(
+            conn, tid,
+            summary="Verdict: BLOCK\norigin relay could not be sent",
+        )
+        events = kb.list_events(conn, tid)
+    finally:
+        conn.close()
+    ack = [e for e in events if e.kind == "ack_relay_status"]
+    assert len(ack) == 1, "exactly one durable ack_relay_status event"
+    payload = ack[0].payload
+    assert payload["ack_status"] == "failed"
+    assert payload["task_verdict"] == "BLOCK"
+    assert "origin relay could not be sent" in payload["matched"]
+
+
+def test_complete_task_clean_summary_emits_no_ack_relay_event(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="leaf task", assignee="worker")
+        # Has a live notify sub, so the empty-notify ambiguity does not apply.
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="c1")
+        kb.complete_task(conn, tid, summary="Verdict: GO\nshipped.")
+        events = kb.list_events(conn, tid)
+    finally:
+        conn.close()
+    assert [e for e in events if e.kind == "ack_relay_status"] == []
+
+
+def test_complete_task_ack_relay_event_emitted_once_no_storm(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="fanin task", assignee="reviewer")
+        kb.complete_task(conn, tid, summary="Verdict: BLOCK no messaging targets")
+        # A second completion call on an already-done task is a no-op and
+        # must not append another ack_relay_status event.
+        kb.complete_task(conn, tid, summary="Verdict: BLOCK no messaging targets")
+        events = kb.list_events(conn, tid)
+    finally:
+        conn.close()
+    assert len([e for e in events if e.kind == "ack_relay_status"]) == 1


### PR DESCRIPTION
## Summary
- records terminal ACK relay status/delivery problems instead of silently losing missing-subscription failures
- extends diagnostics/tests for relay failure visibility

## Tests
- `python3 -m pytest tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_notify.py -q -o addopts=`
- `python3 -m py_compile hermes_cli/kanban_db.py hermes_cli/kanban_diagnostics.py`