### PR TITLE
fix(gateway): use buffer_only mode for Photon to prevent streaming cursor tofu

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13945,7 +13945,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
                     _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
                     _buffer_only = False
-                    if source.platform == Platform.MATRIX:
+                    # Matrix clients and iMessage (Photon) render the
+                    # streaming cursor as a visible tofu/white-box
+                    # artifact.  Suppress the cursor and use buffer-only
+                    # mode so only the final plain-text message is sent.
+                    if source.platform == Platform.MATRIX or getattr(source.platform, "value", "") == "photon":
                         _effective_cursor = ""
                         _buffer_only = True
                     # Fresh-final applies to Telegram only — other
@@ -15112,7 +15116,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # as a visible tofu/white-box artifact.  Keep
                         # streaming text on Matrix, but suppress the cursor.
                         _buffer_only = False
-                        if source.platform == Platform.MATRIX:
+                        # Matrix clients and iMessage (Photon) render the
+                        # streaming cursor as a visible tofu/white-box
+                        # artifact.  Suppress the cursor and use buffer-only
+                        # mode so only the final plain-text message is sent.
+                        if source.platform == Platform.MATRIX or getattr(source.platform, "value", "") == "photon":
                             _effective_cursor = ""
                             _buffer_only = True
                         # Fresh-final applies to Telegram only — other

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -943,6 +943,39 @@ async def test_run_agent_matrix_streaming_omits_cursor(monkeypatch, tmp_path):
     assert any("Continuing to refine:" in text for text in all_text)
 
 
+@pytest.mark.asyncio
+async def test_run_agent_photon_streaming_buffer_only(monkeypatch, tmp_path):
+    """Photon (iMessage) must use buffer_only mode to prevent the
+    streaming cursor from rendering as a white-square/tofu artifact.
+
+    Regression: #49793 -- streaming cursor was visible in iMessage bubbles
+    because Photon was not included in the buffer_only platform check.
+    """
+    photon_platform = Platform("photon")
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingRefineAgent,
+        session_id="sess-photon-buffer-only",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=photon_platform,
+        chat_id="user-123",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    assert result.get("already_sent") is True
+    all_text = [call["content"] for call in adapter.sent] + [call["content"] for call in adapter.edits]
+    assert all_text, "expected streamed Photon content to be sent"
+    # Buffer-only mode: no streaming cursor artifact
+    assert all("\u2589" not in text for text in all_text)
+    # Buffer-only mode: no intermediate edits (only final send)
+    assert len(adapter.edits) == 0, f"expected no edits in buffer_only mode, got {len(adapter.edits)}"
+
+
 class TransformedStreamAgent:
     """Streams a response, then signals the gateway that a plugin hook
     (``transform_llm_output``) modified the final text after streaming


### PR DESCRIPTION
## What does this PR do?

Adds Photon (iMessage) to the `buffer_only` streaming mode check so the streaming cursor character is suppressed. Previously, the cursor rendered as a visible white-square/tofu artifact in iMessage bubbles.

## Related Issue

Fixes #49793

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Add Photon to the `buffer_only=True` condition in both streaming code paths (the `_run_agent` path and the inline-streaming path), alongside the existing Matrix check. Uses `getattr(source.platform, "value", "") == "photon"` since Photon is a plugin platform without an explicit enum member.
- `tests/gateway/test_run_progress_topics.py`: Add `test_run_agent_photon_streaming_buffer_only` regression test verifying no streaming cursor artifact and no intermediate edits for Photon sessions.

## How to Test

1. Configure a Photon/iMessage gateway adapter
2. Send a message that triggers streaming response
3. Verify no white-square characters appear in the iMessage bubble
4. Run `pytest tests/gateway/test_run_progress_topics.py::test_run_agent_photon_streaming_buffer_only -xvs`
5. Run `pytest tests/gateway/test_run_progress_topics.py::test_run_agent_matrix_streaming_omits_cursor -xvs` (regression: Matrix still works)
6. Run `pytest tests/gateway/test_stream_consumer.py::TestBufferOnlyMode -xvs` (regression: buffer_only mode tests still pass)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/run.py` lines 13947-13957 and 15114-15124 (streaming buffer_only logic)
- Blast radius: LOW — additive condition to existing platform check, no control flow change
- Related patterns: Matrix buffer_only (same mechanism, line 13949/15115), StreamConsumerConfig buffer_only mode
