### PR TITLE
fix(gateway): surface silent message-loss in append_to_transcript

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1357,6 +1357,11 @@ class SessionStore:
                      _flush_messages_to_session_db(), preventing the
                      duplicate-write bug (#860).
         """
+        if not self._db and not skip_db:
+            logger.warning(
+                "append_to_transcript: no DB configured, message will not be persisted (role=%s)",
+                message.get("role"),
+            )
         if self._db and not skip_db:
             try:
                 self._db.append_message(
@@ -1381,7 +1386,7 @@ class SessionStore:
                     timestamp=message.get("timestamp"),
                 )
             except Exception as e:
-                logger.debug("Session DB operation failed: %s", e)
+                logger.warning("Session DB operation failed: %s", e)
     
     def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Replace the entire transcript for a session with new messages.


### PR DESCRIPTION
## What does this PR do?
`append_to_transcript` had two silent failure modes:

1. When `self._db` is `None`, the method was a complete no-op — no log, no error, message silently dropped.
2. When `append_message` raised an exception, it was only logged at `DEBUG` level, invisible in production.

This PR promotes both failure paths to `WARNING` so operators can detect message-loss in production logs.

## Type of Change
- [x] Bug fix

## Changes Made
- `gateway/session.py`: added `WARNING` log when `_db` is not configured and `skip_db` is `False`
- `gateway/session.py`: promoted `except`-path log from `DEBUG` to `WARNING`

## How to Test
1. Start Hermes with no `SessionDB` configured.
2. Trigger a message append — confirm a `WARNING` appears in the log.
3. Mock `append_message` to raise — confirm the failure is logged at `WARNING` level.