### PR TITLE
fix(dump): accept GH_TOKEN as a GitHub credential in the env probe

### DIFF
--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -357,6 +357,10 @@ def run_dump(args):
 
     for env_var, label in api_keys:
         val = os.getenv(env_var, "")
+        # `gh` and GitHub Actions also accept GH_TOKEN; mirror that so the dump
+        # doesn't read "not set" when only GH_TOKEN is exported.
+        if not val and label == "github":
+            val = os.getenv("GH_TOKEN", "")
         if show_keys and val:
             display = _redact(val)
         else:

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -358,8 +358,10 @@ def run_dump(args):
     for env_var, label in api_keys:
         val = os.getenv(env_var, "")
         # `gh` and GitHub Actions also accept GH_TOKEN; mirror that so the dump
-        # doesn't read "not set" when only GH_TOKEN is exported.
-        if not val and label == "github":
+        # doesn't read "not set" when only GH_TOKEN is exported. Key off the
+        # env-var name, not the display label, so a label rename can't silently
+        # drop the fallback.
+        if not val and env_var == "GITHUB_TOKEN":
             val = os.getenv("GH_TOKEN", "")
         if show_keys and val:
             display = _redact(val)

--- a/tests/hermes_cli/test_dump_github_token.py
+++ b/tests/hermes_cli/test_dump_github_token.py
@@ -1,0 +1,65 @@
+"""Tests for the GitHub-credential probe in ``hermes dump`` (hermes_cli.dump.run_dump).
+
+``hermes dump`` lists each known credential as "set" / "not set" so support
+triage can see what auth is configured.  GitHub credentials are honored by both
+``GITHUB_TOKEN`` and ``GH_TOKEN`` (the latter is what ``gh`` and GitHub Actions
+export), but the probe only looked at ``GITHUB_TOKEN`` — so a perfectly valid
+``GH_TOKEN``-only environment reported GitHub as "not set".
+
+These tests drive ``run_dump`` end-to-end and assert on the ``github`` line.
+``load_hermes_dotenv`` is patched to a no-op so a real ``.env`` on the test
+machine can't reintroduce a token and mask the env we set.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _github_line(captured_out: str) -> str:
+    for line in captured_out.splitlines():
+        if line.strip().startswith("github "):
+            return line.strip()
+    raise AssertionError(f"no 'github' api_keys line in dump output:\n{captured_out}")
+
+
+def test_dump_reads_github_from_gh_token_when_github_token_unset(monkeypatch, capsys):
+    """GH_TOKEN-only env: the github row must read 'set', not 'not set'."""
+    from hermes_cli import dump
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "ghp_exampletoken")
+
+    with patch("hermes_cli.dump.load_hermes_dotenv"):
+        dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _github_line(capsys.readouterr().out)
+    assert line.endswith("set")
+    assert "not set" not in line
+
+
+def test_dump_reports_github_not_set_when_neither_var_present(monkeypatch, capsys):
+    """Guard against over-broadening: with neither var set it stays 'not set'."""
+    from hermes_cli import dump
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    with patch("hermes_cli.dump.load_hermes_dotenv"):
+        dump.run_dump(SimpleNamespace(show_keys=False))
+
+    assert _github_line(capsys.readouterr().out).endswith("not set")
+
+
+def test_dump_still_reads_github_token_directly(monkeypatch, capsys):
+    """The original GITHUB_TOKEN path is unchanged."""
+    from hermes_cli import dump
+
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_directtoken")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    with patch("hermes_cli.dump.load_hermes_dotenv"):
+        dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _github_line(capsys.readouterr().out)
+    assert line.endswith("set")
+    assert "not set" not in line

--- a/tests/hermes_cli/test_dump_github_token.py
+++ b/tests/hermes_cli/test_dump_github_token.py
@@ -29,7 +29,7 @@ def test_dump_reads_github_from_gh_token_when_github_token_unset(monkeypatch, ca
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setenv("GH_TOKEN", "ghp_exampletoken")
 
-    with patch("hermes_cli.dump.load_hermes_dotenv"):
+    with patch("hermes_cli.dump.load_hermes_dotenv", autospec=True):
         dump.run_dump(SimpleNamespace(show_keys=False))
 
     line = _github_line(capsys.readouterr().out)
@@ -44,7 +44,7 @@ def test_dump_reports_github_not_set_when_neither_var_present(monkeypatch, capsy
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GH_TOKEN", raising=False)
 
-    with patch("hermes_cli.dump.load_hermes_dotenv"):
+    with patch("hermes_cli.dump.load_hermes_dotenv", autospec=True):
         dump.run_dump(SimpleNamespace(show_keys=False))
 
     assert _github_line(capsys.readouterr().out).endswith("not set")
@@ -57,7 +57,7 @@ def test_dump_still_reads_github_token_directly(monkeypatch, capsys):
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_directtoken")
     monkeypatch.delenv("GH_TOKEN", raising=False)
 
-    with patch("hermes_cli.dump.load_hermes_dotenv"):
+    with patch("hermes_cli.dump.load_hermes_dotenv", autospec=True):
         dump.run_dump(SimpleNamespace(show_keys=False))
 
     line = _github_line(capsys.readouterr().out)


### PR DESCRIPTION
## This is a sibling follow-up to #49692

- **#49692 covered:** `hermes_cli/status.py`'s GitHub credential lookup — accepting `GH_TOKEN` alongside `GITHUB_TOKEN`.
- **#49692 did NOT touch:** `hermes_cli/dump.py`'s environment probe — the same single-alias gap reaches a different surface (`hermes dump`).
- **This PR adds:** the same `GH_TOKEN` fallback for the `github` label in `dump.py`, mirroring the existing `openrouter` credential-pool fallback in the same loop.

## What does this PR do?

`hermes dump` reported GitHub as "not set" when only `GH_TOKEN` was exported, even though `gh` and GitHub Actions both honor it. The `api_keys` probe (`hermes_cli/dump.py`) only read `GITHUB_TOKEN`, so a perfectly valid `GH_TOKEN`-only environment was misrepresented as having no GitHub auth.

This adds a `GH_TOKEN` fallback for the `github` label, placed right after the `os.getenv(env_var, "")` call so both the redacted-key path (`show_keys`) and the "set"/"not set" path reflect it. It mirrors the existing `openrouter` credential-pool fallback a few lines below in the same loop.

Self-found while reading `hermes_cli/dump.py` after #49692.

## Related Issue

N/A — sibling follow-up to #49692 (different file/surface), self-found while reading `hermes_cli/dump.py`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dump.py`: in the `api_keys` probe loop, fall back to `GH_TOKEN` when `GITHUB_TOKEN` is unset and the label is `github` (3 lines, mirroring the existing openrouter fallback).
- `tests/hermes_cli/test_dump_github_token.py` (new): drives `run_dump` end-to-end and asserts the `github` row reads "set" for a `GH_TOKEN`-only env, "not set" when neither var is present, and "set" for the original `GITHUB_TOKEN` path.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_dump_github_token.py -v`
2. The `test_dump_reads_github_from_gh_token_when_github_token_unset` test **fails before** the fix (`github ... not set`) and **passes after** (`github ... set`).
3. The neither-set guard and the direct-`GITHUB_TOKEN` test confirm the change is not over-broad.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused test suite (`pytest tests/hermes_cli/test_dump_github_token.py`) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure env-var read, platform-independent — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
tests/hermes_cli/test_dump_github_token.py::test_dump_reads_github_from_gh_token_when_github_token_unset PASSED
tests/hermes_cli/test_dump_github_token.py::test_dump_reports_github_not_set_when_neither_var_present PASSED
tests/hermes_cli/test_dump_github_token.py::test_dump_still_reads_github_token_directly PASSED
3 passed
```