### PR TITLE
feat(teams): hydrate recent context for mentions

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -28,7 +28,7 @@ import json
 import logging
 import os
 from typing import Any, Dict, Optional
-from urllib.parse import quote
+from urllib.parse import quote, quote_plus
 
 # httpx is imported lazily — only the ``_write_summary_via_incoming_webhook``
 # code path actually constructs an ``AsyncClient``. Top-level import here
@@ -692,7 +692,7 @@ class TeamsAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = 28000  # Teams text message limit (~28 KB)
 
-    def __init__(self, config: PlatformConfig):
+    def __init__(self, config: PlatformConfig, *, graph_client: Any | None = None):
         super().__init__(config, Platform("teams"))
         extra = config.extra or {}
         self._client_id = extra.get("client_id") or os.getenv("TEAMS_CLIENT_ID", "")
@@ -707,6 +707,29 @@ class TeamsAdapter(BasePlatformAdapter):
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
         self._conv_refs: Dict[str, Any] = {}
+        self._graph_client = graph_client
+        self._context_message_limit = max(
+            0,
+            min(
+                50,
+                _coerce_port(
+                    extra.get("context_message_limit")
+                    or os.getenv("TEAMS_CONTEXT_MESSAGE_LIMIT", "10"),
+                    default=10,
+                ),
+            ),
+        )
+        self._context_fetch_limit = max(
+            self._context_message_limit,
+            min(
+                50,
+                _coerce_port(
+                    extra.get("context_fetch_limit")
+                    or os.getenv("TEAMS_CONTEXT_FETCH_LIMIT", "50"),
+                    default=50,
+                ),
+            ),
+        )
 
     async def connect(self) -> bool:
         # Lazy-install the Teams SDK on demand (parity with Slack/Discord/etc.),
@@ -966,6 +989,12 @@ class TeamsAdapter(BasePlatformAdapter):
         else:
             msg_type = MessageType.TEXT
 
+        channel_context = await self._build_recent_channel_context(
+            activity,
+            chat_type=chat_type,
+            trigger_message_id=msg_id,
+        )
+
         event = MessageEvent(
             text=text,
             source=source,
@@ -973,8 +1002,125 @@ class TeamsAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
             message_id=msg_id,
+            channel_context=channel_context,
         )
         await self.handle_message(event)
+
+    def _get_graph_client(self) -> Any | None:
+        if self._graph_client is not None:
+            return self._graph_client
+        try:
+            from tools.microsoft_graph_client import MicrosoftGraphClient
+
+            self._graph_client = MicrosoftGraphClient.from_env()
+        except Exception as exc:
+            logger.debug("[teams] recent context disabled: Graph client unavailable: %s", exc)
+            self._graph_client = None
+        return self._graph_client
+
+    async def _build_recent_channel_context(
+        self,
+        activity: Any,
+        *,
+        chat_type: str,
+        trigger_message_id: str | None,
+    ) -> str | None:
+        if chat_type not in {"group", "channel"} or self._context_message_limit <= 0:
+            return None
+        graph_client = self._get_graph_client()
+        if graph_client is None:
+            return None
+
+        path = self._graph_history_path(activity, chat_type)
+        if not path:
+            return None
+        try:
+            payload = await graph_client.get_json(
+                path,
+                params={"$top": self._context_fetch_limit},
+            )
+        except Exception as exc:
+            logger.warning("[teams] Failed to fetch recent context from Graph: %s", exc)
+            return None
+
+        raw_messages = payload.get("value") if isinstance(payload, dict) else None
+        if not isinstance(raw_messages, list):
+            return None
+
+        lines: list[str] = []
+        for raw in reversed(raw_messages):
+            if not isinstance(raw, dict):
+                continue
+            if trigger_message_id and str(raw.get("id") or "") == str(trigger_message_id):
+                continue
+            line = self._format_graph_history_message(raw)
+            if line:
+                lines.append(line)
+
+        if not lines:
+            return None
+        selected = lines[-self._context_message_limit :]
+        return (
+            "[Recent Teams context — previous messages from this chat/channel, "
+            "use this to infer references before asking for clarification]\n"
+            + "\n".join(selected)
+        )
+
+    def _graph_history_path(self, activity: Any, chat_type: str) -> str | None:
+        if chat_type == "group":
+            conv_id = getattr(getattr(activity, "conversation", None), "id", "")
+            return f"/chats/{quote_plus(str(conv_id))}/messages" if conv_id else None
+        if chat_type != "channel":
+            return None
+        channel_data = getattr(activity, "channel_data", None) or {}
+        if not isinstance(channel_data, dict):
+            return None
+        team_info = channel_data.get("team")
+        channel_info = channel_data.get("channel")
+        team_id = team_info.get("id") if isinstance(team_info, dict) else None
+        channel_id = channel_info.get("id") if isinstance(channel_info, dict) else None
+        if not team_id or not channel_id:
+            return None
+        return f"/teams/{quote(str(team_id), safe='')}/channels/{quote(str(channel_id), safe='')}/messages"
+
+    def _format_graph_history_message(self, raw: dict[str, Any]) -> str | None:
+        raw_body = raw.get("body")
+        body: dict[str, Any] = raw_body if isinstance(raw_body, dict) else {}
+        content = str(body.get("content") or "")
+        text = self._teams_html_to_text(content)
+        raw_attachments = raw.get("attachments")
+        attachments: list[Any] = raw_attachments if isinstance(raw_attachments, list) else []
+        attachment_names = [
+            str(att.get("name") or att.get("contentUrl") or "").strip()
+            for att in attachments
+            if isinstance(att, dict) and (att.get("name") or att.get("contentUrl"))
+        ]
+        if not text and not attachment_names:
+            return None
+        sender = "Unknown"
+        raw_from = raw.get("from")
+        from_obj: dict[str, Any] = raw_from if isinstance(raw_from, dict) else {}
+        for key in ("user", "application"):
+            value = from_obj.get(key)
+            if isinstance(value, dict) and value.get("displayName"):
+                sender = str(value["displayName"])
+                break
+        parts = [f"{sender}: {text}" if text else f"{sender}: [attachment]"]
+        if attachment_names:
+            parts.append("Attachments: " + ", ".join(attachment_names))
+        return " | ".join(parts)
+
+    def _teams_html_to_text(self, value: str) -> str:
+        if not value:
+            return ""
+        import re
+
+        value = re.sub(r"<at>[^<]*</at>\s*", "", value)
+        value = re.sub(r"<br\s*/?>", "\n", value, flags=re.IGNORECASE)
+        value = re.sub(r"</p>\s*<p[^>]*>", "\n", value, flags=re.IGNORECASE)
+        value = re.sub(r"<[^>]+>", "", value)
+        value = html.unescape(value)
+        return " ".join(value.split())
 
     async def _send_card(self, chat_id: str, card: "AdaptiveCard") -> "Any":
         """Send an AdaptiveCard, using a stored ConversationReference when available."""

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -733,6 +733,91 @@ class TestTeamsMessageHandling:
         assert event.text == "what is the weather?"
 
     @pytest.mark.anyio
+    async def test_group_mention_injects_recent_chat_context(self):
+        graph_client = SimpleNamespace(get_json=AsyncMock(return_value={
+            "value": [
+                {
+                    "id": "activity-001",
+                    "from": {"user": {"displayName": "Alex Rivera"}},
+                    "body": {"content": "<at>Hermes</at> could fan out PR review?"},
+                },
+                {
+                    "id": "msg-pr-url",
+                    "from": {"user": {"displayName": "Blake Lee"}},
+                    "body": {"content": "Please review https://github.com/example-org/example-repo/pull/123"},
+                },
+                {
+                    "id": "msg-waiting",
+                    "from": {"user": {"displayName": "Casey Morgan"}},
+                    "body": {"content": "I'm waiting for client's response"},
+                },
+            ]
+        }))
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ), graph_client=graph_client)
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(
+            text="<at>Hermes</at> could fan out agent for PR review and share feedback?",
+            conversation_id="19:23e1298338f141aaafb9844331a7f942@thread.v2",
+            conversation_type="groupChat",
+            activity_id="activity-001",
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.text == "could fan out agent for PR review and share feedback?"
+        assert event.channel_context is not None
+        assert "Recent Teams context" in event.channel_context
+        assert "Blake Lee: Please review https://github.com/example-org/example-repo/pull/123" in event.channel_context
+        assert "Casey Morgan: I'm waiting for client's response" in event.channel_context
+        assert "could fan out PR review" not in event.channel_context
+        graph_client.get_json.assert_awaited_once_with(
+            "/chats/19%3A23e1298338f141aaafb9844331a7f942%40thread.v2/messages",
+            params={"$top": 50},
+        )
+
+    @pytest.mark.anyio
+    async def test_channel_mention_uses_team_and_channel_ids_for_recent_context(self):
+        graph_client = SimpleNamespace(get_json=AsyncMock(return_value={
+            "value": [
+                {
+                    "id": "msg-context",
+                    "from": {"user": {"displayName": "Jordan Patel"}},
+                    "body": {"content": "Shared the compliance report.docx for review"},
+                    "attachments": [{"name": "compliance report.docx"}],
+                }
+            ]
+        }))
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ), graph_client=graph_client)
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(
+            text="<at>Hermes</at> check what Jordan shared above",
+            conversation_type="channel",
+        )
+        activity.channel_data = {
+            "team": {"id": "team-id"},
+            "channel": {"id": "channel-id"},
+        }
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert "Jordan Patel: Shared the compliance report.docx for review" in event.channel_context
+        assert "Attachments: compliance report.docx" in event.channel_context
+        graph_client.get_json.assert_awaited_once_with(
+            "/teams/team-id/channels/channel-id/messages",
+            params={"$top": 50},
+        )
+
+    @pytest.mark.anyio
     async def test_deduplication(self):
         adapter = TeamsAdapter(_make_config(
             client_id="bot-id", client_secret="secret", tenant_id="tenant",


### PR DESCRIPTION
## Summary
- Add recent Microsoft Teams context hydration for group/channel mentions.
- Fetch bounded recent Teams history via Microsoft Graph before handing the message to the agent.
- Inject sender-labelled recent context into `MessageEvent.channel_context` so the existing gateway path prepends it before the new message.

## Why
Teams bots in group/channel surfaces often receive short mention prompts like “check this”, “review above”, or “follow up”. Human teammates infer nearby context; Hermes should do the same when Graph permissions are available, instead of immediately asking the user to repeat URLs/files.

## Safety / scope
- Only runs for Teams group/channel messages.
- Does not run for DMs.
- Bounded defaults: fetch up to 50 messages, inject the last 10 previous messages.
- Skips the triggering message.
- Includes sender names and attachment names.
- Gracefully no-ops if Graph credentials are unavailable or Graph fetch fails.
- No tenant-, user-, or organization-specific values are hardcoded.

## Tests
- Added group chat context hydration coverage.
- Added channel team/channel path + attachment-name context coverage.
- Verified locally:
  - `uv run python -m pytest tests/gateway/test_teams.py -q -o 'addopts='`
  - Result: `59 passed`
