### PR TITLE
fix(web): send client-IP header to SearXNG to avoid bot-detection 400

### DIFF
--- a/plugins/web/searxng/provider.py
+++ b/plugins/web/searxng/provider.py
@@ -18,6 +18,14 @@ Config keys this provider responds to::
 Env var::
 
     SEARXNG_URL=http://localhost:8080
+    SEARXNG_CLIENT_IP=127.0.0.1   # optional, overrides the X-Forwarded-For value
+
+When a SearXNG instance is reached directly (e.g. over an SSH tunnel) with no
+reverse proxy populating the client IP, its bot-detection/limiter can reject
+the JSON API request with ``HTTP 400`` because no ``X-Forwarded-For`` nor
+``X-Real-IP`` header is present. We send a loopback client IP on every request
+so the limiter always has an address to key on. Override with
+``SEARXNG_CLIENT_IP`` if the instance trusts a specific source address.
 """
 
 from __future__ import annotations
@@ -42,6 +50,22 @@ def _searxng_url() -> str:
     if val is None:
         val = os.getenv("SEARXNG_URL", "")
     return (val or "").strip()
+
+
+def _client_ip() -> str:
+    """Return the client IP to advertise to SearXNG's bot-detection/limiter.
+
+    Defaults to loopback so a direct (proxy-less) instance always has an
+    address to key on. Override with ``SEARXNG_CLIENT_IP``."""
+    try:
+        from hermes_cli.config import get_env_value
+
+        val = get_env_value("SEARXNG_CLIENT_IP")
+    except Exception:
+        val = None
+    if val is None:
+        val = os.getenv("SEARXNG_CLIENT_IP", "")
+    return (val or "").strip() or "127.0.0.1"
 
 
 class SearXNGWebSearchProvider(WebSearchProvider):
@@ -79,12 +103,17 @@ class SearXNGWebSearchProvider(WebSearchProvider):
             "pageno": 1,
         }
 
+        client_ip = _client_ip()
         try:
             resp = httpx.get(
                 f"{base_url}/search",
                 params=params,
                 timeout=15,
-                headers={"Accept": "application/json"},
+                headers={
+                    "Accept": "application/json",
+                    "X-Forwarded-For": client_ip,
+                    "X-Real-IP": client_ip,
+                },
             )
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -207,6 +207,42 @@ class TestSearXNGSearchProviderSearch:
 
         assert calls[0] == "http://localhost:8080/search", f"Got: {calls[0]}"
 
+    def test_sends_client_ip_headers_by_default(self, monkeypatch):
+        """A loopback client IP is sent so a proxy-less instance's bot-detection
+        does not reject the JSON API request with HTTP 400."""
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        monkeypatch.delenv("SEARXNG_CLIENT_IP", raising=False)
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+        mock_resp = self._make_mock_response({"results": []})
+
+        captured = {}
+        def capture_get(url, **kwargs):
+            captured.update(kwargs.get("headers", {}))
+            return mock_resp
+
+        with patch("httpx.get", side_effect=capture_get):
+            SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert captured.get("X-Forwarded-For") == "127.0.0.1"
+        assert captured.get("X-Real-IP") == "127.0.0.1"
+
+    def test_client_ip_header_overridable_via_env(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        monkeypatch.setenv("SEARXNG_CLIENT_IP", "10.0.0.5")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+        mock_resp = self._make_mock_response({"results": []})
+
+        captured = {}
+        def capture_get(url, **kwargs):
+            captured.update(kwargs.get("headers", {}))
+            return mock_resp
+
+        with patch("httpx.get", side_effect=capture_get):
+            SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert captured.get("X-Forwarded-For") == "10.0.0.5"
+        assert captured.get("X-Real-IP") == "10.0.0.5"
+
 
 # ---------------------------------------------------------------------------
 # Integration: _is_backend_available recognizes "searxng"


### PR DESCRIPTION
What changed and why
---------------------
A SearXNG instance reached directly (e.g. over an SSH tunnel) with no reverse proxy to populate the client IP can reject the JSON API request with `HTTP 400`. The instance logs:

```
ERROR:searx.botdetection: X-Forwarded-For nor X-Real-IP header is set!
```

from its bot-detection/limiter. The `web_search` call then returns nothing useful, surfacing only a bare `{"success": false, "error": "SearXNG returned HTTP 400"}` to the agent, which tends to flail through fallbacks.

The provider previously sent only `Accept: application/json`. This change always sends a client IP (loopback by default) via `X-Forwarded-For` and `X-Real-IP`, so the limiter has an address to key on. The value is overridable with a new optional `SEARXNG_CLIENT_IP` env var for instances that trust a specific source address.

How to test
-----------
- `scripts/run_tests.sh tests/tools/test_web_providers_searxng.py -q` — 28 pass, including two new tests asserting the default loopback headers and the `SEARXNG_CLIENT_IP` override.
- Manual: with a self-hosted SearXNG behind an SSH tunnel (no reverse proxy), `web_search` previously returned intermittent `HTTP 400`; with the header it returns results.

Platforms tested
----------------
macOS (Apple Silicon), Python 3.11, against SearXNG `2026.4.17`.

Notes
-----
No behavior change for setups already behind a reverse proxy that sets these headers (a downstream proxy that appends to `X-Forwarded-For` still sees the real client). One logical change, no unrelated edits.