### PR TITLE
fix(desktop): keep language description stable while saving

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.test.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesConfigRecord } from '@/hermes'
+import { type I18nConfigClient, I18nProvider } from '@/i18n'
+
+import { AppearanceSettings } from './appearance-settings'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+Element.prototype.scrollIntoView = function scrollIntoView() {}
+
+function pendingPromise<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+describe('AppearanceSettings', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the language description stable while the selected locale is saving', async () => {
+    const save = pendingPromise<{ ok: boolean }>()
+    const latestConfig: HermesConfigRecord = { display: { language: 'en', skin: 'slate' } }
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockResolvedValue(latestConfig),
+      saveConfig: vi.fn().mockReturnValue(save.promise)
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <AppearanceSettings />
+      </I18nProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Switch language' }).hasAttribute('disabled')).toBe(false)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch language' }))
+    fireEvent.click(screen.getByRole('option', { name: /日本語/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('デスクトップインターフェイスの言語を選択します。')).not.toBeNull()
+    })
+    expect(screen.queryByText('言語を保存中…')).toBeNull()
+
+    save.resolve({ ok: true })
+  })
+})

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -133,7 +133,7 @@ function VscodeThemeInstaller() {
 }
 
 export function AppearanceSettings() {
-  const { t, isSavingLocale } = useI18n()
+  const { t } = useI18n()
   const { themeName, mode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
   const translucency = useStore($translucency)
@@ -166,7 +166,7 @@ export function AppearanceSettings() {
         <div className="mt-2 divide-y divide-(--ui-stroke-tertiary)">
           <ListRow
             action={<LanguageSwitcher />}
-            description={isSavingLocale ? t.language.saving : t.language.description}
+            description={t.language.description}
             title={t.language.label}
           />
 

--- a/apps/desktop/src/components/language-switcher.test.tsx
+++ b/apps/desktop/src/components/language-switcher.test.tsx
@@ -19,6 +19,15 @@ vi.stubGlobal('ResizeObserver', TestResizeObserver)
 
 Element.prototype.scrollIntoView = function scrollIntoView() {}
 
+function pendingPromise<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
 describe('LanguageSwitcher', () => {
   afterEach(() => {
     cleanup()
@@ -49,5 +58,34 @@ describe('LanguageSwitcher', () => {
 
     await waitFor(() => expect(saveConfig).toHaveBeenCalledTimes(1))
     expect(saveConfig).toHaveBeenCalledWith({ display: { language: 'ja', skin: 'slate' } })
+  })
+
+  it('shows saving status on the trigger while the locale is being persisted', async () => {
+    const save = pendingPromise<{ ok: boolean }>()
+    const latestConfig: HermesConfigRecord = { display: { language: 'en', skin: 'slate' } }
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockResolvedValue(latestConfig),
+      saveConfig: vi.fn().mockReturnValue(save.promise)
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <LanguageSwitcher />
+      </I18nProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Switch language' }).hasAttribute('disabled')).toBe(false)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch language' }))
+    fireEvent.click(screen.getByRole('option', { name: /日本語/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '言語を保存中…' }).hasAttribute('disabled')).toBe(true)
+    })
+
+    save.resolve({ ok: true })
   })
 })

--- a/apps/desktop/src/components/language-switcher.tsx
+++ b/apps/desktop/src/components/language-switcher.tsx
@@ -7,7 +7,7 @@ import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTr
 import { useIsMobile } from '@/hooks/use-mobile'
 import { type Locale, LOCALE_META, useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
-import { Check, ChevronDown, Globe } from '@/lib/icons'
+import { Check, ChevronDown, Globe, Loader2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notifyError } from '@/store/notifications'
 
@@ -35,6 +35,7 @@ export function LanguageSwitcher({ className, collapsed = false, dropUp = false 
   const current = LOCALE_META[locale]
   const allLocales = Object.entries(LOCALE_META) as Array<[Locale, typeof current]>
   const title = t.language.switchTo
+  const triggerTitle = isSavingLocale ? t.language.saving : title
 
   const selectLocale = async (code: Locale) => {
     if (code === locale || isSavingLocale) {
@@ -57,7 +58,8 @@ export function LanguageSwitcher({ className, collapsed = false, dropUp = false 
   const trigger = (
     <Button
       aria-expanded={open}
-      aria-label={title}
+      aria-label={triggerTitle}
+      aria-busy={isSavingLocale || undefined}
       className={cn(
         'min-w-32 justify-between gap-2 border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) px-2.5 text-left text-muted-foreground hover:text-foreground',
         collapsed && 'min-w-0 px-2',
@@ -65,7 +67,7 @@ export function LanguageSwitcher({ className, collapsed = false, dropUp = false 
       )}
       disabled={isSavingLocale}
       size="sm"
-      title={title}
+      title={triggerTitle}
       type="button"
       variant="outline"
     >
@@ -73,7 +75,12 @@ export function LanguageSwitcher({ className, collapsed = false, dropUp = false 
         <Globe className="size-3.5 shrink-0" />
         {!collapsed && <span className="truncate">{current.name}</span>}
       </span>
-      {!collapsed && <ChevronDown className="size-3 shrink-0 opacity-70" />}
+      {!collapsed &&
+        (isSavingLocale ? (
+          <Loader2 className="size-3 shrink-0 animate-spin opacity-70" />
+        ) : (
+          <ChevronDown className="size-3 shrink-0 opacity-70" />
+        ))}
     </Button>
   )
 


### PR DESCRIPTION
Small desktop UX polish / regression fix for language switching feedback.

The settings ListRow refactor made the language row replace its explanatory copy with the saving state while display.language is persisted, which made the locale switch look delayed even though the rest of the UI had already updated.
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
1. Keep the Appearance description tied to the active locale and move the pending-save affordance onto the language switcher trigger. The trigger is disabled while saving and exposes the localized saving label for the in-flight state.

2. Adds regression coverage for the stable Appearance copy and the switcher pending state.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->
```shell
cd apps/desktop
npm run test:ui -- src/app/settings/appearance-settings.test.tsx src/components/language-switcher.test.tsx src/i18n/context.test.tsx
```