### PR TITLE
fix(gateway): correct sys.path insertion in all migrated platform adapters (cron namespace collision)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -98,7 +98,7 @@ except ImportError:
 
 import sys
 from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 

--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -36,7 +36,7 @@ except ImportError:
 
 import sys
 from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -34,7 +34,7 @@ except ImportError:
 import sys
 from pathlib import Path as _Path
 
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -63,7 +63,7 @@ except ImportError:
 
 import sys
 from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -178,7 +178,7 @@ def _terminate_bridge_process(proc, *, force: bool = False) -> None:
         return
 
 import sys
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin


### PR DESCRIPTION
## Summary
Gateway no longer crashes on startup with `ModuleNotFoundError: No module named 'cron.scheduler_provider'`.

**Root cause:** commit `5600105478` migrated the slack/discord/whatsapp/telegram/raft adapters from `gateway/platforms/` to `plugins/platforms/`. Each adapter does `sys.path.insert(0, parents[2])` — one level deeper now, so `parents[2]` resolves to `plugins/` instead of the repo root. With `plugins/` on `sys.path[0]`, `import cron` resolves to the `plugins/cron/` chronos-provider package (which has no `scheduler_provider` submodule), so the first `from cron.scheduler_provider import …` during `start_gateway()` raises `ModuleNotFoundError`.

## Changes
- `plugins/platforms/{discord,raft,slack,whatsapp,telegram}/adapter.py`: `parents[2]` → `parents[3]` so each inserts the repo root, not `plugins/`.

`gateway/platforms/base.py` correctly keeps `parents[2]` (it lives one level shallower, so `parents[2]` is already the repo root there).

## Attribution
- @kyssta-exe (#49431) — original fix for the discord + raft adapters; commit cherry-picked with authorship preserved.
- Follow-up commit widens the same one-line fix to the three remaining affected adapters (slack, whatsapp, telegram) that #49431 missed.
- #49414 (@ochsec) took a different approach — pre-importing `cron.*` at module level to cache `sys.modules` before the bad insert. That treats the symptom (the broken `parents[2]` insert stays, so any module imported after a platform adapter is still at risk) and bundled an unrelated kanban change, so this PR fixes the root cause instead.

## Validation
| | Before | After |
|---|---|---|
| `import cron.scheduler_provider` after any of the 5 adapters loads | `ModuleNotFoundError` | resolves to repo `cron/scheduler_provider.py` |
| `sys.path[0]` after adapter import | `plugins/` | repo root |

E2E: simulated each adapter's `sys.path.insert` and confirmed `cron.scheduler_provider` resolves to the real package for all 5. `tests/cron/test_scheduler_provider.py` + `tests/gateway/test_cron_fire_webhook.py` — 25/25 pass.

Fixes #49410, #49824.

## Infographic

![cron-namespace-collision-fixed](https://v3b.fal.media/files/b/0a9f21ed/S07-tgaKGj63pd3WoSLx6_sXydViPX.png)
