### PR TITLE
feat(computer-use): precise AX-geometry element bounds via Swift AX helper

### DIFF
--- a/scripts/computer_use_geometry_benchmark.py
+++ b/scripts/computer_use_geometry_benchmark.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Read-only geometry coverage benchmark for Hermes computer_use."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.computer_use.cua_backend import CuaDriverBackend  # noqa: E402
+
+
+REPORT_DIR = ROOT / "execution-reports" / "computer-use-geometry"
+
+
+def _is_actionable(element: Any) -> bool:
+    role = str(getattr(element, "role", "") or "").lower()
+    actions = getattr(element, "attributes", {}).get("actions")
+    return bool(
+        actions
+        or any(token in role for token in (
+            "button", "checkbox", "radio", "menu", "textfield", "textarea",
+            "textfield", "link", "slider", "tab", "cell",
+        ))
+    )
+
+
+def _metrics(app: str, cap: Any) -> Dict[str, Any]:
+    elements = list(getattr(cap, "elements", []) or [])
+    bounds_available = [
+        e for e in elements
+        if getattr(e, "attributes", {}).get("bounds_available") is True
+    ]
+    direct = [
+        e for e in elements
+        if getattr(e, "attributes", {}).get("geometry_status") == "direct"
+    ]
+    derived = [
+        e for e in elements
+        if getattr(e, "attributes", {}).get("geometry_status") == "derived"
+    ]
+    missing = [
+        e for e in elements
+        if getattr(e, "attributes", {}).get("bounds_available") is not True
+    ]
+    skipped = (
+        getattr(cap, "width", 0) == 0
+        and getattr(cap, "height", 0) == 0
+        and not elements
+    )
+    return {
+        "app": app,
+        "status": "skipped" if skipped else "captured",
+        "window_title": getattr(cap, "window_title", ""),
+        "capture_width": getattr(cap, "width", 0),
+        "capture_height": getattr(cap, "height", 0),
+        "element_count": len(elements),
+        "bounds_available_count": len(bounds_available),
+        "missing_bounds_count": len(missing),
+        "direct_count": len(direct),
+        "derived_count": len(derived),
+        "missing_actionable_count": len([e for e in missing if _is_actionable(e)]),
+    }
+
+
+def _markdown(results: Iterable[Dict[str, Any]], generated_at: str) -> str:
+    lines = [
+        "# computer_use Geometry Benchmark",
+        "",
+        f"Generated: {generated_at}",
+        "",
+        "| App | Status | Window | Size | Elements | Bounds | Direct | Derived | Missing actionable |",
+        "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in results:
+        size = f"{row.get('capture_width', 0)}x{row.get('capture_height', 0)}"
+        lines.append(
+            f"| {row.get('app', '')} | {row.get('status', '')} | {row.get('window_title', row.get('error', ''))} | {size} | "
+            f"{row.get('element_count', 0)} | {row.get('bounds_available_count', 0)} | "
+            f"{row.get('direct_count', 0)} | {row.get('derived_count', 0)} | {row.get('missing_actionable_count', 0)} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apps", default="Finder,iTerm2,Terminal,TextEdit",
+                        help="Comma-separated app/window filters to capture.")
+    parser.add_argument("--max-depth", type=int, default=4,
+                        help="AX helper max depth, passed via environment-compatible backend setting.")
+    parser.add_argument("--max-nodes", type=int, default=200,
+                        help="AX helper max nodes, passed via environment-compatible backend setting.")
+    args = parser.parse_args()
+
+    if platform.system() != "Darwin":
+        print("computer_use geometry benchmark is macOS-only; skipped.")
+        return 0
+
+    import os
+
+    os.environ["HERMES_AX_GEOMETRY_MAX_DEPTH"] = str(args.max_depth)
+    os.environ["HERMES_AX_GEOMETRY_MAX_NODES"] = str(args.max_nodes)
+
+    apps = [app.strip() for app in args.apps.split(",") if app.strip()]
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    json_path = REPORT_DIR / f"benchmark-{generated_at}.json"
+    md_path = REPORT_DIR / f"benchmark-{generated_at}.md"
+
+    backend = CuaDriverBackend()
+    results: List[Dict[str, Any]] = []
+    try:
+        backend.start()
+        for app in apps:
+            try:
+                cap = backend.capture(mode="som", app=app)
+                results.append(_metrics(app, cap))
+            except Exception as exc:
+                results.append({"app": app, "status": "error", "error": repr(exc)})
+    finally:
+        backend.stop()
+
+    payload = {
+        "generated_at": generated_at,
+        "apps": apps,
+        "results": results,
+        "report_markdown": str(md_path),
+    }
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    md_path.write_text(_markdown(results, generated_at))
+
+    print(json.dumps({"json": str(json_path), "markdown": str(md_path), "results": results}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_computer_use_geometry_contract.py
+++ b/tests/tools/test_computer_use_geometry_contract.py
@@ -1,0 +1,349 @@
+import json
+
+import pytest
+
+
+class _FakeCuaSession:
+    def __init__(self, replies):
+        self.replies = replies
+        self.calls = []
+
+    def call_tool(self, name, args, timeout=30.0):
+        self.calls.append((name, args))
+        queue = self.replies.get(name, [])
+        if not queue:
+            raise AssertionError(f"unexpected call {name}: {args}")
+        if isinstance(queue, list):
+            return queue.pop(0)
+        return queue
+
+
+def _cua_backend_with(fake_session):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    backend._session = fake_session
+    return backend
+
+
+def _list_windows_reply(*windows):
+    return {"data": {"windows": list(windows)}, "structuredContent": None, "images": [], "isError": False}
+
+
+def _state_reply(tree='- AXApplication "TextEdit"\n  - [0] AXWindow "scratch.txt"\n    - [7] AXButton "OK"\n'):
+    return {"data": {"tree_markdown": tree}, "structuredContent": None, "images": [], "isError": False}
+
+
+def test_parse_element_accepts_future_aliases_and_bounds_image_pixels():
+    from tools.computer_use.cua_backend import _parse_element
+
+    element = _parse_element({
+        "element_index": 42,
+        "role": "AXButton",
+        "title": "Continue",
+        "bounds_image_pixels": {"x": 11, "y": 22, "width": 33, "height": 44},
+    })
+
+    assert element.index == 42
+    assert element.label == "Continue"
+    assert element.bounds == (11, 22, 33, 44)
+    assert element.attributes["bounds_available"] is True
+    assert element.attributes["geometry_status"] == "direct"
+    assert element.attributes["geometry_source"] == "cua_driver.elements"
+    assert element.attributes["bounds_coordinate_space"] == "window_logical"
+    assert element.attributes["bounds_confidence"] == 1.0
+
+
+def test_parse_element_marks_structured_nonzero_bounds_as_direct_geometry():
+    from tools.computer_use.cua_backend import _parse_element
+
+    element = _parse_element({
+        "elementIndex": 3,
+        "role": "AXTextField",
+        "description": "Search",
+        "screen_bounds": [100, 200, 300, 40],
+    }, source="cua_driver.ui_elements")
+
+    assert element.index == 3
+    assert element.label == "Search"
+    assert element.bounds == (100, 200, 300, 40)
+    assert element.attributes["geometry_status"] == "direct"
+    assert element.attributes["geometry_source"] == "cua_driver.ui_elements"
+    assert element.attributes["bounds_coordinate_space"] == "screen_logical"
+
+
+def test_tree_markdown_elements_are_explicit_missing_geometry():
+    from tools.computer_use.cua_backend import _parse_elements_from_tree
+
+    elements = _parse_elements_from_tree('- AXApplication "TextEdit"\n  - [7] AXButton "OK"\n')
+
+    assert elements[0].index == 7
+    assert elements[0].bounds == (0, 0, 0, 0)
+    assert elements[0].attributes["bounds_available"] is False
+    assert elements[0].attributes["geometry_status"] == "missing"
+    assert elements[0].attributes["geometry_source"] == "tree_markdown"
+    assert elements[0].attributes["bounds_coordinate_space"] == "unknown"
+    assert elements[0].attributes["bounds_confidence"] == 0.0
+
+
+def test_tree_markdown_parser_scopes_to_window_subtree_not_app_menubar():
+    from tools.computer_use.cua_backend import _parse_elements_from_tree
+
+    tree = '''- AXApplication "iTerm2"
+  - [0] AXWindow "python3" actions=[AXRaise]
+    - [1] AXScrollArea actions=[AXScrollDownByPage]
+      - [2] AXButton
+  - [9] AXMenuBar actions=[AXCancel]
+    - [10] AXMenuBarItem "Apple" actions=[AXPick]
+'''
+
+    elements = _parse_elements_from_tree(tree)
+
+    assert [e.index for e in elements] == [0, 1, 2]
+    assert all("Menu" not in e.role for e in elements)
+
+
+def test_choose_target_window_prefers_real_content_over_menu_and_thumbnail():
+    from tools.computer_use.cua_backend import _choose_target_window
+
+    target = _choose_target_window([
+        {"window_id": 1, "bounds": (0, 0, 2560, 30), "off_screen": True, "z_index": 10},
+        {"window_id": 2, "bounds": (0, 580, 64, 64), "off_screen": True, "z_index": 9},
+        {"window_id": 3, "bounds": (0, 30, 1280, 478), "off_screen": False, "z_index": 8},
+    ])
+
+    assert target is not None
+    assert target["window_id"] == 3
+
+
+def test_fake_ax_helper_merges_geometry_without_renumbering():
+    from tools.computer_use.backend import UIElement
+    from tools.computer_use.cua_backend import _merge_ax_geometry
+
+    elements = [
+        UIElement(
+            index=7,
+            role="AXButton",
+            label="OK",
+            attributes={"bounds_available": False, "geometry_status": "missing"},
+        )
+    ]
+    payload = {
+        "ok": True,
+        "roots": [{
+            "role": "AXWindow",
+            "position": {"x": 100, "y": 200},
+            "size": {"width": 800, "height": 600},
+            "children": [{
+                "role": "AXButton",
+                "text": "OK",
+                "position": {"x": 120, "y": 230},
+                "size": {"width": 50, "height": 20},
+                "actions": ["AXPress"],
+            }],
+        }],
+    }
+
+    merged = _merge_ax_geometry(
+        elements,
+        payload,
+        window_bounds=(100, 200, 800, 600),
+        capture_size=(800, 600),
+    )
+
+    assert merged == 1
+    assert elements[0].index == 7
+    assert elements[0].bounds == (20, 30, 50, 20)
+    assert elements[0].attributes["geometry_status"] == "derived"
+    assert elements[0].attributes["geometry_source"] == "hermes_ax_map"
+
+
+def test_ambiguous_helper_matches_leave_geometry_missing():
+    from tools.computer_use.backend import UIElement
+    from tools.computer_use.cua_backend import _merge_ax_geometry
+
+    elements = [
+        UIElement(
+            index=7,
+            role="AXButton",
+            label="OK",
+            attributes={"bounds_available": False, "geometry_status": "missing"},
+        )
+    ]
+    payload = {
+        "ok": True,
+        "roots": [{
+            "role": "AXWindow",
+            "children": [
+                {"role": "AXButton", "text": "OK", "position": {"x": 10, "y": 10}, "size": {"width": 20, "height": 20}},
+                {"role": "AXButton", "text": "OK", "position": {"x": 40, "y": 10}, "size": {"width": 20, "height": 20}},
+            ],
+        }],
+    }
+
+    merged = _merge_ax_geometry(
+        elements,
+        payload,
+        window_bounds=(0, 0, 100, 100),
+        capture_size=(100, 100),
+    )
+
+    assert merged == 0
+    assert elements[0].bounds == (0, 0, 0, 0)
+    assert elements[0].attributes["geometry_match_error"] == "ambiguous"
+    assert elements[0].attributes["geometry_status"] == "missing"
+
+
+def test_structured_cua_menu_bar_elements_are_filtered_from_window_content():
+    from tools.computer_use.backend import UIElement
+    from tools.computer_use.cua_backend import _is_window_content_element
+
+    assert _is_window_content_element(UIElement(index=1, role="AXMenuButton", label="document actions")) is True
+    assert _is_window_content_element(UIElement(index=2, role="AXMenuBar", label="")) is False
+    assert _is_window_content_element(UIElement(index=3, role="AXMenuBarItem", label="File")) is False
+    assert _is_window_content_element(UIElement(index=4, role="AXMenu", label="")) is False
+
+
+def test_structured_cua_screen_bounds_are_normalized_to_window_local():
+    from tools.computer_use.backend import UIElement
+    from tools.computer_use.cua_backend import _normalize_structured_screen_bounds
+
+    elements = [UIElement(
+        index=0,
+        role="AXWindow",
+        label="node",
+        bounds=(100, 200, 800, 600),
+        attributes={"geometry_source": "cua_driver.elements", "bounds_source": "AXPosition+AXSize"},
+    )]
+
+    _normalize_structured_screen_bounds(
+        elements,
+        window_bounds=(100, 200, 800, 600),
+        capture_size=(800, 600),
+    )
+
+    assert elements[0].bounds == (0, 0, 800, 600)
+    assert elements[0].attributes["geometry_status"] == "direct"
+    assert elements[0].attributes["geometry_source"] == "cua_driver.elements"
+    assert elements[0].attributes["bounds_coordinate_space"] == "window_logical"
+
+
+def test_ax_payload_can_synthesize_coordinate_backed_elements():
+    from tools.computer_use.cua_backend import _elements_from_ax_payload
+
+    payload = {
+        "ok": True,
+        "roots": [{
+            "role": "AXWindow",
+            "text": "scratch.txt",
+            "position": {"x": 100, "y": 200},
+            "size": {"width": 800, "height": 600},
+            "children": [
+                {"role": "AXMenuBar", "text": "Apple", "position": {"x": 0, "y": 0}, "size": {"width": 100, "height": 24}},
+                {"role": "AXTextArea", "text": "body", "position": {"x": 120, "y": 250}, "size": {"width": 700, "height": 500}},
+            ],
+        }],
+    }
+
+    elements = _elements_from_ax_payload(
+        payload,
+        window_bounds=(100, 200, 800, 600),
+        capture_size=(800, 600),
+    )
+
+    assert [e.index for e in elements] == [1, 2]
+    assert elements[0].role == "AXWindow"
+    assert elements[1].role == "AXTextArea"
+    assert elements[1].bounds == (20, 50, 700, 500)
+    assert elements[1].attributes["action_backend"] == "coordinate"
+    assert elements[1].attributes["synthetic_element"] is True
+
+
+def test_empty_label_role_matches_use_stable_order():
+    from tools.computer_use.backend import UIElement
+    from tools.computer_use.cua_backend import _merge_ax_geometry
+
+    elements = [
+        UIElement(index=2, role="AXButton", label="", attributes={"bounds_available": False}),
+        UIElement(index=3, role="AXButton", label="", attributes={"bounds_available": False}),
+    ]
+    payload = {
+        "ok": True,
+        "roots": [{
+            "role": "AXWindow",
+            "children": [
+                {"role": "AXButton", "text": "", "position": {"x": 10, "y": 10}, "size": {"width": 20, "height": 20}},
+                {"role": "AXButton", "text": "", "position": {"x": 40, "y": 10}, "size": {"width": 20, "height": 20}},
+            ],
+        }],
+    }
+
+    merged = _merge_ax_geometry(
+        elements,
+        payload,
+        window_bounds=(0, 0, 100, 100),
+        capture_size=(100, 100),
+    )
+
+    assert merged == 2
+    assert [element.index for element in elements] == [2, 3]
+    assert [element.bounds for element in elements] == [(10, 10, 20, 20), (40, 10, 20, 20)]
+
+
+def test_ax_helper_failure_does_not_break_capture(monkeypatch):
+    import tools.computer_use.cua_backend as cua_backend
+
+    def fail_helper(**kwargs):
+        raise RuntimeError("helper exploded")
+
+    monkeypatch.setattr(cua_backend, "_run_ax_geometry_helper", fail_helper)
+    fake = _FakeCuaSession({
+        "list_windows": [_list_windows_reply({
+            "app_name": "TextEdit",
+            "pid": 123,
+            "window_id": 456,
+            "title": "scratch.txt",
+            "is_on_screen": True,
+            "z_index": 7,
+            "bounds": {"x": 10, "y": 20, "width": 640, "height": 480},
+        })],
+        "get_window_state": [_state_reply()],
+    })
+    backend = _cua_backend_with(fake)
+
+    cap = backend.capture(mode="ax", app="TextEdit")
+
+    assert cap.elements[0].index == 0
+    assert cap.elements[1].index == 7
+    assert cap.elements[1].bounds == (0, 0, 0, 0)
+    assert cap.elements[1].attributes["geometry_status"] == "missing"
+    assert cap.elements[1].attributes["geometry_helper_error"] == "helper exploded"
+
+
+def test_capture_summary_prints_real_bounds_and_geometry_source():
+    from tools.computer_use import tool as cu_tool
+    from tools.computer_use.backend import CaptureResult, UIElement
+
+    cap = CaptureResult(
+        mode="ax",
+        width=100,
+        height=50,
+        elements=[
+            UIElement(
+                index=7,
+                role="AXButton",
+                label="OK",
+                bounds=(10, 20, 30, 40),
+                attributes={
+                    "bounds_available": True,
+                    "geometry_status": "derived",
+                    "geometry_source": "hermes_ax_map",
+                },
+            )
+        ],
+    )
+
+    out = json.loads(cu_tool._capture_response(cap))
+
+    assert "#7 AXButton 'OK' @ (10, 20, 30, 40) source=hermes_ax_map" in out["summary"]
+    assert "bounds unavailable" not in out["summary"]

--- a/tools/computer_use/ax_geometry_helper.swift
+++ b/tools/computer_use/ax_geometry_helper.swift
@@ -1,0 +1,289 @@
+import Foundation
+import ApplicationServices
+
+struct Config {
+    var pid: pid_t = -1
+    var windowTitle: String?
+    var windowIndex: Int = 0
+    var windowBounds: [Double]? = nil
+    var maxDepth: Int = 5
+    var maxNodes: Int = 300
+}
+
+let coreAttributes = [
+    "AXRole", "AXSubrole", "AXTitle", "AXDescription", "AXValue",
+    "AXPlaceholderValue", "AXHelp", "AXIdentifier", "AXRoleDescription",
+    "AXEnabled", "AXFocused", "AXPosition", "AXSize",
+]
+
+let childAttributes = [
+    "AXChildren", "AXVisibleChildren", "AXRows", "AXColumns", "AXTabs",
+    "AXContents", "AXSplitters", "AXToolbarButton",
+]
+
+func emitJSON(_ object: Any, exitCode: Int32 = 0) -> Never {
+    do {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write("\n".data(using: .utf8)!)
+    } catch {
+        fputs("{\"ok\":false,\"error\":\"json_serialization_failed\"}\n", stderr)
+        exit(1)
+    }
+    exit(exitCode)
+}
+
+func usage() -> Never {
+    emitJSON([
+        "ok": false,
+        "error": "usage",
+        "usage": "ax_geometry_helper --pid PID [--window-title TEXT] [--window-index N] [--window-bounds x,y,w,h] [--max-depth N] [--max-nodes N]",
+    ], exitCode: 2)
+}
+
+func parseArgs() -> Config {
+    var cfg = Config()
+    var i = 1
+    let args = CommandLine.arguments
+    while i < args.count {
+        let arg = args[i]
+        func value() -> String {
+            if i + 1 >= args.count { usage() }
+            i += 1
+            return args[i]
+        }
+        switch arg {
+        case "--pid":
+            cfg.pid = pid_t(Int32(value()) ?? -1)
+        case "--window-title":
+            cfg.windowTitle = value()
+        case "--window-index":
+            cfg.windowIndex = Int(value()) ?? 0
+        case "--window-bounds":
+            let parts = value().split(separator: ",").compactMap { Double($0.trimmingCharacters(in: .whitespaces)) }
+            if parts.count == 4 { cfg.windowBounds = parts }
+        case "--max-depth":
+            cfg.maxDepth = max(0, Int(value()) ?? cfg.maxDepth)
+        case "--max-nodes":
+            cfg.maxNodes = max(1, Int(value()) ?? cfg.maxNodes)
+        default:
+            usage()
+        }
+        i += 1
+    }
+    if cfg.pid <= 0 { usage() }
+    return cfg
+}
+
+func copyAttribute(_ element: AXUIElement, _ name: String) -> (Bool, Any?, AXError) {
+    var value: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(element, name as CFString, &value)
+    return (err == .success, value, err)
+}
+
+func actionNames(_ element: AXUIElement) -> [String] {
+    var actions: CFArray?
+    let err = AXUIElementCopyActionNames(element, &actions)
+    guard err == .success, let names = actions as? [String] else { return [] }
+    return names
+}
+
+func cleanValue(_ value: Any?) -> Any? {
+    guard let value = value else { return nil }
+    let cfValue = value as CFTypeRef
+    if CFGetTypeID(cfValue) == AXValueGetTypeID() {
+        let axValue = value as! AXValue
+        switch AXValueGetType(axValue) {
+        case .cgPoint:
+            var point = CGPoint.zero
+            if AXValueGetValue(axValue, .cgPoint, &point) {
+                return ["x": Double(point.x), "y": Double(point.y)]
+            }
+        case .cgSize:
+            var size = CGSize.zero
+            if AXValueGetValue(axValue, .cgSize, &size) {
+                return ["width": Double(size.width), "height": Double(size.height)]
+            }
+        case .cgRect:
+            var rect = CGRect.zero
+            if AXValueGetValue(axValue, .cgRect, &rect) {
+                return [
+                    "x": Double(rect.origin.x), "y": Double(rect.origin.y),
+                    "width": Double(rect.size.width), "height": Double(rect.size.height),
+                ]
+            }
+        case .cfRange:
+            var range = CFRange(location: 0, length: 0)
+            if AXValueGetValue(axValue, .cfRange, &range) {
+                return ["location": range.location, "length": range.length]
+            }
+        default:
+            break
+        }
+        return nil
+    }
+    if CFGetTypeID(cfValue) == AXUIElementGetTypeID() { return nil }
+    if let string = value as? String {
+        return string.count > 500 ? String(string.prefix(500)) : string
+    }
+    if let number = value as? NSNumber {
+        return CFGetTypeID(number) == CFBooleanGetTypeID() ? Bool(truncating: number) : number
+    }
+    return String(describing: value)
+}
+
+func textFromAttributes(_ attrs: [String: Any]) -> String? {
+    for key in ["AXTitle", "AXDescription", "AXValue", "AXPlaceholderValue", "AXHelp", "AXIdentifier"] {
+        if let text = attrs[key] as? String,
+           !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return text
+        }
+    }
+    return nil
+}
+
+func children(_ element: AXUIElement) -> [AXUIElement] {
+    var result: [AXUIElement] = []
+    var seen = Set<String>()
+    for attr in childAttributes {
+        let (ok, value, _) = copyAttribute(element, attr)
+        guard ok, let values = value as? [Any] else { continue }
+        for item in values {
+            let cfItem = item as CFTypeRef
+            if CFGetTypeID(cfItem) == AXUIElementGetTypeID() {
+                let key = String(describing: item)
+                if seen.insert(key).inserted {
+                    result.append(item as! AXUIElement)
+                }
+            }
+        }
+    }
+    return result
+}
+
+func dumpNode(_ element: AXUIElement, depth: Int, cfg: Config, remaining: inout Int, visited: inout Set<UInt>) -> [String: Any]? {
+    if remaining <= 0 { return nil }
+    let identity = CFHash(element)
+    if visited.contains(identity) { return nil }
+    visited.insert(identity)
+    remaining -= 1
+
+    var attrs: [String: Any] = [:]
+    var attrErrors: [String: String] = [:]
+    for attr in coreAttributes {
+        let (ok, value, err) = copyAttribute(element, attr)
+        if ok, let cleaned = cleanValue(value) {
+            attrs[attr] = cleaned
+        } else if attr == "AXPosition" || attr == "AXSize" {
+            attrErrors[attr] = String(describing: err)
+        }
+    }
+
+    var node: [String: Any] = [
+        "role": attrs["AXRole"] ?? NSNull(),
+        "subrole": attrs["AXSubrole"] ?? NSNull(),
+        "text": textFromAttributes(attrs) ?? NSNull(),
+        "role_description": attrs["AXRoleDescription"] ?? NSNull(),
+        "identifier": attrs["AXIdentifier"] ?? NSNull(),
+        "enabled": attrs["AXEnabled"] ?? NSNull(),
+        "focused": attrs["AXFocused"] ?? NSNull(),
+        "position": attrs["AXPosition"] ?? NSNull(),
+        "size": attrs["AXSize"] ?? NSNull(),
+        "actions": actionNames(element),
+    ]
+    if !attrErrors.isEmpty {
+        node["attribute_errors"] = attrErrors
+    }
+    if depth < cfg.maxDepth && remaining > 0 {
+        var dumpedChildren: [[String: Any]] = []
+        for child in children(element) {
+            if let dumped = dumpNode(child, depth: depth + 1, cfg: cfg, remaining: &remaining, visited: &visited) {
+                dumpedChildren.append(dumped)
+            }
+            if remaining <= 0 { break }
+        }
+        if !dumpedChildren.isEmpty {
+            node["children"] = dumpedChildren
+        }
+    }
+    return node
+}
+
+func selectWindowRoots(_ appElement: AXUIElement, cfg: Config) -> ([AXUIElement], [String: Any]) {
+    let (ok, value, err) = copyAttribute(appElement, "AXWindows")
+    guard ok, let values = value as? [Any] else {
+        return ([appElement], ["selected": "application", "windows_error": String(describing: err)])
+    }
+    let windows = values.compactMap { item -> AXUIElement? in
+        let cfItem = item as CFTypeRef
+        return CFGetTypeID(cfItem) == AXUIElementGetTypeID() ? (item as! AXUIElement) : nil
+    }
+    var meta: [String: Any] = ["window_count": windows.count]
+    if let target = cfg.windowBounds {
+        let matches = windows.filter { window in
+            guard let pos = cleanValue(copyAttribute(window, "AXPosition").1) as? [String: Double],
+                  let size = cleanValue(copyAttribute(window, "AXSize").1) as? [String: Double] else { return false }
+            let dx = abs((pos["x"] ?? -999999) - target[0])
+            let dy = abs((pos["y"] ?? -999999) - target[1])
+            let dw = abs((size["width"] ?? -999999) - target[2])
+            let dh = abs((size["height"] ?? -999999) - target[3])
+            return dx <= 8 && dy <= 8 && dw <= 16 && dh <= 16
+        }
+        meta["selected"] = "window_bounds"
+        meta["window_bounds"] = target
+        if !matches.isEmpty { return ([matches[0]], meta) }
+    }
+    if let title = cfg.windowTitle, !title.isEmpty {
+        let needle = title.lowercased()
+        let filtered = windows.filter { window in
+            let (ok, value, _) = copyAttribute(window, "AXTitle")
+            return ok && String(describing: value ?? "").lowercased().contains(needle)
+        }
+        meta["selected"] = "window_title"
+        meta["window_title"] = title
+        return (filtered, meta)
+    }
+    meta["selected"] = "window_index"
+    meta["window_index"] = cfg.windowIndex
+    if cfg.windowIndex >= 0 && cfg.windowIndex < windows.count {
+        return ([windows[cfg.windowIndex]], meta)
+    }
+    return ([], meta)
+}
+
+let cfg = parseArgs()
+let trusted = AXIsProcessTrusted()
+let appElement = AXUIElementCreateApplication(cfg.pid)
+let (rootsToDump, selection) = selectWindowRoots(appElement, cfg: cfg)
+if rootsToDump.isEmpty {
+    emitJSON([
+        "ok": false,
+        "error": "window_not_found",
+        "trusted": trusted,
+        "pid": Int(cfg.pid),
+        "selection": selection,
+    ], exitCode: 1)
+}
+
+var remaining = cfg.maxNodes
+var roots: [[String: Any]] = []
+var visited = Set<UInt>()
+for root in rootsToDump {
+    if let dumped = dumpNode(root, depth: 0, cfg: cfg, remaining: &remaining, visited: &visited) {
+        roots.append(dumped)
+    }
+    if remaining <= 0 { break }
+}
+
+emitJSON([
+    "ok": true,
+    "trusted": trusted,
+    "pid": Int(cfg.pid),
+    "selection": selection,
+    "limits": [
+        "max_depth": cfg.maxDepth,
+        "max_nodes": cfg.maxNodes,
+        "nodes_emitted": cfg.maxNodes - remaining,
+    ],
+    "roots": roots,
+])

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -19,13 +19,17 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 import json
 import logging
 import os
 import re
 import shutil
+import subprocess
 import sys
+import tempfile
 import threading
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from tools.computer_use.backend import (
@@ -69,6 +73,27 @@ _ELEMENT_LINE_RE = re.compile(
     re.MULTILINE,
 )
 
+_AX_HELPER_SOURCE = Path(__file__).with_name("ax_geometry_helper.swift")
+_AX_HELPER_BINARY = Path(tempfile.gettempdir()) / "hermes-ax-geometry-helper"
+
+_GEOMETRY_MISSING_ATTRS: Dict[str, Any] = {
+    "bounds_available": False,
+    "bounds_source": "tree_markdown",
+    "geometry_status": "missing",
+    "geometry_source": "tree_markdown",
+    "bounds_coordinate_space": "unknown",
+    "bounds_confidence": 0.0,
+}
+
+_BOUND_ALIASES = (
+    "bounds_image_pixels",
+    "window_bounds",
+    "bounds",
+    "screen_bounds",
+    "frame",
+    "rect",
+)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -107,6 +132,35 @@ def _parse_windows_from_text(text: str) -> List[Dict[str, Any]]:
     return windows
 
 
+def _window_subtree_markdown(markdown: str) -> str:
+    """Return the first AXWindow subtree from app-level cua-driver markdown."""
+    lines = markdown.splitlines()
+    first = next((line for line in lines if line.strip()), "")
+    if "AXApplication" not in first:
+        return markdown
+
+    start = None
+    start_indent = 0
+    for i, line in enumerate(lines):
+        if "AXWindow" in line:
+            start = i
+            start_indent = len(line) - len(line.lstrip())
+            break
+    if start is None:
+        return markdown
+
+    selected = [lines[start]]
+    for line in lines[start + 1:]:
+        if not line.strip():
+            selected.append(line)
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= start_indent:
+            break
+        selected.append(line)
+    return "\n".join(selected)
+
+
 def _parse_elements_from_tree(markdown: str) -> List[UIElement]:
     """Parse UIElement list from get_window_state AX tree markdown.
 
@@ -114,16 +168,104 @@ def _parse_elements_from_tree(markdown: str) -> List[UIElement]:
     ``id=Label`` format introduced in cua-driver v0.1.6.
     """
     elements = []
-    for m in _ELEMENT_LINE_RE.finditer(markdown):
+    scoped_markdown = _window_subtree_markdown(markdown)
+    for m in _ELEMENT_LINE_RE.finditer(scoped_markdown):
+        role = m.group(2)
+        if role.startswith("AXMenu"):
+            continue
         # group(3) = quoted label (classic); group(4) = id= label (new)
         label = m.group(3) or m.group(4) or ""
         elements.append(UIElement(
             index=int(m.group(1)),
-            role=m.group(2),
+            role=role,
             label=label,
             bounds=(0, 0, 0, 0),
+            attributes=dict(_GEOMETRY_MISSING_ATTRS),
         ))
     return elements
+
+
+def _geometry_attrs(
+    *,
+    available: bool,
+    status: str,
+    source: str,
+    coordinate_space: str,
+    confidence: float,
+) -> Dict[str, Any]:
+    return {
+        "bounds_available": bool(available),
+        "geometry_status": status,
+        "geometry_source": source,
+        "bounds_coordinate_space": coordinate_space,
+        "bounds_confidence": float(confidence),
+    }
+
+
+def _coerce_bounds(value: Any) -> Tuple[int, int, int, int]:
+    """Accept common rect shapes and return an integer x/y/w/h tuple."""
+    if isinstance(value, dict):
+        return (
+            int(float(value.get("x", value.get("left", 0)) or 0)),
+            int(float(value.get("y", value.get("top", 0)) or 0)),
+            int(float(value.get("w", value.get("width", 0)) or 0)),
+            int(float(value.get("h", value.get("height", 0)) or 0)),
+        )
+    if isinstance(value, (list, tuple)) and len(value) == 4:
+        return tuple(int(float(v or 0)) for v in value)  # type: ignore[return-value]
+    return (0, 0, 0, 0)
+
+
+def _bounds_nonzero(bounds: Tuple[int, int, int, int]) -> bool:
+    return bool(bounds[2] > 0 and bounds[3] > 0)
+
+
+def _structured_geometry_source(root_key: str) -> str:
+    return "cua_driver.ui_elements" if root_key == "ui_elements" else "cua_driver.elements"
+
+
+def _image_dimensions_from_b64(b64: str) -> Tuple[int, int]:
+    """Best-effort image dimension sniff for PNG/JPEG base64 payloads."""
+    try:
+        raw = base64.b64decode(b64, validate=False)
+    except (binascii.Error, ValueError):
+        return 0, 0
+    return _image_dimensions_from_bytes(raw)
+
+
+def _window_bounds_tuple(w: Dict[str, Any]) -> Tuple[int, int, int, int]:
+    return _coerce_bounds(w.get("bounds"))
+
+
+def _window_area(w: Dict[str, Any]) -> int:
+    _x, _y, width, height = _window_bounds_tuple(w)
+    return max(0, int(width or 0)) * max(0, int(height or 0))
+
+
+def _looks_like_real_window(w: Dict[str, Any]) -> bool:
+    """Heuristic filter for Dock thumbnails/menu-bar pseudo windows."""
+    _x, _y, width, height = _window_bounds_tuple(w)
+    width = int(width or 0)
+    height = int(height or 0)
+    if width <= 0 or height <= 0:
+        return True
+    if height <= 40:
+        return False
+    if width <= 96 and height <= 96:
+        return False
+    if _window_area(w) < 50_000:
+        return False
+    return True
+
+
+def _choose_target_window(windows: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Choose the best actual content window from z-sorted candidates."""
+    if not windows:
+        return None
+    real_windows = [w for w in windows if _looks_like_real_window(w)]
+    if real_windows:
+        return next((w for w in real_windows if not w.get("off_screen")), real_windows[0])
+    return next((w for w in windows if not w.get("off_screen")), windows[0])
 
 
 def _image_dimensions_from_bytes(raw: bytes) -> Tuple[int, int]:
@@ -171,6 +313,356 @@ def _split_tree_text(full_text: str) -> Tuple[str, str]:
     summary = lines[0]
     tree = lines[1] if len(lines) > 1 else ""
     return summary, tree
+
+
+def _compile_ax_geometry_helper() -> Optional[str]:
+    """Build the read-only Swift AX helper on demand."""
+    if not _is_macos() or not _AX_HELPER_SOURCE.exists():
+        return None
+    swiftc = shutil.which("swiftc")
+    if not swiftc:
+        return None
+    try:
+        if (
+            _AX_HELPER_BINARY.exists()
+            and _AX_HELPER_BINARY.stat().st_mtime >= _AX_HELPER_SOURCE.stat().st_mtime
+        ):
+            return str(_AX_HELPER_BINARY)
+        result = subprocess.run(
+            [swiftc, str(_AX_HELPER_SOURCE), "-o", str(_AX_HELPER_BINARY)],
+            text=True,
+            capture_output=True,
+            timeout=12,
+        )
+        if result.returncode != 0:
+            logger.debug("AX geometry helper compile failed: %s", result.stderr.strip())
+            return None
+        return str(_AX_HELPER_BINARY)
+    except Exception as e:
+        logger.debug("AX geometry helper compile failed: %s", e)
+        return None
+
+
+def _run_ax_geometry_helper(
+    *,
+    pid: int,
+    window_title: str = "",
+    window_index: int = 0,
+    window_bounds: Optional[Tuple[int, int, int, int]] = None,
+    max_depth: int = 5,
+    max_nodes: int = 300,
+    timeout: float = 3.0,
+) -> Optional[Dict[str, Any]]:
+    """Return read-only AX geometry JSON for a process/window, best-effort."""
+    helper = _compile_ax_geometry_helper()
+    if not helper:
+        return None
+    args = [
+        helper,
+        "--pid", str(pid),
+        "--max-depth", str(max_depth),
+        "--max-nodes", str(max_nodes),
+    ]
+    if window_bounds:
+        args.extend(["--window-bounds", ",".join(str(int(v)) for v in window_bounds)])
+    if window_title:
+        args.extend(["--window-title", window_title])
+    else:
+        args.extend(["--window-index", str(window_index)])
+    try:
+        result = subprocess.run(args, text=True, capture_output=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        logger.debug("AX geometry helper timed out for pid=%s", pid)
+        return {"ok": False, "error": "timeout"}
+    except Exception as e:
+        logger.debug("AX geometry helper failed for pid=%s: %s", pid, e)
+        return {"ok": False, "error": str(e)}
+    payload_text = result.stdout.strip()
+    if not payload_text:
+        logger.debug("AX geometry helper returned no JSON: %s", result.stderr.strip())
+        return {"ok": False, "error": "empty_output", "stderr": result.stderr.strip()}
+    try:
+        payload = json.loads(payload_text)
+    except json.JSONDecodeError:
+        logger.debug("AX geometry helper returned invalid JSON: %s", payload_text[:200])
+        return {"ok": False, "error": "invalid_json", "stderr": result.stderr.strip()}
+    if result.returncode != 0:
+        payload.setdefault("ok", False)
+        if payload.get("error") == "window_not_found" and window_title:
+            retry_args = [
+                helper,
+                "--pid", str(pid),
+                "--window-index", str(window_index),
+                "--max-depth", str(max_depth),
+                "--max-nodes", str(max_nodes),
+            ]
+            try:
+                retry = subprocess.run(retry_args, text=True, capture_output=True, timeout=timeout)
+                retry_text = retry.stdout.strip()
+                if retry_text:
+                    retry_payload = json.loads(retry_text)
+                    if retry.returncode == 0 or retry_payload.get("ok"):
+                        retry_payload.setdefault("selection_fallback", "window_index_after_title_miss")
+                        return retry_payload
+            except Exception as e:
+                logger.debug("AX geometry helper title fallback failed for pid=%s: %s", pid, e)
+    return payload
+
+
+def _norm_text(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip().lower()
+
+
+def _norm_role(value: Any) -> str:
+    role = _norm_text(value)
+    if role.startswith("ax"):
+        role = role[2:]
+    return re.sub(r"[^a-z0-9]", "", role)
+
+
+def _role_compatible(cua_role: str, ax_role: str) -> bool:
+    left = _norm_role(cua_role)
+    right = _norm_role(ax_role)
+    if not left or not right:
+        return False
+    if left == right:
+        return True
+    aliases = {
+        "textarea": {"text", "textfield", "textview"},
+        "textfield": {"text", "textarea", "textview"},
+        "statictext": {"text"},
+        "checkbox": {"check box"},
+    }
+    return right in aliases.get(left, set()) or left in aliases.get(right, set())
+
+
+def _label_matches(cua_label: str, ax_label: str) -> bool:
+    left = _norm_text(cua_label)
+    right = _norm_text(ax_label)
+    if not left or not right:
+        return False
+    return left == right or (len(left) >= 3 and left in right) or (len(right) >= 3 and right in left)
+
+
+def _ax_node_label(node: Dict[str, Any]) -> str:
+    for key in ("text", "title", "description", "value", "placeholder", "help", "identifier", "role_description"):
+        value = node.get(key)
+        if value not in (None, "", []):
+            return str(value)
+    attrs = node.get("attributes")
+    if isinstance(attrs, dict):
+        for key in ("AXTitle", "AXDescription", "AXValue", "AXPlaceholderValue", "AXHelp", "AXIdentifier", "AXRoleDescription"):
+            value = attrs.get(key)
+            if value not in (None, "", []):
+                return str(value)
+    return ""
+
+
+def _ax_node_bounds(node: Dict[str, Any]) -> Tuple[int, int, int, int]:
+    position = node.get("position") or node.get("AXPosition")
+    size = node.get("size") or node.get("AXSize")
+    if isinstance(position, dict) and isinstance(size, dict):
+        return (
+            int(float(position.get("x", 0) or 0)),
+            int(float(position.get("y", 0) or 0)),
+            int(float(size.get("width", size.get("w", 0)) or 0)),
+            int(float(size.get("height", size.get("h", 0)) or 0)),
+        )
+    rect = node.get("bounds") or node.get("frame") or node.get("rect")
+    return _coerce_bounds(rect)
+
+
+def _flatten_ax_nodes(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    roots = payload.get("roots") or []
+    out: List[Dict[str, Any]] = []
+
+    def visit(node: Any, order: int) -> int:
+        if not isinstance(node, dict):
+            return order
+        bounds = _ax_node_bounds(node)
+        if _bounds_nonzero(bounds):
+            item = dict(node)
+            item["_bounds_screen"] = bounds
+            item["_label"] = _ax_node_label(node)
+            item["_role"] = str(node.get("role") or "")
+            item["_order"] = order
+            out.append(item)
+            order += 1
+        for child in node.get("children") or []:
+            order = visit(child, order)
+        return order
+
+    order = 0
+    for root in roots:
+        order = visit(root, order)
+    return out
+
+
+def _screen_to_window_bounds(
+    screen_bounds: Tuple[int, int, int, int],
+    *,
+    window_bounds: Tuple[int, int, int, int],
+    capture_size: Tuple[int, int],
+) -> Tuple[int, int, int, int]:
+    sx, sy, sw, sh = screen_bounds
+    wx, wy, ww, wh = window_bounds
+    cw, ch = capture_size
+    local_x = sx - wx
+    local_y = sy - wy
+    if ww > 0 and wh > 0 and cw > 0 and ch > 0 and (cw != ww or ch != wh):
+        scale_x = cw / ww
+        scale_y = ch / wh
+        return (
+            int(round(local_x * scale_x)),
+            int(round(local_y * scale_y)),
+            int(round(sw * scale_x)),
+            int(round(sh * scale_y)),
+        )
+    return (int(local_x), int(local_y), int(sw), int(sh))
+
+
+def _needs_geometry_fallback(elements: List[UIElement]) -> bool:
+    return any(not _bounds_nonzero(e.bounds) or e.attributes.get("bounds_available") is False for e in elements)
+
+
+def _merge_ax_geometry(
+    elements: List[UIElement],
+    payload: Dict[str, Any],
+    *,
+    window_bounds: Tuple[int, int, int, int],
+    capture_size: Tuple[int, int],
+) -> int:
+    """Conservatively fill missing Cua element bounds from AX helper nodes."""
+    candidates = _flatten_ax_nodes(payload)
+    used: set[int] = set()
+    merged = 0
+
+    for element in elements:
+        if _bounds_nonzero(element.bounds) and element.attributes.get("bounds_available") is not False:
+            continue
+        role_matches = [
+            i for i, node in enumerate(candidates)
+            if i not in used and _role_compatible(element.role, str(node.get("_role") or ""))
+        ]
+        if not role_matches:
+            element.attributes.setdefault("geometry_match_error", "no_role_match")
+            continue
+
+        label = element.label
+        if label:
+            label_matches = [
+                i for i in role_matches
+                if _label_matches(label, str(candidates[i].get("_label") or ""))
+            ]
+            if len(label_matches) == 1:
+                chosen = label_matches[0]
+            elif len(label_matches) > 1:
+                element.attributes["geometry_match_error"] = "ambiguous"
+                continue
+            else:
+                element.attributes.setdefault("geometry_match_error", "no_label_match")
+                continue
+        else:
+            chosen = role_matches[0]
+
+        node = candidates[chosen]
+        element.bounds = _screen_to_window_bounds(
+            node["_bounds_screen"],
+            window_bounds=window_bounds,
+            capture_size=capture_size,
+        )
+        if not _bounds_nonzero(element.bounds):
+            element.attributes["geometry_match_error"] = "zero_after_conversion"
+            continue
+        used.add(chosen)
+        element.attributes.pop("geometry_match_error", None)
+        element.attributes.update(_geometry_attrs(
+            available=True,
+            status="derived",
+            source="hermes_ax_map",
+            coordinate_space="window_logical",
+            confidence=0.72,
+        ))
+        element.attributes["geometry_ax_role"] = node.get("_role")
+        element.attributes["geometry_ax_label"] = node.get("_label")
+        merged += 1
+    return merged
+
+
+def _is_window_content_element(element: UIElement) -> bool:
+    """Return false for app-level menu structures outside a window screenshot."""
+    return element.role not in {"AXMenuBar", "AXMenuBarItem", "AXMenu"}
+
+
+def _normalize_structured_screen_bounds(
+    elements: List[UIElement],
+    *,
+    window_bounds: Tuple[int, int, int, int],
+    capture_size: Tuple[int, int],
+) -> None:
+    """Convert structured Cua AXPosition+AXSize screen rects to window-local rects."""
+    for element in elements:
+        source = str(element.attributes.get("geometry_source") or "")
+        bounds_source = str(element.attributes.get("bounds_source") or "")
+        if source != "cua_driver.elements" or bounds_source != "AXPosition+AXSize":
+            continue
+        element.bounds = _screen_to_window_bounds(
+            element.bounds,
+            window_bounds=window_bounds,
+            capture_size=capture_size,
+        )
+        element.attributes.update(_geometry_attrs(
+            available=_bounds_nonzero(element.bounds),
+            status="direct" if _bounds_nonzero(element.bounds) else "missing",
+            source="cua_driver.elements",
+            coordinate_space="window_logical",
+            confidence=1.0 if _bounds_nonzero(element.bounds) else 0.0,
+        ))
+
+
+def _elements_from_ax_payload(
+    payload: Dict[str, Any],
+    *,
+    window_bounds: Tuple[int, int, int, int],
+    capture_size: Tuple[int, int],
+    max_elements: int = 120,
+) -> List[UIElement]:
+    """Create coordinate-addressable elements directly from AX helper output."""
+    out: List[UIElement] = []
+    for node in _flatten_ax_nodes(payload):
+        role = str(node.get("_role") or "")
+        if role.startswith("AXMenu") or role == "AXApplication":
+            continue
+        bounds = _screen_to_window_bounds(
+            node["_bounds_screen"],
+            window_bounds=window_bounds,
+            capture_size=capture_size,
+        )
+        if not _bounds_nonzero(bounds):
+            continue
+        label = str(node.get("_label") or "")
+        out.append(UIElement(
+            index=len(out) + 1,
+            role=role,
+            label=label,
+            bounds=bounds,
+            attributes={
+                **_geometry_attrs(
+                    available=True,
+                    status="derived",
+                    source="hermes_ax_map",
+                    coordinate_space="window_logical",
+                    confidence=0.68,
+                ),
+                "action_backend": "coordinate",
+                "synthetic_element": True,
+                "geometry_ax_role": role,
+                "geometry_ax_label": label,
+            },
+        ))
+        if len(out) >= max_elements:
+            break
+    return out
 
 
 def _parse_key_combo(keys: str) -> Tuple[Optional[str], List[str]]:
@@ -405,6 +897,8 @@ class CuaDriverBackend(ComputerUseBackend):
         # Sticky context — updated by capture(), used by action tools.
         self._active_pid: Optional[int] = None
         self._active_window_id: Optional[int] = None
+        self._active_window: Optional[Dict[str, Any]] = None
+        self._active_elements: Dict[int, UIElement] = {}
         self._last_app: Optional[str] = None  # last app name targeted via capture/focus_app
 
     # ── Lifecycle ──────────────────────────────────────────────────
@@ -423,6 +917,11 @@ class CuaDriverBackend(ComputerUseBackend):
         return cua_driver_binary_available()
 
     # ── Capture ────────────────────────────────────────────────────
+    def _set_active_window(self, target: Dict[str, Any]) -> None:
+        self._active_pid = int(target["pid"])
+        self._active_window_id = int(target["window_id"])
+        self._active_window = dict(target)
+
     def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
         """Capture the frontmost on-screen window (optionally filtered by app name).
 
@@ -436,6 +935,8 @@ class CuaDriverBackend(ComputerUseBackend):
         # text-line parsing for older cua-driver builds.
         sc = lw_out.get("structuredContent") or {}
         raw_windows = sc.get("windows") if sc else None
+        if raw_windows is None and isinstance(lw_out.get("data"), dict):
+            raw_windows = lw_out["data"].get("windows")
         if raw_windows:
             windows = [
                 {
@@ -445,6 +946,7 @@ class CuaDriverBackend(ComputerUseBackend):
                     "off_screen": not w.get("is_on_screen", True),
                     "title": w.get("title", ""),
                     "z_index": w.get("z_index", 0),
+                    "bounds": _window_bounds_tuple(w),
                 }
                 for w in raw_windows
             ]
@@ -483,8 +985,7 @@ class CuaDriverBackend(ComputerUseBackend):
 
         # Pick first on-screen window (sorted by z_index / z-order above).
         target = next((w for w in windows if not w["off_screen"]), windows[0])
-        self._active_pid = target["pid"]
-        self._active_window_id = target["window_id"]
+        self._set_active_window(target)
         app_name = target["app_name"]
         # Record the resolved app name so capture_after= follow-ups can re-target
         # the same app rather than falling back to the frontmost window.
@@ -495,7 +996,10 @@ class CuaDriverBackend(ComputerUseBackend):
         png_b64: Optional[str] = None
         elements: List[UIElement] = []
         width = height = 0
-        window_title = ""
+        window_title = str(target.get("title") or "")
+        bx, by, bw, bh = _window_bounds_tuple(target)
+        if bw and bh:
+            width, height = int(bw), int(bh)
 
         if mode == "vision":
             # screenshot tool: just the PNG, no AX walk.
@@ -511,22 +1015,54 @@ class CuaDriverBackend(ComputerUseBackend):
                 "get_window_state",
                 {"pid": self._active_pid, "window_id": self._active_window_id},
             )
-            text = gws_out["data"] if isinstance(gws_out["data"], str) else ""
-            summary, tree = _split_tree_text(text)
+            state: Dict[str, Any] = {}
+            if isinstance(gws_out.get("data"), dict):
+                state.update(gws_out["data"])
+            if isinstance(gws_out.get("structuredContent"), dict):
+                state.update(gws_out["structuredContent"] or {})
+
+            text = gws_out["data"] if isinstance(gws_out.get("data"), str) else ""
+            summary, tree_from_text = _split_tree_text(text) if text else ("", "")
+            tree = state.get("tree_markdown") or state.get("tree") or tree_from_text
 
             # Parse element count from summary e.g. "✅ AppName — 42 elements, turn 3..."
             m = re.search(r'(\d+)\s+elements?', summary)
-            if tree and not gws_out["images"]:
-                # ax mode — no screenshot
+            raw_element_source = ""
+            raw_elements = None
+            for key in ("elements", "ui_elements"):
+                if isinstance(state.get(key), list):
+                    raw_element_source = _structured_geometry_source(key)
+                    raw_elements = state.get(key)
+                    break
+            if isinstance(raw_elements, list):
+                elements = [
+                    _parse_element(e, source=raw_element_source)
+                    for e in raw_elements
+                    if isinstance(e, dict)
+                ]
+                _normalize_structured_screen_bounds(
+                    elements,
+                    window_bounds=(int(bx or 0), int(by or 0), int(bw or 0), int(bh or 0)),
+                    capture_size=(int(width or 0), int(height or 0)),
+                )
+                elements = [e for e in elements if _is_window_content_element(e)]
+            elif tree:
                 elements = _parse_elements_from_tree(tree)
-            elif gws_out["images"]:
+
+            if gws_out["images"]:
                 png_b64 = gws_out["images"][0]
-                elements = _parse_elements_from_tree(tree)
 
             # Extract window title from the AX tree first AXWindow line.
             wt = re.search(r'AXWindow\s+"([^"]+)"', tree)
             if wt:
                 window_title = wt.group(1)
+            elif state.get("window_title") or state.get("title"):
+                window_title = str(state.get("window_title") or state.get("title") or "")
+
+            if state.get("screenshot_width") and state.get("screenshot_height"):
+                width, height = int(state["screenshot_width"]), int(state["screenshot_height"])
+            elif state.get("width") and state.get("height") and not (width and height):
+                width, height = int(state["width"]), int(state["height"])
 
         png_bytes_len = 0
         if png_b64:
@@ -540,6 +1076,47 @@ class CuaDriverBackend(ComputerUseBackend):
             except Exception:
                 png_bytes_len = len(png_b64) * 3 // 4
 
+        if mode != "vision" and (not elements or _needs_geometry_fallback(elements)):
+            try:
+                helper_payload = _run_ax_geometry_helper(
+                    pid=self._active_pid or int(target.get("pid", 0) or 0),
+                    window_title=window_title,
+                    window_index=0,
+                    window_bounds=(int(bx or 0), int(by or 0), int(bw or 0), int(bh or 0)),
+                    max_depth=int(os.environ.get("HERMES_AX_GEOMETRY_MAX_DEPTH", "5")),
+                    max_nodes=int(os.environ.get("HERMES_AX_GEOMETRY_MAX_NODES", "300")),
+                    timeout=float(os.environ.get("HERMES_AX_GEOMETRY_TIMEOUT", "3")),
+                )
+                if helper_payload and helper_payload.get("ok"):
+                    if elements:
+                        merged = _merge_ax_geometry(
+                            elements,
+                            helper_payload,
+                            window_bounds=(int(bx or 0), int(by or 0), int(bw or 0), int(bh or 0)),
+                            capture_size=(int(width or 0), int(height or 0)),
+                        )
+                        if merged:
+                            logger.debug("AX geometry helper filled %s/%s element bounds", merged, len(elements))
+                    else:
+                        elements = _elements_from_ax_payload(
+                            helper_payload,
+                            window_bounds=(int(bx or 0), int(by or 0), int(bw or 0), int(bh or 0)),
+                            capture_size=(int(width or 0), int(height or 0)),
+                        )
+                        if elements:
+                            logger.debug("AX geometry helper synthesized %s coordinate-backed elements", len(elements))
+                elif helper_payload:
+                    reason = str(helper_payload.get("error") or "helper_failed")
+                    for e in elements:
+                        if not _bounds_nonzero(e.bounds):
+                            e.attributes.setdefault("geometry_helper_error", reason)
+            except Exception as e:
+                logger.debug("AX geometry fallback failed: %s", e)
+                for element in elements:
+                    if not _bounds_nonzero(element.bounds):
+                        element.attributes.setdefault("geometry_helper_error", str(e))
+
+        self._active_elements = {e.index: e for e in elements}
         return CaptureResult(
             mode=mode,
             width=width,
@@ -550,6 +1127,42 @@ class CuaDriverBackend(ComputerUseBackend):
             window_title=window_title,
             png_bytes_len=png_bytes_len,
         )
+
+    def capture_active(self, mode: str = "som") -> CaptureResult:
+        """Capture the currently selected target without reselecting frontmost window."""
+        if self._active_window:
+            target = dict(self._active_window)
+            self._set_active_window(target)
+            app_name = target.get("app_name", "")
+            bx, by, bw, bh = _window_bounds_tuple(target)
+            if mode == "vision":
+                sc_out = self._session.call_tool(
+                    "screenshot",
+                    {"window_id": self._active_window_id, "format": "jpeg", "quality": 85},
+                )
+                png_b64 = sc_out["images"][0] if sc_out["images"] else None
+                width = height = png_bytes_len = 0
+                if png_b64:
+                    try:
+                        raw = base64.b64decode(png_b64, validate=False)
+                        png_bytes_len = len(raw)
+                        width, height = _image_dimensions_from_bytes(raw)
+                    except Exception:
+                        png_bytes_len = len(png_b64) * 3 // 4
+                return CaptureResult(
+                    mode=mode,
+                    width=width or int(bw or 0),
+                    height=height or int(bh or 0),
+                    png_b64=png_b64,
+                    elements=[],
+                    app=app_name,
+                    window_title=str(target.get("title") or ""),
+                    png_bytes_len=png_bytes_len,
+                )
+            # Preserve the selected target by asking capture to re-target the
+            # same resolved app rather than falling back to frontmost.
+            return self.capture(mode=mode, app=app_name or self._last_app)
+        return self.capture(mode=mode)
 
     # ── Pointer ────────────────────────────────────────────────────
     def click(
@@ -577,11 +1190,23 @@ class CuaDriverBackend(ComputerUseBackend):
 
         args: Dict[str, Any] = {"pid": pid}
         if element is not None:
-            if self._active_window_id is None:
-                return ActionResult(ok=False, action=tool,
-                                    message="No active window_id for element_index click.")
-            args["element_index"] = element
-            args["window_id"] = self._active_window_id
+            coordinate_element = self._active_elements.get(int(element)) if self._active_elements else None
+            if (
+                coordinate_element is not None
+                and coordinate_element.attributes.get("action_backend") == "coordinate"
+                and _bounds_nonzero(coordinate_element.bounds)
+            ):
+                cx, cy = coordinate_element.center()
+                args["x"] = cx
+                args["y"] = cy
+                if self._active_window_id is not None:
+                    args["window_id"] = self._active_window_id
+            else:
+                if self._active_window_id is None:
+                    return ActionResult(ok=False, action=tool,
+                                        message="No active window_id for element_index click.")
+                args["element_index"] = element
+                args["window_id"] = self._active_window_id
         elif x is not None and y is not None:
             args["x"] = x
             args["y"] = y
@@ -778,3 +1403,65 @@ class CuaDriverBackend(ComputerUseBackend):
             message = data
         return ActionResult(ok=ok, action=name, message=message,
                             meta=data if isinstance(data, dict) else {})
+
+
+def _parse_element(d: Dict[str, Any], *, source: str = "cua_driver.elements") -> UIElement:
+    bounds_key = ""
+    bounds = (0, 0, 0, 0)
+    for key in _BOUND_ALIASES:
+        if key in d and d.get(key) is not None:
+            candidate = _coerce_bounds(d.get(key))
+            if _bounds_nonzero(candidate) or not bounds_key:
+                bounds_key = key
+                bounds = candidate
+            if _bounds_nonzero(candidate):
+                break
+
+    label = ""
+    for key in ("label", "title", "description", "value", "identifier", "role_description"):
+        value = d.get(key)
+        if value not in (None, ""):
+            label = str(value)
+            break
+
+    attrs = {
+        k: v for k, v in d.items()
+        if k not in {
+            "index", "element_index", "elementIndex", "role", "label", "title",
+            "description", "value", "identifier", "role_description", "app", "pid",
+            "window_id", "windowId", *_BOUND_ALIASES,
+        }
+    }
+    attrs["geometry_bounds_key"] = bounds_key or None
+    if _bounds_nonzero(bounds):
+        coord_space = (
+            "screen_logical"
+            if bounds_key == "screen_bounds" or d.get("bounds_source") == "AXPosition+AXSize"
+            else "window_logical"
+        )
+        attrs.update(_geometry_attrs(
+            available=True,
+            status="direct",
+            source=source,
+            coordinate_space=coord_space,
+            confidence=1.0,
+        ))
+    else:
+        attrs.update(_geometry_attrs(
+            available=False,
+            status="missing",
+            source=source if source.startswith("cua_driver.") else "none",
+            coordinate_space="unknown",
+            confidence=0.0,
+        ))
+
+    return UIElement(
+        index=int(d.get("index", d.get("element_index", d.get("elementIndex", 0))) or 0),
+        role=str(d.get("role", "") or ""),
+        label=label,
+        bounds=bounds,
+        app=str(d.get("app", "") or ""),
+        pid=int(d.get("pid", 0) or 0),
+        window_id=int(d.get("window_id", d.get("windowId", 0)) or 0),
+        attributes=attrs,
+    )

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -135,12 +135,23 @@ def _get_backend() -> ComputerUseBackend:
             backend_name = os.environ.get("HERMES_COMPUTER_USE_BACKEND", "cua").lower()
             if backend_name in {"cua", "cua-driver", ""}:
                 from tools.computer_use.cua_backend import CuaDriverBackend
-                _backend = CuaDriverBackend()
+                candidate = CuaDriverBackend()
             elif backend_name == "noop":  # pragma: no cover
-                _backend = _NoopBackend()
+                candidate = _NoopBackend()
             else:
                 raise RuntimeError(f"Unknown HERMES_COMPUTER_USE_BACKEND={backend_name!r}")
-            _backend.start()
+            # Only cache the backend after it has successfully started.  A
+            # partially-started cua-driver session otherwise poisons the live
+            # process until restart after a transient startup failure.
+            try:
+                candidate.start()
+            except Exception:
+                try:
+                    candidate.stop()
+                except Exception:
+                    pass
+                raise
+            _backend = candidate
         return _backend
 
 
@@ -786,7 +797,10 @@ def _format_elements(elements: List[UIElement], max_lines: int = 40) -> List[str
     out: List[str] = []
     for e in elements[:max_lines]:
         label = e.label.replace("\n", " ")[:60]
-        out.append(f"  #{e.index} {e.role} {label!r} @ {e.bounds}"
+        bounds = "bounds unavailable" if e.attributes.get("bounds_available") is False else str(e.bounds)
+        source = e.attributes.get("geometry_source")
+        source_suffix = f" source={source}" if source and source not in {"none", "tree_markdown"} else ""
+        out.append(f"  #{e.index} {e.role} {label!r} @ {bounds}{source_suffix}"
                    + (f" [{e.app}]" if e.app else ""))
     if len(elements) > max_lines:
         out.append(f"  ... +{len(elements) - max_lines} more (call capture with app= to narrow)")


### PR DESCRIPTION
## What does this PR do?

`cua-driver`'s `get_window_state` returns AX elements whose `bounds` are frequently zero or imprecise, so the set-of-marks (SOM) index it produces can't be trusted for coordinate clicking. This adds a Swift Accessibility-API helper (`ax_geometry_helper.swift`) that resolves real on-screen element geometry and merges/synthesizes coordinate-backed bounds into the element list, with graceful fallback when geometry is unavailable. The result is a SOM index whose coordinates are reliable enough to click.

**Why this approach:** the cua-driver text/AX-tree bounds are the wrong source of truth for clicking (they're derived, not measured). Querying the macOS AX API directly for the target window's element rects gives measured geometry, and merging it onto the existing element indices keeps the SOM stable while making its coordinates trustworthy. It degrades cleanly (elements are tagged with a `geometry_status`/`source`, and "bounds unavailable" is surfaced) so nothing breaks when the helper can't run.

## Related Issue

No prior issue — happy to open one if you'd prefer to track it there.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/computer_use/ax_geometry_helper.swift` — new Swift helper querying the macOS AX API for element geometry (role, label, bounds), depth/node-capped and timeout-bounded; compiled on demand.
- `tools/computer_use/cua_backend.py` — parse structured `elements`/`ui_elements` with geometry, normalize screen→window bounds, and when bounds are missing/zero run the AX helper to **fill** (`_merge_ax_geometry`) or **synthesize** (`_elements_from_ax_payload`) coordinate-backed elements; each element is tagged with geometry status/source. Also memoizes the backend cache only after a successful `start()`, and routes clicks through synthesized helper elements.
- `tools/computer_use/tool.py` — surface the geometry `source` and a "bounds unavailable" marker in the element summary.
- `tests/tools/test_computer_use_geometry_contract.py` — contract tests for the parse / merge / synthesize / fallback paths (no live GUI required; uses fake sessions + unit helpers).
- `scripts/computer_use_geometry_benchmark.py` — small benchmark to measure geometry coverage across apps.

## How to Test

1. `pytest tests/tools/test_computer_use_geometry_contract.py tests/tools/test_computer_use.py -q` → all pass.
2. On macOS with `cua-driver` installed, run a SOM capture against a GUI app (e.g. TextEdit / iTerm2) and confirm element `bounds` are populated (source `cua_driver.*` or the AX helper) instead of `(0,0,0,0)`. `python scripts/computer_use_geometry_benchmark.py` reports per-app element/bounds coverage.

**Platforms tested:** macOS (Apple Silicon). The helper is macOS-only, consistent with the existing `cua-driver` backend — no behavior change on Linux/Windows (geometry simply reports unavailable).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(computer-use): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the relevant tests (`test_computer_use_geometry_contract.py`, `test_computer_use.py`) and they pass
- [x] I've added tests for my changes
