### PR TITLE
fix(kanban): allow completing tasks from todo status

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4101,11 +4101,12 @@ def complete_task(
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
-    """Transition ``running|ready -> done`` and record ``result``.
+    """Transition ``todo|running|ready|blocked -> done`` and record ``result``.
 
-    Accepts a task that is merely ``ready`` too, so a manual CLI
-    completion (``hermes kanban complete <id>``) works without requiring
-    a claim/start/complete sequence.
+    Accepts a task in any non-terminal status so that manual dashboard
+    completions (drag-to-done, "Complete" button) and CLI completions
+    (``hermes kanban complete <id>``) work without requiring the task
+    to have been dispatched first.
 
     ``summary`` and ``metadata`` are stored on the closing run (if any)
     and surfaced to downstream children via :func:`build_worker_context`.
@@ -4175,7 +4176,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('todo', 'running', 'ready', 'blocked')
                 """,
                 (result, now, task_id),
             )
@@ -4192,7 +4193,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('todo', 'running', 'ready', 'blocked')
                    AND current_run_id = ?
                 """,
                 (result, now, task_id, int(expected_run_id)),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4101,12 +4101,12 @@ def complete_task(
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
-    """Transition ``todo|running|ready|blocked -> done`` and record ``result``.
+    """Transition a manually-completed task to ``done`` and record ``result``.
 
-    Accepts a task in any non-terminal status so that manual dashboard
-    completions (drag-to-done, "Complete" button) and CLI completions
-    (``hermes kanban complete <id>``) work without requiring the task
-    to have been dispatched first.
+    Manual dashboard/CLI completion accepts every non-terminal status. The
+    ``expected_run_id`` worker branch below remains restricted to claimed
+    worker states and requires the matching run id, so a stale worker cannot
+    complete a reclaimed task.
 
     ``summary`` and ``metadata`` are stored on the closing run (if any)
     and surfaced to downstream children via :func:`build_worker_context`.
@@ -4176,7 +4176,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('todo', 'running', 'ready', 'blocked')
+                   AND status NOT IN ('done', 'archived')
                 """,
                 (result, now, task_id),
             )
@@ -4193,7 +4193,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('todo', 'running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready', 'blocked')
                    AND current_run_id = ?
                 """,
                 (result, now, task_id, int(expected_run_id)),

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -4234,7 +4234,7 @@
           getDestructiveConfirm(t, "blocked")),
         b(tx(t, "unblock", "Unblock"),   { status: "ready" },    task.status === "blocked"),
         b(tx(t, "complete", "Complete"),  { status: "done" },
-          task.status === "running" || task.status === "ready" || task.status === "blocked",
+          task.status !== "done" && task.status !== "archived",
           getDestructiveConfirm(t, "done")),
         b(tx(t, "archive", "Archive"),   { status: "archived" }, task.status !== "archived",
           getDestructiveConfirm(t, "archived")),

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -4234,7 +4234,7 @@
           getDestructiveConfirm(t, "blocked")),
         b(tx(t, "unblock", "Unblock"),   { status: "ready" },    task.status === "blocked"),
         b(tx(t, "complete", "Complete"),  { status: "done" },
-          task.status !== "done" && task.status !== "archived",
+          !["done", "archived"].includes(task.status),
           getDestructiveConfirm(t, "done")),
         b(tx(t, "archive", "Archive"),   { status: "archived" }, task.status !== "archived",
           getDestructiveConfirm(t, "archived")),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -254,6 +254,7 @@ LEGACY_AUTHOR_MAP = {
     "rebel@rebels-Mac-Studio-2.local": "rebel0789",  # PR #47308 salvage (redact browser_type typed text across display surfaces; #47197)
     "267614622+agt-user@users.noreply.github.com": "agt-user",  # PR #48496 salvage (telegram CLOSE-WAIT polling heartbeat, #48495)
     "80915+DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",  # PR #52272 salvage (route reasoning-model thinking-timeouts to timeout not context_overflow + reasoning-specific guidance; #52271)
+    "DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",  # PR #49909 (allow manual completion from active kanban statuses)
     "66773372+Tranquil-Flow@users.noreply.github.com": "Tranquil-Flow",  # PR #52623 salvage (auxiliary Anthropic base_url host validation; #52608)
     "nikshepsvn@gmail.com": "nikshepsvn",  # PR #27426 salvage (two-layer guard against hallucinated acp_command crashing the gateway on hosts with no ACP CLI)
     "65363919+coygeek@users.noreply.github.com": "coygeek",  # PR #37735 salvage (redact provider error text at api-server HTTP boundary; #37733)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -475,6 +475,66 @@ def test_patch_status_complete(client):
     assert any(x["id"] == t["id"] for x in done["tasks"])
 
 
+def test_patch_status_complete_from_active_statuses(client, kanban_home):
+    """Manual completion accepts every non-terminal source status."""
+    from hermes_cli import kanban_db as kb
+
+    for source_status in sorted(kb.VALID_STATUSES - {"done", "archived"}):
+        t = client.post(
+            "/api/plugins/kanban/tasks",
+            json={"title": f"complete-from-{source_status}"},
+        ).json()["task"]
+        conn = kb.connect()
+        try:
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status = ? WHERE id = ?",
+                    (source_status, t["id"]),
+                )
+        finally:
+            conn.close()
+
+        r = client.patch(
+            f"/api/plugins/kanban/tasks/{t['id']}",
+            json={
+                "status": "done",
+                "result": f"shipped from {source_status}",
+            },
+        )
+        assert r.status_code == 200, (
+            f"{source_status}->done should succeed, got {r.status_code}: {r.text}"
+        )
+        assert r.json()["task"]["status"] == "done"
+
+
+def test_patch_status_complete_rejects_terminal_statuses(client, kanban_home):
+    """Manual completion rejects already-done and archived tasks."""
+    from hermes_cli import kanban_db as kb
+
+    for source_status in ("done", "archived"):
+        t = client.post(
+            "/api/plugins/kanban/tasks",
+            json={"title": f"complete-from-{source_status}"},
+        ).json()["task"]
+        conn = kb.connect()
+        try:
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status = ? WHERE id = ?",
+                    (source_status, t["id"]),
+                )
+        finally:
+            conn.close()
+
+        r = client.patch(
+            f"/api/plugins/kanban/tasks/{t['id']}",
+            json={"status": "done", "result": "should fail"},
+        )
+        assert r.status_code == 409, (
+            f"{source_status}->done should be 409, got {r.status_code}: {r.text}"
+        )
+
+
 def test_patch_block_then_unblock(client):
     t = client.post("/api/plugins/kanban/tasks", json={"title": "x"}).json()["task"]
     r = client.patch(


### PR DESCRIPTION
Fixes #49908

## What

 restricted its SQL UPDATE to , excluding . When a user dragged a  task to the Done column:

1. Frontend showed the completion summary prompt (user typed input)
2. Frontend did optimistic UI update (task appeared in Done)
3. PATCH returned 409 (task not in accepted statuses)
4. Frontend reverted (task snapped back to Todo)

The Complete button was correctly disabled for  tasks, but drag-and-drop bypassed this check entirely.

## How

- : Added  to the  clause in both  UPDATE statements (with and without )
- : Expanded Complete button enablement from  to  — consistent with the backend now accepting all non-terminal statuses

## Testing

All 318 kanban tests pass (223 db + 95 dashboard plugin).