### PR TITLE
fix(skills): install_from_quarantine fails when HERMES_HOME is a symlink

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -2282,3 +2282,84 @@ class TestParallelSearchSourcesTimeout:
         assert source_counts.get("a") == 1
         assert source_counts.get("b") == 1
         assert len(all_results) == 2
+
+
+class TestInstallFromQuarantineSymlinkedHome:
+    """install_from_quarantine must work when HERMES_HOME is a symlink.
+
+    Regression for the living-agent ``.gen/<name>/<gen_id>`` generation layout:
+    ``~/.hermes/profiles/<name>`` is a symlink into the generation store, so the
+    skills dir resolves to a different real path than its unresolved form. The
+    install path is realpath-resolved by ``_resolve_lock_install_path``; recording
+    the lock entry must compare it against the RESOLVED skills root, not the
+    unresolved ``SKILLS_DIR``, or ``Path.relative_to`` raises ValueError and the
+    install is wrongly blocked.
+    """
+
+    def _stage(self, tmp_path):
+        """Build a symlinked profile home with a quarantined skill ready to install."""
+        import tools.skills_hub as hub
+
+        # Real generation dir + a symlink standing in for the live profile home.
+        gen_home = tmp_path / ".gen" / "agent" / "000005"
+        gen_home.mkdir(parents=True)
+        link_home = tmp_path / "profiles" / "agent"
+        link_home.parent.mkdir(parents=True)
+        link_home.symlink_to(gen_home, target_is_directory=True)
+
+        skills_dir = link_home / "skills"          # unresolved: …/profiles/agent/skills
+        hub_dir = skills_dir / ".hub"
+        quarantine_dir = hub_dir / "quarantine"
+        quarantine_dir.mkdir(parents=True)
+
+        # A scanned, quarantined skill bundle on disk.
+        q_path = quarantine_dir / "antigravity-cli"
+        q_path.mkdir()
+        (q_path / "SKILL.md").write_text(
+            "---\nname: antigravity-cli\ndescription: test\n---\nbody\n"
+        )
+        return hub, skills_dir, hub_dir, quarantine_dir, q_path
+
+    def test_install_succeeds_under_symlinked_hermes_home(self, tmp_path, monkeypatch):
+        hub, skills_dir, hub_dir, quarantine_dir, q_path = self._stage(tmp_path)
+
+        # Point the module's path constants at the symlinked tree. HubLockFile's
+        # default ``path`` arg binds LOCK_FILE at import, so also redirect the
+        # lock instance the install creates by patching the class default.
+        monkeypatch.setattr(hub, "SKILLS_DIR", skills_dir)
+        monkeypatch.setattr(hub, "QUARANTINE_DIR", quarantine_dir)
+        monkeypatch.setattr(hub, "LOCK_FILE", hub_dir / "lock.json")
+        monkeypatch.setattr(hub, "AUDIT_LOG", hub_dir / "audit.log")
+        monkeypatch.setattr(
+            hub.HubLockFile.__init__,
+            "__defaults__",
+            (hub_dir / "lock.json",),
+        )
+
+        bundle = SkillBundle(
+            name="antigravity-cli",
+            files={"SKILL.md": "x"},
+            source="official",
+            identifier="official/autonomous-ai-agents/antigravity-cli",
+            trust_level="official",
+            metadata={},
+        )
+        scan_result = MagicMock(verdict="SAFE", findings=[])
+
+        # Before the fix this raised ValueError ("not in the subpath of …") because
+        # the resolved install_dir was compared against the unresolved SKILLS_DIR.
+        install_dir = hub.install_from_quarantine(
+            q_path, "antigravity-cli", "autonomous-ai-agents", bundle, scan_result
+        )
+
+        assert install_dir.exists()
+        assert (install_dir / "SKILL.md").exists()
+        # The install_dir is realpath-resolved and lands under the resolved skills
+        # root at the expected category/name — the exact computation that used to
+        # raise when compared against the unresolved SKILLS_DIR.
+        rel = install_dir.relative_to(skills_dir.resolve())
+        assert str(rel) == "autonomous-ai-agents/antigravity-cli"
+        # Lock entry was recorded with that same relative path.
+        lock_data = json.loads((hub_dir / "lock.json").read_text())
+        recorded = lock_data["installed"]["antigravity-cli"]["install_path"]
+        assert recorded == "autonomous-ai-agents/antigravity-cli"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3386,6 +3386,11 @@ def install_from_quarantine(
 
     # Record in lock file
     lock = HubLockFile()
+    # ``install_dir`` is realpath-resolved (via _resolve_lock_install_path), so
+    # compute its lock-relative path against the RESOLVED skills root. Comparing a
+    # resolved path against the unresolved ``SKILLS_DIR`` raises ValueError when
+    # HERMES_HOME is a symlink (e.g. the living-agent ``.gen/<name>/<gen_id>``
+    # generation layout), wrongly blocking the install. Resolve both sides.
     lock.record_install(
         name=safe_skill_name,
         source=bundle.source,
@@ -3393,7 +3398,7 @@ def install_from_quarantine(
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
         skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(SKILLS_DIR)),
+        install_path=str(install_dir.relative_to(SKILLS_DIR.resolve())),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,
     )


### PR DESCRIPTION
## Summary

`install_from_quarantine` raises `ValueError` and blocks the install when `HERMES_HOME` is a symlink, even though the target is a perfectly valid path inside the skills tree.

## Reproduction

Any layout where the profile home is a symlink. Concretely, with `~/.hermes/profiles/<name>` symlinked to a real directory elsewhere:

```
$ hermes skills install official/autonomous-ai-agents/antigravity-cli
...
Installation blocked: '…/.gen/<name>/<gen_id>/skills/autonomous-ai-agents/antigravity-cli'
is not in the subpath of '…/profiles/<name>/skills' OR one path is relative and the
other is absolute.
```

The destination is the same directory as the skills root — just reached through the symlink — so the install should succeed.

## Root cause

In `tools/skills_hub.py`, `install_from_quarantine` resolves the install directory through `_resolve_lock_install_path`, which ends in `target.resolve()` — a realpath-**resolved** path. It then records the lock entry with:

```python
install_path=str(install_dir.relative_to(SKILLS_DIR)),
```

But `SKILLS_DIR = HERMES_HOME / "skills"` (module level) is **not** resolved. When `HERMES_HOME` is a symlink, the resolved `install_dir` and the unresolved `SKILLS_DIR` diverge, so `Path.relative_to()` raises `ValueError` (`'… is not in the subpath of …'`). The CLI catches it and prints `Installation blocked`.

A stock single-profile host never hits this because a real directory resolves to itself (`resolved == unresolved`). It only manifests when the profile home is a symlink — e.g. generation-store / atomic-flip self-update layouts that point `profiles/<name>` at `.gen/<name>/<gen_id>`.

## Fix

Compare against the **resolved** skills root, so both sides of `relative_to` are in the same (resolved) form. `install_dir` is already resolved, so this is the correct like-for-like comparison:

```python
install_path=str(install_dir.relative_to(SKILLS_DIR.resolve())),
```

One line. No behavior change for non-symlinked homes (`SKILLS_DIR.resolve() == SKILLS_DIR` there). The earlier safety guards in `_resolve_lock_install_path` (symlink-in-tree rejection, escape-out rejection, `resolved == skills_root` rejection) are untouched — this only fixes the lock-relative-path computation.

## Test

Adds `TestInstallFromQuarantineSymlinkedHome` to `tests/tools/test_skills_hub.py`, which:
- builds a real symlinked profile home (`profiles/agent -> .gen/agent/000005`),
- stages a quarantined skill,
- installs it through the real `install_from_quarantine`,
- asserts it no longer raises and records the correct relative `install_path`.

Verified the test **fails without the fix** — it reproduces the exact `ValueError` (`'…/.gen/agent/000005/skills/…' is not in the subpath of '…/profiles/agent/skills'`) — and **passes with it**. Full `tests/tools/test_skills_hub.py` (144 tests) is green; `ruff check` clean on both files.
