### PR TITLE
fix(openviking): synchronous prefetch with current turn's query

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -70,6 +70,8 @@ _OPENVIKING_ENV_KEYS = (
 _TIMEOUT = 30.0
 _SESSION_DRAIN_TIMEOUT = 10.0
 _DEFERRED_COMMIT_TIMEOUT = (_TIMEOUT * 2) + 5.0
+_PREFETCH_TIMEOUT = 1.5        # Sync prefetch shouldn't block the turn loop
+_PREFETCH_MIN_SCORE = 0.35     # Noise filter (matches Claude Code plugin)
 _REMOTE_RESOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
 _SYNC_TRACE_ENV = "HERMES_OPENVIKING_SYNC_TRACE"
 
@@ -2046,15 +2048,56 @@ class OpenVikingMemoryProvider(MemoryProvider):
             )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
-        """Return prefetched results from the background thread."""
+        """Synchronous recall for the current turn.
+
+        Uses the *current* ``query`` to perform a synchronous OV search,
+        addressing the stale-context problem where background prefetch
+        results from the *previous* turn were injected into the current
+        turn. The old background cache is drained to avoid stale re-use.
+
+        A short timeout (``_PREFETCH_TIMEOUT``) prevents a slow or
+        unreachable OV server from blocking the agent turn loop.
+        ``queue_prefetch()`` continues to fire background searches at
+        turn-end for other potential consumers, but ``prefetch()`` no
+        longer consumes its output.
+        """
+        # ------------------------------------------------------------------
+        # 1. Drain stale background cache
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
-            result = self._prefetch_result
             self._prefetch_result = ""
-        if not result:
+
+        query = _derive_openviking_user_text(query)
+        if not self._client or not query:
             return ""
-        return f"## OpenViking Context\n{result}"
+
+        # ------------------------------------------------------------------
+        # 2. Synchronous search with the *current* query
+        try:
+            client = _VikingClient(
+                self._endpoint, self._api_key,
+                account=self._account, user=self._user, agent=self._agent,
+            )
+            resp = client.post("/api/v1/search/find", {
+                "query": query,
+                "limit": 5,
+            }, timeout=_PREFETCH_TIMEOUT)
+            result = resp.get("result", {})
+            parts = []
+            for ctx_type in ("memories", "resources"):
+                items = result.get(ctx_type, [])
+                for item in items[:3]:
+                    uri = item.get("uri", "")
+                    score = item.get("score", 0)
+                    abstract = item.get("abstract", "")
+                    if abstract and score >= _PREFETCH_MIN_SCORE:
+                        parts.append(f"- [{score:.2f}] {abstract} ({uri})")
+            if parts:
+                return "## OpenViking Context\n" + "\n".join(parts)
+        except Exception as e:
+            logger.debug("OpenViking sync prefetch failed: %s", e)
+        return ""
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         """Fire a background search to pre-load relevant context."""


### PR DESCRIPTION
## Problem

The OpenViking memory provider's `prefetch()` method returns stale results from a background thread that fired at the end of the previous turn. The current turn's `query` parameter is completely ignored, meaning automatic memory context is always about the wrong topic.

First turn gets zero context. Every subsequent turn gets stale context from the previous topic.

## Root Cause

`plugins/memory/openviking/__init__.py` — `prefetch()` currently ignores its query parameter and returns whatever the background thread cached from the previous turn's topic.

## Fix

`prefetch()` now performs a **synchronous** `POST /api/v1/search/find` using the **current** turn's `query` parameter — matching Claude Code's plugin behavior.

1. **Uses the actual query** — searches for the current topic, not the previous one
2. **Score threshold** — minimum `_PREFETCH_MIN_SCORE = 0.35`, filters noise
3. **Timeout guard** — `_PREFETCH_TIMEOUT = 1.5s` prevents slow OV from blocking the turn loop
4. **Stale cache drained** — previous turn's background-thread result is discarded

`queue_prefetch()` is **unchanged** — it still fires background searches at turn-end for pre-warming, but `prefetch()` no longer consumes its output.

## Related

- Ref: https://github.com/volcengine/OpenViking/discussions/2253 (root cause analysis)
- Closes: https://github.com/NousResearch/hermes-agent/issues/5820
- Contrast: PR #5838 (sync_recall manager-layer approach — not merged; this PR fixes it at the provider level, similar to the merged Honcho fix #20178)
