### PR TITLE
fix: preserve desktop workspace cwd across continuations

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -563,8 +563,16 @@ def compress_context(
                     agent._flush_messages_to_session_db(messages)
                 except Exception:
                     pass  # best-effort — don't block compression on a flush error
-                # Propagate title to the new session with auto-numbering
+                # Propagate durable session metadata to the continuation.  The
+                # title is auto-numbered below; cwd must be copied verbatim so a
+                # Desktop session that auto-compresses stays under its original
+                # workspace instead of reappearing under "No workspace".
                 old_title = agent._session_db.get_session_title(agent.session_id)
+                try:
+                    old_session_row = agent._session_db.get_session(agent.session_id) or {}
+                    old_cwd = old_session_row.get("cwd") or None
+                except Exception:
+                    old_cwd = None
                 agent._session_db.end_session(agent.session_id, "compression")
                 old_session_id = agent.session_id
                 agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
@@ -598,6 +606,7 @@ def compress_context(
                     model=agent.model,
                     model_config=agent._session_init_model_config,
                     parent_session_id=old_session_id,
+                    cwd=old_cwd,
                 )
                 agent._session_db_created = True
                 # Auto-number the title for the continuation session

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -46,6 +46,7 @@ import {
   setSessionsTotal,
   setTurnStartedAt,
   setYoloActive,
+  resolveWorkspaceCwdForNewSession,
   workspaceCwdForNewSession
 } from '@/store/session'
 import { broadcastSessionsChanged } from '@/store/session-sync'
@@ -214,7 +215,7 @@ function patchSessionWorkspace(sessionId: string, cwd: string | undefined) {
     return
   }
 
-  setSessions(prev => prev.map(session => (session.id === sessionId ? { ...session, cwd } : session)))
+  setSessions(prev => prev.map(session => (sessionMatchesStoredId(session, sessionId) ? { ...session, cwd } : session)))
 }
 
 function sessionMatchesStoredId(session: SessionInfo, storedSessionId: string): boolean {
@@ -448,7 +449,7 @@ export function useSessionActions({
         // a backend resolves its own launch profile to None (_profile_home).
         const newChatProfile = $newChatProfile.get() ?? normalizeProfileKey($activeGatewayProfile.get())
         await ensureGatewayProfile(newChatProfile)
-        const cwd = $currentCwd.get().trim() || workspaceCwdForNewSession()
+        const cwd = $currentCwd.get().trim() || (await resolveWorkspaceCwdForNewSession())
         // The composer's model/effort/fast is sticky UI state ($currentModel,
         // $currentProvider, $currentReasoningEffort, $currentFastMode). Ship it
         // with every session.create so the new chat opens on whatever the picker
@@ -894,7 +895,7 @@ export function useSessionActions({
 
         clearNotifications()
 
-        const cwd = $currentCwd.get().trim()
+        const cwd = $currentCwd.get().trim() || (await resolveWorkspaceCwdForNewSession())
 
         const branched = await requestGateway<SessionCreateResponse>('session.create', {
           cols: 96,

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
@@ -11,6 +11,7 @@ import {
   applyConfiguredDefaultProjectDir,
   getRecentlySettledSessionIds,
   mergeSessionPage,
+  resolveWorkspaceCwdForNewSession,
   sessionPinId,
   setCurrentCwd,
   setSessionAttention,
@@ -36,6 +37,32 @@ const session = (over: Partial<SessionInfo>): SessionInfo => ({
   tool_call_count: 0,
   ...over
 })
+
+function ensureLocalStorage(): void {
+  try {
+    if (window.localStorage) {
+      return
+    }
+  } catch {
+    // Fall through and install an in-memory implementation.
+  }
+
+  const store = new Map<string, string>()
+
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => store.clear(),
+      getItem: (key: string) => store.get(key) ?? null,
+      key: (index: number) => [...store.keys()][index] ?? null,
+      removeItem: (key: string) => store.delete(key),
+      setItem: (key: string, value: string) => store.set(key, value),
+      get length() {
+        return store.size
+      }
+    }
+  })
+}
 
 describe('setSessionAttention', () => {
   it('adds and removes a session id without duplicating it', () => {
@@ -184,6 +211,10 @@ describe('mergeSessionPage', () => {
 })
 
 describe('workspaceCwdForNewSession', () => {
+  beforeEach(() => {
+    ensureLocalStorage()
+  })
+
   afterEach(() => {
     applyConfiguredDefaultProjectDir(null)
     $connection.set(null)
@@ -220,6 +251,33 @@ describe('workspaceCwdForNewSession', () => {
 
     expect($currentCwd.get()).toBe('/live/session/path')
     expect(workspaceCwdForNewSession()).toBe('/home/user/configured')
+  })
+
+  it('syncs the configured desktop default before resolving a new local session cwd', async () => {
+    const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+    const previousBridge = desktopWindow.hermesDesktop
+    const getDefaultProjectDir = vi.fn().mockResolvedValue({ dir: '/Volumes/Kemal HD/My Drive/_Projects' })
+
+    desktopWindow.hermesDesktop = {
+      ...(previousBridge ?? {}),
+      settings: {
+        ...(previousBridge?.settings ?? {}),
+        getDefaultProjectDir
+      }
+    } as unknown as Window['hermesDesktop']
+    window.localStorage.setItem('hermes.desktop.workspace-cwd', '/home/user/sticky')
+    $currentCwd.set('')
+
+    try {
+      await expect(resolveWorkspaceCwdForNewSession()).resolves.toBe('/Volumes/Kemal HD/My Drive/_Projects')
+      expect(getDefaultProjectDir).toHaveBeenCalledTimes(1)
+    } finally {
+      if (previousBridge) {
+        desktopWindow.hermesDesktop = previousBridge
+      } else {
+        delete desktopWindow.hermesDesktop
+      }
+    }
   })
 
   it('keeps remote workspace memory separate from local and other remotes', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -321,6 +321,14 @@ export const workspaceCwdForNewSession = (): string => {
   return getConfiguredDefaultProjectDir() || getRememberedWorkspaceCwd() || $currentCwd.get().trim()
 }
 
+export const resolveWorkspaceCwdForNewSession = async (): Promise<string> => {
+  if ($connection.get()?.mode !== 'remote' && !getConfiguredDefaultProjectDir()) {
+    await syncConfiguredDefaultProjectDir().catch(() => '')
+  }
+
+  return workspaceCwdForNewSession()
+}
+
 export const setCurrentBranch = (next: Updater<string>) => updateAtom($currentBranch, next)
 export const setCurrentUsage = (next: Updater<UsageStats>) => updateAtom($currentUsage, next)
 export const setSessionStartedAt = (next: Updater<number | null>) => updateAtom($sessionStartedAt, next)

--- a/tests/agent/test_compression_logging_session_context.py
+++ b/tests/agent/test_compression_logging_session_context.py
@@ -78,3 +78,22 @@ def test_logging_session_context_follows_compression_rotation(tmp_path: Path) ->
         )
     finally:
         hermes_logging.clear_session_context()
+
+
+def test_compression_continuation_inherits_parent_cwd(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "PARENT_CWD_SESSION"
+    parent_cwd = str(tmp_path / "project")
+    Path(parent_cwd).mkdir()
+    db.create_session(parent_sid, source="cli", cwd=parent_cwd)
+
+    agent = _build_agent_with_db(db, parent_sid)
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+    agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    child_sid = getattr(agent, "session_id")
+    assert child_sid != parent_sid
+    child = db.get_session(child_sid)
+    assert child is not None
+    assert child["parent_session_id"] == parent_sid
+    assert child["cwd"] == parent_cwd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,6 +360,35 @@ def _hermetic_environment(tmp_path, monkeypatch):
     (fake_hermes_home / "skills").mkdir()
     monkeypatch.setenv("HERMES_HOME", str(fake_hermes_home))
 
+    # If hermes_state was imported during test collection, its module-level
+    # DEFAULT_DB_PATH was already frozen to the developer's real HERMES_HOME.
+    # Re-pin it after the per-test env redirect so bare SessionDB() / gateway
+    # _get_db() calls cannot touch ~/.hermes/state.db. Also clear the gateway's
+    # cached singleton DB between tests; otherwise one test can keep using the
+    # previous test's temp DB (or, before this guard, the real DB).
+    hermes_state_mod = sys.modules.get("hermes_state")
+    if hermes_state_mod is not None:
+        monkeypatch.setattr(
+            hermes_state_mod,
+            "DEFAULT_DB_PATH",
+            fake_hermes_home / "state.db",
+            raising=False,
+        )
+        try:
+            hermes_state_mod._set_last_init_error(None)
+        except Exception:
+            pass
+    gateway_server_mod = sys.modules.get("tui_gateway.server")
+    if gateway_server_mod is not None:
+        existing_db = getattr(gateway_server_mod, "_db", None)
+        if existing_db is not None:
+            try:
+                existing_db.close()
+            except Exception:
+                pass
+        monkeypatch.setattr(gateway_server_mod, "_db", None, raising=False)
+        monkeypatch.setattr(gateway_server_mod, "_db_error", None, raising=False)
+
     # 4. Deterministic locale / timezone / hashseed. CI runs in UTC with
     #    C.UTF-8 locale; local dev often doesn't. Pin everything.
     monkeypatch.setenv("TZ", "UTC")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -86,6 +86,151 @@ def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
         server._sessions.pop(sid, None)
 
 
+def test_fallback_session_info_uses_lazy_session_cwd(monkeypatch, tmp_path):
+    """Lazy/live resume payloads must not fall back to the gateway cwd.
+
+    A session can be live before its agent is fully built. During that window
+    _live_session_payload() uses _fallback_session_info(); if that reports the
+    process cwd ($HOME / launch dir) instead of session["cwd"], the desktop
+    patches a correct persisted row into the wrong workspace group.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    launcher = tmp_path / "launcher"
+    launcher.mkdir()
+    env_cwd = tmp_path / "homeish"
+    env_cwd.mkdir()
+
+    monkeypatch.chdir(launcher)
+    monkeypatch.setenv("TERMINAL_CWD", str(env_cwd))
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(
+        server,
+        "_git_branch_for_cwd",
+        lambda cwd: "project-branch" if cwd == str(project) else "wrong",
+    )
+
+    info = server._fallback_session_info(
+        {"session_key": "lazy-key", "cwd": str(project), "explicit_cwd": True}
+    )
+
+    assert info["cwd"] == str(project)
+    assert info["branch"] == "project-branch"
+
+
+def test_fallback_session_info_preserves_no_workspace_for_missing_cwd(monkeypatch, tmp_path):
+    """Legacy NULL-cwd live sessions should stay No workspace, not $HOME."""
+    launcher = tmp_path / "launcher"
+    launcher.mkdir()
+    env_cwd = tmp_path / "homeish"
+    env_cwd.mkdir()
+
+    monkeypatch.chdir(launcher)
+    monkeypatch.setenv("TERMINAL_CWD", str(env_cwd))
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+
+    def fail_branch_lookup(cwd):
+        raise AssertionError(f"branch lookup should not run for empty cwd: {cwd!r}")
+
+    monkeypatch.setattr(server, "_git_branch_for_cwd", fail_branch_lookup)
+
+    info = server._fallback_session_info({"session_key": "lazy-key"})
+
+    assert info["cwd"] == ""
+    assert info["branch"] == ""
+
+
+def test_session_live_item_includes_only_declared_cwd(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    session = {
+        "created_at": 10.0,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "session_key": "lazy-key",
+    }
+
+    assert server._session_live_item("sid", session)["cwd"] == ""
+
+    session["cwd"] = str(project)
+    session["explicit_cwd"] = True
+    assert server._session_live_item("sid", session)["cwd"] == str(project)
+
+
+def test_session_live_item_hydrates_declared_cwd_from_stored_row(monkeypatch, tmp_path):
+    """A live session missing explicit_cwd should self-heal from its DB row.
+
+    This is the exact Desktop symptom Kemal saw: the sidebar active-list first
+    grouped the live tip under "No workspace", then clicking the row read the
+    stored session and moved it back under kOS_Projects.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+
+    class DbContext:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def get_session(self, key):
+            assert key == "live-tip"
+            return {"cwd": str(project)}
+
+    registered = []
+    session = {
+        "created_at": 10.0,
+        "cwd": str(project),
+        "explicit_cwd": False,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "session_key": "live-tip",
+    }
+    monkeypatch.setattr(server, "_session_db", lambda _session: DbContext())
+    monkeypatch.setattr(server, "_register_session_cwd", lambda s: registered.append(s["cwd"]))
+
+    row = server._session_live_item("sid", session)
+
+    assert row["cwd"] == str(project)
+    assert session["explicit_cwd"] is True
+    assert registered == [str(project)]
+
+
+def test_session_declared_cwd_negative_caches_only_stored_null_rows(monkeypatch, tmp_path):
+    """Avoid hot-loop DB reads for true no-workspace rows, but not absent rows."""
+
+    class DbContext:
+        def __init__(self, row):
+            self.row = row
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def get_session(self, _key):
+            calls.append(_key)
+            return self.row
+
+    calls = []
+    stored_null = {"session_key": "stored-null", "cwd": str(tmp_path)}
+    monkeypatch.setattr(server, "_session_db", lambda _session: DbContext({"cwd": None}))
+
+    assert server._session_declared_cwd(stored_null) == ""
+    assert server._session_declared_cwd(stored_null) == ""
+    assert calls == ["stored-null"]
+
+    calls.clear()
+    absent = {"session_key": "absent-row", "cwd": str(tmp_path)}
+    monkeypatch.setattr(server, "_session_db", lambda _session: DbContext(None))
+
+    assert server._session_declared_cwd(absent) == ""
+    assert server._session_declared_cwd(absent) == ""
+    assert calls == ["absent-row", "absent-row"]
+
+
 def test_handoff_fail_marks_only_inflight_rows(monkeypatch):
     class DbContext:
         def __init__(self, db):
@@ -1999,12 +2144,16 @@ def test_session_create_does_not_persist_empty_row(monkeypatch):
 def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):
     """An explicitly chosen workspace is persisted as the session cwd."""
     created = []
+    updated_cwds = []
 
     class _FakeDB:
         def create_session(self, key, source=None, model=None, model_config=None, cwd=None):
             created.append(
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
+
+        def update_session_cwd(self, key, cwd):
+            updated_cwds.append({"key": key, "cwd": cwd})
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
@@ -2014,6 +2163,7 @@ def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):
     assert created == [
         {"key": "k1", "source": "tui", "model": "test-model", "model_config": None, "cwd": str(tmp_path)}
     ]
+    assert updated_cwds == [{"key": "k1", "cwd": str(tmp_path)}]
 
 
 def test_ensure_session_db_row_persists_session_source(monkeypatch):
@@ -3745,6 +3895,8 @@ def test_prompt_submit_sets_approval_session_key(monkeypatch):
     server._sessions["sid"] = _session(agent=_Agent())
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
 
@@ -3800,6 +3952,8 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
     server._sessions["sid"] = _session(agent=_Agent())
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setitem(sys.modules, "agent.context_references", fake_ctx)
@@ -5214,6 +5368,22 @@ def test_session_create_no_race_keeps_worker_alive(monkeypatch):
         server._sessions.update(_saved_sessions)
 
 
+def test_get_db_uses_per_test_hermes_home(monkeypatch):
+    """Bare gateway _get_db() must never open the developer's real state.db."""
+    monkeypatch.setattr(server, "_db", None)
+    monkeypatch.setattr(server, "_db_error", None)
+
+    db = server._get_db()
+    try:
+        assert db is not None
+        assert db.db_path == Path(os.environ["HERMES_HOME"]) / "state.db"
+        assert db.db_path != Path.home() / ".hermes" / "state.db"
+    finally:
+        if db is not None:
+            db.close()
+        server._db = None
+
+
 def test_get_db_degrades_cleanly_when_sessiondb_init_fails(monkeypatch):
     fake_mod = types.ModuleType("hermes_state")
 
@@ -5790,6 +5960,7 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
     rows = {row["id"]: row for row in session_rows}
     assert rows["sid-a"] == {
         "current": False,
+        "cwd": "",
         "id": "sid-a",
         "last_active": 20.0,
         "message_count": 1,
@@ -6236,10 +6407,12 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
         resp["result"]["messages"][0]
         == "Chromium-family browser isn't running with remote debugging — attempting to launch..."
     )
-    assert any(
-        "No supported Chromium-family browser executable was found" in line
-        for line in resp["result"]["messages"]
-    )
+    # The exact launch hint is platform/environment dependent: on a developer
+    # Mac with Chrome installed it includes an `open -a "Google Chrome" ...`
+    # command, while CI without a Chromium executable reports that no supported
+    # executable was found.  The contract this test cares about is that Hermes
+    # gives the user an actionable remote-debugging hint after the auto-launch
+    # attempt failed.
     assert any(
         "--remote-debugging-port=9222" in line for line in resp["result"]["messages"]
     )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1148,6 +1148,52 @@ def _session_cwd(session: dict | None) -> str:
     return _completion_cwd()
 
 
+def _session_declared_cwd(session: dict | None) -> str:
+    """Return only the cwd explicitly associated with this session.
+
+    UI/session metadata payloads must not fall back to the gateway launch cwd:
+    if a legacy row truly has no cwd, the desktop should keep it in the
+    synthetic "No workspace" bucket instead of grouping it under $HOME.
+
+    Some live sessions were created before this metadata split (or rotated by
+    compression while the desktop process was still running): their in-memory
+    dict may have a correct ``cwd`` but lack ``explicit_cwd``. Hydrate once from
+    the owning SessionDB row so the sidebar's live/active-list refresh does not
+    temporarily group the row under "No workspace" until the user clicks it.
+    """
+    if not session:
+        return ""
+    raw = str(session.get("cwd") or "").strip()
+    if raw and session.get("explicit_cwd"):
+        return raw
+    if session.get("_declared_cwd_checked"):
+        return ""
+
+    key = str(session.get("session_key") or "").strip()
+    if not key:
+        return ""
+    try:
+        with _session_db(session) as db:
+            row = db.get_session(key) if db is not None else None
+        stored = str((row or {}).get("cwd") or "").strip()
+        if stored:
+            session["cwd"] = stored
+            session["explicit_cwd"] = True
+            try:
+                _register_session_cwd(session)
+            except Exception:
+                pass
+            return stored
+        # Cache only a real stored NULL/empty-cwd row. If the row is absent, do
+        # not cache: first-turn lazy creation or compression rotation may still
+        # create a row with a cwd later in this live process.
+        if row is not None:
+            session["_declared_cwd_checked"] = True
+    except Exception:
+        logger.debug("failed to hydrate declared cwd from session row", exc_info=True)
+    return ""
+
+
 def _session_source(session: dict | None) -> str:
     if session:
         source = str(session.get("source") or "").strip()
@@ -1260,6 +1306,14 @@ def _ensure_session_db_row(session: dict) -> None:
             model_config=model_config or None,
             cwd=_session_cwd(session) if session.get("explicit_cwd") else None,
         )
+        # create_session is INSERT OR IGNORE. If another path (notably the
+        # AIAgent's own lazy _ensure_db_session, or a retry from an earlier
+        # transient failure) already inserted this row with cwd=NULL, repair the
+        # explicitly chosen workspace now. Without this, a later resume treats
+        # the row as workspace-less and can permanently backfill the configured
+        # default/launch cwd instead of the user's actual project.
+        if session.get("explicit_cwd"):
+            db.update_session_cwd(key, _session_cwd(session))
     except Exception:
         logger.debug("failed to persist desktop session row", exc_info=True)
     finally:
@@ -2607,7 +2661,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
             if candidate.get("agent") is agent:
                 session = candidate
                 break
-    cwd = _session_cwd(session)
+    cwd = _session_declared_cwd(session)
     cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
     personality = (session or {}).get("personality", cfg_personality)
     reasoning_config = getattr(agent, "reasoning_config", None)
@@ -2647,7 +2701,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "tools": {},
         "skills": {},
         "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
+        "branch": _git_branch_for_cwd(cwd) if cwd else "",
         "personality": str(personality or ""),
         "running": bool((session or {}).get("running")),
         "desktop_contract": DESKTOP_BACKEND_CONTRACT,
@@ -3756,6 +3810,7 @@ def _init_session(
     history: list,
     cols: int = 80,
     cwd: str | None = None,
+    explicit_cwd: bool = False,
     session_db=None,
 ):
     now = time.time()
@@ -3773,6 +3828,7 @@ def _init_session(
             "attached_images": [],
             "image_counter": 0,
             "cwd": cwd or _completion_cwd(),
+            "explicit_cwd": bool(explicit_cwd),
             "cols": cols,
             "slash_worker": None,
             "show_reasoning": _load_show_reasoning(),
@@ -3794,7 +3850,8 @@ def _init_session(
             with _sessions_lock:
                 if sid in _sessions:
                     _sessions[sid]["cwd"] = row["cwd"]
-        else:
+                    _sessions[sid]["explicit_cwd"] = True
+        elif explicit_cwd:
             try:
                 db.update_session_cwd(key, _sessions[sid]["cwd"])
             except Exception:
@@ -4480,9 +4537,8 @@ def _(rid, params: dict) -> dict:
             target = tip
             found = db.get_session(target) or found
 
-    profile_resume_cwd = str(found.get("cwd") or "").strip() or _profile_configured_cwd(
-        profile_home
-    )
+    stored_resume_cwd = str(found.get("cwd") or "").strip()
+    profile_resume_cwd = stored_resume_cwd or _profile_configured_cwd(profile_home)
 
     def _reuse_live_payload(sid: str, session: dict) -> dict:
         payload = _live_session_payload(
@@ -4558,7 +4614,7 @@ def _(rid, params: dict) -> dict:
                     "created_at": now,
                     "display_history_prefix": [],
                     "edit_snapshots": {},
-                    "explicit_cwd": False,
+                    "explicit_cwd": bool(stored_resume_cwd),
                     "history": history,
                     "history_lock": threading.Lock(),
                     "history_version": 0,
@@ -4580,6 +4636,7 @@ def _(rid, params: dict) -> dict:
                     "transport": current_transport() or _stdio_transport,
                 }
                 _register_session_cwd(_sessions[sid])
+        declared_cwd = _session_declared_cwd(_sessions.get(sid))
         return _ok(
             rid,
             {
@@ -4588,8 +4645,8 @@ def _(rid, params: dict) -> dict:
                 "message_count": len(messages),
                 "messages": messages,
                 "info": {
-                    "cwd": cwd,
-                    "branch": _git_branch_for_cwd(cwd),
+                    "cwd": declared_cwd,
+                    "branch": _git_branch_for_cwd(declared_cwd) if declared_cwd else "",
                     "model": _resolve_model(),
                     "tools": {},
                     "skills": {},
@@ -4806,6 +4863,7 @@ def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
     now = time.time()
     return {
         "current": sid == current_sid,
+        "cwd": _session_declared_cwd(session),
         "id": sid,
         "last_active": float(session.get("last_active") or session.get("created_at") or now),
         "message_count": len(history),
@@ -4831,8 +4889,15 @@ def _fallback_session_info(session: dict) -> dict:
     agent = session.get("agent")
     if agent is not None:
         return _session_info(agent)
+    cwd = _session_declared_cwd(session)
     return {
-        "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
+        # Preserve the session's own workspace even while the agent is still
+        # lazy / building. Falling back to the gateway process cwd here makes a
+        # live resume report the launch directory (often $HOME), and the desktop
+        # then patches an otherwise-correct persisted row into the synthetic
+        # "kemaldoganay" workspace.
+        "cwd": cwd,
+        "branch": _git_branch_for_cwd(cwd) if cwd else "",
         "lazy": True,
         "model": _resolve_model(),
         "skills": {},


### PR DESCRIPTION
## Summary

- Preserve the parent session `cwd` when context compression rotates into a continuation session.
- Separate declared workspace cwd from execution/runtime cwd in TUI gateway session metadata so legacy/no-workspace sessions do not get grouped under the gateway launch directory.
- Hydrate live Desktop sidebar payloads from the stored SessionDB row when a resumed/live session has a persisted cwd but no in-memory explicit marker.
- Sync the Desktop default project dir before resolving cwd for new local sessions and branches.
- Tighten regression coverage for workspace/no-workspace semantics, DB isolation, compression cwd inheritance, Desktop cwd resolution, and an environment-dependent browser hint test.

## Test plan

- `venv/bin/python -m pytest tests/test_tui_gateway_server.py tests/agent/test_compression_logging_session_context.py -q`
  - `289 passed, 8 warnings`
- `npm --prefix apps/desktop run typecheck`
  - passed
- `npm --prefix apps/desktop run test:ui -- src/store/session.test.ts`
  - `21 passed`

## Notes

This fixes a Desktop sidebar drift case where compression continuation sessions could reappear under `No workspace` after app restart even though their parent session belonged to a concrete workspace.
