### PR TITLE
fix(desktop): preserve URL markdown link text (#49822)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -94,6 +94,40 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('<https://www.getyourguide.com/culebra-island-l145468/from-fajardo-tour-t19894/>')
   })
 
+  it('preserves urls used as markdown link labels', () => {
+    const cases = [
+      '[https://example.com](https://example.com)',
+      '[https://example.com:8080/path?q=test#hash](https://example.com:8080/path?q=test#hash)',
+      '[http://user@example.com](http://user@example.com)'
+    ]
+
+    for (const input of cases) {
+      expect(preprocessMarkdown(input)).toBe(input)
+    }
+  })
+
+  it('matches the outer label bracket around bracket-containing urls', () => {
+    const cases = [
+      '[https://[::1]:8080/status](https://[::1]:8080/status)',
+      '[docs [https://example.com/path]](https://example.com/path)',
+      '[prefix [nested] https://example.com/path](https://example.com/path)',
+      '[[inner](https://i.example) outer](https://o.example)',
+      '[a\\]b](https://example.com)'
+    ]
+
+    for (const input of cases) {
+      expect(preprocessMarkdown(input)).toBe(input)
+    }
+  })
+
+  it('keeps bare prose autolinking and inline code behavior', () => {
+    const input = 'Docs: https://example.com/docs and `https://example.com/code`'
+    const output = preprocessMarkdown(input)
+
+    expect(output).toContain('Docs: <https://example.com/docs>')
+    expect(output).toContain('`https://example.com/code`')
+  })
+
   it('strips orphan numeric citation markers outside code spans', () => {
     const output = preprocessMarkdown('This is the source[0], but keep `items[0]` untouched.')
 

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -127,12 +127,50 @@ function isUrlOnlyBlock(lines: string[]): boolean {
   return nonEmpty.length > 0 && nonEmpty.every(line => URL_ONLY_LINE_RE.test(line))
 }
 
+function isEscaped(text: string, index: number): boolean {
+  let slashCount = 0
+
+  for (let cursor = index - 1; cursor >= 0 && text[cursor] === '\\'; cursor -= 1) {
+    slashCount += 1
+  }
+
+  return slashCount % 2 === 1
+}
+
+function isInsideMarkdownLinkText(text: string, index: number): boolean {
+  const openBrackets: number[] = []
+
+  for (let cursor = 0; cursor < text.length; cursor += 1) {
+    if (isEscaped(text, cursor)) {
+      continue
+    }
+
+    if (text[cursor] === '[') {
+      openBrackets.push(cursor)
+
+      continue
+    }
+
+    if (text[cursor] !== ']' || openBrackets.length === 0) {
+      continue
+    }
+
+    const open = openBrackets.pop()
+
+    if (open !== undefined && open < index && index < cursor && text[cursor + 1] === '(') {
+      return true
+    }
+  }
+
+  return false
+}
+
 function autoLinkRawUrls(text: string): string {
   return text.replace(RAW_URL_RE, (url: string, index: number) => {
     const previous = text[index - 1] || ''
     const beforePrevious = text[index - 2] || ''
 
-    if (previous === '<' || (beforePrevious === ']' && previous === '(')) {
+    if (previous === '<' || (beforePrevious === ']' && previous === '(') || isInsideMarkdownLinkText(text, index)) {
       return url
     }
 


### PR DESCRIPTION
Fixes #49822

## Summary
- Preserve Markdown links whose visible text contains lowercase `http://` or `https://` URLs.
- Add an unescaped Markdown link-text context check before wrapping bare URLs in GFM autolinks.
- Keep existing behavior for bare prose URLs, Markdown link destinations, non-http/case-variant link text, and inline code spans.

## Verification
- `npm run test:ui -- --run src/components/assistant-ui/markdown-text.test.ts` — 19 passed
- `npm run typecheck` — passed

## Competitor / duplicate check
- Same-author issue-number search: no open Tranquil-Flow PRs for #49822.
- Same-author branch search: no open Tranquil-Flow `fix/49822*` PRs.
- Upstream PR searches for `49822` and `autoLinkRawUrls markdown link text`: no open focused competitors found.

Auto-published by Moonsong via Path B automated pipeline.
