### PR TITLE
fix(kanban): goal_mode clean exit no longer triggers protocol_violation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6010,7 +6010,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # (task_id, pid, claimer, protocol_violation, error_text)
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
+            "SELECT id, worker_pid, claim_lock, started_at, goal_mode FROM tasks "
             "WHERE status = 'running' AND worker_pid IS NOT NULL"
         ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
@@ -6033,22 +6033,42 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
+            goal_mode_turn = False
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
-                # ``kanban_complete`` / ``kanban_block``. Retrying won't
-                # help.
-                protocol_violation = True
-                error_text = (
-                    "worker exited cleanly (rc=0) without calling "
-                    "kanban_complete or kanban_block — protocol violation"
-                )
-                event_kind = "protocol_violation"
-                event_payload = {
-                    "pid": pid,
-                    "claimer": row["claim_lock"],
-                    "exit_code": code,
-                }
+                # ``kanban_complete`` / ``kanban_block``.
+                # In goal_mode, this is expected — the orchestrator
+                # finishes its turn so children can be promoted and
+                # the dispatcher can restart it for the next turn.
+                # Don't flag as a protocol violation; don't count
+                # toward the circuit breaker; just release and restart.
+                goal_mode = bool(row["goal_mode"]) if "goal_mode" in row.keys() else False
+                if goal_mode:
+                    protocol_violation = False
+                    goal_mode_turn = True
+                    error_text = (
+                        "worker exited cleanly (rc=0) in goal_mode — "
+                        "releasing for next turn"
+                    )
+                    event_kind = "goal_turn_complete"
+                    event_payload = {
+                        "pid": pid,
+                        "claimer": row["claim_lock"],
+                        "exit_code": code,
+                    }
+                else:
+                    protocol_violation = True
+                    error_text = (
+                        "worker exited cleanly (rc=0) without calling "
+                        "kanban_complete or kanban_block — protocol violation"
+                    )
+                    event_kind = "protocol_violation"
+                    event_payload = {
+                        "pid": pid,
+                        "claimer": row["claim_lock"],
+                        "exit_code": code,
+                    }
             elif kind == "rate_limited":
                 # Worker bailed because the provider rate-limited / exhausted
                 # quota (EX_TEMPFAIL sentinel). This is NOT a task failure —
@@ -6117,6 +6137,14 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         (error_text[:500], row["id"]),
                     )
                     rate_limited.append(row["id"])
+                elif goal_mode_turn:
+                    # Goal-mode clean exit — release without counting as
+                    # failure so the orchestrator can run unlimited turns
+                    # without tripping the circuit breaker.
+                    conn.execute(
+                        "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+                        (error_text[:500], row["id"]),
+                    )
                 else:
                     crashed.append(row["id"])
                     crash_details.append(

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -36,6 +36,7 @@ from typing import Any, Optional
 from agent.redact import redact_sensitive_text
 from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get, load_config
+from hermes_cli.goals import judge_goal
 
 logger = logging.getLogger(__name__)
 
@@ -475,6 +476,23 @@ def _handle_list(args: dict, **kw) -> str:
         return tool_error(f"kanban_list: {e}")
 
 
+
+def _goal_judge_available() -> bool:
+    """True when an auxiliary client is configured for the goal judge.
+    
+    judge_goal is fail-open: when no auxiliary model can be reached it
+    returns a "continue" verdict. The completion gate must not treat that
+    as a rejection, or an unconfigured/degraded auxiliary would wedge
+    every goal_mode worker.
+    """
+    try:
+        from agent.auxiliary_client import get_text_auxiliary_client
+        client, model = get_text_auxiliary_client("goal_judge")
+    except Exception:
+        return False
+    return client is not None and bool(model)
+
+
 def _handle_complete(args: dict, **kw) -> str:
     """Mark the current task done with a structured handoff."""
     tid = _default_task_id(args.get("task_id"))
@@ -567,6 +585,28 @@ def _handle_complete(args: dict, **kw) -> str:
         kb, conn = _connect(board=board)
         try:
             try:
+                # Goal-mode pre-completion judge gate (Issue #38367).
+                # Prevent workers from bypassing the auxiliary judge by
+                # calling kanban_complete before acceptance criteria are met.
+                task = kb.get_task(conn, tid)
+                if task and task.goal_mode and _goal_judge_available():
+                    try:
+                        verdict, reason, _ = judge_goal(
+                            f"{task.title}\n{task.body or ''}", summary or ""
+                        )
+                        if verdict != "done":
+                            return tool_error(
+                                f"Goal completion rejected by judge: {reason}. "
+                                f"The task is in goal_mode — you must satisfy "
+                                f"the acceptance criteria before completing. "
+                                f"Continue working or create child tasks."
+                            )
+                    except Exception as judge_exc:
+                        logger.warning(
+                            "goal judge check failed, allowing completion: %s",
+                            judge_exc,
+                        )
+                
                 ok = kb.complete_task(
                     conn, tid,
                     result=result, summary=summary, metadata=metadata,


### PR DESCRIPTION
## Problem

Goal-mode orchestrators (kanban intent workers) need to exit their turn cleanly so children are promoted and the dispatcher can restart them for the next turn. Previously, a clean exit without calling kanban_complete or kanban_block was treated as a protocol_violation, tripping the circuit breaker immediately (failure_limit=1).

This created a double-bind where goal_mode workers had no valid way to end a turn:
- kanban_block deadlocks children (they don't get promoted)
- kanban_complete ends the goal prematurely (judge marks it done)
- Clean exit was a protocol violation (immediate breaker trip)

## Fix

Detects goal_mode tasks during liveness checking and releases them without counting a failure — same treatment as rate-limited exits. The event is logged as goal_turn_complete instead of protocol_violation.

Changes:
1. SELECT query now includes goal_mode column
2. Clean exit in goal_mode → goal_mode_turn=True, protocol_violation=False
3. Goal-mode turns skip crash_details entirely → no breaker trip

## Related
- #38696 — Extend goal_mode judge gate to kanban_block
- #38388 — gate goal_mode task completion with auxiliary judge