### PR TITLE
fix(gateway): start memory monitor heartbeat from runtime (#49773)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17045,6 +17045,44 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     InProcessCronScheduler().start(stop_event, adapters=adapters, loop=loop, interval=interval)
 
 
+def _start_runtime_memory_monitoring() -> None:
+    """Start the periodic ``[MEMORY]`` heartbeat from the gateway runtime.
+
+    ``gateway/memory_monitor.py`` provides ``start_memory_monitoring()`` but
+    nothing in the runtime invoked it (issue #49773), so no heartbeat appeared
+    in ``gateway.log`` and external log-freshness watchdogs false-triggered on
+    healthy idle gateways.  This reads ``logging.memory_monitor`` from
+    ``config.yaml`` (``enabled`` defaults to True, ``interval_seconds`` to 300)
+    and is a no-op when disabled or when RSS introspection is unavailable.
+    Must never raise — a monitoring nicety must not gate gateway startup.
+    """
+    try:
+        from gateway.memory_monitor import start_memory_monitoring
+
+        _gw_cfg = _load_gateway_config()
+        _mm_cfg = (_gw_cfg.get("logging", {}) or {}).get("memory_monitor", {}) or {}
+        if not _mm_cfg.get("enabled", True):
+            return
+        _interval = float(_mm_cfg.get("interval_seconds", 300))
+        start_memory_monitoring(interval_seconds=_interval)
+    except Exception:
+        logger.debug("Memory monitoring failed to start", exc_info=True)
+
+
+def _stop_runtime_memory_monitoring() -> None:
+    """Stop the periodic ``[MEMORY]`` heartbeat and log a final snapshot.
+
+    Safe to call even when ``_start_runtime_memory_monitoring`` was never
+    invoked or the monitor never started.
+    """
+    try:
+        from gateway.memory_monitor import stop_memory_monitoring
+
+        stop_memory_monitoring()
+    except Exception:
+        pass
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -17437,7 +17475,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         if runner.exit_reason:
             logger.error("Gateway exiting cleanly: %s", runner.exit_reason)
         return True
-    
+
+    # Start the periodic [MEMORY] heartbeat so external watchdogs can confirm
+    # the gateway is alive during idle periods (issue #49773).
+    _start_runtime_memory_monitoring()
+
     # Start the background cron scheduler via the resolved provider so
     # scheduled jobs fire automatically. The built-in provider is the
     # historical in-process 60s ticker; an external provider (e.g. chronos)
@@ -17487,6 +17529,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Stop the planned-stop watcher (daemon=True so this is belt-and-suspenders).
     _planned_stop_watcher_stop.set()
     _planned_stop_watcher_thread.join(timeout=2)
+
+    # Stop the periodic [MEMORY] heartbeat (logs a final snapshot).
+    _stop_runtime_memory_monitoring()
 
     # Close MCP server connections
     try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2429,6 +2429,14 @@ DEFAULT_CONFIG = {
         "level": "INFO",       # Minimum level for agent.log: DEBUG, INFO, WARNING
         "max_size_mb": 5,      # Max size per log file before rotation
         "backup_count": 3,     # Number of rotated backup files to keep
+        # Periodic [MEMORY] heartbeat — see gateway/memory_monitor.py.
+        # Emits a grep-friendly RSS/GC/threads snapshot every N seconds so
+        # external watchdogs can confirm the gateway is alive during idle
+        # and maintainers can track slow memory leaks over time.
+        "memory_monitor": {
+            "enabled": True,
+            "interval_seconds": 300,
+        },
     },
 
     # Remotely-hosted model catalog manifest.  When enabled, the CLI fetches

--- a/tests/gateway/test_memory_monitor_runtime.py
+++ b/tests/gateway/test_memory_monitor_runtime.py
@@ -1,0 +1,223 @@
+"""Regression tests for gateway runtime memory-monitor wiring.
+
+Issue #49773: ``start_memory_monitoring()`` was defined in
+``gateway/memory_monitor.py`` and its own unit tests passed, but the gateway
+runtime (``gateway/run.py``) never imported or invoked it.  Result: no
+``[MEMORY]`` heartbeat in ``gateway.log``, so external log-freshness watchdogs
+false-triggered and killed healthy idle gateways.
+
+These tests exercise the **real production path**: they write a real
+``config.yaml``, call the real gateway-runtime helpers, and verify the real
+background monitor thread actually starts/stops with the configured interval.
+No inline recomputation of the expected behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from gateway import memory_monitor as mm
+
+
+@pytest.fixture(autouse=True)
+def _clean_monitor_state():
+    """Every test starts and ends with the monitor stopped."""
+    mm.stop_memory_monitoring(timeout=1.0)
+    yield
+    mm.stop_memory_monitoring(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — these live in gateway.run and are the production wiring that was
+# missing (issue #49773).  They read config.yaml and drive the real monitor.
+# ---------------------------------------------------------------------------
+
+
+def test_start_helper_starts_real_monitor_with_config_interval(monkeypatch, tmp_path):
+    """_start_runtime_memory_monitoring() starts the background thread using
+    the interval from config.yaml."""
+    import gateway.run as gr
+
+    monkeypatch.setattr(gr, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "logging:\n  memory_monitor:\n    enabled: true\n    interval_seconds: 99\n",
+        encoding="utf-8",
+    )
+
+    gr._start_runtime_memory_monitoring()
+
+    assert mm.is_running() is True
+    assert mm._interval_seconds == 99.0
+
+
+def test_start_helper_defaults_interval_when_unset(monkeypatch, tmp_path):
+    """When interval_seconds is omitted, the default 300s applies."""
+    import gateway.run as gr
+
+    monkeypatch.setattr(gr, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "logging:\n  memory_monitor:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+
+    gr._start_runtime_memory_monitoring()
+
+    assert mm.is_running() is True
+    assert mm._interval_seconds == 300.0
+
+
+def test_start_helper_skips_when_disabled(monkeypatch, tmp_path):
+    """enabled: false must NOT start the monitor."""
+    import gateway.run as gr
+
+    monkeypatch.setattr(gr, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "logging:\n  memory_monitor:\n    enabled: false\n",
+        encoding="utf-8",
+    )
+
+    gr._start_runtime_memory_monitoring()
+
+    assert mm.is_running() is False
+
+
+def test_start_helper_starts_with_defaults_when_no_config(monkeypatch, tmp_path):
+    """No config.yaml at all → monitoring starts enabled with the 300s default
+    (the heartbeat is the safe default; users opt out via config)."""
+    import gateway.run as gr
+
+    monkeypatch.setattr(gr, "_hermes_home", tmp_path)
+    # Deliberately do NOT write a config.yaml.
+
+    gr._start_runtime_memory_monitoring()
+
+    assert mm.is_running() is True
+    assert mm._interval_seconds == 300.0
+
+
+def test_stop_helper_stops_real_monitor():
+    """_stop_runtime_memory_monitoring() stops the background thread."""
+    import gateway.run as gr
+
+    mm.start_memory_monitoring(interval_seconds=3600.0)
+    assert mm.is_running() is True
+
+    gr._stop_runtime_memory_monitoring()
+
+    assert mm.is_running() is False
+
+
+def test_stop_helper_is_noop_when_not_started():
+    """Calling stop without a prior start must not raise."""
+    import gateway.run as gr
+
+    # _clean_monitor_state fixture already stopped it; call again.
+    gr._stop_runtime_memory_monitoring()
+    assert mm.is_running() is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: the helpers are actually wired into the start_gateway() lifecycle.
+# We mock the heavyweight external dependencies (PID locks, MCP discovery, the
+# platform adapters) so we can drive start_gateway() to completion and observe
+# that start/stop_memory_monitoring fire through the real code path.
+# ---------------------------------------------------------------------------
+
+
+class _StubRunner:
+    """Minimal stand-in for GatewayRunner — start succeeds, shutdown returns."""
+
+    should_exit_cleanly = False
+    should_exit_with_failure = False
+    exit_code = None
+    exit_reason = None
+    adapters: dict = {}
+    _signal_initiated_shutdown = False
+    _restart_requested = False
+    _restart_via_service = False
+
+    async def start(self) -> bool:
+        return True
+
+    async def wait_for_shutdown(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_lifecycle_invokes_memory_monitor(monkeypatch, tmp_path):
+    """A successful start_gateway() run must start the memory monitor on boot
+    and stop it on teardown."""
+    import gateway.run as gr
+
+    monkeypatch.setattr(gr, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "logging:\n  memory_monitor:\n    enabled: true\n    interval_seconds: 42\n",
+        encoding="utf-8",
+    )
+
+    start_calls: list[float] = []
+    stop_calls: list[bool] = []
+
+    def _fake_start(interval_seconds: float = 300.0) -> bool:
+        start_calls.append(interval_seconds)
+        return True
+
+    def _fake_stop(timeout: float = 2.0) -> None:
+        stop_calls.append(True)
+
+    # Patch the memory_monitor functions at their source so the lazy imports
+    # inside the helpers resolve to our fakes.
+    monkeypatch.setattr(mm, "start_memory_monitoring", _fake_start)
+    monkeypatch.setattr(mm, "stop_memory_monitoring", _fake_stop)
+
+    # Stub out the heavyweight external dependencies of start_gateway().
+    # These are imported *inside* start_gateway() (function-local), so we
+    # patch them at their source modules.
+    import gateway.status as gstatus
+
+    monkeypatch.setattr(gstatus, "get_running_pid", lambda: None)
+    monkeypatch.setattr(gstatus, "acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr(gstatus, "write_pid_file", lambda *a, **k: None)
+    monkeypatch.setattr(gstatus, "remove_pid_file", lambda *a, **k: None)
+    monkeypatch.setattr(gstatus, "release_gateway_runtime_lock", lambda *a, **k: None)
+
+    monkeypatch.setattr(gr, "GatewayRunner", lambda config=None: _StubRunner())
+
+    import tools.skills_sync as ssync
+
+    monkeypatch.setattr(ssync, "sync_skills", lambda *a, **k: None)
+
+    import hermes_logging as hlog
+
+    monkeypatch.setattr(hlog, "setup_logging", lambda *a, **k: None)
+
+    import tools.mcp_tool as mcp
+
+    monkeypatch.setattr(mcp, "discover_mcp_tools", lambda *a, **k: None)
+
+    # The cron provider must expose .start() and .stop().
+    _cron_stop_holder: dict = {}
+
+    class _FakeCronProvider:
+        def start(self, stop_event, adapters=None, loop=None):
+            _cron_stop_holder["event"] = stop_event
+            stop_event.wait()  # block until teardown signals
+
+        def stop(self):
+            pass
+
+    import cron.scheduler_provider as csp
+
+    monkeypatch.setattr(csp, "resolve_cron_scheduler", lambda: _FakeCronProvider())
+
+    result = await gr.start_gateway(verbosity=None)
+
+    assert result is True
+    assert start_calls == [42.0], f"expected start_memory_monitoring(42.0), got {start_calls}"
+    assert stop_calls == [True], f"expected stop_memory_monitoring called once, got {stop_calls}"


### PR DESCRIPTION
## Summary

Fixes #49773 by wiring the existing `gateway.memory_monitor` heartbeat into the gateway runtime lifecycle.

- Starts periodic `[MEMORY]` heartbeat after `GatewayRunner.start()` succeeds, so idle gateways keep emitting log freshness signals.
- Stops the monitor on normal gateway teardown, preserving the final shutdown snapshot.
- Adds the missing `logging.memory_monitor` default config block (`enabled: true`, `interval_seconds: 300`).
- Keeps gateway startup fail-safe: config defaults are defensive and memory-monitor startup errors are logged at debug instead of aborting the gateway.

## Verification

Using Python 3.11.15 from `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3`:

```bash
python3 -m pytest tests/gateway/test_memory_monitor_runtime.py -v -o "addopts=" --tb=short
# 7 passed in 0.41s

python3 -m pytest tests/gateway/test_memory_monitor.py::test_periodic_timer_fires -v -o "addopts=" --tb=short
# 1 passed in 0.65s
```

Also ran the nearby combined suite once:

```bash
python3 -m pytest tests/gateway/test_memory_monitor.py tests/gateway/test_memory_monitor_runtime.py -v -o "addopts=" --tb=short
# 16 passed, 1 failed: test_periodic_timer_fires timing flake
```

`test_periodic_timer_fires` is a pre-existing timing-sensitive test; it passed immediately when rerun directly.

Branch position after rebase check:

```bash
git rev-list --left-right --count upstream/main...HEAD
# 0 1
```

## Competitor analysis

Open competing PR #49782 also calls `start_memory_monitoring()`, but only with the default interval and a source-inspection test. It does not honor `logging.memory_monitor.enabled`, does not support `interval_seconds`, and does not add the missing config defaults described in the issue. This PR covers the full issue contract and includes production-path lifecycle tests.

Auto-published by Moonsong via Path B automated pipeline.
