### PR TITLE
fix(desktop): unify Spawn tree scope with status bar indicator

### DIFF
--- a/apps/desktop/src/app/agents/index.tsx
+++ b/apps/desktop/src/app/agents/index.tsx
@@ -9,7 +9,6 @@ import { type Translations, useI18n } from '@/i18n'
 import { AlertCircle, CheckCircle2, Sparkles } from '@/lib/icons'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
-import { $activeSessionId } from '@/store/session'
 import {
   $subagentsBySession,
   buildSubagentTree,
@@ -77,12 +76,19 @@ interface AgentsViewProps {
 
 export function AgentsView({ onClose }: AgentsViewProps) {
   const { t } = useI18n()
-  const activeSessionId = useStore($activeSessionId)
   const subagentsBySession = useStore($subagentsBySession)
 
+  // Aggregate subagents across every session — the status bar's
+  // "Agents N running" count uses the same aggregate (see
+  // use-statusbar-items.tsx → activeSubagentCount over
+  // Object.values(subagentsBySession)). Filtering to only the active
+  // session here produced a desynced Spawn tree (#49808): users saw
+  // "Agents 2 running" in the status bar while the Spawn tree overlay
+  // rendered the "No live subagents" empty state because the running
+  // agents belonged to a different session.
   const activeSubagents = useMemo(
-    () => (activeSessionId ? (subagentsBySession[activeSessionId] ?? []) : []),
-    [activeSessionId, subagentsBySession]
+    () => Object.values(subagentsBySession).flat(),
+    [subagentsBySession]
   )
 
   const tree = useMemo(() => buildSubagentTree(activeSubagents), [activeSubagents])

--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -109,3 +109,69 @@ describe('subagent store', () => {
     expect($subagentsBySession.get().s2).toHaveLength(1)
   })
 })
+
+// Regression test for #49808: the Spawn tree overlay and the status
+// bar's "Agents N running" indicator used to disagree because they
+// filtered $subagentsBySession differently — the status bar
+// aggregated every session, the Spawn tree kept only the active
+// session. This block pins the post-fix contract: both indicators
+// read from the same aggregate scope.
+describe('#49808 — Spawn tree / status bar aggregate scope', () => {
+  beforeEach(() => $subagentsBySession.set({}))
+
+  it('status bar count and Spawn tree aggregate over the same scope', () => {
+    // Two sessions, two running subagents each. The "active session"
+    // would be s1 in the old implementation; s2 is non-active but
+    // still owns running subagents.
+    upsertSubagent('s1', { goal: 'scan files', status: 'running', subagent_id: 'a1', task_index: 0 })
+    upsertSubagent('s1', { goal: 'patch tests', status: 'running', subagent_id: 'a2', task_index: 1 })
+    upsertSubagent('s2', { goal: 'background work', status: 'running', subagent_id: 'b1', task_index: 0 })
+    upsertSubagent('s2', { goal: 'cron poll', status: 'running', subagent_id: 'b2', task_index: 1 })
+
+    // The status bar uses Object.values(...).reduce(...activeSubagentCount...).
+    const statusBarCount = Object.values($subagentsBySession.get()).reduce(
+      (sum, items) => sum + activeSubagentCount(items),
+      0
+    )
+    expect(statusBarCount).toBe(4)
+
+    // The Spawn tree (post-fix) uses Object.values(...).flat() — the
+    // same scope as the status bar.
+    const spawnTreeFlat = Object.values($subagentsBySession.get()).flat()
+    const spawnTreeRoots = buildSubagentTree(spawnTreeFlat)
+    const spawnTreeTotal = spawnTreeRoots.reduce(
+      (sum, root) => sum + 1 + root.children.length,
+      0
+    )
+    expect(spawnTreeTotal).toBe(4)
+
+    // Counter-example that documents the regression: filtering to
+    // only the active session would yield 2 subagents while the
+    // status bar counted 4. The post-fix Spawn tree must include
+    // s2's subagents too.
+    const activeOnly = $subagentsBySession.get()['s1'] ?? []
+    expect(activeOnly).toHaveLength(2)
+    expect(statusBarCount).not.toBe(activeOnly.length)
+  })
+
+  it('Spawn tree stays empty only when no session has running subagents', () => {
+    // Empty-state pin: with only terminal subagents, both indicators
+    // agree on zero running/queued and the Spawn tree renders its
+    // empty placeholder. Note that buildSubagentTree includes
+    // completed/failed nodes (so we count activeSubagentCount instead
+    // of tree length for the Spawn-tree side of the contract).
+    upsertSubagent('s1', { goal: 'done', status: 'completed', subagent_id: 'a1', task_index: 0 })
+
+    const spawnTreeFlat = Object.values($subagentsBySession.get()).flat()
+    const spawnTreeActiveCount = activeSubagentCount(spawnTreeFlat)
+
+    const statusBarCount = Object.values($subagentsBySession.get()).reduce(
+      (sum, items) => sum + activeSubagentCount(items),
+      0
+    )
+    expect(spawnTreeActiveCount).toBe(0)
+    expect(statusBarCount).toBe(0)
+    // Both indicators agree — the regression condition for #49808.
+    expect(spawnTreeActiveCount).toBe(statusBarCount)
+  })
+})


### PR DESCRIPTION
## Summary

Two UI indicators read from `$subagentsBySession` but used different filters: the status bar's "Agents N running" aggregated across every session, while the Spawn tree overlay kept only the active session. Users saw "Agents 2 running" in the status bar while the Spawn tree rendered "No live subagents" because the running agents belonged to a non-active session (e.g. background work, cron polling).

---

## Root Cause

`apps/desktop/src/app/agents/index.tsx` filtered the store down to `activeSessionId` before calling `buildSubagentTree`. The status bar (`apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx`) already aggregated the same store via `Object.values(...).reduce(..., activeSubagentCount)`.

---

## Fix

Aggregate the same way in `AgentsView`:

 const activeSubagents = useMemo(
-  () => (activeSessionId ? (subagentsBySession[activeSessionId] ?? []) : []),
-  [activeSessionId, subagentsBySession]
+  () => Object.values(subagentsBySession).flat(),
+  [subagentsBySession]
 )

This removes the now-unused `$activeSessionId` import and the `activeSessionId` `useStore` call. Both indicators now read from the same aggregate scope, restoring the contract that the user can trust: "Agents N running" === the number of running subagents visible in the Spawn tree.

---

## Tests

`apps/desktop/src/store/subagents.test.ts` gains two regression tests under #49808 — Spawn tree / status bar aggregate scope:

1. Aggregate parity — two sessions × two running subagents each → both indicators report 4 (the active-session-only filter would have reported 2 — counter-example documented in the test).
2. Empty parity — only terminal subagents → both indicators report 0.

npx vitest run src/store/subagents.test.ts
✓ src/store/subagents.test.ts (8 tests) 11ms
Test Files  1 passed (1)
     Tests  8 passed (8)

---

## Files Changed

apps/desktop/src/app/agents/index.tsx | 14 +++++--
apps/desktop/src/store/subagents.test.ts | 66 ++++++++++++++++++++++

---

Fixes #49808