### PR TITLE
feat(cli): show reasoning effort in status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4085,6 +4085,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if len(model_short) > 26:
             model_short = f"{model_short[:23]}..."
 
+        rc = getattr(self, "reasoning_config", None)
+        if rc and rc.get("enabled"):
+            effort = str(rc.get("effort", "medium") or "medium")
+            suffix = f"[{effort}]"
+            if not model_short.endswith(suffix):
+                model_short = f"{model_short}{suffix}"
+
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
         snapshot = {
             "model_name": model_name,

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -105,6 +105,25 @@ class TestCLIStatusBar:
         assert "-1" not in text
         assert "0/200K" in text
 
+    def test_status_bar_model_short_includes_reasoning_effort_once(self):
+        cli_obj = _make_cli()
+        cli_obj.model = "openai/gpt-5.5"
+        cli_obj.reasoning_config = {"enabled": True, "effort": "high"}
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["model_short"].endswith("[high]")
+        assert snapshot["model_short"].count("[high]") == 1
+
+    def test_status_bar_model_short_omits_reasoning_when_disabled(self):
+        cli_obj = _make_cli()
+        cli_obj.model = "openai/gpt-5.5"
+        cli_obj.reasoning_config = {"enabled": False, "effort": "high"}
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert "[high]" not in snapshot["model_short"]
+
     def test_input_height_counts_prompt_only_on_first_wrapped_row(self):
         # Regression for prompt_toolkit classic CLI resize glitches: the prompt
         # is inserted by BeforeInput only on logical line 0. At three terminal


### PR DESCRIPTION
## What

When reasoning is enabled, append the active effort level (e.g. `[high]`, `[medium]`) to the model short name in the CLI status bar.

## Why

The CLI already tracks `reasoning_config` (parsed from `reasoning.effort` via `parse_reasoning_effort`), but this state isn't surfaced anywhere visible. Showing the effort level in the status bar gives immediate feedback about the active reasoning mode without requiring a `/status` call.

## How

`_get_status_bar_snapshot()` reads `self.reasoning_config` and, when reasoning is enabled, appends `[<effort>]` to `model_short`. The suffix is added idempotently — repeated snapshot calls won't stack duplicate tags. When reasoning is disabled, no suffix is appended and the status bar is unchanged.

No new config keys, env vars, or tools.
