### PR TITLE
fix(kanban): avoid duplicate 'default' labels in orchestrator profile dropdown

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1619,7 +1619,7 @@
     }
 
     const profileOptions = profiles.map(function (p) {
-      const tag = p.is_default ? " (default)" : "";
+      const tag = (p.is_default && p.name !== "default") ? " (default)" : "";
       return h(SelectOption, { key: p.name, value: p.name }, p.name + tag);
     });
 


### PR DESCRIPTION
## Problem

The Orchestrator profile dropdown in the Kanban Orchestration settings panel shows two near-identical entries when the active Hermes profile is `default`:

1. `default (default)` — the profile list entry (profile name + `is_default` suffix)
2. `(default: default)` — the hardcoded sentinel "inherit from active profile" option

These mean different things (explicit pick vs. inherit) but look like duplicates.

**Fixes #49846**

## Fix

`plugins/kanban/dashboard/dist/index.js` line 1622 — skip the ` (default)` suffix when the profile is already named `default`:

```diff
- const tag = p.is_default ? " (default)" : "";
+ const tag = (p.is_default && p.name !== "default") ? " (default)" : "";
```

Non-default-named profiles with `is_default: true` still get the annotation. The dropdown now shows:

| Before | After |
|---|---|
| `default (default)` | `default` |
| `(default: default)` | `(default: default)` (unchanged) |

One-line change, no behavioral side effects.
