### PR TITLE
fix(whatsapp): resolve bridge path to repo root, not plugins/ (#49831)

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -262,7 +262,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     """
 
     # Default bridge location relative to the hermes-agent install
-    _DEFAULT_BRIDGE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "whatsapp-bridge"
+    _DEFAULT_BRIDGE_DIR = Path(__file__).resolve().parents[3] / "scripts" / "whatsapp-bridge"
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WHATSAPP)

--- a/tests/gateway/test_whatsapp_bridge_path.py
+++ b/tests/gateway/test_whatsapp_bridge_path.py
@@ -1,0 +1,48 @@
+"""Regression test for WhatsApp _DEFAULT_BRIDGE_DIR path resolution.
+
+Issue #49831: After the adapter was relocated into
+``plugins/platforms/whatsapp/``, the ``parents[2]`` index pointed at
+``plugins/`` instead of the repo root, so the default bridge path
+resolved to ``plugins/scripts/whatsapp-bridge/`` (non-existent) instead
+of ``scripts/whatsapp-bridge/``.
+
+The fix changes ``parents[2]`` → ``parents[3]``.
+"""
+
+from pathlib import Path
+
+
+def test_default_bridge_dir_resolves_to_repo_root_scripts():
+    """_DEFAULT_BRIDGE_DIR must point at <repo>/scripts/whatsapp-bridge."""
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    bridge_dir = WhatsAppAdapter._DEFAULT_BRIDGE_DIR
+    assert bridge_dir.name == "whatsapp-bridge"
+    assert bridge_dir.parent.name == "scripts"
+
+    # The scripts/ directory must be at repo root (sibling of run_agent.py
+    # or .git), not inside plugins/.
+    repo_root = bridge_dir.parent.parent
+    assert (repo_root / ".git").exists() or (repo_root / "run_agent.py").exists(), (
+        f"_DEFAULT_BRIDGE_DIR parent chain does not reach repo root: {bridge_dir}"
+    )
+
+
+def test_default_bridge_dir_not_under_plugins():
+    """_DEFAULT_BRIDGE_DIR must NOT resolve under plugins/ (the old bug)."""
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    bridge_dir = WhatsAppAdapter._DEFAULT_BRIDGE_DIR
+    parts = bridge_dir.parts
+    # "plugins" should NOT appear between the repo root and "scripts"
+    # Find where "scripts" is and check the part before it
+    try:
+        scripts_idx = parts.index("scripts")
+    except ValueError:
+        raise AssertionError(f"'scripts' not in path: {bridge_dir}")
+
+    if scripts_idx > 0:
+        preceding = parts[scripts_idx - 1]
+        assert preceding != "plugins", (
+            f"_DEFAULT_BRIDGE_DIR resolves under plugins/: {bridge_dir}"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes the `_DEFAULT_BRIDGE_DIR` path resolution in `WhatsAppAdapter` — `parents[2]` pointed at `plugins/` instead of the repo root after the adapter was relocated into `plugins/platforms/whatsapp/`. On editable/source installs, the WhatsApp gateway fails to start because the bridge script is resolved at `plugins/scripts/whatsapp-bridge/bridge.js` (non-existent) instead of `scripts/whatsapp-bridge/bridge.js`.

## Related Issue

Fixes #49831

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/whatsapp/adapter.py`: Change `parents[2]` → `parents[3]` so `_DEFAULT_BRIDGE_DIR` resolves to `<repo>/scripts/whatsapp-bridge` instead of `<repo>/plugins/scripts/whatsapp-bridge`
- `tests/gateway/test_whatsapp_bridge_path.py`: Add 2 regression tests — one verifying the path reaches repo root, one verifying it does not resolve under `plugins/`

## How to Test

1. Clone the repo as an editable install (`pip install -e .`)
2. Enable WhatsApp (`WHATSAPP_ENABLED=true`) with the bridge at `scripts/whatsapp-bridge/bridge.js`
3. Start the gateway — WhatsApp should log `✓ whatsapp connected` instead of `Bridge script not found`
4. Run `pytest tests/gateway/test_whatsapp_bridge_path.py -v` — both tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/platforms/whatsapp/adapter.py` (`_DEFAULT_BRIDGE_DIR`, `WhatsAppAdapter.__init__`)
- Blast radius: LOW — single constant change, only affects default bridge path resolution on editable installs
- Related patterns: PR #39980 proposed a layout-independent `get_bundled_whatsapp_bridge_dir()` helper for packaged installs; this fix complements it by correcting the editable-install path
