### PR TITLE
fix(gateway): start the [MEMORY] heartbeat from the gateway runtime (#49773)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2785,6 +2785,32 @@ def _gateway_config_home() -> Path:
     return _hermes_home
 
 
+def _start_gateway_memory_monitor() -> None:
+    """Start the periodic [MEMORY] heartbeat thread if enabled in config.
+
+    The heartbeat (``gateway/memory_monitor.py``) logs an RSS/GC/thread
+    snapshot to gateway.log every ``logging.memory_monitor.interval_seconds``.
+    Besides memory observability it keeps the log fresh while the gateway is
+    idle, so external watchdogs that treat log staleness as a hung-detection
+    signal don't false-trigger and kill a healthy gateway (#49773).
+
+    Runs on a daemon thread (never blocks exit). Best-effort: any failure is
+    logged at warning and never aborts gateway startup.
+    """
+    try:
+        cfg = _load_gateway_config()
+        if not cfg_get(cfg, "logging", "memory_monitor", "enabled", default=True):
+            return
+        from gateway.memory_monitor import start_memory_monitoring
+
+        interval = cfg_get(
+            cfg, "logging", "memory_monitor", "interval_seconds", default=300
+        )
+        start_memory_monitoring(interval_seconds=float(interval))
+    except Exception as exc:
+        logger.warning("Memory monitor start skipped: %s", exc)
+
+
 def _load_gateway_config() -> dict:
     """Load and parse ~/.hermes/config.yaml, returning {} on any error.
 
@@ -7975,6 +8001,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._start_loop_liveness_guards(self._gateway_loop)
         logger.info("Session storage: %s", self.config.sessions_dir)
 
+        # Start the periodic [MEMORY] heartbeat so gateway.log keeps emitting a
+        # freshness signal even while the gateway is idle (#49773).
+        _start_gateway_memory_monitor()
+
         # Sanity-check that systemd's TimeoutStopSec covers our drain
         # window.  When the user upgraded hermes-agent without re-running
         # ``hermes setup``, their unit file may still encode the old
@@ -9749,6 +9779,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 await stop_watchdog()
 
             await self._cancel_secondary_profile_reconnect_tasks()
+
+            # Stop the [MEMORY] heartbeat thread and log a final snapshot.
+            # Safe even if it was never started (config-disabled). #49773.
+            try:
+                from gateway.memory_monitor import stop_memory_monitoring
+
+                stop_memory_monitoring()
+            except Exception as exc:
+                logger.warning("Memory monitor stop skipped: %s", exc)
 
             # Notify all chats with active agents BEFORE draining.
             # Adapters are still connected here, so messages can be sent.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2806,7 +2806,21 @@ def _start_gateway_memory_monitor() -> None:
         interval = cfg_get(
             cfg, "logging", "memory_monitor", "interval_seconds", default=300
         )
-        start_memory_monitoring(interval_seconds=float(interval))
+        try:
+            interval = float(interval)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Memory monitor interval_seconds=%r is not numeric; using default 300",
+                interval,
+            )
+            interval = 300.0
+        if interval <= 0:
+            logger.warning(
+                "Memory monitor interval_seconds=%s is non-positive; using default 300",
+                interval,
+            )
+            interval = 300.0
+        start_memory_monitoring(interval_seconds=interval)
     except Exception as exc:
         logger.warning("Memory monitor start skipped: %s", exc)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3244,6 +3244,32 @@ def _gateway_config_home() -> Path:
     return _hermes_home
 
 
+def _start_gateway_memory_monitor() -> None:
+    """Start the periodic [MEMORY] heartbeat thread if enabled in config.
+
+    The heartbeat (``gateway/memory_monitor.py``) logs an RSS/GC/thread
+    snapshot to gateway.log every ``logging.memory_monitor.interval_seconds``.
+    Besides memory observability it keeps the log fresh while the gateway is
+    idle, so external watchdogs that treat log staleness as a hung-detection
+    signal don't false-trigger and kill a healthy gateway (#49773).
+
+    Runs on a daemon thread (never blocks exit). Best-effort: any failure is
+    logged at warning and never aborts gateway startup.
+    """
+    try:
+        cfg = _load_gateway_config()
+        if not cfg_get(cfg, "logging", "memory_monitor", "enabled", default=True):
+            return
+        from gateway.memory_monitor import start_memory_monitoring
+
+        interval = cfg_get(
+            cfg, "logging", "memory_monitor", "interval_seconds", default=300
+        )
+        start_memory_monitoring(interval_seconds=float(interval))
+    except Exception as exc:
+        logger.warning("Memory monitor start skipped: %s", exc)
+
+
 def _load_gateway_config() -> dict:
     """Load and parse ~/.hermes/config.yaml, returning {} on any error.
 
@@ -11065,6 +11091,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._start_loop_liveness_guards(self._gateway_loop)
         logger.info("Session storage: %s", self.config.sessions_dir)
 
+        # Start the periodic [MEMORY] heartbeat so gateway.log keeps emitting a
+        # freshness signal even while the gateway is idle (#49773).
+        _start_gateway_memory_monitor()
+
         # Sanity-check that systemd's TimeoutStopSec covers our drain
         # window.  When the user upgraded hermes-agent without re-running
         # ``hermes setup``, their unit file may still encode the old
@@ -13177,6 +13207,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 await stop_watchdog()
 
             await self._cancel_secondary_profile_reconnect_tasks()
+
+            # Stop the [MEMORY] heartbeat thread and log a final snapshot.
+            # Safe even if it was never started (config-disabled). #49773.
+            try:
+                from gateway.memory_monitor import stop_memory_monitoring
+
+                stop_memory_monitoring()
+            except Exception as exc:
+                logger.warning("Memory monitor stop skipped: %s", exc)
 
             # Notify all chats with active agents BEFORE draining.
             # Adapters are still connected here, so messages can be sent.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3265,7 +3265,21 @@ def _start_gateway_memory_monitor() -> None:
         interval = cfg_get(
             cfg, "logging", "memory_monitor", "interval_seconds", default=300
         )
-        start_memory_monitoring(interval_seconds=float(interval))
+        try:
+            interval = float(interval)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Memory monitor interval_seconds=%r is not numeric; using default 300",
+                interval,
+            )
+            interval = 300.0
+        if interval <= 0:
+            logger.warning(
+                "Memory monitor interval_seconds=%s is non-positive; using default 300",
+                interval,
+            )
+            interval = 300.0
+        start_memory_monitoring(interval_seconds=interval)
     except Exception as exc:
         logger.warning("Memory monitor start skipped: %s", exc)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3093,6 +3093,14 @@ DEFAULT_CONFIG = {
         "level": "INFO",       # Minimum level for agent.log: DEBUG, INFO, WARNING
         "max_size_mb": 5,      # Max size per log file before rotation
         "backup_count": 3,     # Number of rotated backup files to keep
+        # Periodic [MEMORY] heartbeat in gateway.log — an RSS/GC/thread
+        # snapshot every interval_seconds. Doubles as a log-freshness signal
+        # for external watchdogs during idle periods. See
+        # gateway/memory_monitor.py; started by the gateway runtime.
+        "memory_monitor": {
+            "enabled": True,
+            "interval_seconds": 300,
+        },
     },
 
     # Remotely-hosted model catalog manifest.  When enabled, the CLI fetches

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2474,6 +2474,14 @@ DEFAULT_CONFIG = {
         "level": "INFO",       # Minimum level for agent.log: DEBUG, INFO, WARNING
         "max_size_mb": 5,      # Max size per log file before rotation
         "backup_count": 3,     # Number of rotated backup files to keep
+        # Periodic [MEMORY] heartbeat in gateway.log — an RSS/GC/thread
+        # snapshot every interval_seconds. Doubles as a log-freshness signal
+        # for external watchdogs during idle periods. See
+        # gateway/memory_monitor.py; started by the gateway runtime.
+        "memory_monitor": {
+            "enabled": True,
+            "interval_seconds": 300,
+        },
     },
 
     # Remotely-hosted model catalog manifest.  When enabled, the CLI fetches

--- a/tests/gateway/test_memory_monitor_wiring.py
+++ b/tests/gateway/test_memory_monitor_wiring.py
@@ -56,3 +56,39 @@ def test_start_helper_never_raises_on_bad_config():
     ) as mock_start:
         run._start_gateway_memory_monitor()  # should swallow and return
     mock_start.assert_not_called()
+
+
+def test_start_helper_logs_warning_on_failure(caplog):
+    """Failure must be visible at WARNING level, not silently debug-logged.
+
+    The entire purpose of the heartbeat is observability. If it fails silently
+    (debug level), the gateway goes dark — the same symptom as the bug (#49773).
+    """
+    import logging
+
+    with patch.object(run, "_load_gateway_config", side_effect=RuntimeError("boom")), patch(
+        "gateway.memory_monitor.start_memory_monitoring"
+    ):
+        with caplog.at_level(logging.WARNING):
+            run._start_gateway_memory_monitor()
+    assert any("Memory monitor start skipped" in r.message for r in caplog.records), (
+        "Failure must be logged at WARNING level, not debug"
+    )
+
+
+def test_gateway_start_calls_memory_monitor():
+    """Regression: GatewayRunner.start() must call _start_gateway_memory_monitor().
+
+    This is the exact failure class of #49773: the helper existed and was
+    tested, but nothing in the runtime called it. If a future refactor removes
+    the call from start(), this test catches it.
+    """
+    import inspect
+
+    from gateway.run import GatewayRunner
+
+    src = inspect.getsource(GatewayRunner.start)
+    assert "_start_gateway_memory_monitor" in src, (
+        "GatewayRunner.start() must call _start_gateway_memory_monitor() — "
+        "regression guard for #49773"
+    )

--- a/tests/gateway/test_memory_monitor_wiring.py
+++ b/tests/gateway/test_memory_monitor_wiring.py
@@ -1,0 +1,58 @@
+"""Tests that the gateway runtime actually starts the [MEMORY] heartbeat.
+
+Regression for #49773: ``gateway/memory_monitor.start_memory_monitoring()``
+existed and was tested in isolation, but nothing in the gateway runtime called
+it, so the heartbeat never ran in production and idle gateways went silent
+(false-tripping external log-freshness watchdogs).
+
+These tests exercise the wiring helper ``gateway.run._start_gateway_memory_monitor``
+and the config default block that backs it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import gateway.run as run
+from hermes_cli.config import DEFAULT_CONFIG, cfg_get
+
+
+def test_memory_monitor_default_config_present():
+    """The defaults expose logging.memory_monitor so the heartbeat is on by default."""
+    assert cfg_get(DEFAULT_CONFIG, "logging", "memory_monitor", "enabled") is True
+    assert (
+        cfg_get(DEFAULT_CONFIG, "logging", "memory_monitor", "interval_seconds") == 300
+    )
+
+
+def test_start_helper_starts_monitor_with_configured_interval():
+    with patch.object(run, "_load_gateway_config", return_value={
+        "logging": {"memory_monitor": {"enabled": True, "interval_seconds": 123}}
+    }), patch("gateway.memory_monitor.start_memory_monitoring") as mock_start:
+        run._start_gateway_memory_monitor()
+    mock_start.assert_called_once_with(interval_seconds=123.0)
+
+
+def test_start_helper_defaults_to_300_when_unconfigured():
+    with patch.object(run, "_load_gateway_config", return_value={}), patch(
+        "gateway.memory_monitor.start_memory_monitoring"
+    ) as mock_start:
+        run._start_gateway_memory_monitor()
+    mock_start.assert_called_once_with(interval_seconds=300.0)
+
+
+def test_start_helper_skips_when_disabled():
+    with patch.object(run, "_load_gateway_config", return_value={
+        "logging": {"memory_monitor": {"enabled": False}}
+    }), patch("gateway.memory_monitor.start_memory_monitoring") as mock_start:
+        run._start_gateway_memory_monitor()
+    mock_start.assert_not_called()
+
+
+def test_start_helper_never_raises_on_bad_config():
+    """A broken config loader must not abort gateway startup."""
+    with patch.object(run, "_load_gateway_config", side_effect=RuntimeError("boom")), patch(
+        "gateway.memory_monitor.start_memory_monitoring"
+    ) as mock_start:
+        run._start_gateway_memory_monitor()  # should swallow and return
+    mock_start.assert_not_called()

--- a/tests/gateway/test_memory_monitor_wiring.py
+++ b/tests/gateway/test_memory_monitor_wiring.py
@@ -11,9 +11,12 @@ and the config default block that backs it.
 
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import gateway.run as run
+from gateway.run import GatewayRunner
 from hermes_cli.config import DEFAULT_CONFIG, cfg_get
 
 
@@ -76,19 +79,65 @@ def test_start_helper_logs_warning_on_failure(caplog):
     )
 
 
-def test_gateway_start_calls_memory_monitor():
-    """Regression: GatewayRunner.start() must call _start_gateway_memory_monitor().
+def _make_partial_runner(tmp_path):
+    """Partially-constructed GatewayRunner, enough for the start() prologue.
 
-    This is the exact failure class of #49773: the helper existed and was
-    tested, but nothing in the runtime called it. If a future refactor removes
-    the call from start(), this test catches it.
+    Follows the established pattern (see test_teams_pipeline_runtime_wiring):
+    ``__new__`` + only the attributes the exercised code path touches. The
+    stubbed ``_abort_startup_if_shutdown_requested`` makes start() return at
+    its first checkpoint — which sits *after* the memory-monitor wiring — so
+    no adapters, servers, or background loops are ever started.
     """
-    import inspect
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(sessions_dir=str(tmp_path))
+    runner._start_loop_liveness_guards = lambda loop: None
 
-    from gateway.run import GatewayRunner
+    async def _abort(*_args, **_kwargs) -> bool:
+        return True
 
-    src = inspect.getsource(GatewayRunner.start)
-    assert "_start_gateway_memory_monitor" in src, (
-        "GatewayRunner.start() must call _start_gateway_memory_monitor() — "
-        "regression guard for #49773"
+    runner._abort_startup_if_shutdown_requested = _abort
+    return runner
+
+
+def test_gateway_runner_start_starts_memory_monitor(monkeypatch, tmp_path):
+    """Regression for #49773: starting the runner must start the heartbeat.
+
+    This is the exact failure class of the bug: ``start_memory_monitoring()``
+    existed and was tested in isolation, but nothing in the gateway runtime
+    called it. This test drives ``GatewayRunner.start()`` itself (up to its
+    first shutdown checkpoint) and asserts the monitor is actually started
+    with the configured interval.
+    """
+    runner = _make_partial_runner(tmp_path)
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"logging": {"memory_monitor": {"enabled": True, "interval_seconds": 60}}},
     )
+    # Keep the test from touching the real ~/.hermes runtime-status file.
+    monkeypatch.setattr(
+        "gateway.status.write_runtime_status", lambda **_kw: None
+    )
+
+    with patch("gateway.memory_monitor.start_memory_monitoring") as mock_start:
+        result = asyncio.run(GatewayRunner.start(runner))
+
+    assert result is True
+    mock_start.assert_called_once_with(interval_seconds=60.0)
+
+
+def test_gateway_runner_start_respects_disabled_config(monkeypatch, tmp_path):
+    """start() must not spin up the heartbeat when the operator disabled it."""
+    runner = _make_partial_runner(tmp_path)
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"logging": {"memory_monitor": {"enabled": False}}},
+    )
+    monkeypatch.setattr(
+        "gateway.status.write_runtime_status", lambda **_kw: None
+    )
+
+    with patch("gateway.memory_monitor.start_memory_monitoring") as mock_start:
+        result = asyncio.run(GatewayRunner.start(runner))
+
+    assert result is True
+    mock_start.assert_not_called()


### PR DESCRIPTION
Fixes #49773.

## Problem

`gateway/memory_monitor.start_memory_monitoring()` logs a periodic `[MEMORY]` RSS/GC/thread snapshot to `gateway.log` every `interval_seconds`. Beyond memory observability, it keeps the log fresh while the gateway is idle.

The function is implemented and unit-tested (`tests/gateway/test_memory_monitor.py`), but **nothing in the gateway runtime ever calls it** — `grep -rn start_memory_monitoring` outside tests/the module itself returns nothing on `main`. So in production the heartbeat never runs: an idle gateway's log goes silent, and external watchdogs that use log staleness as a hung-detection heuristic false-trigger and kill a healthy gateway (the issue reports 4 needless restarts in one hour). The module docstring even points at "`hermes_cli/config.py` for the defaults block" — but no `logging.memory_monitor` defaults block exists, confirming the feature was only half-wired.

## Fix

- `GatewayRunner.start()` calls a new module-level `_start_gateway_memory_monitor()` helper right after the "Session storage" log line; `stop()` calls `stop_memory_monitoring()` during teardown (safe even if it was never started).
- Both are best-effort (wrapped in try/except → `logger.debug`) so a config or import error can never abort gateway startup/shutdown. The monitor itself runs on a daemon thread and never blocks exit.
- Added the missing `logging.memory_monitor` defaults block to `DEFAULT_CONFIG` (`enabled: true`, `interval_seconds: 300`) — the value the docstring already referenced. The helper honours it via `cfg_get`, so operators can disable it or change the cadence.

## Tests

`tests/gateway/test_memory_monitor_wiring.py`:
- the `logging.memory_monitor` default is present (enabled, 300s);
- the helper starts the monitor with the configured interval;
- defaults to 300s when unconfigured;
- skips when `enabled: false`;
- never raises if the config loader throws.

All pass locally, alongside the existing `tests/gateway/test_memory_monitor.py` (10 passed).