### PR TITLE
fix(gateway): call start_memory_monitoring() from start_gateway()

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17466,7 +17466,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         name="gateway-housekeeping",
     )
     housekeeping_thread.start()
-    
+
+    # Periodic memory usage heartbeat — daemon thread logs RSS + GC stats
+    # every 5 min so external watchdogs can monitor log freshness as a
+    # hung-detection heuristic.  Safe to call; creates its own daemon thread.
+    from gateway.memory_monitor import start_memory_monitoring
+    start_memory_monitoring()
+
     # Wait for shutdown
     await runner.wait_for_shutdown()
 
@@ -17483,6 +17489,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         logger.debug("Cron provider stop() error: %s", e)
     cron_thread.join(timeout=5)
     housekeeping_thread.join(timeout=5)
+
+    # Stop memory monitor (logs a final RSS snapshot before teardown).
+    try:
+        from gateway.memory_monitor import stop_memory_monitoring
+        stop_memory_monitoring()
+    except Exception:
+        pass
 
     # Stop the planned-stop watcher (daemon=True so this is belt-and-suspenders).
     _planned_stop_watcher_stop.set()

--- a/tests/gateway/test_memory_monitor.py
+++ b/tests/gateway/test_memory_monitor.py
@@ -7,6 +7,7 @@ leaks show up as a time series in agent.log / gateway.log.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import time
 
@@ -120,3 +121,23 @@ def test_unavailable_rss_warns_and_does_not_start(caplog, monkeypatch):
     assert started is False
     assert mm.is_running() is False
     assert any("Memory monitoring unavailable" in r.getMessage() for r in caplog.records)
+
+
+def test_start_gateway_calls_start_memory_monitoring():
+    """Regression: start_gateway() must call start_memory_monitoring().
+
+    Issue #49773 — the memory heartbeat was never started because
+    start_gateway() did not import or call start_memory_monitoring().
+    This test verifies the call site exists in the source.
+    """
+    import gateway.run as run_mod
+
+    source = inspect.getsource(run_mod.start_gateway)
+    assert "start_memory_monitoring" in source, (
+        "start_gateway() must call start_memory_monitoring() for the "
+        "memory heartbeat to work — see issue #49773"
+    )
+    assert "from gateway.memory_monitor import" in source, (
+        "start_gateway() must import start_memory_monitoring from "
+        "gateway.memory_monitor — see issue #49773"
+    )


### PR DESCRIPTION
## What does this PR do?

Calls `start_memory_monitoring()` from `start_gateway()` so the memory heartbeat daemon thread actually starts. Previously, the function existed but was never invoked, causing external watchdogs that monitor `gateway.log` freshness to false-trigger on idle gateways.

## Related Issue

Fixes #49773

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Import and call `start_memory_monitoring()` after housekeeping thread start; call `stop_memory_monitoring()` in the shutdown path for clean teardown
- `tests/gateway/test_memory_monitor.py`: Add regression test verifying `start_gateway()` source contains the `start_memory_monitoring` call site

## How to Test

1. Start the gateway: `hermes gateway run`
2. Wait 5+ minutes
3. Check for heartbeat entries: `grep "[MEMORY]" ~/.hermes/logs/gateway.log | tail -5`
4. Verify periodic `[MEMORY] rss=...` lines appear every ~5 minutes
5. Stop the gateway and verify a `[MEMORY] shutdown` line appears

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_memory_monitor.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/run.py::start_gateway()` (callers: 1 via `main()`, flows: gateway startup)
- Analyzed: `gateway/memory_monitor.py::start_memory_monitoring()` (callers: 0 before fix, 1 after)
- Blast radius: LOW — adds a daemon thread call to existing startup sequence; `start_memory_monitoring()` is idempotent and safe to call multiple times
- Related patterns: Similar to `_start_gateway_housekeeping()` and cron scheduler startup — daemon thread with shutdown coordination
