### PR TITLE
feat(hooks): add pre_response_delivery hook for turn-level validation

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4399,6 +4399,51 @@ def run_conversation(
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.
+
+    # ── pre_response_delivery hook gate ────────────────────────────────
+    # Plugins can inspect conversation_history and block delivery if
+    # required tool calls are missing. If a hook returns
+    # {"action": "block", "message": "..."}, the turn is re-entered with
+    # the block reason injected as a user correction. Max one retry.
+    _response_retried = False
+    if final_response and not interrupted and not _response_retried:
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook, has_hook as _has_hook
+            if _has_hook("pre_response_delivery"):
+                _hook_results = _invoke_hook(
+                    "pre_response_delivery",
+                    session_id=agent.session_id,
+                    turn_id=turn_id,
+                    user_message=user_message,
+                    final_response=final_response,
+                    conversation_history=list(messages),
+                    platform=getattr(agent, "platform", None) or "",
+                )
+                for _result in _hook_results:
+                    if isinstance(_result, dict) and _result.get("action") == "block":
+                        _reason = _result.get("message", "Blocked by pre_response_delivery hook")
+                        logger.info(
+                            "pre_response_delivery: BLOCKED — %s (session=%s)",
+                            _reason, agent.session_id,
+                        )
+                        messages.append({
+                            "role": "user",
+                            "content": (
+                                f"⚠️ Your response was blocked before delivery: {_reason}\n\n"
+                                "Please regenerate your response with ALL required "
+                                "delivery steps before composing text."
+                            ),
+                        })
+                        final_response = None
+                        _response_retried = True
+                        break
+        except Exception as exc:
+            logger.warning("pre_response_delivery hook failed: %s", exc)
+            _response_retried = True  # Prevent retry loop on hook error
+
+    if _response_retried:
+        continue  # Re-enter the tool-calling loop with correction injected
+
     from agent.turn_finalizer import finalize_turn
     return finalize_turn(
         agent,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -167,6 +167,14 @@ VALID_HOOKS: Set[str] = {
     #   choice: "once" | "session" | "always" | "deny" | "timeout"
     "pre_approval_request",
     "post_approval_response",
+    # Pre-response delivery hook. Fires after the tool-calling loop completes
+    # but BEFORE the turn result is finalized and returned. Plugins may
+    # inspect conversation_history and return {"action": "block", "message": "..."}
+    # to block delivery — causing the conversation loop to re-enter with a
+    # correction injected as a user message. First block wins.
+    # Kwargs: session_id, turn_id, user_message, final_response,
+    #         conversation_history, platform
+    "pre_response_delivery",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"


### PR DESCRIPTION
## Summary

Adds a new plugin hook `pre_response_delivery` that fires after the tool-calling loop completes but BEFORE the turn result is finalized and returned. Plugins can inspect `conversation_history` and return `{"action": "block", "message": "..."}` to block delivery.

## Motivation

This hook is the structural fix for what has been the #1 recurring failure mode in the Iris AI assistant personality — the agent skips voice delivery (TTS + audio playback) on Desktop/CLI under cognitive load despite a text-prompted mandate. With 25+ documented user corrections, a prompt self-policing mechanism has proven insufficient.

The hook enables an external shell script or Python plugin to:
1. Check whether `text_to_speech()` was called this turn
2. Check whether `voice-queue.sh` was dispatched
3. If missing → return `{"action": "block", "message": "Voice mandate: ..."}`
4. The agent loop re-enters with the correction injected

Max one retry prevents infinite loops. Zero overhead when no hook is configured (single `has_hook()` dict lookup).

## Changes

- `hermes_cli/plugins.py` — Add `pre_response_delivery` to VALID_HOOKS set
- `agent/conversation_loop.py` — Insert hook gate before `finalize_turn()`, with retry logic

## Design

- **Block via synthetic user message**: Reuses existing conversation loop — no new retry infrastructure
- **Same payload shape as `post_llm_call`**: Full `conversation_history`, `session_id`, `platform`, etc.
- **First block wins**: Multiple hooks can register; the first block result is honored
- **`has_hook()` gate**: Zero overhead when no listeners registered (consistent with `post_tool_call` pattern)

## References

This hook was designed in consultation with the Iris project's voice mandate enforcement needs. The companion shell hook script is at `~/.hermes/scripts/voice-mandate-gate.sh`.

AGENTS.md precedent: *"A hook is NOT speculative if a contributor has a real, stated use case."*
