### PR TITLE
fix(cli): strip PyYAML source snippet from managed-scope parse error log

### DIFF
--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -100,11 +100,15 @@ def _cached_read(path: Path, cache: Dict[str, tuple], parse):
         with open(path, encoding="utf-8") as f:
             parsed = parse(f)
     except Exception as exc:  # noqa: BLE001 — fail-open, but LOUD
+        # PyYAML's MarkedYAMLError embeds a snippet of the offending source
+        # line in str(exc) — log only the first line so a secret sitting on
+        # that line never reaches the log.
+        exc_summary = str(exc).split("\n", 1)[0]
         logger.warning(
             "managed scope: failed to parse %s: %s — IGNORING this managed file. "
             "Admin policy from this file is NOT being applied. Fix and restart.",
             path,
-            exc,
+            exc_summary,
         )
         return None
     with _CACHE_LOCK:


### PR DESCRIPTION
## What does this PR do?
Truncates the PyYAML `MarkedYAMLError` message to its first line before logging, so secrets on a malformed YAML line cannot leak into the log file.

## Related Issue
N/A — found via static analysis audit.

## Type of Change
- [x] Bug fix
- [x] Security fix

## Changes Made
`hermes_cli/managed_scope.py`: added `exc_summary = str(exc).split('\n', 1)[0]` and replaced `exc` with `exc_summary` in the `logger.warning` call.

## How to Test
1. Create a managed scope YAML file with a syntax error on a line containing a secret value.
2. Start Hermes — confirm the log shows only the error type/message, not the source line snippet.