### PR TITLE
fix(desktop): keep update actions reachable

### DIFF
--- a/apps/desktop/src/app/updates-overlay.test.tsx
+++ b/apps/desktop/src/app/updates-overlay.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DesktopUpdateCommit } from '@/global'
+import {
+  $backendUpdateApply,
+  $backendUpdateChecking,
+  $backendUpdateStatus,
+  $updateApply,
+  $updateChecking,
+  $updateOverlayOpen,
+  $updateOverlayTarget,
+  $updateStatus
+} from '@/store/updates'
+
+import { UpdatesOverlay } from './updates-overlay'
+
+function slot(root: ParentNode, name: string): HTMLElement {
+  const element = root.querySelector(`[data-slot="${name}"]`)
+
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`Missing ${name}`)
+  }
+
+  return element
+}
+
+function commits(count: number): DesktopUpdateCommit[] {
+  return Array.from({ length: count }, (_, index) => ({
+    at: Date.now() - index,
+    author: 'Hermes',
+    sha: `commit-${index}`,
+    summary: `fix(desktop): keep update dialog action ${index + 1} reachable`
+  }))
+}
+
+function resetUpdateStores() {
+  const idleApply = {
+    applying: false,
+    command: null,
+    error: null,
+    log: [],
+    message: '',
+    percent: null,
+    stage: 'idle' as const
+  }
+
+  $updateOverlayOpen.set(false)
+  $updateOverlayTarget.set('client')
+  $updateStatus.set(null)
+  $updateChecking.set(false)
+  $updateApply.set(idleApply)
+  $backendUpdateStatus.set(null)
+  $backendUpdateChecking.set(false)
+  $backendUpdateApply.set(idleApply)
+}
+
+describe('UpdatesOverlay', () => {
+  beforeEach(() => {
+    resetUpdateStores()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    resetUpdateStores()
+  })
+
+  it('keeps update actions outside the scrollable release notes area', () => {
+    $updateStatus.set({
+      behind: 30,
+      commits: commits(24),
+      fetchedAt: Date.now(),
+      supported: true,
+      targetSha: 'target-sha'
+    })
+    $updateOverlayOpen.set(true)
+
+    render(<UpdatesOverlay />)
+
+    expect(screen.getByText('New update available')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Update now' })).toBeTruthy()
+
+    const notes = slot(document.body, 'updates-overlay-notes')
+    const actions = slot(document.body, 'updates-overlay-actions')
+
+    expect(slot(document.body, 'updates-overlay-idle').className).toContain('max-h-[85dvh]')
+    expect(notes.className).toContain('min-h-0')
+    expect(notes.className).toContain('flex-1')
+    expect(notes.className).toContain('overflow-y-auto')
+    expect(actions.className).toContain('shrink-0')
+    expect(notes.contains(screen.getByRole('button', { name: 'Update now' }))).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -11,8 +11,8 @@ import type { DesktopUpdateCommit, DesktopUpdateStage, DesktopUpdateStatus } fro
 import { useI18n } from '@/i18n'
 import { buildCommitChangelog, type CommitGroup } from '@/lib/commit-changelog'
 import { AlertCircle, Check, CheckCircle2, Copy, Terminal } from '@/lib/icons'
-import { cn } from '@/lib/utils'
 import { resolveUpdateCopy, type UpdateTarget } from '@/lib/update-copy'
+import { cn } from '@/lib/utils'
 import {
   $backendUpdateApply,
   $backendUpdateChecking,
@@ -143,7 +143,10 @@ function IdleView({
 
   if (!status && checking) {
     return (
-      <CenteredStatus icon={<Loader className="size-12" label={u.checking} type="lemniscate-bloom" />} title={u.checking} />
+      <CenteredStatus
+        icon={<Loader className="size-12" label={u.checking} type="lemniscate-bloom" />}
+        title={u.checking}
+      />
     )
   }
 
@@ -207,33 +210,42 @@ function IdleView({
   const { title, body } = resolveUpdateCopy({ target, shownItems, copy: u })
 
   return (
-    <div className="grid gap-5 px-6 pb-6 pt-7 pr-8">
-      <div className="flex flex-col items-center gap-3 text-center">
+    <div className="flex max-h-[85dvh] min-h-0 flex-col" data-slot="updates-overlay-idle">
+      <div className="flex shrink-0 flex-col items-center gap-3 px-6 pt-7 pr-8 text-center">
         <BrandMark className="size-16" />
 
         <DialogTitle className="text-center text-xl">{title}</DialogTitle>
-        <DialogDescription className="text-center text-sm">
-          {body}
-        </DialogDescription>
+        <DialogDescription className="text-center text-sm">{body}</DialogDescription>
       </div>
 
-      <div className="grid gap-3 rounded-xl border border-border/70 bg-muted/20 px-4 py-3">
-        {groups.map(group => (
-          <div key={group.id}>
-            <p className="text-[0.625rem] font-semibold uppercase tracking-wide text-muted-foreground">{group.label}</p>
-            <ul className="mt-1.5 grid gap-1.5 text-xs text-foreground">
-              {group.items.map(item => (
-                <li className="flex items-start gap-2" key={item}>
-                  <span aria-hidden className="mt-1.5 inline-block size-1 shrink-0 rounded-full bg-primary" />
-                  <span className="leading-snug">{item}</span>
-                </li>
-              ))}
-            </ul>
+      <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4 pr-8" data-slot="updates-overlay-notes">
+        {groups.length > 0 && (
+          <div className="grid gap-3 rounded-xl border border-border/70 bg-muted/20 px-4 py-3">
+            {groups.map(group => (
+              <div key={group.id}>
+                <p className="text-[0.625rem] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {group.label}
+                </p>
+                <ul className="mt-1.5 grid gap-1.5 text-xs text-foreground">
+                  {group.items.map(item => (
+                    <li className="flex items-start gap-2" key={item}>
+                      <span aria-hidden className="mt-1.5 inline-block size-1 shrink-0 rounded-full bg-primary" />
+                      <span className="leading-snug">{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
           </div>
-        ))}
+        )}
+
+        {remaining > 0 && <p className="mt-3 text-center text-xs text-muted-foreground">{u.moreChanges(remaining)}</p>}
       </div>
 
-      <div className="grid gap-2">
+      <div
+        className="grid shrink-0 gap-2 border-t border-border/60 bg-(--ui-chat-bubble-background) px-6 pb-6 pt-4 pr-8"
+        data-slot="updates-overlay-actions"
+      >
         <Button className="font-semibold" onClick={onInstall} size="lg">
           {u.updateNow}
         </Button>
@@ -241,12 +253,6 @@ function IdleView({
           {u.maybeLater}
         </Button>
       </div>
-
-      {remaining > 0 && (
-        <p className="text-center text-xs text-muted-foreground">
-          {u.moreChanges(remaining)}
-        </p>
-      )}
     </div>
   )
 }
@@ -269,9 +275,7 @@ function ManualView({ command, onDone }: { command: string; onDone: () => void }
         <Terminal className="size-8 text-primary" />
 
         <DialogTitle className="text-center text-xl">{u.manualTitle}</DialogTitle>
-        <DialogDescription className="text-center text-sm">
-          {u.manualBody}
-        </DialogDescription>
+        <DialogDescription className="text-center text-sm">{u.manualBody}</DialogDescription>
       </div>
 
       <button
@@ -298,9 +302,7 @@ function ManualView({ command, onDone }: { command: string; onDone: () => void }
         </span>
       </button>
 
-      <p className="text-center text-xs text-muted-foreground">
-        {u.manualPickedUp}
-      </p>
+      <p className="text-center text-xs text-muted-foreground">{u.manualPickedUp}</p>
 
       <Button className="font-semibold" onClick={onDone} size="lg" variant="secondary">
         {u.done}
@@ -326,9 +328,7 @@ function ApplyingView({ apply, isBackend }: { apply: UpdateApplyState; isBackend
         <Loader className="size-16" label={label} type="lemniscate-bloom" />
 
         <DialogTitle className="text-center text-xl">{label}</DialogTitle>
-        <DialogDescription className="text-center text-sm">
-          {body}
-        </DialogDescription>
+        <DialogDescription className="text-center text-sm">{body}</DialogDescription>
       </div>
 
       <div className="h-2 overflow-hidden rounded-full bg-muted">
@@ -358,9 +358,7 @@ function ErrorView({ message, onDismiss, onRetry }: { message: string; onDismiss
           {message || u.errorBody}
         </DialogDescription>
       }
-      title={
-        <DialogTitle className="text-center text-xl font-semibold tracking-tight">{u.errorTitle}</DialogTitle>
-      }
+      title={<DialogTitle className="text-center text-xl font-semibold tracking-tight">{u.errorTitle}</DialogTitle>}
     >
       <Button className="font-semibold" onClick={onRetry} size="lg">
         {u.tryAgain}


### PR DESCRIPTION
## Summary
- Split the desktop update-available overlay into fixed header/actions and a scrollable release-notes body
- Keep the action buttons outside the scrollable notes area so they remain reachable under zoom or long changelogs
- Add a renderer test that locks the scroll/action structure for the update overlay

Fixes #49888

## Tests
- npm run test:ui -- src/app/updates-overlay.test.tsx
- npx eslint src/app/updates-overlay.tsx src/app/updates-overlay.test.tsx
- npx prettier --check src/app/updates-overlay.tsx src/app/updates-overlay.test.tsx
- git diff --check
- npm run typecheck
- npm run build