### PR TITLE
fix(mcp): pass HTTP timeout as timedelta on the deprecated client (#49629)

### DIFF
--- a/tests/tools/test_mcp_http_timeout.py
+++ b/tests/tools/test_mcp_http_timeout.py
@@ -1,0 +1,33 @@
+"""Regression tests for #49629 — HTTP MCP timeout must be a timedelta.
+
+The mcp SDK's ``streamablehttp_client`` (notably the deprecated pre-1.24.0
+API) expects ``timeout`` as a ``timedelta`` and calls ``.seconds`` on it.
+Hermes previously passed a raw ``float``, so every ``url:`` MCP connection
+crashed with ``'float' object has no attribute 'seconds'``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from tools.mcp_tool import _as_timeout_timedelta
+
+
+def test_float_seconds_coerced_to_timedelta():
+    assert _as_timeout_timedelta(60.0) == timedelta(seconds=60)
+
+
+def test_int_seconds_coerced_to_timedelta():
+    assert _as_timeout_timedelta(30) == timedelta(seconds=30)
+
+
+def test_existing_timedelta_passthrough():
+    td = timedelta(seconds=120)
+    assert _as_timeout_timedelta(td) is td
+
+
+def test_result_is_timedelta_not_float():
+    result = _as_timeout_timedelta(45)
+    assert isinstance(result, timedelta)
+    # The crash was `.seconds` on a float; confirm the attribute now exists.
+    assert result.seconds == 45

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -95,7 +95,7 @@ import sys
 import threading
 import time
 from typing import Callable
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Coroutine, Dict, List, Optional
 from urllib.parse import urlparse
 
@@ -277,6 +277,21 @@ if _MCP_AVAILABLE and not _MCP_MESSAGE_HANDLER_SUPPORTED:
 _DEFAULT_TOOL_TIMEOUT = 300      # seconds for tool calls
 _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
 _MAX_RECONNECT_RETRIES = 5
+
+
+def _as_timeout_timedelta(value) -> timedelta:
+    """Coerce a config timeout (seconds, int/float) to a ``timedelta``.
+
+    The mcp SDK's ``streamablehttp_client`` — in particular the deprecated
+    pre-1.24.0 API — expects ``timeout``/``sse_read_timeout`` as ``timedelta``
+    and does ``.seconds`` on them internally. Passing a raw float/int crashes
+    every ``url:`` (HTTP) MCP connection with
+    ``'float' object has no attribute 'seconds'`` (#49629). Idempotent for
+    values that are already ``timedelta``.
+    """
+    if isinstance(value, timedelta):
+        return value
+    return timedelta(seconds=float(value))
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
 
@@ -2112,9 +2127,12 @@ class MCPServerTask:
                             )
         else:
             # Deprecated API (mcp < 1.24.0): manages httpx client internally.
+            # This SDK expects ``timeout`` as a timedelta; a raw float raises
+            # "'float' object has no attribute 'seconds'" and breaks every
+            # HTTP MCP connection (#49629).
             _http_kwargs: dict = {
                 "headers": headers,
-                "timeout": float(connect_timeout),
+                "timeout": _as_timeout_timedelta(connect_timeout),
                 "verify": ssl_verify,
             }
             if _oauth_auth is not None:


### PR DESCRIPTION
Fixes #49629.

## Problem

On mcp < 1.24.0, every `url:` (HTTP / StreamableHTTP) MCP connection fails with:

```
'float' object has no attribute 'seconds'
```

stdio (`command:`) MCPs are unaffected.

## Root cause

In `tools/mcp_tool.py`, the deprecated-API branch (`mcp < 1.24.0`) calls `streamablehttp_client(url, timeout=float(connect_timeout), ...)`. That SDK expects `timeout` (and `sse_read_timeout`) as `timedelta` and does `.seconds` on it internally, so a raw float crashes the connection. (The newer `>=1.24.0` path builds its own `httpx.AsyncClient` and passes `http_client=`, so it isn't affected — which is why this only bites older mcp installs.)

## Fix

- Add an idempotent `_as_timeout_timedelta()` helper that coerces an int/float number of seconds to a `timedelta` (and passes `timedelta` through unchanged).
- Use it when building the deprecated-path `streamablehttp_client` kwargs.

Minimal and scoped to the broken branch; the modern path is untouched.

## Tests

`tests/tools/test_mcp_http_timeout.py`: float→timedelta, int→timedelta, timedelta passthrough, and that the result exposes `.seconds` (the attribute the crash was about). All pass locally.