### PR TITLE
feat(web): add Keenable as a native web search & extract provider (keyless-capable)

### DIFF
--- a/optional-mcps/keenable/manifest.yaml
+++ b/optional-mcps/keenable/manifest.yaml
@@ -1,0 +1,29 @@
+manifest_version: 1
+
+name: keenable
+description: Web search and page-to-markdown fetch via Keenable's search API.
+source: https://docs.keenable.ai/mcp-server
+
+transport:
+  type: http
+  url: https://api.keenable.ai/mcp
+
+# Free tier needs no auth, and the catalog's HTTP path can't inject an api-key
+# header anyway — higher-limit use goes through the keenable-cli skill.
+auth:
+  type: none
+
+tools:
+  default_enabled:
+    - search_web_pages
+    - fetch_page_content
+
+post_install: |
+  Keenable's MCP works on a free tier with no credentials. Searches and
+  fetches are rate-limited until you authenticate.
+
+  To raise limits, sign up at https://keenable.ai/signup for an API key and
+  use it via the Keenable CLI (`keenable login`) or the REST API
+  (X-API-Key header). The optional `keenable-cli` skill covers both.
+
+  Start a new Hermes session to load the Keenable tools.

--- a/optional-skills/research/keenable-cli/SKILL.md
+++ b/optional-skills/research/keenable-cli/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: keenable-cli
+description: Search the web and fetch pages as markdown via Keenable.
+version: 1.0.0
+author: Ilya Gusev (Keenable)
+license: MIT
+platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: KEENABLE_API_KEY
+    prompt: Keenable API key (optional)
+    help: Create one at https://keenable.ai/signup. Skippable — the free tier works without a key; a key raises rate limits.
+    required_for: higher rate limits
+metadata:
+  hermes:
+    tags: [Research, Web, Search, Fetch, Markdown, CLI]
+    related_skills: [parallel-cli, searxng-search, duckduckgo-search]
+---
+
+# Keenable CLI
+
+`keenable` is a single-binary CLI over Keenable's web search and content APIs. It returns search hits with snippets/dates and fetches any page as clean markdown — both work on a free tier without login, and an API key only raises rate limits.
+
+This is an optional third-party vendor workflow, not a Hermes core capability. It overlaps native `web_search` / `web_extract`, so don't prefer it for ordinary lookups — reach for it when the user names Keenable, when a terminal-native search/fetch flow is cleaner, or as a fallback when the `web` toolset is unconfigured.
+
+## When to Use
+
+- The user explicitly mentions Keenable or `keenable`.
+- You want index-date / publication-date filtering on search results.
+- You need a page converted to clean markdown from the terminal.
+- Native `web_search` / `web_extract` are unavailable and you need a search/fetch fallback.
+
+Prefer native `web_search` / `web_extract` for one-off lookups when Keenable isn't specifically requested.
+
+## Prerequisites
+
+Install the binary, then verify with `keenable --version`. Run every command below through the `terminal` tool.
+
+Homebrew (macOS / Linux):
+```bash
+brew install keenableai/tap/keenable-cli
+```
+
+Installer script (macOS / Linux — two steps, no pipe; updates PATH for future shells only):
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf -o /tmp/keenable-install.sh \
+  https://github.com/keenableai/keenable-cli/releases/latest/download/keenable-cli-installer.sh
+sh /tmp/keenable-install.sh
+# Source the env file so the current shell sees it (either dir may exist):
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+[ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env"
+```
+
+Windows (PowerShell):
+```powershell
+Invoke-WebRequest -OutFile $env:TEMP\keenable-install.ps1 `
+  https://github.com/keenableai/keenable-cli/releases/latest/download/keenable-cli-installer.ps1
+& $env:TEMP\keenable-install.ps1
+```
+
+From source: `cargo install --git https://github.com/keenableai/keenable-cli`.
+Update with `brew upgrade keenable-cli` or by re-running the installer.
+
+**Auth is optional.** The free tier needs nothing. To raise rate limits, either run `keenable login` (device-code flow — prints a link + code, works headless) or pass `--api-key keen_***` on any command. `KEENABLE_API_KEY` from `~/.hermes/.env` is picked up as the key for REST calls.
+
+## How to Run
+
+```bash
+# Search (YAML output, designed for agents)
+keenable search "rust async patterns"
+# Fetch a page as markdown
+keenable fetch https://example.com
+```
+
+## Quick Reference
+
+| Command | Purpose |
+|---|---|
+| `keenable search "<query>"` | Web search, YAML results |
+| `keenable search "<q>" -p` | Pretty output (for humans) |
+| `keenable search "<q>" --site techcrunch.com` | Restrict to one site |
+| `keenable search "<q>" --published-after 2026-05-01` | Filter by publication date |
+| `keenable search "<q>" --acquired-after 7d` | Filter by index date |
+| `keenable fetch <url>` | Page content as markdown (YAML: content, title, url) |
+| `keenable login` / `keenable logout` | Manage credentials in `~/.keenable/` |
+| `keenable configure-mcp --all` | Wire Keenable MCP into detected AI clients |
+| `keenable config` | View CLI settings |
+
+Date filters (`--published-after/-before`, `--acquired-after/-before`) accept `YYYY-MM-DD`, ISO 8601 datetimes, or relative values (`12h`, `7d`, `3mo`, `1y`).
+
+Each search result is YAML with: `title`, `url`, `description`, `snippet`, `published_at`, `acquired_at`. `fetch` returns `content` (markdown), `title`, `url`.
+
+## Procedure
+
+1. Confirm the binary is present: `keenable --version`. If missing, install per **Prerequisites**.
+2. Search: `keenable search "<query>"` — add `--site` / date filters to narrow. Parse the YAML; pick the relevant `url`s.
+3. Read a result in full: `keenable fetch <url>` and work from the returned markdown `content`.
+4. For tighter rate limits or many calls, authenticate once with `keenable login` (or set `KEENABLE_API_KEY`).
+
+## Pitfalls
+
+- **Free-tier rate limits.** Unauthenticated use is throttled; authenticate before batch/loop calls.
+- **Default output is YAML, not JSON.** Don't add `-p` (pretty) when parsing programmatically — parse the default YAML.
+- **PATH after the installer.** The installer only updates future shells; source the printed env file (shown above) or the `keenable` call will fail with "command not found" in the same session.
+- **`configure-mcp` targets other clients.** It supports Claude Code, Claude Desktop, Cursor, Windsurf, Codex, and OpenCode — not Hermes. To use Keenable's MCP inside Hermes, install the catalog entry: `hermes mcp install official/keenable`.
+- **Overlaps native tools.** Don't default to this over `web_search` / `web_extract` for simple lookups.
+
+## Verification
+
+```bash
+keenable --version && keenable search "hello world" | head -20
+```
+Prints a version string followed by YAML search results.


### PR DESCRIPTION
## What does this PR do?

Adds **Keenable** (low-latency web search + page-to-markdown fetch for agents) as a native Web Search & Extract provider, following the plugin architecture from #25182 and the provider precedents in #29042 (xAI) / #46559 (iFlow).

Users select Keenable from the Web Search & Extract provider picker (or `web.backend: keenable` in `config.yaml`). It maps:

- `WebSearchProvider.search()` → `GET /v1/search?query=` (result count applied client-side)
- `WebSearchProvider.extract()` → `GET /v1/fetch?url=`

against `https://api.keenable.ai` (endpoints/DTOs per the published OpenAPI spec at `docs.keenable.ai/api-reference`). The `X-API-Key` header is sent when a key is configured; requests also send `X-Keenable-Title: Hermes` for client attribution.

The PR also ships two optional, separable surfaces for the same vendor (see **Scope** below): an optional CLI skill and an MCP catalog entry.

## Motivation

Keenable fits the Web Search & Extract provider layer (search + page fetch in one provider, no browser sessions). **Keyless, but opt-in.** Keenable's free tier works without a key: when `KEENABLE_API_KEY` is unset the provider calls the `/public` endpoint variants (rate-limited) and omits `X-API-Key`, mirroring Keenable's official MCP client. To avoid the silent-default issue the keyless-Parallel revert (#46350) addressed, keenable is **never auto-selected** — `is_available()` stays key-gated so it is excluded from the no-credential fallback, and it serves keyless only when explicitly chosen via `web.backend` / `web.*_backend`. A `KEENABLE_API_KEY` raises rate limits.

## Scope note (happy to split)

This PR bundles three logical pieces for one vendor. If reviewers prefer one-change-per-PR, I'll split into:
1. **Native provider** — `plugins/web/keenable/` + core wiring (the primary change).
2. **Optional CLI skill** — `optional-skills/research/keenable-cli/`.
3. **MCP catalog entry** — `optional-mcps/keenable/`.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🎯 New skill (optional, not bundled)

## Changes Made

**Native provider**
- `plugins/web/keenable/{plugin.yaml,__init__.py,provider.py}` — `KeenableWebSearchProvider` (search + extract), keyless `/public` fallback, `KEENABLE_API_URL` override.
- `tools/web_tools.py` — register `keenable` in the configured-backend sets, auto-detect candidate, `_is_backend_available`, and tool-metadata env vars.
- `hermes_cli/config.py` — `KEENABLE_API_KEY` in `OPTIONAL_ENV_VARS` + the API-key display/allowlist lists.
- `agent/web_search_registry.py` — added to the legacy fallback preference.

**Optional skill + MCP catalog**
- `optional-skills/research/keenable-cli/SKILL.md` — CLI skill (HARDLINE-compliant: 56-char description, modern section order).
- `optional-mcps/keenable/manifest.yaml` — remote HTTP MCP catalog entry (`api.keenable.ai/mcp`).

**Packaging / attribution / docs**
- `pyproject.toml` — `data-files` target so the MCP manifest ships in the wheel.
- `scripts/release.py` — `AUTHOR_MAP` entry.
- `website/docs/**` + `website/i18n/zh-Hans/**` — Keenable added to provider/env-var tables (EN + zh).

**Tests**
- `tests/tools/conftest.py` + `tests/plugins/web/test_web_search_provider_plugins.py` — existing provider-set/capability assertions updated to include `keenable`.

## How to Test

```bash
# Provider discovery + capability + ABC conformance (no network)
uv run --extra dev pytest tests/plugins/web/test_web_search_provider_plugins.py -q
# MCP catalog + packaging
uv run --extra dev pytest tests/hermes_cli/test_mcp_catalog.py tests/test_packaging_metadata.py -q
# Live smoke (keyless works; export KEENABLE_API_KEY to raise limits)
hermes config set web.backend keenable
hermes -q "search the web for the latest on AI agents and summarize the top result"
```

## Checklist

- [x] I've read the Contributing Guide
- [x] Commits follow Conventional Commits
- [x] PR contains only Keenable-related changes
- [ ] `pytest tests/ -q` locally — **not run by the author locally** (no dev env); CI is the gate. Provider request/response shaping verified via injected-`httpx` checks (keyed + keyless paths).
- [ ] Dedicated provider test (`tests/tools/test_web_providers_keenable.py`) — **not yet added**; existing provider-set tests updated instead. Happy to add to match the xAI/iFlow pattern.
- [x] Tested on Linux / Python 3.11 (request shapes + normalization)
- [x] Cross-platform: pure-Python `httpx`; skill declares all three platforms; MCP is a remote URL
- [x] Docs updated (EN + zh-Hans provider/env-var tables)
- [x] No new PyPI dependencies (reuses existing `httpx`)

## Notes for maintainers

Endpoints/DTOs follow Keenable's published OpenAPI spec (`docs.keenable.ai/api-reference`). **Live keyless smoke test passed** against `api.keenable.ai` (`/v1/search/public` + `/v1/fetch/public`): search returns ranked results, fetch returns page markdown. The smoke test also caught and fixed a spec/live mismatch — `/v1/search` takes no `count` param, so `limit` is applied client-side. The keyed `X-API-Key` path is covered by injected-`httpx` checks (no raw API key on hand for a live keyed run). Squash-merge recommended.
