### PR TITLE
fix(desktop): resolve pinned messaging sessions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -103,6 +103,7 @@ import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarLoadMoreRow } from './load-more-row'
 import { resolveManualSessionOrderIds } from './order'
 import { ProfileRail } from './profile-switcher'
+import { buildSessionByAnyId } from './session-index'
 import { SidebarSessionRow } from './session-row'
 import { VirtualSessionList } from './virtual-session-list'
 import { type SidebarSessionGroup, type SidebarWorkspaceTree, workspaceTreeFor } from './workspace-groups'
@@ -428,21 +429,8 @@ export function ChatSidebar({
   // Index sessions by both their live id and their lineage-root id so a pin
   // stored as the pre-compression root resolves to the live continuation tip.
   const sessionByAnyId = useMemo(() => {
-    const map = new Map<string, SessionInfo>()
-
-    // Cron sessions are listed separately but can still be pinned, so index
-    // them too — otherwise a pinned cron job can't resolve into the Pinned
-    // section. Recents take precedence on id collisions (set last).
-    for (const s of [...cronSessions, ...visibleSessions]) {
-      map.set(s.id, s)
-
-      if (s._lineage_root_id && !map.has(s._lineage_root_id)) {
-        map.set(s._lineage_root_id, s)
-      }
-    }
-
-    return map
-  }, [visibleSessions, cronSessions])
+    return buildSessionByAnyId(visibleSessions, cronSessions, messagingSessions)
+  }, [visibleSessions, cronSessions, messagingSessions])
 
   const pinnedSessions = useMemo(() => {
     const seen = new Set<string>()
@@ -533,6 +521,7 @@ export function ChatSidebar({
 
     if (!next.length && agentOrderIds.length) {
       setSidebarSessionOrderIds([])
+
       return
     }
 

--- a/apps/desktop/src/app/chat/sidebar/session-index.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-index.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { buildSessionByAnyId } from './session-index'
+
+const session = (overrides: Partial<SessionInfo>): SessionInfo => ({
+  archived: false,
+  cwd: null,
+  ended_at: null,
+  id: 'live',
+  input_tokens: 0,
+  is_active: false,
+  last_active: 0,
+  message_count: 0,
+  model: null,
+  output_tokens: 0,
+  preview: null,
+  source: null,
+  started_at: 0,
+  title: null,
+  tool_call_count: 0,
+  ...overrides
+})
+
+describe('buildSessionByAnyId', () => {
+  it('indexes messaging sessions so pinned non-local sessions still resolve', () => {
+    const messaging = session({
+      id: 'telegram-tip',
+      _lineage_root_id: 'telegram-root',
+      source: 'telegram'
+    })
+
+    const byId = buildSessionByAnyId([], [], [messaging])
+
+    expect(byId.get('telegram-tip')).toBe(messaging)
+    expect(byId.get('telegram-root')).toBe(messaging)
+  })
+
+  it('lets recents win direct id collisions with separately rendered groups', () => {
+    const cron = session({ id: 'shared', title: 'cron copy', source: 'cron' })
+    const recent = session({ id: 'shared', title: 'recent copy', source: 'cli' })
+
+    const byId = buildSessionByAnyId([recent], [cron], [])
+
+    expect(byId.get('shared')).toBe(recent)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-index.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-index.ts
@@ -1,0 +1,21 @@
+import type { SessionInfo } from '@/types/hermes'
+
+export function buildSessionByAnyId(
+  visibleSessions: SessionInfo[],
+  cronSessions: SessionInfo[],
+  messagingSessions: SessionInfo[]
+): Map<string, SessionInfo> {
+  const map = new Map<string, SessionInfo>()
+
+  // Non-recents can still be pinned, so index them before recents. Recents
+  // go last and win direct id collisions with the separately rendered groups.
+  for (const session of [...cronSessions, ...messagingSessions, ...visibleSessions]) {
+    map.set(session.id, session)
+
+    if (session._lineage_root_id && !map.has(session._lineage_root_id)) {
+      map.set(session._lineage_root_id, session)
+    }
+  }
+
+  return map
+}


### PR DESCRIPTION
Fixes #49667

## Summary
- index pinned-session lookups across messaging sessions as well as recents and cron
- keep the pin resolver in a small helper so non-local-source pins stay covered by tests
- add a regression test for pinned Telegram-session resolution

## Testing
- npm run test:ui -- src/app/chat/sidebar/session-index.test.ts
- npx eslint src/app/chat/sidebar/index.tsx src/app/chat/sidebar/session-index.ts src/app/chat/sidebar/session-index.test.ts
- git diff --check
