### PR TITLE
feat(picker): surface model_aliases models in the model picker

### DIFF
--- a/apps/desktop/src/components/model-picker.test.tsx
+++ b/apps/desktop/src/components/model-picker.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -147,5 +147,31 @@ describe('ModelPickerDialog download rows', () => {
     await waitFor(() => {
       expect(vi.mocked(requestModelOptions).mock.calls.length).toBe(2)
     })
+  })
+})
+
+describe('ModelPickerDialog aliases', () => {
+  it('finds, labels, and selects an injected alias by its real model id', async () => {
+    const onSelect = vi.fn()
+    vi.mocked(requestModelOptions).mockResolvedValue({
+      providers: [
+        {
+          slug: 'openrouter',
+          name: 'OpenRouter',
+          models: ['vendor/aliased-model'],
+          model_aliases: { 'vendor/aliased-model': 'fast-model' },
+          authenticated: true
+        }
+      ]
+    })
+    renderPicker({ currentModel: '', currentProvider: '', onSelect })
+
+    const alias = await screen.findByText('fast-model')
+    expect(screen.getByText('(vendor/aliased-model)')).toBeTruthy()
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'fast-model' } })
+    fireEvent.click(alias.closest('[cmdk-item]')!)
+
+    expect(onSelect).toHaveBeenCalledWith({ provider: 'openrouter', model: 'vendor/aliased-model' })
   })
 })

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -267,6 +267,7 @@ function ModelResults({
   const matches = (provider: ModelOptionProvider, model: string) =>
     !q ||
     modelSearchText(model).toLowerCase().includes(q) ||
+    (provider.model_aliases?.[model]?.toLowerCase().includes(q) ?? false) ||
     provider.name.toLowerCase().includes(q) ||
     provider.slug.toLowerCase().includes(q)
 
@@ -318,6 +319,7 @@ function ModelResults({
               // real load percent inline (keyed by exact model id — remote
               // providers never match).
               const loadProgress = loadingModels[model]
+              const aliasName = provider.model_aliases?.[model]
 
               return (
                 <CommandItem
@@ -337,7 +339,16 @@ function ModelResults({
                   value={`${provider.slug}:${model}`}
                 >
                   <span className="min-w-0 flex-1 truncate">
-                    <HighlightMatches query={search} text={model} />
+                    {aliasName ? (
+                      <>
+                        <HighlightMatches query={search} text={aliasName} />{' '}
+                        <span className="text-muted-foreground">
+                          (<HighlightMatches query={search} text={model} />)
+                        </span>
+                      </>
+                    ) : (
+                      <HighlightMatches query={search} text={model} />
+                    )}
                   </span>
                   {loadProgress && (
                     <span className="flex shrink-0 items-center gap-1.5" title={copy.loadingIntoMemory}>

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -178,6 +178,7 @@ function ModelResults({
   const matches = (provider: ModelOptionProvider, model: string) =>
     !q ||
     modelSearchText(model).toLowerCase().includes(q) ||
+    (provider.aliases?.[model]?.toLowerCase().includes(q) ?? false) ||
     provider.name.toLowerCase().includes(q) ||
     provider.slug.toLowerCase().includes(q)
 
@@ -211,6 +212,7 @@ function ModelResults({
               const isCurrent = model === currentModel && provider.slug === currentProvider
               const price = provider.pricing?.[model]
               const locked = unavailable.has(model)
+              const aliasName = provider.aliases?.[model]
 
               return (
                 <CommandItem
@@ -230,7 +232,16 @@ function ModelResults({
                   value={`${provider.slug}:${model}`}
                 >
                   <span className="min-w-0 flex-1 truncate">
-                    <HighlightMatches query={search} text={model} />
+                    {aliasName ? (
+                      <>
+                        <HighlightMatches query={search} text={aliasName} />{' '}
+                        <span className="text-muted-foreground">
+                          (<HighlightMatches query={search} text={model} />)
+                        </span>
+                      </>
+                    ) : (
+                      <HighlightMatches query={search} text={model} />
+                    )}
                   </span>
                   {locked && (
                     <span className="shrink-0 text-[0.62rem] uppercase tracking-wide opacity-80">{copy.pro}</span>

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -439,6 +439,10 @@ export interface ModelOptionProvider {
   /** Per-model option support, keyed by model id (present when the picker
    *  requested capabilities). Lets the UI gate fast/reasoning controls. */
   capabilities?: Record<string, ModelCapabilities>
+  /** Alias name keyed by resolved model id, for models surfaced from the
+   *  user's `model_aliases:` (e.g. `{ "qwen/qwen3.6-27b": "qwen27b" }`). Lets
+   *  the picker label an entry as `qwen27b (qwen/qwen3.6-27b)`. */
+  model_aliases?: Record<string, string>
 }
 
 export interface ModelCapabilities {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -418,6 +418,10 @@ export interface ModelOptionProvider {
   /** Per-model option support, keyed by model id (present when the picker
    *  requested capabilities). Lets the UI gate fast/reasoning controls. */
   capabilities?: Record<string, ModelCapabilities>
+  /** Alias name keyed by resolved model id, for models surfaced from the
+   *  user's `model_aliases:` (e.g. `{ "qwen/qwen3.6-27b": "qwen27b" }`). Lets
+   *  the picker label an entry as `qwen27b (qwen/qwen3.6-27b)`. */
+  aliases?: Record<string, string>
 }
 
 export interface ModelCapabilities {

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2053,6 +2053,63 @@ def _scoped_key_env(name: str) -> str:
         return ""
 
 
+def _inject_aliases_into_rows(results: List[dict]) -> None:
+    """Surface user-defined model aliases in the picker rows in place.
+
+    Aliases (``config.yaml`` ``model_aliases:``) are otherwise CLI-only —
+    invisible in the gateway/desktop picker, which renders these rows
+    verbatim. Crucially, aggregator rows (e.g. ``openrouter``) show a curated
+    subset, so an alias targeting an off-curation model is unreachable in the
+    GUI even though the alias works from the CLI.
+
+    For each alias, attach it to the row whose ``slug`` matches the alias's
+    target provider (covering canonical, user-defined and custom rows
+    uniformly):
+
+    - Prepend the alias's *resolved model id* onto ``models`` when the row's
+      curated/live list omits it, so it becomes selectable. Prepending (vs.
+      appending) keeps it visible above a large catalog that ``max_models``
+      may otherwise truncate. Selecting the real id routes directly — no
+      alias resolution required — and lets pricing/capabilities lookups hit.
+    - Record the alias name in a per-row ``aliases`` map keyed by model id, so
+      the UI can label the entry (e.g. ``qwen27b (qwen/qwen3.6-27b)``). The
+      label is recorded even when the model was already in the curated list.
+
+    Aliases whose target provider has no row (provider not configured /
+    authenticated) are skipped — there is no section to attach them to.
+    """
+    try:
+        _ensure_direct_aliases()
+        if not DIRECT_ALIASES:
+            return
+        rows_by_slug: dict = {}
+        for row in results:
+            slug = str(row.get("slug", "")).lower()
+            if slug and slug not in rows_by_slug:
+                rows_by_slug[slug] = row
+        for alias_name, alias in DIRECT_ALIASES.items():
+            row = rows_by_slug.get(str(alias.provider or "").lower())
+            if row is None:
+                continue
+            model_id = str(alias.model or "").strip()
+            if not model_id:
+                continue
+            models = row.get("models")
+            if not isinstance(models, list):
+                continue
+            # Label the entry regardless of whether the model is already
+            # listed; first alias wins if several map to the same model.
+            labels = row.setdefault("aliases", {})
+            labels.setdefault(model_id, alias_name)
+            # Surface the model itself only when the curated/live list omits it.
+            if any(model_id.lower() == str(m).lower() for m in models):
+                continue
+            models.insert(0, model_id)
+            row["total_models"] = row.get("total_models", len(models) - 1) + 1
+    except Exception:
+        pass
+
+
 def list_authenticated_providers(
     current_provider: str = "",
     current_base_url: str = "",
@@ -3275,6 +3332,9 @@ def list_authenticated_providers(
                 _row["models"] = [current_model, *_models]
                 _row["total_models"] = _row.get("total_models", len(_models)) + 1
             break
+
+    # Surface user-defined model aliases in the picker (see the helper).
+    _inject_aliases_into_rows(results)
 
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2056,7 +2056,7 @@ def _scoped_key_env(name: str) -> str:
 def _inject_aliases_into_rows(results: List[dict]) -> None:
     """Surface user-defined model aliases in the picker rows in place.
 
-    Aliases (``config.yaml`` ``model_aliases:``) are otherwise CLI-only —
+    Aliases (``config.yaml`` ``model_aliases:``) are otherwise CLI-only -
     invisible in the gateway/desktop picker, which renders these rows
     verbatim. Crucially, aggregator rows (e.g. ``openrouter``) show a curated
     subset, so an alias targeting an off-curation model is unreachable in the
@@ -2069,14 +2069,14 @@ def _inject_aliases_into_rows(results: List[dict]) -> None:
     - Prepend the alias's *resolved model id* onto ``models`` when the row's
       curated/live list omits it, so it becomes selectable. Prepending (vs.
       appending) keeps it visible above a large catalog that ``max_models``
-      may otherwise truncate. Selecting the real id routes directly — no
-      alias resolution required — and lets pricing/capabilities lookups hit.
+      may otherwise truncate. Selecting the real id routes directly - no
+      alias resolution required - and lets pricing/capabilities lookups hit.
     - Record the alias name in a per-row ``aliases`` map keyed by model id, so
       the UI can label the entry (e.g. ``qwen27b (qwen/qwen3.6-27b)``). The
       label is recorded even when the model was already in the curated list.
 
     Aliases whose target provider has no row (provider not configured /
-    authenticated) are skipped — there is no section to attach them to.
+    authenticated) are skipped - there is no section to attach them to.
     """
     try:
         _ensure_direct_aliases()

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -1084,6 +1084,30 @@ def list_authenticated_providers(
     return _finalize_picker_rows(b.results, user_providers, current_model)
 
 
+def _inject_aliases_into_rows(results: list[dict]) -> None:
+    """Surface configured model aliases on matching picker rows."""
+    try:
+        from hermes_cli.model_switch import DIRECT_ALIASES, _ensure_direct_aliases
+
+        _ensure_direct_aliases()
+        rows = {str(row.get("slug", "")).lower(): row for row in results}
+        for alias_name, alias in DIRECT_ALIASES.items():
+            row = rows.get(str(alias.provider or "").lower())
+            model = str(alias.model or "").strip()
+            if row is None or not model:
+                continue
+            models = row.get("models")
+            if not isinstance(models, list):
+                continue
+            row.setdefault("model_aliases", {}).setdefault(model, alias_name)
+            if any(model.lower() == str(item).lower() for item in models):
+                continue
+            models.insert(0, model)
+            row["total_models"] = row.get("total_models", len(models) - 1) + 1
+    except Exception:
+        pass
+
+
 def _finalize_picker_rows(results: list, user_providers, current_model: str) -> list:
     """Post-passes: drop ``providers.<name>.enabled: false`` rows, inject the current model, sort."""
     # The enabled post-filter covers built-in rows (sections 1-2) that bypass the per-section
@@ -1114,6 +1138,8 @@ def _finalize_picker_rows(results: list, user_providers, current_model: str) -> 
                 row["models"] = [current_model, *models]
                 row["total_models"] = row.get("total_models", len(models)) + 1
             break
+
+    _inject_aliases_into_rows(results)
 
     # Current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))

--- a/tests/hermes_cli/test_picker_alias_injection.py
+++ b/tests/hermes_cli/test_picker_alias_injection.py
@@ -1,0 +1,147 @@
+"""Tests for ``_inject_aliases_into_rows`` — surfacing ``model_aliases:`` in
+the picker.
+
+Model aliases (``config.yaml`` ``model_aliases:``) are CLI-only by default and
+never appear in the gateway/desktop picker, which renders the
+``list_authenticated_providers`` rows verbatim. Aggregator rows (e.g.
+``openrouter``) only show a curated subset, so an alias pointing at an
+off-curation model is unreachable in the GUI. ``_inject_aliases_into_rows``
+prepends the alias's resolved model id onto the matching provider row (so it
+becomes selectable) and records the alias name in a per-row ``model_aliases`` map so
+the UI can label the entry (e.g. ``qwen27b (qwen/qwen3.6-27b)``).
+
+These tests exercise the helper in isolation by monkeypatching
+``DIRECT_ALIASES``, so no config, network or auth state is required.
+"""
+
+from hermes_cli import model_switch, model_switch_providers
+from hermes_cli.inventory import build_models_payload, load_picker_context
+from hermes_cli.model_switch import DirectAlias
+
+
+def _make_provider(slug, models, *, total_models=None, source="built-in"):
+    """Build a dict shaped like ``list_authenticated_providers`` output."""
+    return {
+        "slug": slug,
+        "name": slug.title(),
+        "is_current": False,
+        "is_user_defined": False,
+        "models": list(models),
+        "total_models": len(models) if total_models is None else total_models,
+        "source": source,
+    }
+
+
+def _set_aliases(monkeypatch, aliases):
+    """Force DIRECT_ALIASES to a fixed map and skip lazy config loading."""
+    monkeypatch.setattr(model_switch, "DIRECT_ALIASES", dict(aliases))
+    monkeypatch.setattr(model_switch, "_ensure_direct_aliases", lambda: None)
+
+
+def test_offcuration_alias_model_prepended_and_labeled(monkeypatch):
+    """An openrouter alias whose model is absent from the curated list is
+    prepended as the real model id and labeled with the alias name."""
+    rows = [_make_provider("openrouter", ["a/model", "b/model"], total_models=2)]
+    _set_aliases(monkeypatch, {
+        "qwen27b": DirectAlias(model="qwen/qwen3.6-27b",
+                               provider="openrouter", base_url=""),
+    })
+
+    model_switch_providers._inject_aliases_into_rows(rows)
+
+    assert rows[0]["models"] == ["qwen/qwen3.6-27b", "a/model", "b/model"]
+    assert rows[0]["model_aliases"] == {"qwen/qwen3.6-27b": "qwen27b"}
+    # total_models reflects the added model so picker sort/labels stay in sync.
+    assert rows[0]["total_models"] == 3
+
+
+def test_alias_for_provider_without_row_is_skipped(monkeypatch):
+    """An alias targeting a provider with no row leaves rows untouched."""
+    rows = [_make_provider("openrouter", ["a/model"])]
+    _set_aliases(monkeypatch, {
+        "localqwen": DirectAlias(model="qwen3.6-27b",
+                                 provider="llamaproxy", base_url=""),
+    })
+
+    model_switch_providers._inject_aliases_into_rows(rows)
+
+    assert rows[0]["models"] == ["a/model"]
+    assert rows[0]["total_models"] == 1
+    assert "model_aliases" not in rows[0]
+
+
+def test_model_already_curated_is_labeled_not_duplicated(monkeypatch):
+    """If the aliased model is already in the curated list, it is labeled but
+    not added a second time."""
+    rows = [_make_provider("openrouter", ["qwen/qwen3.6-35b-a3b", "a/model"])]
+    _set_aliases(monkeypatch, {
+        "qwen35b": DirectAlias(model="qwen/qwen3.6-35b-a3b",
+                               provider="openrouter", base_url=""),
+    })
+
+    model_switch_providers._inject_aliases_into_rows(rows)
+
+    assert rows[0]["models"] == ["qwen/qwen3.6-35b-a3b", "a/model"]
+    assert rows[0]["model_aliases"] == {"qwen/qwen3.6-35b-a3b": "qwen35b"}
+    assert rows[0]["total_models"] == 2
+
+
+def test_no_aliases_leaves_rows_unchanged(monkeypatch):
+    """With no aliases configured, the rows pass through verbatim."""
+    rows = [_make_provider("openrouter", ["a/model", "b/model"])]
+    _set_aliases(monkeypatch, {})
+
+    model_switch_providers._inject_aliases_into_rows(rows)
+
+    assert rows[0]["models"] == ["a/model", "b/model"]
+    assert rows[0]["total_models"] == 2
+    assert "model_aliases" not in rows[0]
+
+
+def test_alias_matches_user_defined_provider_row(monkeypatch):
+    """Slug matching also covers user-defined / custom provider rows; an
+    unrelated row is left untouched."""
+    rows = [
+        _make_provider("openrouter", ["a/model"]),
+        _make_provider("llamaproxy", ["gemma4-12b"], source="user-config"),
+    ]
+    _set_aliases(monkeypatch, {
+        "bigqwen": DirectAlias(model="qwen3.6-72b",
+                               provider="llamaproxy", base_url=""),
+    })
+
+    model_switch_providers._inject_aliases_into_rows(rows)
+
+    assert rows[0]["models"] == ["a/model"]  # unrelated row untouched
+    assert "model_aliases" not in rows[0]
+    assert rows[1]["models"] == ["qwen3.6-72b", "gemma4-12b"]
+    assert rows[1]["model_aliases"] == {"qwen3.6-72b": "bigqwen"}
+    assert rows[1]["total_models"] == 2
+
+
+def test_config_alias_is_injected_into_picker_payload(tmp_path, monkeypatch):
+    """A config.yaml alias reaches the picker payload with its UI label."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: static-gateway\n"
+        "  default: configured-model\n"
+        "providers:\n"
+        "  static-gateway:\n"
+        "    base_url: https://router.example.test/v1\n"
+        "    models: [configured-model]\n"
+        "model_aliases:\n"
+        "  picker-alias:\n"
+        "    model: aliased-model\n"
+        "    provider: static-gateway\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(model_switch, "DIRECT_ALIASES", {})
+
+    payload = build_models_payload(load_picker_context(), probe_custom_providers=False)
+
+    row = next(row for row in payload["providers"] if row["slug"] == "static-gateway")
+    assert row["models"] == ["aliased-model", "configured-model"]
+    assert row["model_aliases"] == {"aliased-model": "picker-alias"}

--- a/tests/hermes_cli/test_picker_alias_injection.py
+++ b/tests/hermes_cli/test_picker_alias_injection.py
@@ -10,8 +10,9 @@ prepends the alias's resolved model id onto the matching provider row (so it
 becomes selectable) and records the alias name in a per-row ``model_aliases`` map so
 the UI can label the entry (e.g. ``qwen27b (qwen/qwen3.6-27b)``).
 
-These tests exercise the helper in isolation by monkeypatching
-``DIRECT_ALIASES``, so no config, network or auth state is required.
+The unit tests exercise the helper in isolation by monkeypatching
+``DIRECT_ALIASES``. The final regression test uses a temporary config and the
+shared payload builder to cover the full picker path without network or auth.
 """
 
 from hermes_cli import model_switch, model_switch_providers

--- a/tests/hermes_cli/test_picker_alias_injection.py
+++ b/tests/hermes_cli/test_picker_alias_injection.py
@@ -1,4 +1,4 @@
-"""Tests for ``_inject_aliases_into_rows`` — surfacing ``model_aliases:`` in
+"""Tests for ``_inject_aliases_into_rows`` - surfacing ``model_aliases:`` in
 the picker.
 
 Model aliases (``config.yaml`` ``model_aliases:``) are CLI-only by default and
@@ -10,12 +10,12 @@ prepends the alias's resolved model id onto the matching provider row (so it
 becomes selectable) and records the alias name in a per-row ``aliases`` map so
 the UI can label the entry (e.g. ``qwen27b (qwen/qwen3.6-27b)``).
 
-These tests exercise the helper in isolation by monkeypatching
-``DIRECT_ALIASES``, so no config, network or auth state is required.
+The unit tests exercise the helper in isolation by monkeypatching
+``DIRECT_ALIASES``. The final regression test uses a temporary config and the
+shared payload builder to cover the full picker path without network or auth.
 """
 
 from hermes_cli import model_switch
-from hermes_cli.config import load_config, save_config
 from hermes_cli.inventory import build_models_payload, load_picker_context
 from hermes_cli.model_switch import DirectAlias
 
@@ -120,27 +120,31 @@ def test_alias_matches_user_defined_provider_row(monkeypatch):
     assert rows[1]["total_models"] == 2
 
 
-def test_config_alias_reaches_picker_payload(tmp_path, monkeypatch):
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    cfg = load_config()
-    cfg["model"] = {"provider": "openrouter", "default": "a/model"}
-    cfg["model_aliases"] = {
-        "qwen27b": {
-            "model": "qwen/qwen3.6-27b",
-            "provider": "openrouter",
-        }
-    }
-    save_config(cfg)
-    model_switch.DIRECT_ALIASES.clear()
+def test_config_alias_is_injected_into_picker_payload(tmp_path, monkeypatch):
+    """A config.yaml alias reaches the picker payload with its UI label."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: static-gateway\n"
+        "  default: configured-model\n"
+        "providers:\n"
+        "  static-gateway:\n"
+        "    base_url: https://router.example.test/v1\n"
+        "    models: [configured-model]\n"
+        "model_aliases:\n"
+        "  picker-alias:\n"
+        "    model: aliased-model\n"
+        "    provider: static-gateway\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(model_switch, "DIRECT_ALIASES", {})
 
-    def picker_rows(**_kwargs):
-        rows = [_make_provider("openrouter", ["a/model"])]
-        model_switch._inject_aliases_into_rows(rows)
-        return rows
+    payload = build_models_payload(
+        load_picker_context(), probe_custom_providers=False,
+    )
 
-    monkeypatch.setattr(model_switch, "list_authenticated_providers", picker_rows)
-
-    payload = build_models_payload(load_picker_context())
-    row = payload["providers"][0]
-    assert row["models"] == ["qwen/qwen3.6-27b", "a/model"]
-    assert row["aliases"] == {"qwen/qwen3.6-27b": "qwen27b"}
+    row = next(row for row in payload["providers"] if row["slug"] == "static-gateway")
+    assert row["models"] == ["aliased-model", "configured-model"]
+    assert row["aliases"] == {"aliased-model": "picker-alias"}

--- a/tests/hermes_cli/test_picker_alias_injection.py
+++ b/tests/hermes_cli/test_picker_alias_injection.py
@@ -1,0 +1,146 @@
+"""Tests for ``_inject_aliases_into_rows`` — surfacing ``model_aliases:`` in
+the picker.
+
+Model aliases (``config.yaml`` ``model_aliases:``) are CLI-only by default and
+never appear in the gateway/desktop picker, which renders the
+``list_authenticated_providers`` rows verbatim. Aggregator rows (e.g.
+``openrouter``) only show a curated subset, so an alias pointing at an
+off-curation model is unreachable in the GUI. ``_inject_aliases_into_rows``
+prepends the alias's resolved model id onto the matching provider row (so it
+becomes selectable) and records the alias name in a per-row ``aliases`` map so
+the UI can label the entry (e.g. ``qwen27b (qwen/qwen3.6-27b)``).
+
+These tests exercise the helper in isolation by monkeypatching
+``DIRECT_ALIASES``, so no config, network or auth state is required.
+"""
+
+from hermes_cli import model_switch
+from hermes_cli.config import load_config, save_config
+from hermes_cli.inventory import build_models_payload, load_picker_context
+from hermes_cli.model_switch import DirectAlias
+
+
+def _make_provider(slug, models, *, total_models=None, source="built-in"):
+    """Build a dict shaped like ``list_authenticated_providers`` output."""
+    return {
+        "slug": slug,
+        "name": slug.title(),
+        "is_current": False,
+        "is_user_defined": False,
+        "models": list(models),
+        "total_models": len(models) if total_models is None else total_models,
+        "source": source,
+    }
+
+
+def _set_aliases(monkeypatch, aliases):
+    """Force DIRECT_ALIASES to a fixed map and skip lazy config loading."""
+    monkeypatch.setattr(model_switch, "DIRECT_ALIASES", dict(aliases))
+    monkeypatch.setattr(model_switch, "_ensure_direct_aliases", lambda: None)
+
+
+def test_offcuration_alias_model_prepended_and_labeled(monkeypatch):
+    """An openrouter alias whose model is absent from the curated list is
+    prepended as the real model id and labeled with the alias name."""
+    rows = [_make_provider("openrouter", ["a/model", "b/model"], total_models=2)]
+    _set_aliases(monkeypatch, {
+        "qwen27b": DirectAlias(model="qwen/qwen3.6-27b",
+                               provider="openrouter", base_url=""),
+    })
+
+    model_switch._inject_aliases_into_rows(rows)
+
+    assert rows[0]["models"] == ["qwen/qwen3.6-27b", "a/model", "b/model"]
+    assert rows[0]["aliases"] == {"qwen/qwen3.6-27b": "qwen27b"}
+    # total_models reflects the added model so picker sort/labels stay in sync.
+    assert rows[0]["total_models"] == 3
+
+
+def test_alias_for_provider_without_row_is_skipped(monkeypatch):
+    """An alias targeting a provider with no row leaves rows untouched."""
+    rows = [_make_provider("openrouter", ["a/model"])]
+    _set_aliases(monkeypatch, {
+        "localqwen": DirectAlias(model="qwen3.6-27b",
+                                 provider="llamaproxy", base_url=""),
+    })
+
+    model_switch._inject_aliases_into_rows(rows)
+
+    assert rows[0]["models"] == ["a/model"]
+    assert rows[0]["total_models"] == 1
+    assert "aliases" not in rows[0]
+
+
+def test_model_already_curated_is_labeled_not_duplicated(monkeypatch):
+    """If the aliased model is already in the curated list, it is labeled but
+    not added a second time."""
+    rows = [_make_provider("openrouter", ["qwen/qwen3.6-35b-a3b", "a/model"])]
+    _set_aliases(monkeypatch, {
+        "qwen35b": DirectAlias(model="qwen/qwen3.6-35b-a3b",
+                               provider="openrouter", base_url=""),
+    })
+
+    model_switch._inject_aliases_into_rows(rows)
+
+    assert rows[0]["models"] == ["qwen/qwen3.6-35b-a3b", "a/model"]
+    assert rows[0]["aliases"] == {"qwen/qwen3.6-35b-a3b": "qwen35b"}
+    assert rows[0]["total_models"] == 2
+
+
+def test_no_aliases_leaves_rows_unchanged(monkeypatch):
+    """With no aliases configured, the rows pass through verbatim."""
+    rows = [_make_provider("openrouter", ["a/model", "b/model"])]
+    _set_aliases(monkeypatch, {})
+
+    model_switch._inject_aliases_into_rows(rows)
+
+    assert rows[0]["models"] == ["a/model", "b/model"]
+    assert rows[0]["total_models"] == 2
+    assert "aliases" not in rows[0]
+
+
+def test_alias_matches_user_defined_provider_row(monkeypatch):
+    """Slug matching also covers user-defined / custom provider rows; an
+    unrelated row is left untouched."""
+    rows = [
+        _make_provider("openrouter", ["a/model"]),
+        _make_provider("llamaproxy", ["gemma4-12b"], source="user-config"),
+    ]
+    _set_aliases(monkeypatch, {
+        "bigqwen": DirectAlias(model="qwen3.6-72b",
+                               provider="llamaproxy", base_url=""),
+    })
+
+    model_switch._inject_aliases_into_rows(rows)
+
+    assert rows[0]["models"] == ["a/model"]  # unrelated row untouched
+    assert "aliases" not in rows[0]
+    assert rows[1]["models"] == ["qwen3.6-72b", "gemma4-12b"]
+    assert rows[1]["aliases"] == {"qwen3.6-72b": "bigqwen"}
+    assert rows[1]["total_models"] == 2
+
+
+def test_config_alias_reaches_picker_payload(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cfg = load_config()
+    cfg["model"] = {"provider": "openrouter", "default": "a/model"}
+    cfg["model_aliases"] = {
+        "qwen27b": {
+            "model": "qwen/qwen3.6-27b",
+            "provider": "openrouter",
+        }
+    }
+    save_config(cfg)
+    model_switch.DIRECT_ALIASES.clear()
+
+    def picker_rows(**_kwargs):
+        rows = [_make_provider("openrouter", ["a/model"])]
+        model_switch._inject_aliases_into_rows(rows)
+        return rows
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers", picker_rows)
+
+    payload = build_models_payload(load_picker_context())
+    row = payload["providers"][0]
+    assert row["models"] == ["qwen/qwen3.6-27b", "a/model"]
+    assert row["aliases"] == {"qwen/qwen3.6-27b": "qwen27b"}


### PR DESCRIPTION
## What

Surface models from `model_aliases` in the Desktop model picker. Aliases are searchable and shown as `alias (resolved/model-id)`, while selection still sends the resolved model ID.

The backend adds aliased models to the matching provider row when they are missing from its curated list. Existing entries are labeled without being duplicated.

## Why

An alias can work in the CLI but remain unavailable in the Desktop picker when its resolved model is outside the provider's curated model list.

Fixes #49803.

## Tests

- `tests/hermes_cli/test_picker_alias_injection.py`: 6 passed
- `apps/desktop/src/components/model-picker.test.tsx`: 5 passed
- Desktop typecheck and lint passed
- `git diff --check upstream/main...HEAD` passed

Tested on macOS.
