### PR TITLE
fix(voice): respect false-like beep_enabled strings

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9354,9 +9354,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """Return whether CLI voice mode should play record start/stop beeps."""
         try:
             from hermes_cli.config import load_config
+            from utils import is_truthy_value
             voice_cfg = load_config().get("voice", {})
             if isinstance(voice_cfg, dict):
-                return bool(voice_cfg.get("beep_enabled", True))
+                return is_truthy_value(voice_cfg.get("beep_enabled"), default=True)
         except Exception:
             pass
         return True

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -248,10 +248,11 @@ def _beeps_enabled() -> bool:
     """CLI parity: voice.beep_enabled in config.yaml (default True)."""
     try:
         from hermes_cli.config import load_config
+        from utils import is_truthy_value
 
         voice_cfg = load_config().get("voice", {})
         if isinstance(voice_cfg, dict):
-            return bool(voice_cfg.get("beep_enabled", True))
+            return is_truthy_value(voice_cfg.get("beep_enabled"), default=True)
     except Exception:
         pass
     return True

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -948,6 +948,25 @@ class TestVoiceBeepConfigReal:
         cli = _make_voice_cli()
         assert cli._voice_beeps_enabled() is False
 
+    @pytest.mark.parametrize("value", ["false", "0", "off"])
+    def test_false_like_string_values_disable_beeps(self, value):
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"voice": {"beep_enabled": value}},
+        ):
+            cli = _make_voice_cli()
+            assert cli._voice_beeps_enabled() is False
+
+    @pytest.mark.parametrize("value", ["false", "0", "off"])
+    def test_standalone_voice_loop_false_like_string_values_disable_beeps(self, value):
+        from hermes_cli.voice import _beeps_enabled
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"voice": {"beep_enabled": value}},
+        ):
+            assert _beeps_enabled() is False
+
     @patch("cli._cprint")
     @patch("cli.threading.Thread")
     @patch("tools.voice_mode.play_beep")


### PR DESCRIPTION
## What does this PR do?

Fixes voice beep configuration parsing so quoted false-like values such as `"false"`, `"0"`, and `"off"` disable record start/stop beeps instead of being treated as enabled.

The root cause is raw Python truthiness: `bool("false")` is `True` because any non-empty string is truthy. This PR switches the affected voice config paths to the existing shared `is_truthy_value(..., default=True)` helper.

## Related Issue

Fixes #49883

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: parse `voice.beep_enabled` with `is_truthy_value()` in the interactive CLI voice path.
- `hermes_cli/voice.py`: apply the same parsing in the standalone voice loop helper.
- `tests/tools/test_voice_cli_integration.py`: add regression coverage for `"false"`, `"0"`, and `"off"` in both voice beep config paths.

## How to Test

1. Configure voice beeps with a quoted false-like value:
   ```yaml
   voice:
     beep_enabled: "false"
   ```
2. Verify the CLI and standalone voice beep helpers treat the value as disabled.
3. Run the focused tests:
   ```bash
   scripts/run_tests.sh tests/tools/test_voice_cli_integration.py
   scripts/run_tests.sh tests/test_utils_truthy_values.py
   python -m pytest tests/tools/test_voice_cli_integration.py -q
   python -m pytest tests/test_utils_truthy_values.py -q
   python -m py_compile cli.py hermes_cli/voice.py tests/tools/test_voice_cli_integration.py
   git diff --check
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A - config parsing fix with no visual UI change.

Focused validation passed locally:

```text
scripts/run_tests.sh tests/tools/test_voice_cli_integration.py
90 tests passed

scripts/run_tests.sh tests/test_utils_truthy_values.py
4 tests passed

python -m pytest tests/tools/test_voice_cli_integration.py -q
90 passed

python -m pytest tests/test_utils_truthy_values.py -q
4 passed
```