### PR TITLE
feat(plugins): expose transient LLM execution status hooks

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1111,6 +1111,28 @@ def run_conversation(
                     if agent.thinking_callback:
                         agent.thinking_callback("")
 
+                _first_delta_callbacks = []
+
+                def _emit_llm_execution_status(text, kind="status"):
+                    if not text or not agent.status_callback:
+                        return
+                    try:
+                        agent.status_callback(str(kind or "status"), str(text))
+                    except Exception:
+                        logger.debug("llm execution status_callback error", exc_info=True)
+
+                def _register_on_first_delta(callback):
+                    if callable(callback):
+                        _first_delta_callbacks.append(callback)
+
+                def _handle_first_delta():
+                    for callback in list(_first_delta_callbacks):
+                        try:
+                            callback()
+                        except Exception:
+                            logger.debug("llm execution first-delta callback error", exc_info=True)
+                    _stop_spinner()
+
                 _use_streaming = True
                 # Provider signaled "stream not supported" on a previous
                 # attempt — switch to non-streaming for the rest of this
@@ -1138,7 +1160,7 @@ def run_conversation(
                 def _perform_api_call(next_api_kwargs):
                     if _use_streaming:
                         return agent._interruptible_streaming_api_call(
-                            next_api_kwargs, on_first_delta=_stop_spinner
+                            next_api_kwargs, on_first_delta=_handle_first_delta
                         )
                     return agent._interruptible_api_call(next_api_kwargs)
 
@@ -1158,6 +1180,9 @@ def run_conversation(
                     base_url=agent.base_url,
                     api_mode=agent.api_mode,
                     api_call_count=api_call_count,
+                    streaming=_use_streaming,
+                    emit_status=_emit_llm_execution_status,
+                    register_on_first_delta=_register_on_first_delta,
                     middleware_trace=list(_llm_middleware_trace),
                 )
                 

--- a/docs/middleware/README.md
+++ b/docs/middleware/README.md
@@ -46,7 +46,7 @@ Supported middleware kinds:
 | --- | --- | --- | --- |
 | `llm_request` | `request`, `original_request` | `{"request": {...}}` | Replace effective provider kwargs before provider execution. |
 | `tool_request` | `tool_name`, `args`, `original_args` | `{"args": {...}}` | Replace effective tool args before hooks, guardrails, approvals, and execution. |
-| `llm_execution` | `request`, `original_request`, `next_call` | Any provider response | Wrap or replace the actual provider call. |
+| `llm_execution` | `request`, `original_request`, `next_call`, `streaming`, `emit_status`, `register_on_first_delta` | Any provider response | Wrap or replace the actual provider call. |
 | `tool_execution` | `tool_name`, `args`, `original_args`, `next_call` | Any tool result | Wrap or replace the actual tool call. |
 
 Request middleware can return optional trace fields:
@@ -213,6 +213,28 @@ def time_llm_execution(**kwargs):
 Return the same response shape Hermes expects from the provider adapter. Do not
 wrap the response in a plugin-specific envelope unless the rest of the runtime
 expects that envelope.
+
+`llm_execution` middleware may also surface transient driver status while the
+provider call is open. This is useful for custom OpenAI-compatible GPU
+backends that accept a request while a box is cold-starting or a model is still
+loading into VRAM:
+
+```python
+def wait_for_model_backend(**kwargs):
+    emit_status = kwargs["emit_status"]
+    emit_status("backend: warming")
+
+    # Clear or replace the warmup label as soon as real stream output starts.
+    kwargs["register_on_first_delta"](lambda: emit_status("backend: ready"))
+
+    return kwargs["next_call"](kwargs["request"])
+```
+
+`emit_status(text, kind="status")` is fail-open and routes through the active
+driver's transient status channel; it does not add assistant messages or mutate
+conversation history. `register_on_first_delta(callback)` runs callbacks only
+for streaming provider calls, so check `streaming` before relying on it for
+non-streaming backends.
 
 ### Tool Execution Middleware
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -25,6 +25,7 @@ from hermes_cli.middleware import (
     VALID_MIDDLEWARE,
     apply_llm_request_middleware,
     apply_tool_request_middleware,
+    run_llm_execution_middleware,
     run_tool_execution_middleware,
 )
 
@@ -148,6 +149,42 @@ class TestPluginDiscovery:
             run_tool_execution_middleware("terminal", {"command": "false"}, terminal)
 
         assert calls == [{"command": "false"}]
+
+    def test_llm_execution_middleware_receives_transient_status_context(self, monkeypatch):
+        statuses = []
+        callbacks = []
+        seen = {}
+
+        def middleware(**kwargs):
+            seen["streaming"] = kwargs["streaming"]
+            kwargs["emit_status"]("backend: warming")
+            kwargs["register_on_first_delta"](
+                lambda: kwargs["emit_status"]("backend: ready")
+            )
+            return kwargs["next_call"](kwargs["request"])
+
+        manager = types.SimpleNamespace(_middleware={"llm_execution": [middleware]})
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        result = run_llm_execution_middleware(
+            {"messages": []},
+            lambda request: {"ok": request},
+            streaming=True,
+            emit_status=lambda text, kind="status": statuses.append((kind, text)),
+            register_on_first_delta=callbacks.append,
+        )
+
+        assert result == {"ok": {"messages": []}}
+        assert seen == {"streaming": True}
+        assert statuses == [("status", "backend: warming")]
+        assert len(callbacks) == 1
+
+        callbacks[0]()
+
+        assert statuses == [
+            ("status", "backend: warming"),
+            ("status", "backend: ready"),
+        ]
 
     def test_middleware_helpers_skip_no_listener_work(self, monkeypatch):
         manager = types.SimpleNamespace(_middleware={})

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3540,6 +3540,59 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_llm_execution_middleware_status_clears_on_first_stream_delta(self, agent):
+        self._setup_agent(agent)
+        agent.client = object()
+        agent._has_stream_consumers = lambda: True
+        statuses = []
+        seen_context = {}
+        agent.status_callback = (
+            lambda kind, text=None: statuses.append((kind, text))
+        )
+
+        def middleware_runner(request, next_call, **context):
+            seen_context["streaming"] = context["streaming"]
+            seen_context["has_emit_status"] = callable(context["emit_status"])
+            seen_context["has_first_delta"] = callable(
+                context["register_on_first_delta"]
+            )
+            context["emit_status"]("backend: warming")
+            context["register_on_first_delta"](
+                lambda: context["emit_status"]("backend: ready")
+            )
+            return next_call(request)
+
+        def stream_call(api_kwargs, *, on_first_delta=None):
+            assert on_first_delta is not None
+            on_first_delta()
+            return _mock_response(content="Done", finish_reason="stop")
+
+        with (
+            patch(
+                "hermes_cli.middleware.run_llm_execution_middleware",
+                side_effect=middleware_runner,
+            ),
+            patch.object(
+                agent, "_interruptible_streaming_api_call", side_effect=stream_call
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Done"
+        assert result["completed"] is True
+        assert seen_context == {
+            "streaming": True,
+            "has_emit_status": True,
+            "has_first_delta": True,
+        }
+        assert statuses == [
+            ("status", "backend: warming"),
+            ("status", "backend: ready"),
+        ]
+
     def test_ollama_small_runtime_context_fails_before_api_call(self, agent, caplog):
         self._setup_agent(agent)
         agent.model = "qwen3.5:9b"


### PR DESCRIPTION
## What does this PR do?

Adds a small, generic lifecycle surface for `llm_execution` middleware so plugins can surface transient provider-execution status while an LLM request is open, then clear or replace it on the first real stream delta.

Use case: custom/self-hosted OpenAI-compatible GPU inference backends where a request may be accepted while a GPU box cold-starts or a model is still loading into VRAM. Without this, Hermes can only look like it is generally thinking, and plugins have no clean first-delta-aware way to show `backend: warming` / `backend: ready` without injecting fake assistant messages or patching UI code.

## Related Issue

Related: #37672, #39575, #32299, #8642, #49304

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py` — passes `streaming`, `emit_status`, and `register_on_first_delta` into `llm_execution` middleware. First-delta callbacks run before the existing spinner stop path.
- `docs/middleware/README.md` — documents the transient execution-status use case for custom GPU/model warmup.
- `tests/hermes_cli/test_plugins.py` — verifies middleware receives and can use the transient status context.
- `tests/run_agent/test_run_agent.py` — verifies the real conversation-loop path exposes the callables and first-delta callbacks fire when streaming starts.

## How to Test

1. `uv run --extra dev python -m pytest tests/hermes_cli/test_plugins.py -k 'llm_execution_middleware_receives_transient_status_context or middleware_helpers_skip_no_listener_work' -q`
2. `uv run --extra dev python -m pytest tests/run_agent/test_run_agent.py -k 'llm_execution_middleware_status_clears_on_first_stream_delta' -q`
3. `scripts/run_tests.sh tests/hermes_cli/test_plugins.py tests/run_agent/test_run_agent.py`
4. `uv run --extra dev python -m ruff check agent/conversation_loop.py tests/hermes_cli/test_plugins.py tests/run_agent/test_run_agent.py`
5. `scripts/check-windows-footguns.py`
6. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — middleware/backend lifecycle surface only.