### PR TITLE
fix(plugins): dedupe plugins by logical identity and idempotent hook registration

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -267,6 +267,9 @@ class PluginManifest:
     # category plugin at ``plugins/image_gen/openai/`` the key is
     # ``image_gen/openai``. When empty, falls back to ``name``.
     key: str = ""
+    # Logical identity — optional stable identifier for deduping the same
+    # plugin when it appears under multiple keys (e.g. bundled vs user copy).
+    logical_id: str = ""
 
 
 @dataclass
@@ -1224,7 +1227,8 @@ class PluginManager:
         enabled = _get_enabled_plugins()  # None = opt-in default (nothing enabled)
         winners: Dict[str, PluginManifest] = {}
         for manifest in manifests:
-            winners[manifest.key or manifest.name] = manifest
+            winner_key = manifest.logical_id or manifest.key or manifest.name
+            winners[winner_key] = manifest
         for manifest in winners.values():
             lookup_key = manifest.key or manifest.name
 
@@ -1476,6 +1480,7 @@ class PluginManager:
                 path=str(plugin_dir),
                 kind=kind,
                 key=key,
+                logical_id=str(data.get("logical_id", "") or "").strip(),
             )
         except Exception as exc:
             logger.warning(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1001,7 +1001,8 @@ class PluginContext:
         """Register a lifecycle hook callback.
 
         Unknown hook names produce a warning but are still stored so
-        forward-compatible plugins don't break.
+        forward-compatible plugins don't break. Registering the same
+        callback for the same plugin and hook is idempotent.
         """
         if hook_name not in VALID_HOOKS:
             logger.warning(
@@ -1011,6 +1012,16 @@ class PluginContext:
                 hook_name,
                 ", ".join(sorted(VALID_HOOKS)),
             )
+        plugin_key = self.manifest.key or self.manifest.name
+        callback_id = f"{plugin_key}:{hook_name}:{id(callback)}"
+        if callback_id in self._manager._hook_callback_ids:
+            logger.debug(
+                "Plugin %s hook %s callback already registered; skipping duplicate",
+                self.manifest.name,
+                hook_name,
+            )
+            return
+        self._manager._hook_callback_ids.add(callback_id)
         self._manager._hooks.setdefault(hook_name, []).append(callback)
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 
@@ -1113,6 +1124,9 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # Deduplication set for hook callbacks: (plugin_key, hook_name, callback_id).
+        # Cleared on each forced discovery so re-registration during reload is possible.
+        self._hook_callback_ids: Set[str] = set()
 
     # -----------------------------------------------------------------------
     # Public
@@ -1146,6 +1160,7 @@ class PluginManager:
             self._plugin_skills.clear()
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
+            self._hook_callback_ids.clear()
             self._context_engine = None
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep

--- a/tests/hermes_cli/test_plugins_dedupe.py
+++ b/tests/hermes_cli/test_plugins_dedupe.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+
+def _write_plugin(root: Path, rel: str, *, name: str, logical_id: str) -> None:
+    plugin_dir = root / rel
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        f"""
+name: {name}
+version: 1.0.0
+description: duplicate test
+logical_id: {logical_id}
+provides_hooks:
+  - on_session_start
+""".strip() + "\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        "    def cb(**kwargs):\n"
+        "        return None\n"
+        "    ctx.register_hook('on_session_start', cb)\n",
+        encoding="utf-8",
+    )
+
+
+def test_plugin_discovery_dedupes_by_logical_id(monkeypatch, tmp_path):
+    from hermes_cli.plugins import PluginManager
+
+    bundled = tmp_path / "bundled"
+    user = tmp_path / "user" / "plugins"
+    _write_plugin(bundled, "reasoning-display", name="reasoning-display", logical_id="statusbar.reasoning-display")
+    _write_plugin(user, "status/reasoning-display", name="reasoning-display", logical_id="statusbar.reasoning-display")
+
+    monkeypatch.setattr("hermes_cli.plugins.get_bundled_plugins_dir", lambda: bundled)
+    monkeypatch.setattr("hermes_cli.plugins.get_hermes_home", lambda: tmp_path / "user")
+    monkeypatch.setattr("hermes_cli.plugins._get_enabled_plugins", lambda: {"reasoning-display", "status/reasoning-display"})
+    monkeypatch.setattr("hermes_cli.plugins._get_disabled_plugins", lambda: set())
+
+    manager = PluginManager()
+    manager.discover_and_load(force=True)
+
+    loaded = [p for p in manager.list_plugins() if p["enabled"] and p["name"] == "reasoning-display"]
+    assert len(loaded) == 1
+    assert loaded[0]["source"] == "user"

--- a/tests/hermes_cli/test_plugins_dedupe.py
+++ b/tests/hermes_cli/test_plugins_dedupe.py
@@ -43,3 +43,77 @@ def test_plugin_discovery_dedupes_by_logical_id(monkeypatch, tmp_path):
     loaded = [p for p in manager.list_plugins() if p["enabled"] and p["name"] == "reasoning-display"]
     assert len(loaded) == 1
     assert loaded[0]["source"] == "user"
+
+
+def test_hook_registration_is_idempotent_for_same_callback(monkeypatch, tmp_path):
+    from hermes_cli.plugins import PluginManager
+
+    plugin_dir = tmp_path / "hook-twice"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        """
+name: hook-twice
+version: 1.0.0
+logical_id: test.hook-twice
+provides_hooks:
+  - on_session_start
+""".strip() + "\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        "    def cb(**kwargs):\n"
+        "        return None\n"
+        "    ctx.register_hook('on_session_start', cb)\n"
+        "    ctx.register_hook('on_session_start', cb)\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("hermes_cli.plugins.get_bundled_plugins_dir", lambda: tmp_path)
+    monkeypatch.setattr("hermes_cli.plugins.get_hermes_home", lambda: tmp_path / "home")
+    monkeypatch.setattr("hermes_cli.plugins._get_enabled_plugins", lambda: {"hook-twice"})
+    monkeypatch.setattr("hermes_cli.plugins._get_disabled_plugins", lambda: set())
+
+    manager = PluginManager()
+    manager.discover_and_load(force=True)
+
+    hooks = manager._hooks.get("on_session_start", [])
+    assert len(hooks) == 1
+
+
+def test_hook_registration_allows_different_callbacks_same_hook(monkeypatch, tmp_path):
+    from hermes_cli.plugins import PluginManager
+
+    plugin_dir = tmp_path / "two-cbs"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        """
+name: two-cbs
+version: 1.0.0
+logical_id: test.two-cbs
+provides_hooks:
+  - on_session_start
+""".strip() + "\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        "    def cb1(**kwargs):\n"
+        "        return 1\n"
+        "    def cb2(**kwargs):\n"
+        "        return 2\n"
+        "    ctx.register_hook('on_session_start', cb1)\n"
+        "    ctx.register_hook('on_session_start', cb2)\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("hermes_cli.plugins.get_bundled_plugins_dir", lambda: tmp_path)
+    monkeypatch.setattr("hermes_cli.plugins.get_hermes_home", lambda: tmp_path / "home")
+    monkeypatch.setattr("hermes_cli.plugins._get_enabled_plugins", lambda: {"two-cbs"})
+    monkeypatch.setattr("hermes_cli.plugins._get_disabled_plugins", lambda: set())
+
+    manager = PluginManager()
+    manager.discover_and_load(force=True)
+
+    hooks = manager._hooks.get("on_session_start", [])
+    assert len(hooks) == 2


### PR DESCRIPTION
## What

Two fixes to plugin discovery and hook registration:

1. **Dedupe plugins by logical identity.** Adds an optional `logical_id` field to `PluginManifest`. When set, the plugin manager dedupes the same plugin appearing under multiple discovery paths (e.g. a bundled copy and a user-installed copy) down to one winner — the user copy takes precedence, matching the existing discovery order. Without it, both copies load and their lifecycle hooks fire twice.

2. **Idempotent hook registration.** `PluginContext.register_hook()` now tracks `(plugin_key, hook_name, callback_id)` and skips if the exact callback is already registered for that hook. This prevents double-firing when a plugin's `register()` is called more than once during reload.

## Why

When the same plugin exists in both bundled and user plugin directories, discovery loads both copies. Their lifecycle hooks (`on_session_start`, etc.) fire twice, producing duplicate side effects. The `logical_id` field lets plugin authors declare "these are the same plugin" so the manager keeps only one.

## Backward compatibility

`logical_id` defaults to `""` — existing plugins that don't set it fall back to the existing `key or name` dedup behavior. The hook dedup set is cleared on each forced discovery so reload still works.

## Tests

Three new tests: dedup by `logical_id` (bundled vs user, user wins), idempotent registration of the same callback, and distinct callbacks for the same hook both still register.
