### PR TITLE
feat: add 4 new platform skills (v2ex, bilibili, reddit, xueqiu) + augment xurl and youtube-content

### DIFF
--- a/skills/media/youtube-content/SKILL.md
+++ b/skills/media/youtube-content/SKILL.md
@@ -1,7 +1,14 @@
 ---
 name: youtube-content
-description: "YouTube transcripts to summaries, threads, blogs."
+description: "Use when the user shares a YouTube URL or asks to summarize a video — transcript extraction, video search, comment extraction, and audio transcription for unsubtitled videos. Output formats: summaries, chapters, threads, blog posts."
+version: 1.1.0
+author: Hermes Agent
+license: MIT
 platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [youtube, video, transcript, subtitles, search]
+    related_skills: [bilibili]
 ---
 
 # YouTube Content Tool
@@ -70,7 +77,112 @@ After fetching the transcript, format it based on what the user asks for:
 
 ## Error Handling
 
-- **Transcript disabled**: tell the user; suggest they check if subtitles are available on the video page.
+- **Transcript disabled**: tell the user; suggest they check if subtitles are
+  available on the video page. Also try the yt-dlp fallback (see Extended
+  Capabilities below).
 - **Private/unavailable video**: relay the error and ask the user to verify the URL.
-- **No matching language**: retry without `--language` to fetch any available transcript, then note the actual language to the user.
+- **No matching language**: retry without `--language` to fetch any available
+  transcript, then note the actual language to the user.
 - **Dependency missing**: run `uv pip install youtube-transcript-api` and retry.
+
+## Extended Capabilities (via yt-dlp)
+
+The `youtube-transcript-api` helper above handles simple transcript fetching.
+For video search, comment extraction, metadata, and transcription of
+unsubtitled videos, use yt-dlp as a more powerful backend.
+
+### Setup
+
+```bash
+pip install yt-dlp
+# yt-dlp needs a JS runtime for some features.
+# deno is preferred (works out of box), or node.js with config.
+```
+
+### Video Search
+
+```bash
+# Search YouTube and get video metadata
+yt-dlp --dump-json "ytsearch5:query"
+
+# Just titles and URLs
+yt-dlp --print "%(title)s | %(webpage_url)s" "ytsearch5:query"
+```
+
+### Video Metadata
+
+```bash
+# Full metadata dump (title, duration, uploader, views, likes, etc.)
+yt-dlp --dump-json "URL"
+```
+
+### Comment Extraction
+
+```bash
+# Extract comments (best-effort, uses webpage scraping)
+yt-dlp --write-comments --skip-download --write-info-json \
+  --extractor-args "youtube:max_comments=20" \
+  -o "/tmp/%(id)s" "URL"
+# Comments are in the .info.json file under the "comments" field
+```
+
+> Note: `--write-comments` uses webpage scraping, not the official Data API.
+> Some comments may be missing.
+
+### yt-dlp Transcript Extraction (fallback)
+
+When `youtube-transcript-api` fails, use yt-dlp:
+
+```bash
+# Auto-generated subtitles
+yt-dlp --write-auto-sub --sub-lang "en" --skip-download -o "/tmp/%(id)s" "URL"
+# Manually uploaded
+yt-dlp --write-sub --sub-lang "en" --skip-download -o "/tmp/%(id)s" "URL"
+# Read the .vtt file
+cat /tmp/VIDEO_ID.*.vtt
+```
+
+### Audio Transcription (for unsubtitled videos)
+
+When a video has no subtitles at all:
+
+```bash
+# Download audio
+yt-dlp -f "bestaudio" --extract-audio --audio-format mp3 \
+  -o "/tmp/%(id)s.%(ext)s" "URL"
+
+# Transcribe with Groq Whisper (free key from console.groq.com)
+curl -X POST "https://api.groq.com/openai/v1/audio/transcriptions" \
+  -H "Authorization: Bearer *** \  -F "file=@/tmp/VIDEO_ID.mp3" \
+  -F "model=whisper-large-v3-turbo" \
+  -F "response_format=verbose_json"
+
+# For local transcription (privacy-preserving), use whisper.cpp:
+ffmpeg -i /tmp/VIDEO_ID.mp3 -ar 16000 -ac 1 /tmp/VIDEO_ID.wav
+whisper-cli -m /path/to/ggml-model.bin -f /tmp/VIDEO_ID.wav
+```
+
+## Backend Selection
+
+| Task | Primary | Fallback |
+|------|---------|----------|
+| Transcript | youtube-transcript-api (Python) | yt-dlp --write-auto-sub |
+| Search | yt-dlp ytsearch | web_search site:youtube.com |
+| Comments | yt-dlp --write-comments | Not available otherwise |
+| Metadata | yt-dlp --dump-json | web_extract on watch page |
+| Unsubtitled audio | yt-dlp audio + Whisper | — |
+
+## Common Pitfalls
+
+1. **Transcripts disabled.** Some videos have no subtitles at all. Use the
+   audio transcription fallback.
+2. **youtube-transcript-api ratelimit.** Frequent requests may trigger IP
+   blocks. Space requests or use yt-dlp as alternative.
+3. **yt-dlp JS runtime.** yt-dlp needs deno or node.js for some features.
+   Install deno for simpler setup.
+
+## Verification Checklist
+
+- [ ] `uv pip install youtube-transcript-api` succeeds
+- [ ] Helper script fetches a transcript from a known public video
+- [ ] yt-dlp is installed and `yt-dlp --version` works

--- a/skills/research/xueqiu/SKILL.md
+++ b/skills/research/xueqiu/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: xueqiu
+description: "Use when the user wants Chinese stock market data — real-time quotes, stock search, hot stock rankings, or trending community posts from Xueqiu (雪球). Requires login cookie (xq_a_token) extracted from Chrome after logging into xueqiu.com."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [xueqiu, snowball, stocks, finance, china, market-data, quotes]
+    related_skills: [polymarket]
+prerequisites:
+  commands: [curl]
+---
+
+# Xueqiu (雪球) Skill
+
+Xueqiu (Snowball Finance) is a major Chinese investment community and market
+data platform. Its API provides real-time quotes, stock search, hot stock
+rankings, and community posts — covering A-shares (沪/深), HK stocks, and US
+stocks.
+
+**Login is mandatory for all API endpoints.** The xq_a_token cookie from
+logging into xueqiu.com is required.
+
+## When to Use
+
+- User asks for a Chinese stock quote (茅台, 腾讯, AAPL, 00700, etc.)
+- User wants to search for Chinese stocks by name or ticker
+- User wants hot stock rankings or market sentiment
+- User asks about Chinese investment community discussions
+
+Don't use for: US market data (use other financial APIs), or any write
+operations (posting, commenting).
+
+## One-Time Setup
+
+All API endpoints require the `xq_a_token` login cookie. Extract it from Chrome:
+
+```bash
+pip install browser-cookie3
+python3 -c "
+import browser_cookie3
+for c in browser_cookie3.chrome(domain_name='.xueqiu.com'):
+    if c.name == 'xq_a_token':
+        print(c.value)
+"
+```
+
+If browser-cookie3 can't access Chrome (keychain locked, etc.), use
+Cookie-Editor (Chrome extension) to manually export the `xq_a_token` value.
+
+Set up the session:
+
+```bash
+export XQ_TOKEN="your_token_here"
+UA="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+curl -s -c /tmp/xq_cookies.txt -o /dev/null -A "$UA" "https://xueqiu.com/"
+```
+
+## Quick Reference
+
+All commands need both session cookie and auth token:
+
+```bash
+# Stock quote
+curl -s -b /tmp/xq_cookies.txt -A "$UA" -e "https://xueqiu.com/" \
+  -H "Cookie: xq_a_token=$XQ_TOKEN" \
+  "https://stock.xueqiu.com/v5/stock/batch/quote.json?symbol=SH600519"
+
+# Multi-symbol
+curl -s -b /tmp/xq_cookies.txt -A "$UA" -e "https://xueqiu.com/" \
+  -H "Cookie: xq_a_token=$XQ_TOKEN" \
+  "https://stock.xueqiu.com/v5/stock/batch/quote.json?symbol=SH600519,SZ000858,AAPL"
+
+# Stock search (URL-encode Chinese names)
+curl -s -b /tmp/xq_cookies.txt -A "$UA" -e "https://xueqiu.com/" \
+  -H "Cookie: xq_a_token=$XQ_TOKEN" \
+  "https://xueqiu.com/stock/search.json?code=URL_ENCODED_QUERY&size=10"
+
+# Hot stocks (type 10=popular, 12=attention)
+curl -s -b /tmp/xq_cookies.txt -A "$UA" -e "https://xueqiu.com/" \
+  -H "Cookie: xq_a_token=$XQ_TOKEN" \
+  "https://stock.xueqiu.com/v5/stock/hot_stock/list.json?size=10&type=10"
+
+# Hot posts
+curl -s -b /tmp/xq_cookies.txt -A "$UA" -e "https://xueqiu.com/" \
+  -H "Cookie: xq_a_token=$XQ_TOKEN" \
+  "https://xueqiu.com/v4/statuses/public_timeline_by_category.json?since_id=-1&max_id=-1&count=15&category=-1"
+```
+
+## Stock Symbol Format
+
+| Market | Prefix | Example | Stock |
+|--------|--------|---------|-------|
+| Shanghai | SH | SH600519 | 贵州茅台 |
+| Shenzhen | SZ | SZ000858 | 五粮液 |
+| US stocks | (none) | AAPL | Apple |
+| HK stocks | (none) | 00700 | 腾讯 |
+
+## Response Fields
+
+**Stock Quote** (`data.items[].quote`): symbol, name, current, percent, chg,
+high, low, open, last_close, volume, amount, market_capital, turnover_rate,
+pe_ttm, timestamp.
+
+**Stock Search** (`stocks[]`): code, name, exchange.
+
+**Hot Stocks** (`data.items[]`): code, name, current, percent.
+
+**Hot Posts** (`list[]`): each item's `data` field is a JSON string — parse
+twice. Post fields: id, title, text (HTML), user.screen_name, like_count.
+
+## Procedure
+
+1. If XQ_TOKEN not set, guide user through cookie extraction (browser-cookie3
+   or Cookie-Editor).
+2. Get session cookie: visit xueqiu.com homepage with `-c /tmp/xq_cookies.txt`.
+3. For quotes: determine symbol format and call the quote endpoint.
+4. For search: URL-encode Chinese queries with `urllib.parse.quote()`.
+5. For hot posts: parse the double-JSON (item.data is JSON string within JSON).
+6. Strip HTML from post text fields before presenting.
+
+## Common Pitfalls
+
+1. **Login is mandatory.** All API endpoints return error 400016 without
+   `xq_a_token`. The homepage session cookie alone is not enough.
+2. **Cookie extraction on macOS.** `browser-cookie3` may fail if Chrome's
+   cookies are locked by Keychain. Fall back to Cookie-Editor manual export.
+3. **URL-encode Chinese.** Search queries with Chinese characters must be
+   percent-encoded.
+4. **Double JSON in posts.** Hot post responses embed a JSON string in the
+   `data` field — parse it with `fromjson` (jq) or `json.loads()`.
+5. **U.S./HK stocks.** Use the ticker directly without SH/SZ prefix.
+
+## Verification Checklist
+
+- [ ] `xq_a_token` cookie is extracted and `XQ_TOKEN` is set
+- [ ] Quote endpoint returns valid data for a known symbol (e.g. SH600519)
+- [ ] Search endpoint returns results for a Chinese name query

--- a/skills/social-media/bilibili/SKILL.md
+++ b/skills/social-media/bilibili/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: bilibili
+description: "Use when the user wants to search, browse, or get details about Bilibili (B站) videos — Chinese video platform. Primarily read-only via bili-cli (no login needed for search and metadata). Subtitle support via OpenCLI."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [bilibili, b站, chinese, video, search, trending, bili-cli]
+    related_skills: [youtube-content, v2ex]
+prerequisites:
+  commands: [bili]
+---
+
+# Bilibili (B站) Skill
+
+Bilibili is the dominant Chinese video/streaming platform. The `bili-cli` tool
+provides read-only access to search, video metadata, trending, and rankings
+with no login required for most operations.
+
+## When to Use
+
+- User asks to search Bilibili for videos by keyword
+- User shares a Bilibili URL and wants video details (title, uploader, stats)
+- User wants trending/hot videos or category rankings
+- User wants audio from a Bilibili video for transcription
+
+Don't use for: subtitles without OpenCLI (bili-cli can't extract them), or
+writing comments/posting (requires login).
+
+## Prerequisites
+
+```bash
+uv tool install bilibili-cli
+# or: pipx install bilibili-cli
+```
+
+Verify: `bili hot -n 3`
+
+## Quick Reference
+
+```bash
+# Search videos
+bili search "keyword" --type video -n 5
+
+# Video detail (supports BV ID or full URL)
+bili video BVxxxxxxxxxx
+
+# Hot / trending
+bili hot -n 10
+
+# Rankings
+bili rank -n 10
+
+# Download audio for transcription
+bili audio BVxxxxxxxxxx
+
+# Optional: login for dynamics/favorites
+bili login
+```
+
+## Video Detail Output
+
+`bili video BVxxx` returns: title, description, uploader name, duration,
+publish date, play count, danmaku count, likes, coins, favorites, shares,
+and subtitle availability flag.
+
+## Curl Fallback (zero-dependency)
+
+When bili-cli is unavailable, the Bilibili search API is accessible directly:
+
+```bash
+UA="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+curl -s -c /tmp/bili_ck.txt -o /dev/null -A "$UA" "https://www.bilibili.com/"
+curl -s -b /tmp/bili_ck.txt -A "$UA" -e "https://www.bilibili.com/" \
+  "https://api.bilibili.com/x/web-interface/search/all/v2?keyword=QUERY&page=1"
+```
+
+Response is JSON with `data.result[]` — each result has `type` and `data` with
+title, author, play count, danmaku, duration.
+
+## Subtitles (OpenCLI, desktop only)
+
+When OpenCLI is installed (Chrome extension, reuses browser login):
+
+```bash
+opencli bilibili subtitle BVxxxxxxxxxx
+```
+
+## Procedure
+
+1. Determine intent: search, video detail, trending, or audio for transcription.
+2. For search: `bili search "query" --type video -n 5`
+3. For video detail: extract BV ID from URL (e.g. `BV1xx411c7mD`) and run `bili video BVxxx`
+4. For trending: `bili hot -n 10`
+5. If bili-cli is not installed, fall back to the curl search API.
+6. If subtitles are needed and OpenCLI is available, use `opencli bilibili subtitle`.
+
+## Common Pitfalls
+
+1. **Never use yt-dlp for Bilibili.** B站 risk control fully blocks yt-dlp
+   (412 errors in all configurations). Use bili-cli or the curl API fallback.
+2. **Subtitles require OpenCLI.** bili-cli cannot extract subtitles on its own.
+3. **bili-cli upstream may be stale.** Last updated 2026-03. If commands fail,
+   try the curl fallback.
+4. **Network latency.** Bilibili may be slow outside China. Consider a CN proxy
+   if consistently slow.
+5. **No comment reading.** bili-cli only reads video metadata, not comments.
+
+## Verification Checklist
+
+- [ ] `bili hot -n 3` returns trending videos
+- [ ] `bili search "test" -n 2` returns search results
+- [ ] The curl fallback API also works for the current network

--- a/skills/social-media/reddit/SKILL.md
+++ b/skills/social-media/reddit/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: reddit
+description: "Use when the user wants to search Reddit posts, read threads and comments, browse subreddits, or check hot/popular feeds. Requires rdt-cli with cookie-based login — no anonymous access exists since Reddit blocked it in 2024."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [reddit, social-media, forum, search, rdt-cli]
+    related_skills: [v2ex, xurl]
+prerequisites:
+  commands: [rdt]
+---
+
+# Reddit Skill
+
+Reddit is a massive community/forum platform. Since 2024, Reddit requires
+authentication for ALL API access — anonymous `.json` endpoints return 403,
+and the official API closed self-service registration in 2025-11.
+
+The `rdt-cli` tool provides read access via cookie-based auth. On desktop,
+OpenCLI (Chrome extension that reuses browser login) is also an option.
+
+## When to Use
+
+- User wants to search Reddit for information, opinions, or discussions
+- User shares a Reddit post URL and wants the content + comments
+- User wants to browse a specific subreddit
+- User asks what's trending on Reddit (hot/popular feeds)
+
+Don't use for: posting, commenting, or voting (rdt-cli supports some write ops
+but they're secondary). Don't attempt anonymous access — it will always 403.
+
+## Prerequisites
+
+rdt-cli must be installed from git (PyPI version 0.4.1 is behind):
+
+```bash
+uv tool install 'git+https://github.com/public-clis/rdt-cli.git@5e4fb3720d5c174e976cd425ccc3b879d52cac66'
+```
+
+Then log in (requires being logged into reddit.com in Chrome first):
+
+```bash
+rdt login
+```
+
+Verify: `rdt status --json` should show `"authenticated": true`.
+
+### Manual Cookie Setup (headless / servers)
+
+If `rdt login` can't access Chrome cookies, use Cookie-Editor to export:
+
+1. Install Cookie-Editor Chrome extension
+2. Log into reddit.com → click extension → find `reddit_session` → copy Value
+3. Create `~/.config/rdt-cli/credential.json`:
+```json
+{"cookies": {"reddit_session": "PASTE_VALUE"}, "source": "manual",
+ "username": "YOUR_USERNAME", "modhash": null, "saved_at": 0,
+ "last_verified_at": null}
+```
+
+## Quick Reference
+
+```bash
+# Search Reddit
+rdt search "query" --limit 10
+
+# Read a post + comments (by ID or full URL)
+rdt read POST_ID
+
+# Browse a subreddit
+rdt sub LocalLLaMA --limit 20
+
+# Hot / Popular / All feeds
+rdt hot --limit 10
+rdt popular --limit 10
+rdt all --limit 10
+
+# Structured output for AI processing
+rdt search "query" --json --limit 5
+```
+
+Post IDs are the 6-char string in URLs like
+`https://www.reddit.com/r/sub/comments/1abc123/title/`. rdt accepts full URLs.
+
+## Desktop Alternative: OpenCLI
+
+If OpenCLI is installed, it reuses the browser's Reddit login — no setup:
+
+```bash
+opencli reddit search "query" -f yaml
+opencli reddit read POST_ID -f yaml
+opencli reddit subreddit LocalLLaMA -f yaml
+opencli reddit hot -f yaml
+opencli reddit popular -f yaml
+```
+
+## Procedure
+
+1. Verify login: `rdt status --json`
+2. If not authenticated, guide the user through login or cookie setup.
+3. For research: `rdt search "keyword" --limit 10`
+4. For specific posts: `rdt read POST_ID`
+5. For community pulse: `rdt sub SUBREDDIT --limit 20`
+6. For trending: `rdt hot` or `rdt popular`
+7. Use `--json` for structured output when processing results further.
+
+## Common Pitfalls
+
+1. **Must be logged in.** Reddit blocks all anonymous API requests (403).
+2. **rdt-cli upstream may be stale.** Last updated 2026-03. If commands break,
+   try OpenCLI as fallback.
+3. **Cookie expiry.** `reddit_session` cookies can expire. Re-export from
+   browser and update `credential.json`.
+4. **PyPI version outdated.** Always install from the git source, not
+   `pip install rdt-cli`.
+5. **Rate limiting.** Space requests by 1-2 seconds.
+6. **China access.** Reddit is blocked inside China — proxy required.
+
+## Verification Checklist
+
+- [ ] `rdt --help` shows available commands
+- [ ] `rdt status --json` shows `"authenticated": true` (after login)
+- [ ] `rdt hot --limit 3` returns trending posts

--- a/skills/social-media/v2ex/SKILL.md
+++ b/skills/social-media/v2ex/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: v2ex
+description: "Use when the user wants to browse or search V2EX (Chinese developer community) — hot topics, node browsing, topic details with replies, user profiles. Zero-auth public REST API."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [v2ex, chinese, developer-community, forum, tech, zero-auth]
+    related_skills: [reddit, bilibili]
+---
+
+# V2EX Skill
+
+V2EX is a Chinese developer/tech forum at https://www.v2ex.com. Its public REST
+API requires no authentication, no API key, and no setup — just curl. All
+endpoints return JSON.
+
+## When to Use
+
+- User asks about trending tech topics in the Chinese developer community
+- User shares a V2EX URL (https://www.v2ex.com/t/...) and wants to read it
+- User wants to browse a specific node (python, tech, jobs, etc.)
+- User asks about a V2EX user's profile
+
+Don't use for: searching V2EX (their API lacks a search endpoint — use
+`web_search` with `site:v2ex.com` instead), or any write operations.
+
+## Quick Reference
+
+```bash
+# Hot topics
+curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: hermes/1.0"
+
+# Node topics (node_name: python, tech, jobs, qna, programmers, etc.)
+curl -s "https://www.v2ex.com/api/topics/show.json?node_name=NODE&page=1" -H "User-Agent: hermes/1.0"
+
+# Topic detail (ID from URL like https://www.v2ex.com/t/1234567)
+curl -s "https://www.v2ex.com/api/topics/show.json?id=TOPIC_ID" -H "User-Agent: hermes/1.0"
+
+# Topic replies (first page, up to 100)
+curl -s "https://www.v2ex.com/api/replies/show.json?topic_id=TOPIC_ID&page=1" -H "User-Agent: hermes/1.0"
+
+# User profile
+curl -s "https://www.v2ex.com/api/members/show.json?username=USERNAME" -H "User-Agent: hermes/1.0"
+```
+
+Always include `-H "User-Agent: hermes/1.0"` — V2EX rejects requests without a
+User-Agent header.
+
+## Available Endpoints
+
+### Hot Topics
+`GET https://www.v2ex.com/api/topics/hot.json`
+Returns array of topics with `id`, `title`, `url`, `content` (HTML), `replies`
+(count), `node` (name + title), `member` (username).
+
+### Nodes
+Browse all nodes at https://www.v2ex.com/planes. Common nodes: `python`,
+`tech`, `jobs`, `qna`, `programmers`, `create`, `share`, `macos`, `linux`.
+
+### Node Topics
+`GET .../api/topics/show.json?node_name=NODE&page=1`
+Same structure as hot topics, filtered by node.
+
+### Topic Detail
+`GET .../api/topics/show.json?id=TOPIC_ID`
+Full topic with `content` (HTML), `replies` count, node info, author info.
+
+### Topic Replies
+`GET .../api/replies/show.json?topic_id=TOPIC_ID&page=1`
+Array of replies: `content` (HTML), `member` (username), `created` (timestamp).
+
+### User Profile
+`GET .../api/members/show.json?username=USERNAME`
+Returns: `id`, `username`, `website`, `twitter`, `github`, `location`, `bio`,
+`avatar_large`, `created`.
+
+## Procedure
+
+1. Determine the user's intent (hot topics, specific topic, node browse, user lookup).
+2. For topic URLs like `https://www.v2ex.com/t/1234567`, extract the numeric ID.
+3. Fetch the API endpoint with curl + User-Agent header.
+4. Content fields contain HTML — strip `<p>`, `<br>`, `<a>` tags for readability.
+5. Present results. For topics with many replies, only show the most relevant ones.
+
+## Python Helper (optional, for structured processing)
+
+```python
+import json, urllib.request
+
+def v2ex_get(url):
+    req = urllib.request.Request(url, headers={"User-Agent": "hermes/1.0"})
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+```
+
+## Common Pitfalls
+
+1. **No User-Agent → empty response.** Always include the header.
+2. **GFW / network issues.** V2EX is hosted outside China. If unreachable, use
+   a proxy or fall back to `web_extract` on the page URL.
+3. **Search not available via API.** Use `web_search` with `site:v2ex.com`.
+4. **Content is HTML.** Strip tags before presenting to the user.
+5. **Rate limiting.** V2EX's API is free and has no documented limits, but
+   don't hammer it with rapid requests.
+
+## Verification Checklist
+
+- [ ] `curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: hermes/1.0"` returns a JSON array
+- [ ] User-Agent header is included in every request
+- [ ] Content fields are stripped of HTML tags before display

--- a/skills/social-media/xurl/SKILL.md
+++ b/skills/social-media/xurl/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: xurl
 description: "X/Twitter via xurl CLI: post, search, DM, media, v2 API."
-version: 1.1.1
+version: 1.2.0
 author: xdevplatform + openclaw + Hermes Agent
 license: MIT
 platforms: [linux, macos]
@@ -422,6 +422,70 @@ xurl --app staging /2/users/me             # one-off against staging
 - **Multiple accounts per app:** Select with `-u / --username`, or set a default with `xurl auth default APP USER`.
 - **Token storage:** `~/.xurl` is YAML. In Docker, use the Hermes subprocess HOME (`/opt/data/home` in the official image) so tokens land under `/opt/data/home/.xurl`. Never read or send this file to LLM context.
 - **Cost:** X API access is typically paid for meaningful usage. Many failures are plan/permission problems, not code problems.
+
+---
+
+## Free Read-Only Alternatives
+
+When the user's X API credits are depleted, xurl auth is not set up, or they
+only need read access, use these free cookie-based backends instead of xurl.
+
+### twitter-cli (preferred free backend)
+
+```bash
+# Install
+pipx install twitter-cli
+
+# Auth (one-time, use Cookie-Editor in Chrome)
+# Export cookies from x.com, set environment variables:
+export TWITTER_AUTH_TOKEN=*** TWITTER_CT0="yyy"
+
+# Search (may 404 if X changed GraphQL endpoints)
+twitter search "query" -n 10
+
+# Home timeline
+twitter feed -n 20
+
+# Read a tweet (single + replies)
+twitter tweet URL_OR_ID
+
+# Read X Article / longform
+twitter article URL_OR_ID
+
+# User timeline / profile
+twitter user-posts @username -n 20
+twitter user @username
+```
+
+#### Search Retry Chain
+
+Twitter GraphQL endpoints change frequently. If `twitter search` returns 404:
+
+1. Retry once: `twitter search "query" -n 10`
+2. Upgrade and retry: `pipx upgrade twitter-cli && twitter search "query" -n 10`
+3. Fall back to OpenCLI (desktop): `opencli twitter search "query" -f yaml`
+4. As last resort, use stable commands: `twitter feed` or `twitter user-posts @somebody`
+
+> IP risk: Don't run twitter-cli on VPS/datacenter IPs (followers/following
+> especially). Use residential IP or local environment.
+
+### OpenCLI (desktop, zero-config)
+
+If OpenCLI is installed (Chrome extension that reuses browser login state):
+
+```bash
+opencli twitter search "query" -f yaml     # Search
+opencli twitter article URL_OR_ID -f yaml  # Read article
+opencli twitter user-posts @user -f yaml   # User timeline
+```
+
+No API key, no cookie export — just log into x.com in Chrome once.
+
+### Backend Selection Priority
+
+1. xurl (official API, full read+write) — preferred when available
+2. twitter-cli (cookie-based, read-only, free) — fallback for reads
+3. OpenCLI (browser session, read-only, free) — zero-config desktop fallback
 
 ---
 


### PR DESCRIPTION
## Summary

Adds 4 new platform access skills, adapted from Agent Reach channel implementations to Hermes skill conventions. Also augments 2 existing skills with additional backends and capabilities.

### New Skills
- **v2ex** — Chinese developer community reader. Zero-auth public REST API, pure curl commands.
- **bilibili** — BiliBili (B站) video search, metadata, trending. Uses bili-cli (read-only, no login needed) with curl API fallback.
- **reddit** — Reddit post search, thread reading, subreddit browsing. Uses rdt-cli with cookie-based auth (no anonymous access exists since 2024).
- **xueqiu** — Chinese stock market data from Xueqiu (雪球). Real-time quotes, stock search, hot rankings, community posts. Covers A-shares, HK, and US stocks.

### Augmented Skills
- **xurl** (v1.1.1 → v1.2.0) — Added "Free Read-Only Alternatives" section with twitter-cli and OpenCLI as free cookie-based backends when X API credits are depleted. Includes search retry chain for handling GraphQL endpoint changes.
- **youtube-content** (→ v1.1.0) — Added "Extended Capabilities via yt-dlp" section covering video search, comment extraction, metadata retrieval, yt-dlp transcript fallback, and audio transcription pipeline for unsubtitled videos. Fixed missing frontmatter fields (version, author, license, metadata).

### Validation
All 6 skills pass the frontmatter validator (name, description ≤1024 chars, body present). Follow the peer-matched structure (Overview → When to Use → body → Common Pitfalls → Verification Checklist).

### Credit
Platform knowledge adapted from [Agent Reach](https://github.com/Panniantong/Agent-Reach) (MIT).