### PR TITLE
fix(kanban): remove dead COLUMN_ORDER, add missing column help entries

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -86,8 +86,6 @@
     return body || raw;
   }
 
-  // Order matches BOARD_COLUMNS in plugin_api.py.
-  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "done"];
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
@@ -106,6 +104,8 @@
     ready: "Dependencies satisfied; assign a profile to dispatch",
     running: "Claimed by a worker — in-flight",
     blocked: "Worker asked for human input",
+    scheduled: "Waiting on a scheduled time or follow-up",
+    review: "Awaiting human review before moving to done",
     done: "Completed",
     archived: "Archived",
   };


### PR DESCRIPTION
## Summary

- Remove dead `COLUMN_ORDER` constant from the Kanban dashboard frontend
- Add missing `scheduled` and `review` entries to `FALLBACK_COLUMN_HELP`

## Root Cause

`COLUMN_ORDER` (`dist/index.js:149`) was defined but never referenced — the board renders columns from the backend's `BOARD_COLUMNS` response directly. The constant's list was stale: missing `scheduled` and `review` which were added to `BOARD_COLUMNS` (`plugin_api.py:150`) and `kanban_db.VALID_STATUSES` (`kanban_db.py:100`).

`FALLBACK_COLUMN_HELP` (line 162) had the same drift — no entries for those two columns, so `getColumnHelp()` returned `""` for them.

## Verification

- `grep -c COLUMN_ORDER dist/index.js` → 0 (was 1 before the fix)
- `FALLBACK_COLUMN_HELP` now has 9 entries matching `VALID_STATUSES`
- All 95 existing plugin tests pass

Fixes #49891
