### PR TITLE
feat(worktree): enable git worktree isolation by default

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -158,12 +158,16 @@ model:
 # =============================================================================
 # Git Worktree Isolation
 # =============================================================================
-# When enabled, each CLI session creates an isolated git worktree so multiple
-# agents can work on the same repo concurrently without file collisions.
-# Equivalent to always passing --worktree / -w on the command line.
+# Worktree isolation is ON by default: each CLI/TUI session in a git repo
+# creates an isolated git worktree so multiple agents can work on the same
+# repo concurrently without file collisions.
 #
-# worktree: true    # Always create a worktree when in a git repo
-# worktree: false   # Default — only create when -w flag is passed
+# To opt out:
+#   - Pass --no-worktree on the command line (per-session)
+#   - Set worktree: false here (permanent)
+#
+# worktree: true    # Default — create a worktree when in a git repo
+# worktree: false   # Disable worktree isolation
 
 # =============================================================================
 # Terminal Tool Configuration

--- a/cli.py
+++ b/cli.py
@@ -495,6 +495,11 @@ def load_cli_config() -> Dict[str, Any]:
             # shown once per install then latched here.
             "seen": {},
         },
+        # Git worktree isolation is ON by default so multiple agents working
+        # on the same repo get independent working trees.  Set to false in
+        # config.yaml or pass --no-worktree to opt out.  Has no effect
+        # outside a git repository.
+        "worktree": True,
     }
     
     # Track whether the config file explicitly set terminal config.
@@ -14394,6 +14399,7 @@ def main(
     resume: str = None,
     worktree: bool = False,
     w: bool = False,
+    no_worktree: bool = False,
     checkpoints: bool = False,
     pass_session_id: bool = False,
     ignore_user_config: bool = False,
@@ -14420,6 +14426,7 @@ def main(
         resume: Resume a previous session by its ID (e.g., 20260225_143052_a1b2c3)
         worktree: Run in an isolated git worktree (for parallel agents). Alias: -w
         w: Shorthand for --worktree
+        no_worktree: Disable worktree isolation even if on by default. Alias: --no-w
     
     Examples:
         python cli.py                            # Start interactive mode
@@ -14459,8 +14466,12 @@ def main(
     if not list_tools and not list_toolsets:
         # ── Git worktree isolation (#652) ──
         # Create an isolated worktree so this agent instance doesn't collide
-        # with other agents working on the same repo.
-        use_worktree = worktree or w or CLI_CONFIG.get("worktree", False)
+        # with other agents working on the same repo.  On by default; opt out
+        # with --no-worktree or ``worktree: false`` in config.
+        explicit_worktree = worktree or w
+        use_worktree = (
+            explicit_worktree or CLI_CONFIG.get("worktree", True)
+        ) and not no_worktree
         wt_info = None
         if use_worktree:
             # Prune stale worktrees from crashed/killed sessions
@@ -14472,10 +14483,12 @@ def main(
                 _active_worktree = wt_info
                 os.environ["TERMINAL_CWD"] = wt_info["path"]
                 atexit.register(_cleanup_worktree, wt_info)
-            else:
-                # Worktree was explicitly requested but setup failed —
+            elif explicit_worktree:
+                # Explicitly requested via --worktree/-w but setup failed —
                 # don't silently run without isolation.
                 return
+            # else: default-on but not in a git repo / setup failed —
+            # continue without a worktree (no-op outside git repos)
     else:
         wt_info = None
     

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -165,6 +165,12 @@ def build_top_level_parser():
         default=False,
         help="Run in an isolated git worktree (for parallel agents)",
     )
+    parser.add_argument(
+        "--no-worktree",
+        action="store_true",
+        default=False,
+        help="Disable worktree isolation (overrides default-on behavior)",
+    )
     _inherited_flag(
         parser,
         "--accept-hooks",
@@ -320,6 +326,12 @@ def build_top_level_parser():
         action="store_true",
         default=argparse.SUPPRESS,
         help="Run in an isolated git worktree (for parallel agents on the same repo)",
+    )
+    chat_parser.add_argument(
+        "--no-worktree",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Disable worktree isolation (overrides default-on behavior)",
     )
     _inherited_flag(
         chat_parser,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1923,6 +1923,7 @@ def _launch_tui(
     query: Optional[str] = None,
     image: Optional[str] = None,
     worktree: bool = False,
+    no_worktree: bool = False,
     checkpoints: bool = False,
     pass_session_id: bool = False,
     max_turns: Optional[int] = None,
@@ -1952,7 +1953,16 @@ def _launch_tui(
     env.setdefault("NODE_ENV", "development" if tui_dev else "production")
 
     wt_info = None
-    if worktree:
+    # Resolve worktree decision: default-on via config, explicit-on via
+    # --worktree/-w, opt-out via --no-worktree or ``worktree: false`` in config.
+    _config_wt = True
+    try:
+        from cli import CLI_CONFIG
+        _config_wt = CLI_CONFIG.get("worktree", True)
+    except Exception:
+        pass
+    _want_worktree = (worktree or _config_wt) and not no_worktree
+    if _want_worktree:
         try:
             from cli import (
                 _cleanup_worktree,
@@ -1969,9 +1979,15 @@ def _launch_tui(
             print(f"✗ Failed to create TUI worktree: {exc}", file=sys.stderr)
             wt_info = None
         if not wt_info:
-            sys.exit(1)
-        env["HERMES_CWD"] = wt_info["path"]
-        env["TERMINAL_CWD"] = wt_info["path"]
+            if worktree:
+                # Explicitly requested via --worktree/-w but setup failed —
+                # don't silently run without isolation.
+                sys.exit(1)
+            # else: default-on but not in a git repo / setup failed —
+            # continue without a worktree
+        if wt_info:
+            env["HERMES_CWD"] = wt_info["path"]
+            env["TERMINAL_CWD"] = wt_info["path"]
 
     if model:
         env["HERMES_MODEL"] = model
@@ -2301,6 +2317,7 @@ def cmd_chat(args):
             query=getattr(args, "query", None),
             image=getattr(args, "image", None),
             worktree=getattr(args, "worktree", False),
+            no_worktree=getattr(args, "no_worktree", False),
             checkpoints=getattr(args, "checkpoints", False),
             pass_session_id=getattr(args, "pass_session_id", False),
             max_turns=getattr(args, "max_turns", None),
@@ -2322,6 +2339,7 @@ def cmd_chat(args):
         "image": getattr(args, "image", None),
         "resume": getattr(args, "resume", None),
         "worktree": getattr(args, "worktree", False),
+        "no_worktree": getattr(args, "no_worktree", False),
         "checkpoints": getattr(args, "checkpoints", False),
         "pass_session_id": getattr(args, "pass_session_id", False),
         "max_turns": getattr(args, "max_turns", None),
@@ -11316,6 +11334,7 @@ def _set_chat_arg_defaults(args) -> None:
         ("resume", None),
         ("continue_last", None),
         ("worktree", False),
+        ("no_worktree", False),
     ]:
         if not hasattr(args, attr):
             setattr(args, attr, default)
@@ -12615,6 +12634,7 @@ def main():
             ("toolsets", None),
             ("verbose", None),
             ("worktree", False),
+            ("no_worktree", False),
         ]:
             if not hasattr(args, attr):
                 setattr(args, attr, default)
@@ -12632,6 +12652,7 @@ def main():
             ("resume", None),
             ("continue_last", None),
             ("worktree", False),
+            ("no_worktree", False),
         ]:
             if not hasattr(args, attr):
                 setattr(args, attr, default)

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -188,7 +188,7 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
         lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
     )
 
-    cli_mod.main(query="hello", quiet=False, toolsets="terminal")
+    cli_mod.main(query="hello", quiet=False, toolsets="terminal", no_worktree=True)
 
     assert calls == [
         ("claim", "cli", False),
@@ -262,7 +262,7 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
     )
 
     with pytest.raises(SystemExit) as exc_info:
-        cli_mod.main(query="hello", quiet=True, toolsets="terminal")
+        cli_mod.main(query="hello", quiet=True, toolsets="terminal", no_worktree=True)
 
     assert exc_info.value.code == 1
     assert ("claim", "cli", True) in calls

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -799,39 +799,94 @@ class TestEdgeCases:
 
 
 class TestCLIFlagLogic:
-    """Test the flag/config OR logic from main()."""
+    """Test the flag/config OR logic from main().
+
+    Worktree isolation is ON by default (config default = True).  Opt out
+    with --no-worktree or ``worktree: false`` in config.
+    """
 
     def test_worktree_flag_triggers(self):
         """--worktree flag should trigger worktree creation."""
         worktree = True
         w = False
+        no_worktree = False
         config_worktree = False
-        use_worktree = worktree or w or config_worktree
+        explicit = worktree or w
+        use_worktree = (explicit or config_worktree) and not no_worktree
         assert use_worktree
 
     def test_w_flag_triggers(self):
         """-w flag should trigger worktree creation."""
         worktree = False
         w = True
+        no_worktree = False
         config_worktree = False
-        use_worktree = worktree or w or config_worktree
+        explicit = worktree or w
+        use_worktree = (explicit or config_worktree) and not no_worktree
         assert use_worktree
 
     def test_config_triggers(self):
         """worktree: true in config should trigger worktree creation."""
         worktree = False
         w = False
+        no_worktree = False
         config_worktree = True
-        use_worktree = worktree or w or config_worktree
+        explicit = worktree or w
+        use_worktree = (explicit or config_worktree) and not no_worktree
         assert use_worktree
 
-    def test_none_set_no_trigger(self):
-        """No flags and no config should not trigger."""
+    def test_default_on_when_no_flags(self):
+        """With no flags and no explicit config, worktree should be ON.
+
+        The config default is True, so the absence of the key still means on.
+        """
         worktree = False
         w = False
-        config_worktree = False
-        use_worktree = worktree or w or config_worktree
+        no_worktree = False
+        config_worktree = True  # CLI_CONFIG.get("worktree", True) → True
+        explicit = worktree or w
+        use_worktree = (explicit or config_worktree) and not no_worktree
+        assert use_worktree
+
+    def test_no_worktree_flag_opts_out(self):
+        """--no-worktree should disable worktree even when default is on."""
+        worktree = False
+        w = False
+        no_worktree = True
+        config_worktree = True  # default-on
+        explicit = worktree or w
+        use_worktree = (explicit or config_worktree) and not no_worktree
         assert not use_worktree
+
+    def test_no_worktree_flag_overrides_explicit_worktree(self):
+        """--no-worktree should win even if --worktree is also passed."""
+        worktree = True
+        w = False
+        no_worktree = True
+        config_worktree = True
+        explicit = worktree or w
+        use_worktree = (explicit or config_worktree) and not no_worktree
+        assert not use_worktree
+
+    def test_config_false_opts_out(self):
+        """worktree: false in config should disable worktree by default."""
+        worktree = False
+        w = False
+        no_worktree = False
+        config_worktree = False  # explicit opt-out in config
+        explicit = worktree or w
+        use_worktree = (explicit or config_worktree) and not no_worktree
+        assert not use_worktree
+
+    def test_worktree_flag_overrides_config_false(self):
+        """--worktree flag should override worktree: false in config."""
+        worktree = True
+        w = False
+        no_worktree = False
+        config_worktree = False  # opt-out in config
+        explicit = worktree or w
+        use_worktree = (explicit or config_worktree) and not no_worktree
+        assert use_worktree
 
 
 class TestTerminalCWDIntegration:
@@ -1011,3 +1066,40 @@ class TestSystemPromptInjection:
         assert info["repo_root"] in wt_note
         assert "isolated git worktree" in wt_note
         assert "commit and push" in wt_note
+
+
+class TestConfigDefault:
+    """Verify the config-level default for worktree isolation is True.
+
+    This is an E2E test against the real config loader, not a logic replay.
+    """
+
+    def test_config_defaults_to_true(self):
+        """CLI_CONFIG should have worktree=True by default (no user config).
+
+        The test conftest redirects HERMES_HOME to a temp dir with no
+        config.yaml, so load_cli_config() falls back to built-in defaults.
+        """
+        from cli import CLI_CONFIG
+
+        assert CLI_CONFIG.get("worktree") is True
+
+    def test_config_false_overrides_default(self, tmp_path, monkeypatch):
+        """worktree: false in config.yaml should override the default."""
+        import importlib
+
+        # Create a minimal HERMES_HOME with a config that opts out
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("worktree: false\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_IGNORE_USER_CONFIG", "0")
+
+        # Reload cli to pick up the new config
+        import cli
+        importlib.reload(cli)
+        assert cli.CLI_CONFIG.get("worktree") is False
+
+        # Restore the module so other tests aren't affected
+        importlib.reload(cli)


### PR DESCRIPTION
## Summary

Git worktree isolation is now **ON by default** for CLI and TUI sessions started inside a git repository. This lets multiple agents work on the same repo concurrently without file collisions — the original use case for `--worktree`.

## Motivation

Users running multiple agents on the same codebase (e.g. via tmux spawning) need isolation by default to avoid file conflicts. The current opt-in behavior (`-w` flag or `worktree: true` in config) is easy to forget, leading to agents stepping on each other's changes. Making worktrees default-on matches user expectations when opening a git project directory.

## Changes

- **`cli.py`**: Added `"worktree": True` to `load_cli_config()` defaults. Added `no_worktree` param to `main()`. Updated gate logic: `(explicit_worktree or CLI_CONFIG.get("worktree", True)) and not no_worktree`. When default-on but not in a git repo, session continues silently (no hard exit) — only explicit `--worktree/-w` failures still exit.
- **`hermes_cli/_parser.py`**: Added `--no-worktree` flag to both the top-level parser and the `chat` subparser.
- **`hermes_cli/main.py`**: Wired `no_worktree` through `_launch_tui()`, the TUI call site, CLI kwargs dict, and all three `_set_chat_arg_defaults` blocks. TUI path now also checks `CLI_CONFIG` for the worktree key (previously only checked the flag).
- **`cli-config.yaml.example`**: Updated documented default and opt-out instructions.
- **`tests/cli/test_worktree.py`**: Updated `TestCLIFlagLogic` (8 tests covering default-on, opt-out via flag, opt-out via config, flag overrides config). Added `TestConfigDefault` E2E tests verifying `CLI_CONFIG.get("worktree")` is `True` by default and that `worktree: false` in config.yaml overrides it.

## Opt-out paths

- `--no-worktree` CLI flag (per-session)
- `worktree: false` in `config.yaml` (permanent)

## Precedence rules

| `--worktree` / `-w` | `--no-worktree` | config `worktree` | Result |
|---|---|---|---|
| — | — | (absent, default True) | **Worktree ON** |
| — | — | `false` | Off |
| — | yes | (absent, default True) | Off |
| yes | — | `false` | **Worktree ON** (flag overrides config) |
| yes | yes | (any) | Off (no-worktree wins) |

## Behavior outside git repos

When worktree is default-on but `_setup_worktree()` fails (not in a git repo), the session continues normally — no `sys.exit`. This is a no-op outside git repos. Only an explicit `--worktree/-w` that fails triggers a hard exit, preserving existing behavior.

## Test results

All 47 tests in `tests/cli/test_worktree.py` pass, plus 46 tests in `tests/hermes_cli/test_tui_resume_flow.py`.