### PR TITLE
fix(copilot): derive api_mode from target model so GPT-5+ uses Responses API

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -235,22 +235,64 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
-def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+def _copilot_runtime_api_mode(
+    model_cfg: Dict[str, Any],
+    api_key: str,
+    target_model: Optional[str] = None,
+) -> str:
+    """Resolve the api_mode for a Copilot model, preferring the model in use.
+
+    Copilot is a multi-family provider: GPT-5+ models are served only on the
+    Responses API (``/responses``) and are rejected on ``/chat/completions``
+    with ``unsupported_api_for_model`` — which surfaces in Hermes as an empty
+    reply / ``no final response was produced``. Claude- and Gemini-via-Copilot
+    use Chat Completions. api_mode is therefore a function of the *model being
+    invoked*, not a value that can be pinned once in config.
+
+    ``target_model`` is the model actually being used (an explicit
+    ``--model``/``/model`` switch); it overrides ``model_cfg["default"]`` so
+    api_mode follows the switch instead of a stale persisted default. We
+    re-derive the family-required mode *before* honoring a persisted
+    ``api_mode`` so the setup wizard's default ``chat_completions`` (written
+    once, then stale the moment the user picks a GPT-5 model) cannot silently
+    misroute GPT-5+ traffic. When the model does not force a mode, the
+    explicit persisted api_mode still wins (e.g. Claude-via-Copilot users who
+    intentionally pin ``chat_completions``), preserving existing setups.
+
+    Mirrors the per-target re-derivation already in place for the other
+    multi-family providers — opencode-zen/go (#15106, #16878) and
+    azure-foundry (#16361).
+    """
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+
+    # Prefer the actually-requested model over the persisted default so a
+    # /model switch (or an explicit --model) drives api_mode.
+    effective_model = str(target_model or model_cfg.get("default") or "").strip()
+
+    model_inferred_mode: Optional[str] = None
+    if effective_model:
+        try:
+            from hermes_cli.models import copilot_model_api_mode
+
+            model_inferred_mode = copilot_model_api_mode(effective_model, api_key=api_key)
+        except Exception:
+            model_inferred_mode = None
+
+    # A family-restricted mode (GPT-5+ -> codex_responses, Claude-only
+    # deployments -> anthropic_messages) beats a stale persisted
+    # chat_completions: routing GPT-5+ to /chat/completions returns an empty
+    # response. This is the narrow correctness guard.
+    if model_inferred_mode and model_inferred_mode != "chat_completions":
+        return model_inferred_mode
+
+    # Otherwise honor an explicitly persisted api_mode for the Copilot
+    # provider (so a deliberate chat_completions pin is respected).
     if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
-    if not model_name:
-        return "chat_completions"
-
-    try:
-        from hermes_cli.models import copilot_model_api_mode
-
-        return copilot_model_api_mode(model_name, api_key=api_key)
-    except Exception:
-        return "chat_completions"
+    # Fall back to whatever the model lookup produced, defaulting safe.
+    return model_inferred_mode or "chat_completions"
 
 
 _VALID_API_MODES = {
@@ -356,7 +398,11 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "nous":
         api_mode = "chat_completions"
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        api_mode = _copilot_runtime_api_mode(
+            model_cfg,
+            getattr(entry, "runtime_api_key", ""),
+            target_model=effective_model,
+        )
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
@@ -1240,6 +1286,7 @@ def _resolve_explicit_runtime(
     model_cfg: Dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
@@ -1359,7 +1406,7 @@ def _resolve_explicit_runtime(
 
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
+            api_mode = _copilot_runtime_api_mode(model_cfg, api_key, target_model=target_model)
         elif provider == "xai":
             api_mode = "codex_responses"
         else:
@@ -1460,6 +1507,7 @@ def resolve_runtime_provider(
         model_cfg=model_cfg,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=target_model,
     )
     if explicit_runtime:
         return explicit_runtime
@@ -1799,7 +1847,9 @@ def resolve_runtime_provider(
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
+            api_mode = _copilot_runtime_api_mode(
+                model_cfg, creds.get("api_key", ""), target_model=target_model
+            )
         elif provider == "xai":
             api_mode = "codex_responses"
         else:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2083,6 +2083,126 @@ class TestAzureFoundryResolution:
 
 
 # ──────────────────────────────────────────────────────────────────────────
+# Copilot — per-model api_mode re-derivation (GitHub #27132)
+#
+# Copilot is a multi-family provider. GPT-5+ models are served ONLY on the
+# Responses API (/responses); Copilot rejects them on /chat/completions with
+# ``unsupported_api_for_model``, which surfaces in Hermes as an empty reply /
+# "no final response was produced". Claude- and Gemini-via-Copilot use Chat
+# Completions. So api_mode MUST be a function of the model actually in use,
+# not a value pinned once in config.
+#
+# The bug: ``_copilot_runtime_api_mode`` honored a persisted
+# ``api_mode: chat_completions`` (written by the setup wizard) and derived the
+# model from ``model_cfg["default"]`` (often a Claude model) — so an explicit
+# request for ``gpt-5.5`` (e.g. an LM-council seat invoked with
+# ``--provider copilot --model gpt-5.5``) silently routed to chat_completions
+# and returned nothing. The fix re-derives the family-required mode from the
+# target model BEFORE honoring a persisted chat_completions pin.
+#
+# Mirrors the sibling re-derivation for azure-foundry (above) and
+# opencode-zen/go.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestCopilotPerModelApiMode:
+    """Unit tests for _copilot_runtime_api_mode target-model preference."""
+
+    def _cfg(self, default="claude-opus-4.8", api_mode="chat_completions"):
+        # The classic trap: setup wizard pinned chat_completions while the
+        # persisted default is a Claude model.
+        return {"provider": "copilot", "default": default, "api_mode": api_mode}
+
+    def test_gpt5_target_overrides_persisted_chat_completions(self):
+        """The core bug: gpt-5.5 seat must reach codex_responses despite a
+        persisted chat_completions pin + a Claude default."""
+        mode = rp._copilot_runtime_api_mode(
+            self._cfg(), "", target_model="gpt-5.5"
+        )
+        assert mode == "codex_responses"
+
+    def test_gpt5_codex_target_overrides_pin(self):
+        mode = rp._copilot_runtime_api_mode(
+            self._cfg(), "", target_model="gpt-5.4"
+        )
+        assert mode == "codex_responses"
+
+    def test_claude_target_uses_chat_completions(self):
+        """A Claude seat on the same council must stay on chat_completions."""
+        mode = rp._copilot_runtime_api_mode(
+            self._cfg(), "", target_model="claude-opus-4.7"
+        )
+        assert mode == "chat_completions"
+
+    def test_gpt5_mini_stays_chat_completions(self):
+        """gpt-5-mini is the documented Responses-API exception."""
+        mode = rp._copilot_runtime_api_mode(
+            self._cfg(), "", target_model="gpt-5-mini"
+        )
+        assert mode == "chat_completions"
+
+    def test_no_target_falls_back_to_default_model(self):
+        """Without a target_model, derive from the (Claude) default →
+        chat_completions. No regression for steady-state Claude users."""
+        mode = rp._copilot_runtime_api_mode(self._cfg(), "")
+        assert mode == "chat_completions"
+
+    def test_no_target_gpt5_default_still_upgrades(self):
+        """If the persisted default itself is a GPT-5 model, a stale
+        chat_completions pin must not pin it to the wrong transport."""
+        mode = rp._copilot_runtime_api_mode(
+            self._cfg(default="gpt-5.5", api_mode="chat_completions"), ""
+        )
+        assert mode == "codex_responses"
+
+    def test_claude_pin_preserved_when_model_is_neutral(self):
+        """A deliberate chat_completions pin still wins when the model does
+        not force a family mode (Claude returns chat_completions, which does
+        not trigger the override branch)."""
+        mode = rp._copilot_runtime_api_mode(
+            self._cfg(default="claude-opus-4.8", api_mode="chat_completions"),
+            "",
+            target_model="claude-opus-4.8",
+        )
+        assert mode == "chat_completions"
+
+    def test_end_to_end_pool_path_gpt5(self, monkeypatch):
+        """Full resolve_runtime_provider through the Copilot pool path: a
+        gpt-5.5 target must resolve to codex_responses end to end."""
+
+        class _Entry:
+            runtime_api_key = "copilot-token"
+            access_token = "copilot-token"
+            runtime_base_url = "https://api.githubcopilot.com"
+            base_url = "https://api.githubcopilot.com"
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+        monkeypatch.setattr(
+            rp,
+            "_get_model_config",
+            lambda: {
+                "provider": "copilot",
+                "default": "claude-opus-4.8",
+                "api_mode": "chat_completions",
+            },
+        )
+        monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+
+        resolved = rp.resolve_runtime_provider(
+            requested="copilot", target_model="gpt-5.5"
+        )
+
+        assert resolved["api_mode"] == "codex_responses"
+
+
+# ──────────────────────────────────────────────────────────────────────────
 # Azure Anthropic — honor user-specified env var hints (key_env / api_key_env)
 #
 # When the user points provider=anthropic at an Azure Foundry base URL, the

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -985,6 +985,51 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         creds = _resolve_delegation_credentials(cfg, parent)
         self.assertEqual(creds["api_mode"], "anthropic_messages")
 
+    def test_direct_copilot_endpoint_gpt5_uses_codex_responses(self):
+        # GitHub #27132: a delegated subagent pointed at the direct Copilot
+        # endpoint with a GPT-5+ model must use the Responses API. Copilot
+        # rejects GPT-5+ on /chat/completions (unsupported_api_for_model),
+        # which surfaces as an empty subagent reply. The host is multi-family,
+        # so the mode is derived from the model, not the host.
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "gpt-5.5",
+            "provider": "custom",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-token",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["provider"], "copilot")
+        self.assertEqual(creds["api_mode"], "codex_responses")
+
+    def test_direct_copilot_endpoint_claude_uses_chat_completions(self):
+        # The same Copilot host serves Claude on Chat Completions — a Claude
+        # delegation must NOT be force-upgraded to the Responses API.
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "claude-opus-4.7",
+            "provider": "custom",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-token",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["provider"], "copilot")
+        self.assertEqual(creds["api_mode"], "chat_completions")
+
+    def test_direct_copilot_endpoint_explicit_api_mode_still_wins(self):
+        # An explicit delegation.api_mode overrides the model-derived default,
+        # consistent with every other direct-endpoint case.
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "gpt-5.5",
+            "provider": "custom",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-token",
+            "api_mode": "chat_completions",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_mode"], "chat_completions")
+
     def test_direct_endpoint_explicit_api_mode_overrides_url_detection(self):
         # Explicit api_mode in config always wins over auto-detection.
         parent = _make_mock_parent(depth=0)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2713,6 +2713,26 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         elif base_url_hostname(configured_base_url) == "api.anthropic.com":
             provider = "anthropic"
             api_mode = "anthropic_messages"
+        elif base_url_hostname(configured_base_url) == "api.githubcopilot.com":
+            # Copilot is a multi-family endpoint: GPT-5+ is served only on the
+            # Responses API and is rejected on /chat/completions
+            # (unsupported_api_for_model → empty subagent reply), while
+            # Claude/Gemini-via-Copilot use chat_completions. Derive the mode
+            # from the delegation model rather than defaulting to
+            # chat_completions, mirroring the main runtime resolver's
+            # _copilot_runtime_api_mode. Without this, a delegated
+            # gpt-5.x subagent silently misroutes and returns nothing.
+            provider = "copilot"
+            api_mode = "chat_completions"
+            if configured_model:
+                try:
+                    from hermes_cli.models import copilot_model_api_mode
+
+                    api_mode = copilot_model_api_mode(
+                        configured_model, api_key=configured_api_key or None
+                    )
+                except Exception:
+                    api_mode = "chat_completions"
         elif "api.kimi.com/coding" in base_lower:
             provider = "custom"
             api_mode = "anthropic_messages"


### PR DESCRIPTION
## Summary

Copilot is a multi-family provider: **GPT-5+ models are served only on the Responses API** (`/responses`) and are rejected on `/chat/completions` with `unsupported_api_for_model` — which surfaces in Hermes as an empty reply / *"no final response was produced."* Claude- and Gemini-via-Copilot use Chat Completions. So `api_mode` for Copilot is a function of the **model in use**, not a value that can be pinned once in config.

This PR makes `_copilot_runtime_api_mode` derive the transport from the **target model** and threads `target_model` through every Copilot resolver call site, plus the subagent delegation credential resolver.

## Root cause

`_copilot_runtime_api_mode(model_cfg, api_key)` had two defects:

1. **Honored a stale persisted pin first.** The setup wizard writes `api_mode: chat_completions` into `config.yaml`. The function returned that immediately for *any* model — including GPT-5.x — before considering the model family.
2. **Derived the model from `model_cfg["default"]`**, not the model actually being invoked. With a Claude default (a very common Copilot setup), an explicit request for a GPT-5 model never even *saw* `gpt-5.x`.

The result: invoking a GPT-5 model on Copilot — e.g. `hermes chat --provider copilot --model gpt-5.5`, or a multi-model "council" seat — silently routed to `/chat/completions` and returned nothing. The upstream opencode-zen fix (#16878) had already threaded `target_model` through the resolver, but the **copilot branch was never updated to use it**.

## Changes

| File | Change |
|---|---|
| `hermes_cli/runtime_provider.py` | Rewrote `_copilot_runtime_api_mode` to accept `target_model` and re-derive the family-required mode **before** honoring a persisted `chat_completions` pin. Threaded `target_model` into all **4** call sites (pool entry, `_resolve_explicit_runtime` + its caller, api-key provider path). |
| `tools/delegate_tool.py` | Added an `api.githubcopilot.com` host case to `_resolve_delegation_credentials` so a delegated GPT-5+ Copilot subagent picks `codex_responses` (derived from the model) instead of falling back to `provider=custom` + `chat_completions`. |

The precedence is preserved for existing setups: a **family-restricted** mode (GPT-5+ → `codex_responses`, Claude-only deployments → `anthropic_messages`) wins over a stale `chat_completions` pin, but a deliberate Claude `chat_completions` pin is still respected when the model does not force a mode. Mirrors the per-target re-derivation already in place for `azure-foundry` (#16361) and `opencode-zen/go` (#15106, #16878).

## Validation

| Check | Result |
|---|---|
| `TestCopilotPerModelApiMode` (runtime, incl. end-to-end pool path) | **8 passed** |
| Copilot delegation tests (direct endpoint: GPT-5→responses, Claude→chat, explicit override) | **3 passed** |
| Red/green — tests fail without the fix | **4 runtime + 2 delegation fail** (the bug paths); no-regression guards pass either way |
| `tests/hermes_cli/test_runtime_provider_resolution.py` (full) | **137 passed** |
| `ruff check` (4 changed files) | clean |
| **Live wire test** — `--provider copilot --model gpt-5.5`, `HERMES_DUMP_REQUESTS=1` | `request.url = https://api.githubcopilot.com/responses` ✅ (was `/chat/completions`) |

## Related issues

- Addresses the Copilot GPT-5 → Responses API routing described in #23893 (*"GPT-5.x models on custom providers never auto-upgrade to Responses API"*).
- Related to #46527 (*api_mode recompute for copilot gpt-5-mini on the fallback chain*) — this PR fixes the **resolution-time** derivation; the fallback-chain recompute path in #46527 is complementary.
