### PR TITLE
fix(photon): stop silent sidecar reconnect death spiral

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -417,6 +417,8 @@ class PhotonAdapter(BasePlatformAdapter):
             except Exception as e:
                 if not self._inbound_running:
                     break
+                if await self._promote_dead_sidecar_to_fatal(self._sidecar_proc):
+                    break
                 logger.warning(
                     "[photon] inbound stream dropped (%s); reconnecting in %.1fs",
                     e, backoff,
@@ -825,6 +827,28 @@ class PhotonAdapter(BasePlatformAdapter):
             f"Photon sidecar did not become ready within 15s: {last_err}"
         )
 
+    async def _promote_dead_sidecar_to_fatal(
+        self, proc: Optional[subprocess.Popen]
+    ) -> bool:
+        """Escalate an unexpected sidecar exit into a retryable fatal error."""
+        if (
+            proc is None
+            or proc is not self._sidecar_proc
+            or not self._inbound_running
+            or self.has_fatal_error
+        ):
+            return False
+
+        returncode = proc.poll()
+        if returncode is None:
+            return False
+
+        message = f"Photon sidecar exited unexpectedly (code {returncode})."
+        logger.warning("[photon] %s", message)
+        self._set_fatal_error("SIDECAR_EXITED", message, retryable=True)
+        await self._notify_fatal_error()
+        return True
+
     async def _supervise_sidecar(self, proc: subprocess.Popen) -> None:
         """Pump the sidecar's stdout/stderr into our logger."""
         if proc.stdout is None:  # subprocess was launched without stdout=PIPE
@@ -839,6 +863,8 @@ class PhotonAdapter(BasePlatformAdapter):
                 logger.info("[photon-sidecar] %s", line.decode("utf-8", "replace").rstrip())
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("[photon-sidecar] supervisor exited: %s", e)
+        finally:
+            await self._promote_dead_sidecar_to_fatal(proc)
 
     async def _stop_sidecar(self) -> None:
         proc = self._sidecar_proc

--- a/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
+++ b/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
@@ -8,6 +8,7 @@ spawning Node or binding ports.
 """
 from __future__ import annotations
 
+import asyncio
 import subprocess
 from typing import Any, Dict, List, Tuple
 
@@ -169,3 +170,107 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
     kwargs = spawned["kwargs"]
     assert kwargs["stdin"] is subprocess.PIPE
     assert kwargs["env"]["PHOTON_SIDECAR_WATCH_STDIN"] == "1"
+
+
+class _EOFStdout:
+    def readline(self) -> bytes:
+        return b""
+
+
+class _BrokenInboundClient:
+    def stream(self, *a: Any, **k: Any) -> Any:
+        class _Ctx:
+            async def __aenter__(self) -> Any:
+                raise RuntimeError("All connection attempts failed")
+
+            async def __aexit__(self, *exc: Any) -> bool:
+                return False
+
+        return _Ctx()
+
+
+@pytest.mark.asyncio
+async def test_supervisor_promotes_unexpected_sidecar_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter._inbound_running = True
+    notified = asyncio.Event()
+
+    async def _fatal_handler(_adapter: PhotonAdapter) -> None:
+        notified.set()
+
+    adapter.set_fatal_error_handler(_fatal_handler)
+
+    class _DeadProc:
+        stdout = _EOFStdout()
+
+        @staticmethod
+        def poll() -> int:
+            return 7
+
+    proc = _DeadProc()
+    adapter._sidecar_proc = proc
+
+    await adapter._supervise_sidecar(proc)
+
+    assert adapter.fatal_error_code == "SIDECAR_EXITED"
+    assert adapter.fatal_error_retryable is True
+    assert "code 7" in (adapter.fatal_error_message or "")
+    assert notified.is_set()
+
+
+@pytest.mark.asyncio
+async def test_supervisor_ignores_expected_shutdown_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter._inbound_running = False
+
+    class _StoppedProc:
+        stdout = _EOFStdout()
+
+        @staticmethod
+        def poll() -> int:
+            return 0
+
+    proc = _StoppedProc()
+    adapter._sidecar_proc = proc
+
+    await adapter._supervise_sidecar(proc)
+
+    assert adapter.fatal_error_code is None
+    assert adapter.has_fatal_error is False
+
+
+@pytest.mark.asyncio
+async def test_inbound_loop_promotes_dead_sidecar_without_backoff_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter._inbound_running = True
+    adapter._http_client = _BrokenInboundClient()
+    notified = asyncio.Event()
+
+    async def _fatal_handler(_adapter: PhotonAdapter) -> None:
+        notified.set()
+
+    adapter.set_fatal_error_handler(_fatal_handler)
+
+    class _DeadProc:
+        @staticmethod
+        def poll() -> int:
+            return 9
+
+    adapter._sidecar_proc = _DeadProc()
+
+    async def _unexpected_sleep(_delay: float) -> None:
+        raise AssertionError("inbound loop should not back off after sidecar exit")
+
+    monkeypatch.setattr(photon_adapter.asyncio, "sleep", _unexpected_sleep)
+
+    await adapter._inbound_loop()
+
+    assert adapter.fatal_error_code == "SIDECAR_EXITED"
+    assert "code 9" in (adapter.fatal_error_message or "")
+    assert notified.is_set()


### PR DESCRIPTION
## Summary
- promote unexpected Photon sidecar death to a fatal adapter error instead of silently looping reconnects
- trigger the fatal path both from inbound stream failures and sidecar supervisor EOF
- add regression coverage for unexpected exit, expected shutdown, and dead-sidecar inbound failure

Closes #49858

## Testing
- uv run --frozen pytest -q tests/plugins/platforms/photon/test_sidecar_lifecycle.py
- uv run --frozen pytest -q tests/plugins/platforms/photon
- uv run --frozen ruff check plugins/platforms/photon/adapter.py tests/plugins/platforms/photon/test_sidecar_lifecycle.py
- git diff --check