### PR TITLE
fix(kanban): add missing scheduled/review columns to dashboard fallbacks

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -86,26 +86,29 @@
     return body || raw;
   }
 
-  // Order matches BOARD_COLUMNS in plugin_api.py.
-  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "done"];
+  // COLUMN_ORDER removed — columns render in backend BOARD_COLUMNS order.
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
   const FALLBACK_COLUMN_LABEL = {
     triage: "Triage",
     todo: "Todo",
+    scheduled: "Scheduled",
     ready: "Ready",
     running: "In Progress",
     blocked: "Blocked",
+    review: "Review",
     done: "Done",
     archived: "Archived",
   };
   const FALLBACK_COLUMN_HELP = {
     triage: "Raw ideas — a specifier will flesh out the spec",
     todo: "Waiting on dependencies or unassigned",
+    scheduled: "Queued for automatic dispatch when a worker slot opens",
     ready: "Dependencies satisfied; assign a profile to dispatch",
     running: "Claimed by a worker — in-flight",
     blocked: "Worker asked for human input",
+    review: "Awaiting human review before merging or shipping",
     done: "Completed",
     archived: "Archived",
   };
@@ -154,9 +157,11 @@
   const COLUMN_DOT = {
     triage: "hermes-kanban-dot-triage",
     todo: "hermes-kanban-dot-todo",
+    scheduled: "hermes-kanban-dot-scheduled",
     ready: "hermes-kanban-dot-ready",
     running: "hermes-kanban-dot-running",
     blocked: "hermes-kanban-dot-blocked",
+    review: "hermes-kanban-dot-review",
     done: "hermes-kanban-dot-done",
     archived: "hermes-kanban-dot-archived",
   };

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -168,6 +168,8 @@
 .hermes-kanban-dot-blocked  { background: var(--color-destructive, #d14a4a); }
 .hermes-kanban-dot-done     { background: #4a8cd1; }  /* blue */
 .hermes-kanban-dot-archived { background: var(--color-border); }
+.hermes-kanban-dot-scheduled { background: #b47dd6; }  /* lilac — queued */
+.hermes-kanban-dot-review   { background: #d48b3c; }  /* tangerine — needs review */
 
 /* ---- Progress pill (N/M child tasks done) --------------------------- */
 


### PR DESCRIPTION
## Summary

- Remove dead `COLUMN_ORDER` constant (defined but never referenced, stale column list)
- Add missing `scheduled` and `review` entries to `FALLBACK_COLUMN_LABEL`, `FALLBACK_COLUMN_HELP`, and `COLUMN_DOT`
- Add CSS dot colors for `scheduled` (lilac) and `review` (tangerine)

Without these entries, the `scheduled` and `review` columns from `BOARD_COLUMNS` render with no label tooltip, no help text, and no status dot color.

Fixes #49891

## Test plan
- [x] `COLUMN_ORDER` grep confirms 0 occurrences after removal
- [x] `FALLBACK_COLUMN_LABEL` covers all 9 BOARD_COLUMNS + archived
- [x] `FALLBACK_COLUMN_HELP` covers all 9 BOARD_COLUMNS + archived
- [x] `COLUMN_DOT` covers all 9 BOARD_COLUMNS + archived
- [x] CSS classes defined for scheduled + review dots
