### PR TITLE
fix(telegram): replace table-to-bullet conversion with monospaced code block

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -230,55 +230,29 @@ def _split_markdown_table_row(line: str) -> list[str]:
 
 
 def _render_table_block_for_telegram(table_block: list[str]) -> str:
-    """Render a detected GFM table as Telegram-friendly row groups."""
-    if len(table_block) < 3:
-        return "\n".join(table_block)
+    """Render a detected GFM table as a monospaced code block.
 
-    headers = _split_markdown_table_row(table_block[0])
-    if len(headers) < 2:
-        return "\n".join(table_block)
-
-    # Detect row-label column: present when data rows have one more cell
-    # than the header row (the row-label column carries no header).
-    first_data_row = _split_markdown_table_row(table_block[2]) if len(table_block) > 2 else []
-    has_row_label_col = len(first_data_row) == len(headers) + 1
-
-    rendered_groups: list[str] = []
-    for index, row in enumerate(table_block[2:], start=1):
+    Preserves the original pipe-table structure instead of converting to
+    bullet groups, so the data remains column-aligned and readable on
+    Telegram MarkdownV2 (which has no native table syntax).
+    """
+    # Strip the delimiter row (| :--- | :---: |) — it adds no info for the user.
+    header = table_block[0]
+    data_rows = [row for row in table_block[2:] if row.strip()]
+    # Pad short rows to match header column count.
+    headers = _split_markdown_table_row(header)
+    ncols = len(headers)
+    padded = [header]
+    for row in data_rows:
         cells = _split_markdown_table_row(row)
-        if has_row_label_col:
-            # First cell is the row-label (heading); remaining cells align with headers.
-            heading = cells[0] if cells and cells[0] else f"Row {index}"
-            data_cells = cells[1:]
-        else:
-            # No row-label column: use first non-empty cell as heading.
-            heading = next((cell for cell in cells if cell), f"Row {index}")
-            data_cells = cells
-
-        # Pad or trim data_cells to match headers length.
-        if len(data_cells) < len(headers):
-            data_cells.extend([""] * (len(headers) - len(data_cells)))
-        elif len(data_cells) > len(headers):
-            data_cells = data_cells[: len(headers)]
-
-        # Build the bulleted lines for this row.  Skip any bullet whose value
-        # duplicates the heading text -- when has_row_label_col is False the
-        # heading IS the first data cell, and emitting it twice (once as the
-        # bold heading, once as the first bullet) is visual noise.
-        bullets: list[str] = []
-        for header, value in zip(headers, data_cells):
-            if not has_row_label_col and value == heading:
-                continue
-            bullets.append(f"• {header}: {value}")
-
-        # Within a row-group: single newline between heading and its bullets,
-        # and between successive bullets.  This keeps the row visually tight
-        # on Telegram instead of stretching each bullet into its own paragraph.
-        group_lines = [f"**{heading}**", *bullets]
-        rendered_groups.append("\n".join(group_lines))
-
-    # Between row-groups: blank line so each group reads as a distinct block.
-    return "\n\n".join(rendered_groups)
+        while len(cells) < ncols:
+            cells.append("")
+        padded.append("| " + " | ".join(cells) + " |")
+    # Rebuild the header with uniform alignment markers.
+    padded[0] = "| " + " | ".join(headers) + " |"
+    sep = "| " + " | ".join("---" for _ in headers) + " |"
+    lines = [padded[0], sep] + padded[1:]
+    return "```\n" + "\n".join(lines) + "\n```"
 
 
 def _wrap_markdown_tables(text: str) -> str:
@@ -5093,7 +5067,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # 0) Rewrite GFM-style pipe tables into Telegram-friendly row groups
         #    before the normal MarkdownV2 conversions run.
-        text = _wrap_markdown_tables(text)
+        #    Skip when rich_messages is enabled — the rich path handles native
+        #    tables; forcing bullet groups here makes them unreadable.
+        if not getattr(self, '_rich_messages_enabled', False):
+            text = _wrap_markdown_tables(text)
 
         # 1) Protect fenced code blocks (``` ... ```)
         #    Per MarkdownV2 spec, \ and ` inside pre/code must be escaped.


### PR DESCRIPTION
## Summary

Replaces _render_table_block_for_telegram's bullet-group output with a monospaced code block that preserves the original pipe-table structure.

## Problem

When rich_messages is not available or the message falls back to MarkdownV2 (streaming finalization via editMessageText), GFM pipe tables are converted to bold headings + bullet lists per row. This loses column alignment and makes tabular data hard to scan.

## Fix (Option C from #49452)

Instead of bullet lists, the function now wraps tables in a monospaced code block preserving the original pipe format. This keeps columns visually aligned in both MarkdownV2 and rich message paths.

## Changes

- adapter.py - _render_table_block_for_telegram: Rewrote to emit a code block with the original pipe format instead of bullet groups.
- adapter.py - format_message: Added a guard before _wrap_markdown_tables, so conversion only runs when rich messages are disabled.

Closes #49452