### PR TITLE
fix(desktop): raise remote liveness probe timeout from 2.5s to 10s

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5306,7 +5306,7 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
 
   const base = conn.baseUrl.replace(/\/+$/, '')
   try {
-    await fetchPublicJson(`${base}/api/status`, { timeoutMs: 2_500 })
+    await fetchPublicJson(`${base}/api/status`, { timeoutMs: 10_000 })
     return { ok: true, rebuilt: false }
   } catch {
     // Unreachable remote: drop the stale cache so the renderer's next reconnect


### PR DESCRIPTION
## Summary

Fixes the connect → immediately-stale → reconnect loop reported in #49787 for remote backends reached via high-latency paths (Tailscale relay, cross-region VPN).

## Root cause

`hermes:connection:revalidate` probes `/api/status` with a hardcoded `2_500`ms timeout:

```js
// main.cjs:5309 (before)
await fetchPublicJson(`${base}/api/status`, { timeoutMs: 2_500 })
```

This fires on every sleep/wake (`onPowerResume`), network online event, and `visibilitychange`. On a Tailscale-connected remote, relay latency can intermittently exceed 2.5s — causing the probe to time out and drop the cached connection as stale even when the backend is perfectly healthy. The result is an infinite loop:

```
Remote Hermes backend is ready
→ Cached remote Hermes backend failed liveness probe; dropping stale connection.
→ startHermes() rebuilds from scratch (boot progress overlay reappears at ~24%)
→ next wake/focus event fires revalidateConnection() again
→ same 2.5s race → drop again → loop
```

This is distinct from the bootstrap marker issue also reported in #49787 (setup screen on every launch), which has a separate fix.

## Fix

Raise the revalidate timeout to `10_000`ms, matching the timeout already used for the connection test (`fetchPublicJson` at line 4437):

```js
// main.cjs:5309 (after)
await fetchPublicJson(`${base}/api/status`, { timeoutMs: 10_000 })
```

A genuinely dead backend still fails within 10s. A live backend over a high-latency relay no longer gets false-evicted.

## Verification

- Affected setup: Mac M5, macOS Tahoe 26.5.1, Hermes Desktop v0.17.0, remote backend on Mac mini via Tailscale tunnel
- Tailscale round-trip: ~223ms average with occasional spikes above 2.5s
- `GET /api/status` returns HTTP 200 with valid JSON when probed directly; Let's Encrypt cert, no TLS issues
- With `timeoutMs: 2_500`: desktop.log shows repeated `Cached remote Hermes backend failed liveness probe` within seconds of each `Remote Hermes backend is ready` — confirmed via 8–10 loop iterations per session
- With `timeoutMs: 10_000`: probe succeeds reliably; loop stops

## Related

- Closes #49787
- Related: #43913 (different symptom, same desktop boot area — local mode Python 3.9 detection loop)
- Related: PR #43983 (missing bootstrap marker → setup screen; complements this fix)