### PR TITLE
fix(tui): preserve detached sessions with active work

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1769,6 +1769,36 @@ def test_ws_orphan_reap_spares_reattached_session(monkeypatch):
     assert server._ws_session_is_orphaned(done) is False
 
 
+def test_ws_orphan_reap_spares_detached_session_still_in_progress(monkeypatch):
+    """A crashed desktop window must not reap work that can still resume."""
+
+    building_ready = threading.Event()
+    building = _session(
+        transport=server._detached_ws_transport,
+        running=False,
+        agent_ready=building_ready,
+        agent_build_started=True,
+    )
+    assert server._ws_session_is_orphaned(building, "building-sid") is False
+
+    inflight = _session(
+        transport=server._detached_ws_transport,
+        running=False,
+        inflight_turn={"user": "still streaming"},
+    )
+    assert server._ws_session_is_orphaned(inflight, "inflight-sid") is False
+
+    pending_event = threading.Event()
+    server._pending["approval-1"] = ("prompt-sid", pending_event)
+    server._pending_prompt_payloads["approval-1"] = ("approval.request", {})
+    try:
+        waiting = _session(transport=server._detached_ws_transport, running=False)
+        assert server._ws_session_is_orphaned(waiting, "prompt-sid") is False
+    finally:
+        server._pending.pop("approval-1", None)
+        server._pending_prompt_payloads.pop("approval-1", None)
+
+
 def test_ws_orphan_reap_disabled_when_grace_zero(monkeypatch):
     """Grace=0 disables the reaper entirely (pre-fix park-forever behaviour)."""
     fired = {"timer": False}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -493,16 +493,24 @@ def _close_session_by_id(sid: str, *, end_reason: str = "tui_close") -> bool:
 
 
 
-def _ws_session_is_orphaned(session: dict | None) -> bool:
+def _ws_session_is_orphaned(session: dict | None, sid: str | None = None) -> bool:
     """True if a WS session has no live transport and no in-flight turn.
 
     After ``handle_ws`` detaches a disconnected client it points the session at
     ``_detached_ws_transport``. A session left on that transport (and not
-    mid-turn) is genuinely orphaned and safe to reap.
+    mid-turn / mid-build / waiting on input) is genuinely orphaned and safe to
+    reap.
     """
     if not session or session.get("_finalized"):
         return False
     if session.get("running"):
+        return False
+    if sid and _session_pending_kind(sid):
+        return False
+    if session.get("inflight_turn") is not None:
+        return False
+    ready = session.get("agent_ready")
+    if ready is not None and not ready.is_set() and session.get("agent_build_started"):
         return False
     return session.get("transport") is _detached_ws_transport
 
@@ -528,7 +536,7 @@ def _schedule_ws_orphan_reap(sid: str) -> None:
         # guard with _sessions_lock). _sessions_lock is an RLock and the global
         # ordering is always resume_lock -> sessions_lock, so nesting is safe.
         with _session_resume_lock:
-            if not _ws_session_is_orphaned(_sessions.get(sid)):
+            if not _ws_session_is_orphaned(_sessions.get(sid), sid):
                 return
             _close_session_by_id(sid, end_reason="ws_orphan_reap")
 


### PR DESCRIPTION
## Summary
- Preserve detached TUI WebSocket sessions that still have resumable work.
- Treat sessions with an in-flight turn, in-progress agent build, or pending prompt/approval as not orphaned.
- Pass the session id into the orphan check so pending prompts can be detected before reaping.

## Why
A disconnected desktop/TUI WebSocket transport should not cause active or resumable work to be closed by the orphan reaper. The reaper should only close sessions that are detached and have no active turn, build, or pending user input.

## Tests
- Added coverage for detached sessions that are still building, still handling an in-flight turn, or waiting on a pending prompt.
- Verified locally:
  - `uv run python -m pytest tests/test_tui_gateway_server.py -q -o 'addopts=' -k 'ws_orphan_reap'`
  - Result: `4 passed, 278 deselected`
