### PR TITLE
feat(desktop): let the agent reap background processes + neutral signal-kill rendering

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -12,6 +12,7 @@ import { type Translations, useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 import {
   $statusItemsBySession,
+  clearFinishedBackgroundProcesses,
   type ComposerStatusItem,
   dismissBackgroundProcess,
   groupStatusItems,
@@ -98,6 +99,16 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
               variant="text"
             >
               {t.statusStack.agents}
+            </Button>
+          ) : group.type === 'background' && group.items.some(i => i.state !== 'running') ? (
+            <Button
+              className="text-muted-foreground/75 hover:text-foreground/90"
+              onClick={() => sessionId && clearFinishedBackgroundProcesses(sessionId)}
+              size="micro"
+              type="button"
+              variant="text"
+            >
+              {t.statusStack.clearFinished}
             </Button>
           ) : undefined
         }

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -11,7 +11,7 @@ import { type Translations, useI18n } from '@/i18n'
 import { ArrowUpRight, X } from '@/lib/icons'
 import type { TodoStatus } from '@/lib/todos'
 import { cn } from '@/lib/utils'
-import type { ComposerStatusItem } from '@/store/composer-status'
+import { exitCodeLabel, type ComposerStatusItem } from '@/store/composer-status'
 
 const toolLabel = (name: string) =>
   name
@@ -59,7 +59,10 @@ function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack']):
   return (
     <span
       aria-hidden
-      className={cn('size-1.5 rounded-full', item.state === 'failed' ? 'bg-destructive/80' : 'bg-emerald-500/70')}
+      className={cn(
+        'size-1.5 rounded-full',
+        item.state === 'failed' ? 'bg-destructive/80' : item.state === 'stopped' ? 'bg-muted-foreground/60' : 'bg-emerald-500/70'
+      )}
     />
   )
 }
@@ -85,6 +88,7 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
   const s = t.statusStack
   const [outputOpen, setOutputOpen] = useState(false)
   const failed = item.state === 'failed'
+  const stopped = item.state === 'stopped'
   const running = item.state === 'running'
 
   const action =
@@ -142,11 +146,17 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
             {toolLabel(item.currentTool)}
           </span>
         )}
-        {failed && typeof item.exitCode === 'number' && item.exitCode !== 0 && (
-          <span className="shrink-0 rounded bg-destructive/15 px-1 text-[0.58rem] font-semibold text-destructive tabular-nums">
-            {s.exit(item.exitCode)}
-          </span>
-        )}
+        {(failed || stopped) && typeof item.exitCode === 'number' && item.exitCode !== 0 && (() => {
+          const lbl = exitCodeLabel(item.exitCode)
+          return (
+            <span className={cn(
+              'shrink-0 rounded px-1 text-[0.58rem] font-semibold tabular-nums',
+              stopped ? 'bg-muted-foreground/15 text-muted-foreground' : 'bg-destructive/15 text-destructive'
+            )}>
+              {lbl.signal ? lbl.text : s.exit(item.exitCode)}
+            </span>
+          )
+        })()}
         {hasOutput && <DisclosureCaret className="shrink-0 text-muted-foreground/45" open={outputOpen} size="0.8em" />}
       </StatusRow>
       {hasOutput && outputOpen && <TerminalOutput className="mx-auto mb-1 max-w-[90%]" text={item.output!} />}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1344,6 +1344,8 @@ export const en: Translations = {
     running: 'Running',
     stop: 'Stop',
     dismiss: 'Dismiss',
+    stopped: 'Stopped',
+    clearFinished: 'Clear finished',
     exit: code => `exit ${code}`
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1472,6 +1472,8 @@ export const ja = defineLocale({
     running: '実行中',
     stop: '停止',
     dismiss: '閉じる',
+    stopped: '停止しました',
+    clearFinished: '完了分をクリア',
     exit: code => `終了コード ${code}`
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1023,6 +1023,8 @@ export interface Translations {
     running: string
     stop: string
     dismiss: string
+    stopped: string
+    clearFinished: string
     exit: (code: number) => string
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1425,6 +1425,8 @@ export const zhHant = defineLocale({
     running: '執行中',
     stop: '停止',
     dismiss: '關閉',
+    stopped: '已停止',
+    clearFinished: '清除已完成',
     exit: code => `結束碼 ${code}`
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1530,6 +1530,8 @@ export const zh: Translations = {
     running: '运行中',
     stop: '停止',
     dismiss: '关闭',
+    stopped: '已停止',
+    clearFinished: '清除已完成',
     exit: code => `退出码 ${code}`
   },
 

--- a/apps/desktop/src/store/composer-status.test.ts
+++ b/apps/desktop/src/store/composer-status.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { $backgroundStatusBySession, dismissBackgroundProcess, reconcileBackgroundProcesses } from './composer-status'
+import {
+  $backgroundStatusBySession,
+  clearFinishedBackgroundProcesses,
+  dismissBackgroundProcess,
+  reconcileBackgroundProcesses
+} from './composer-status'
 
 const SID = 'sess-1'
 
@@ -95,5 +100,46 @@ describe('reconcileBackgroundProcesses', () => {
     reconcileBackgroundProcesses(SID, [])
 
     expect($backgroundStatusBySession.get()).toEqual({})
+  })
+
+  it('maps negative exit code to stopped state', () => {
+    reconcileBackgroundProcesses(SID, [exited('a', -15)])
+
+    expect(items()[0]!.state).toBe('stopped')
+    expect(items()[0]!.exitCode).toBe(-15)
+  })
+
+  it('maps exit code 1 to failed state', () => {
+    reconcileBackgroundProcesses(SID, [exited('a', 1)])
+
+    expect(items()[0]!.state).toBe('failed')
+  })
+
+  it('maps exit code 0 to done state', () => {
+    reconcileBackgroundProcesses(SID, [exited('a', 0)])
+
+    expect(items()[0]!.state).toBe('done')
+  })
+})
+
+describe('clearFinishedBackgroundProcesses', () => {
+  beforeEach(() => {
+    $backgroundStatusBySession.set({})
+  })
+
+  it('keeps running rows and drops finished rows', () => {
+    reconcileBackgroundProcesses(SID, [running('a'), exited('b', 0), exited('c', 1)])
+
+    clearFinishedBackgroundProcesses(SID)
+
+    expect(items().map(i => i.id)).toEqual(['a'])
+  })
+
+  it('does nothing when session id is empty', () => {
+    reconcileBackgroundProcesses(SID, [exited('a', 0)])
+
+    clearFinishedBackgroundProcesses('')
+
+    expect(items().length).toBeGreaterThan(0)
   })
 })

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -9,7 +9,7 @@ import { $subagentsBySession, type SubagentProgress } from './subagents'
 import { $todosBySession } from './todos'
 
 /** Composer status stack feed — merged todos, subagents, background per session. */
-export type StatusItemState = 'done' | 'failed' | 'running'
+export type StatusItemState = 'done' | 'failed' | 'running' | 'stopped'
 export type StatusItemType = 'background' | 'subagent' | 'todo'
 
 export interface ComposerStatusItem {
@@ -133,15 +133,24 @@ const toBackgroundItem = (proc: GatewayProcessEntry): ComposerStatusItem => {
   const exited = proc.status === 'exited'
   const exitCode = typeof proc.exit_code === 'number' ? proc.exit_code : undefined
 
+  const state: StatusItemState = !exited ? 'running'
+    : exitCode === undefined || exitCode === 0 ? 'done'
+    : exitCode < 0 ? 'stopped'
+    : 'failed'
+
   return {
     exitCode,
     id: proc.session_id ?? '',
     output: proc.output_tail || undefined,
-    state: exited ? (exitCode ? 'failed' : 'done') : 'running',
+    state,
     title: (proc.command ?? '').split('\n')[0]!.trim() || 'background process',
     type: 'background'
   }
 }
+
+const SIGNAL_NAMES: Record<number, string> = { 2: 'SIGINT', 9: 'SIGKILL', 15: 'SIGTERM' }
+export const exitCodeLabel = (code: number): { signal: boolean; text: string } =>
+  code < 0 ? { signal: true, text: SIGNAL_NAMES[-code] ?? `signal ${-code}` } : { signal: false, text: String(code) }
 
 const sameItem = (a: ComposerStatusItem, b: ComposerStatusItem) =>
   a.state === b.state && a.title === b.title && a.output === b.output && a.exitCode === b.exitCode
@@ -231,12 +240,24 @@ export function dismissBackgroundProcess(sid: string, id: string) {
   dismissed.add(id)
   dismissedBySession.set(sid, dismissed)
 
+  void $gateway.get()?.request('process.remove', { process_id: id, session_id: sid }).catch(() => undefined)
+
   const list = $backgroundStatusBySession.get()[sid] ?? []
 
   writeBackground(
     sid,
     list.filter(item => item.id !== id)
   )
+}
+
+export function clearFinishedBackgroundProcesses(sid: string) {
+  if (!sid) return
+  void $gateway.get()?.request('process.clear_finished', { session_id: sid }).catch(() => undefined)
+  const list = $backgroundStatusBySession.get()[sid] ?? []
+  const dismissed = dismissedBySession.get(sid) ?? new Set<string>()
+  for (const item of list) { if (item.state !== 'running') dismissed.add(item.id) }
+  dismissedBySession.set(sid, dismissed)
+  writeBackground(sid, list.filter(item => item.state === 'running'))
 }
 
 /** X on a running row: kill the process for real, then drop the row. */

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1318,3 +1318,122 @@ class TestTerminateHostPidPosix:
         pr.ProcessRegistry._terminate_host_pid(12345)
 
         assert kill_calls == [(12345, signal.SIGTERM)]
+
+
+class TestProcessRegistryREAP:
+    """Tests for remove() and clear_finished() reaping methods."""
+
+    def test_remove_evicts_finished_session(self, registry):
+        """remove() deletes a finished session from _finished."""
+        s = _make_session(sid="fin1", exited=True, exit_code=0)
+        registry._finished["fin1"] = s
+        registry._write_checkpoint = MagicMock()
+
+        result = registry.remove("fin1")
+
+        assert result == {"status": "removed", "session_id": "fin1"}
+        assert "fin1" not in registry._finished
+        registry._write_checkpoint.assert_called_once()
+
+    def test_remove_refuses_running_process(self, registry):
+        """remove() returns an error if the session is still running."""
+        s = _make_session(sid="run1", exited=False)
+        registry._running["run1"] = s
+
+        result = registry.remove("run1")
+
+        assert result["status"] == "running"
+        assert "is still running" in result["error"]
+        assert "run1" in registry._running
+
+    def test_remove_idempotent_not_found(self, registry):
+        """remove() on a non-existent session returns not_found."""
+        result = registry.remove("ghost")
+
+        assert result == {"status": "not_found", "session_id": "ghost"}
+
+    def test_remove_clears_completion_consumed(self, registry):
+        """remove() discards the session from _completion_consumed."""
+        s = _make_session(sid="done1", exited=True, exit_code=0)
+        registry._finished["done1"] = s
+        registry._completion_consumed.add("done1")
+        registry._write_checkpoint = MagicMock()
+
+        registry.remove("done1")
+
+        assert "done1" not in registry._completion_consumed
+
+    def test_clear_finished_removes_all(self, registry):
+        """clear_finished() removes all finished sessions."""
+        s1 = _make_session(sid="f1", task_id="t1", exited=True, exit_code=0)
+        s2 = _make_session(sid="f2", task_id="t1", exited=True, exit_code=1)
+        registry._finished["f1"] = s1
+        registry._finished["f2"] = s2
+        registry._write_checkpoint = MagicMock()
+
+        result = registry.clear_finished()
+
+        assert result["status"] == "ok"
+        assert result["removed"] == 2
+        assert set(result["session_ids"]) == {"f1", "f2"}
+        assert len(registry._finished) == 0
+        registry._write_checkpoint.assert_called_once()
+
+    def test_clear_finished_scoped_by_task_id(self, registry):
+        """clear_finished(task_id=...) only removes matching finished sessions."""
+        s1 = _make_session(sid="f1", task_id="t1", exited=True)
+        s2 = _make_session(sid="f2", task_id="t2", exited=True)
+        registry._finished["f1"] = s1
+        registry._finished["f2"] = s2
+        registry._write_checkpoint = MagicMock()
+
+        result = registry.clear_finished(task_id="t1")
+
+        assert result["removed"] == 1
+        assert result["session_ids"] == ["f1"]
+        assert "f1" not in registry._finished
+        assert "f2" in registry._finished
+
+    def test_clear_finished_scoped_by_session_key(self, registry):
+        """clear_finished(session_key=...) only removes matching sessions."""
+        s1 = _make_session(sid="f1", exited=True)
+        s1.session_key = "key-a"
+        s2 = _make_session(sid="f2", exited=True)
+        s2.session_key = "key-b"
+        registry._finished["f1"] = s1
+        registry._finished["f2"] = s2
+        registry._write_checkpoint = MagicMock()
+
+        result = registry.clear_finished(session_key="key-a")
+
+        assert result["removed"] == 1
+        assert "f1" not in registry._finished
+        assert "f2" in registry._finished
+
+    def test_clear_finished_leaves_running_alone(self, registry):
+        """clear_finished() does NOT remove running sessions."""
+        s_run = _make_session(sid="run", exited=False)
+        s_fin = _make_session(sid="fin", exited=True, exit_code=0)
+        registry._running["run"] = s_run
+        registry._finished["fin"] = s_fin
+        registry._write_checkpoint = MagicMock()
+
+        result = registry.clear_finished()
+
+        assert result["removed"] == 1
+        assert "run" in registry._running
+        assert "fin" not in registry._finished
+
+    def test_clear_finished_no_matching_sessions(self, registry):
+        """clear_finished() returns removed=0 when no sessions match."""
+        s = _make_session(sid="f1", task_id="t1", exited=True)
+        registry._finished["f1"] = s
+        registry._write_checkpoint = MagicMock()
+
+        result = registry.clear_finished(task_id="no-such-task")
+
+        assert result == {"status": "ok", "removed": 0, "session_ids": []}
+        assert "f1" in registry._finished
+        # _write_checkpoint should NOT be called when nothing was removed
+        registry._write_checkpoint.assert_not_called()
+

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1236,6 +1236,31 @@ class ProcessRegistry:
         except Exception as e:
             return {"status": "error", "error": str(e)}
 
+    def remove(self, session_id: str) -> dict:
+        """Evict ONE finished session from _finished. Refuses to remove a running process."""
+        with self._lock:
+            if session_id in self._running:
+                return {"status": "running", "error": f"Process {session_id} is still running; kill it first"}
+            existed = self._finished.pop(session_id, None) is not None
+        self._completion_consumed.discard(session_id)
+        if existed:
+            self._write_checkpoint()
+            return {"status": "removed", "session_id": session_id}
+        return {"status": "not_found", "session_id": session_id}
+
+    def clear_finished(self, task_id: str = None, session_key: str = None) -> dict:
+        """Evict ALL finished sessions, optionally scoped by task_id and/or session_key."""
+        with self._lock:
+            ids = [sid for sid, s in self._finished.items()
+                   if (task_id is None or s.task_id == task_id)
+                   and (session_key is None or (s.session_key or "") == session_key)]
+            for sid in ids:
+                del self._finished[sid]
+                self._completion_consumed.discard(sid)
+        if ids:
+            self._write_checkpoint()
+        return {"status": "ok", "removed": len(ids), "session_ids": ids}
+
     def write_stdin(self, session_id: str, data: str) -> dict:
         """Send raw data to a running process's stdin (no newline appended)."""
         session = self.get(session_id)
@@ -1748,14 +1773,15 @@ PROCESS_SCHEMA = {
         "Actions: 'list' (show all), 'poll' (check status + new output), "
         "'log' (full output with pagination), 'wait' (block until done or timeout), "
         "'kill' (terminate), 'write' (send raw stdin data without newline), "
-        "'submit' (send data + Enter, for answering prompts), 'close' (close stdin/send EOF)."
+        "'submit' (send data + Enter, for answering prompts), 'close' (close stdin/send EOF), "
+        "'remove' (evict one finished process from registry), 'clear' (evict all finished processes)."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["list", "poll", "log", "wait", "kill", "write", "submit", "close"],
+                "enum": ["list", "poll", "log", "wait", "kill", "write", "submit", "close", "remove", "clear"],
                 "description": "Action to perform on background processes"
             },
             "session_id": {
@@ -1794,7 +1820,9 @@ def _handle_process(args, **kw):
 
     if action == "list":
         return json.dumps({"processes": process_registry.list_sessions(task_id=task_id)}, ensure_ascii=False)
-    elif action in {"poll", "log", "wait", "kill", "write", "submit", "close"}:
+    elif action == "clear":
+        return json.dumps(process_registry.clear_finished(task_id=task_id), ensure_ascii=False)
+    elif action in {"poll", "log", "wait", "kill", "write", "submit", "close", "remove"}:
         if not session_id:
             return tool_error(f"session_id is required for {action}")
         if action == "poll":
@@ -1812,7 +1840,9 @@ def _handle_process(args, **kw):
             return json.dumps(process_registry.submit_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
         elif action == "close":
             return json.dumps(process_registry.close_stdin(session_id), ensure_ascii=False)
-    return tool_error(f"Unknown process action: {action}. Use: list, poll, log, wait, kill, write, submit, close")
+        elif action == "remove":
+            return json.dumps(process_registry.remove(session_id), ensure_ascii=False)
+    return tool_error(f"Unknown process action: {action}. Use: list, poll, log, wait, kill, write, submit, close, remove, clear")
 
 
 registry.register(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8370,6 +8370,42 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5010, str(e))
 
 
+@method("process.remove")
+def _(rid, params: dict) -> dict:
+    """Reap ONE finished background process from the registry — session-scoped."""
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    proc_id = str(params.get("process_id") or "")
+    if not proc_id:
+        return _err(rid, 4012, "process_id required")
+    try:
+        from tools.process_registry import process_registry
+        proc = process_registry.get(proc_id)
+        if proc is None or str(getattr(proc, "session_key", "") or "") != str(session.get("session_key") or ""):
+            return _err(rid, 4044, f"no such process: {proc_id}")
+        result = process_registry.remove(proc_id)
+        if result.get("status") == "running":
+            return _err(rid, 4090, result["error"])
+        return _ok(rid, result)
+    except Exception as e:
+        return _err(rid, 5010, str(e))
+
+
+@method("process.clear_finished")
+def _(rid, params: dict) -> dict:
+    """Reap ALL finished background processes owned by the caller's session."""
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    try:
+        from tools.process_registry import process_registry
+        key = str(session.get("session_key") or "")
+        return _ok(rid, process_registry.clear_finished(session_key=key))
+    except Exception as e:
+        return _err(rid, 5010, str(e))
+
+
 @method("reload.mcp")
 def _(rid, params: dict) -> dict:
     session = _sessions.get(params.get("session_id", ""))


### PR DESCRIPTION
feat(desktop): let the agent reap background processes + stop mislabeling signal-kills as failures

Two gaps in the background-process status stack:

1. REAP CAPABILITY — finished/killed background entries piled up with no way
   for the agent (or a re-poll-safe UI action) to evict them. The agent could
   `kill` a LIVE process but had no primitive to drop a FINISHED one from the
   registry, so the desktop "Background" group accumulated dead rows that only
   cleared on a 30-min TTL or app restart.
   - ProcessRegistry.remove(session_id): evict one finished entry; refuses a
     running process (returns status 'running' — kill it first); idempotent.
   - ProcessRegistry.clear_finished(task_id?, session_key?): evict all finished
     entries, optionally scoped.
   - Gateway: process.remove (session-scoped, 4044 if not owned, 4090 if still
     running) and process.clear_finished (caller-session-scoped), mirroring the
     existing process.kill scoping.
   - Agent `process` tool: new `remove` and `clear` actions so the agent can
     up/down background sessions during its own iteration.
   - Desktop: dismissBackgroundProcess now fires process.remove so the eviction
     is registry-authoritative (other windows + re-polls won't resurrect it),
     plus a "Clear finished" accessory on the Background group header that
     bulk-reaps via process.clear_finished.

2. SIGNAL-EXIT RENDERING — a negative exit code is a signal termination
   (kill_process sets -15 = SIGTERM), i.e. a DELIBERATE teardown, not a crash.
   It was painted the same scary red "failed" with a raw "exit -15" badge as a
   genuine exit-1 failure. Now exitCode < 0 maps to a new neutral 'stopped'
   state (muted dot + muted badge) and the badge renders the signal NAME
   (SIGTERM/SIGINT/SIGKILL) instead of a raw negative number. A real non-zero
   exit still renders red "failed" with "exit N".

i18n: statusStack gains `stopped` and `clearFinished` (en/ja/zh/zh-hant +
types.ts).

Tests: process_registry remove/clear_finished (evict, refuse-running,
idempotent, session-key scoping — 80 pass); composer-status (negative exit ->
'stopped', exit 1 -> 'failed', clearFinished keeps running rows). tsc clean.
