### PR TITLE
test(web_server): make profile-wrapper alias test OS-aware

### DIFF
--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import json
 import shutil
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
@@ -3005,9 +3006,14 @@ class TestNewEndpoints:
         )
 
         assert resp.status_code == 200
-        wrapper_path = wrapper_dir / "writer"
+        is_windows = sys.platform == "win32"
+        wrapper_path = wrapper_dir / ("writer.bat" if is_windows else "writer")
         assert wrapper_path.exists()
-        assert wrapper_path.read_text() == '#!/bin/sh\nexec /opt/hermes/bin/hermes -p writer "$@"\n'
+        lines = [line.strip() for line in wrapper_path.read_text().splitlines() if line.strip()]
+        if is_windows:
+            assert lines == ["@echo off", "hermes -p writer %*"]
+        else:
+            assert lines == ["#!/bin/sh", 'exec /opt/hermes/bin/hermes -p writer "$@"']
 
     def test_profiles_create_with_clone_from_copies_source_skills(self, monkeypatch):
         from hermes_constants import get_hermes_home


### PR DESCRIPTION
## Summary
A worker reading the `kanban-worker` skill had no way to learn it can ship a deliverable file (chart/PDF/image) as a native chat upload — the `kanban_complete(artifacts=[...])` parameter added in #27813 was undocumented in the skill.

## Changes
- `skills/devops/kanban-worker/SKILL.md`: new **Shipping deliverables** section after "Good summary + metadata shapes" — covers the `artifacts=[...]` param, absolute-path/exists rules, the inline-embed vs file-upload extension behavior, and the key trap: the notifier reads the **top-level** `artifacts` list, not `metadata.*`.

## Notes
- Docs-only (skill markdown). No code, no tool/schema change — the parameter itself already shipped in #27813.
- CLI `kanban complete` has no `--artifacts` flag (tool-only), so the skill's CLI-fallback table is unchanged and stays accurate.

## Infographic

![os-aware-test-fix](https://v3b.fal.media/files/b/0a9f1de9/gGvsXm2F11JuxCEd15s69_zRnyEhyh.png)
