### PR TITLE
fix: drain stream consumer before sending clarify card to prevent message ordering race

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20460,6 +20460,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception:
                     pass
 
+                # Drain the stream consumer before sending the clarify card.
+                # Without this, streamed text from the same model turn can
+                # arrive AFTER the clarify card on platforms with async
+                # delivery (Telegram), making the card appear above the
+                # question text.  drain() blocks until the background task
+                # has flushed all queued deltas/segment-breaks.
+                _sc = stream_consumer_holder[0] if stream_consumer_holder else None
+                if _sc is not None:
+                    try:
+                        _sc.drain(timeout=2.0)
+                    except Exception:
+                        logger.debug("Stream consumer drain before clarify failed", exc_info=True)
+
                 send_ok = False
                 fut = safe_schedule_threadsafe(
                     _status_adapter.send_clarify(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1959,6 +1959,41 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+def _schedule_clarify_after_stream_drain(
+    *,
+    stream_consumer: Any,
+    adapter: Any,
+    chat_id: str,
+    question: str,
+    choices: Any,
+    clarify_id: str,
+    session_key: str,
+    metadata: Any,
+    loop: Any,
+    schedule: Callable[..., Any] = safe_schedule_threadsafe,
+):
+    """Drain pending stream output before scheduling a clarify card."""
+    if stream_consumer is not None:
+        try:
+            stream_consumer.drain(timeout=2.0)
+        except Exception:
+            logger.debug("Stream consumer drain before clarify failed", exc_info=True)
+
+    return schedule(
+        adapter.send_clarify(
+            chat_id=chat_id,
+            question=question,
+            choices=choices,
+            clarify_id=clarify_id,
+            session_key=session_key,
+            metadata=metadata,
+        ),
+        loop,
+        logger=logger,
+        log_message="Clarify send failed to schedule",
+    )
+
+
 _OWN_POLICY_OPEN_ENV = {
     Platform.WECOM: ("WECOM_DM_POLICY", "WECOM_GROUP_POLICY", "WECOM_ALLOW_ALL_USERS"),
     Platform.WEIXIN: ("WEIXIN_DM_POLICY", "WEIXIN_GROUP_POLICY", "WEIXIN_ALLOW_ALL_USERS"),
@@ -20460,32 +20495,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception:
                     pass
 
-                # Drain the stream consumer before sending the clarify card.
-                # Without this, streamed text from the same model turn can
-                # arrive AFTER the clarify card on platforms with async
-                # delivery (Telegram), making the card appear above the
-                # question text.  drain() blocks until the background task
-                # has flushed all queued deltas/segment-breaks.
                 _sc = stream_consumer_holder[0] if stream_consumer_holder else None
-                if _sc is not None:
-                    try:
-                        _sc.drain(timeout=2.0)
-                    except Exception:
-                        logger.debug("Stream consumer drain before clarify failed", exc_info=True)
-
                 send_ok = False
-                fut = safe_schedule_threadsafe(
-                    _status_adapter.send_clarify(
-                        chat_id=_status_chat_id,
-                        question=question,
-                        choices=list(choices) if choices else None,
-                        clarify_id=clarify_id,
-                        session_key=session_key or "",
-                        metadata=_status_thread_metadata,
-                    ),
-                    _loop_for_step,
-                    logger=logger,
-                    log_message="Clarify send failed to schedule",
+                fut = _schedule_clarify_after_stream_drain(
+                    stream_consumer=_sc,
+                    adapter=_status_adapter,
+                    chat_id=_status_chat_id,
+                    question=question,
+                    choices=list(choices) if choices else None,
+                    clarify_id=clarify_id,
+                    session_key=session_key or "",
+                    metadata=_status_thread_metadata,
+                    loop=_loop_for_step,
                 )
                 if fut is None:
                     send_ok = False

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -20,6 +20,7 @@ import inspect
 import logging
 import queue
 import re
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
@@ -45,6 +46,11 @@ _DONE = object()
 # Sentinel to signal a tool boundary — finalize current message and start a
 # new one so that subsequent text appears below tool progress messages.
 _NEW_SEGMENT = object()
+
+# Sentinel for drain() — the background task sets _drain_event when it
+# processes this, allowing a sync caller on the agent thread to wait until
+# all queued deltas/segment-breaks have been flushed to the platform.
+_DRAIN_SYNC = object()
 
 # Queue marker for a completed assistant commentary message emitted between
 # API/tool iterations (for example: "I'll inspect the repo first.").
@@ -222,6 +228,12 @@ class GatewayStreamConsumer:
         self._draft_failures = 0
         self._before_finalize_notified = False
 
+        # Drain sync: allows a sync caller on the agent thread to wait until
+        # the background task has processed all queued items up to a drain
+        # sentinel.  Used by _clarify_callback_sync to ensure streamed text
+        # is flushed before the clarify card is sent.
+        self._drain_event: threading.Event = threading.Event()
+
     def _metadata_for_send(
         self,
         *,
@@ -384,6 +396,23 @@ class GatewayStreamConsumer:
     def finish(self) -> None:
         """Signal that the stream is complete."""
         self._queue.put(_DONE)
+
+    def drain(self, timeout: float = 2.0) -> bool:
+        """Block the calling (agent) thread until the background task has
+        processed all queued deltas and segment breaks.
+
+        Puts a ``_DRAIN_SYNC`` sentinel at the tail of the queue and waits
+        for the background task to set ``_drain_event``.  This ensures
+        streamed text is fully flushed to the platform before a subsequent
+        sync send (e.g. ``send_clarify``) fires — preventing the clarify
+        card from appearing above the streamed text.
+
+        Returns ``True`` if the drain completed within *timeout*, ``False``
+        on timeout (the caller should proceed anyway rather than hang).
+        """
+        self._drain_event.clear()
+        self._queue.put(_DRAIN_SYNC)
+        return self._drain_event.wait(timeout=timeout)
 
     # ── Think-block filtering ────────────────────────────────────────
     # Models like MiniMax emit inline <think>...</think> blocks in their
@@ -582,6 +611,7 @@ class GatewayStreamConsumer:
                 # Drain all available items from the queue
                 got_done = False
                 got_segment_break = False
+                got_drain_sync = False
                 commentary_text = None
                 while True:
                     try:
@@ -591,6 +621,9 @@ class GatewayStreamConsumer:
                             break
                         if item is _NEW_SEGMENT:
                             got_segment_break = True
+                            break
+                        if item is _DRAIN_SYNC:
+                            got_drain_sync = True
                             break
                         if isinstance(item, tuple) and len(item) == 2 and item[0] is _COMMENTARY:
                             commentary_text = item[1]
@@ -627,6 +660,7 @@ class GatewayStreamConsumer:
                 should_edit = (
                     got_done
                     or got_segment_break
+                    or got_drain_sync
                     or commentary_text is not None
                 )
                 if not self.cfg.buffer_only:
@@ -857,6 +891,21 @@ class GatewayStreamConsumer:
                     ):
                         await self._flush_segment_tail_on_edit_failure()
                     self._reset_segment_state(preserve_no_edit=True)
+
+                # Drain sync: signal the waiting agent thread that all
+                # queued deltas and segment breaks have been processed.
+                # The caller (drain()) puts _DRAIN_SYNC after any pending
+                # _NEW_SEGMENT, so by the time we get here the segment
+                # break has already been handled above.  Treat drain_sync
+                # like a segment break for state-reset purposes so the
+                # next text block starts a fresh message.
+                if got_drain_sync:
+                    if self._accumulated and not current_update_visible:
+                        # Flush any remaining accumulated text that wasn't
+                        # sent by the should_edit path above.
+                        await self._send_or_edit(self._accumulated, finalize=True)
+                    self._reset_segment_state(preserve_no_edit=True)
+                    self._drain_event.set()
 
                 await asyncio.sleep(0.05)  # Small yield to not busy-loop
 

--- a/tests/gateway/test_clarify_drain_ordering.py
+++ b/tests/gateway/test_clarify_drain_ordering.py
@@ -1,0 +1,53 @@
+"""Regression coverage for clarify-card ordering at the gateway boundary."""
+
+import asyncio
+import concurrent.futures
+from types import SimpleNamespace
+
+from gateway.run import _schedule_clarify_after_stream_drain
+
+
+class _FakeStreamConsumer:
+    def __init__(self, events):
+        self._events = events
+
+    def drain(self, timeout=2.0):
+        self._events.append("drain")
+        return True
+
+
+class _FakeAdapter:
+    def __init__(self, events):
+        self._events = events
+
+    async def send_clarify(self, **kwargs):
+        self._events.append("send_clarify")
+        return SimpleNamespace(success=True)
+
+
+def test_clarify_send_is_scheduled_after_stream_drain():
+    events = []
+    consumer = _FakeStreamConsumer(events)
+    adapter = _FakeAdapter(events)
+
+    def schedule(coro, loop, *, logger, log_message):
+        result = asyncio.run(coro)
+        future = concurrent.futures.Future()
+        future.set_result(result)
+        return future
+
+    future = _schedule_clarify_after_stream_drain(
+        stream_consumer=consumer,
+        adapter=adapter,
+        chat_id="chat-1",
+        question="What color?",
+        choices=["red", "blue"],
+        clarify_id="clarify-1",
+        session_key="session-1",
+        metadata=None,
+        loop=None,
+        schedule=schedule,
+    )
+
+    assert future.result().success is True
+    assert events == ["drain", "send_clarify"]

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -2379,3 +2379,119 @@ class TestStripOrphanCloseTags:
             assert tag not in consumer._accumulated
         assert "trailing prose" in consumer._accumulated
         assert "more" in consumer._accumulated
+
+
+# ── drain() sync barrier tests ──────────────────────────────────────────
+
+
+class TestDrainSync:
+    """Verify drain() blocks the calling thread until the background task
+    has flushed all queued deltas/segment-breaks to the platform."""
+
+    @pytest.mark.asyncio
+    async def test_drain_returns_after_segment_break_processed(self):
+        """drain() should return True after the background task processes
+        a pending _NEW_SEGMENT and the _DRAIN_SYNC sentinel."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="m1",
+        ))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="m1",
+        ))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.REQUIRES_EDIT_FINALIZE = False
+
+        consumer = GatewayStreamConsumer(adapter, "chat_drain")
+        task = asyncio.create_task(consumer.run())
+
+        # Give the background task a moment to start.
+        await asyncio.sleep(0.1)
+
+        # Queue some text and a segment break.
+        consumer.on_delta("Hello world")
+        consumer.on_delta(None)  # segment break
+
+        # drain() blocks the calling thread — run it in a separate thread
+        # so it doesn't block the event loop that the background task needs.
+        import threading as _t
+        result = {}
+        def _do_drain():
+            result["ok"] = consumer.drain(timeout=3.0)
+        t = _t.Thread(target=_do_drain)
+        t.start()
+
+        # Yield to the event loop so the background task can process
+        # the queue while the drain thread waits.
+        deadline = asyncio.get_event_loop().time() + 5.0
+        while t.is_alive() and asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.05)
+        t.join(timeout=0.1)
+
+        ok = result.get("ok")
+        assert ok is True, "drain() should return True when the event fires"
+
+        consumer.finish()
+        await asyncio.wait_for(task, timeout=2.0)
+
+    @pytest.mark.asyncio
+    async def test_drain_timeout_returns_false(self):
+        """drain() should return False on timeout if the background task
+        never processes the sentinel (e.g. it hasn't started yet)."""
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        consumer = GatewayStreamConsumer(adapter, "chat_timeout")
+
+        # Don't start the background task — drain should time out.
+        # Run in a thread so we don't block the event loop.
+        import threading as _t
+        result = {}
+        def _do_drain():
+            result["ok"] = consumer.drain(timeout=0.1)
+        t = _t.Thread(target=_do_drain)
+        t.start()
+        t.join(timeout=2.0)
+
+        assert result.get("ok") is False, "drain() should return False on timeout"
+
+    @pytest.mark.asyncio
+    async def test_drain_flushes_accumulated_text(self):
+        """drain() should cause accumulated (unflushed) text to be sent
+        to the platform before the event is set."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="m1",
+        ))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="m1",
+        ))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.REQUIRES_EDIT_FINALIZE = False
+
+        consumer = GatewayStreamConsumer(adapter, "chat_flush")
+        task = asyncio.create_task(consumer.run())
+
+        # Give the background task a moment to start.
+        await asyncio.sleep(0.1)
+
+        # Queue text without a segment break, then drain.
+        consumer.on_delta("Flushing test")
+
+        import threading as _t
+        result = {}
+        def _do_drain():
+            result["ok"] = consumer.drain(timeout=3.0)
+        t = _t.Thread(target=_do_drain)
+        t.start()
+
+        deadline = asyncio.get_event_loop().time() + 5.0
+        while t.is_alive() and asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.05)
+        t.join(timeout=0.1)
+
+        assert result.get("ok") is True
+        # The text should have been sent (either via send or edit_message).
+        assert adapter.send.called or adapter.edit_message.called
+
+        consumer.finish()
+        await asyncio.wait_for(task, timeout=2.0)


### PR DESCRIPTION
## Problem

On platforms with async delivery (Telegram), the clarify card can appear **above** the streamed text from the same model turn. This is a race condition between the streaming consumer's background task and the synchronous clarify callback.

### Root cause

When the agent calls `clarify` after emitting text in the same turn:

1. `stream_delta_callback(None)` queues `_NEW_SEGMENT` (finalizes current message)
2. The agent thread immediately enters `_clarify_callback_sync`
3. `send_clarify()` is scheduled on the event loop and awaited (15s timeout)
4. **But** the stream consumer's background task may not have processed the `_NEW_SEGMENT` yet — the finalize edit is still pending in the queue
5. The clarify card lands in the chat **before** the streamed text is finalized

The agent thread never waits for the stream consumer to flush before sending the clarify card.

## Fix

Add a `drain()` method to `GatewayStreamConsumer` that acts as a sync barrier:

- Puts a `_DRAIN_SYNC` sentinel at the tail of the queue
- Blocks the calling (agent) thread on a `threading.Event`
- The background task sets the event after processing all queued items up to and including the sentinel
- Called in `_clarify_callback_sync` before `send_clarify()`, with a 2s timeout

### Why not just sleep?

A fixed `asyncio.sleep` is unreliable — too short on slow networks, too long when unnecessary. `drain()` blocks until the queue is actually flushed, with a safety timeout.

### Message ordering guarantee

```
Agent thread                    Background task (event loop)
─────────────                   ──────────────────────────────
stream_delta_callback(None)  →  _NEW_SEGMENT in queue
                                → finalize message (async)
clarify_callback_sync:
  drain(2.0)                 →  _DRAIN_SYNC in queue
  wait on Event...              → processes _NEW_SEGMENT
                                → processes _DRAIN_SYNC
                                → Event.set()
  Event unblocks ────────────→  (flushed!)
  send_clarify()  ← card arrives AFTER text
```

## Changes

| File | Change |
|------|--------|
| `gateway/stream_consumer.py` | `_DRAIN_SYNC` sentinel, `_drain_event` threading.Event, `drain()` method, processing in `run()` loop |
| `gateway/run.py` | `drain(timeout=2.0)` call before `send_clarify` in `_clarify_callback_sync` |
| `tests/gateway/test_stream_consumer.py` | 3 new tests in `TestDrainSync` class |

## Testing

- `179 passed` — all existing stream consumer + clarify tests
- 3 new tests:
  - `test_drain_returns_after_segment_break_processed` — drain returns True after background task processes pending items
  - `test_drain_timeout_returns_false` — drain returns False on timeout when background task never starts
  - `test_drain_flushes_accumulated_text` — drain causes unflushed text to be sent before event fires

## Safety

- **Cache-safe**: no changes to system prompt, tools, or context
- **Alternation-safe**: no message role changes
- **Timeout-bounded**: drain never hangs the agent thread (2s max)
- **Graceful degradation**: on timeout, clarify proceeds anyway — better to show the card late than never
- **No new env vars or config**: pure code fix