### PR TITLE
test(agent): isolate anthropic token resolution tests from macOS Keyc…

### DIFF
--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -271,6 +271,18 @@ class TestIsClaudeCodeTokenValid:
 
 
 class TestResolveAnthropicToken:
+    @pytest.fixture(autouse=True)
+    def no_keychain(self, monkeypatch):
+    # resolve_anthropic_token() reads real macOS Keychain credentials via
+    # read_claude_code_credentials() before falling back to the mocked
+    # Path.home() cred file. Without this, these tests are not hermetic:
+    # on a Mac with Claude Code installed, the test reads the developer's
+    # real OAuth token from Keychain instead of the mocked value, making
+    # the test pass/fail based on local machine state.
+        monkeypatch.setattr(
+        "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+        lambda: None,
+    )
     def test_prefers_oauth_token_over_api_key(self, monkeypatch, tmp_path):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-mykey")
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
@@ -450,6 +462,14 @@ class TestWriteClaudeCodeCredentials:
 
 
 class TestResolveWithRefresh:
+    @pytest.fixture(autouse=True)
+    def no_keychain(self, monkeypatch):
+        # See TestResolveAnthropicToken.no_keychain — same hermeticity gap.
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_auto_refresh_on_expired_creds(self, monkeypatch, tmp_path):
         """When cred file has expired token + refresh token, auto-refresh is attempted."""
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -497,6 +517,22 @@ class TestResolveWithRefresh:
 
 
 class TestRunOauthSetupToken:
+    @pytest.fixture(autouse=True)
+    def no_keychain(self, monkeypatch):
+        # read_claude_code_credentials() (called internally by
+        # run_oauth_setup_token()) checks the macOS Keychain via its own
+        # subprocess.run(["security", ...]) call before falling back to the
+        # cred file. Tests in this class patch subprocess.run globally to
+        # mock the `claude setup-token` invocation, which also intercepts
+        # the keychain lookup and returns a generic MagicMock — crashing
+        # json.loads() on a non-str/bytes object. Block the keychain lookup
+        # so these tests only exercise the credential-file/env-var paths
+        # they're actually testing.
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_raises_when_claude_not_installed(self, monkeypatch):
         monkeypatch.setattr("shutil.which", lambda _: None)
         with pytest.raises(FileNotFoundError, match="claude.*CLI.*not installed"):


### PR DESCRIPTION
## What does this PR do?

Fixes a test isolation bug in `tests/agent/test_anthropic_adapter.py`. Three test classes (`TestResolveAnthropicToken`, `TestResolveWithRefresh`, `TestRunOauthSetupToken`) call `resolve_anthropic_token()` / `run_oauth_setup_token()`, which internally check the macOS Keychain via `_read_claude_code_credentials_from_keychain()` before falling back to the mocked credential sources the tests set up.

On a Mac with Claude Code installed (real OAuth credentials present in Keychain), this causes two failure modes:

1. Tests asserting on mocked credential values fail because the real Keychain token is returned instead (e.g. `assert None == 'cc-auto-token'`).
2. Tests in `TestRunOauthSetupToken` that mock `subprocess.run` globally (to fake the `claude setup-token` subprocess call) also intercept the Keychain's own `subprocess.run(["security", ...])` call, returning a generic `MagicMock` that crashes `json.loads()` with `TypeError: the JSON object must be str, bytes or bytearray, not MagicMock`.

This makes the test suite non-deterministic. It passes or fails depending on what's in the developer's real Keychain, not on the code logic being tested.

The fix adds an `autouse` `no_keychain` pytest fixture to all three affected classes, mirroring the fixture already correctly used in `TestReadClaudeCodeCredentials` in the same file. This blocks the Keychain lookup so these tests only exercise the credential file and env var paths they're actually meant to test.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/agent/test_anthropic_adapter.py`: added an `autouse` `no_keychain` pytest fixture to `TestResolveAnthropicToken`, `TestResolveWithRefresh`, and `TestRunOauthSetupToken`, each mocking `agent.anthropic_adapter._read_claude_code_credentials_from_keychain` to return `None`. This matches the existing pattern already used in `TestReadClaudeCodeCredentials` in the same file.

## How to Test

1. On macOS with Claude Code installed and logged in (real OAuth credentials present in Keychain), run `scripts/run_tests.sh tests/agent/test_anthropic_adapter.py`.
2. Before this fix, 5 to 6 of 160 tests fail non deterministically (varies by run) with either an `AssertionError` (real Keychain token returned instead of mocked value) or `TypeError: the JSON object must be str, bytes or bytearray, not MagicMock` (Keychain subprocess call intercepted by an unrelated `subprocess.run` mock).
3. After this fix, all 160 tests pass consistently. `scripts/run_tests.sh tests/agent/test_anthropic_adapter.py` returns 160 tests passed, 0 failed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Sequoia), Python 3.12.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A, this fix only affects macOS-specific Keychain test isolation
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

### Before fix (failing)

<img width="1116" height="535" alt="before1" src="https://github.com/user-attachments/assets/e44dab8a-d097-48a4-8d93-810a1be02dc9" />
<img width="1116" height="608" alt="before2" src="https://github.com/user-attachments/assets/dbcdfc0a-4079-4e4f-a9c3-e26d1c25dea8" />
<img width="1116" height="608" alt="before3" src="https://github.com/user-attachments/assets/32123fc1-14b3-4282-88b8-07719879f8a3" />
<img width="1116" height="574" alt="before4" src="https://github.com/user-attachments/assets/3032c37e-0be8-4a71-9e11-08141aa04ea2" />


### After fix (passing)

<img width="1029" height="356" alt="after1" src="https://github.com/user-attachments/assets/e75f93df-8636-4013-9686-b37fc0042dfe" />
<img width="1044" height="674" alt="Screenshot 2026-06-20 at 3 38 11 PM" src="https://github.com/user-attachments/assets/56f7ea1f-f370-4445-b54d-abdfd313eccd" />
<img width="1044" height="773" alt="Screenshot 2026-06-20 at 3 38 19 PM" src="https://github.com/user-attachments/assets/d7ea349c-4418-401d-9025-1e3e7ecc5490" />
<img width="854" height="244" alt="Screenshot 2026-06-20 at 3 39 11 PM" src="https://github.com/user-attachments/assets/a3785cee-cc94-4440-9206-c920a89422ac" />
