### PR TITLE
fix(kanban): add horizontal scrollbar to board columns

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -67,6 +67,7 @@
   gap: 0.75rem;
   align-items: start;
   overflow-x: auto;
+  min-width: 0;
 }
 
 .hermes-kanban-column {


### PR DESCRIPTION
## Summary

Adds `min-width: 0` to `.hermes-kanban-columns` so the `overflow-x: auto` rule actually produces a horizontal scrollbar when the board is wider than the viewport.

## Root Cause

`.hermes-kanban-columns` is a flex item inside `.hermes-kanban` (`display: flex; flex-direction: column`). The default `min-width: auto` on flex items computes to the content-based minimum size. With 6 columns at `flex: 0 0 280px` plus gaps, the min-content width is ~1740px — wider than most viewports. This prevents `overflow-x: auto` from ever constraining the element, so no scrollbar appears.

`style.css:65-70` — the `.hermes-kanban-columns` rule already has `overflow-x: auto` but it's inert without a width constraint.

## Fix

One line: `min-width: 0` on `.hermes-kanban-columns`. This is the standard CSS fix for the flex item overflow class of bugs. It allows the element to shrink to the parent's width, at which point `overflow-x: auto` clips and scrolls.

## Test Plan

- [ ] Open Kanban board at 1440px viewport width → horizontal scrollbar appears below columns
- [ ] Scrollbar scrolls through all columns (triage → done → trash)
- [ ] At 2400px+ width → no scrollbar (all columns fit)
- [ ] Drag-and-drop between columns still works with horizontal scroll position
- [ ] Columns `max-height: calc(100vh - 220px)` and vertical scroll within columns unaffected

Closes #49878
