### PR TITLE
fix(kanban): '→ ready' button triggers false diagnostic and respawn guard blocks dispatch

### DIFF
--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -926,14 +926,26 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     # ``created`` covers tasks born ready; ``promoted`` covers parent-
     # done auto-promotion; ``reclaimed`` covers TTL/crash recovery;
     # ``unblocked`` covers human-driven resumes.
+    # ``status`` with payload {"status": "ready"} covers dashboard
+    # "→ ready" button / drag-drop moves (written by
+    # ``_set_status_direct``).
     READY_TRANSITION_KINDS = {
         "created", "promoted", "reclaimed", "unblocked",
     }
     last_ready_ts = 0
     for ev in events:
-        if _event_kind(ev) in READY_TRANSITION_KINDS:
+        ek = _event_kind(ev)
+        if ek in READY_TRANSITION_KINDS:
             t = _event_ts(ev)
             last_ready_ts = max(last_ready_ts, t)
+        elif ek == "status":
+            # Direct status write (e.g. dashboard "→ ready" button,
+            # drag-drop).  Check payload to confirm it was a move TO
+            # ready, not away from it.
+            p = _parse_payload(ev)
+            if isinstance(p, dict) and p.get("status") == "ready":
+                t = _event_ts(ev)
+                last_ready_ts = max(last_ready_ts, t)
 
     # Fallback: if no qualifying event exists (very old task or events
     # truncated), fall back to ``created_at`` on the task row. Better

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -207,6 +207,7 @@ AUTHOR_MAP = {
     "rebel@rebels-Mac-Studio-2.local": "rebel0789",  # PR #47308 salvage (redact browser_type typed text across display surfaces; #47197)
     "267614622+agt-user@users.noreply.github.com": "agt-user",  # PR #48496 salvage (telegram CLOSE-WAIT polling heartbeat, #48495)
     "80915+DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",  # PR #52272 salvage (route reasoning-model thinking-timeouts to timeout not context_overflow + reasoning-specific guidance; #52271)
+    "DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",  # PR #49871 (kanban: diagnostic status-to-ready recognition + test coverage)
     "66773372+Tranquil-Flow@users.noreply.github.com": "Tranquil-Flow",  # PR #52623 salvage (auxiliary Anthropic base_url host validation; #52608)
     "nikshepsvn@gmail.com": "nikshepsvn",  # PR #27426 salvage (two-layer guard against hallucinated acp_command crashing the gateway on hosts with no ACP CLI)
     "65363919+coygeek@users.noreply.github.com": "coygeek",  # PR #37735 salvage (redact provider error text at api-server HTTP boundary; #37733)

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -633,6 +633,27 @@ def test_stranded_in_ready_ignores_non_ready_status_event():
     assert stranded[0].data["age_seconds"] == 4 * 3600
 
 
+def test_stranded_in_ready_handles_malformed_status_payload():
+    """A ``status`` event with no payload, or a payload that is not a
+    dict with a ``status`` key, must not crash and should fall back to
+    ``created_at``.  ``_parse_payload`` already normalises None / JSON
+    strings / parse errors to ``{}``, so the ``isinstance(p, dict)``
+    guard is defensive — this test confirms the fallback path."""
+    now = 100_000
+    task = _task(
+        status="ready", assignee="demo", created_at=now - 4 * 3600,
+    )
+    # No payload at all.
+    events = [
+        _event("created", ts=now - 4 * 3600),
+        _event("status", ts=now - 10 * 60),  # no kwargs → payload=None
+    ]
+    diags = kd.compute_task_diagnostics(task, events, [], now=now)
+    stranded = [d for d in diags if d.kind == "stranded_in_ready"]
+    assert len(stranded) == 1
+    assert stranded[0].data["age_seconds"] == 4 * 3600
+
+
 def test_stranded_in_ready_works_on_real_db_row(kanban_home):
     """Round-trip through real kanban_db.connect() — confirms the rule
     works on sqlite3.Row objects, not just dicts."""

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -600,6 +600,39 @@ def test_stranded_in_ready_falls_back_to_created_at():
     assert stranded[0].data["age_seconds"] == 4 * 3600
 
 
+def test_stranded_in_ready_recognises_status_to_ready_event():
+    """A ``status`` event whose payload sets ``status`` to ``ready``
+    (written by the dashboard \"→ ready\" button / drag-drop via
+    ``_set_status_direct``) is a valid ready transition — the rule
+    must age from that event, not fall back to ``created_at``."""
+    now = 100_000
+    task = _task(status="ready", assignee="demo")
+    events = [
+        _event("created", ts=now - 6 * 3600),       # 6 h ago
+        _event("status", ts=now - 10 * 60, status="ready"),  # 10 min ago
+    ]
+    diags = kd.compute_task_diagnostics(task, events, [], now=now)
+    assert [d for d in diags if d.kind == "stranded_in_ready"] == []
+
+
+def test_stranded_in_ready_ignores_non_ready_status_event():
+    """A ``status`` event with a payload that does NOT set status to
+    ``ready`` (e.g. a move to ``done``) must NOT count as a ready
+    transition — the rule should fall back to ``created_at``."""
+    now = 100_000
+    task = _task(
+        status="ready", assignee="demo", created_at=now - 4 * 3600,
+    )
+    events = [
+        _event("created", ts=now - 4 * 3600),
+        _event("status", ts=now - 10 * 60, status="done"),
+    ]
+    diags = kd.compute_task_diagnostics(task, events, [], now=now)
+    stranded = [d for d in diags if d.kind == "stranded_in_ready"]
+    assert len(stranded) == 1
+    assert stranded[0].data["age_seconds"] == 4 * 3600
+
+
 def test_stranded_in_ready_works_on_real_db_row(kanban_home):
     """Round-trip through real kanban_db.connect() — confirms the rule
     works on sqlite3.Row objects, not just dicts."""


### PR DESCRIPTION
Fixes #49870

## What

`_rule_stranded_in_ready` didn't recognize `kind='status'` events (written by the dashboard "→ ready" button via `_set_status_direct`) as valid ready transitions. Fell back to `created_at` — the task's original creation time — making a seconds-old ready task appear stranded for hours.

(Note: the companion respawn-guard issue is already fixed on `main` by `77db9d6bf`, which bypasses `recent_success` for `status`/`promoted`/`unblocked`/`reclaimed` events after a completed run.)

## How

In the `_rule_stranded_in_ready` event scan loop, also recognize `kind='status'` events where `payload.status == "ready"` as valid ready transitions.

## Testing

- All 50 `test_kanban_diagnostics.py` tests pass, including:
  - `test_stranded_in_ready_recognises_status_to_ready_event` — a recent `status` event with `payload.status == "ready"` prevents the false positive
  - `test_stranded_in_ready_ignores_non_ready_status_event` — a `status` event with `payload.status == "done"` does NOT count as a ready transition
