### PR TITLE
fix(email): normalize EMAIL_IMAP_HOST/EMAIL_SMTP_HOST before connect (#49736)

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -32,6 +32,7 @@ from email.mime.base import MIMEBase
 from email.utils import formatdate
 from email import encoders
 from pathlib import Path
+from urllib.parse import urlsplit
 from typing import Any, Dict, List, Optional, Tuple
 
 from gateway.platforms.base import (
@@ -65,6 +66,29 @@ _AUTOMATED_HEADERS = {
 MAX_MESSAGE_LENGTH = 50_000
 
 SMTP_CONNECT_TIMEOUT = 30
+
+
+def _normalize_host(host: str) -> str:
+    """Sanitize a mail-server host read from env/config before connecting.
+
+    Hosts entered via ``hermes gateway setup`` or copied into config files
+    occasionally carry stray whitespace, surrounding quotes, a URL scheme,
+    userinfo, or an appended ``:port``. Any of these makes
+    ``socket.getaddrinfo`` reject an otherwise valid host with
+    ``[Errno 8] nodename nor servname provided`` (EAI_NONAME), so reduce the
+    value to a bare hostname.
+    """
+    cleaned = host.strip().strip("\"'").strip()
+    if not cleaned:
+        return cleaned
+    # Parse via urlsplit so a scheme, userinfo, port, path, or IPv6 literal are
+    # all handled uniformly; urlsplit needs a "//" prefix to populate netloc.
+    to_parse = cleaned if "://" in cleaned else "//" + cleaned
+    try:
+        hostname = urlsplit(to_parse).hostname
+    except ValueError:
+        hostname = None
+    return hostname or cleaned
 
 
 def _create_ipv4_connection(
@@ -309,10 +333,24 @@ class EmailAdapter(BasePlatformAdapter):
 
         self._address = os.getenv("EMAIL_ADDRESS", "")
         self._password = os.getenv("EMAIL_PASSWORD", "")
-        self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
+        raw_imap_host = os.getenv("EMAIL_IMAP_HOST", "")
+        self._imap_host = _normalize_host(raw_imap_host)
         self._imap_port = env_int("EMAIL_IMAP_PORT", 993)
-        self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
+        raw_smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
+        self._smtp_host = _normalize_host(raw_smtp_host)
         self._smtp_port = env_int("EMAIL_SMTP_PORT", 587)
+        for _var, _raw, _norm in (
+            ("EMAIL_IMAP_HOST", raw_imap_host, self._imap_host),
+            ("EMAIL_SMTP_HOST", raw_smtp_host, self._smtp_host),
+        ):
+            if _norm != _raw:
+                # Log only the normalized host; the raw value may embed userinfo.
+                logger.warning(
+                    "[Email] Normalized %s to %r before connecting "
+                    "(stripped whitespace/quotes/scheme/userinfo/port)",
+                    _var,
+                    _norm,
+                )
         self._poll_interval = env_int("EMAIL_POLL_INTERVAL", 15)
 
         # Skip attachments — configured via config.yaml:
@@ -915,7 +953,7 @@ async def _standalone_send(
     extra = getattr(pconfig, "extra", {}) or {}
     address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
     password = os.getenv("EMAIL_PASSWORD", "")
-    smtp_host = extra.get("smtp_host") or os.getenv("EMAIL_SMTP_HOST", "")
+    smtp_host = _normalize_host(extra.get("smtp_host") or os.getenv("EMAIL_SMTP_HOST", ""))
     try:
         smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
     except (ValueError, TypeError):

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1392,5 +1392,64 @@ class TestConnectSmtp(unittest.TestCase):
         self.assertIs(_socket.getaddrinfo, original_getaddrinfo)
 
 
+class TestHostNormalization(unittest.TestCase):
+    """Mail-server hosts are sanitized before connecting (regression for #49736)."""
+
+    def test_normalize_host_strips_junk(self):
+        from plugins.platforms.email.adapter import _normalize_host
+
+        cases = {
+            "imap.mail.me.com": "imap.mail.me.com",
+            "  imap.mail.me.com  ": "imap.mail.me.com",
+            "imap.mail.me.com\n": "imap.mail.me.com",
+            '"imap.mail.me.com"': "imap.mail.me.com",
+            "'imap.mail.me.com'": "imap.mail.me.com",
+            "IMAP.Mail.ME.com": "imap.mail.me.com",
+            "imaps://imap.mail.me.com": "imap.mail.me.com",
+            "imap.mail.me.com:993": "imap.mail.me.com",
+            "imaps://imap.mail.me.com:993/INBOX": "imap.mail.me.com",
+            "imaps://user:pass@imap.mail.me.com:993/INBOX": "imap.mail.me.com",
+            "[::1]": "::1",
+            "[::1]:993": "::1",
+            "imaps://[2001:db8::1]:993": "2001:db8::1",
+            "": "",
+        }
+        for value, expected in cases.items():
+            self.assertEqual(_normalize_host(value), expected, msg=repr(value))
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": " imaps://imap.mail.me.com:993 ",
+        "EMAIL_SMTP_HOST": "smtp.mail.me.com\n",
+        "EMAIL_IMAP_PORT": "993",
+        "EMAIL_SMTP_PORT": "587",
+    }, clear=False)
+    def test_adapter_init_normalizes_hosts(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        adapter = EmailAdapter(PlatformConfig(enabled=True))
+        self.assertEqual(adapter._imap_host, "imap.mail.me.com")
+        self.assertEqual(adapter._smtp_host, "smtp.mail.me.com")
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "imaps://user:s3cr3t@imap.mail.me.com:993/INBOX",
+        "EMAIL_SMTP_HOST": "smtp.mail.me.com",
+    }, clear=False)
+    def test_normalize_host_does_not_log_credentials(self):
+        from plugins.platforms.email import adapter as email_mod
+        from gateway.config import PlatformConfig
+
+        with self.assertLogs(email_mod.logger, level="WARNING") as cm:
+            adapter = email_mod.EmailAdapter(PlatformConfig(enabled=True))
+        self.assertEqual(adapter._imap_host, "imap.mail.me.com")
+        joined = "\n".join(cm.output)
+        self.assertNotIn("s3cr3t", joined)
+        self.assertNotIn("user:", joined)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #49736.

`imap.mail.me.com` resolves fine in standalone Python but fails inside the gateway with `[Errno 8] nodename nor servname provided` (EAI_NONAME). That error is what `getaddrinfo` returns for a malformed *host string* (not a DNS/network failure), so the value passed to `imaplib.IMAP4_SSL` carries junk — stray whitespace/newline, surrounding quotes, a URL scheme, userinfo, or an appended `:port` — picked up from `hermes gateway setup` or a hand-edited config.

`_normalize_host()` reduces the configured host to a bare hostname via `urlsplit().hostname` (handles scheme, userinfo, port, and IPv6 literals), applied to `EMAIL_IMAP_HOST` / `EMAIL_SMTP_HOST` in `EmailAdapter.__init__` (the warn-on-change log prints only the normalized host, never the raw value, which may embed userinfo) and in the standalone SMTP sender. Adds regression tests.

If this has already been addressed via a separate patch, feel free to close.