### PR TITLE
Add Linear controls to Kanban dashboard

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -171,6 +171,41 @@
     return p.phantom_cards || p.phantom_refs || [];
   }
 
+  function linearAttention(linear) {
+    if (!linear) return false;
+    return !!(linear.last_error || linear.conflict_reason ||
+      linear.sync_status === "error" || linear.sync_status === "conflict");
+  }
+
+  function linearStatusLabel(linear) {
+    if (!linear) return "Not linked";
+    if (!linear.sync_enabled) return "Paused";
+    if (linear.conflict_reason || linear.sync_status === "conflict") return "Conflict";
+    if (linear.last_error || linear.sync_status === "error") return "Sync error";
+    if (linear.sync_status === "create_requested") return "Create requested";
+    if (linear.sync_status === "sync_requested") return "Sync requested";
+    return linear.sync_status || "Linked";
+  }
+
+  function linearClass(linear) {
+    if (!linear) return "";
+    if (!linear.sync_enabled) return "hermes-kanban-linear--paused";
+    if (linear.conflict_reason || linear.sync_status === "conflict") return "hermes-kanban-linear--conflict";
+    if (linear.last_error || linear.sync_status === "error") return "hermes-kanban-linear--error";
+    if (linear.sync_status === "create_requested" || linear.sync_status === "sync_requested") return "hermes-kanban-linear--pending";
+    return "hermes-kanban-linear--linked";
+  }
+
+  function linearSummary(linear) {
+    if (!linear) return "Linear: not linked";
+    const bits = [linear.linear_identifier || "Linear issue", linearStatusLabel(linear)];
+    if (linear.linear_state) bits.push("State: " + linear.linear_state);
+    if (linear.linear_priority) bits.push("Priority: " + linear.linear_priority);
+    if (linear.last_error) bits.push("Error: " + linear.last_error);
+    if (linear.conflict_reason) bits.push("Conflict: " + linear.conflict_reason);
+    return bits.join(" · ");
+  }
+
   // Takes an optional `t` so the prompt/alert text is localised. Callers
   // outside React components can pass null and fall through to English.
   function withCompletionSummary(patch, count, t) {
@@ -2489,6 +2524,7 @@
 
     const progress = t.progress;
     const needsAssignee = t.status === "ready" && !t.assignee;
+    const linear = t.linear || null;
 
     return h("div", {
       ref: cardRef,
@@ -2526,6 +2562,21 @@
             ),
             h("span", { className: "hermes-kanban-card-id",
                         title: `Task id: ${t.id}. Use this id with kanban_show, /kanban show, or hermes kanban show.` }, t.id),
+            linear
+              ? (linear.linear_url
+                  ? h("a", {
+                      className: cn("hermes-kanban-linear-badge", linearClass(linear)),
+                      href: linear.linear_url,
+                      target: "_blank",
+                      rel: "noopener noreferrer",
+                      title: linearSummary(linear),
+                      onClick: function (e) { e.stopPropagation(); },
+                    }, linear.linear_identifier || "Linear")
+                  : h("span", {
+                      className: cn("hermes-kanban-linear-badge", linearClass(linear)),
+                      title: linearSummary(linear),
+                    }, linear.linear_identifier || "Linear"))
+              : null,
             t.warnings && t.warnings.count > 0
               ? h("span", {
                   className: cn(
@@ -2901,6 +2952,24 @@
         .catch(function (e) { setPatchErr(parseApiErrorMessage(e)); });
     };
 
+    const doLinearAction = function (kind, payload) {
+      setPatchErr(null);
+      let url = withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/linear`, boardSlug);
+      let method = "PATCH";
+      let body = payload || {};
+      if (kind === "link") { method = "PUT"; }
+      else if (kind === "unlink") { method = "DELETE"; body = null; }
+      else if (kind === "force_sync" || kind === "create_issue") {
+        method = "POST";
+        url = withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/linear/actions`, boardSlug);
+        body = { action: kind };
+      }
+      const opts = { method: method, headers: { "Content-Type": "application/json" } };
+      if (body) opts.body = JSON.stringify(body);
+      return SDK.fetchJSON(url, opts).then(function () { load(); props.onRefresh(); })
+        .catch(function (e) { setPatchErr(parseApiErrorMessage(e)); });
+    };
+
     // Triage specifier — calls the auxiliary LLM to flesh out a rough
     // idea in the Triage column into a concrete spec (title + body with
     // goal, approach, acceptance criteria) and promotes it to todo.
@@ -3033,6 +3102,7 @@
           assignees: props.assignees || [],
           boardSlug: boardSlug,
           onPatch: doPatch,
+          onLinearAction: doLinearAction,
           onSpecify: doSpecify,
           onDecompose: doDecompose,
           onAddParent: addLink,
@@ -3047,6 +3117,7 @@
           onDeleteAttachment: handleDeleteAttachment,
           uploadBusy: uploadBusy,
           uploadErr: uploadErr,
+          patchErr: patchErr,
         }) : null,
         data ? h("div", { className: "hermes-kanban-drawer-comment-row" },
           h(Input, {
@@ -3183,11 +3254,15 @@
     const events = props.data.events || [];
     const attachments = props.data.attachments || [];
     const links = props.data.links || { parents: [], children: [] };
+    const linear = t.linear || null;
+    const linearEditBlockReason = linearAttention(linear)
+      ? "Linear sync needs attention before editing Linear-backed fields."
+      : null;
 
     return h("div", { className: "hermes-kanban-drawer-body" },
       h("div", { className: "hermes-kanban-drawer-title" },
         h("span", { className: cn("hermes-kanban-dot", COLUMN_DOT[t.status]) }),
-        props.editing
+        props.editing && !linearEditBlockReason
           ? h(TitleEditor, {
               initial: t.title || "",
               onSave: function (newTitle) {
@@ -3196,15 +3271,15 @@
               onCancel: function () { props.setEditing(false); },
             })
           : h("span", {
-              className: "hermes-kanban-drawer-title-text",
-              title: tx(i18n, "clickToEdit", "Click to edit"),
-              onClick: function () { props.setEditing(true); },
+              className: cn("hermes-kanban-drawer-title-text", linearEditBlockReason ? "hermes-kanban-edit-locked" : ""),
+              title: linearEditBlockReason || tx(i18n, "clickToEdit", "Click to edit"),
+              onClick: function () { if (!linearEditBlockReason) props.setEditing(true); },
             }, t.title || tx(i18n, "untitled", "(untitled)")),
       ),
       h("div", { className: "hermes-kanban-drawer-meta" },
         h(MetaRow, { label: tx(i18n, "status", "Status"), value: t.status }),
-        h(AssigneeEditor, { task: t, onPatch: props.onPatch }),
-        h(PriorityEditor, { task: t, onPatch: props.onPatch }),
+        h(AssigneeEditor, { task: t, onPatch: props.onPatch, disabledReason: linearEditBlockReason }),
+        h(PriorityEditor, { task: t, onPatch: props.onPatch, disabledReason: linearEditBlockReason }),
         t.tenant ? h(MetaRow, { label: tx(i18n, "tenant", "Tenant"), value: t.tenant }) : null,
         h(MetaRow, {
           label: tx(i18n, "workspace", "Workspace"),
@@ -3222,6 +3297,11 @@
         }) : null,
         t.created_by ? h(MetaRow, { label: tx(i18n, "createdBy", "Created by"), value: t.created_by }) : null,
       ),
+      h(LinearSection, {
+        linear: linear,
+        onLinearAction: props.onLinearAction,
+        patchErr: props.patchErr,
+      }),
       h(StatusActions, {
         task: t,
         onPatch: props.onPatch,
@@ -3244,6 +3324,7 @@
         task: t,
         renderMarkdown: props.renderMarkdown,
         onPatch: props.onPatch,
+        disabledReason: linearEditBlockReason,
       }),
       h(DependencyEditor, {
         task: t,
@@ -3456,6 +3537,70 @@
     );
   }
 
+  function LinearSection(props) {
+    const { t } = useI18n();
+    const linear = props.linear || null;
+    const [value, setValue] = useState("");
+    const [busy, setBusy] = useState(null);
+    const run = function (kind, payload) {
+      if (!props.onLinearAction) return Promise.resolve();
+      setBusy(kind);
+      return props.onLinearAction(kind, payload).finally(function () { setBusy(null); });
+    };
+    return h("div", { className: cn("hermes-kanban-section hermes-kanban-linear-section", linearClass(linear)) },
+      h("div", { className: "hermes-kanban-section-head-row" },
+        h("span", { className: "hermes-kanban-section-head" }, "Linear"),
+        linear ? h("span", { className: cn("hermes-kanban-linear-status", linearClass(linear)) },
+          linearStatusLabel(linear)) : h("span", { className: "hermes-kanban-linear-status" }, "Not linked"),
+      ),
+      linear
+        ? h("div", { className: "hermes-kanban-linear-body" },
+            h("div", { className: "hermes-kanban-linear-main" },
+              linear.linear_url
+                ? h("a", { href: linear.linear_url, target: "_blank", rel: "noopener noreferrer", className: "hermes-kanban-linear-link" },
+                    linear.linear_identifier || linear.linear_url)
+                : h("span", { className: "hermes-kanban-linear-link" }, linear.linear_identifier || "Linear issue pending"),
+              linear.linear_state ? h("span", { className: "hermes-kanban-linear-chip" }, "State: " + linear.linear_state) : null,
+              linear.linear_priority ? h("span", { className: "hermes-kanban-linear-chip" }, "Priority: " + linear.linear_priority) : null,
+            ),
+            linear.conflict_reason ? h("div", { className: "hermes-kanban-linear-alert" }, "Conflict: " + linear.conflict_reason) : null,
+            linear.last_error ? h("div", { className: "hermes-kanban-linear-alert" }, "Sync error: " + linear.last_error) : null,
+            linearAttention(linear) ? h("div", { className: "hermes-kanban-linear-note" },
+              "Title, assignee, priority, and description edits are locked until the Linear conflict/error is resolved, paused, or unlinked.") : null,
+            h("div", { className: "hermes-kanban-linear-actions" },
+              linear.linear_url ? h(Button, { size: "sm", onClick: function () { window.open(linear.linear_url, "_blank", "noopener,noreferrer"); } }, "Open Linear") : null,
+              h(Button, { size: "sm", disabled: !!busy, onClick: function () { run("force_sync"); } }, busy === "force_sync" ? "Requesting…" : "Force sync"),
+              h(Button, { size: "sm", disabled: !!busy, onClick: function () { run(linear.sync_enabled ? "pause" : "resume", { sync_enabled: !linear.sync_enabled }); } },
+                linear.sync_enabled ? "Pause sync" : "Resume sync"),
+              h(Button, { size: "sm", variant: "destructive", disabled: !!busy, onClick: function () { if (window.confirm("Unlink this Linear issue from the Kanban task?")) run("unlink"); } }, "Unlink"),
+            ),
+          )
+        : h("div", { className: "hermes-kanban-linear-body" },
+            h("div", { className: "hermes-kanban-linear-note" },
+              "Link an existing ENT issue, or request creating a new Linear issue from this card. Secrets stay server-side."),
+            h("div", { className: "hermes-kanban-linear-link-row" },
+              h(Input, {
+                value: value,
+                onChange: function (e) { setValue(e.target.value); },
+                placeholder: "ENT-123 or Linear URL",
+                className: "h-8 text-xs flex-1",
+              }),
+              h(Button, {
+                size: "sm",
+                disabled: !!busy || !value.trim(),
+                onClick: function () { run("link", { identifier_or_url: value.trim() }).then(function () { setValue(""); }); },
+              }, busy === "link" ? "Linking…" : "Link"),
+              h(Button, {
+                size: "sm",
+                disabled: !!busy,
+                onClick: function () { run("create_issue"); },
+              }, busy === "create_issue" ? "Requesting…" : "Create issue"),
+            ),
+          ),
+      props.patchErr ? h("div", { className: "hermes-kanban-linear-alert" }, props.patchErr) : null,
+    );
+  }
+
   function MetaRow(props) {
     return h("div", { className: "hermes-kanban-meta-row" },
       h("span", { className: "hermes-kanban-meta-label" }, props.label),
@@ -3499,9 +3644,9 @@
       return h("div", { className: "hermes-kanban-meta-row" },
         h("span", { className: "hermes-kanban-meta-label" }, tx(t, "assignee", "Assignee")),
         h("span", {
-          className: "hermes-kanban-meta-value hermes-kanban-editable",
-          onClick: function () { setEditing(true); },
-          title: tx(t, "clickToEditAssignee", "Click to edit assignee"),
+          className: cn("hermes-kanban-meta-value", props.disabledReason ? "hermes-kanban-edit-locked" : "hermes-kanban-editable"),
+          onClick: function () { if (!props.disabledReason) setEditing(true); },
+          title: props.disabledReason || tx(t, "clickToEditAssignee", "Click to edit assignee"),
         }, props.task.assignee || tx(t, "unassigned", "unassigned")),
       );
     }
@@ -3536,9 +3681,9 @@
       return h("div", { className: "hermes-kanban-meta-row" },
         h("span", { className: "hermes-kanban-meta-label" }, tx(t, "priority", "Priority")),
         h("span", {
-          className: "hermes-kanban-meta-value hermes-kanban-editable",
-          onClick: function () { setEditing(true); },
-          title: tx(t, "clickToEdit", "Click to edit"),
+          className: cn("hermes-kanban-meta-value", props.disabledReason ? "hermes-kanban-edit-locked" : "hermes-kanban-editable"),
+          onClick: function () { if (!props.disabledReason) setEditing(true); },
+          title: props.disabledReason || tx(t, "clickToEdit", "Click to edit"),
         }, String(props.task.priority)),
       );
     }
@@ -3581,10 +3726,11 @@
             )
           : h("button", {
               type: "button",
-              onClick: function () { setEditing(true); },
-              className: "hermes-kanban-edit-link",
-              title: "Edit description",
-            }, tx(t, "edit", "edit")),
+              onClick: function () { if (!props.disabledReason) setEditing(true); },
+              disabled: !!props.disabledReason,
+              className: cn("hermes-kanban-edit-link", props.disabledReason ? "hermes-kanban-edit-locked" : ""),
+              title: props.disabledReason || "Edit description",
+            }, props.disabledReason ? "locked" : tx(t, "edit", "edit")),
       ),
       editing
         ? h("textarea", {

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -1581,3 +1581,84 @@
 .hermes-kanban-trash-label {
   font-weight: 500;
 }
+
+/* ---- Linear integration affordances ---------------------------------- */
+.hermes-kanban-linear-badge,
+.hermes-kanban-linear-status,
+.hermes-kanban-linear-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+  padding: 0.05rem 0.4rem;
+  font-size: 0.62rem;
+  line-height: 1.2;
+  text-decoration: none;
+  color: var(--color-foreground);
+  background: color-mix(in srgb, var(--color-foreground) 6%, transparent);
+}
+.hermes-kanban-linear-badge::before,
+.hermes-kanban-linear-status::before {
+  content: "↗";
+  font-size: 0.6rem;
+}
+.hermes-kanban-linear--linked {
+  border-color: color-mix(in srgb, #4a8cd1 45%, var(--color-border));
+  background: color-mix(in srgb, #4a8cd1 12%, transparent);
+}
+.hermes-kanban-linear--pending {
+  border-color: color-mix(in srgb, #d4b348 55%, var(--color-border));
+  background: color-mix(in srgb, #d4b348 16%, transparent);
+}
+.hermes-kanban-linear--paused {
+  border-color: color-mix(in srgb, var(--color-muted-foreground) 50%, var(--color-border));
+  background: color-mix(in srgb, var(--color-muted-foreground) 12%, transparent);
+}
+.hermes-kanban-linear--error,
+.hermes-kanban-linear--conflict {
+  border-color: color-mix(in srgb, var(--color-destructive, #d14a4a) 60%, var(--color-border));
+  background: color-mix(in srgb, var(--color-destructive, #d14a4a) 14%, transparent);
+}
+.hermes-kanban-linear-section {
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  border-radius: var(--radius-sm, 0.25rem);
+  padding: 0.65rem;
+}
+.hermes-kanban-linear-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+.hermes-kanban-linear-main,
+.hermes-kanban-linear-actions,
+.hermes-kanban-linear-link-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+}
+.hermes-kanban-linear-link {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.8rem;
+  color: var(--color-foreground);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.hermes-kanban-linear-note {
+  font-size: 0.72rem;
+  color: var(--color-muted-foreground);
+}
+.hermes-kanban-linear-alert {
+  border-left: 3px solid var(--color-destructive, #d14a4a);
+  padding: 0.35rem 0.5rem;
+  border-radius: var(--radius-sm, 0.25rem);
+  background: color-mix(in srgb, var(--color-destructive, #d14a4a) 10%, transparent);
+  color: var(--color-foreground);
+  font-size: 0.75rem;
+}
+.hermes-kanban-edit-locked {
+  cursor: not-allowed;
+  opacity: 0.72;
+  text-decoration: none !important;
+}

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -132,7 +132,94 @@ def _conn(board: Optional[str] = None):
         kanban_db.init_db(board=board)
     except Exception as exc:
         log.warning("kanban init_db failed: %s", exc)
-    return kanban_db.connect(board=board)
+    conn = kanban_db.connect(board=board)
+    _ensure_linear_table(conn)
+    return conn
+
+
+def _linear_board_slug(board: Optional[str]) -> str:
+    return board or kanban_db.DEFAULT_BOARD
+
+
+def _ensure_linear_table(conn: sqlite3.Connection) -> None:
+    """Create the lightweight dashboard-side Linear mapping cache.
+
+    The sync daemon/backend owns actual Linear API credentials and reconciliation.
+    The dashboard stores only non-secret linkage/status fields and emits events
+    for actions (create/force-sync) that an integration worker can process.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS kanban_linear_links (
+            task_id TEXT PRIMARY KEY,
+            board_slug TEXT NOT NULL DEFAULT 'default',
+            linear_issue_id TEXT,
+            linear_identifier TEXT,
+            linear_url TEXT,
+            linear_state TEXT,
+            linear_priority TEXT,
+            sync_enabled INTEGER NOT NULL DEFAULT 1,
+            sync_status TEXT NOT NULL DEFAULT 'linked',
+            last_synced_at INTEGER,
+            last_error TEXT,
+            conflict_reason TEXT,
+            updated_at INTEGER NOT NULL
+        )
+        """
+    )
+
+
+def _linear_dict(row: sqlite3.Row | None) -> Optional[dict[str, Any]]:
+    if row is None:
+        return None
+    return {
+        "task_id": row["task_id"],
+        "board_slug": row["board_slug"],
+        "linear_issue_id": row["linear_issue_id"],
+        "linear_identifier": row["linear_identifier"],
+        "linear_url": row["linear_url"],
+        "linear_state": row["linear_state"],
+        "linear_priority": row["linear_priority"],
+        "sync_enabled": bool(row["sync_enabled"]),
+        "sync_status": row["sync_status"],
+        "last_synced_at": row["last_synced_at"],
+        "last_error": row["last_error"],
+        "conflict_reason": row["conflict_reason"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def _linear_for_tasks(conn: sqlite3.Connection, task_ids: list[str]) -> dict[str, dict[str, Any]]:
+    if not task_ids:
+        return {}
+    placeholders = ",".join(["?"] * len(task_ids))
+    rows = conn.execute(
+        f"SELECT * FROM kanban_linear_links WHERE task_id IN ({placeholders})",
+        tuple(task_ids),
+    ).fetchall()
+    return {row["task_id"]: _linear_dict(row) for row in rows if row is not None}
+
+
+def _parse_linear_identifier_or_url(value: str) -> tuple[str, str]:
+    raw = (value or "").strip()
+    if not raw:
+        raise HTTPException(status_code=400, detail="Linear issue identifier or URL is required")
+    import re
+    match = re.search(r"([A-Za-z][A-Za-z0-9]+-\d+)", raw)
+    if not match:
+        raise HTTPException(status_code=400, detail="Expected a Linear issue key like ENT-123 or issue URL")
+    ident = match.group(1).upper()
+    url = raw if raw.startswith(("http://", "https://")) else f"https://linear.app/issue/{ident}"
+    return ident, url
+
+
+def _record_linear_event(
+    conn: sqlite3.Connection,
+    task_id: str,
+    kind: str,
+    payload: Optional[dict[str, Any]] = None,
+) -> None:
+    kanban_db._append_event(conn, task_id, kind, payload or {})
 
 
 # ---------------------------------------------------------------------------
@@ -457,7 +544,9 @@ def get_board(
         # window-function query (avoids N+1 ``latest_summary`` calls
         # for boards with hundreds of tasks). Truncated to a card-size
         # preview here — the full text is available via /tasks/:id.
-        summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
+        task_ids = [t.id for t in tasks]
+        summary_map = kanban_db.latest_summaries(conn, task_ids)
+        linear_map = _linear_for_tasks(conn, task_ids)
 
         for t in tasks:
             full = summary_map.get(t.id)
@@ -468,6 +557,7 @@ def get_board(
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
+            d["linear"] = linear_map.get(t.id)
             diags = diagnostics_per_task.get(t.id)
             if diags:
                 # Full list goes into the payload so the drawer can render
@@ -546,6 +636,7 @@ def get_task(
         # a second round-trip. Cards on /board carry a 200-char preview.
         full_summary = kanban_db.latest_summary(conn, task_id)
         task_d = _task_dict(task, latest_summary=full_summary)
+        task_d["linear"] = _linear_for_tasks(conn, [task_id]).get(task_id)
         # Attach diagnostics so the drawer's Diagnostics section can
         # render recovery actions without a second round-trip.
         diags = _compute_task_diagnostics(conn, task_ids=[task_id])
@@ -569,6 +660,157 @@ def get_task(
                 )
             ],
         }
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Linear linkage controls (dashboard-safe; no Linear secrets exposed)
+# ---------------------------------------------------------------------------
+
+class LinearLinkBody(BaseModel):
+    identifier_or_url: str
+    issue_id: Optional[str] = None
+    state: Optional[str] = None
+    priority: Optional[str] = None
+
+
+class LinearPatchBody(BaseModel):
+    sync_enabled: Optional[bool] = None
+    sync_status: Optional[str] = None
+    state: Optional[str] = None
+    priority: Optional[str] = None
+    last_error: Optional[str] = None
+    conflict_reason: Optional[str] = None
+
+
+class LinearActionBody(BaseModel):
+    action: str
+
+
+@router.put("/tasks/{task_id}/linear")
+def link_linear_issue(task_id: str, payload: LinearLinkBody, board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    ident, url = _parse_linear_identifier_or_url(payload.identifier_or_url)
+    conn = _conn(board=board)
+    try:
+        if kanban_db.get_task(conn, task_id) is None:
+            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+        now = int(time.time())
+        with kanban_db.write_txn(conn):
+            conn.execute(
+                """
+                INSERT INTO kanban_linear_links (
+                    task_id, board_slug, linear_issue_id, linear_identifier, linear_url,
+                    linear_state, linear_priority, sync_enabled, sync_status, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, 'linked', ?)
+                ON CONFLICT(task_id) DO UPDATE SET
+                    board_slug = excluded.board_slug,
+                    linear_issue_id = excluded.linear_issue_id,
+                    linear_identifier = excluded.linear_identifier,
+                    linear_url = excluded.linear_url,
+                    linear_state = excluded.linear_state,
+                    linear_priority = excluded.linear_priority,
+                    sync_enabled = 1,
+                    sync_status = 'linked',
+                    last_error = NULL,
+                    conflict_reason = NULL,
+                    updated_at = excluded.updated_at
+                """,
+                (task_id, _linear_board_slug(board), payload.issue_id, ident, url, payload.state, payload.priority, now),
+            )
+            _record_linear_event(conn, task_id, "linear_linked", {"identifier": ident, "url": url})
+        row = conn.execute("SELECT * FROM kanban_linear_links WHERE task_id = ?", (task_id,)).fetchone()
+        return {"linear": _linear_dict(row)}
+    finally:
+        conn.close()
+
+
+@router.patch("/tasks/{task_id}/linear")
+def update_linear_link(task_id: str, payload: LinearPatchBody, board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        if kanban_db.get_task(conn, task_id) is None:
+            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+        row = conn.execute("SELECT * FROM kanban_linear_links WHERE task_id = ?", (task_id,)).fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="task is not linked to Linear")
+        now = int(time.time())
+        updates: dict[str, Any] = {"updated_at": now}
+        if payload.sync_enabled is not None:
+            updates["sync_enabled"] = 1 if payload.sync_enabled else 0
+            updates["sync_status"] = "linked" if payload.sync_enabled else "paused"
+        if payload.sync_status is not None:
+            updates["sync_status"] = payload.sync_status
+        if payload.state is not None:
+            updates["linear_state"] = payload.state
+        if payload.priority is not None:
+            updates["linear_priority"] = payload.priority
+        if payload.last_error is not None:
+            updates["last_error"] = payload.last_error or None
+        if payload.conflict_reason is not None:
+            updates["conflict_reason"] = payload.conflict_reason or None
+        assignments = ", ".join(f"{k} = ?" for k in updates.keys())
+        with kanban_db.write_txn(conn):
+            conn.execute(
+                f"UPDATE kanban_linear_links SET {assignments} WHERE task_id = ?",
+                (*updates.values(), task_id),
+            )
+            _record_linear_event(conn, task_id, "linear_link_updated", updates)
+        row = conn.execute("SELECT * FROM kanban_linear_links WHERE task_id = ?", (task_id,)).fetchone()
+        return {"linear": _linear_dict(row)}
+    finally:
+        conn.close()
+
+
+@router.delete("/tasks/{task_id}/linear")
+def unlink_linear_issue(task_id: str, board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        if kanban_db.get_task(conn, task_id) is None:
+            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+        with kanban_db.write_txn(conn):
+            conn.execute("DELETE FROM kanban_linear_links WHERE task_id = ?", (task_id,))
+            _record_linear_event(conn, task_id, "linear_unlinked", {})
+        return {"ok": True}
+    finally:
+        conn.close()
+
+
+@router.post("/tasks/{task_id}/linear/actions")
+def request_linear_action(task_id: str, payload: LinearActionBody, board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    action = (payload.action or "").strip()
+    if action not in {"force_sync", "create_issue"}:
+        raise HTTPException(status_code=400, detail="unknown Linear action")
+    conn = _conn(board=board)
+    try:
+        if kanban_db.get_task(conn, task_id) is None:
+            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+        now = int(time.time())
+        with kanban_db.write_txn(conn):
+            if action == "create_issue":
+                conn.execute(
+                    """
+                    INSERT INTO kanban_linear_links (
+                        task_id, board_slug, sync_enabled, sync_status, updated_at
+                    ) VALUES (?, ?, 1, 'create_requested', ?)
+                    ON CONFLICT(task_id) DO UPDATE SET
+                        sync_enabled = 1, sync_status = 'create_requested', updated_at = excluded.updated_at
+                    """,
+                    (task_id, _linear_board_slug(board), now),
+                )
+                _record_linear_event(conn, task_id, "linear_create_requested", {})
+            else:
+                conn.execute(
+                    "UPDATE kanban_linear_links SET sync_enabled = 1, sync_status = 'sync_requested', updated_at = ? WHERE task_id = ?",
+                    (now, task_id),
+                )
+                _record_linear_event(conn, task_id, "linear_sync_requested", {})
+        row = conn.execute("SELECT * FROM kanban_linear_links WHERE task_id = ?", (task_id,)).fetchone()
+        return {"linear": _linear_dict(row)}
     finally:
         conn.close()
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -114,6 +114,76 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_linear_linkage_surfaces_on_board_and_task_detail(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "Add Linear UI"},
+    ).json()["task"]
+
+    r = client.put(
+        f"/api/plugins/kanban/tasks/{task['id']}/linear",
+        json={"identifier_or_url": "ENT-123", "state": "In Progress", "priority": "High"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["linear"]["linear_identifier"] == "ENT-123"
+    assert r.json()["linear"]["sync_enabled"] is True
+
+    board = client.get("/api/plugins/kanban/board").json()
+    linked = next(
+        t
+        for column in board["columns"]
+        for t in column["tasks"]
+        if t["id"] == task["id"]
+    )
+    assert linked["linear"]["linear_identifier"] == "ENT-123"
+    assert linked["linear"]["linear_state"] == "In Progress"
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{task['id']}").json()
+    assert detail["task"]["linear"]["linear_priority"] == "High"
+
+
+def test_linear_controls_pause_force_sync_and_unlink(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "Linear controls"},
+    ).json()["task"]
+    client.put(
+        f"/api/plugins/kanban/tasks/{task['id']}/linear",
+        json={"identifier_or_url": "https://linear.app/entrixflow/issue/ENT-456/foo"},
+    )
+
+    paused = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}/linear",
+        json={"sync_enabled": False},
+    )
+    assert paused.status_code == 200, paused.text
+    assert paused.json()["linear"]["sync_enabled"] is False
+    assert paused.json()["linear"]["sync_status"] == "paused"
+
+    requested = client.post(
+        f"/api/plugins/kanban/tasks/{task['id']}/linear/actions",
+        json={"action": "force_sync"},
+    )
+    assert requested.status_code == 200, requested.text
+    assert requested.json()["linear"]["sync_enabled"] is True
+    assert requested.json()["linear"]["sync_status"] == "sync_requested"
+
+    unlinked = client.delete(f"/api/plugins/kanban/tasks/{task['id']}/linear")
+    assert unlinked.status_code == 200, unlinked.text
+    assert client.get(f"/api/plugins/kanban/tasks/{task['id']}").json()["task"]["linear"] is None
+
+
+def test_dashboard_bundle_contains_linear_controls():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert "function LinearSection(props)" in js
+    assert "hermes-kanban-linear-badge" in js
+    assert "Force sync" in js
+    assert "Pause sync" in js
+    assert "Create issue" in js
+    assert "Linear sync needs attention before editing Linear-backed fields." in js
+
+
 def test_scheduled_tasks_have_their_own_column_not_todo(client):
     """Scheduled/time-delay tasks must not be silently bucketed into todo."""
 


### PR DESCRIPTION
## Summary
- Add dashboard-side Linear link metadata/cache endpoints for Kanban tasks.
- Surface Linear status badges and a drawer section with link, create, force-sync, pause/resume, and unlink controls.
- Lock Linear-backed title/assignee/priority/description edits when sync conflicts/errors need attention.

## Test plan
- git diff --check
- python -m py_compile plugins/kanban/dashboard/plugin_api.py
- node --check plugins/kanban/dashboard/dist/index.js
- python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q

Kanban: t_acffc645 (implementation t_6db004a2, review t_4461c453 approved)