### PR TITLE
fix(supermemory): fall back to content/chunk/text fields in search and profile results

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -316,7 +316,7 @@ class _SupermemoryClient:
         for item in (getattr(response, "results", None) or []):
             results.append({
                 "id": getattr(item, "id", ""),
-                "memory": getattr(item, "memory", "") or "",
+                "memory": getattr(item, "memory", "") or getattr(item, "content", "") or getattr(item, "chunk", "") or getattr(item, "text", "") or "",
                 "similarity": getattr(item, "similarity", None),
                 "updated_at": getattr(item, "updated_at", None) or getattr(item, "updatedAt", None),
                 "metadata": getattr(item, "metadata", None),
@@ -342,7 +342,7 @@ class _SupermemoryClient:
                     search_results.append(item)
                 else:
                     search_results.append({
-                        "memory": getattr(item, "memory", ""),
+                        "memory": getattr(item, "memory", "") or getattr(item, "content", "") or getattr(item, "chunk", "") or getattr(item, "text", "") or "",
                         "updated_at": getattr(item, "updated_at", None) or getattr(item, "updatedAt", None),
                         "similarity": getattr(item, "similarity", None),
                     })

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -457,3 +457,101 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+class _FakeSDKItem:
+    """Simulate a supermemory SDK response item with arbitrary attributes."""
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class _FakeSearchResponse:
+    def __init__(self, items):
+        self.results = items
+
+
+class _FakeProfileResponse:
+    def __init__(self, search_items, static=None, dynamic=None):
+        self.profile = type("P", (), {"static": static or [], "dynamic": dynamic or []})()
+        self.search_results = type("S", (), {"results": search_items})()
+
+
+class _FakeSDKClient:
+    """Minimal mock of the Supermemory SDK client."""
+    def __init__(self):
+        self._search_items = []
+        self._profile_items = []
+        self.search = self
+        self.profile = self
+
+    def memories(self, **kwargs):
+        return _FakeSearchResponse(self._search_items)
+
+    def __call__(self, **kwargs):
+        return _FakeProfileResponse(self._profile_items)
+
+
+def test_search_memories_fallback_to_content_field(monkeypatch, tmp_path):
+    """search_memories should fall back to 'content' when 'memory' is empty."""
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "test-key")
+    from plugins.memory.supermemory import _SupermemoryClient
+
+    client = _SupermemoryClient.__new__(_SupermemoryClient)
+    client._api_key = "test-key"
+    client._container_tag = "test"
+    client._search_mode = "hybrid"
+    client._timeout = 10.0
+    sdk = _FakeSDKClient()
+    sdk._search_items = [
+        _FakeSDKItem(id="1", content="Hello from content", memory="", similarity=0.9),
+        _FakeSDKItem(id="2", content="", memory="Hello from memory", similarity=0.8),
+        _FakeSDKItem(id="3", chunk="Hello from chunk", memory="", similarity=0.7),
+    ]
+    client._client = sdk
+
+    results = client.search_memories("test query")
+    assert results[0]["memory"] == "Hello from content"
+    assert results[1]["memory"] == "Hello from memory"
+    assert results[2]["memory"] == "Hello from chunk"
+
+
+def test_search_memories_fallback_to_text_field(monkeypatch, tmp_path):
+    """search_memories should fall back to 'text' when other fields are empty."""
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "test-key")
+    from plugins.memory.supermemory import _SupermemoryClient
+
+    client = _SupermemoryClient.__new__(_SupermemoryClient)
+    client._api_key = "test-key"
+    client._container_tag = "test"
+    client._search_mode = "hybrid"
+    client._timeout = 10.0
+    sdk = _FakeSDKClient()
+    sdk._search_items = [
+        _FakeSDKItem(id="1", text="Hello from text", memory="", content="", chunk=""),
+    ]
+    client._client = sdk
+
+    results = client.search_memories("test query")
+    assert results[0]["memory"] == "Hello from text"
+
+
+def test_get_profile_search_fallback_to_content_field(monkeypatch, tmp_path):
+    """get_profile search results should fall back to 'content' when 'memory' is empty."""
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "test-key")
+    from plugins.memory.supermemory import _SupermemoryClient
+
+    client = _SupermemoryClient.__new__(_SupermemoryClient)
+    client._api_key = "test-key"
+    client._container_tag = "test"
+    client._search_mode = "hybrid"
+    client._timeout = 10.0
+    sdk = _FakeSDKClient()
+    sdk._profile_items = [
+        _FakeSDKItem(id="1", content="Profile content", memory="", similarity=0.85),
+    ]
+    client._client = sdk
+
+    result = client.get_profile(query="test")
+    assert len(result["search_results"]) == 1
+    assert result["search_results"][0]["memory"] == "Profile content"


### PR DESCRIPTION
## What does this PR do?

Adds fallback to `content`, `chunk`, and `text` attributes when the Supermemory SDK returns search results with text in a field other than `memory`. This fixes empty memory text on self-hosted instances and raw-document cloud hits where the SDK uses alternative field names.

## Related Issue

Fixes #49849

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/supermemory/__init__.py`: Add `or`-chain fallback to `content`/`chunk`/`text` fields in `search_memories()` (line 319) and `get_profile()` (line 345) when `memory` attribute is empty
- `tests/plugins/memory/test_supermemory_provider.py`: Add 3 regression tests covering `content`, `text`, and `chunk` fallback paths

## How to Test

1. Configure Hermes with supermemory as the memory provider
2. Store a memory via `supermemory_store`
3. Call `supermemory_search` — results from self-hosted instances or raw-document cloud hits now correctly return the text instead of empty strings
4. Run `pytest tests/plugins/memory/test_supermemory_provider.py -q` — all 34 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/memory/supermemory/__init__.py` — `_SupermemoryClient.search_memories`, `_SupermemoryClient.get_profile`
- Blast radius: LOW — data-only change, no control flow modification
- Related patterns: `getattr` fallback chain already used for `updated_at`/`updatedAt` in same file
