### PR TITLE
fix(transports): strip internal timestamp field from chat-completions messages for strict providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -150,6 +150,13 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - ``timestamp`` on user messages — written by
+          ``_apply_persist_user_message_override()`` to preserve the
+          platform event time as message metadata for the session DB,
+          but not part of the Chat Completions schema. Strict providers
+          (opencode-go, Fireworks) reject any payload containing it with
+          ``Extra inputs are not permitted, field: 'messages[N].timestamp'``.
+          Permissive providers silently ignore the field.
         - Hermes-internal scaffolding markers — any top-level message key
           starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
           ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
@@ -172,6 +179,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                or "timestamp" in msg
             ):
                 needs_sanitize = True
                 break
@@ -201,6 +209,7 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            msg.pop("timestamp", None)
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -104,6 +104,24 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[2]["tool_name"] == "execute_code"
 
+    def test_convert_messages_strips_timestamp(self, transport):
+        """Internal ``timestamp`` (set by ``_apply_persist_user_message_override``
+        to preserve platform event time for the session DB) is not part of the
+        OpenAI Chat Completions schema. Strict providers like opencode-go reject
+        it with HTTP 400 'Extra inputs are not permitted, field:
+        messages[N].timestamp'.
+        """
+        msgs = [
+            {"role": "user", "content": "hello", "timestamp": 1781980690},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "timestamp" not in result[0]
+        assert result[0]["content"] == "hello"
+        assert result[0]["role"] == "user"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[0]["timestamp"] == 1781980690
+
     def test_convert_messages_strips_internal_scaffolding_markers(self, transport):
         """Hermes-internal ``_``-prefixed markers must never reach the wire.
 


### PR DESCRIPTION
## Bug Description

Strict chat-completions gateways (opencode-go, Fireworks) reject any API request whose messages contain a `timestamp` key:

```
HTTP 400: Extra inputs are not permitted, field: 'messages[1].timestamp', value: 1781980690
```

This poisons every subsequent request in the session — on messaging platforms (Telegram, Discord) the user sees error messages instead of agent replies, and the session becomes unusable until reset.

## Root Cause

`_apply_persist_user_message_override()` in `run_agent.py` (line ~1510) attaches a `timestamp` key to user messages to preserve the platform event time as metadata for the session DB:

```python
if timestamp is not None:
    msg["timestamp"] = timestamp
```

This field is Hermes-internal — it is not part of the OpenAI Chat Completions message schema. `ChatCompletionsTransport.convert_messages()` already strips other internal fields (`tool_name`, `codex_reasoning_items`, `codex_message_items`, `_`-prefixed scaffolding markers) that strict providers reject, but `timestamp` was missing from the strip list.

The bug was masked on permissive providers (OpenRouter, MiniMax, real OpenAI) that silently ignore unknown message keys. It only surfaced on strict gateways that validate the request body against the schema.

## Fix

Add `timestamp` to the strip list in `convert_messages()` — same pattern, same risk class as the existing `tool_name` strip:

1. **Detection** — add `or "timestamp" in msg` to the `needs_sanitize` check
2. **Stripping** — add `msg.pop("timestamp", None)` to the sanitization loop
3. **Docstring** — document why `timestamp` is stripped (matching the existing entries for `tool_name` and scaffolding markers)

## How to Verify

1. Configure Hermes with a strict provider (e.g. opencode-go via `model.provider: opencode-go`)
2. Send a message from Telegram/gateway → before fix: HTTP 400 `Extra inputs are not permitted, field: 'messages[N].timestamp'`; after fix: normal response
3. Or run the regression test:
   ```bash
   python -m pytest tests/agent/transports/test_chat_completions.py::TestChatCompletionsConvertMessages::test_convert_messages_strips_timestamp -v
   ```

## Test Plan

- [x] Added regression test `test_convert_messages_strips_timestamp` — verifies the field is stripped, content is preserved, and the original list is untouched (deepcopy-on-demand)
- [x] Existing tests pass (90 passed in `tests/agent/transports/test_chat_completions.py` + `tests/gateway/test_message_timestamps.py`)
- [x] Manual verification: Telegram gateway with opencode-go provider — HTTP 400 resolved, normal responses restored

## Risk Assessment

**Low** — The `timestamp` field is Hermes-internal metadata written by the persistence layer; no provider in the OpenAI Chat Completions ecosystem expects it in the message body. Stripping it before the wire is identical in pattern and safety to the existing strips for `tool_name` and `_`-prefixed markers. The field continues to be preserved in the session DB (the strip happens only in `convert_messages`, which builds the API payload, not in `_persist_session` which writes to SQLite).
