### PR TITLE
docs(config): correct MCP docs path in cli-config.yaml.example

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -803,7 +803,7 @@ platform_toolsets:
 # =============================================================================
 # Connect to external MCP servers to add tools from the MCP ecosystem.
 # Each server's tools are automatically discovered and registered.
-# See docs/mcp.md for full documentation.
+# See website/docs/user-guide/features/mcp.md for full documentation.
 #
 # Stdio servers (spawn a subprocess):
 #   command: the executable to run


### PR DESCRIPTION
The MCP section in `cli-config.yaml.example` pointed to `docs/mcp.md`, but that file does not exist in the repo.

The actual MCP documentation lives at:

`website/docs/user-guide/features/mcp.md`

This PR updates the comment to point to the correct docs path, matching the existing `website/docs/user-guide/features/hooks.md` reference convention used elsewhere in the same file.

Comment-only change:

* one file changed
* one line updated
* no runtime behavior changes
* no config behavior changes
