### PR TITLE
feat(web): add You.com search provider with YDC key compatibility

### DIFF
--- a/agent/web_search_provider.py
+++ b/agent/web_search_provider.py
@@ -14,7 +14,7 @@ Providers live in ``<repo>/plugins/web/<name>/`` (built-in, auto-loaded as
 
 This ABC is the SINGLE plugin-facing surface for web providers — every
 provider in the tree (brave-free, ddgs, searxng, exa, parallel, tavily,
-firecrawl) implements it. The legacy in-tree ``tools.web_providers.base``
+firecrawl, you, xai) implements it. The legacy in-tree ``tools.web_providers.base``
 ABCs were deleted in PR #25182 along with the per-vendor inline helpers
 in ``tools/web_tools.py``; the response-shape contract documented below
 is preserved bit-for-bit so the tool wrapper does not have to translate.

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -17,7 +17,7 @@ The active provider is chosen by configuration with this precedence:
 3. If exactly one capability-eligible provider is registered AND available,
    use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
-   ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
+   ``exa`` → ``you`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
    candidate order so installs that never set a config key keep landing
    on the same provider they did before the plugin migration.
@@ -124,6 +124,7 @@ _LEGACY_PREFERENCE = (
     "parallel",
     "tavily",
     "exa",
+    "you",
     "searxng",
     "brave-free",
     "ddgs",
@@ -148,7 +149,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
 
     3. **Legacy preference walk, filtered by availability.** Walk the
        :data:`_LEGACY_PREFERENCE` order (firecrawl → parallel → tavily →
-       exa → searxng → brave-free → ddgs) looking for a provider whose
+       exa → you → searxng → brave-free → ddgs) looking for a provider whose
        ``supports_<capability>()`` is True AND whose ``is_available()`` is
        True. Matches the historic ``tools.web_tools._get_backend()``
        candidate order so users with credentials but no explicit config

--- a/plugins/web/you/__init__.py
+++ b/plugins/web/you/__init__.py
@@ -1,0 +1,10 @@
+"""You.com Search plugin — bundled, auto-loaded."""
+
+from __future__ import annotations
+
+from plugins.web.you.provider import YouWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the You.com Search provider with the plugin context."""
+    ctx.register_web_search_provider(YouWebSearchProvider())

--- a/plugins/web/you/plugin.yaml
+++ b/plugins/web/you/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-you
+version: 1.0.0
+description: "You.com Search API — search-only web backend for Hermes. Supports YOU_API_KEY or legacy YDC_API_KEY."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - you

--- a/plugins/web/you/provider.py
+++ b/plugins/web/you/provider.py
@@ -1,0 +1,136 @@
+"""You.com Search API — plugin form.
+
+Search-only provider backed by You.com's Search API.
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "you"          # explicit per-capability
+      backend: "you"                 # shared fallback
+
+Auth env vars::
+
+    YOU_API_KEY=...   # canonical name
+    YDC_API_KEY=...   # legacy alias supported for backward compatibility
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_YOU_ENDPOINT = "https://ydc-index.io/v1/search"
+
+
+def _you_api_key() -> str:
+    """Return the configured You.com API key, preferring the modern name."""
+    return (
+        os.getenv("YOU_API_KEY", "").strip()
+        or os.getenv("YDC_API_KEY", "").strip()
+    )
+
+
+class YouWebSearchProvider(WebSearchProvider):
+    """Search-only You.com provider using the Search API."""
+
+    @property
+    def name(self) -> str:
+        return "you"
+
+    @property
+    def display_name(self) -> str:
+        return "You.com Search"
+
+    def is_available(self) -> bool:
+        return bool(_you_api_key())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        import httpx
+
+        api_key = _you_api_key()
+        if not api_key:
+            return {
+                "success": False,
+                "error": "YOU_API_KEY or YDC_API_KEY is not set",
+            }
+
+        count = max(1, min(int(limit), 100))
+
+        try:
+            resp = httpx.get(
+                _YOU_ENDPOINT,
+                params={"query": query, "count": count},
+                headers={
+                    "X-API-Key": api_key,
+                    "Accept": "application/json",
+                },
+                timeout=20,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("You.com Search HTTP error: %s", exc)
+            return {
+                "success": False,
+                "error": f"You.com Search returned HTTP {exc.response.status_code}",
+            }
+        except httpx.RequestError as exc:
+            logger.warning("You.com Search request error: %s", exc)
+            return {
+                "success": False,
+                "error": f"Could not reach You.com Search: {exc}",
+            }
+
+        try:
+            data = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("You.com Search response parse error: %s", exc)
+            return {
+                "success": False,
+                "error": "Could not parse You.com Search response as JSON",
+            }
+
+        raw_results = ((data.get("results") or {}).get("web") or [])
+        truncated = raw_results[:limit]
+        web_results = [
+            {
+                "title": str(r.get("title", "")),
+                "url": str(r.get("url", "")),
+                "description": str(r.get("description", "")),
+                "position": i + 1,
+            }
+            for i, r in enumerate(truncated)
+        ]
+
+        logger.info(
+            "You.com Search '%s': %d results (from %d raw, limit %d)",
+            query,
+            len(web_results),
+            len(raw_results),
+            limit,
+        )
+        return {"success": True, "data": {"web": web_results}}
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "You.com Search",
+            "badge": "paid · search only",
+            "tag": "You.com / YDC Search API — search only. Supports YOU_API_KEY or legacy YDC_API_KEY.",
+            "env_vars": [
+                {
+                    "key": "YOU_API_KEY",
+                    "prompt": "You.com Search API key",
+                    "url": "https://you.com/platform",
+                },
+            ],
+        }

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,8 +2,8 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl, xai) instantiate and self-report the expected
+- All nine bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+  tavily, firecrawl, you, xai) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
@@ -44,6 +44,8 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "FIRECRAWL_GATEWAY_URL",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
+        "YOU_API_KEY",
+        "YDC_API_KEY",
         "XAI_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
@@ -68,9 +70,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All nine bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_nine_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -84,6 +86,7 @@ class TestBundledPluginsRegister:
             "searxng",
             "tavily",
             "xai",
+            "you",
         ]
 
     @pytest.mark.parametrize(
@@ -96,6 +99,7 @@ class TestBundledPluginsRegister:
             ("parallel", True, True),
             ("tavily", True, True),
             ("firecrawl", True, True),
+            ("you", True, False),
             # xai: search-only via Grok's agentic web_search tool.
             ("xai", True, False),
         ],
@@ -116,7 +120,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "you", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +133,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "you", "xai"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -234,6 +238,19 @@ class TestIsAvailable:
         assert p is not None
         # Truthy or falsy, just must not raise.
         _ = bool(p.is_available())
+
+    def test_you_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("you")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("YOU_API_KEY", "real")
+        assert p.is_available() is True
+        monkeypatch.delenv("YOU_API_KEY", raising=False)
+        monkeypatch.setenv("YDC_API_KEY", "real")
+        assert p.is_available() is True
 
     def test_xai_requires_api_key_or_oauth(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """xAI needs XAI_API_KEY or OAuth tokens in auth.json."""
@@ -491,6 +508,17 @@ class TestErrorResponseShapes:
         from agent.web_search_registry import get_provider
 
         p = get_provider("xai")
+        assert p is not None
+        result = p.search("test", limit=5)
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert "error" in result
+
+    def test_you_search_returns_error_dict_when_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("you")
         assert p is not None
         result = p.search("test", limit=5)
         assert isinstance(result, dict)

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -27,6 +27,7 @@ def register_all_web_providers():
     from plugins.web.parallel.provider import ParallelWebSearchProvider
     from plugins.web.searxng.provider import SearXNGWebSearchProvider
     from plugins.web.tavily.provider import TavilyWebSearchProvider
+    from plugins.web.you.provider import YouWebSearchProvider
     from plugins.web.xai.provider import XAIWebSearchProvider
 
     _reset_for_tests()
@@ -38,6 +39,7 @@ def register_all_web_providers():
         ParallelWebSearchProvider,
         SearXNGWebSearchProvider,
         TavilyWebSearchProvider,
+        YouWebSearchProvider,
         XAIWebSearchProvider,
     ):
         register_provider(cls())

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -24,7 +24,7 @@ from tests.tools.conftest import register_all_web_providers
 class TestWebProviderABCs:
     """The unified WebSearchProvider ABC enforces the interface contract.
 
-    After PR #25182, all seven providers are subclasses of
+    After PR #25182, all nine bundled providers are subclasses of
     :class:`agent.web_search_provider.WebSearchProvider`. The legacy
     in-tree ABCs at ``tools.web_providers.base`` (separate
     ``WebSearchProvider`` + ``WebExtractProvider``) were deleted in the
@@ -288,6 +288,9 @@ class TestUnconfiguredErrorEnvelopeParity:
             "FIRECRAWL_API_URL",
             "FIRECRAWL_GATEWAY_URL",
             "TOOL_GATEWAY_DOMAIN",
+            "YOU_API_KEY",
+            "YDC_API_KEY",
+            "XAI_API_KEY",
         ):
             monkeypatch.delenv(k, raising=False)
 

--- a/tests/tools/test_web_providers_you.py
+++ b/tests/tools/test_web_providers_you.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestYouProvider:
+    def test_is_available_accepts_you_or_ydc_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from plugins.web.you.provider import YouWebSearchProvider
+
+        p = YouWebSearchProvider()
+        assert p.is_available() is False
+
+        monkeypatch.setenv("YOU_API_KEY", "real")
+        assert p.is_available() is True
+
+        monkeypatch.delenv("YOU_API_KEY", raising=False)
+        monkeypatch.setenv("YDC_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_search_normalizes_results(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from plugins.web.you.provider import YouWebSearchProvider
+
+        monkeypatch.setenv("YDC_API_KEY", "ydc-test")
+        provider = YouWebSearchProvider()
+
+        response = MagicMock()
+        response.json.return_value = {
+            "results": {
+                "web": [
+                    {
+                        "title": "Hermes Agent",
+                        "url": "https://hermes-agent.nousresearch.com",
+                        "description": "Hermes docs",
+                    },
+                    {
+                        "title": "Nous Research",
+                        "url": "https://nousresearch.com",
+                        "description": "Nous homepage",
+                    },
+                ]
+            }
+        }
+        response.raise_for_status.return_value = None
+
+        with patch("httpx.get", return_value=response) as mocked_get:
+            result = provider.search("hermes agent", limit=2)
+
+        assert result["success"] is True
+        assert result["data"]["web"] == [
+            {
+                "title": "Hermes Agent",
+                "url": "https://hermes-agent.nousresearch.com",
+                "description": "Hermes docs",
+                "position": 1,
+            },
+            {
+                "title": "Nous Research",
+                "url": "https://nousresearch.com",
+                "description": "Nous homepage",
+                "position": 2,
+            },
+        ]
+        mocked_get.assert_called_once()
+        assert mocked_get.call_args.kwargs["headers"]["X-API-Key"] == "ydc-test"
+        assert mocked_get.call_args.kwargs["params"]["query"] == "hermes agent"
+        assert mocked_get.call_args.kwargs["params"]["count"] == 2
+
+    def test_search_returns_typed_error_when_unconfigured(self) -> None:
+        from plugins.web.you.provider import YouWebSearchProvider
+
+        result = YouWebSearchProvider().search("test", limit=5)
+        assert result["success"] is False
+        assert "error" in result
+
+
+class TestYouProviderIntegration:
+    def test_plugin_discovery_registers_you_provider(self) -> None:
+        from agent.web_search_registry import get_provider
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        provider = get_provider("you")
+
+        assert provider is not None
+        assert provider.name == "you"
+        assert provider.supports_search() is True
+        assert provider.supports_extract() is False
+
+    def test_check_web_api_key_accepts_you_as_configured_backend(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tools import web_tools
+
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        monkeypatch.delenv("FIRECRAWL_API_URL", raising=False)
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        monkeypatch.delenv("SEARXNG_URL", raising=False)
+        monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+        monkeypatch.setenv("YDC_API_KEY", "ydc-test")
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "you"})
+
+        assert web_tools.check_web_api_key() is True
+
+    def test_check_web_api_key_accepts_you_in_autodetect_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tools import web_tools
+
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        monkeypatch.delenv("FIRECRAWL_API_URL", raising=False)
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        monkeypatch.delenv("SEARXNG_URL", raising=False)
+        monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+        monkeypatch.setenv("YDC_API_KEY", "ydc-test")
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+
+        assert web_tools.check_web_api_key() is True
+
+    def test_backend_autodetect_prefers_you_over_ddgs_when_you_key_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tools import web_tools
+
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        monkeypatch.delenv("FIRECRAWL_API_URL", raising=False)
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        monkeypatch.delenv("SEARXNG_URL", raising=False)
+        monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+        monkeypatch.setenv("YDC_API_KEY", "ydc-test")
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+
+        assert web_tools._get_search_backend() == "you"
+
+    def test_backend_autodetect_keeps_tavily_ahead_of_you(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tools import web_tools
+
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        monkeypatch.delenv("FIRECRAWL_API_URL", raising=False)
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+        monkeypatch.delenv("SEARXNG_URL", raising=False)
+        monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+        monkeypatch.setenv("TAVILY_API_KEY", "tvly-test")
+        monkeypatch.setenv("YDC_API_KEY", "ydc-test")
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+
+        assert web_tools._get_search_backend() == "tavily"
+
+    def test_backend_autodetect_keeps_firecrawl_ahead_of_you(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tools import web_tools
+
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        monkeypatch.delenv("SEARXNG_URL", raising=False)
+        monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+        monkeypatch.setenv("YDC_API_KEY", "ydc-test")
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+
+        assert web_tools._get_search_backend() == "firecrawl"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -16,6 +16,7 @@ Backend compatibility:
 - Firecrawl: https://docs.firecrawl.dev/introduction (search, extract; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
 - Tavily: https://tavily.com (search, extract)
+- You.com: https://you.com/docs/api-reference/search/v1-search (search only)
 
 LLM Processing:
 - Uses OpenRouter API with Gemini 3 Flash Preview for intelligent content extraction
@@ -149,7 +150,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "you", "ddgs", "xai"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -165,6 +166,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL")),
         ("firecrawl", _is_tool_gateway_ready()),
+        ("you", _has_env("YOU_API_KEY") or _has_env("YDC_API_KEY")),
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
@@ -228,6 +230,8 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("SEARXNG_URL")
     if backend == "brave-free":
         return _has_env("BRAVE_SEARCH_API_KEY")
+    if backend == "you":
+        return _has_env("YOU_API_KEY") or _has_env("YDC_API_KEY")
     if backend == "ddgs":
         return _ddgs_package_importable()
     if backend == "xai":
@@ -283,6 +287,8 @@ def _web_requires_env() -> list[str]:
         "EXA_API_KEY",
         "PARALLEL_API_KEY",
         "TAVILY_API_KEY",
+        "YOU_API_KEY",
+        "YDC_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
         "FIRECRAWL_GATEWAY_URL",
@@ -840,8 +846,9 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch through the web search registry. All 7 providers
-        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
+        # Dispatch through the web search registry. All 9 providers
+        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl,
+        # you, xai)
         # now live as plugins; the dispatcher is just a registry lookup +
         # delegation. Sync only — every provider's search() is sync.
         _ensure_web_plugins_loaded()
@@ -1185,11 +1192,11 @@ async def web_extract_tool(
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "you", "ddgs", "xai"}:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "you", "searxng", "brave-free", "ddgs", "xai")
     )
 
 
@@ -1225,6 +1232,8 @@ if __name__ == "__main__":
             print("   Using Parallel API (https://parallel.ai)")
         elif backend == "tavily":
             print("   Using Tavily API (https://tavily.com)")
+        elif backend == "you":
+            print("   Using You.com Search API (search only)")
         elif backend == "searxng":
             print(f"   Using SearXNG (search only): {_env_value('SEARXNG_URL')}")
         elif backend == "brave-free":


### PR DESCRIPTION
# Hermes Agent PR Draft — Add You.com web search provider

## Suggested branch

`feat/web-you-provider`

## Suggested commit message

```text
feat(web): add You.com search provider with YDC key compatibility
```

## Suggested PR title

`feat(web): add You.com search provider with YDC key compatibility`

## PR body

### Summary

This PR adds **You.com** as a built-in **search-only** web backend for Hermes Agent.

It introduces a new bundled provider under `plugins/web/you/`, wires it into backend discovery and availability checks, and adds compatibility for both:

- `YOU_API_KEY` (canonical)
- `YDC_API_KEY` (legacy / backward-compatible alias)

### What changed

- Added a bundled You.com provider:
  - `plugins/web/you/provider.py`
  - `plugins/web/you/__init__.py`
  - `plugins/web/you/plugin.yaml`
- Registered the provider in test helper coverage
- Added provider-specific tests:
  - availability via `YOU_API_KEY` and `YDC_API_KEY`
  - normalized search response shape
  - typed error behavior when unconfigured
  - plugin discovery / registration
  - backend autodetect ordering
  - `check_web_api_key()` coverage
- Updated backend selection and availability logic so `you` participates in:
  - configured backend resolution
  - autodetect fallback selection
  - top-level web availability checks
- Updated registry/docs/comments to reflect the new built-in provider set

### Fallback behavior

This PR **does not** implement request-time automatic failover on 429/quota errors.

What it does do:
- make `you` available as a normal Hermes web backend
- keep it **behind Firecrawl / Tavily / Exa** in the default preference order
- place it **ahead of SearXNG / Brave / DDGS** as a lower-priority paid/search-only fallback candidate

So this is a provider-addition PR, not a dynamic provider-rotation PR.

### Why this is useful

Some users already have working You.com / YDC search credentials. This lets Hermes use them directly instead of leaving those keys outside the built-in web backend system.

The `YDC_API_KEY` alias also preserves compatibility with earlier local setups that stored the key under the older name.

### Validation

#### Targeted tests run

```bash
pytest tests/tools/test_web_providers_you.py \
       tests/plugins/web/test_web_search_provider_plugins.py \
       tests/tools/test_web_providers.py \
       tests/tools/test_web_providers_brave_free.py \
       tests/tools/test_web_tools_tavily.py -q
```

Result:

```text
113 passed, 1 warning
```

#### Live verification

Forced `web_search_tool(... )` through `backend='you'` with a real configured key and verified a successful search response.

Observed result:
- `success: True`
- `count: 3`
- first URL: `https://hermes-agent.nousresearch.com/docs/user-guide/features/web-search`

### Notes for reviewers

- The provider is intentionally **search-only** (`supports_extract() == False`)
- The endpoint used matches current You.com docs: `https://ydc-index.io/v1/search`
- We preserve Hermes' normalized `web_search` response shape:
  - `title`
  - `url`
  - `description`
  - `position`

### Future follow-up (separate PR)

A separate PR could add **request-time provider rotation / automatic failover** for cases like:
- 429 rate limits
- quota exhaustion
- transient upstream request errors

That is intentionally kept out of this PR to keep scope small and reviewable.

## Files touched

- `agent/web_search_provider.py`
- `agent/web_search_registry.py`
- `tools/web_tools.py`
- `plugins/web/you/__init__.py`
- `plugins/web/you/plugin.yaml`
- `plugins/web/you/provider.py`
- `tests/tools/conftest.py`
- `tests/tools/test_web_providers.py`
- `tests/tools/test_web_providers_you.py`
- `tests/plugins/web/test_web_search_provider_plugins.py`

## Reviewer status

Independent review verdict:

```json
{"passed":true,"security_concerns":[],"logic_errors":[],"suggestions":["Consider adding a small unit test that exercises the provider's result-count clamping behavior directly, so future refactors don't diverge from the public web_search limit contract."],"summary":"The patch cleanly adds a search-only You.com provider with matching registry and test coverage, and I did not find any blocking security or logic issues."}
```
