### PR TITLE
fix(doctor): audit WhatsApp bridge at its resolved HERMES_HOME dir (follow-up #49561)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1585,11 +1585,20 @@ def run_doctor(args):
         # glob (which pulls in Electron, node-pty, etc.) is never resolved
         # for a routine security check. The web and ui-tui workspaces are
         # audited separately via --workspace flags. See #38772.
+        # The WhatsApp bridge may live under a writable HERMES_HOME mirror
+        # instead of the (possibly read-only) install tree in Docker — resolve
+        # it through the shared helper so we audit the dir that actually holds
+        # node_modules. See #49561.
+        try:
+            from gateway.platforms.whatsapp_common import resolve_whatsapp_bridge_dir
+            _whatsapp_bridge_dir = resolve_whatsapp_bridge_dir()
+        except Exception:
+            _whatsapp_bridge_dir = PROJECT_ROOT / "scripts" / "whatsapp-bridge"
         npm_audit_targets = [
             (PROJECT_ROOT, "Browser tools (agent-browser)", ["--workspaces=false"]),
             (PROJECT_ROOT, "web workspace", ["--workspace", "web"]),
             (PROJECT_ROOT, "ui-tui workspace", ["--workspace", "ui-tui"]),
-            (PROJECT_ROOT / "scripts" / "whatsapp-bridge", "WhatsApp bridge", []),
+            (_whatsapp_bridge_dir, "WhatsApp bridge", []),
         ]
         for npm_dir, label, audit_extra in npm_audit_targets:
             # For workspace-scoped audits run from PROJECT_ROOT the


### PR DESCRIPTION
## Summary
Follow-up to #49839: `hermes doctor`'s npm audit hardcoded `PROJECT_ROOT/scripts/whatsapp-bridge`, so in read-only Docker installs — where the bridge deps now live in the writable `HERMES_HOME` mirror (#49561) — doctor never found `node_modules` there and silently skipped the WhatsApp bridge audit.

## Changes
- `hermes_cli/doctor.py`: resolve the bridge dir via the shared `resolve_whatsapp_bridge_dir()` helper before auditing, so doctor audits the directory that actually holds the installed deps. Falls back to the install-tree path if the helper is unavailable.

## Validation
| | Before | After |
|---|---|---|
| Read-only Docker install | bridge `node_modules` not at PROJECT_ROOT → audit silently skipped | audits the resolved HERMES_HOME mirror where deps live |
| Normal writable install | audits PROJECT_ROOT bridge | unchanged (helper returns install dir) |

Targeted tests: 78/78 doctor tests green. Helper imports cleanly at runtime; `py_compile` passes.

## Infographic

![whatsapp-bridge-readonly-docker-fix](https://v3b.fal.media/files/b/0a9f1c9a/QNj0PsZZdVorwues7zaHL_KRYFNmAo.png)
