### PR TITLE
feat: add writing-plans + subagent-driven-development skills, update requesting-code-review

### DIFF
--- a/skills/software-development/requesting-code-review/SKILL.md
+++ b/skills/software-development/requesting-code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: requesting-code-review
 description: "Pre-commit review: security scan, quality gates, auto-fix."
-version: 2.0.0
+version: 2.1.0
 author: Hermes Agent (adapted from obra/superpowers + MorAlekss)
 license: MIT
 platforms: [linux, macos, windows]
@@ -109,7 +109,56 @@ which go && go vet ./... 2>&1 | tail -10
 **Baseline comparison:** If baseline was clean and your changes introduce failures,
 that's a regression. If baseline already had failures, only count NEW ones.
 
-## Step 4 — Self-review checklist
+## Step 4 — Confidence Gates (BEFORE self-review)
+
+Every finding — from static scan, lint, and the reviewer subagent — MUST pass
+these gates before being reported to the user. Findings that fail any gate are
+suppressed from the report (not escalated).
+
+### The Cite-the-Line Gate
+
+**For every security concern or logic error:** you MUST quote the specific
+source line (file:line) that motivates the finding. If you cannot quote the
+motivating line, force confidence to LOW and suppress from the main report.
+
+```
+Finding: "Possible SQL injection in user lookup"
+Motivating line: src/db/queries.py:47 — cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")
+Confidence: HIGH (line directly shows string interpolation in SQL)
+Verdict: REPORT
+```
+
+```
+Finding: "Authentication might be bypassed"
+Motivating line: [cannot quote a specific line]
+Confidence: LOW (speculative without code evidence)
+Verdict: SUPPRESS — do not report unless a specific line is found
+```
+
+### Hard Exclusions (auto-discard these)
+
+The following are NOT security concerns and should be silently discarded:
+- DoS / resource exhaustion (unless exploitable by unauthenticated user)
+- Missing audit logging
+- Theoretical race conditions without a concrete exploit path
+- Input validation on non-security-critical fields (display names, bios)
+- Dependency CVEs with CVSS < 4.0 and no known public exploit
+- Git history secrets that were committed AND removed in the same PR
+- Memory/CPU/file descriptor concerns in application code
+- Log spoofing / log injection
+- "This could be refactored" (not a security finding)
+
+### Confidence Calibration
+
+| Score | Meaning | Action |
+|-------|---------|--------|
+| 9-10 | Verified by reading specific code | Report normally |
+| 7-8 | High-confidence pattern match | Report with link to pattern |
+| 5-6 | Moderate — could be false positive | Report with caveat |
+| 3-4 | Low confidence | Suppress to appendix |
+| 1-2 | Speculation | Suppress entirely |
+
+## Step 5 — Self-review checklist
 
 Quick scan before dispatching the reviewer:
 
@@ -122,7 +171,7 @@ Quick scan before dispatching the reviewer:
 - [ ] No commented-out code
 - [ ] New code has tests (if test suite exists)
 
-## Step 5 — Independent reviewer subagent
+## Step 6 — Independent reviewer subagent
 
 Call `delegate_task` directly — it is NOT available inside execute_code or scripts.
 
@@ -136,7 +185,10 @@ these changes were made. Review the git diff and return ONLY valid JSON.
 
 FAIL-CLOSED RULES:
 - security_concerns non-empty -> passed must be false
+- Each concern MUST include the motivating file:line
+- Concerns without a cited line are SUPPRESSED (confidence LOW)
 - logic_errors non-empty -> passed must be false
+- Each error MUST include the motivating file:line
 - Cannot parse diff -> passed must be false
 - Only set passed=true when BOTH lists are empty
 
@@ -173,13 +225,13 @@ Return ONLY this JSON:
 )
 ```
 
-## Step 6 — Evaluate results
+## Step 7 — Evaluate results
 
-Combine results from Steps 2, 3, and 5.
+Combine results from Steps 2, 3, and 6.
 
-**All passed:** Proceed to Step 8 (commit).
+**All passed:** Proceed to Step 9 (commit).
 
-**Any failures:** Report what failed, then proceed to Step 7 (auto-fix).
+**Any failures:** Report what failed, then proceed to Step 8 (auto-fix).
 
 ```
 VERIFICATION FAILED
@@ -191,7 +243,7 @@ New lint errors: [details]
 Suggestions (non-blocking): [list]
 ```
 
-## Step 7 — Auto-fix loop
+## Step 8 — Auto-fix loop
 
 **Maximum 2 fix-and-reverify cycles.**
 
@@ -219,13 +271,13 @@ Fix each issue precisely. Describe what you changed and why.""",
 )
 ```
 
-After the fix agent completes, re-run Steps 1-6 (full verification cycle).
-- Passed: proceed to Step 8
-- Failed and attempts < 2: repeat Step 7
+After the fix agent completes, re-run Steps 1-7 (full verification cycle).
+- Passed: proceed to Step 9
+- Failed and attempts < 2: repeat Step 8
 - Failed after 2 attempts: escalate to user with the remaining issues and
   suggest `git stash` or `git reset` to undo
 
-## Step 8 — Commit
+## Step 9 — Commit
 
 If verification passed:
 

--- a/skills/software-development/subagent-driven-development/SKILL.md
+++ b/skills/software-development/subagent-driven-development/SKILL.md
@@ -1,0 +1,407 @@
+---
+name: subagent-driven-development
+description: "Execute plans via delegate_task subagents (2-stage review)."
+version: 1.2.0
+author: Hermes Agent (adapted from obra/superpowers)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [delegation, subagent, implementation, workflow, parallel]
+    related_skills: [writing-plans, requesting-code-review, test-driven-development]
+---
+
+# Subagent-Driven Development
+
+## Overview
+
+Execute implementation plans by dispatching fresh subagents per task with systematic two-stage review.
+
+**Core principle:** Fresh subagent per task + two-stage review (spec then quality) = high quality, fast iteration.
+
+## Iron Law
+
+**NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE.**
+
+A subagent claiming "task complete, tests passing" is a self-report — not
+proof. Before marking any task complete, the parent MUST independently verify:
+
+- **For file creation/modification:** `read_file` the changed file and confirm
+  the expected content exists.
+- **For test results:** Run the tests YOURSELF — do not accept the subagent's
+  claim. Use `terminal(command="pytest tests/path/test_file.py -v")` or
+  equivalent.
+- **For external operations** (HTTP POST, file upload, deploy): Require the
+  subagent to return a verifiable handle (URL, path, ID) and verify it
+  yourself before reporting success to the user.
+
+This is the single most important rule. Subagent summaries are self-reports;
+they can be wrong. Always verify.
+
+### Tiered Verification Depth
+
+Match verification depth to risk:
+
+| Risk level | Verification | Example |
+|------------|-------------|---------|
+| **HIGH** (auth, payments, data loss) | Full: read every changed file, run full test suite | Payment processing, password handling |
+| **MEDIUM** (feature code, API changes) | Spot-check: read 2-3 key files, run relevant tests | New endpoint, UI component |
+| **LOW** (docs, config, formatting) | Light: git diff --stat, spot-check one file | README update, .gitignore change |
+
+## When to Use
+
+Use this skill when:
+- You have an implementation plan (from writing-plans skill or user requirements)
+- Tasks are mostly independent
+- Quality and spec compliance are important
+- You want automated review between tasks
+
+**vs. manual execution:**
+- Fresh context per task (no confusion from accumulated state)
+- Automated review process catches issues early
+- Consistent quality checks across all tasks
+- Subagents can ask questions before starting work
+
+## The Process
+
+### 1. Read and Parse Plan
+
+Read the plan file. Extract ALL tasks with their full text and context upfront. Create a todo list:
+
+```python
+# Read the plan
+read_file("docs/plans/feature-plan.md")
+
+# Create todo list with all tasks
+todo([
+    {"id": "task-1", "content": "Create User model with email field", "status": "pending"},
+    {"id": "task-2", "content": "Add password hashing utility", "status": "pending"},
+    {"id": "task-3", "content": "Create login endpoint", "status": "pending"},
+])
+```
+
+**Key:** Read the plan ONCE. Extract everything. Don't make subagents read the plan file — provide the full task text directly in context.
+
+### 2. Per-Task Workflow
+
+For EACH task in the plan:
+
+#### Step 1: Dispatch Implementer Subagent
+
+Use `delegate_task` with complete context:
+
+```python
+delegate_task(
+    goal="Implement Task 1: Create User model with email and password_hash fields",
+    context="""
+    TASK FROM PLAN:
+    - Create: src/models/user.py
+    - Add User class with email (str) and password_hash (str) fields
+    - Use bcrypt for password hashing
+    - Include __repr__ for debugging
+
+    FOLLOW TDD:
+    1. Write failing test in tests/models/test_user.py
+    2. Run: pytest tests/models/test_user.py -v (verify FAIL)
+    3. Write minimal implementation
+    4. Run: pytest tests/models/test_user.py -v (verify PASS)
+    5. Run: pytest tests/ -q (verify no regressions)
+    6. Commit: git add -A && git commit -m "feat: add User model with password hashing"
+
+    PROJECT CONTEXT:
+    - Python 3.11, Flask app in src/app.py
+    - Existing models in src/models/
+    - Tests use pytest, run from project root
+    - bcrypt already in requirements.txt
+    """,
+    toolsets=['terminal', 'file']
+)
+```
+
+#### Step 2: Dispatch Spec Compliance Reviewer
+
+After the implementer completes, verify against the original spec:
+
+```python
+delegate_task(
+    goal="Review if implementation matches the spec from the plan",
+    context="""
+    ORIGINAL TASK SPEC:
+    - Create src/models/user.py with User class
+    - Fields: email (str), password_hash (str)
+    - Use bcrypt for password hashing
+    - Include __repr__
+
+    CHECK:
+    - [ ] All requirements from spec implemented?
+    - [ ] File paths match spec?
+    - [ ] Function signatures match spec?
+    - [ ] Behavior matches expected?
+    - [ ] Nothing extra added (no scope creep)?
+
+    OUTPUT: PASS or list of specific spec gaps to fix.
+    """,
+    toolsets=['file']
+)
+```
+
+**If spec issues found:** Fix gaps, then re-run spec review. Continue only when spec-compliant.
+
+#### Step 3: Dispatch Code Quality Reviewer
+
+After spec compliance passes:
+
+```python
+delegate_task(
+    goal="Review code quality for Task 1 implementation",
+    context="""
+    FILES TO REVIEW:
+    - src/models/user.py
+    - tests/models/test_user.py
+
+    CHECK:
+    - [ ] Follows project conventions and style?
+    - [ ] Proper error handling?
+    - [ ] Clear variable/function names?
+    - [ ] Adequate test coverage?
+    - [ ] No obvious bugs or missed edge cases?
+    - [ ] No security issues?
+
+    OUTPUT FORMAT:
+    - Critical Issues: [must fix before proceeding]
+    - Important Issues: [should fix]
+    - Minor Issues: [optional]
+    - Verdict: APPROVED or REQUEST_CHANGES
+    """,
+    toolsets=['file']
+)
+```
+
+**If quality issues found:** Fix issues, re-review. Continue only when approved.
+
+#### Step 4: Verify (Iron Law)
+
+Before marking complete, independently verify the subagent's claims:
+
+```bash
+# Verify key files were changed
+git diff --stat
+
+# Run the tests yourself (don't trust subagent claim)
+pytest tests/path/test_file.py -v
+
+# Read a key file to confirm expected content
+read_file("src/path/file.py") — check the key lines match the spec
+```
+
+Only mark complete AFTER independent verification passes.
+
+#### Step 5: Mark Complete
+
+```python
+todo([{"id": "task-1", "content": "Create User model with email field", "status": "completed"}], merge=True)
+```
+
+### 3. Final Review
+
+After ALL tasks are complete, dispatch a final integration reviewer:
+
+```python
+delegate_task(
+    goal="Review the entire implementation for consistency and integration issues",
+    context="""
+    All tasks from the plan are complete. Review the full implementation:
+    - Do all components work together?
+    - Any inconsistencies between tasks?
+    - All tests passing?
+    - Ready for merge?
+    """,
+    toolsets=['terminal', 'file']
+)
+```
+
+### 4. Verify and Commit
+
+```bash
+# Run full test suite
+pytest tests/ -q
+
+# Review all changes
+git diff --stat
+
+# Final commit if needed
+git add -A && git commit -m "feat: complete [feature name] implementation"
+```
+
+## Task Granularity
+
+**Each task = 2-5 minutes of focused work.**
+
+**Too big:**
+- "Implement user authentication system"
+
+**Right size:**
+- "Create User model with email and password fields"
+- "Add password hashing function"
+- "Create login endpoint"
+- "Add JWT token generation"
+- "Create registration endpoint"
+
+## Red Flags — Never Do These
+
+- Start implementation without a plan
+- Skip reviews (spec compliance OR code quality)
+- Proceed with unfixed critical/important issues
+- **Trust a subagent self-report without independent verification (Iron Law violation)**
+- Accept "tests passing" claim without running them yourself
+- Report success to user without verifying external side-effects
+- Dispatch multiple implementation subagents for tasks that touch the same files
+- Make subagent read the plan file (provide full text in context instead)
+- Skip scene-setting context (subagent needs to understand where the task fits)
+- Ignore subagent questions (answer before letting them proceed)
+- Accept "close enough" on spec compliance
+- Skip review loops (reviewer found issues → implementer fixes → review again)
+- Let implementer self-review replace actual review (both are needed)
+- **Start code quality review before spec compliance is PASS** (wrong order)
+- Move to next task while either review has open issues
+
+## Handling Issues
+
+### If Subagent Asks Questions
+
+- Answer clearly and completely
+- Provide additional context if needed
+- Don't rush them into implementation
+
+### If Reviewer Finds Issues
+
+- Implementer subagent (or a new one) fixes them
+- Reviewer reviews again
+- Repeat until approved
+- Don't skip the re-review
+
+### If Subagent Fails a Task
+
+- Dispatch a new fix subagent with specific instructions about what went wrong
+- Don't try to fix manually in the controller session (context pollution)
+
+## Efficiency Notes
+
+**Why fresh subagent per task:**
+- Prevents context pollution from accumulated state
+- Each subagent gets clean, focused context
+- No confusion from prior tasks' code or reasoning
+
+**Why two-stage review:**
+- Spec review catches under/over-building early
+- Quality review ensures the implementation is well-built
+- Catches issues before they compound across tasks
+
+**Cost trade-off:**
+- More subagent invocations (implementer + 2 reviewers per task)
+- But catches issues early (cheaper than debugging compounded problems later)
+
+## Integration with Other Skills
+
+### With writing-plans
+
+This skill EXECUTES plans created by the writing-plans skill:
+1. User requirements → writing-plans → implementation plan
+2. Implementation plan → subagent-driven-development → working code
+
+### With test-driven-development
+
+Implementer subagents should follow TDD:
+1. Write failing test first
+2. Implement minimal code
+3. Verify test passes
+4. Commit
+
+Include TDD instructions in every implementer context.
+
+### With requesting-code-review
+
+The two-stage review process IS the code review. For final integration review, use the requesting-code-review skill's review dimensions.
+
+### With systematic-debugging
+
+If a subagent encounters bugs during implementation:
+1. Follow systematic-debugging process
+2. Find root cause before fixing
+3. Write regression test
+4. Resume implementation
+
+## Example Workflow
+
+```
+[Read plan: docs/plans/auth-feature.md]
+[Create todo list with 5 tasks]
+
+--- Task 1: Create User model ---
+[Dispatch implementer subagent]
+  Implementer: "Should email be unique?"
+  You: "Yes, email must be unique"
+  Implementer: Implemented, 3/3 tests passing, committed.
+
+[Dispatch spec reviewer]
+  Spec reviewer: ✅ PASS — all requirements met
+
+[Dispatch quality reviewer]
+  Quality reviewer: ✅ APPROVED — clean code, good tests
+
+[Mark Task 1 complete]
+
+--- Task 2: Password hashing ---
+[Dispatch implementer subagent]
+  Implementer: No questions, implemented, 5/5 tests passing.
+
+[Dispatch spec reviewer]
+  Spec reviewer: ❌ Missing: password strength validation (spec says "min 8 chars")
+
+[Implementer fixes]
+  Implementer: Added validation, 7/7 tests passing.
+
+[Dispatch spec reviewer again]
+  Spec reviewer: ✅ PASS
+
+[Dispatch quality reviewer]
+  Quality reviewer: Important: Magic number 8, extract to constant
+  Implementer: Extracted MIN_PASSWORD_LENGTH constant
+  Quality reviewer: ✅ APPROVED
+
+[Mark Task 2 complete]
+
+... (continue for all tasks)
+
+[After all tasks: dispatch final integration reviewer]
+[Run full test suite: all passing]
+[Done!]
+```
+
+## Remember
+
+```
+Iron Law: NO completion claims without fresh verification
+Tiered verification: HIGH=full, MEDIUM=spot-check, LOW=light
+Verify BEFORE marking complete:
+  - git diff --stat
+  - Run tests yourself
+  - Read key files
+Fresh subagent per task
+Two-stage review every time
+Spec compliance FIRST
+Code quality SECOND
+Never skip reviews
+Catch issues early
+```
+
+**Quality is not an accident. It's the result of systematic process.**
+
+## Further reading (load when relevant)
+
+When the orchestration involves significant context usage, long review loops, or complex validation checkpoints, load these references for the specific discipline:
+
+- **`references/context-budget-discipline.md`** — Four-tier context degradation model (PEAK / GOOD / DEGRADING / POOR), read-depth rules that scale with context window size, and early warning signs of silent degradation. Load when a run will clearly consume significant context (multi-phase plans, many subagents, large artifacts).
+- **`references/gates-taxonomy.md`** — The four canonical gate types (Pre-flight, Revision, Escalation, Abort) with behavior, recovery, and examples. Load when designing or reviewing any workflow that has validation checkpoints — use the vocabulary explicitly so each gate has defined entry, failure behavior, and resumption rules.
+
+Both references adapted from gsd-build/get-shit-done (MIT © 2025 Lex Christopherson).

--- a/skills/software-development/writing-plans/SKILL.md
+++ b/skills/software-development/writing-plans/SKILL.md
@@ -1,0 +1,354 @@
+---
+name: writing-plans
+description: "Write implementation plans: bite-sized tasks, paths, code."
+version: 1.2.0
+author: Hermes Agent (adapted from obra/superpowers)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [planning, design, implementation, workflow, documentation]
+    related_skills: [subagent-driven-development, test-driven-development, requesting-code-review]
+---
+
+# Writing Implementation Plans
+
+## Overview
+
+Write comprehensive implementation plans assuming the implementer has zero context for the codebase and questionable taste. Document everything they need: which files to touch, complete code, testing commands, docs to check, how to verify. Give them bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.
+
+Assume the implementer is a skilled developer but knows almost nothing about the toolset or problem domain. Assume they don't know good test design very well.
+
+**Core principle:** A good plan makes implementation obvious. If someone has to guess, the plan is incomplete.
+
+## Phase 0: Mandatory Interrogation (BEFORE writing any plan)
+
+Answer these five questions before producing a single task. If any cannot be
+answered, STOP — do not write the plan. Ask the user for clarification.
+
+1. **Who** is affected? (end user, automated system, internal team)
+2. **What** is the current behavior? (verified — not assumed — cite file:line)
+3. **What** should the behavior be instead? (precise, observable)
+4. **Why now?** (blocking work? costing money? compliance risk? opportunity?)
+5. **How will we know it's done?** (measurable, verifiable outcome)
+
+After answering, present a **scope mode** to the user:
+
+| Mode | Posture | When to use |
+|------|---------|-------------|
+| **EXPANSION** | Push scope UP, dream big | Greenfield features, "go big" requests |
+| **SELECTIVE** | Cherry-pick expansions on solid baseline | Feature enhancements, iterations |
+| **HOLD** | Maximum rigor, no scope changes | Bug fixes, hotfixes, refactors |
+| **REDUCTION** | Strip to essentials | Overbuilt plans, >15 files |
+
+Present 2+ implementation alternatives with equal weight:
+- One "minimal viable" — fewest files, smallest diff
+- One "ideal architecture" — best long-term trajectory
+
+Let the user choose the mode and approach before writing tasks.
+
+## Prime Directives (apply to every task in the plan)
+
+These are invariant rules. Every task MUST satisfy all of them:
+
+1. **Zero silent failures** — every failure mode must be visible.
+   Flag any operation that could fail without the user knowing.
+2. **Every error has a name** — specify exact exception classes,
+   trigger conditions, and recovery paths. No bare `except:` blocks.
+3. **Data flows have shadow paths** — for every data flow, trace
+   the happy path AND nil/empty/error/upstream-failure paths.
+4. **Everything deferred is written down** — if something is out of
+   scope or deferred, it goes in a `## Deferred` section of the plan.
+   If it's not written, it doesn't exist.
+5. **Optimize for 6-month future** — flag if today's solution creates
+   tomorrow's nightmare (tight coupling, missing interfaces, hardcoded
+   assumptions). Add a `## Future Risks` section when relevant.
+6. **Observability is scope** — dashboards, logs, alerts, and error
+   messages are first-class deliverables, not afterthoughts.
+
+## When to Use
+
+**Always use before:**
+- Implementing multi-step features
+- Breaking down complex requirements
+- Delegating to subagents via subagent-driven-development
+
+**Don't skip when:**
+- Feature seems simple (assumptions cause bugs)
+- You plan to implement it yourself (future you needs guidance)
+- Working alone (documentation matters)
+
+## Bite-Sized Task Granularity
+
+**Each task = 2-5 minutes of focused work.**
+
+Every step is one action:
+- "Write the failing test" — step
+- "Run it to make sure it fails" — step
+- "Implement the minimal code to make the test pass" — step
+- "Run the tests and make sure they pass" — step
+- "Commit" — step
+
+**Too big:**
+```markdown
+### Task 1: Build authentication system
+[50 lines of code across 5 files]
+```
+
+**Right size:**
+```markdown
+### Task 1: Create User model with email field
+[10 lines, 1 file]
+
+### Task 2: Add password hash field to User
+[8 lines, 1 file]
+
+### Task 3: Create password hashing utility
+[15 lines, 1 file]
+```
+
+## Plan Document Structure
+
+### Header (Required)
+
+Every plan MUST start with:
+
+```markdown
+# [Feature Name] Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries]
+
+---
+```
+
+### Task Structure
+
+Each task follows this format:
+
+````markdown
+### Task N: [Descriptive Name]
+
+**Objective:** What this task accomplishes (one sentence)
+
+**Files:**
+- Create: `exact/path/to/new_file.py`
+- Modify: `exact/path/to/existing.py:45-67` (line numbers if known)
+- Test: `tests/path/to/test_file.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_specific_behavior():
+    result = function(input)
+    assert result == expected
+```
+
+**Step 2: Run test to verify failure**
+
+Run: `pytest tests/path/test.py::test_specific_behavior -v`
+Expected: FAIL — "function not defined"
+
+**Step 3: Write minimal implementation**
+
+```python
+def function(input):
+    return expected
+```
+
+**Step 4: Run test to verify pass**
+
+Run: `pytest tests/path/test.py::test_specific_behavior -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/path/test.py src/path/file.py
+git commit -m "feat: add specific feature"
+```
+````
+
+## Writing Process
+
+### Step 1: Understand Requirements
+
+Read and understand:
+- Feature requirements
+- Design documents or user description
+- Acceptance criteria
+- Constraints
+
+### Step 2: Explore the Codebase
+
+Use Hermes tools to understand the project:
+
+```python
+# Understand project structure
+search_files("*.py", target="files", path="src/")
+
+# Look at similar features
+search_files("similar_pattern", path="src/", file_glob="*.py")
+
+# Check existing tests
+search_files("*.py", target="files", path="tests/")
+
+# Read key files
+read_file("src/app.py")
+```
+
+### Step 3: Design Approach
+
+Decide:
+- Architecture pattern
+- File organization
+- Dependencies needed
+- Testing strategy
+
+### Step 4: Write Tasks
+
+Create tasks in order:
+1. Setup/infrastructure
+2. Core functionality (TDD for each)
+3. Edge cases
+4. Integration
+5. Cleanup/documentation
+
+### Step 5: Add Complete Details
+
+For each task, include:
+- **Exact file paths** (not "the config file" but `src/config/settings.py`)
+- **Complete code examples** (not "add validation" but the actual code)
+- **Exact commands** with expected output
+- **Verification steps** that prove the task works
+
+### Step 6: Review the Plan
+
+Check:
+- [ ] Phase 0 interrogation complete (all 5 questions answered)
+- [ ] Prime Directives satisfied (silent failures, named errors, shadow paths, deferred documented, future risks flagged, observability covered)
+- [ ] Tasks are sequential and logical
+- [ ] Each task is bite-sized (2-5 min)
+- [ ] File paths are exact
+- [ ] Code examples are complete (copy-pasteable)
+- [ ] Commands are exact with expected output
+- [ ] No missing context
+- [ ] DRY, YAGNI, TDD principles applied
+
+### Step 7: Save the Plan
+
+```bash
+mkdir -p docs/plans
+# Save plan to docs/plans/YYYY-MM-DD-feature-name.md
+git add docs/plans/
+git commit -m "docs: add implementation plan for [feature]"
+```
+
+## Principles
+
+### DRY (Don't Repeat Yourself)
+
+**Bad:** Copy-paste validation in 3 places
+**Good:** Extract validation function, use everywhere
+
+### YAGNI (You Aren't Gonna Need It)
+
+**Bad:** Add "flexibility" for future requirements
+**Good:** Implement only what's needed now
+
+```python
+# Bad — YAGNI violation
+class User:
+    def __init__(self, name, email):
+        self.name = name
+        self.email = email
+        self.preferences = {}  # Not needed yet!
+        self.metadata = {}     # Not needed yet!
+
+# Good — YAGNI
+class User:
+    def __init__(self, name, email):
+        self.name = name
+        self.email = email
+```
+
+### TDD (Test-Driven Development)
+
+Every task that produces code should include the full TDD cycle:
+1. Write failing test
+2. Run to verify failure
+3. Write minimal code
+4. Run to verify pass
+
+See `test-driven-development` skill for details.
+
+### Frequent Commits
+
+Commit after every task:
+```bash
+git add [files]
+git commit -m "type: description"
+```
+
+## Common Mistakes
+
+### Vague Tasks
+
+**Bad:** "Add authentication"
+**Good:** "Create User model with email and password_hash fields"
+
+### Incomplete Code
+
+**Bad:** "Step 1: Add validation function"
+**Good:** "Step 1: Add validation function" followed by the complete function code
+
+### Missing Verification
+
+**Bad:** "Step 3: Test it works"
+**Good:** "Step 3: Run `pytest tests/test_auth.py -v`, expected: 3 passed"
+
+### Missing File Paths
+
+**Bad:** "Create the model file"
+**Good:** "Create: `src/models/user.py`"
+
+## Execution Handoff
+
+After saving the plan, offer the execution approach:
+
+**"Plan complete and saved. Ready to execute using subagent-driven-development — I'll dispatch a fresh subagent per task with two-stage review (spec compliance then code quality). Shall I proceed?"**
+
+When executing, use the `subagent-driven-development` skill:
+- Fresh `delegate_task` per task with full context
+- Spec compliance review after each task
+- Code quality review after spec passes
+- Proceed only when both reviews approve
+
+## Remember
+
+```
+Phase 0: interrogate BEFORE writing
+Mode selection: EXPANSION / SELECTIVE / HOLD / REDUCTION
+2+ alternatives, equal weight
+Prime Directives on every task:
+  Zero silent failures
+  Every error has a name
+  Shadow paths for every data flow
+  Deferred = written down
+  Optimize for 6-month future
+  Observability is scope
+Bite-sized tasks (2-5 min each)
+Exact file paths
+Complete code (copy-pasteable)
+Exact commands with expected output
+Verification steps
+DRY, YAGNI, TDD
+Frequent commits
+```
+
+**A good plan makes implementation obvious.**


### PR DESCRIPTION
## Summary

Adds 2 new software-development methodology skills and updates an existing one, all adapted from obra/superpowers.

### New Skills
- **writing-plans** (v1.2.0) — Methodology for writing implementation plans: Phase 0 mandatory interrogation, bite-sized tasks structure, complete code snippets, file paths. Complementary to the existing `plan` skill (which is about plan-mode/no-execution behavior). This skill is about HOW to write good plans.
- **subagent-driven-development** (v1.2.0) — Execute implementation plans via `delegate_task` subagents with a 2-stage review workflow. Workers implement, reviewer validates before merging.

### Updated
- **requesting-code-review** (v2.0.0 → v2.1.0) — Expanded pre-commit review with additional security scanning rules and quality gates.

All skills cross-reference each other and the existing test-driven-development skill in related_skills metadata.