### PR TITLE
fix(update): resolve venv dir for both `venv` and `.venv` layouts (#49665)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6061,7 +6061,7 @@ def _update_via_zip(args):
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        uv_env = {**os.environ, "VIRTUAL_ENV": str(_resolve_project_venv_dir() or (PROJECT_ROOT / "venv"))}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -6790,7 +6790,7 @@ def _recover_from_interrupted_install() -> None:
 
             uv_bin = ensure_uv()
             if uv_bin:
-                uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+                uv_env = {**os.environ, "VIRTUAL_ENV": str(_resolve_project_venv_dir() or (PROJECT_ROOT / "venv"))}
                 if _is_termux_env(uv_env):
                     uv_env.pop("PYTHONPATH", None)
                     uv_env.pop("PYTHONHOME", None)
@@ -6873,10 +6873,26 @@ def _is_windows() -> bool:
     return sys.platform == "win32"
 
 
+def _resolve_project_venv_dir() -> Path | None:
+    """Return the project virtualenv directory, or None if there isn't one.
+
+    Honors both ``venv`` and ``.venv`` — the latter is the name
+    ``python -m venv`` suggests by convention and is extremely common. The
+    previous hardcoded ``venv``-only check silently returned None for ``.venv``
+    installs, disabling the Windows update quarantine and concurrent-instance
+    detection that depend on it (#49665).
+    """
+    for name in ("venv", ".venv"):
+        candidate = PROJECT_ROOT / name
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
 def _venv_scripts_dir() -> Path | None:
     """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
-    if not venv_dir.is_dir():
+    venv_dir = _resolve_project_venv_dir()
+    if venv_dir is None:
         return None
     scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
     return scripts if scripts.is_dir() else None
@@ -8985,7 +9001,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            uv_env = {**os.environ, "VIRTUAL_ENV": str(_resolve_project_venv_dir() or (PROJECT_ROOT / "venv"))}
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/tests/cli/test_venv_scripts_dir.py
+++ b/tests/cli/test_venv_scripts_dir.py
@@ -1,0 +1,60 @@
+"""Regression tests for #49665 — venv directory resolution must honor ``.venv``.
+
+``_venv_scripts_dir()`` previously hardcoded ``PROJECT_ROOT / "venv"`` and
+returned None for installs using the ``.venv`` convention (the name
+``python -m venv`` suggests). That silently disabled the Windows update
+quarantine and concurrent-instance detection that key off it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import hermes_cli.main as main
+
+
+def test_resolve_finds_plain_venv(tmp_path):
+    (tmp_path / "venv").mkdir()
+    with patch.object(main, "PROJECT_ROOT", tmp_path):
+        assert main._resolve_project_venv_dir() == tmp_path / "venv"
+
+
+def test_resolve_finds_dot_venv(tmp_path):
+    (tmp_path / ".venv").mkdir()
+    with patch.object(main, "PROJECT_ROOT", tmp_path):
+        assert main._resolve_project_venv_dir() == tmp_path / ".venv"
+
+
+def test_resolve_prefers_plain_venv_over_dot_venv(tmp_path):
+    (tmp_path / "venv").mkdir()
+    (tmp_path / ".venv").mkdir()
+    with patch.object(main, "PROJECT_ROOT", tmp_path):
+        assert main._resolve_project_venv_dir() == tmp_path / "venv"
+
+
+def test_resolve_none_when_absent(tmp_path):
+    with patch.object(main, "PROJECT_ROOT", tmp_path):
+        assert main._resolve_project_venv_dir() is None
+
+
+def test_scripts_dir_resolves_for_dot_venv(tmp_path):
+    scripts = tmp_path / ".venv" / "bin"
+    scripts.mkdir(parents=True)
+    with patch.object(main, "PROJECT_ROOT", tmp_path), patch.object(
+        main, "_is_windows", return_value=False
+    ):
+        assert main._venv_scripts_dir() == scripts
+
+
+def test_scripts_dir_resolves_for_dot_venv_windows(tmp_path):
+    scripts = tmp_path / ".venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    with patch.object(main, "PROJECT_ROOT", tmp_path), patch.object(
+        main, "_is_windows", return_value=True
+    ):
+        assert main._venv_scripts_dir() == scripts
+
+
+def test_scripts_dir_none_when_no_venv(tmp_path):
+    with patch.object(main, "PROJECT_ROOT", tmp_path):
+        assert main._venv_scripts_dir() is None


### PR DESCRIPTION
Fixes #49665.

## Problem

`_venv_scripts_dir()` in `hermes_cli/main.py` hardcoded `PROJECT_ROOT / "venv"` and returned `None` whenever the virtualenv was named `.venv` — the name `python -m venv` suggests by convention and an extremely common layout.

When it returns `None`, two Windows update safety mechanisms are silently skipped:
- **`_quarantine_running_hermes_exe()`** never runs, so `uv pip install -e .` tries to overwrite the *running* `hermes.exe` → `Access is denied. (os error 5)`.
- **`_detect_concurrent_hermes_instances()`** never runs, so the pre-update abort check is bypassed entirely.

The same hardcoded path also backed three `VIRTUAL_ENV` environment constructions, pointing `uv` at a non-existent directory on `.venv` installs.

This is the same class of latent bug as #26670 / #49428 — the quarantine machinery was built and merged, but a path assumption silently disables it for `.venv` users.

## Fix

- Add `_resolve_project_venv_dir()`, which checks `venv` then `.venv` and returns `None` when neither exists.
- Route `_venv_scripts_dir()` and the three `VIRTUAL_ENV` constructions through it, falling back to `PROJECT_ROOT / "venv"` only when no venv is found (preserving prior behaviour for the no-venv case).

## Tests

`tests/cli/test_venv_scripts_dir.py` (7 cases): resolves plain `venv`, resolves `.venv`, prefers `venv` when both exist, returns `None` when absent, and resolves the scripts dir for `.venv` on both POSIX (`bin`) and Windows (`Scripts`). All pass locally.