### PR TITLE
fix(custom): honor disable_tools on custom providers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -151,6 +151,53 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
     agent.request_overrides = overrides
 
 
+def _custom_provider_disable_tools_for_agent(
+    *,
+    provider: str,
+    model: str,
+    base_url: str,
+    custom_providers: List[Dict[str, Any]],
+) -> bool:
+    if (provider or "").strip().lower() != "custom":
+        return False
+
+    target_url = _normalized_custom_base_url(base_url)
+    if not target_url:
+        return False
+
+    fallback: Optional[bool] = None
+    for entry in custom_providers or []:
+        if not isinstance(entry, dict):
+            continue
+        if _normalized_custom_base_url(entry.get("base_url")) != target_url:
+            continue
+        disable_tools = entry.get("disable_tools")
+        if not isinstance(disable_tools, bool):
+            continue
+        provider_model = str(entry.get("model", "") or "").strip()
+        if provider_model:
+            if _custom_provider_model_matches(model, entry):
+                return disable_tools
+        elif fallback is None:
+            fallback = disable_tools
+
+    return bool(fallback)
+
+
+def _merge_custom_provider_disable_tools(agent, custom_providers: List[Dict[str, Any]]) -> None:
+    if not _custom_provider_disable_tools_for_agent(
+        provider=agent.provider,
+        model=agent.model,
+        base_url=agent.base_url,
+        custom_providers=custom_providers,
+    ):
+        return
+
+    overrides = dict(getattr(agent, "request_overrides", {}) or {})
+    overrides["disable_tools"] = True
+    agent.request_overrides = overrides
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -1431,6 +1478,7 @@ def init_agent(
     # compression model context-length detection needs the same list).
     agent._custom_providers = _custom_providers
     _merge_custom_provider_extra_body(agent, _custom_providers)
+    _merge_custom_provider_disable_tools(agent, _custom_providers)
 
     # Check custom_providers per-model context_length
     if _config_context_length is None and _custom_providers:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -554,7 +554,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
-    tools_for_api = agent.tools
+    request_overrides = dict(getattr(agent, "request_overrides", {}) or {})
+    disable_tools = bool(request_overrides.pop("disable_tools", False))
+    tools_for_api = None if disable_tools else agent.tools
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
@@ -574,7 +576,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             preserve_dots=agent._anthropic_preserve_dots(),
             context_length=ctx_len,
             base_url=getattr(agent, "_anthropic_base_url", None),
-            fast_mode=(agent.request_overrides or {}).get("speed") == "fast",
+            fast_mode=request_overrides.get("speed") == "fast",
             drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)),
         )
 
@@ -649,7 +651,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             session_id=getattr(agent, "session_id", None),
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
-            request_overrides=agent.request_overrides,
+            request_overrides=request_overrides,
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
@@ -751,7 +753,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             ephemeral_max_output_tokens=_ephemeral_out,
             max_tokens_param_fn=agent._max_tokens_param,
             reasoning_config=agent.reasoning_config,
-            request_overrides=agent.request_overrides,
+            request_overrides=request_overrides,
             session_id=getattr(agent, "session_id", None),
             provider_profile=_profile,
             ollama_num_ctx=agent._ollama_num_ctx,
@@ -783,7 +785,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         ephemeral_max_output_tokens=_ephemeral_out,
         max_tokens_param_fn=agent._max_tokens_param,
         reasoning_config=agent.reasoning_config,
-        request_overrides=agent.request_overrides,
+        request_overrides=request_overrides,
         session_id=getattr(agent, "session_id", None),
         model_lower=(agent.model or "").lower(),
         is_openrouter=_is_or,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4049,6 +4049,7 @@ def _normalize_custom_provider_entry(
         "defaultModel": "default_model",
         "contextLength": "context_length",
         "rateLimitDelay": "rate_limit_delay",
+        "disableTools": "disable_tools",
     }
     # api_key_env is a documented snake_case alias for key_env (see
     # website/docs/guides/azure-foundry.md).  Normalize it up front so the
@@ -4060,7 +4061,7 @@ def _normalize_custom_provider_entry(
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
-        "discover_models", "extra_body",
+        "discover_models", "extra_body", "disable_tools",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -4158,6 +4159,10 @@ def _normalize_custom_provider_entry(
     extra_body = entry.get("extra_body")
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
+
+    disable_tools = entry.get("disable_tools")
+    if isinstance(disable_tools, bool):
+        normalized["disable_tools"] = disable_tools
 
     return normalized
 
@@ -4386,7 +4391,7 @@ _KNOWN_ROOT_KEYS = {
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay", "extra_body",
+    "context_length", "rate_limit_delay", "extra_body", "disable_tools",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -1,6 +1,9 @@
 from types import SimpleNamespace
 
-from agent.agent_init import _merge_custom_provider_extra_body
+from agent.agent_init import (
+    _merge_custom_provider_disable_tools,
+    _merge_custom_provider_extra_body,
+)
 
 
 def test_custom_provider_extra_body_merges_into_request_overrides():
@@ -86,6 +89,52 @@ def test_custom_provider_extra_body_ignores_other_custom_models():
                 "base_url": "https://example.test/v1",
                 "model": "google/gemma-4-31b-it",
                 "extra_body": {"enable_thinking": True},
+            }
+        ],
+    )
+
+    assert agent.request_overrides == {}
+
+
+def test_custom_provider_disable_tools_sets_request_override():
+    agent = SimpleNamespace(
+        provider="custom",
+        model="sonar",
+        base_url="https://api.perplexity.ai",
+        request_overrides={},
+    )
+
+    _merge_custom_provider_disable_tools(
+        agent,
+        [
+            {
+                "name": "perplexity",
+                "base_url": "https://api.perplexity.ai/",
+                "model": "sonar",
+                "disable_tools": True,
+            }
+        ],
+    )
+
+    assert agent.request_overrides == {"disable_tools": True}
+
+
+def test_custom_provider_disable_tools_ignores_other_models():
+    agent = SimpleNamespace(
+        provider="custom",
+        model="sonar-pro",
+        base_url="https://api.perplexity.ai",
+        request_overrides={},
+    )
+
+    _merge_custom_provider_disable_tools(
+        agent,
+        [
+            {
+                "name": "perplexity",
+                "base_url": "https://api.perplexity.ai",
+                "model": "sonar",
+                "disable_tools": True,
             }
         ],
     )

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2299,6 +2299,21 @@ class TestProviderEntryApiKeyEnvAlias:
         assert normalized is not None
         assert "extra_body" in _VALID_CUSTOM_PROVIDER_FIELDS
         assert normalized["extra_body"] == entry["extra_body"]
+
+    def test_disable_tools_is_supported_schema(self):
+        from hermes_cli.config import (
+            _VALID_CUSTOM_PROVIDER_FIELDS,
+            _normalize_custom_provider_entry,
+        )
+        entry = {
+            "name": "vendor",
+            "base_url": "https://api.vendor.example.com/v1",
+            "disable_tools": True,
+        }
+        normalized = _normalize_custom_provider_entry(dict(entry), provider_key="vendor")
+        assert normalized is not None
+        assert "disable_tools" in _VALID_CUSTOM_PROVIDER_FIELDS
+        assert normalized["disable_tools"] is True
 # =============================================================================
 # Tencent TokenHub — API-key provider runtime resolution
 # =============================================================================

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -108,6 +108,15 @@ class TestBuildApiKwargsOpenRouter:
         tool_names = [t["function"]["name"] for t in kwargs["tools"]]
         assert "web_search" in tool_names
 
+    def test_disable_tools_override_omits_tool_definitions(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "custom", base_url="https://api.perplexity.ai")
+        agent.model = "sonar"
+        agent.request_overrides = {"disable_tools": True}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "tools" not in kwargs
+        assert "disable_tools" not in kwargs
+
     def test_no_responses_api_fields(self, monkeypatch):
         agent = _make_agent(monkeypatch, "openrouter")
         messages = [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
## Summary
- preserve `disable_tools: true` in custom provider config normalization
- merge that flag into custom-provider request overrides and omit tool schemas from outbound API requests
- add regression coverage for config normalization, agent init merging, and API kwargs generation

Fixes #49761

## Testing
- `uv run --frozen pytest tests/hermes_cli/test_runtime_provider_resolution.py::TestProviderEntryApiKeyEnvAlias::test_disable_tools_is_supported_schema tests/agent/test_custom_provider_extra_body.py tests/run_agent/test_provider_parity.py::TestBuildApiKwargsOpenRouter::test_disable_tools_override_omits_tool_definitions`
- `uv run --frozen ruff check hermes_cli/config.py agent/agent_init.py agent/chat_completion_helpers.py tests/agent/test_custom_provider_extra_body.py tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_provider_parity.py`
- `git diff --check`