### PR TITLE
feat: add morning PR review brief helper

### DIFF
--- a/scripts/morning_pr_brief.py
+++ b/scripts/morning_pr_brief.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Build a compact morning review brief for open GitHub PRs.
+
+Spec / plan:
+- Input: JSON array shaped like `gh pr list --json ...`, from `--json-file`, stdin,
+  or live `gh pr list` when no JSON is supplied.
+- Output: deterministic Markdown grouped by action priority so Joe can review the
+  few PRs that need attention first.
+- Safety: read-only helper; it never mutates GitHub state, sends messages, or
+  shells out except for `gh pr list`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+GH_FIELDS = (
+    "number,title,url,headRefName,author,updatedAt,reviewDecision,isDraft,"
+    "mergeStateStatus,statusCheckRollup"
+)
+PRIORITY_ORDER = ("Review now", "Stale / blocked", "Approved / low-touch")
+
+
+@dataclasses.dataclass(frozen=True)
+class PullRequest:
+    number: int
+    title: str
+    url: str
+    branch: str
+    author: str
+    updated_at: dt.datetime
+    age_label: str
+    review_decision: str
+    is_draft: bool
+    merge_state: str
+    checks_summary: str
+    priority: str
+
+
+def _parse_time(value: str) -> dt.datetime:
+    if not value:
+        return dt.datetime.fromtimestamp(0, tz=dt.timezone.utc)
+    normalized = value.replace("Z", "+00:00")
+    parsed = dt.datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _age_label(updated_at: dt.datetime, now: dt.datetime) -> str:
+    seconds = max(0, int((now - updated_at).total_seconds()))
+    if seconds < 3600:
+        minutes = max(1, seconds // 60)
+        return f"{minutes}m"
+    if seconds < 86_400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86_400}d"
+
+
+def _checks_summary(raw_checks: Any) -> str:
+    if not raw_checks:
+        return "checks unknown"
+    nodes = raw_checks.get("nodes", []) if isinstance(raw_checks, dict) else []
+    if not nodes:
+        return "checks unknown"
+    counts: dict[str, int] = defaultdict(int)
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        state = node.get("conclusion") or node.get("status") or "UNKNOWN"
+        counts[str(state).lower()] += 1
+    if not counts:
+        return "checks unknown"
+    return ", ".join(f"{count} {state}" for state, count in sorted(counts.items()))
+
+
+def _priority(is_draft: bool, review_decision: str, merge_state: str, age_days: int) -> str:
+    merge_state = merge_state.upper()
+    review_decision = review_decision.upper()
+    if is_draft or merge_state in {"DIRTY", "BLOCKED", "UNKNOWN"} or age_days >= 7:
+        return "Stale / blocked"
+    if review_decision in {"REVIEW_REQUIRED", "CHANGES_REQUESTED", ""}:
+        return "Review now"
+    return "Approved / low-touch"
+
+
+def normalize_pull_requests(raw_prs: Iterable[dict[str, Any]], *, now: dt.datetime | None = None) -> list[PullRequest]:
+    """Normalize GitHub PR JSON and sort by Joe's morning-review priority."""
+    now = (now or dt.datetime.now(dt.timezone.utc)).astimezone(dt.timezone.utc)
+    normalized: list[PullRequest] = []
+    for raw in raw_prs:
+        updated_at = _parse_time(str(raw.get("updatedAt") or ""))
+        age_days = max(0, int((now - updated_at).total_seconds() // 86_400))
+        review_decision = str(raw.get("reviewDecision") or "")
+        merge_state = str(raw.get("mergeStateStatus") or "UNKNOWN")
+        is_draft = bool(raw.get("isDraft", False))
+        author = raw.get("author") or {}
+        author_login = author.get("login", "unknown") if isinstance(author, dict) else str(author)
+        normalized.append(
+            PullRequest(
+                number=int(raw.get("number", 0)),
+                title=str(raw.get("title") or "(untitled)"),
+                url=str(raw.get("url") or ""),
+                branch=str(raw.get("headRefName") or ""),
+                author=author_login,
+                updated_at=updated_at,
+                age_label=_age_label(updated_at, now),
+                review_decision=review_decision or "UNKNOWN",
+                is_draft=is_draft,
+                merge_state=merge_state,
+                checks_summary=_checks_summary(raw.get("statusCheckRollup")),
+                priority=_priority(is_draft, review_decision, merge_state, age_days),
+            )
+        )
+
+    priority_rank = {name: idx for idx, name in enumerate(PRIORITY_ORDER)}
+    return sorted(normalized, key=lambda pr: (priority_rank[pr.priority], pr.updated_at), reverse=False)
+
+
+def build_brief(raw_prs: Sequence[dict[str, Any]], *, now: dt.datetime | None = None, limit: int = 10) -> str:
+    """Return a Markdown morning brief, or `[SILENT]` when there are no PRs."""
+    prs = normalize_pull_requests(raw_prs, now=now)
+    if not prs:
+        return "[SILENT]"
+
+    selected = prs[:limit]
+    omitted = max(0, len(prs) - len(selected))
+    lines = ["# Morning PR review brief", "", f"Open PRs scanned: {len(prs)}", ""]
+
+    for priority in PRIORITY_ORDER:
+        bucket = [pr for pr in selected if pr.priority == priority]
+        if not bucket:
+            continue
+        lines.extend([f"## {priority}", ""])
+        for pr in bucket:
+            draft = " draft" if pr.is_draft else ""
+            lines.append(f"- [#{pr.number} {pr.title}]({pr.url}) — {pr.age_label} ago{draft}")
+            lines.append(
+                f"  - branch `{pr.branch}` by @{pr.author}; review `{pr.review_decision}`; "
+                f"merge `{pr.merge_state}`; {pr.checks_summary}"
+            )
+        lines.append("")
+
+    if omitted:
+        plural = "s" if omitted != 1 else ""
+        lines.append(f"_{omitted} additional PR{plural} omitted by --limit._")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _fetch_open_pr_json() -> str:
+    cmd = ["gh", "pr", "list", "--state", "open", "--limit", "25", "--json", GH_FIELDS]
+    last_error: subprocess.CalledProcessError | None = None
+    for attempt in range(3):
+        try:
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            return result.stdout
+        except subprocess.CalledProcessError as exc:
+            last_error = exc
+            if attempt < 2:
+                time.sleep(1 + attempt)
+    stderr = (last_error.stderr or "").strip() if last_error else ""
+    raise RuntimeError(f"gh pr list failed after retries: {stderr or last_error}")
+
+
+def _load_json(path: str | None) -> list[dict[str, Any]]:
+    if path:
+        text = Path(path).read_text(encoding="utf-8")
+    elif not sys.stdin.isatty():
+        # Many automation shells attach a non-interactive stdin even when no
+        # pipe is provided.  Treat empty stdin as "use live gh" rather than as
+        # "there are no PRs", otherwise cron smoke checks falsely go silent.
+        text = sys.stdin.read()
+        if not text.strip():
+            text = _fetch_open_pr_json()
+    else:
+        text = _fetch_open_pr_json()
+    data = json.loads(text or "[]")
+    if not isinstance(data, list):
+        raise ValueError("Expected a JSON array of pull requests")
+    return [item for item in data if isinstance(item, dict)]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a compact morning PR review brief.")
+    parser.add_argument("--json-file", help="Read gh-pr-list JSON from this file instead of stdin/live gh.")
+    parser.add_argument("--limit", type=int, default=10, help="Maximum PRs to include in the brief.")
+    args = parser.parse_args(argv)
+
+    try:
+        raw_prs = _load_json(args.json_file)
+        print(build_brief(raw_prs, limit=max(1, args.limit)), end="")
+    except Exception as exc:  # pragma: no cover - CLI guardrail
+        print(f"morning_pr_brief failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/morning_pr_brief.py
+++ b/scripts/morning_pr_brief.py
@@ -5,7 +5,7 @@ Spec / plan:
 - Input: JSON array shaped like `gh pr list --json ...`, from `--json-file`, stdin,
   or live `gh pr list` when no JSON is supplied.
 - Output: deterministic Markdown grouped by action priority so Joe can review the
-  few PRs that need attention first.
+  few PRs that need attention first, with a concrete next-action hint per PR.
 - Safety: read-only helper; it never mutates GitHub state, sends messages, or
   shells out except for `gh pr list`.
 """
@@ -43,6 +43,8 @@ class PullRequest:
     is_draft: bool
     merge_state: str
     checks_summary: str
+    has_failed_checks: bool
+    next_action: str
     priority: str
 
 
@@ -83,6 +85,17 @@ def _checks_summary(raw_checks: Any) -> str:
     return ", ".join(f"{count} {state}" for state, count in sorted(counts.items()))
 
 
+def _has_failed_checks(raw_checks: Any) -> bool:
+    nodes = raw_checks.get("nodes", []) if isinstance(raw_checks, dict) else []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        state = str(node.get("conclusion") or node.get("status") or "").upper()
+        if state in {"FAILURE", "FAILED", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"}:
+            return True
+    return False
+
+
 def _priority(is_draft: bool, review_decision: str, merge_state: str, age_days: int) -> str:
     merge_state = merge_state.upper()
     review_decision = review_decision.upper()
@@ -91,6 +104,24 @@ def _priority(is_draft: bool, review_decision: str, merge_state: str, age_days: 
     if review_decision in {"REVIEW_REQUIRED", "CHANGES_REQUESTED", ""}:
         return "Review now"
     return "Approved / low-touch"
+
+
+def _next_action(is_draft: bool, review_decision: str, merge_state: str, has_failed_checks: bool) -> str:
+    merge_state = merge_state.upper()
+    review_decision = review_decision.upper()
+    if is_draft:
+        return "wait for draft to be marked ready"
+    if merge_state == "DIRTY":
+        return "resolve merge conflict or rebase"
+    if has_failed_checks:
+        return "fix failing checks before review"
+    if review_decision == "CHANGES_REQUESTED":
+        return "address requested changes"
+    if review_decision in {"REVIEW_REQUIRED", ""}:
+        return "review and decide"
+    if merge_state in {"BLOCKED", "UNKNOWN"}:
+        return "inspect merge blocker"
+    return "low-touch follow-up"
 
 
 def normalize_pull_requests(raw_prs: Iterable[dict[str, Any]], *, now: dt.datetime | None = None) -> list[PullRequest]:
@@ -103,6 +134,8 @@ def normalize_pull_requests(raw_prs: Iterable[dict[str, Any]], *, now: dt.dateti
         review_decision = str(raw.get("reviewDecision") or "")
         merge_state = str(raw.get("mergeStateStatus") or "UNKNOWN")
         is_draft = bool(raw.get("isDraft", False))
+        raw_checks = raw.get("statusCheckRollup")
+        has_failed_checks = _has_failed_checks(raw_checks)
         author = raw.get("author") or {}
         author_login = author.get("login", "unknown") if isinstance(author, dict) else str(author)
         normalized.append(
@@ -117,7 +150,9 @@ def normalize_pull_requests(raw_prs: Iterable[dict[str, Any]], *, now: dt.dateti
                 review_decision=review_decision or "UNKNOWN",
                 is_draft=is_draft,
                 merge_state=merge_state,
-                checks_summary=_checks_summary(raw.get("statusCheckRollup")),
+                checks_summary=_checks_summary(raw_checks),
+                has_failed_checks=has_failed_checks,
+                next_action=_next_action(is_draft, review_decision, merge_state, has_failed_checks),
                 priority=_priority(is_draft, review_decision, merge_state, age_days),
             )
         )
@@ -148,6 +183,7 @@ def build_brief(raw_prs: Sequence[dict[str, Any]], *, now: dt.datetime | None = 
                 f"  - branch `{pr.branch}` by @{pr.author}; review `{pr.review_decision}`; "
                 f"merge `{pr.merge_state}`; {pr.checks_summary}"
             )
+            lines.append(f"  - next action: {pr.next_action}")
         lines.append("")
 
     if omitted:

--- a/tests/test_morning_pr_brief.py
+++ b/tests/test_morning_pr_brief.py
@@ -1,0 +1,110 @@
+import datetime as dt
+import io
+import sys
+
+import scripts.morning_pr_brief as morning_pr_brief
+from scripts.morning_pr_brief import build_brief, normalize_pull_requests
+
+
+def test_normalize_pull_requests_scores_review_priority():
+    now = dt.datetime(2026, 6, 21, 0, 0, tzinfo=dt.timezone.utc)
+    raw = [
+        {
+            "number": 10,
+            "title": "fix gateway restart",
+            "url": "https://example.test/pull/10",
+            "headRefName": "joe/fix-gateway",
+            "author": {"login": "alice"},
+            "updatedAt": "2026-06-20T22:00:00Z",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "isDraft": False,
+            "mergeStateStatus": "CLEAN",
+        },
+        {
+            "number": 11,
+            "title": "draft large refactor",
+            "url": "https://example.test/pull/11",
+            "headRefName": "joe/refactor",
+            "author": {"login": "bob"},
+            "updatedAt": "2026-06-10T00:00:00Z",
+            "reviewDecision": "APPROVED",
+            "isDraft": True,
+            "mergeStateStatus": "DIRTY",
+        },
+    ]
+
+    prs = normalize_pull_requests(raw, now=now)
+
+    assert [pr.number for pr in prs] == [10, 11]
+    assert prs[0].priority == "Review now"
+    assert prs[0].age_label == "2h"
+    assert prs[1].priority == "Stale / blocked"
+    assert prs[1].age_label == "11d"
+
+
+def test_build_brief_groups_prs_and_limits_output():
+    now = dt.datetime(2026, 6, 21, 0, 0, tzinfo=dt.timezone.utc)
+    raw = [
+        {
+            "number": 1,
+            "title": "ready change",
+            "url": "https://example.test/pull/1",
+            "headRefName": "joe/ready",
+            "author": {"login": "alice"},
+            "updatedAt": "2026-06-20T23:30:00Z",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "isDraft": False,
+            "mergeStateStatus": "CLEAN",
+        },
+        {
+            "number": 2,
+            "title": "approved change",
+            "url": "https://example.test/pull/2",
+            "headRefName": "joe/approved",
+            "author": {"login": "alice"},
+            "updatedAt": "2026-06-19T00:00:00Z",
+            "reviewDecision": "APPROVED",
+            "isDraft": False,
+            "mergeStateStatus": "CLEAN",
+        },
+        {
+            "number": 3,
+            "title": "old conflict",
+            "url": "https://example.test/pull/3",
+            "headRefName": "joe/conflict",
+            "author": {"login": "alice"},
+            "updatedAt": "2026-06-01T00:00:00Z",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "isDraft": False,
+            "mergeStateStatus": "DIRTY",
+        },
+    ]
+
+    brief = build_brief(raw, now=now, limit=2)
+
+    assert "# Morning PR review brief" in brief
+    assert "## Review now" in brief
+    assert "#1 ready change" in brief
+    assert "## Stale / blocked" in brief
+    assert "#3 old conflict" in brief
+    assert "#2 approved change" not in brief
+    assert "1 additional PR omitted" in brief
+
+
+def test_load_json_falls_back_to_gh_when_automation_stdin_is_empty(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    monkeypatch.setattr(
+        morning_pr_brief,
+        "_fetch_open_pr_json",
+        lambda: '[{"number": 99, "title": "from gh"}]',
+    )
+
+    loaded = morning_pr_brief._load_json(None)
+
+    assert loaded == [{"number": 99, "title": "from gh"}]
+
+
+def test_build_brief_returns_silent_marker_when_empty():
+    now = dt.datetime(2026, 6, 21, 0, 0, tzinfo=dt.timezone.utc)
+
+    assert build_brief([], now=now) == "[SILENT]"

--- a/tests/test_morning_pr_brief.py
+++ b/tests/test_morning_pr_brief.py
@@ -91,6 +91,40 @@ def test_build_brief_groups_prs_and_limits_output():
     assert "1 additional PR omitted" in brief
 
 
+def test_build_brief_includes_next_action_for_failed_checks_and_conflicts():
+    now = dt.datetime(2026, 6, 21, 0, 0, tzinfo=dt.timezone.utc)
+    raw = [
+        {
+            "number": 4,
+            "title": "failing checks",
+            "url": "https://example.test/pull/4",
+            "headRefName": "joe/failing",
+            "author": {"login": "alice"},
+            "updatedAt": "2026-06-20T23:00:00Z",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "isDraft": False,
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": {"nodes": [{"conclusion": "FAILURE"}]},
+        },
+        {
+            "number": 5,
+            "title": "merge conflict",
+            "url": "https://example.test/pull/5",
+            "headRefName": "joe/conflict",
+            "author": {"login": "bob"},
+            "updatedAt": "2026-06-20T22:00:00Z",
+            "reviewDecision": "APPROVED",
+            "isDraft": False,
+            "mergeStateStatus": "DIRTY",
+        },
+    ]
+
+    brief = build_brief(raw, now=now)
+
+    assert "next action: fix failing checks before review" in brief
+    assert "next action: resolve merge conflict or rebase" in brief
+
+
 def test_load_json_falls_back_to_gh_when_automation_stdin_is_empty(monkeypatch):
     monkeypatch.setattr(sys, "stdin", io.StringIO(""))
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- add a read-only `scripts/morning_pr_brief.py` helper that turns `gh pr list` JSON/live output into a compact Markdown morning review queue
- group open PRs by Review now / Stale or blocked / Approved low-touch so the highest-leverage reviews are first
- add per-PR `next action` hints for conflicts, failing checks, requested changes, drafts, and low-touch follow-up
- handle cron/non-interactive empty stdin by falling back to live `gh`, with lightweight retries for transient GitHub GraphQL 5xxs

## Spec / plan
- Input: `gh pr list` JSON from `--json-file`, stdin, or live `gh` when no JSON is provided
- Output: deterministic Markdown; emit `[SILENT]` only when there are genuinely no PRs
- Safety: read-only; no GitHub mutation, no message sending, no deployment

## Tests
- `scripts/run_tests.sh tests/test_morning_pr_brief.py`
- `python scripts/morning_pr_brief.py --json-file <sample-json>`
