### PR TITLE
fix(gateway): preserve runtime provider model (#48061)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1044,6 +1044,7 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         from run_agent import AIAgent
         from gateway.run import (
+            _consume_runtime_model,
             _current_max_iterations,
             _resolve_runtime_agent_kwargs,
             _resolve_gateway_model,
@@ -1055,6 +1056,7 @@ class APIServerAdapter(BasePlatformAdapter):
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
+        model, runtime_kwargs = _consume_runtime_model(model, runtime_kwargs)
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1724,7 +1724,27 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
         "max_tokens": max_tokens,
+        "model": runtime.get("model"),
     }
+
+
+def _consume_runtime_model(model: str, runtime_kwargs: dict) -> tuple[str, dict]:
+    """Apply and remove a runtime-provider model from agent kwargs.
+
+    Runtime provider resolution may supply an explicit model in addition to
+    credentials. AIAgent still receives ``model`` as a separate constructor
+    argument, so callers must consume this handoff key instead of forwarding it
+    through ``**runtime_kwargs`` where it would collide with ``model=...``.
+    """
+    runtime_model = runtime_kwargs.pop("model", None)
+    if runtime_model:
+        logger.info(
+            "Runtime provider supplied explicit model override: %s -> %s",
+            model,
+            runtime_model,
+        )
+        model = runtime_model
+    return model, runtime_kwargs
 
 
 def _try_resolve_fallback_provider() -> dict | None:
@@ -3292,14 +3312,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
-        runtime_model = runtime_kwargs.pop("model", None)
-        if runtime_model:
-            logger.info(
-                "Runtime provider supplied explicit model override: %s -> %s",
-                model,
-                runtime_model,
-            )
-            model = runtime_model
+        model, runtime_kwargs = _consume_runtime_model(model, runtime_kwargs)
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs

--- a/plugins/platforms/feishu/feishu_comment.py
+++ b/plugins/platforms/feishu/feishu_comment.py
@@ -979,8 +979,9 @@ def _resolve_model_and_runtime() -> Tuple[str, dict]:
     user_config = _load_gateway_config()
     model = _resolve_gateway_model(user_config)
 
-    from gateway.run import _resolve_runtime_agent_kwargs
+    from gateway.run import _consume_runtime_model, _resolve_runtime_agent_kwargs
     runtime_kwargs = _resolve_runtime_agent_kwargs()
+    model, runtime_kwargs = _consume_runtime_model(model, runtime_kwargs)
 
     # Fall back to provider's default model if none configured
     if not model and runtime_kwargs.get("provider"):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -337,6 +337,41 @@ class TestAdapterInit:
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
 
+    def test_create_agent_consumes_runtime_provider_model(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "custom-runtime",
+                "base_url": "https://example.test/v1",
+                "api_mode": "openai",
+                "model": "runtime/model-from-provider",
+            },
+        )
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_reasoning_config",
+            staticmethod(lambda: {}),
+        )
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        agent = adapter._create_agent(session_id="api-session")
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["model"] == "runtime/model-from-provider"
+        assert captured["provider"] == "custom-runtime"
+
     def test_create_agent_refreshes_max_iterations_from_runtime_config(self, monkeypatch):
         captured = {}
 

--- a/tests/gateway/test_runtime_provider_model_handoff.py
+++ b/tests/gateway/test_runtime_provider_model_handoff.py
@@ -1,0 +1,102 @@
+from gateway import run as gateway_run
+
+
+def _runner():
+    runner = gateway_run.GatewayRunner.__new__(gateway_run.GatewayRunner)
+    runner._session_model_overrides = {}
+    runner._last_resolved_model = {}
+    return runner
+
+
+def test_runtime_agent_kwargs_preserves_explicit_provider_model(monkeypatch):
+    def fake_resolve_runtime_provider():
+        return {
+            "api_key": "sk-test",
+            "base_url": "https://example.test/v1",
+            "provider": "custom-runtime",
+            "api_mode": "openai",
+            "model": "runtime/model-from-provider",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config",
+        lambda: {"default": ""},
+    )
+
+    kwargs = gateway_run._resolve_runtime_agent_kwargs()
+
+    assert kwargs["provider"] == "custom-runtime"
+    assert kwargs["model"] == "runtime/model-from-provider"
+
+
+def test_session_runtime_uses_provider_model_when_config_model_empty(monkeypatch):
+    def fake_resolve_runtime_provider():
+        return {
+            "api_key": "sk-test",
+            "base_url": "https://example.test/v1",
+            "provider": "custom-runtime",
+            "api_mode": "openai",
+            "model": "runtime/model-from-provider",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config",
+        lambda: {"default": ""},
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda _cfg=None: "")
+
+    model, runtime_kwargs = _runner()._resolve_session_agent_runtime(session_key="sid")
+
+    assert model == "runtime/model-from-provider"
+    assert "model" not in runtime_kwargs
+    assert runtime_kwargs["provider"] == "custom-runtime"
+
+
+def test_consume_runtime_model_leaves_kwargs_safe_for_agent_constructor():
+    model, runtime_kwargs = gateway_run._consume_runtime_model(
+        "",
+        {
+            "provider": "custom-runtime",
+            "model": "runtime/model-from-provider",
+        },
+    )
+
+    assert model == "runtime/model-from-provider"
+    assert runtime_kwargs == {"provider": "custom-runtime"}
+
+
+def test_session_runtime_keeps_provider_default_fallback_without_runtime_model(monkeypatch):
+    def fake_resolve_runtime_provider():
+        return {
+            "api_key": "sk-test",
+            "base_url": "https://example.test/v1",
+            "provider": "custom-runtime",
+            "api_mode": "openai",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config",
+        lambda: {"default": ""},
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda _cfg=None: "")
+    monkeypatch.setattr(
+        "hermes_cli.models.get_default_model_for_provider",
+        lambda provider: "catalog/default" if provider == "custom-runtime" else "",
+    )
+
+    model, runtime_kwargs = _runner()._resolve_session_agent_runtime(session_key="sid")
+
+    assert model == "catalog/default"
+    assert runtime_kwargs["provider"] == "custom-runtime"


### PR DESCRIPTION
## Summary

Fixes #48061 by making runtime-provider model handoff consistent across all current agent creation paths.

When `_resolve_runtime_agent_kwargs()` returns a runtime-supplied `model`, that value is now consumed through a shared `_consume_runtime_model()` helper. This preserves explicit runtime provider model overrides while removing `model` from `runtime_kwargs`, so callers do not pass both `model=...` and `**runtime_kwargs` into `AIAgent`.

Covered paths:
- `GatewayRunner._resolve_session_agent_runtime`
- `APIServerAdapter._create_agent`
- Feishu comment runtime resolution

## Verification

Run after rebase onto current `upstream/main`:

```bash
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest \
  tests/gateway/test_runtime_provider_model_handoff.py \
  tests/gateway/test_api_server.py::TestAdapterInit::test_create_agent_consumes_runtime_provider_model \
  tests/gateway/test_api_server.py::TestAdapterInit::test_create_agent_forwards_config_reasoning_effort \
  tests/test_tui_gateway_server.py::test_config_set_model_explicit_provider_skips_broken_default_init \
  -v -o "addopts=" --tb=short
```

Result: `7 passed, 2 warnings in 4.34s`.

## Duplicate / competitor check

Before publication, checked:
- Open Tranquil-Flow PRs referencing `48061`: none
- Open Tranquil-Flow branches matching `fix/48061*`: none
- Open PR search for `48061`: none
- Open PR keyword search for `runtime provider model`: none

Auto-published by Moonsong via Path B automated pipeline.
