### PR TITLE
fix(terminal): detect all Windows drive letters in host paths (#49703)

### DIFF
--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -101,6 +101,45 @@ class TestCwdHandling:
         config = _tt_mod._get_env_config()
         assert config["cwd"] == "/root"
 
+    def test_windows_non_c_drive_replaced_for_modal(self, monkeypatch):
+        """D:\\ paths must be treated as host paths, not just C:\\.
+
+        On a Windows host, D:\\ is absolute — so the is_relative fallback
+        does NOT catch it.  The host-path check must detect any drive letter.
+        See #49703.
+        """
+        # Simulate Windows path semantics where D:\ is absolute
+        _real_isabs = os.path.isabs
+
+        def _win_isabs(path):
+            if len(path) >= 3 and path[0].isalpha() and path[1] == ":" and path[2] in ("\\", "/"):
+                return True
+            return _real_isabs(path)
+
+        monkeypatch.setattr("tools.terminal_tool.os.path.isabs", _win_isabs)
+        monkeypatch.setenv("TERMINAL_ENV", "modal")
+        monkeypatch.setenv("TERMINAL_CWD", "D:\\Users\\someone\\projects")
+        config = _tt_mod._get_env_config()
+        assert config["cwd"] == "/root", (
+            f"Expected /root, got {config['cwd']}. "
+            "D:\\ paths should be replaced for modal backend."
+        )
+
+    def test_windows_forward_slash_drive_replaced_for_modal(self, monkeypatch):
+        """E:/ paths (forward-slash variant) must also be detected."""
+        _real_isabs = os.path.isabs
+
+        def _win_isabs(path):
+            if len(path) >= 3 and path[0].isalpha() and path[1] == ":" and path[2] in ("\\", "/"):
+                return True
+            return _real_isabs(path)
+
+        monkeypatch.setattr("tools.terminal_tool.os.path.isabs", _win_isabs)
+        monkeypatch.setenv("TERMINAL_ENV", "modal")
+        monkeypatch.setenv("TERMINAL_CWD", "E:/dev/code")
+        config = _tt_mod._get_env_config()
+        assert config["cwd"] == "/root"
+
     @pytest.mark.parametrize("backend", ["modal", "docker", "singularity", "daytona"])
     def test_default_cwd_is_root_for_container_backends(self, backend, monkeypatch):
         """Container backends should default to /root, not ~."""
@@ -274,17 +313,24 @@ class TestEnsurepipFix:
 # =========================================================================
 
 class TestHostPrefixList:
-    """Verify the host prefix list catches common host-only paths."""
+    """Verify host path detection catches common host-only paths."""
 
     def test_all_common_host_prefixes_caught(self):
-        """The host prefix check should catch /Users/, /home/, C:\\, C:/."""
-        # Read the actual source to verify the prefixes
-        import inspect
-        source = inspect.getsource(_tt_mod._get_env_config)
-        for prefix in ["/Users/", "/home/", 'C:\\\\"', "C:/"]:
-            # Normalize for source comparison
-            check = prefix.rstrip('"')
-            assert check in source or prefix in source, (
-                f"Host prefix {prefix!r} not found in _get_env_config. "
-                "Container backends need this to avoid using host paths."
-            )
+        """_is_host_path must detect /Users/, /home/, and all Windows drive letters."""
+        is_host = _tt_mod._is_host_path
+        # POSIX home directories
+        assert is_host("/Users/someone/projects")
+        assert is_host("/home/user/work")
+        # Windows C: drive (the original case from #34097)
+        assert is_host("C:\\Users\\someone")
+        assert is_host("C:/Users/someone")
+        # Other Windows drive letters — the generalization from #49703
+        assert is_host("D:\\Users\\someone")
+        assert is_host("E:/dev/code")
+        assert is_host("Z:\\data\\repos")
+        # Non-host paths should return False
+        assert not is_host("/root")
+        assert not is_host("/workspace")
+        assert not is_host("/tmp")
+        assert not is_host("relative/path")
+        assert not is_host("")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1086,6 +1086,24 @@ def _safe_getcwd() -> str:
         return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
 
 
+def _is_host_path(path: str) -> bool:
+    """Detect host-local paths that won't resolve inside a container.
+
+    Covers POSIX home directories (``/Users/``, ``/home/``) and any
+    Windows drive-letter path (``C:\\``, ``D:\\``, …, ``Z:\\`` and
+    their forward-slash variants).  Only ``C:`` was checked previously,
+    silently passing ``D:\\``-style paths through as the container cwd.
+    """
+    if path.startswith(("/Users/", "/home/")):
+        return True
+    return (
+        len(path) >= 3
+        and path[0].isalpha()
+        and path[1] == ":"
+        and path[2] in ("\\", "/")
+    )
+
+
 def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
@@ -1138,19 +1156,18 @@ def _get_env_config() -> Dict[str, Any]:
     if cwd:
         cwd = os.path.expanduser(cwd)
     host_cwd = None
-    host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
     if env_type == "docker" and mount_docker_cwd:
         docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
-            any(candidate.startswith(p) for p in host_prefixes)
+            _is_host_path(candidate)
             or (os.path.isabs(candidate) and os.path.isdir(candidate) and not candidate.startswith(("/workspace", "/root")))
         ):
             host_cwd = candidate
             cwd = "/workspace"
     elif env_type in {"modal", "docker", "singularity", "daytona"} and cwd:
         # Host paths and relative paths that won't work inside containers
-        is_host_path = any(cwd.startswith(p) for p in host_prefixes)
+        is_host_path = _is_host_path(cwd)
         is_relative = not os.path.isabs(cwd)  # e.g. "." or "src/"
         if (is_host_path or is_relative) and cwd != default_cwd:
             logger.info("Ignoring TERMINAL_CWD=%r for %s backend "


### PR DESCRIPTION
Fixes #49703

## What changed
- Replaced the hardcoded host-path prefix tuple in `tools/terminal_tool.py` with `_is_host_path()`.
- Detects POSIX host homes (`/Users/`, `/home/`) and any Windows drive-letter path (`C:\\`, `D:\\`, `E:/`, etc.) before passing cwd to container backends.
- Keeps `/root`, `/workspace`, `/tmp`, and relative paths classified correctly for existing container behavior.

## Why
Windows users with projects on non-`C:` drives (for example `D:\\Users\\...` or `E:/dev/...`) could have host paths passed through as Linux container working directories. Docker/Modal/Singularity/Daytona containers cannot interpret those Windows paths, causing invalid `-w` values or failed `cd` during session initialization.

## Verification
- RED proof in artifacts: new `D:\\` and `E:/` regression tests fail on upstream/main with cwd left as the host path.
- GREEN after fix:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/tools/test_modal_sandbox_fixes.py -v -o "addopts=" --tb=short`
  - Result: 21 passed, 3 warnings.
- Rebased onto current `upstream/main`; verified branch is exactly one commit ahead (`0 1`).

## Competitor / duplicate check
- No open Tranquil-Flow PR found for issue #49703.
- No open upstream PR found by issue-number search or keyword search (`Windows Docker cwd working directory drive letter`).

Auto-published by Moonsong via Path B automated pipeline.
