### PR TITLE
docs(.env.example): add HF_BASE_URL placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,7 @@
 # Get your token at: https://huggingface.co/settings/tokens
 # Required permission: "Make calls to Inference Providers"
 # HF_TOKEN=
+# HF_BASE_URL=https://router.huggingface.co/v1  # Override default base URL
 # OPENCODE_GO_BASE_URL=https://opencode.ai/zen/go/v1  # Override default base URL
 
 # =============================================================================


### PR DESCRIPTION
## What does this PR do?

Adds the missing commented `HF_BASE_URL` placeholder to `.env.example`.

Every first-class provider section in `.env.example` documents its `*_BASE_URL` override except Hugging Face. `HF_BASE_URL` is a supported override checked by Hermes provider/config/doctor code and defaults to:

`https://router.huggingface.co/v1`

This PR adds the missing commented placeholder for consistency.

## Related Issue

N/A

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] 🌟 New feature (non-breaking change that adds functionality)
* [ ] 🔒 Security fix
* [x] 📝 Documentation update
* [ ] ✅ Tests (adding or improving test coverage)
* [ ] ♻️ Refactor (no behavior change)
* [ ] 🎯 New skill (bundled or hub)

## Changes Made

* Added a commented `HF_BASE_URL` placeholder to `.env.example`
* No code changes
* No runtime behavior changes
* No config behavior changes
* No unrelated provider keys changed

## Notes

This is independent of #28722, which only relocates the `OPENCODE_GO_BASE_URL` line.
