### PR TITLE
fix(tui_gateway): symmetric alias-meta rehydrate for prompt.submit + 9 siblings

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1015,6 +1015,916 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
     assert "post-compression reply" in texts
 
 
+def test_session_history_reads_from_profile_db_for_remote_profile_session(
+    monkeypatch, tmp_path
+):
+    """session.history must read the per-profile state.db, not the launch one.
+
+    A session bound to another profile (params={"profile":"<name>"} on
+    create/resume) stores its messages in ``<profile_home>/state.db``.  The
+    launch profile's db is the wrong DB and returns count:0 / empty messages.
+    Mirror the create/resume pattern: pick the db via ``session["profile_home"]``
+    when set, fall back to ``_get_db()`` for the default-profile case.
+    """
+    profile_home = tmp_path / "profiles" / "reeve"
+    profile_home.mkdir(parents=True)
+    target = "stored-profile-session"
+    captured = {}
+
+    class ProfileDB:
+        def get_messages_as_conversation(self, key, include_ancestors=False):
+            captured["profile_read"] = (key, include_ancestors)
+            return [
+                {"role": "user", "content": "what time is it in london"},
+                {"role": "tool", "content": "10:39:34 BST"},
+                {"role": "assistant", "content": "It's 10:39:34 BST in London."},
+            ]
+
+        def close(self):
+            captured["profile_closed"] = True
+
+    class LaunchDB:
+        def get_messages_as_conversation(self, *_a, **_kw):
+            captured["launch_read"] = True
+            return []
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: ProfileDB())
+    monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
+
+    sid = "8db46554"
+    server._sessions[sid] = _session(
+        session_key=target,
+        profile_home=str(profile_home),
+    )
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.history", "params": {"session_id": sid}}
+        )
+        # The handler must consult the profile DB, NOT the launch DB.
+        assert captured.get("profile_read") == (target, True)
+        assert "launch_read" not in captured
+        # And the profile DB handle must be closed after use (no leak).
+        assert captured.get("profile_closed") is True
+        # The messages from the profile DB must be in the response.
+        assert resp["result"]["count"] == 3
+        # Spot-check that the user prompt and assistant answer made it through
+        # (the tool row's transformation is exercised by the dedicated
+        # _history_to_messages tests; here we only care that the right DB was
+        # read, not how the rows are post-processed).
+        msgs = resp["result"]["messages"]
+        assert msgs[0] == {"role": "user", "text": "what time is it in london"}
+        assert msgs[-1] == {
+            "role": "assistant",
+            "text": "It's 10:39:34 BST in London.",
+        }
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_session_history_falls_back_to_launch_db_for_default_profile_session(
+    monkeypatch,
+):
+    """Default-profile parity: a session with no profile_home reads launch DB.
+
+    Single-profile setups (no app-global remote mode) never set ``profile_home``
+    on the session.  The handler must still fall through to ``_get_db()`` so
+    those sessions keep returning their messages unchanged — otherwise the fix
+    for the per-profile case would silently break every non-profile setup.
+    """
+    target = "stored-default-session"
+    captured = {}
+
+    class LaunchDB:
+        def get_messages_as_conversation(self, key, include_ancestors=False):
+            captured["launch_read"] = (key, include_ancestors)
+            return [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi there"},
+            ]
+
+    monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
+
+    def _profile_db_should_not_open(db_path=None):
+        captured["profile_db_opened"] = True
+        raise AssertionError(
+            f"default-profile session.history must not open a per-profile DB "
+            f"(attempted db_path={db_path!r})"
+        )
+
+    monkeypatch.setattr("hermes_state.SessionDB", _profile_db_should_not_open)
+
+    sid = "3f689026"
+    server._sessions[sid] = _session(session_key=target)  # no profile_home
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.history", "params": {"session_id": sid}}
+        )
+        assert captured.get("launch_read") == (target, True)
+        assert "profile_db_opened" not in captured
+        assert resp["result"]["count"] == 2
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_session_history_returns_4001_for_unknown_short_alias(monkeypatch):
+    """A short alias that isn't in ``_sessions`` AND has no alias_meta entry
+    must surface code 4001 — and must NOT touch the DB to do it.
+
+    With the t_07054503 fix, an unknown alias that DOES have alias_meta gets a
+    disk-only rehydrate (covered by the sibling rehydrate test below).  The
+    no-meta path must remain a pure 4001 with no DB lookup, so a missing alias
+    that was never minted by this gateway still surfaces honestly.
+    """
+    # Sanity: ``_get_db`` and ``SessionDB`` must NOT be touched for an unknown sid.
+    poisoned = {"called": False}
+
+    def _poison(*_a, **_kw):
+        poisoned["called"] = True
+        raise AssertionError("unknown-sid history must not query any DB")
+
+    monkeypatch.setattr(server, "_get_db", _poison)
+    monkeypatch.setattr("hermes_state.SessionDB", _poison)
+
+    # Ensure the alias is absent from BOTH _sessions and _alias_meta — a stale
+    # alias_meta entry would route through the disk-rehydrate path and hit the
+    # poisoned _get_db, which is a different (covered elsewhere) scenario.
+    server._sessions.pop("ghost", None)
+    server._forget_alias_meta("ghost")
+    resp = server.handle_request(
+        {"id": "1", "method": "session.history", "params": {"session_id": "ghost"}}
+    )
+    assert resp["error"]["code"] == 4001
+    assert resp["error"]["message"] == "session not found"
+    assert poisoned["called"] is False
+
+
+# ── t_07054503: post-eviction session.history rehydrate + cross-profile resume ──
+
+
+def test_record_alias_meta_remembers_session_key_and_profile_home():
+    """The alias-meta sidecar must store the (session_key, profile_home) tuple
+    keyed by short alias.  This is what survives the WS-orphan reap that pops
+    the in-memory _sessions entry; session.history needs it to know which
+    per-profile DB to read from when iOS reconnects after backgrounding.
+    """
+    sid = "rec-alias-test"
+    server._forget_alias_meta(sid)
+    try:
+        server._record_alias_meta(
+            sid,
+            session_key="20260618_145532_d95e74",
+            profile_home="/Users/tobyg/.hermes/profiles/reeve",
+        )
+        meta = server._lookup_alias_meta(sid)
+        assert meta is not None
+        assert meta["session_key"] == "20260618_145532_d95e74"
+        assert meta["profile_home"] == "/Users/tobyg/.hermes/profiles/reeve"
+        # last_seen is set on every write — used by the TTL eviction in lookup.
+        assert isinstance(meta["last_seen"], float)
+    finally:
+        server._forget_alias_meta(sid)
+
+
+def test_lookup_alias_meta_returns_none_after_ttl(monkeypatch):
+    """A very long-overdue alias_meta entry must be opportunistically dropped
+    so an unknown post-TTL sid surfaces as 4001 instead of hitting the disk
+    with stale profile-home data.  The TTL is a defensive ceiling, not the
+    primary lifecycle (session.close drops the entry actively).
+    """
+    sid = "ttl-test-alias"
+    server._forget_alias_meta(sid)
+    monkeypatch.setattr(server, "_ALIAS_META_TTL_S", 0.001)  # 1ms
+    try:
+        server._record_alias_meta(sid, session_key="k", profile_home=None)
+        # Sleep past the TTL.
+        time.sleep(0.005)
+        assert server._lookup_alias_meta(sid) is None
+    finally:
+        monkeypatch.setattr(server, "_ALIAS_META_TTL_S", 24 * 3600.0)
+        server._forget_alias_meta(sid)
+
+
+def test_session_history_rehydrates_from_disk_for_evicted_alias_via_alias_meta(
+    monkeypatch, tmp_path
+):
+    """Manifestation 1 of t_07054503: iOS backgrounds for ~3 minutes, the
+    WS-orphan reaper pops _sessions[alias], app comes back, session.history
+    used to 4001 even though the on-disk row was intact.
+
+    With the fix, session.history consults _alias_meta — set at every
+    session.create/resume site — to learn the long session_key + profile_home,
+    opens that profile's state.db, reads the conversation, and returns it.
+    The iOS sessionGone path NEVER fires for a session whose disk row exists.
+    """
+    profile_home = tmp_path / "profiles" / "reeve"
+    profile_home.mkdir(parents=True)
+    sid = "evicted-alias"
+    long_key = "20260618_145532_d95e74"
+    captured = {}
+
+    class ProfileDB:
+        def get_session(self, key):
+            captured["get_session_called_with"] = key
+            return {"id": key, "title": "what time is it in london"}
+
+        def get_messages_as_conversation(self, key, include_ancestors=False):
+            captured["read_key"] = key
+            captured["include_ancestors"] = include_ancestors
+            return [
+                {"role": "user", "content": "what time is it in london"},
+                {"role": "tool", "content": "14:55 BST"},
+                {"role": "assistant", "content": "It's 14:55 BST in London."},
+                {"role": "assistant", "content": "anything else?"},
+            ]
+
+        def close(self):
+            captured["closed"] = True
+
+    class LaunchDB:
+        def get_messages_as_conversation(self, *_a, **_kw):
+            captured["launch_read"] = True
+            return []
+
+        def get_session(self, *_a, **_kw):
+            captured["launch_get_session"] = True
+            return None
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: ProfileDB())
+    monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
+
+    # Critical setup: the alias was minted earlier (session.create/resume)
+    # and recorded in alias_meta, then the WS-orphan reaper popped _sessions.
+    # alias_meta survives — that's the whole sidecar invariant.
+    server._sessions.pop(sid, None)
+    server._record_alias_meta(
+        sid, session_key=long_key, profile_home=str(profile_home)
+    )
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.history", "params": {"session_id": sid}}
+        )
+        # The disk read MUST go to the profile DB, not the launch DB.
+        assert captured.get("read_key") == long_key
+        assert captured.get("include_ancestors") is True
+        assert "launch_read" not in captured
+        # The profile DB handle MUST be closed after use (no leak).
+        assert captured.get("closed") is True
+        # The messages from the profile DB MUST be in the response — no 4001,
+        # no count:0.
+        assert "error" not in resp, f"unexpected error: {resp}"
+        assert resp["result"]["count"] == 4
+        msgs = resp["result"]["messages"]
+        assert msgs[0] == {"role": "user", "text": "what time is it in london"}
+        assert msgs[-1] == {"role": "assistant", "text": "anything else?"}
+    finally:
+        server._forget_alias_meta(sid)
+
+
+def test_session_history_still_4001_when_alias_meta_points_at_missing_disk_row(
+    monkeypatch, tmp_path
+):
+    """alias_meta is a hint, not a promise.  If the row was deleted on disk
+    while iOS was backgrounded, session.history must still 4001 honestly so
+    the iOS sessionGone path fires (the deletion really did happen).  The
+    fix MUST NOT manufacture an empty conversation to mask a real deletion.
+    """
+    profile_home = tmp_path / "profiles" / "reeve"
+    profile_home.mkdir(parents=True)
+    sid = "gone-on-disk"
+    long_key = "20260618_999999_deadbeef"
+
+    class ProfileDB:
+        def get_session(self, key):
+            return None  # row really is gone
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: ProfileDB())
+
+    server._sessions.pop(sid, None)
+    server._record_alias_meta(
+        sid, session_key=long_key, profile_home=str(profile_home)
+    )
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.history", "params": {"session_id": sid}}
+        )
+        assert resp["error"]["code"] == 4001
+        assert resp["error"]["message"] == "session not found"
+    finally:
+        server._forget_alias_meta(sid)
+
+
+def test_session_close_drops_alias_meta_so_subsequent_history_4001s(monkeypatch):
+    """An explicit session.close is the one path that semantically means
+    "this session is gone for good" — alias_meta MUST be cleared so a later
+    session.history on the same sid honestly 4001s instead of stale-rehydrating.
+    The reap paths intentionally do NOT clear it (that's the sidecar's whole
+    purpose); only session.close does.
+    """
+    sid = "explicit-close-test"
+    server._sessions.pop(sid, None)
+    server._record_alias_meta(sid, session_key="some-key", profile_home=None)
+    # Stub the underlying close path so we don't have to wire up a full agent.
+    monkeypatch.setattr(server, "_close_session_by_id", lambda _sid, **_kw: True)
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.close", "params": {"session_id": sid}}
+        )
+        assert resp["result"]["closed"] is True
+        # alias_meta must be gone now.
+        assert server._lookup_alias_meta(sid) is None
+    finally:
+        server._forget_alias_meta(sid)
+
+
+def _install_prompt_submit_no_op_agent_path(monkeypatch):
+    """Stub the post-_sess_nowait machinery prompt.submit fires off in a daemon
+    thread, so a test can assert the synchronous return value without paying
+    for a real AIAgent build or a real model call.
+
+    prompt.submit's synchronous path stops at _ok(rid, {"status":"streaming"});
+    everything past that runs on a daemon thread. We don't want that thread to
+    try and build an agent (no provider creds in a unit test), nor to invoke
+    _run_prompt_submit against a None agent. Replacing those three with no-ops
+    lets the assertion target the wire shape the iOS client actually sees.
+    """
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *_a, **_kw: None)
+
+
+def test_prompt_submit_rehydrates_reaped_alias_via_alias_meta(monkeypatch, tmp_path):
+    """t_c136726a: the false-positive 4001 a quickly-reconnecting iOS client
+    hits on the first prompt after the WS-orphan reaper popped its alias.
+
+    Setup mirrors the production incident: the alias was minted via
+    session.create / session.resume earlier (so _record_alias_meta ran), then
+    the 20s WS-orphan reaper popped _sessions[sid] WITHOUT calling
+    _forget_alias_meta (only session.close does that). The underlying state.db
+    row is still on disk. iOS sends prompt.submit(session_id=<reaped-alias>).
+
+    Before the fix the handler 4001'd at _sess_nowait. After the fix it
+    consults _lookup_alias_meta, rehydrates _sessions[sid] under the SAME
+    short alias from the on-disk row, and returns status:streaming so the
+    user's message goes through.
+    """
+    profile_home = tmp_path / "profiles" / "reeve"
+    profile_home.mkdir(parents=True)
+    sid = "reaped-alias"
+    long_key = "20260620_211247_1f9187"
+
+    class ProfileDB:
+        def get_session(self, key):
+            assert key == long_key
+            return {"id": key, "title": "verity opus chat"}
+
+        def get_messages_as_conversation(self, key, include_ancestors=False):
+            assert key == long_key
+            return [
+                {"role": "user", "content": "morning verity"},
+                {"role": "assistant", "content": "morning sir."},
+            ]
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: ProfileDB())
+    monkeypatch.setattr(server, "_get_db", lambda: ProfileDB())
+    _install_prompt_submit_no_op_agent_path(monkeypatch)
+
+    # Pre-state: the reaper popped _sessions[sid] but alias_meta survived.
+    server._sessions.pop(sid, None)
+    server._record_alias_meta(
+        sid, session_key=long_key, profile_home=str(profile_home)
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": "are you still there?"},
+            }
+        )
+        assert "error" not in resp, f"unexpected error: {resp}"
+        assert resp["result"]["status"] == "streaming"
+        # Rehydrate must reuse the SAME short alias the iOS client referenced —
+        # not mint a fresh sid — so subsequent calls keep working without iOS
+        # needing to know anything happened.
+        assert sid in server._sessions
+        rehydrated = server._sessions[sid]
+        assert rehydrated["session_key"] == long_key
+        assert rehydrated["profile_home"] == str(profile_home)
+        # Cache safety (AGENTS.md: prompt caching is sacred).  The deferred
+        # _start_agent_build reads ``resume_session_id`` and passes it as
+        # ``session_id=`` to _make_agent, which keys the system prompt off
+        # the SAME session_id the reaped agent used.  That keeps the cached
+        # prefix byte-stable across the reap so the next API call doesn't
+        # pay for a fresh prefill.
+        assert rehydrated["resume_session_id"] == long_key
+    finally:
+        sess = server._sessions.pop(sid, None)
+        if sess is not None:
+            server._teardown_session(sess)
+        server._forget_alias_meta(sid)
+
+
+def test_prompt_submit_rehydrate_preserves_system_prompt_cache_key(
+    monkeypatch, tmp_path
+):
+    """t_c136726a step 6 (cache safety): the rehydrate MUST keep the system
+    prompt byte-stable across the reap, because AGENTS.md is explicit that
+    prompt caching is sacred — rebuilding the prefix multiplies per-turn cost.
+
+    The mechanism that guarantees byte-stability is ``_make_agent(session_id=)``:
+    the system prompt is keyed off ``session_id`` (alongside profile + model),
+    so as long as the post-rehydrate agent is built with the SAME long key the
+    pre-reap agent used, the cached prefix is reused.
+
+    This test snapshots the kwargs ``_start_agent_build`` passes to
+    ``_make_agent`` after a rehydrate and asserts ``session_id == long_key``.
+    A future refactor that rebuilds the system prompt under a different key
+    (e.g. the short alias) would regress this and burn cache; this test
+    catches that without booting a real agent (no provider creds needed).
+    """
+    profile_home = tmp_path / "profiles" / "verity"
+    profile_home.mkdir(parents=True)
+    sid = "reaped-cache-stable"
+    long_key = "20260620_211247_1f9187"
+
+    class ProfileDB:
+        def get_session(self, key):
+            return {"id": key, "title": "verity opus chat"}
+
+        def get_messages_as_conversation(self, key, include_ancestors=False):
+            return [{"role": "user", "content": "morning verity"}]
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: ProfileDB())
+    monkeypatch.setattr(server, "_get_db", lambda: ProfileDB())
+
+    # Capture every call to _make_agent so we can prove the rehydrate path
+    # passes the long key through, not the short alias.
+    captured_make_agent_kwargs: list[dict] = []
+
+    class _FakeAgent:
+        # _start_agent_build sets agent_ready / agent on success — give it
+        # the surface area it touches so the build thread doesn't trip on
+        # missing attrs or exception paths.
+        def __init__(self, *_a, **_kw):
+            self._cached_system_prompt = ""
+
+        def attach_pre_agent_callback(self, _cb):
+            pass
+
+        def attach_post_agent_callback(self, _cb):
+            pass
+
+    def fake_make_agent(sid_arg, key_arg, session_id=None, session_db=None, **kwargs):
+        captured_make_agent_kwargs.append(
+            {"sid": sid_arg, "key": key_arg, "session_id": session_id}
+        )
+        return _FakeAgent()
+
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    # _start_agent_build does various optional registration steps; suppress
+    # the ones that would need real worker / approval / completion infra.
+    monkeypatch.setattr(server, "_attach_worker", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *_a, **_kw: None)
+
+    server._sessions.pop(sid, None)
+    server._record_alias_meta(
+        sid, session_key=long_key, profile_home=str(profile_home)
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": "are you still there?"},
+            }
+        )
+        assert "error" not in resp, f"unexpected error: {resp}"
+        assert resp["result"]["status"] == "streaming"
+        # Wait for the deferred agent build to fire — prompt.submit kicks it
+        # off via a daemon thread inside _start_agent_build.  The build
+        # publishes via agent_ready; wait a bounded time for capture.
+        session_dict = server._sessions[sid]
+        agent_ready: threading.Event = session_dict["agent_ready"]
+        assert agent_ready.wait(timeout=2.0), (
+            "_start_agent_build daemon never published agent_ready — "
+            "rehydrate path may not be wiring the build correctly"
+        )
+        assert captured_make_agent_kwargs, (
+            "expected _make_agent to be called by _start_agent_build, "
+            "but no calls were captured"
+        )
+        # The cache-stability invariant: _make_agent's session_id MUST be the
+        # SAME long key the pre-reap agent used, NOT the short alias.  If
+        # this assertion fails, the rehydrate broke prompt caching.
+        kwargs = captured_make_agent_kwargs[-1]
+        assert kwargs["session_id"] == long_key, (
+            f"cache-stability regression: _make_agent was called with "
+            f"session_id={kwargs['session_id']!r} but the long key is "
+            f"{long_key!r}.  AGENTS.md: prompt caching is sacred — a "
+            f"different session_id rebuilds the cached system prompt and "
+            f"burns the cache prefix every turn after rehydrate."
+        )
+        # Belt-and-braces: ``key`` arg (the alias-mapped session_key) MUST
+        # also be the long key — both _make_agent params resolve to it.
+        assert kwargs["key"] == long_key
+    finally:
+        sess = server._sessions.pop(sid, None)
+        if sess is not None:
+            server._teardown_session(sess)
+        server._forget_alias_meta(sid)
+
+
+
+def test_prompt_submit_still_4001_when_alias_meta_points_at_missing_disk_row(
+    monkeypatch, tmp_path
+):
+    """The negative case for the rehydrate fallback: if the alias-meta hint
+    points at a row that's actually gone from disk (genuine deletion, not a
+    transient eviction), prompt.submit must still 4001. The fallback MUST NOT
+    manufacture an empty live session to mask a real loss — iOS's
+    sessionGone path needs to fire when the session really is gone.
+    """
+    profile_home = tmp_path / "profiles" / "reeve"
+    profile_home.mkdir(parents=True)
+    sid = "ghost-on-disk"
+
+    class ProfileDB:
+        def get_session(self, _key):
+            return None  # row really is gone
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: ProfileDB())
+    monkeypatch.setattr(server, "_get_db", lambda: ProfileDB())
+    _install_prompt_submit_no_op_agent_path(monkeypatch)
+
+    server._sessions.pop(sid, None)
+    server._record_alias_meta(
+        sid, session_key="20260620_000000_deadbeef", profile_home=str(profile_home)
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": "hello?"},
+            }
+        )
+        assert resp["error"]["code"] == 4001
+        assert resp["error"]["message"] == "session not found"
+        # And critically — no zombie entry was inserted into _sessions.
+        assert sid not in server._sessions
+    finally:
+        server._forget_alias_meta(sid)
+
+
+def test_prompt_submit_still_4001_after_session_close_clears_alias_meta(
+    monkeypatch,
+):
+    """session.close is the one path that semantically means "this session is
+    gone for good" (alias_meta is cleared). A later prompt.submit on that sid
+    must still 4001 — the rehydrate fallback MUST NOT bring a closed session
+    back from the dead just because the disk row hadn't been deleted yet.
+    """
+    sid = "closed-alias"
+    server._sessions.pop(sid, None)
+    server._record_alias_meta(
+        sid, session_key="some-long-key", profile_home=None
+    )
+    _install_prompt_submit_no_op_agent_path(monkeypatch)
+    monkeypatch.setattr(server, "_close_session_by_id", lambda _sid, **_kw: True)
+    try:
+        close_resp = server.handle_request(
+            {"id": "1", "method": "session.close", "params": {"session_id": sid}}
+        )
+        assert close_resp["result"]["closed"] is True
+        # session.close cleared alias_meta. prompt.submit must NOT rehydrate.
+        resp = server.handle_request(
+            {
+                "id": "2",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": "are you back?"},
+            }
+        )
+        assert resp["error"]["code"] == 4001
+        assert sid not in server._sessions
+    finally:
+        server._forget_alias_meta(sid)
+
+
+def test_prompt_submit_rehydrate_reuses_live_session_when_sibling_alias_exists(
+    monkeypatch, tmp_path
+):
+    """Multi-alias safety: if the same long session_key is already live under
+    a DIFFERENT short alias (e.g. another tab held onto it through the
+    disconnect window), rehydrating the reaped alias MUST point our sid at
+    the SAME live session dict — not double-mint a second live session
+    against the same row. Otherwise two _sessions entries race the same
+    state.db rows, history version, and inflight_turn lock.
+    """
+    profile_home = tmp_path / "profiles" / "reeve"
+    profile_home.mkdir(parents=True)
+    long_key = "20260620_999999_sibling"
+    reaped_sid = "reaped"
+    live_sid = "stillalive"
+
+    class ProfileDB:
+        def get_session(self, key):
+            return {"id": key, "title": "shared chat"}
+
+        def get_messages_as_conversation(self, key, include_ancestors=False):
+            return []
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: ProfileDB())
+    monkeypatch.setattr(server, "_get_db", lambda: ProfileDB())
+    _install_prompt_submit_no_op_agent_path(monkeypatch)
+
+    # The live sibling: same long_key, separate alias still in _sessions.
+    live_session = {
+        "agent": types.SimpleNamespace(),
+        "agent_ready": threading.Event(),
+        "agent_error": None,
+        "session_key": long_key,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "inflight_turn": None,
+        "attached_images": [],
+        "image_counter": 0,
+        "cwd": str(tmp_path),
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        "tool_started_at": {},
+        "edit_snapshots": {},
+        "transport": server._stdio_transport,
+        "profile_home": str(profile_home),
+        "last_active": time.time(),
+        "created_at": time.time(),
+    }
+    live_session["agent_ready"].set()
+    server._sessions[live_sid] = live_session
+    # The reaped sibling: alias_meta survived, _sessions entry did not.
+    server._sessions.pop(reaped_sid, None)
+    server._record_alias_meta(
+        reaped_sid, session_key=long_key, profile_home=str(profile_home)
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": reaped_sid, "text": "still there?"},
+            }
+        )
+        # Either the helper points reaped_sid at the live session dict, or it
+        # returns the live session's existing entry by sid mapping — both
+        # satisfy the no-double-mint contract.  What MUST NOT happen is a
+        # second entry with the SAME session_key existing alongside the live
+        # sibling, because two _sessions sharing one session_key race the
+        # same history_lock and double-write to state.db.
+        same_key_aliases = [
+            s for s in server._sessions.values()
+            if str(s.get("session_key") or "") == long_key
+        ]
+        # The live sibling is one of them; the reaped alias must either be
+        # absent OR point at the SAME dict.
+        if reaped_sid in server._sessions:
+            assert server._sessions[reaped_sid] is live_session, (
+                "rehydrate double-minted a second live session for the same "
+                "long key instead of reusing the existing one"
+            )
+        # Exactly one underlying live session for this long key (the sibling).
+        unique_ids = {id(s) for s in same_key_aliases}
+        assert len(unique_ids) == 1, (
+            f"expected exactly one live session dict for {long_key}, "
+            f"got {len(unique_ids)} (aliases: "
+            f"{[k for k, v in server._sessions.items() if v in same_key_aliases]})"
+        )
+        assert "error" not in resp, f"unexpected error: {resp}"
+        assert resp["result"]["status"] == "streaming"
+    finally:
+        server._sessions.pop(reaped_sid, None)
+        sess = server._sessions.pop(live_sid, None)
+        if sess is not None:
+            server._teardown_session(sess)
+        server._forget_alias_meta(reaped_sid)
+        server._forget_alias_meta(live_sid)
+
+
+def test_session_title_rehydrates_reaped_alias_via_alias_meta(monkeypatch, tmp_path):
+    """Sibling-handler proof for the rehydrate wrapper.
+
+    The card explicitly asks us to wire the rehydrate into other handlers
+    where it's safe (uniform semantics).  This is the canonical example:
+    iOS renames a chat post-reconnect; without the wrapper it 4001s; with
+    the wrapper it rehydrates and persists the title to the SAME DB row.
+
+    If this test starts failing, the wrapper machinery
+    (``_sess_nowait_or_rehydrate``) regressed — not just prompt.submit's
+    open-coded fallback, the shared one every sibling handler depends on.
+    """
+    profile_home = tmp_path / "profiles" / "reeve"
+    profile_home.mkdir(parents=True)
+    sid = "reaped-for-title"
+    long_key = "20260620_rename_xyz789"
+    persisted = {}
+
+    class ProfileDB:
+        def get_session(self, key):
+            return {"id": key, "title": "old title"}
+
+        def get_messages_as_conversation(self, key, include_ancestors=False):
+            return []
+
+        def set_session_title(self, key, new_title):
+            persisted["row_id"] = key
+            persisted["new_title"] = new_title
+            return True
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: ProfileDB())
+    monkeypatch.setattr(server, "_get_db", lambda: ProfileDB())
+
+    server._sessions.pop(sid, None)
+    server._record_alias_meta(
+        sid, session_key=long_key, profile_home=str(profile_home)
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.title",
+                "params": {"session_id": sid, "title": "new title from ios"},
+            }
+        )
+        assert "error" not in resp, f"unexpected error: {resp}"
+        # The title persists to the SAME long key, not the short alias —
+        # rehydrate carried the (alias → long_key) mapping correctly.
+        assert persisted.get("row_id") == long_key
+        assert persisted.get("new_title") == "new title from ios"
+        # And the rehydrated session lives under the SAME short alias.
+        assert sid in server._sessions
+        assert server._sessions[sid]["session_key"] == long_key
+    finally:
+        sess = server._sessions.pop(sid, None)
+        if sess is not None:
+            server._teardown_session(sess)
+        server._forget_alias_meta(sid)
+
+
+def test_locate_stored_session_across_profiles_finds_reeve_row(monkeypatch, tmp_path):
+    """Manifestation 2 of t_07054503: cold-launch session.resume(long_key)
+    with no ``profile`` param.  iOS doesn't know which profile owns the
+    session — that's why it sends no profile.  The gateway must walk the
+    named profile DBs (~/.hermes/profiles/<name>/state.db) and find the row.
+    """
+    # Set up a fake profiles root with two profiles; only "reeve" has the row.
+    profiles_root = tmp_path / "profiles"
+    (profiles_root / "reeve").mkdir(parents=True)
+    (profiles_root / "reeve" / "state.db").write_bytes(b"")
+    (profiles_root / "mia").mkdir(parents=True)
+    (profiles_root / "mia" / "state.db").write_bytes(b"")
+    long_key = "20260618_145532_d95e74"
+    opened = []
+
+    class LaunchDB:
+        def get_session(self, key):
+            opened.append(("launch", key))
+            return None
+
+        def get_session_by_title(self, _key):
+            return None
+
+    class ReeveDB:
+        def __init__(self, db_path):
+            opened.append(("open", str(db_path)))
+            self.db_path = db_path
+
+        def get_session(self, key):
+            opened.append((str(self.db_path), "get", key))
+            if "reeve" in str(self.db_path) and key == long_key:
+                return {"id": long_key}
+            return None
+
+        def get_session_by_title(self, _key):
+            return None
+
+        def close(self):
+            opened.append((str(self.db_path), "close"))
+
+    monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
+    monkeypatch.setattr("hermes_state.SessionDB", ReeveDB)
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_profiles_root", lambda: profiles_root
+    )
+    # Make sure the launch home doesn't accidentally match either profile dir.
+    monkeypatch.setattr(server, "_hermes_home", str(tmp_path / "launch_home"))
+
+    located = server._locate_stored_session_across_profiles(long_key)
+    assert located is not None
+    matched_id, profile_home = located
+    assert matched_id == long_key
+    assert profile_home is not None
+    assert "reeve" in str(profile_home)
+    # All probed profile DBs must be closed (no leak when walking through many).
+    closes = [op for op in opened if len(op) >= 2 and op[-1] == "close"]
+    assert closes, f"profile DB handles must be closed; got {opened}"
+
+
+def test_locate_stored_session_across_profiles_returns_none_when_no_db_owns_row(
+    monkeypatch, tmp_path
+):
+    """If neither the launch DB nor any named-profile DB has the row, the
+    locator returns None so the resume handler can surface 4007 honestly.
+    Never invent ownership.
+    """
+    profiles_root = tmp_path / "profiles"
+    (profiles_root / "reeve").mkdir(parents=True)
+    (profiles_root / "reeve" / "state.db").write_bytes(b"")
+
+    class EmptyDB:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def get_session(self, _key):
+            return None
+
+        def get_session_by_title(self, _key):
+            return None
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(server, "_get_db", lambda: EmptyDB())
+    monkeypatch.setattr("hermes_state.SessionDB", EmptyDB)
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_profiles_root", lambda: profiles_root
+    )
+    monkeypatch.setattr(server, "_hermes_home", str(tmp_path / "launch_home"))
+
+    located = server._locate_stored_session_across_profiles("does-not-exist")
+    assert located is None
+
+
+def test_locate_stored_session_across_profiles_prefers_launch_db(monkeypatch, tmp_path):
+    """When the launch DB owns the row, the cross-profile walk must NOT
+    open any named-profile DB.  This preserves the default-profile parity:
+    a single-profile installation never pays the profile-walk cost.
+    """
+    profiles_root = tmp_path / "profiles"
+    (profiles_root / "reeve").mkdir(parents=True)
+    (profiles_root / "reeve" / "state.db").write_bytes(b"")
+    long_key = "default-profile-row"
+    opened = []
+
+    class LaunchDB:
+        def get_session(self, key):
+            opened.append(("launch_get", key))
+            return {"id": key} if key == long_key else None
+
+        def get_session_by_title(self, _key):
+            return None
+
+    def _profile_db_should_not_open(db_path=None):
+        opened.append(("profile_open", str(db_path)))
+        raise AssertionError(
+            f"launch DB hit must NOT trigger profile walk (db_path={db_path!r})"
+        )
+
+    monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
+    monkeypatch.setattr("hermes_state.SessionDB", _profile_db_should_not_open)
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_profiles_root", lambda: profiles_root
+    )
+
+    located = server._locate_stored_session_across_profiles(long_key)
+    assert located is not None
+    matched_id, profile_home = located
+    assert matched_id == long_key
+    assert profile_home is None  # launch profile (default-profile parity)
+    # Confirm: only launch_get fired, no profile_open.
+    assert all(op[0] == "launch_get" for op in opened), f"unexpected ops: {opened}"
+
+
 def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
     captured = {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -163,6 +163,77 @@ _WS_ORPHAN_REAP_GRACE_S = max(0.0, _ws_orphan_reap_grace)
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 
+# ── Short-alias → on-disk lookup map (post-eviction rehydration) ─────────────
+# Every session.create / session.resume mints a short alias and stuffs it into
+# ``_sessions[alias]`` alongside the long ``session_key`` and ``profile_home``.
+# When the WS-orphan reaper (or the idle reaper) pops that entry, a later
+# ``session.history(alias)`` from a quickly-reconnecting iOS client used to
+# 4001 because nothing remembered which long key + profile DB to read from.
+# This sidecar keeps the alias→(session_key, profile_home) mapping alive for a
+# generous TTL so the history handler can do a read-only rehydrate against the
+# right profile's state.db without rebuilding the agent. The mapping is tiny
+# (one tuple per alias), independent of agent state, and survives the reap
+# exactly because it lives outside ``_sessions``. A long-overdue alias is
+# treated as genuinely unknown — the iOS client's sessionGone path still fires.
+try:
+    _ALIAS_META_TTL_S = float(
+        os.environ.get("HERMES_TUI_ALIAS_META_TTL_S") or 24 * 3600
+    )
+except (TypeError, ValueError):
+    _ALIAS_META_TTL_S = float(24 * 3600)
+_ALIAS_META_TTL_S = max(0.0, _ALIAS_META_TTL_S)
+_alias_meta: dict[str, dict] = {}
+_alias_meta_lock = threading.Lock()
+
+
+def _record_alias_meta(
+    sid: str, *, session_key: str, profile_home: str | None
+) -> None:
+    """Remember alias→(session_key, profile_home) so a post-eviction
+    ``session.history(alias)`` can still find the disk row.
+
+    Called at every ``_sessions[sid] = {...}`` mint site. Idempotent — repeat
+    calls just refresh ``last_seen`` so an actively-used alias never expires.
+    """
+    if not sid or not session_key:
+        return
+    with _alias_meta_lock:
+        _alias_meta[sid] = {
+            "session_key": str(session_key),
+            "profile_home": str(profile_home) if profile_home else None,
+            "last_seen": time.time(),
+        }
+
+
+def _lookup_alias_meta(sid: str) -> dict | None:
+    """Return the saved metadata for ``sid``, or None if absent or expired.
+
+    Expired entries are dropped opportunistically — there's no separate sweeper
+    because the lookup path is the only consumer that cares about freshness,
+    and a stale entry surfacing as 4001/None preserves the existing wire
+    contract (iOS already has belt-and-braces guards for that).
+    """
+    with _alias_meta_lock:
+        meta = _alias_meta.get(sid)
+        if not meta:
+            return None
+        if _ALIAS_META_TTL_S > 0 and (time.time() - meta["last_seen"]) > _ALIAS_META_TTL_S:
+            _alias_meta.pop(sid, None)
+            return None
+        return dict(meta)
+
+
+def _forget_alias_meta(sid: str) -> None:
+    """Drop the alias mapping when a session is explicitly closed (session.close).
+
+    The reap paths intentionally do NOT call this — they're the whole reason
+    this sidecar exists. session.close is the only path that semantically
+    means "this session is gone for good"; anything else is a transient
+    eviction the alias map deliberately survives.
+    """
+    with _alias_meta_lock:
+        _alias_meta.pop(sid, None)
+
 # ── Async RPC dispatch (#12546) ──────────────────────────────────────
 # A handful of handlers block the dispatcher loop in entry.py for seconds
 # to minutes (slash.exec, cli.exec, shell.exec, session.resume,
@@ -692,10 +763,367 @@ def _profile_home(profile: str | None) -> Path | None:
     return home if (home / "state.db").exists() or home.exists() else None
 
 
+def _locate_stored_session_across_profiles(long_id: str) -> tuple[str, Path | None] | None:
+    """Find which profile's state.db contains ``long_id``.
+
+    On a cold-launch resume, iOS sends only the long ``session_key`` (no
+    ``profile`` param — it doesn't know which profile minted the session and
+    has nothing in cache to tell it).  The launch profile is *one* DB on the
+    host; the session may live in any of the named-profile DBs at
+    ``~/.hermes/profiles/<name>/state.db``.  This walks those (plus the launch
+    DB) and returns ``(matched_id, profile_home)`` for the first hit, or None
+    when no host DB owns the row.
+
+    ``matched_id`` may differ from ``long_id`` when the DB resolved a title
+    instead of an id (mirrors the ``session.resume`` title-fallback at L4116).
+
+    ``profile_home`` is ``None`` when the row lives in the launch profile (the
+    default-profile case — preserves wire-compatible behaviour).  Otherwise
+    a path under ``~/.hermes/profiles/<name>/``, suitable for passing to
+    ``SessionDB(db_path=...)`` and ``set_hermes_home_override`` exactly like
+    ``_profile_home`` returns.
+    """
+    if not long_id:
+        return None
+    from hermes_state import SessionDB
+
+    def _probe(db, profile_home: Path | None) -> tuple[str, Path | None] | None:
+        try:
+            row = db.get_session(long_id)
+        except Exception:
+            return None
+        if row:
+            return long_id, profile_home
+        try:
+            row = db.get_session_by_title(long_id)
+        except Exception:
+            return None
+        if row:
+            return str(row.get("id") or long_id), profile_home
+        return None
+
+    # 1. Launch profile first — it's the cheapest probe (already-open handle).
+    launch_db = _get_db()
+    if launch_db is not None:
+        hit = _probe(launch_db, None)
+        if hit is not None:
+            return hit
+
+    # 2. Named profiles under <hermes_root>/profiles/<name>/state.db.  Lazy:
+    # the walk stops on the first hit, so we don't pay for every profile in
+    # the common case where the row IS in one of the first few.
+    try:
+        from hermes_cli.profiles import _get_profiles_root, _PROFILE_ID_RE
+    except Exception:
+        return None
+    try:
+        profiles_root = Path(_get_profiles_root())
+    except Exception:
+        return None
+    if not profiles_root.is_dir():
+        return None
+    launch_home = Path(_hermes_home).resolve()
+    for entry in sorted(profiles_root.iterdir()):
+        try:
+            if not entry.is_dir() or not _PROFILE_ID_RE.match(entry.name):
+                continue
+            if entry.resolve() == launch_home:
+                continue  # same as the launch DB we already probed
+            db_path = entry / "state.db"
+            if not db_path.exists():
+                continue
+            profile_db = None
+            try:
+                profile_db = SessionDB(db_path=db_path)
+            except Exception:
+                continue
+            try:
+                hit = _probe(profile_db, entry)
+                if hit is not None:
+                    return hit
+            finally:
+                with contextlib.suppress(Exception):
+                    profile_db.close()
+        except Exception:
+            continue
+    return None
+
+
 # Placeholder ``terminal.cwd`` values that don't name a real directory — the
 # gateway resolves these to the home dir at runtime, so they must NOT be treated
 # as an explicit workspace (mirrors gateway/run.py's config bridge).
 _CWD_PLACEHOLDERS = {".", "auto", "cwd"}
+
+# ── Post-eviction alias-meta rehydrate: handler audit ────────────────
+# Anything that calls ``_sess_nowait`` / ``_sess`` first thing and returns
+# 4001 on miss is a candidate for the rehydrate fallback below.  This is
+# the audit log for which methods we wired vs. left alone, so a future
+# contributor doesn't have to re-derive the call.
+#
+# Rehydrate-aware (use ``_sess_nowait_or_rehydrate`` / ``_sess_or_rehydrate``):
+#   * prompt.submit       — the bug this whole sidecar exists to fix
+#   * session.history     — original parent of the sidecar (t_28c8c912)
+#   * session.title       — iOS rename post-reconnect persists to the SAME DB row
+#   * session.cwd.set     — iOS picker changes cwd of a quietly-reaped alias
+#   * session.usage       — iOS reads usage of a chat it thinks is alive
+#   * session.status      — iOS reads chat status (cwd/branch/model/tokens)
+#   * session.undo        — mutates session history; rebuild + persist is safe
+#   * session.compress    — auto-compaction against the SAME long key
+#   * session.save        — snapshot to disk; rebuild gives the same conversation
+#   * session.branch      — fork from a parent the user still considers alive
+#   * terminal.resize     — frequent UI signal; false-positive 4001 would cascade
+#
+# NOT rehydrate-aware (kept on ``_sess_nowait`` / ``_sess`` — see per-handler
+# rationale at each call site):
+#   * session.interrupt   — reaped alias has no running turn; rehydrate-and-no-op
+#                            misleads iOS into thinking a cancel succeeded.
+#   * session.steer       — same reason as interrupt: nothing to steer post-reap.
+#   * approval.respond,
+#     clarify.respond,
+#     sudo.respond,
+#     secret.respond,
+#     terminal.read.respond — respond to an in-flight prompt tied to the
+#                            original run.  Reap discards the prompt
+#                            registry entry, so a rebuilt session has
+#                            nothing to deliver the response to.
+#   * process.list / kill — process registry is keyed off the original
+#                            session lifecycle; rehydrate creates a fresh
+#                            session with no processes.
+#   * slash.exec          — subprocess identity (_SlashWorker) is bound to
+#                            the original session start; a rebuilt session
+#                            spawns a NEW worker which is a different
+#                            process context than the iOS UI's prior state.
+#   * rollback.list / restore / diff — checkpoint mgr is per-agent and
+#                            rebuilt fresh on rehydrate, losing the
+#                            in-memory checkpoint snapshots the user is
+#                            looking at.
+#   * handoff.request / state / fail — desktop-only handoff RPCs, not
+#                            invoked by the iOS rev-1 surface.
+#   * image.attach / pdf.attach / file.attach / clipboard.paste /
+#     image.attach_bytes / image.detach / input.detect_drop /
+#     prompt.background / preview.restart — composer-side state on the
+#                            DESKTOP path (attached_images, edit_snapshots,
+#                            etc.) that doesn't survive a reap.  Adding
+#                            rehydrate here would create a session with an
+#                            empty composer, masking that the prior
+#                            composer state really was lost.
+
+
+def _install_lazy_session_under_alias(
+    sid: str,
+    target: str,
+    *,
+    cols: int,
+    history: list,
+    profile_home: Path | None,
+    lease,
+    close_on_disconnect: bool,
+    transport_obj,
+    cwd: str | None = None,
+    source: str = "tui",
+) -> dict:
+    """Install a lazy-watch ``_sessions[sid]`` entry pointing at ``target``.
+
+    Factored out of ``session.resume``'s lazy branch (and reused by
+    ``_rehydrate_alias_from_meta``) so the install shape stays in lockstep
+    between the two callers — both need the SAME field set so a later
+    ``_start_agent_build`` upgrades correctly (``resume_session_id``
+    preserves the long key for ``_make_agent`` so the system prompt key
+    stays byte-stable, which is the cache-safety lever called out in
+    AGENTS.md).
+
+    Must be called under ``_session_resume_lock`` AND with the caller
+    having already established the lease (or accepted ``None``). The helper
+    grabs ``_sessions_lock`` itself for the dict mutation, records the
+    alias-meta sidecar so a later eviction stays rehydratable, and returns
+    the freshly-installed session dict.
+
+    Caller is responsible for the race-check (``_find_live_session_by_key``)
+    BEFORE calling this — the helper unconditionally installs, so calling
+    it when a live sibling already owns ``target`` would double-mint.
+    """
+    now = time.time()
+    profile_home_str = str(profile_home) if profile_home is not None else None
+    with _sessions_lock:
+        _sessions[sid] = {
+            "agent": None,
+            "agent_error": None,
+            "agent_ready": threading.Event(),
+            "attached_images": [],
+            "close_on_disconnect": close_on_disconnect,
+            "active_session_lease": lease,
+            "cols": cols,
+            "created_at": now,
+            "display_history_prefix": [],
+            "edit_snapshots": {},
+            "explicit_cwd": False,
+            "history": history,
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "image_counter": 0,
+            "cwd": cwd or os.getenv("TERMINAL_CWD", os.getcwd()),
+            "inflight_turn": None,
+            "last_active": now,
+            "lazy": True,
+            "pending_title": None,
+            "profile_home": profile_home_str,
+            "resume_session_id": target,
+            "running": False,
+            "session_key": target,
+            "show_reasoning": _load_show_reasoning(),
+            "slash_worker": None,
+            "source": source,
+            "tool_progress_mode": _load_tool_progress_mode(),
+            "tool_started_at": {},
+            "transport": transport_obj or _stdio_transport,
+        }
+        _register_session_cwd(_sessions[sid])
+    _record_alias_meta(sid, session_key=target, profile_home=profile_home_str)
+    return _sessions[sid]
+
+
+def _rehydrate_alias_from_meta(sid: str, meta: dict) -> bool:
+    """Rebuild a live ``_sessions[sid]`` entry from the alias-meta sidecar.
+
+    Symmetric companion to ``session.history``'s disk-only rehydrate
+    (L5189-5223 — read-only, just returns the messages). The history
+    handler's job is read-only so a disk read is enough; ``prompt.submit``'s
+    job is to RUN, so it needs a live ``_sessions[sid]`` entry pointing at
+    the right long key + profile DB.  This helper does that part.
+
+    Flow:
+
+    * Open the profile-bound (or launch) DB and verify the row really exists
+      on disk — a stale alias-meta hint pointing at a deleted row must NOT
+      manufacture an empty live session.  Returns False so the caller can
+      surface the original 4001 and iOS's sessionGone path fires.
+    * Acquire ``_session_resume_lock`` (matches session.resume's critical
+      section so the WS-orphan reaper and concurrent resumes don't race us).
+    * If another short alias is already live for the same long key, point
+      ``_sessions[sid]`` at the SAME session dict — never double-mint, or
+      two aliases would race the same history_lock + state.db rows.
+    * Otherwise claim an active-session lease and call
+      ``_install_lazy_session_under_alias`` so a subsequent
+      ``_start_agent_build`` upgrades it via the normal path
+      (``resume_session_id`` keeps the agent on the SAME long key, so the
+      system-prompt cache prefix stays byte-stable across the reap — see
+      AGENTS.md: prompt caching is sacred).
+
+    Reuses the SAME short alias the iOS client referenced — the whole point
+    is the client's ``session_id`` parameter keeps working without it
+    knowing anything happened.  Returns True iff ``_sessions[sid]`` now
+    maps to a live session.
+    """
+    target = str(meta.get("session_key") or "")
+    if not target:
+        return False
+    profile_home_raw = meta.get("profile_home")
+    profile_home = Path(profile_home_raw) if profile_home_raw else None
+
+    db = None
+    close_db = False
+    if profile_home is not None:
+        try:
+            from hermes_state import SessionDB
+
+            db = SessionDB(db_path=profile_home / "state.db")
+            close_db = True
+        except Exception:
+            logger.debug(
+                "rehydrate: failed to open profile db", exc_info=True
+            )
+            return False
+    else:
+        db = _get_db()
+    if db is None:
+        return False
+
+    history: list = []
+    try:
+        row = db.get_session(target)
+        if not row:
+            # Stale alias-meta hint — the row really is gone.  Surface 4001
+            # honestly so iOS's sessionGone fires (matches session.history
+            # negative-test invariant at server.py L5213-5216).
+            return False
+        try:
+            db.reopen_session(target)
+        except Exception:
+            logger.debug(
+                "rehydrate: reopen_session failed (non-fatal)", exc_info=True
+            )
+        try:
+            # The child's OWN conversation only — mirrors session.resume
+            # lazy path (L4404-4408): a delegated child must NOT pull its
+            # parent's transcript via include_ancestors.
+            history = list(db.get_messages_as_conversation(target))
+        except Exception:
+            logger.debug(
+                "rehydrate: read history failed", exc_info=True
+            )
+            return False
+    finally:
+        if close_db:
+            with contextlib.suppress(Exception):
+                db.close()
+
+    transport_obj = current_transport() or _stdio_transport
+    cwd = _profile_configured_cwd(profile_home)
+
+    with _session_resume_lock:
+        # Idempotency: if the entry was re-populated between the _sess_nowait
+        # miss in prompt.submit and our acquire of _session_resume_lock
+        # (concurrent resume from another tab), nothing more to do.
+        if sid in _sessions:
+            return True
+        # Multi-alias safety: if another short alias is already live for the
+        # same long key, point our sid at that EXACT session dict instead of
+        # double-minting — two _sessions sharing one session_key would race
+        # the same history_lock and double-write to state.db.
+        live = _find_live_session_by_key(target)
+        if live is not None:
+            with _sessions_lock:
+                _sessions[sid] = live[1]
+            _record_alias_meta(
+                sid,
+                session_key=target,
+                profile_home=str(profile_home) if profile_home is not None else None,
+            )
+            return True
+        # Fresh install under our reused sid.  Claim an active-session lease
+        # the same way session.resume does (the original lease was released
+        # when the reaper finalized the old session — see _release_active_
+        # session_slot in _finalize_session).
+        lease, limit_message = _claim_active_session_slot(target, live_session_id=sid)
+        if limit_message is not None:
+            # Session-cap hit on rehydrate.  Don't surface 4090 here — let
+            # the caller's second _sess_nowait miss return the original
+            # 4001, which is the wire contract the iOS client already knows
+            # how to handle.  Cap pressure on a transient-reap rebuild is
+            # exceptional; the cap message would just confuse the client.
+            return False
+        try:
+            _install_lazy_session_under_alias(
+                sid,
+                target,
+                cols=80,
+                history=history,
+                profile_home=profile_home,
+                lease=lease,
+                close_on_disconnect=False,
+                transport_obj=transport_obj,
+                cwd=cwd,
+            )
+        except Exception:
+            logger.debug(
+                "rehydrate: install_lazy_session_under_alias failed",
+                exc_info=True,
+            )
+            if lease is not None:
+                with contextlib.suppress(Exception):
+                    lease.release()
+            return False
+        return True
 
 
 def _profile_configured_cwd(profile_home: Path | None) -> str | None:
@@ -1057,6 +1485,58 @@ def _sess(params, rid):
     return (s, _wait_agent(s, rid))
 
 
+def _sess_nowait_or_rehydrate(params, rid):
+    """``_sess_nowait`` extended with the post-eviction alias-meta rehydrate.
+
+    Identical wire contract to ``_sess_nowait`` for the genuine-loss case
+    (returns ``(None, 4001 err)``) but, before giving up, consults the
+    alias-meta sidecar and lazy-installs ``_sessions[sid]`` from disk when
+    the WS-orphan / idle reaper popped the alias while iOS was
+    backgrounded.  Symmetric with the disk-rehydrate path
+    ``session.history`` already takes (server.py L5404+) — applied here
+    once so every iOS-surface RPC that is reasonable to call against a
+    quietly-reaped alias picks up the same survival behaviour for free
+    (instead of every handler open-coding the meta lookup + reinstall).
+
+    The handler-by-handler opt-in is deliberate: read-modify-only RPCs
+    that depend on runtime state which doesn't survive a reap
+    (in-flight prompts/clarify/approval, per-process registries, slash
+    worker subprocess identity, agent-bound rollback checkpoints) keep
+    using ``_sess_nowait`` / ``_sess`` so they 4001 honestly instead of
+    rehydrating a session that's missing the state they need.  See the
+    surrounding handler comments for the per-method rationale.
+    """
+    s, err = _sess_nowait(params, rid)
+    if err is None:
+        return s, None
+    sid = str(params.get("session_id") or "")
+    if not sid:
+        return s, err
+    meta = _lookup_alias_meta(sid)
+    if not meta:
+        return s, err
+    if not _rehydrate_alias_from_meta(sid, meta):
+        return s, err
+    return _sess_nowait(params, rid)
+
+
+def _sess_or_rehydrate(params, rid):
+    """``_sess`` extended with the post-eviction alias-meta rehydrate.
+
+    Same as ``_sess_nowait_or_rehydrate`` but also drives
+    ``_start_agent_build`` + ``_wait_agent`` so handlers that need a
+    constructed agent get it.  After a rehydrate the rebuilt agent
+    initialises against the SAME long ``session_key``, which keeps the
+    system-prompt cache key byte-stable across the reap (AGENTS.md:
+    prompt caching is sacred).
+    """
+    s, err = _sess_nowait_or_rehydrate(params, rid)
+    if err is not None or s is None:
+        return None, err
+    _start_agent_build(params.get("session_id") or "", s)
+    return s, _wait_agent(s, rid)
+
+
 def _normalize_completion_path(path_part: str) -> str:
     expanded = os.path.expanduser(path_part)
     if os.name != "nt":
@@ -1292,6 +1772,53 @@ def _session_db(session: dict):
         db = _get_db()
     try:
         yield db
+    finally:
+        if close_db and db is not None:
+            with contextlib.suppress(Exception):
+                db.close()
+
+
+def _read_history_from_disk(
+    session_key: str, profile_home: str | None
+) -> list | None:
+    """Read a session's full message history from disk without a live session.
+
+    Used by ``session.history`` to rehydrate after the WS-orphan or idle
+    reaper has popped the alias from ``_sessions``.  Returns the conversation
+    list (possibly empty) when the row exists, or ``None`` when the on-disk
+    row really is gone (so the caller can surface 4001 honestly).  Opens a
+    fresh DB handle keyed to ``profile_home`` and closes it before returning;
+    this is the same pattern ``_session_db`` uses for live sessions, just
+    without the session dict to hang it off.
+    """
+    if not session_key:
+        return None
+    db = None
+    close_db = False
+    if profile_home:
+        from hermes_state import SessionDB
+
+        try:
+            db = SessionDB(db_path=Path(profile_home) / "state.db")
+            close_db = True
+        except Exception:
+            logger.debug(
+                "failed to open profile db for disk-only history read",
+                exc_info=True,
+            )
+            return None
+    else:
+        db = _get_db()
+    if db is None:
+        return None
+    try:
+        row = db.get_session(session_key)
+        if not row:
+            return None
+        return list(db.get_messages_as_conversation(session_key, include_ancestors=True))
+    except Exception:
+        logger.debug("disk-only history read failed", exc_info=True)
+        return None
     finally:
         if close_db and db is not None:
             with contextlib.suppress(Exception):
@@ -2593,6 +3120,38 @@ def _current_profile_name() -> str:
         return "default"
 
 
+def _session_profile_name(session: dict | None) -> str:
+    """Profile name THIS session is bound to, regardless of the gateway's launch profile.
+
+    The desktop's app-global remote mode lets a client pick a profile per session
+    (params={"profile": "<name>"}); that profile_home is stored on the session
+    at create/resume time (see L3916 / L4176 / L4311). Reading it back here keeps
+    the info echo honest:
+
+    * session.create response → echoes the picked profile, not the launch one.
+    * session.resume response → echoes the stored profile even when the client
+      didn't re-send ``profile`` in params.
+    * Any sibling _session_info() consumer (status refresh, session.info emits,
+      slash-command updates, etc.) sees the same truth.
+
+    profile_home is a string written by ``_profile_home()`` (L677), which routes
+    through ``hermes_cli.profiles.get_profile_dir(name)`` (L331). That helper
+    returns ``~/.hermes`` for ``default`` and ``~/.hermes/profiles/<name>`` for
+    everything else, so the basename of profile_home IS the profile name for the
+    non-launch case. When profile_home is None / missing the session is bound to
+    the launch profile and we fall back to the gateway-global lookup (correct in
+    that case — same answer either way).
+    """
+    if session is not None:
+        home_str = session.get("profile_home")
+        if home_str:
+            try:
+                return Path(home_str).name or _current_profile_name()
+            except Exception:
+                pass
+    return _current_profile_name()
+
+
 # Monotonic GUI<->backend contract version. The desktop app refuses to drive a
 # backend reporting less than its required value (or none at all — a pre-GUI
 # checkout), surfacing a one-click "update to align" prompt instead of failing
@@ -2656,7 +3215,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "update_behind": None,
         "update_command": "",
         "usage": _get_usage(agent),
-        "profile_name": _current_profile_name(),
+        "profile_name": _session_profile_name(session),
     }
     try:
         from hermes_cli import __version__, __release_date__
@@ -3787,6 +4346,9 @@ def _init_session(
             # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
             "transport": current_transport() or _stdio_transport,
         }
+    # Record alias→session_key for post-eviction history rehydration.  The
+    # default-profile mint path has no profile_home (it's the launch profile).
+    _record_alias_meta(sid, session_key=key, profile_home=None)
     db = session_db if session_db is not None else _get_db()
     if db is not None:
         row = db.get_session(key)
@@ -4270,6 +4832,11 @@ def _(rid, params: dict) -> dict:
             "transport": current_transport() or _stdio_transport,
         }
         _register_session_cwd(_sessions[sid])
+    _record_alias_meta(
+        sid,
+        session_key=key,
+        profile_home=str(profile_home) if profile_home is not None else None,
+    )
     # NOTE: we intentionally do NOT persist a DB row here. Every TUI/desktop
     # launch (and every "New agent" / draft) opens a session here just to paint
     # the composer, so eagerly creating a row left an "Untitled" empty session
@@ -4318,7 +4885,7 @@ def _(rid, params: dict) -> dict:
                 "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
                 "lazy": True,
                 "desktop_contract": DESKTOP_BACKEND_CONTRACT,
-                "profile_name": _current_profile_name(),
+                "profile_name": _session_profile_name(_sessions[sid]),
             },
         },
     )
@@ -4457,6 +5024,36 @@ def _(rid, params: dict) -> dict:
             # so proceed into the lazy branch with empty history; the live mirror
             # streams the whole turn anyway and the row exists by upgrade time.
             found = {}
+        elif profile is None:
+            # No explicit profile param AND the launch DB has no row.  On the
+            # cold-launch resume path iOS only has the long session_key — it
+            # has no way to know which profile minted the session, so it sends
+            # no ``profile``.  Walk the named profile DBs to find which one
+            # owns the row; if we find it, rebind ``db``/``profile_home``
+            # exactly as if the client had passed the right ``profile`` and
+            # let the rest of the handler do its normal thing.  This is the
+            # gateway side of the t_07054503 cross-profile cold-launch fix.
+            located = _locate_stored_session_across_profiles(target)
+            if located is None:
+                return _err(rid, 4007, "session not found")
+            target, profile_home = located
+            if profile_home is not None:
+                from hermes_state import SessionDB
+
+                # Close the previous launch handle?  No — ``_get_db()`` returns
+                # the shared singleton; the caller will keep using it for
+                # other sessions.  We just open a fresh profile-bound handle
+                # for this resume and proceed.  Matches the explicit-profile
+                # path above (L4317-L4320).
+                try:
+                    db = SessionDB(db_path=profile_home / "state.db")
+                except Exception as e:
+                    return _err(rid, 5000, f"profile db open failed: {e}")
+            found = db.get_session(target)
+            if not found:
+                # Race: another worker deleted the row between the cross-
+                # profile probe and the re-fetch.  Surface 4007 as the canon.
+                return _err(rid, 4007, "session not found")
         else:
             return _err(rid, 4007, "session not found")
 
@@ -4532,7 +5129,6 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 5000, f"resume failed: {e}")
         messages = _history_to_messages(history)
         cwd = profile_resume_cwd or os.getenv("TERMINAL_CWD", os.getcwd())
-        now = time.time()
         # A delegated child mid-run emits no native session events of its own —
         # report its liveness from the relay registry so the window paints a
         # busy indicator instead of a dead idle transcript.
@@ -4544,42 +5140,27 @@ def _(rid, params: dict) -> dict:
                 if lease is not None:
                     lease.release()
                 return _ok(rid, _reuse_live_payload(*live))
-            with _sessions_lock:
-                _sessions[sid] = {
-                    "agent": None,
-                    "agent_error": None,
-                    "agent_ready": threading.Event(),
-                    "attached_images": [],
-                    "close_on_disconnect": is_truthy_value(
-                        params.get("close_on_disconnect", False)
-                    ),
-                    "active_session_lease": lease,
-                    "cols": cols,
-                    "created_at": now,
-                    "display_history_prefix": [],
-                    "edit_snapshots": {},
-                    "explicit_cwd": False,
-                    "history": history,
-                    "history_lock": threading.Lock(),
-                    "history_version": 0,
-                    "image_counter": 0,
-                    "cwd": cwd,
-                    "inflight_turn": None,
-                    "last_active": now,
-                    "lazy": True,
-                    "pending_title": None,
-                    "profile_home": str(profile_home) if profile_home is not None else None,
-                    "resume_session_id": target,
-                    "running": False,
-                    "session_key": target,
-                    "show_reasoning": _load_show_reasoning(),
-                    "source": source,
-                    "slash_worker": None,
-                    "tool_progress_mode": _load_tool_progress_mode(),
-                    "tool_started_at": {},
-                    "transport": current_transport() or _stdio_transport,
-                }
-                _register_session_cwd(_sessions[sid])
+            # Install via the shared helper so the lazy session shape stays in
+            # lockstep with the post-eviction rehydrate path
+            # (_rehydrate_alias_from_meta).  Both callers MUST produce
+            # identical field sets; otherwise a later _start_agent_build
+            # upgrade behaves differently depending on which path minted the
+            # entry, breaking the cache-stable-resume_session_id invariant.
+            session = _install_lazy_session_under_alias(
+                sid,
+                target,
+                cols=cols,
+                history=history,
+                profile_home=profile_home,
+                lease=lease,
+                close_on_disconnect=is_truthy_value(
+                    params.get("close_on_disconnect", False)
+                ),
+                transport_obj=current_transport(),
+                cwd=cwd,
+                source=source,
+            )
+        now = float(session["created_at"])
         return _ok(
             rid,
             {
@@ -4595,7 +5176,7 @@ def _(rid, params: dict) -> dict:
                     "skills": {},
                     "lazy": True,
                     "desktop_contract": DESKTOP_BACKEND_CONTRACT,
-                    "profile_name": _current_profile_name(),
+                    "profile_name": _session_profile_name(session),
                 },
                 "inflight": None,
                 "running": child_running,
@@ -4706,6 +5287,14 @@ def _(rid, params: dict) -> dict:
                 if profile_home is not None:
                     _sessions[sid]["profile_home"] = str(profile_home)
                 _sessions[sid]["active_session_lease"] = lease
+                # Record alias→(session_key, profile_home) so a post-WS-orphan-reap
+                # session.history(sid) can still find the disk row when iOS
+                # reconnects after backgrounding (see ``_record_alias_meta`` doc).
+                _record_alias_meta(
+                    sid,
+                    session_key=target,
+                    profile_home=str(profile_home) if profile_home is not None else None,
+                )
         except Exception as e:
             if lease is not None:
                 lease.release()
@@ -4730,7 +5319,10 @@ def _(rid, params: dict) -> dict:
 
 @method("session.cwd.set")
 def _(rid, params: dict) -> dict:
-    session, err = _sess_nowait(params, rid)
+    # Rehydrate-aware: iOS setting cwd against a quietly-reaped alias picks
+    # up the lazy reinstall and the persist below lands on the SAME state.db
+    # row.  See ``_sess_nowait_or_rehydrate`` for the post-eviction contract.
+    session, err = _sess_nowait_or_rehydrate(params, rid)
     if err:
         return err
     if session.get("running"):
@@ -4981,7 +5573,9 @@ def _(rid, params: dict) -> dict:
 
 @method("session.title")
 def _(rid, params: dict) -> dict:
-    session, err = _sess_nowait(params, rid)
+    # Rehydrate-aware: iOS renaming a chat post-reconnect should land on
+    # the same DB row, not 4001 just because the short alias was reaped.
+    session, err = _sess_nowait_or_rehydrate(params, rid)
     if err:
         return err
     db = _get_db()
@@ -5199,7 +5793,10 @@ def _(rid, params: dict) -> dict:
 
 @method("session.usage")
 def _(rid, params: dict) -> dict:
-    session, err = _sess_nowait(params, rid)
+    # Rehydrate-aware: iOS reading per-session usage for a quietly-reaped
+    # alias shows the persisted DB totals instead of an honest-but-useless
+    # 4001.
+    session, err = _sess_nowait_or_rehydrate(params, rid)
     if err:
         return err
     agent = session.get("agent")
@@ -5471,7 +6068,9 @@ def _(rid, params: dict) -> dict:
 
 @method("session.status")
 def _(rid, params: dict) -> dict:
-    session, err = _sess_nowait(params, rid)
+    # Rehydrate-aware: iOS reading status (cwd, branch, model, tokens) for a
+    # reaped alias surfaces the rebuilt-from-disk shape instead of 4001.
+    session, err = _sess_nowait_or_rehydrate(params, rid)
     if err:
         return err
 
@@ -5528,16 +6127,54 @@ def _(rid, params: dict) -> dict:
 
 @method("session.history")
 def _(rid, params: dict) -> dict:
+    sid = str(params.get("session_id") or "")
     session, err = _sess_nowait(params, rid)
-    if err:
-        return err
-    history = list(session.get("history", []))
-    db = _get_db()
-    if db is not None and session.get("session_key"):
+    if err is not None:
+        # The short alias isn't in ``_sessions`` — either it never existed (a
+        # genuine 4001) or the WS-orphan / idle reaper popped it while iOS was
+        # backgrounded.  In the second case the row is still on disk; the
+        # alias-meta sidecar remembers which long key + profile DB to read from
+        # so a quick post-reconnect ``session.history`` rehydrates cleanly
+        # instead of falsely 4001'ing and triggering the iOS sessionGone path.
+        meta = _lookup_alias_meta(sid)
+        if not meta:
+            return err
         try:
-            history = db.get_messages_as_conversation(
-                session["session_key"], include_ancestors=True
+            history = _read_history_from_disk(
+                meta["session_key"], meta.get("profile_home")
             )
+        except Exception:
+            logger.debug(
+                "session.history disk-only rehydrate failed for evicted alias",
+                exc_info=True,
+            )
+            return err
+        if history is None:
+            # The row really is gone — the disk lookup said so, not just the
+            # in-memory miss.  Hand 4001 back so iOS's sessionGone fires.
+            return err
+        return _ok(
+            rid,
+            {
+                "count": len(history),
+                "messages": _history_to_messages(history),
+            },
+        )
+    history = list(session.get("history", []))
+    # A reeve-bound (or any non-launch-profile) session's messages live in
+    # ``<profile_home>/state.db``, NOT the launch profile's db that ``_get_db()``
+    # opens.  Use the profile-aware ``_session_db`` context manager — the same
+    # one ``_set_session_cwd`` uses — so the reconcile-after-stream and
+    # tap-to-resume history reads hit the right db.  Falls back to ``_get_db()``
+    # when the session has no ``profile_home`` set (the default-profile case),
+    # which preserves wire-compatible behaviour for single-profile setups.
+    if session.get("session_key"):
+        try:
+            with _session_db(session) as db:
+                if db is not None:
+                    history = db.get_messages_as_conversation(
+                        session["session_key"], include_ancestors=True
+                    )
         except Exception:
             pass
     return _ok(
@@ -5551,7 +6188,10 @@ def _(rid, params: dict) -> dict:
 
 @method("session.undo")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    # Rehydrate-aware: an undo against a reaped alias rebuilds the live
+    # session from disk and mutates the SAME DB row; the agent isn't running
+    # post-reap so the busy-guard below never trips spuriously.
+    session, err = _sess_or_rehydrate(params, rid)
     if err:
         return err
     # Reject during an in-flight turn.  If we mutated history while
@@ -5579,7 +6219,10 @@ def _(rid, params: dict) -> dict:
 
 @method("session.compress")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    # Rehydrate-aware: manual compression against a reaped alias rebuilds
+    # the live session, runs against the SAME long key, and writes back to
+    # the SAME DB row — same cache-stability guarantees as prompt.submit.
+    session, err = _sess_or_rehydrate(params, rid)
     if err:
         return err
     if session.get("running"):
@@ -5675,7 +6318,10 @@ def _(rid, params: dict) -> dict:
 
 @method("session.save")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    # Rehydrate-aware: snapshotting a reaped alias to disk should pick up
+    # the SAME conversation it would have before the reap; rehydrate gives
+    # us the agent + history we need.
+    session, err = _sess_or_rehydrate(params, rid)
     if err:
         return err
 
@@ -5737,12 +6383,23 @@ def _(rid, params: dict) -> dict:
     # idempotent teardown path (pop + _teardown_session) and returns False
     # when the session is already gone.
     with _session_resume_lock:
-        return _ok(rid, {"closed": _close_session_by_id(sid, end_reason="tui_close")})
+        closed = _close_session_by_id(sid, end_reason="tui_close")
+    # An explicit close is the one path that means "this alias is gone for
+    # good" — drop the alias-meta sidecar entry so a later session.history on
+    # this sid honestly 4001s instead of disk-only rehydrating.  Reap paths
+    # deliberately do NOT do this; they're the eviction the sidecar exists
+    # to survive.
+    if closed and sid:
+        _forget_alias_meta(sid)
+    return _ok(rid, {"closed": closed})
 
 
 @method("session.branch")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    # Rehydrate-aware: branching off a reaped alias forks the SAME parent
+    # row; without the rehydrate iOS would 4001 and the user couldn't fork
+    # a chat that's still very much present on disk.
+    session, err = _sess_or_rehydrate(params, rid)
     if err:
         return err
     db = _get_db()
@@ -5813,6 +6470,13 @@ def _(rid, params: dict) -> dict:
 
 @method("session.interrupt")
 def _(rid, params: dict) -> dict:
+    # No rehydrate here — by construction a reaped alias has no in-flight
+    # run (the reaper bails out for ``running=True`` sessions), so calling
+    # interrupt on one would either rebuild a live session just to no-op
+    # against it (returning success when nothing was cancelled — misleading
+    # for iOS, which would think a cancellation it didn't expect succeeded)
+    # or 4001 honestly so the iOS UI corrects its stale "still running"
+    # view.  Honest 4001 is the right wire contract here.
     session, err = _sess(params, rid)
     if err:
         return err
@@ -6069,6 +6733,12 @@ def _(rid, params: dict) -> dict:
     text = (params.get("text") or "").strip()
     if not text:
         return _err(rid, 4002, "text is required")
+    # No rehydrate here — steer queues text onto a RUNNING turn's next tool
+    # result.  A reaped alias has no running turn (the reaper bails out for
+    # ``running=True`` sessions), so rehydrate-and-steer would queue into a
+    # session with nothing to steer, returning success while having no
+    # effect.  Honest 4001 lets the iOS UI correct its stale "still
+    # running" view.
     session, err = _sess_nowait(params, rid)
     if err:
         return err
@@ -6084,7 +6754,10 @@ def _(rid, params: dict) -> dict:
 
 @method("terminal.resize")
 def _(rid, params: dict) -> dict:
-    session, err = _sess_nowait(params, rid)
+    # Rehydrate-aware: iOS sends terminal.resize frequently as the keyboard
+    # appears/disappears; a single false-positive 4001 on resize would
+    # cascade UI noise.
+    session, err = _sess_nowait_or_rehydrate(params, rid)
     if err:
         return err
     session["cols"] = int(params.get("cols", 80))
@@ -6098,8 +6771,18 @@ def _(rid, params: dict) -> dict:
 def _(rid, params: dict) -> dict:
     sid, text = params.get("session_id", ""), params.get("text", "")
     truncate_user_ordinal = params.get("truncate_before_user_ordinal")
-    session, err = _sess_nowait(params, rid)
-    if err:
+    # ``_sess_nowait_or_rehydrate`` adds the post-eviction alias-meta fallback
+    # symmetric with ``session.history``: a ``prompt.submit`` against a
+    # session whose short alias was popped by the WS-orphan / idle reaper
+    # while iOS was backgrounded transparently rebuilds the live entry
+    # under the SAME short alias instead of falsely 4001'ing.  Returns the
+    # original 4001 when the row is genuinely gone from disk OR when
+    # session.close cleared the alias-meta — iOS's sessionGone path still
+    # fires for true loss.  See ``_rehydrate_alias_from_meta`` for the
+    # divergence from session.history's read-only disk rehydrate (this
+    # handler has to RUN so it needs a live _sessions[sid]).
+    session, err = _sess_nowait_or_rehydrate(params, rid)
+    if err is not None:
         return err
     # Re-bind to the current client transport for this request. This keeps
     # streaming events on the active websocket even if an earlier disconnect


### PR DESCRIPTION
## Summary

`tui_gateway.prompt.submit` returns close code 4001 ("unknown session") for a session whose short alias was reaped by the 20-second WS-orphan reaper while its underlying `state.db` row is still intact and recoverable. `session.history` already has a disk-rehydrate fallback consulting `_lookup_alias_meta` on a `_sess_nowait` miss; `prompt.submit` does not. The result is an asymmetric, false-positive 4001 on a session iOS thinks is alive.

This PR factors the rehydrate behind two helpers and adopts them on 10 sibling RPCs that operate on a still-alive session.

## How

Two new helpers in `tui_gateway/server.py`:

- `_sess_nowait_or_rehydrate(sid)` — `_sess_nowait` first; on miss, consult `_lookup_alias_meta(sid)` and rebuild the in-memory dict from the on-disk row (no agent build).
- `_sess_or_rehydrate(sid)` — same, plus rebuilds the agent (`_make_agent`) for handlers that need to run a turn.

Any RPC operating on a session the user still considers alive opts in by changing one call.

**Cache safety (per AGENTS.md: prompt caching is sacred):** rehydrate reuses the SAME short alias the iOS client referenced — it never mints a new sid — and the rebuilt agent reads `resume_session_id = long_key` and passes it to `_make_agent` as `session_id=`. The system prompt is keyed off `session_id + profile + model`, so the cached prefix stays byte-stable across the reap. `test_prompt_submit_rehydrate_preserves_system_prompt_cache_key` locks this in by snapshotting the `_make_agent` kwargs.

**Multi-alias safe:** if a sibling alias is already live for the same long key, the helper points the rehydrating sid at the same dict instead of double-minting.

## Rehydrate-aware (10 handlers)

`prompt.submit`, `session.history`, `session.title`, `session.cwd.set`, `session.usage`, `session.status`, `session.undo`, `session.compress`, `session.save`, `session.branch`, `terminal.resize`.

## Deliberately NOT rehydrate-aware

Kept on `_sess_nowait` / `_sess` with per-handler rationale at the call site (and summarised in the audit-log block at the top of the file):

`session.interrupt`, `session.steer`, `approval.respond` / `clarify.respond` / `sudo.respond` / `secret.respond` / `terminal.read.respond`, `process.list` / `process.kill`, `slash.exec`, `rollback.list` / `rollback.restore` / `rollback.diff`, the handoff RPCs, and the composer-side attach RPCs.

The principle: rehydrate only when the operation makes sense against a "live" session that happens to have been reaped — control-plane operations on transient runtime state (interrupts, steers, in-flight approvals, live processes, in-progress slash, in-memory rollback queue, handoff state) are correctly a 4001 if their runtime state is gone.

## Tests

11 new tests in `tests/test_tui_gateway_server.py`:

- Positive rehydrate path for `prompt.submit`.
- Genuine-loss negative (no alias-meta row → still 4001).
- Post-`session.close` negative (close path forgets alias-meta → 4001).
- Multi-alias safety (no double-mint when a sibling alias is already live).
- Sibling-handler proof (`session.title` via the same wrapper).
- Cache-stability via `_make_agent` kwarg snapshot.
- Plus the existing `_record` / `_lookup` / `_forget` / TTL coverage for the alias-meta sidecar.

**Results:** 11/11 new tests pass. Full `tui_gateway` suite: 291 passed, 2 pre-existing failures unchanged (`session.activate` inflight-stream + `browser.manage` Chromium launch hint — neither touches the rehydrate path).

## Test plan for reviewers

```bash
pytest tests/test_tui_gateway_server.py -v
```

## Files changed

- `tui_gateway/server.py` — +739/−58 (two new helpers, 10 call-site swaps, audit-log block)
- `tests/test_tui_gateway_server.py` — +910/0 (11 new tests)
