### PR TITLE
fix(compression): deduplicate consecutive identical assistant messages in tail

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2424,8 +2424,20 @@ This compaction should PRIORITISE preserving all information related to the focu
                 COMPRESSED_SUMMARY_METADATA_KEY: True,
             })
 
+        _prev_tail_content = None
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()
+            # Deduplicate consecutive identical assistant messages in tail.
+            # In tool-calling loops, the model often produces identical text
+            # ("103 passed!") across turns. After _hyg_msgs strips tool_calls,
+            # these become consecutive identical entries that compound across
+            # compression cycles.
+            _msg_content = msg.get("content")
+            if (msg.get("role") == "assistant"
+                    and _msg_content == _prev_tail_content
+                    and not msg.get("tool_calls")):
+                continue
+            _prev_tail_content = _msg_content
             if _merge_summary_into_tail and i == compress_end:
                 merged_prefix = summary + "\n\n" + _SUMMARY_END_MARKER + "\n\n"
                 msg["content"] = _append_text_to_content(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2598,9 +2598,18 @@ class SessionDB:
         now_ts = time.time()
         inserted = 0
         tool_calls_total = 0
+        _prev_dedup_content = None
         for msg in messages:
             role = msg.get("role", "unknown")
             tool_calls = msg.get("tool_calls")
+            # Defense-in-depth: skip consecutive identical assistant messages
+            # that slipped through upstream dedup (context_compressor.py).
+            _msg_content = msg.get("content")
+            if (role == "assistant"
+                    and _msg_content == _prev_dedup_content
+                    and not tool_calls):
+                continue
+            _prev_dedup_content = _msg_content
             message_timestamp = now_ts
             if msg.get("timestamp") is not None:
                 try:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2368,3 +2368,104 @@ class TestPreflightSentinelGuard:
         compressor.last_prompt_tokens = 50_000
         result = self._seed(compressor.last_prompt_tokens, 10_000)
         assert result == 50_000
+
+
+class TestTailDedup:
+    """Regression: compression should not duplicate consecutive identical assistant messages.
+
+    Bug: _hyg_msgs strips tool_calls, making non-consecutive identical assistant
+    messages appear consecutive. compress() tail copy preserves them, causing
+    cascading duplication across compression cycles.
+    """
+
+    @staticmethod
+    def _make_compressor(compressor):
+        """Configure compressor for tail-dedup testing with mocked internals."""
+        compressor.context_length = 1_000_000
+        compressor.threshold_percent = 0.5
+        compressor.threshold_tokens = 500_000
+        compressor.tail_token_budget = 20000
+        compressor.protect_last_n = 2
+        compressor.quiet_mode = True
+        compressor.compression_count = 0
+        compressor._previous_summary = None
+        compressor._summary_failure_cooldown_until = 0.0
+        compressor._ineffective_compression_count = 0
+        compressor._last_compress_aborted = False
+        compressor._last_summary_error = None
+        compressor._last_summary_dropped_count = 0
+        compressor._last_summary_fallback_used = False
+        compressor._last_aux_model_failure_error = None
+        compressor._last_aux_model_failure_model = None
+        compressor.abort_on_summary_failure = False
+        compressor.last_prompt_tokens = 10000
+        compressor.last_compression_rough_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor.awaiting_real_usage_after_compression = False
+        compressor._last_compression_savings_pct = 0.0
+        compressor._last_compression_summary_warning = None
+        compressor._last_aux_fallback_warning_key = None
+        # Mock methods to bypass LLM calls and complex boundary logic
+        compressor._generate_summary = lambda turns, focus_topic=None: "Summary of work done."
+        compressor._protect_head_size = lambda msgs: 1
+        compressor._align_boundary_forward = lambda msgs, idx: idx
+        compressor._find_tail_cut_by_tokens = lambda msgs, start: 2
+        compressor._find_latest_context_summary = lambda msgs, start, end: (None, None)
+        compressor._derive_auto_focus_topic = lambda msgs: None
+        compressor._sanitize_tool_pairs = lambda msgs: msgs
+        return compressor
+
+    def test_consecutive_identical_tail_deduplicated(self, compressor):
+        """Two consecutive identical assistant messages (no tool_calls) in tail -> one survives."""
+        c = self._make_compressor(compressor)
+        # Messages after compress_start=1: tail includes indices 2-6
+        # Indices 4 and 5 are consecutive identical assistant messages
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Run tests"},
+            {"role": "assistant", "content": "Running tests...", "tool_calls": [{"id": "tc1", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "content": "103 passed", "tool_call_id": "tc1"},
+            {"role": "assistant", "content": "103 passed! All good."},   # first
+            {"role": "assistant", "content": "103 passed! All good."},   # consecutive duplicate
+        ]
+        result = c.compress(messages, current_tokens=10000)
+
+        dups = [m for m in result if m.get("role") == "assistant" and m.get("content") == "103 passed! All good."]
+        assert len(dups) == 1, f"Expected 1 copy, got {len(dups)}"
+
+    def test_non_consecutive_identical_preserved(self, compressor):
+        """Non-consecutive identical assistant messages should NOT be deduplicated."""
+        c = self._make_compressor(compressor)
+        # Tail: indices 2-8. Indices 4 and 7 are identical but NOT consecutive
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Run tests"},
+            {"role": "assistant", "content": "Running tests...", "tool_calls": [{"id": "tc1", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "content": "103 passed", "tool_call_id": "tc1"},
+            {"role": "assistant", "content": "103 passed! All good."},  # first occurrence
+            {"role": "user", "content": "Now run lint"},
+            {"role": "assistant", "content": "Running lint...", "tool_calls": [{"id": "tc3", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "content": "0 errors", "tool_call_id": "tc3"},
+            {"role": "assistant", "content": "103 passed! All good."},  # NOT consecutive
+        ]
+        result = c.compress(messages, current_tokens=10000)
+
+        dups = [m for m in result if m.get("role") == "assistant" and m.get("content") == "103 passed! All good."]
+        assert len(dups) == 2, f"Expected 2 copies (non-consecutive), got {len(dups)}"
+
+    def test_identical_with_tool_calls_preserved(self, compressor):
+        """Assistant messages with tool_calls should NOT be deduplicated even if identical."""
+        c = self._make_compressor(compressor)
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Run tests"},
+            {"role": "assistant", "content": "Running tests...", "tool_calls": [{"id": "tc1", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "content": "103 passed", "tool_call_id": "tc1"},
+            {"role": "assistant", "content": "Running tests...", "tool_calls": [{"id": "tc4", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "content": "490 passed", "tool_call_id": "tc4"},
+            {"role": "user", "content": "Done"},
+        ]
+        result = c.compress(messages, current_tokens=10000)
+
+        running = [m for m in result if m.get("role") == "assistant" and m.get("content") == "Running tests..."]
+        assert len(running) == 2, f"Expected 2 copies (with tool_calls), got {len(running)}"


### PR DESCRIPTION
## Problem

Session hygiene auto-compression introduces duplicate assistant messages into transcripts. Each subsequent compression amplifies the duplication — a cascading bug.

**User-facing symptom**: Multiple identical messages appear in chat after long tool-calling sessions.

## Root Cause

Three-layer issue:

1.  filter (gateway/run.py:9178) strips  metadata, making non-consecutive identical assistant messages appear consecutive
2.  tail copy (context_compressor.py:2378) preserves consecutive identical content without dedup
3.  (hermes_state.py:2588) writes them without checking

## Fix

**agent/context_compressor.py** — Skip consecutive identical assistant messages (no tool_calls) when copying tail messages:



**hermes_state.py** — Defense-in-depth dedup at write time in .

## Tests

3 new tests in :
-  — consecutive identical assistant messages → 1 survives
-  — non-consecutive identical messages → both preserved
-  — identical messages with tool_calls → both preserved

**104/104 context_compressor tests pass, 3/3 replace_messages tests pass.**

---

Clean branch based on latest `origin/main`. Replaces #49763 which had unclean git history.