### PR TITLE
docs: remove file tools TBD placeholder

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -421,7 +421,7 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
 
     Three detectors run in order:
 
-    * cross-profile (#TBD) — writes that hit another profile's
+    * cross-profile — writes that hit another profile's
       ``skills/plugins/cron/memories`` directory.
     * sandbox-mirror (#32049) — writes that hit the
       ``…/sandboxes/<backend>/<task>/home/.hermes/…`` mirror created by a


### PR DESCRIPTION
## Summary

Removes an unresolved `(#TBD)` placeholder from the `_check_cross_profile_path()` docstring in `tools/file_tools.py`.

This is a docstring-only cleanup and does not change cross-profile guard behavior.
