### PR TITLE
fix(kanban): promote auto-decompose failures from DEBUG to rate-limited WARNING

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -75,6 +75,24 @@ def _release_singleton_lock(handle) -> None:
         pass
 
 
+def _rate_limited_log(
+    warn_state: list,  # [last_warn_epoch]; mutable for caller-side closure
+    now: int,
+    message: str,
+    *args: object,
+) -> None:
+    """Rate-limit warning logs: first occurrence at WARNING, then once every 5 minutes.
+
+    Used by the dispatcher watcher so persistent misconfigurations (e.g. no
+    auxiliary client configured) are visible without spamming every tick.
+    """
+    if now - warn_state[0] >= 300:
+        logger.warning(message, *args)
+        warn_state[0] = now
+    else:
+        logger.debug(message, *args)
+
+
 class GatewayKanbanWatchersMixin:
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
 
@@ -1063,18 +1081,12 @@ class GatewayKanbanWatchersMixin:
                             # First failure at WARNING, then once every 5 min
                             # so persistent misconfigurations are visible
                             # without spamming on transient hiccups.
-                            now = int(time.time())
-                            if now - _decompose_warn_state[0] >= 300:
-                                logger.warning(
-                                    "kanban auto-decompose [%s]: %s skipped: %s",
-                                    slug, tid, outcome.reason,
-                                )
-                                _decompose_warn_state[0] = now
-                            else:
-                                logger.debug(
-                                    "kanban auto-decompose [%s]: %s skipped: %s",
-                                    slug, tid, outcome.reason,
-                                )
+                            _rate_limited_log(
+                                _decompose_warn_state,
+                                int(time.time()),
+                                "kanban auto-decompose [%s]: %s skipped: %s",
+                                slug, tid, outcome.reason,
+                            )
                 finally:
                     if prev_env is None:
                         os.environ.pop("HERMES_KANBAN_BOARD", None)

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -807,6 +807,7 @@ class GatewayKanbanWatchersMixin:
         HEALTH_WINDOW = 6
         bad_ticks = 0
         last_warn_at = 0
+        _decompose_warn_state = [0]  # [last_warn_epoch]; mutable for closure
         # Avoid hot-looping corrupt-looking board DBs, but do not suppress
         # same-fingerprint retries forever: transient WAL/open races can
         # surface as "database disk image is malformed" for one tick.
@@ -1059,12 +1060,21 @@ class GatewayKanbanWatchersMixin:
                                     slug, tid,
                                 )
                         else:
-                            # Common no-op reasons (no aux client configured) shouldn't
-                            # spam logs every tick. Log at debug.
-                            logger.debug(
-                                "kanban auto-decompose [%s]: %s skipped: %s",
-                                slug, tid, outcome.reason,
-                            )
+                            # First failure at WARNING, then once every 5 min
+                            # so persistent misconfigurations are visible
+                            # without spamming on transient hiccups.
+                            now = int(time.time())
+                            if now - _decompose_warn_state[0] >= 300:
+                                logger.warning(
+                                    "kanban auto-decompose [%s]: %s skipped: %s",
+                                    slug, tid, outcome.reason,
+                                )
+                                _decompose_warn_state[0] = now
+                            else:
+                                logger.debug(
+                                    "kanban auto-decompose [%s]: %s skipped: %s",
+                                    slug, tid, outcome.reason,
+                                )
                 finally:
                     if prev_env is None:
                         os.environ.pop("HERMES_KANBAN_BOARD", None)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -702,6 +702,7 @@ AUTHOR_MAP = {
     "170458616+ghostmfr@users.noreply.github.com": "ghostmfr",
     "1848670+mewwts@users.noreply.github.com": "mewwts",
     "1930707+haru398801@users.noreply.github.com": "haru398801",
+    "DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",
     "rapabelias@gmail.com": "badgerbees",
     "xnb888@proton.me": "xnbi",
     "xiahu889889@proton.me": "xiahu88988",

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -119,20 +119,6 @@ def test_rate_limit_warning_after_five_minutes(caplog):
     assert "test skipped: no client" in warnings[0].message
 
 
-def test_rate_limit_exact_boundary(caplog):
-    """Exactly 300 seconds since last warn triggers WARNING."""
-    import logging
-
-    from gateway.kanban_watchers import _rate_limited_log
-
-    warn_state = [100]
-    caplog.set_level(logging.DEBUG, logger="gateway.run")
-    _rate_limited_log(warn_state, 400, "test skipped: %s", "no client")  # 300s >= 300
-    assert warn_state[0] == 400  # updated
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert len(warnings) == 1
-
-
 def test_rate_limit_just_under_boundary(caplog):
     """299 seconds since last warn stays at DEBUG."""
     import logging

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -67,3 +67,81 @@ def test_singleton_dispatcher_lock_is_exclusive(tmp_path):
     h3, st3 = _acquire_singleton_lock(lock)
     assert st3 == "held" and h3 is not None
     _release_singleton_lock(h3)
+
+
+# ── _rate_limited_log — controlled-time rate-limit tests ────────────────────
+
+
+def test_rate_limit_initial_warning(caplog):
+    """First failure logs at WARNING level."""
+    import logging
+
+    from gateway.kanban_watchers import _rate_limited_log
+
+    warn_state = [0]
+    caplog.set_level(logging.DEBUG, logger="gateway.run")
+    _rate_limited_log(warn_state, 500, "test skipped: %s", "no client")
+    assert warn_state[0] == 500  # timestamp updated
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "test skipped: no client" in warnings[0].message
+
+
+def test_rate_limit_debug_suppression(caplog):
+    """Subsequent failures within 5 minutes stay at DEBUG."""
+    import logging
+
+    from gateway.kanban_watchers import _rate_limited_log
+
+    warn_state = [100]  # last warn at t=100
+    caplog.set_level(logging.DEBUG, logger="gateway.run")
+    _rate_limited_log(warn_state, 200, "test skipped: %s", "no client")
+    assert warn_state[0] == 100  # timestamp NOT updated (still suppressed)
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 0
+    debugs = [r for r in caplog.records if r.levelno == logging.DEBUG]
+    assert len(debugs) == 1
+    assert "test skipped: no client" in debugs[0].message
+
+
+def test_rate_limit_warning_after_five_minutes(caplog):
+    """After 300 seconds, the WARNING boundary resets."""
+    import logging
+
+    from gateway.kanban_watchers import _rate_limited_log
+
+    warn_state = [100]  # last warn at t=100
+    caplog.set_level(logging.DEBUG, logger="gateway.run")
+    _rate_limited_log(warn_state, 400, "test skipped: %s", "no client")
+    assert warn_state[0] == 400  # timestamp updated
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "test skipped: no client" in warnings[0].message
+
+
+def test_rate_limit_exact_boundary(caplog):
+    """Exactly 300 seconds since last warn triggers WARNING."""
+    import logging
+
+    from gateway.kanban_watchers import _rate_limited_log
+
+    warn_state = [100]
+    caplog.set_level(logging.DEBUG, logger="gateway.run")
+    _rate_limited_log(warn_state, 400, "test skipped: %s", "no client")  # 300s >= 300
+    assert warn_state[0] == 400  # updated
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+
+
+def test_rate_limit_just_under_boundary(caplog):
+    """299 seconds since last warn stays at DEBUG."""
+    import logging
+
+    from gateway.kanban_watchers import _rate_limited_log
+
+    warn_state = [100]
+    caplog.set_level(logging.DEBUG, logger="gateway.run")
+    _rate_limited_log(warn_state, 399, "test skipped: %s", "no client")  # 299s < 300
+    assert warn_state[0] == 100  # NOT updated
+    debugs = [r for r in caplog.records if r.levelno == logging.DEBUG]
+    assert len(debugs) == 1


### PR DESCRIPTION
## Problem

Auto-decompose failures log at `DEBUG`, which is invisible at the gateway's default `INFO` log level. A persistent misconfiguration (e.g. `auxiliary.kanban_decomposer` not resolving) causes triage tasks to sit indefinitely with zero visibility into why.

**Fixes #49859**

## Fix

`gateway/kanban_watchers.py` — rate-limit the failure log: first occurrence at `WARNING`, then once every 5 minutes. Subsequent tick-level failures stay at `DEBUG`. Same pattern as the existing dispatcher stuck-check (lines 1119–1129).

```diff
- logger.debug(
-     "kanban auto-decompose [%s]: %s skipped: %s",
-     slug, tid, outcome.reason,
- )
+ now = int(time.time())
+ if now - _decompose_warn_state[0] >= 300:
+     logger.warning(
+         "kanban auto-decompose [%s]: %s skipped: %s",
+         slug, tid, outcome.reason,
+     )
+     _decompose_warn_state[0] = now
+ else:
+     logger.debug(
+         "kanban auto-decompose [%s]: %s skipped: %s",
+         slug, tid, outcome.reason,
+     )
```

Uses a mutable list (`_decompose_warn_state`) for the closure variable, consistent with the file's existing patterns.
