### PR TITLE
fix: keep status secrets redacted

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -165,12 +165,15 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        # Never print raw API keys, even with --all.  "--all" expands status
+        # sections, but it must not downgrade secret redaction because status
+        # output is commonly pasted into chats, issues, and logs.
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -3,15 +3,36 @@ from types import SimpleNamespace
 from hermes_cli.status import show_status
 
 
-def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
+def test_show_status_includes_redacted_tavily_key(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-dev-abcdefghijklmnopqrstuvwxyz")
 
     show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
     assert "Tavily" in output
-    assert "tvly...cdef" in output
+    assert "tvly...wxyz" in output
+    assert "tvly-dev-abcdefghijklmnopqrstuvwxyz" not in output
+
+
+def test_show_status_all_keeps_api_keys_redacted(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-dev-abcdefghijklmnopqrstuvwxyz")
+    anthropic_key = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
+    monkeypatch.setenv("ANTHROPIC_API_KEY", anthropic_key)
+    monkeypatch.setattr(status_mod, "get_anthropic_key", lambda: anthropic_key, raising=False)
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Tavily" in output
+    assert "Anthropic" in output
+    assert "tvly...wxyz" in output
+    assert "sk-a...wxyz" in output
+    assert "tvly-dev-abcdefghijklmnopqrstuvwxyz" not in output
+    assert anthropic_key not in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## Summary
- keep provider/API key values redacted in `hermes status --all`
- clarify that `--all` expands status sections but does not reveal raw secrets
- add regression coverage for Tavily and Anthropic key redaction in all-mode status output

## Tests
- `/root/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_status.py -q`
- Result: `18 passed`
- Also covered by combined targeted suite: `189 passed, 3 warnings`
