### PR TITLE
fix(chat-completions): strip internal timestamp field before strict providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -172,6 +172,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                or "timestamp" in msg  # #47868 — strict providers reject this
             ):
                 needs_sanitize = True
                 break
@@ -201,6 +202,7 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            msg.pop("timestamp", None)  # #47868 — leak into strict providers
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "w31rdm4ch1n3z@protonmail.com": "w31rdm4ch1nZ",
+    "xtpeeps@gmail.com": "x7peeps",
     "rratmansky@gmail.com": "rratmansky",
     "lkz-de@users.noreply.github.com": "lkz-de",
     "charles@salesondemand.io": "salesondemandio",

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -104,6 +104,31 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[2]["tool_name"] == "execute_code"
 
+    def test_convert_messages_strips_timestamp(self, transport):
+        """Internal per-message ``timestamp`` metadata (stamped by
+        ``_apply_persist_user_message_override`` to preserve platform event
+        time without embedding it in content, and persisted to the SQLite
+        store) is not part of the OpenAI Chat Completions schema. Strict
+        providers like Mistral / Fireworks-backed endpoints reject it with
+        HTTP 422 'Extra inputs are not permitted, field: messages[N].timestamp'.
+        Regression test for #47868.
+        """
+        msgs = [
+            {"role": "user", "content": "hi", "timestamp": 1781976577.0},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "timestamp" not in result[0]
+        assert result[0]["content"] == "hi"
+        assert result[0]["role"] == "user"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[0]["timestamp"] == 1781976577.0
+
+    def test_convert_messages_no_copy_without_timestamp(self, transport):
+        """A timestamp-free message list needs no sanitize pass and is
+        returned by identity (preserves the deepcopy-on-demand contract)."""
+        msgs = [{"role": "user", "content": "hi"}]
+        assert transport.convert_messages(msgs) is msgs
+
     def test_convert_messages_strips_internal_scaffolding_markers(self, transport):
         """Hermes-internal ``_``-prefixed markers must never reach the wire.
 


### PR DESCRIPTION
## Summary
Strict OpenAI-compatible providers (Mistral, Fireworks-backed endpoints like OpenCode Go `glm-5.2`) no longer fail with HTTP 422 `extra_forbidden` on `messages[N].timestamp`.

Root cause: `_apply_persist_user_message_override` (run_agent.py) deliberately stamps an internal `timestamp` onto the user message to preserve platform event time as metadata (also persisted to the SQLite store). `ChatCompletionsTransport.convert_messages` strips every other internal-only field (`tool_name`, `codex_*`, `_`-prefixed scaffolding, Gemini `extra_content`) but missed `timestamp`, so it leaked to the wire. Permissive providers ignore unknown keys; strict ones reject the whole request — which is why the reporter saw ~1-in-2 Telegram turns fail with the Mistral custom provider while other providers worked.

Codex and Anthropic transports rebuild message items field-by-field and never reference `timestamp`, so chat-completions is the sole leak path — the fix is complete.

## Changes
- `agent/transports/chat_completions.py`: add `timestamp` to the sanitize check and the pop-keys in `convert_messages` (mirrors the existing `tool_name` strip). — @x7peeps
- `tests/agent/transports/test_chat_completions.py`: regression test asserting `timestamp` is stripped and the original list is untouched, plus the identity-return path for timestamp-free lists.
- `scripts/release.py`: AUTHOR_MAP entry for the contributor (release attribution gate).

## Validation
| | Before | After |
|---|---|---|
| Strict provider gets `messages[N].timestamp` | HTTP 422, turn fails | field stripped, request succeeds |
| `tests/agent/transports/test_chat_completions.py` + `tests/gateway/test_message_timestamps.py` | — | 91 passed |

Salvages #47875 by @x7peeps onto current `main` (authorship preserved). Closes #47868.

## Infographic

![strip-internal-timestamp-field](https://v3b.fal.media/files/b/0a9f1ca1/EAg0dRqCP7juIVhFfBdhy_vKkDRSvw.png)
