### PR TITLE
feat(cli): add runtime smoke and context audit commands

### DIFF
--- a/hermes_cli/context_audit.py
+++ b/hermes_cli/context_audit.py
@@ -1,0 +1,263 @@
+"""Context-budget audit for ``hermes context audit``.
+
+This diagnostic is read-only and offline.  It measures the fixed prompt/context
+surfaces that tend to surprise users: project context files from the current
+working directory, the fresh-session prompt breakdown, memory/profile blocks,
+and tool-schema payload size.  It never calls an LLM.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+from contextlib import contextmanager, redirect_stdout, redirect_stderr
+from pathlib import Path
+from typing import Any, Dict, List
+
+def _bytes(text: str) -> int:
+    return len(text.encode("utf-8"))
+
+
+def _fmt_kb(n: int) -> str:
+    return f"{n / 1024:.1f} KB"
+
+
+def _safe_read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+@contextmanager
+def _suppress_context_truncation_warnings():
+    """Keep audit output compact while measuring known-large context files.
+
+    The prompt builder logs truncation warnings for real agent startup. This
+    audit reports the same over-cap condition in its own table, so repeating
+    those warnings on stderr makes the diagnostic noisy without adding signal.
+    """
+    logger = logging.getLogger("agent.prompt_builder")
+    previous_disabled = logger.disabled
+    previous_level = logger.level
+    try:
+        logger.disabled = True
+        logger.setLevel(logging.CRITICAL + 1)
+        yield
+    finally:
+        logger.disabled = previous_disabled
+        logger.setLevel(previous_level)
+
+
+def _context_file_limit(prompt_builder: Any) -> int:
+    """Return the same effective cap used by the prompt builder."""
+    getter = getattr(prompt_builder, "_get_context_file_max_chars", None)
+    if getter:
+        return int(getter())
+    return int(getattr(prompt_builder, "CONTEXT_FILE_MAX_CHARS", 20_000))
+
+
+def _find_project_context_files(cwd: Path, prompt_builder: Any) -> List[Path]:
+    """Mirror ``build_context_files_prompt`` discovery, returning only loaded files.
+
+    The builder uses first-match-wins priority: nearest .hermes.md/HERMES.md
+    up to the git root, else AGENTS.md, else CLAUDE.md, else cursor rules.
+    The audit must not list every candidate file because that over-reports
+    files that the real prompt never injects.
+    """
+    finder = getattr(prompt_builder, "_find_hermes_md", None)
+    hermes_md = finder(cwd) if finder else None
+    if hermes_md and hermes_md.is_file():
+        return [hermes_md]
+
+    for name in ("AGENTS.md", "agents.md"):
+        candidate = cwd / name
+        if candidate.is_file():
+            return [candidate]
+
+    for name in ("CLAUDE.md", "claude.md"):
+        candidate = cwd / name
+        if candidate.is_file():
+            return [candidate]
+
+    cursor_files: List[Path] = []
+    cursorrules = cwd / ".cursorrules"
+    if cursorrules.is_file():
+        cursor_files.append(cursorrules)
+    cursor_dir = cwd / ".cursor" / "rules"
+    if cursor_dir.is_dir():
+        cursor_files.extend(p for p in sorted(cursor_dir.glob("*.mdc")) if p.is_file())
+    return cursor_files
+
+
+def measure_context_budget(cwd: str | Path | None = None, platform: str = "cli") -> Dict[str, Any]:
+    """Return a read-only context budget report.
+
+    ``cwd`` defaults to the process cwd.  The returned dict is JSON-serialisable
+    and intentionally contains sizes/paths only, not file contents or secrets.
+
+    Note: the fresh-session prompt breakdown is intentionally measured as the
+    agent would see the requested cwd. The lower-level prompt-size diagnostic
+    currently discovers cwd through process state, so this function temporarily
+    changes cwd around that isolated offline measurement and restores it before
+    returning. Do not call it concurrently from a multi-threaded server path.
+    """
+    from agent import prompt_builder as pb
+    from hermes_cli.config import get_hermes_home
+    from hermes_cli.prompt_size import compute_prompt_breakdown
+
+    root = Path(cwd or Path.cwd()).expanduser().resolve()
+    context_limit = _context_file_limit(pb)
+
+    files: List[Dict[str, Any]] = []
+    for path in _find_project_context_files(root, pb):
+        text = _safe_read(path)
+        files.append(
+            {
+                "path": str(path),
+                "chars": len(text),
+                "bytes": _bytes(text),
+                "over_default_limit": len(text) > int(context_limit),
+            }
+        )
+
+    try:
+        with _suppress_context_truncation_warnings(), redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            rendered_project_context = pb.build_context_files_prompt(cwd=str(root), skip_soul=True) or ""
+            if hasattr(pb, "drain_truncation_warnings"):
+                pb.drain_truncation_warnings()
+        project_context_error = ""
+    except Exception as exc:  # pragma: no cover - defensive
+        rendered_project_context = ""
+        project_context_error = str(exc)
+
+    try:
+        old_cwd = os.getcwd()
+        os.chdir(root)
+        try:
+            with _suppress_context_truncation_warnings(), redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                prompt = compute_prompt_breakdown(platform=platform)
+                if hasattr(pb, "drain_truncation_warnings"):
+                    pb.drain_truncation_warnings()
+        finally:
+            os.chdir(old_cwd)
+        prompt_error = ""
+    except Exception as exc:  # pragma: no cover - defensive
+        prompt = {}
+        prompt_error = str(exc)
+
+    home = Path(get_hermes_home())
+    home_files = []
+    for rel in ("SOUL.md", "memories/MEMORY.md", "memories/USER.md"):
+        p = home / rel
+        text = _safe_read(p) if p.exists() else ""
+        home_files.append({"path": str(p), "chars": len(text), "bytes": _bytes(text), "exists": p.exists()})
+
+    recommendations: List[str] = []
+    if rendered_project_context:
+        recommendations.append(
+            "Project context is non-empty for this cwd; for routine Ops, launch from a neutral cwd and use git -C/path commands."
+        )
+    large_files = [f for f in files if f["over_default_limit"]]
+    if large_files:
+        recommendations.append(
+            "At least one context file exceeds the configured/default char cap; split or narrow it if it loads in non-coding sessions."
+        )
+    if prompt and (prompt.get("skills_index") or {}).get("bytes", 0) > 5 * 1024:
+        recommendations.append("Skills index is a major fixed block; disable/archive unused overlapping skills before trimming safety guidance.")
+    if prompt and (prompt.get("tools") or {}).get("json_bytes", 0) > 20 * 1024:
+        recommendations.append("Tool schemas are large; prefer minimal toolsets for one-shot/profile-specific routine work.")
+
+    return {
+        "cwd": str(root),
+        "platform": platform,
+        "context_file_char_limit": int(context_limit),
+        "context_files": files,
+        "rendered_project_context": {
+            "chars": len(rendered_project_context),
+            "bytes": _bytes(rendered_project_context),
+            "error": project_context_error,
+        },
+        "home_files": home_files,
+        "prompt_breakdown": prompt,
+        "prompt_error": prompt_error,
+        "recommendations": recommendations,
+    }
+
+
+def render_context_audit(data: Dict[str, Any]) -> str:
+    lines: List[str] = []
+    lines.append(f"Context audit (platform={data['platform']})")
+    lines.append(f"  cwd: {data['cwd']}")
+    lines.append(f"  context file cap: {data['context_file_char_limit']:,} chars")
+    lines.append("")
+
+    rpc = data["rendered_project_context"]
+    lines.append(
+        f"  Rendered project context: {rpc['bytes']:>8,} B  ({_fmt_kb(rpc['bytes'])}, {rpc['chars']:,} chars)"
+    )
+    if rpc.get("error"):
+        lines.append(f"    error: {rpc['error']}")
+
+    lines.append("")
+    lines.append("  Context files in cwd:")
+    if data["context_files"]:
+        for item in sorted(data["context_files"], key=lambda x: x["bytes"], reverse=True):
+            flag = "  OVER-CAP" if item.get("over_default_limit") else ""
+            lines.append(f"    {item['bytes']:>8,} B  {_fmt_kb(item['bytes']):>8}  {item['path']}{flag}")
+    else:
+        lines.append("    (none)")
+
+    lines.append("")
+    lines.append("  Hermes home prompt files:")
+    for item in data["home_files"]:
+        exists = "" if item.get("exists") else "  missing"
+        lines.append(f"    {item['bytes']:>8,} B  {_fmt_kb(item['bytes']):>8}  {item['path']}{exists}")
+
+    prompt = data.get("prompt_breakdown") or {}
+    if prompt:
+        sp = prompt.get("system_prompt", {})
+        lines.append("")
+        lines.append(
+            f"  Fresh-session system prompt: {sp.get('bytes', 0):>8,} B  ({_fmt_kb(sp.get('bytes', 0))})"
+        )
+        si = prompt.get("skills_index", {})
+        mem = prompt.get("memory", {})
+        up = prompt.get("user_profile", {})
+        tools = prompt.get("tools", {})
+        lines.append(f"    skills index : {si.get('bytes', 0):>8,} B  ({_fmt_kb(si.get('bytes', 0))})")
+        lines.append(f"    memory       : {mem.get('bytes', 0):>8,} B  ({_fmt_kb(mem.get('bytes', 0))})")
+        lines.append(f"    user profile : {up.get('bytes', 0):>8,} B  ({_fmt_kb(up.get('bytes', 0))})")
+        lines.append(
+            f"    tool schemas : {tools.get('json_bytes', 0):>8,} B  ({_fmt_kb(tools.get('json_bytes', 0))}, {tools.get('count', 0)} tools)"
+        )
+    elif data.get("prompt_error"):
+        lines.append("")
+        lines.append(f"  Prompt breakdown unavailable: {data['prompt_error']}")
+
+    lines.append("")
+    lines.append("  Notes:")
+    lines.append("    - Discovery mirrors prompt-builder priority; only files that would be injected are listed.")
+    lines.append("    - Fresh prompt sizing temporarily switches cwd for an isolated offline measurement.")
+
+    if data["recommendations"]:
+        lines.append("")
+        lines.append("  Recommendations:")
+        for rec in data["recommendations"]:
+            lines.append(f"    - {rec}")
+    return "\n".join(lines)
+
+
+def cmd_context(args: Any) -> None:
+    action = getattr(args, "context_command", None) or "audit"
+    if action != "audit":
+        raise SystemExit(f"unknown context subcommand: {action}")
+    data = measure_context_budget(cwd=getattr(args, "cwd", None), platform=getattr(args, "platform", "cli") or "cli")
+    if getattr(args, "json", False):
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    else:
+        print(render_context_audit(data))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -474,6 +474,8 @@ from hermes_cli.subcommands.dashboard import build_dashboard_parser
 from hermes_cli.subcommands.gui import build_gui_parser
 from hermes_cli.subcommands.logs import build_logs_parser
 from hermes_cli.subcommands.prompt_size import build_prompt_size_parser
+from hermes_cli.subcommands.context import build_context_parser
+from hermes_cli.subcommands.smoke import build_smoke_parser
 from hermes_cli.subcommands.memory import build_memory_parser
 from hermes_cli.subcommands.acp import build_acp_parser
 from hermes_cli.subcommands.tools import build_tools_parser
@@ -10509,7 +10511,9 @@ def _coalesce_session_name_args(argv: list) -> list:
         "backup",
         "import",
         "completion",
+        "context",
         "logs",
+        "smoke",
     }
     _SESSION_FLAGS = {"-c", "--continue", "-r", "--resume"}
 
@@ -11865,6 +11869,20 @@ def cmd_prompt_size(args):
     _impl(args)
 
 
+def cmd_context(args):
+    """Inspect context/prompt budget surfaces."""
+    from hermes_cli.context_audit import cmd_context as _impl
+
+    _impl(args)
+
+
+def cmd_smoke(args):
+    """Run read-only Hermes runtime smoke checks."""
+    from hermes_cli.smoke import cmd_smoke as _impl
+
+    _impl(args)
+
+
 def cmd_logs(args):
     """View and filter Hermes log files."""
     from hermes_cli.logs import tail_log, list_logs
@@ -11922,7 +11940,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
     {
         "acp", "approvals", "auth", "backup", "bundles", "checkpoints", "claw", "completion",
         "computer-use",
-        "config", "console", "cron", "curator", "dashboard", "serve", "debug", "doctor",
+        "config", "console", "context", "cron", "curator", "dashboard", "serve", "debug", "doctor",
         "dump", "egress", "fallback", "gateway", "hooks", "import", "import-agent", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",
@@ -11930,7 +11948,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "project", "proxy",
         "prompt-size",
         "resume",
-        "send", "sessions", "setup",
+        "send", "sessions", "setup", "smoke",
         "skin", "skills", "slack", "status", "sync", "tools", "uninstall", "update",
         "webhook", "whatsapp", "whatsapp-cloud", "worktree", "chat", "secrets", "security",
         "verify",
@@ -14137,6 +14155,16 @@ def main():
     # prompt-size command  (parser built in hermes_cli/subcommands/prompt_size.py)
     # =========================================================================
     build_prompt_size_parser(subparsers, cmd_prompt_size=cmd_prompt_size)
+
+    # =========================================================================
+    # context command  (parser built in hermes_cli/subcommands/context.py)
+    # =========================================================================
+    build_context_parser(subparsers, cmd_context=cmd_context)
+
+    # =========================================================================
+    # smoke command  (parser built in hermes_cli/subcommands/smoke.py)
+    # =========================================================================
+    build_smoke_parser(subparsers, cmd_smoke=cmd_smoke)
 
     # =========================================================================
     # Parse and execute

--- a/hermes_cli/smoke.py
+++ b/hermes_cli/smoke.py
@@ -1,0 +1,261 @@
+"""Runtime smoke diagnostics for ``hermes smoke``.
+
+The default command is read-only and side-effect-light: it runs local/status
+checks, prints a compact report, and does not create artifacts or persistent
+Hermes chat sessions unless explicitly requested.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, List
+
+
+@dataclass
+class SmokeResult:
+    name: str
+    ok: bool
+    detail: str
+    elapsed_s: float | None = None
+    artifact: str | None = None
+
+
+def _now_stamp() -> str:
+    return datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def _hermes_cmd(explicit: str | None = None) -> List[str]:
+    """Return the Hermes CLI command, with a source-tree fallback.
+
+    ``explicit`` is supplied by argparse/configured callers.  We intentionally
+    avoid a non-secret ``HERMES_*`` environment override here; Hermes policy
+    keeps non-secret behavior in CLI flags/config rather than ad-hoc env vars.
+    """
+    if explicit:
+        return [explicit]
+    installed = shutil.which("hermes")
+    if installed:
+        return [installed]
+    return [sys.executable, "-m", "hermes_cli.main"]
+
+
+def _run(cmd: List[str], timeout: int = 120, env: dict[str, str] | None = None) -> tuple[int, str, str, float]:
+    start = time.monotonic()
+    proc = subprocess.run(
+        cmd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        timeout=timeout,
+        env=env,
+    )
+    return proc.returncode, proc.stdout, proc.stderr, time.monotonic() - start
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _maybe_write(artifact_dir: Path | None, filename: str, text: str) -> str | None:
+    if artifact_dir is None:
+        return None
+    path = artifact_dir / filename
+    _write(path, text)
+    return str(path)
+
+
+def _profile_exists(profile: str) -> bool:
+    """Return whether a chat-smoke target profile exists on this host."""
+    name = str(profile).strip()
+    if name.casefold() == "default":
+        return True
+    if not name:
+        return False
+    hermes_home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
+    profiles_root = hermes_home / "profiles"
+    if hermes_home.name == name.lower() and hermes_home.parent.name == "profiles":
+        profiles_root = hermes_home.parent
+    return (profiles_root / name.lower()).is_dir()
+
+
+def _timeout_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value
+
+
+def smoke_profile(profile: str, artifact_dir: Path | None, *, cli: str | None = None, timeout: int = 180) -> SmokeResult:
+    """Run an opt-in real chat smoke for one profile.
+
+    This creates a persistent Hermes session by design, so callers must only
+    invoke it when the user requested ``--chat``.
+    """
+    if not _profile_exists(profile):
+        return SmokeResult(f"profile:{profile}", True, "skipped; profile not found on this host")
+
+    expected = f"SMOKE_{profile}_OK"
+    cmd = [
+        *_hermes_cmd(cli),
+        "--profile",
+        profile,
+        "chat",
+        "-Q",
+        "--max-turns",
+        "1",
+        "--source",
+        "smoke",
+        "-q",
+        f"Antworte exakt: {expected}",
+    ]
+    safe_profile = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in profile)
+    try:
+        rc, out, err, elapsed = _run(cmd, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        out_path = _maybe_write(artifact_dir, f"profile-{safe_profile}.stdout", _timeout_text(exc.stdout))
+        _maybe_write(artifact_dir, f"profile-{safe_profile}.stderr", _timeout_text(exc.stderr))
+        return SmokeResult(f"profile:{profile}", False, f"timeout after {timeout}s", None, out_path)
+    out_path = _maybe_write(artifact_dir, f"profile-{safe_profile}.stdout", out)
+    _maybe_write(artifact_dir, f"profile-{safe_profile}.stderr", err)
+    got = " ".join(out.split())
+    ok = rc == 0 and expected in got
+    detail = f"rc={rc}; stdout={got[:120]!r}"
+    if ok and got != expected:
+        detail += "; expected token present in non-exact output"
+    return SmokeResult(f"profile:{profile}", ok, detail, elapsed, out_path)
+
+
+def smoke_command(
+    name: str,
+    cmd: List[str],
+    expected_substring: str | None,
+    artifact_dir: Path | None,
+    timeout: int = 120,
+) -> SmokeResult:
+    try:
+        rc, out, err, elapsed = _run(cmd, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        out_path = _maybe_write(artifact_dir, f"{name}.stdout", _timeout_text(exc.stdout))
+        _maybe_write(artifact_dir, f"{name}.stderr", _timeout_text(exc.stderr))
+        return SmokeResult(name, False, f"timeout after {timeout}s", None, out_path)
+    out_path = _maybe_write(artifact_dir, f"{name}.stdout", out)
+    _maybe_write(artifact_dir, f"{name}.stderr", err)
+    combined = out + err
+    ok = rc == 0 and (expected_substring is None or expected_substring in combined)
+    return SmokeResult(name, ok, f"rc={rc}", elapsed, out_path)
+
+
+def _openrouter_credits() -> SmokeResult:
+    try:
+        from hermes_cli.config import get_env_value
+        import urllib.request
+
+        key = get_env_value("OPENROUTER_API_KEY") or ""
+        if not key:
+            return SmokeResult("openrouter-credits", False, "OPENROUTER_API_KEY missing")
+        req = urllib.request.Request(
+            "https://openrouter.ai/api/v1/credits",
+            headers={"Authorization": f"Bearer {key}", "User-Agent": "hermes-smoke"},
+        )
+        start = time.monotonic()
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 - fixed HTTPS endpoint
+            data = json.load(resp)
+        elapsed = time.monotonic() - start
+        credits = (data or {}).get("data") or {}
+        total = float(credits.get("total_credits") or 0)
+        usage = float(credits.get("total_usage") or 0)
+        remaining = total - usage
+        return SmokeResult("openrouter-credits", True, f"remaining_usd={remaining:.2f}", elapsed)
+    except Exception as exc:  # pragma: no cover - network/env dependent
+        return SmokeResult("openrouter-credits", False, f"{type(exc).__name__}: {exc}")
+
+
+def _resolve_artifact_dir(artifact_dir: str | Path | None, *, write_artifacts: bool) -> Path | None:
+    if artifact_dir:
+        return Path(artifact_dir).expanduser().resolve()
+    if write_artifacts:
+        return Path(tempfile.gettempdir()) / f"hermes-smoke-{_now_stamp()}"
+    return None
+
+
+def run_smoke(
+    profiles: Iterable[str] = ("default", "cheap", "lab"),
+    *,
+    artifact_dir: str | Path | None = None,
+    write_artifacts: bool = False,
+    chat: bool = False,
+    include_credits: bool = False,
+    cli: str | None = None,
+) -> dict[str, Any]:
+    artifacts = _resolve_artifact_dir(artifact_dir, write_artifacts=write_artifacts)
+    if artifacts is not None:
+        artifacts.mkdir(parents=True, exist_ok=True)
+
+    results: List[SmokeResult] = []
+    base = _hermes_cmd(cli)
+    results.append(smoke_command("version", base + ["--version"], "Hermes Agent", artifacts, timeout=60))
+    results.append(smoke_command("auth-list", base + ["auth", "list"], None, artifacts, timeout=120))
+    results.append(smoke_command("tools-list", base + ["tools", "list"], None, artifacts, timeout=120))
+    results.append(smoke_command("doctor", base + ["doctor"], "Hermes Doctor", artifacts, timeout=240))
+    results.append(smoke_command("gateway-status", base + ["gateway", "status"], None, artifacts, timeout=120))
+    results.append(smoke_command("cron-status", base + ["cron", "status"], None, artifacts, timeout=120))
+    results.append(smoke_command("context-audit", base + ["context", "audit", "--cwd", str(Path.cwd())], "Context audit", artifacts, timeout=120))
+
+    if include_credits:
+        results.append(_openrouter_credits())
+
+    if chat:
+        for profile in profiles:
+            results.append(smoke_profile(profile, artifacts, cli=cli))
+
+    payload = {
+        "artifact_dir": str(artifacts) if artifacts is not None else None,
+        "results": [asdict(r) for r in results],
+        "ok": all(r.ok for r in results),
+    }
+    if artifacts is not None:
+        _write(artifacts / "summary.json", json.dumps(payload, ensure_ascii=False, indent=2))
+    return payload
+
+
+def render_smoke_report(data: dict[str, Any]) -> str:
+    artifact_line = data["artifact_dir"] if data.get("artifact_dir") else "not written (use --write-artifacts or --output-dir)"
+    lines = ["Hermes smoke report", f"  artifacts: {artifact_line}", ""]
+    for item in data["results"]:
+        mark = "OK" if item["ok"] else "FAIL"
+        elapsed = "" if item.get("elapsed_s") is None else f" ({item['elapsed_s']:.2f}s)"
+        lines.append(f"  {mark:4} {item['name']:<24} {item['detail']}{elapsed}")
+    lines.append("")
+    lines.append(f"Overall: {'OK' if data['ok'] else 'FAIL'}")
+    return "\n".join(lines)
+
+
+def cmd_smoke(args: Any) -> None:
+    profiles_raw = getattr(args, "profiles", "default,cheap,lab") or ""
+    profiles = [p.strip() for p in profiles_raw.split(",") if p.strip()]
+    chat = bool(getattr(args, "chat", False)) and not bool(getattr(args, "skip_chat", False))
+    data = run_smoke(
+        profiles=profiles,
+        artifact_dir=getattr(args, "output_dir", None),
+        write_artifacts=getattr(args, "write_artifacts", False),
+        chat=chat,
+        include_credits=getattr(args, "credits", False),
+        cli=getattr(args, "cli", None),
+    )
+    if getattr(args, "json", False):
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    else:
+        print(render_smoke_report(data))
+    raise SystemExit(0 if data["ok"] else 1)

--- a/hermes_cli/subcommands/context.py
+++ b/hermes_cli/subcommands/context.py
@@ -1,0 +1,25 @@
+"""``hermes context`` subcommand parser."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_context_parser(subparsers, *, cmd_context: Callable) -> None:
+    """Attach the ``context`` subcommand tree to ``subparsers``."""
+    context_parser = subparsers.add_parser(
+        "context",
+        help="Inspect context/prompt budget surfaces",
+        description="Inspect fixed context and prompt budget sources without making an API call.",
+    )
+    sub = context_parser.add_subparsers(dest="context_command")
+    audit = sub.add_parser(
+        "audit",
+        help="Measure project context, skills, memory, and tool-schema payloads",
+        description="Read-only context budget audit. Runs offline and prints sizes only.",
+    )
+    audit.add_argument("--cwd", default=None, help="Directory whose project context files should be measured")
+    audit.add_argument("--platform", default="cli", help="Platform to simulate for prompt sizing. Default: cli")
+    audit.add_argument("--json", action="store_true", help="Emit JSON")
+    audit.set_defaults(func=cmd_context)
+    context_parser.set_defaults(func=cmd_context, context_command="audit")

--- a/hermes_cli/subcommands/smoke.py
+++ b/hermes_cli/subcommands/smoke.py
@@ -1,0 +1,39 @@
+"""``hermes smoke`` subcommand parser."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_smoke_parser(subparsers, *, cmd_smoke: Callable) -> None:
+    """Attach the ``smoke`` subcommand to ``subparsers``."""
+    smoke_parser = subparsers.add_parser(
+        "smoke",
+        help="Run runtime smoke checks",
+        description=(
+            "Run a compact runtime smoke report. By default this is side-effect-light: "
+            "no artifacts are written and no persistent chat sessions are created. "
+            "Use --chat and/or --write-artifacts when those side effects are desired."
+        ),
+    )
+    smoke_parser.add_argument(
+        "--profiles",
+        default="default,cheap,lab",
+        help="Comma-separated profiles for exact-string chat smokes. Default: default,cheap,lab",
+    )
+    smoke_parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Artifact directory. Implies artifact writing. Default: do not write artifacts",
+    )
+    smoke_parser.add_argument(
+        "--write-artifacts",
+        action="store_true",
+        help="Write stdout/stderr and summary artifacts under the platform temp directory",
+    )
+    smoke_parser.add_argument("--chat", action="store_true", help="Opt in to real model/provider chat smokes")
+    smoke_parser.add_argument("--skip-chat", action="store_true", help="Deprecated compatibility alias; chat smokes are skipped by default")
+    smoke_parser.add_argument("--credits", action="store_true", help="Check OpenRouter credits if configured")
+    smoke_parser.add_argument("--cli", default=None, help="Hermes CLI executable to smoke. Default: resolve hermes on PATH")
+    smoke_parser.add_argument("--json", action="store_true", help="Emit JSON")
+    smoke_parser.set_defaults(func=cmd_smoke)

--- a/tests/hermes_cli/test_coalesce_session_args.py
+++ b/tests/hermes_cli/test_coalesce_session_args.py
@@ -37,3 +37,15 @@ class TestCoalesceSessionNameArgs:
         assert _coalesce_session_name_args(
             ["-c", "my", "setup"]
         ) == ["-c", "my", "setup"]
+
+    def test_stops_at_context_subcommand(self):
+        """hermes -c my context audit → 'context' is a subcommand boundary."""
+        assert _coalesce_session_name_args(
+            ["-c", "my", "context", "audit"]
+        ) == ["-c", "my", "context", "audit"]
+
+    def test_stops_at_smoke_subcommand(self):
+        """hermes -c my smoke → 'smoke' is a subcommand boundary."""
+        assert _coalesce_session_name_args(
+            ["-c", "my", "smoke"]
+        ) == ["-c", "my", "smoke"]

--- a/tests/hermes_cli/test_context_audit.py
+++ b/tests/hermes_cli/test_context_audit.py
@@ -1,0 +1,65 @@
+import json
+
+from hermes_cli.context_audit import measure_context_budget, render_context_audit
+
+
+def test_context_audit_reports_real_loaded_cwd_context_file(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    text = "x" * 21000
+    (tmp_path / "AGENTS.md").write_text(text, encoding="utf-8")
+
+    data = measure_context_budget(cwd=tmp_path, platform="cli")
+
+    assert data["cwd"] == str(tmp_path.resolve())
+    assert data["context_files"][0]["path"] == str((tmp_path / "AGENTS.md").resolve())
+    assert data["context_files"][0]["over_default_limit"] is True
+
+    rendered = render_context_audit(data)
+    assert "Context audit" in rendered
+    assert "AGENTS.md" in rendered
+    assert "OVER-CAP" in rendered
+
+
+def test_context_audit_payload_is_json_serializable(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (tmp_path / "AGENTS.md").write_text("small context", encoding="utf-8")
+
+    data = measure_context_budget(cwd=tmp_path, platform="cli")
+
+    encoded = json.dumps(data, ensure_ascii=False)
+    assert "small context" not in encoded
+    assert str((tmp_path / "AGENTS.md").resolve()) in encoded
+
+
+def test_context_audit_uses_top_level_context_file_cap(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "config.yaml").write_text("context_file_max_chars: 100\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (tmp_path / "AGENTS.md").write_text("x" * 101, encoding="utf-8")
+
+    data = measure_context_budget(cwd=tmp_path, platform="cli")
+
+    assert data["context_file_char_limit"] == 100
+    assert data["context_files"][0]["over_default_limit"] is True
+
+
+def test_context_audit_reports_only_real_priority_context_source(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    repo = tmp_path / "repo"
+    child = repo / "child"
+    child.mkdir(parents=True)
+    (repo / ".git").mkdir()
+    (repo / ".hermes.md").write_text("root hermes context", encoding="utf-8")
+    (child / "AGENTS.md").write_text("child agents context", encoding="utf-8")
+
+    data = measure_context_budget(cwd=child, platform="cli")
+
+    paths = [item["path"] for item in data["context_files"]]
+    assert paths == [str((repo / ".hermes.md").resolve())]

--- a/tests/hermes_cli/test_smoke.py
+++ b/tests/hermes_cli/test_smoke.py
@@ -1,0 +1,120 @@
+import argparse
+
+from hermes_cli.smoke import render_smoke_report, run_smoke, smoke_profile
+
+
+def test_run_smoke_default_does_not_write_summary_or_chat(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_smoke_command(name, cmd, expected_substring, artifact_dir, timeout=120):
+        calls.append((name, cmd, expected_substring, artifact_dir))
+        from hermes_cli.smoke import SmokeResult
+
+        return SmokeResult(name, True, "rc=0", 0.01, None)
+
+    monkeypatch.setattr("hermes_cli.smoke.smoke_command", fake_smoke_command)
+
+    data = run_smoke(profiles=["default"])
+
+    assert data["ok"] is True
+    assert data["artifact_dir"] is None
+    assert not (tmp_path / "summary.json").exists()
+    assert all(call[3] is None for call in calls)
+    names = [item["name"] for item in data["results"]]
+    assert "version" in names
+    assert "doctor" in names
+    assert "context-audit" in names
+    assert not any(name.startswith("profile:") for name in names)
+    assert "not written" in render_smoke_report(data)
+
+
+def test_run_smoke_writes_artifacts_when_requested(monkeypatch, tmp_path):
+    def fake_smoke_command(name, cmd, expected_substring, artifact_dir, timeout=120):
+        from hermes_cli.smoke import SmokeResult
+
+        assert artifact_dir == tmp_path
+        return SmokeResult(name, True, "rc=0", 0.01, str(artifact_dir / f"{name}.stdout"))
+
+    monkeypatch.setattr("hermes_cli.smoke.smoke_command", fake_smoke_command)
+
+    data = run_smoke(profiles=["default"], artifact_dir=tmp_path)
+
+    assert data["artifact_dir"] == str(tmp_path)
+    assert (tmp_path / "summary.json").exists()
+
+
+def test_run_smoke_chat_is_opt_in(monkeypatch, tmp_path):
+    profile_calls = []
+
+    def fake_smoke_command(name, cmd, expected_substring, artifact_dir, timeout=120):
+        from hermes_cli.smoke import SmokeResult
+
+        return SmokeResult(name, True, "rc=0", 0.01, None)
+
+    def fake_smoke_profile(profile, artifact_dir, *, cli=None, timeout=180):
+        profile_calls.append((profile, artifact_dir, cli))
+        from hermes_cli.smoke import SmokeResult
+
+        return SmokeResult(f"profile:{profile}", True, "rc=0", 0.01, None)
+
+    monkeypatch.setattr("hermes_cli.smoke.smoke_command", fake_smoke_command)
+    monkeypatch.setattr("hermes_cli.smoke.smoke_profile", fake_smoke_profile)
+
+    data = run_smoke(profiles=["default"], chat=True, cli="/bin/hermes-test")
+
+    assert data["ok"] is True
+    assert profile_calls == [("default", None, "/bin/hermes-test")]
+
+
+def test_smoke_profile_accepts_sentinel_in_non_exact_output(monkeypatch):
+    monkeypatch.setattr("hermes_cli.smoke._profile_exists", lambda profile: True)
+
+    def fake_run(cmd, timeout=120, env=None):
+        return 0, "Here is the result: SMOKE_default_OK\n", "", 0.01
+
+    monkeypatch.setattr("hermes_cli.smoke._run", fake_run)
+
+    result = smoke_profile("default", None, cli="/bin/hermes-test")
+
+    assert result.ok is True
+    assert "expected token present in non-exact output" in result.detail
+
+
+def test_smoke_profile_skips_missing_named_profile(monkeypatch):
+    called = False
+
+    def fake_run(cmd, timeout=120, env=None):
+        nonlocal called
+        called = True
+        return 0, "SMOKE_lab_OK", "", 0.01
+
+    monkeypatch.setattr("hermes_cli.smoke._profile_exists", lambda profile: False)
+    monkeypatch.setattr("hermes_cli.smoke._run", fake_run)
+
+    result = smoke_profile("lab", None, cli="/bin/hermes-test")
+
+    assert result.ok is True
+    assert "skipped; profile not found" in result.detail
+    assert called is False
+
+
+def test_smoke_uses_configurable_cli_argument():
+    from hermes_cli.smoke import _hermes_cmd
+
+    assert _hermes_cmd("/tmp/fake-hermes") == ["/tmp/fake-hermes"]
+
+
+def test_smoke_parser_has_no_placeholder_flags():
+    from hermes_cli.subcommands.smoke import build_smoke_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_smoke_parser(subparsers, cmd_smoke=lambda args: None)
+
+    help_text = parser.format_help()
+    assert "--browser" not in help_text
+    assert "--delegation" not in help_text
+    args = parser.parse_args(["smoke", "--chat", "--profiles", "default", "--cli", "/bin/hermes"])
+    assert args.chat is True
+    assert args.profiles == "default"
+    assert args.cli == "/bin/hermes"

--- a/tests/hermes_cli/test_subcommands_batch.py
+++ b/tests/hermes_cli/test_subcommands_batch.py
@@ -16,6 +16,7 @@ import pytest
 from hermes_cli.subcommands.auth import build_auth_parser
 from hermes_cli.subcommands.backup import build_backup_parser
 from hermes_cli.subcommands.config import build_config_parser
+from hermes_cli.subcommands.context import build_context_parser
 from hermes_cli.subcommands.dashboard import build_dashboard_parser
 from hermes_cli.subcommands.debug import build_debug_parser
 from hermes_cli.subcommands.doctor import build_doctor_parser
@@ -32,6 +33,7 @@ from hermes_cli.subcommands.prompt_size import build_prompt_size_parser
 from hermes_cli.subcommands.security import build_security_parser
 from hermes_cli.subcommands.setup import build_setup_parser
 from hermes_cli.subcommands.slack import build_slack_parser
+from hermes_cli.subcommands.smoke import build_smoke_parser
 from hermes_cli.subcommands.status import build_status_parser
 from hermes_cli.subcommands.uninstall import build_uninstall_parser
 from hermes_cli.subcommands.update import build_update_parser
@@ -66,11 +68,13 @@ SINGLE_HANDLER_CASES = [
     ("backup", build_backup_parser, "cmd_backup", ["backup"]),
     ("import", build_import_cmd_parser, "cmd_import", ["import", "/tmp/x.zip"]),
     ("config", build_config_parser, "cmd_config", ["config"]),
+    ("context", build_context_parser, "cmd_context", ["context", "audit"]),
     ("update", build_update_parser, "cmd_update", ["update"]),
     ("uninstall", build_uninstall_parser, "cmd_uninstall", ["uninstall"]),
     ("gui", build_gui_parser, "cmd_gui", ["gui"]),
     ("logs", build_logs_parser, "cmd_logs", ["logs"]),
     ("prompt-size", build_prompt_size_parser, "cmd_prompt_size", ["prompt-size"]),
+    ("smoke", build_smoke_parser, "cmd_smoke", ["smoke", "--skip-chat"]),
 ]
 
 


### PR DESCRIPTION
## Summary
- add read-only `hermes context audit` diagnostics for prompt/context surface inspection
- add read-only `hermes smoke` diagnostics for lightweight runtime checks
- wire both commands through the CLI subcommand registry with tests

## Tests
- `/root/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_context_audit.py tests/hermes_cli/test_smoke.py tests/hermes_cli/test_subcommands_batch.py -q`
- Result: `37 passed, 3 warnings`
- Also covered by combined targeted suite: `189 passed, 3 warnings`
