### PR TITLE
fix(tui): Ctrl+C always interrupts a running turn, even in VS Code/Cursor terminals

### DIFF
--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -5,6 +5,7 @@ import {
   applyVoiceRecordResponse,
   dismissSensitivePrompt,
   handleIdleHotkeyExit,
+  isRawCtrlC,
   resolveCtrlCComposerAction,
   shouldAllowIdleHotkeyExit,
   shouldFallThroughForScroll
@@ -79,6 +80,32 @@ describe('resolveCtrlCComposerAction — draft wins over interrupt', () => {
 
   it('does not interrupt a busy session that has no sid yet', () => {
     expect(resolveCtrlCComposerAction({ busy: true, hasDraft: false, hasSession: false })).toBe('exit')
+  })
+})
+
+describe('isRawCtrlC — busy interrupt must exclude forwarded Cmd+C copy', () => {
+  it('matches a genuine raw Ctrl+C (no action modifier)', () => {
+    expect(isRawCtrlC({ ctrl: true, meta: false, super: false }, 'c')).toBe(true)
+    expect(isRawCtrlC({ ctrl: true, meta: false, super: false }, 'C')).toBe(true)
+  })
+
+  it('rejects the VS Code/Cursor forwarded Cmd+C copy shape (super+ctrl)', () => {
+    // This is the shape isCopyShortcut() accepts as copy; the busy interrupt
+    // must NOT claim it, or Cmd+C copy during a running turn becomes an interrupt.
+    expect(isRawCtrlC({ ctrl: true, meta: false, super: true }, 'c')).toBe(false)
+  })
+
+  it('rejects the legacy meta-forwarded Cmd+C shape (meta+ctrl)', () => {
+    expect(isRawCtrlC({ ctrl: true, meta: true, super: false }, 'c')).toBe(false)
+  })
+
+  it('rejects a bare Cmd+C with no ctrl bit (pure super/meta copy)', () => {
+    expect(isRawCtrlC({ ctrl: false, meta: false, super: true }, 'c')).toBe(false)
+    expect(isRawCtrlC({ ctrl: false, meta: true, super: false }, 'c')).toBe(false)
+  })
+
+  it('rejects other Ctrl chords (only c interrupts)', () => {
+    expect(isRawCtrlC({ ctrl: true, meta: false, super: false }, 'x')).toBe(false)
   })
 })
 

--- a/ui-tui/src/__tests__/useInputHandlersRouting.test.tsx
+++ b/ui-tui/src/__tests__/useInputHandlersRouting.test.tsx
@@ -1,0 +1,221 @@
+import { PassThrough } from 'stream'
+
+import { renderSync, Text } from '@hermes/ink'
+import type * as Ink from '@hermes/ink'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setInputSelection } from '../app/inputSelectionStore.js'
+import type { InputHandlerContext } from '../app/interfaces.js'
+import { resetOverlayState } from '../app/overlayStore.js'
+import { turnController } from '../app/turnController.js'
+import { patchUiState, resetUiState } from '../app/uiStore.js'
+import { useInputHandlers } from '../app/useInputHandlers.js'
+
+let inputHandler: null | ((input: string, key: Record<string, boolean>) => void) = null
+
+vi.mock('@hermes/ink', async importOriginal => {
+  const actual = await importOriginal<typeof Ink>()
+
+  return {
+    ...actual,
+    useInput: (handler: (input: string, key: Record<string, boolean>) => void) => {
+      inputHandler = handler
+    }
+  }
+})
+
+const ref = <T,>(current: T) => ({ current })
+const fn = () => vi.fn()
+
+const buildContext = (): InputHandlerContext =>
+  ({
+    actions: {
+      answerClarify: fn(),
+      appendMessage: fn(),
+      die: fn(),
+      dispatchSubmission: fn(),
+      guardBusySessionSwitch: vi.fn(() => false),
+      newSession: fn(),
+      sys: fn()
+    },
+    composer: {
+      actions: {
+        attachClipboardImage: fn(),
+        attachImagePath: fn(),
+        clearIn: fn(),
+        dequeue: vi.fn(() => undefined),
+        enqueue: fn(),
+        handleTextPaste: vi.fn(async () => null),
+        openEditor: vi.fn(async () => undefined),
+        prependQueue: fn(),
+        pushHistory: fn(),
+        removeQueue: fn(),
+        setCompIdx: fn(),
+        setComposerTokens: fn(),
+        setHistoryIdx: fn(),
+        setInput: fn(),
+        setInputBuf: fn(),
+        setQueueEdit: fn(),
+        syncTokens: fn(),
+        takeQueue: vi.fn(() => undefined)
+      },
+      refs: {
+        historyDraftRef: ref(''),
+        historyRef: ref<string[]>([]),
+        queueEditRef: ref<null | number>(null),
+        queueRef: ref([]),
+        submitRef: ref(fn()),
+        tokensRef: ref([])
+      },
+      state: {
+        compIdx: 0,
+        compReplace: 0,
+        completions: [],
+        historyIdx: null,
+        input: '',
+        inputBuf: [],
+        queueEditIdx: null,
+        queuedDisplay: [],
+        tokens: []
+      }
+    },
+    gateway: {
+      gw: {
+        publishLocalEvent: fn(),
+        request: vi.fn(async () => ({}))
+      },
+      rpc: vi.fn(async () => null)
+    },
+    terminal: {
+      hasSelection: false,
+      scrollRef: ref(null),
+      scrollWithSelection: fn(),
+      selection: {
+        captureScrolledRows: fn(),
+        clearSelection: fn(),
+        copySelection: vi.fn(async () => ''),
+        copySelectionNoClear: vi.fn(async () => ''),
+        getState: vi.fn(() => null),
+        shiftAnchor: fn(),
+        shiftSelection: fn(),
+        version: vi.fn(() => 0)
+      }
+    },
+    voice: {
+      enabled: false,
+      recordKey: { ch: 'b', mod: 'ctrl', raw: 'ctrl+b' },
+      recording: false,
+      setProcessing: fn(),
+      setRecording: fn(),
+      setVoiceEnabled: fn(),
+      setVoiceTts: fn()
+    },
+    wheelStep: 3
+  }) as unknown as InputHandlerContext
+
+const key = (overrides: Record<string, boolean>) => ({
+  ctrl: false,
+  downArrow: false,
+  escape: false,
+  meta: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  shift: false,
+  super: false,
+  tab: false,
+  upArrow: false,
+  wheelDown: false,
+  wheelUp: false,
+  ...overrides
+})
+
+const mountHandler = (ctx: InputHandlerContext) => {
+  function Harness() {
+    useInputHandlers(ctx)
+
+    return <Text>input handler harness</Text>
+  }
+
+  const stdin = new PassThrough()
+  const stdout = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+  Object.assign(stderr, { isTTY: false })
+
+  return renderSync(<Harness />, {
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+}
+
+describe('useInputHandlers busy Ctrl+C routing', () => {
+  beforeEach(() => {
+    inputHandler = null
+    resetOverlayState()
+    resetUiState()
+    patchUiState({ busy: true, sid: 'busy-session' })
+  })
+
+  afterEach(() => {
+    setInputSelection(null)
+    vi.restoreAllMocks()
+  })
+
+  it('calls interruptTurn for raw Ctrl+C during a busy turn', () => {
+    const ctx = buildContext()
+    const interrupt = vi.spyOn(turnController, 'interruptTurn').mockImplementation(() => undefined)
+    const instance = mountHandler(ctx)
+
+    try {
+      expect(inputHandler).not.toBeNull()
+      inputHandler!('c', key({ ctrl: true }))
+
+      expect(interrupt).toHaveBeenCalledOnce()
+      expect(interrupt).toHaveBeenCalledWith({
+        appendMessage: ctx.actions.appendMessage,
+        gw: ctx.gateway.gw,
+        sid: 'busy-session',
+        sys: ctx.actions.sys
+      })
+    } finally {
+      instance.unmount()
+    }
+  })
+
+  it.each([
+    ['Ctrl+Super+C', { ctrl: true, super: true }],
+    ['Ctrl+Meta+C', { ctrl: true, meta: true }]
+  ])('copies the active composer selection for %s without interrupting', (_name, modifiers) => {
+    const ctx = buildContext()
+    const copy = fn()
+    const interrupt = vi.spyOn(turnController, 'interruptTurn').mockImplementation(() => undefined)
+
+    setInputSelection({
+      clear: fn(),
+      collapseToEnd: fn(),
+      copy,
+      cut: fn(),
+      end: 4,
+      start: 1,
+      value: 'copy me'
+    })
+
+    const instance = mountHandler(ctx)
+
+    try {
+      expect(inputHandler).not.toBeNull()
+      inputHandler!('c', key(modifiers))
+
+      expect(copy).toHaveBeenCalledOnce()
+      expect(interrupt).not.toHaveBeenCalled()
+    } finally {
+      instance.unmount()
+    }
+  })
+})

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -388,6 +388,24 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return
     }
 
+    // Ctrl+C while a turn is running ALWAYS interrupts, before any copy /
+    // selection / clear handling can swallow it. isCopyShortcut() intentionally
+    // also matches the VS Code/Cursor/Windsurf shape where Cmd+C arrives as
+    // super+ctrl; on those terminals a genuine Ctrl+C could otherwise be
+    // captured by the copy branch and consumed by its `if (isMac) return`
+    // early-out, so the running turn never stopped (only Ctrl+X did, because it
+    // sits above that early-out). Anchoring the busy-interrupt here, keyed on
+    // the plain ctrl bit, makes Ctrl+C behave the same in every terminal.
+    // Copy is unaffected: a copy chord only fires when no turn is in flight.
+    if (isCtrl(key, ch, 'c') && live.busy && live.sid) {
+      return turnController.interruptTurn({
+        appendMessage: actions.appendMessage,
+        gw: gateway.gw,
+        sid: live.sid,
+        sys: actions.sys
+      })
+    }
+
     if (key.wheelUp || key.wheelDown) {
       const dir: -1 | 1 = key.wheelUp ? -1 : 1
       const now = Date.now()

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -33,6 +33,19 @@ import { getUiState } from './uiStore.js'
 const isCtrl = (key: { ctrl: boolean }, ch: string, target: string) => key.ctrl && ch.toLowerCase() === target
 const DASHBOARD_NEW_SESSION_MESSAGE = 'starting a fresh dashboard chat...'
 
+/**
+ * Raw Ctrl+C: the plain ctrl bit with NO action modifier (super/meta) held.
+ *
+ * The busy-session interrupt anchors on this instead of a bare ctrl check so it
+ * cannot swallow the VS Code/Cursor/Windsurf forwarded Cmd+C copy shape, which
+ * arrives as `{ctrl:true, super:true}` (see `isCopyShortcut` in platform.ts and
+ * its "accepts the VS Code/Cursor forwarded Cmd+C copy sequence on macOS" test).
+ * Excluding super/meta keeps forwarded Cmd+C on the selection-copy path while a
+ * genuine Ctrl+C still interrupts a running turn in every terminal.
+ */
+export const isRawCtrlC = (key: { ctrl: boolean; meta: boolean; super?: boolean }, ch: string): boolean =>
+  key.ctrl && !key.meta && key.super !== true && ch.toLowerCase() === 'c'
+
 export const shouldAllowIdleHotkeyExit = (dashboardTuiMode = DASHBOARD_TUI_MODE) => !dashboardTuiMode
 
 export function handleInputSelectionClipboard(
@@ -497,6 +510,26 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       cActions.setCompIdx(i => (key.upArrow ? (i - 1 + len) % len : (i + 1) % len))
 
       return
+    }
+
+    // Ctrl+C while a turn is running ALWAYS interrupts, before any copy /
+    // selection / clear handling can swallow it. isCopyShortcut() intentionally
+    // also matches the VS Code/Cursor/Windsurf shape where Cmd+C arrives as
+    // super+ctrl; on those terminals a genuine Ctrl+C could otherwise be
+    // captured by the copy branch and consumed by its `if (isMac) return`
+    // early-out, so the running turn never stopped (only Ctrl+X did, because it
+    // sits above that early-out). Anchoring the busy-interrupt here, keyed on
+    // RAW Ctrl+C (isRawCtrlC excludes the super/meta action bits), makes Ctrl+C
+    // behave the same in every terminal WITHOUT stealing forwarded Cmd+C: that
+    // super+ctrl copy shape carries the super bit, so it skips this branch and
+    // reaches the selection-copy path below, preserving copy during a busy turn.
+    if (isRawCtrlC(key, ch) && live.busy && live.sid) {
+      return turnController.interruptTurn({
+        appendMessage: actions.appendMessage,
+        gw: gateway.gw,
+        sid: live.sid,
+        sys: actions.sys
+      })
     }
 
     if (key.wheelUp || key.wheelDown) {

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -34,14 +34,11 @@ const isCtrl = (key: { ctrl: boolean }, ch: string, target: string) => key.ctrl 
 const DASHBOARD_NEW_SESSION_MESSAGE = 'starting a fresh dashboard chat...'
 
 /**
- * Raw Ctrl+C: the plain ctrl bit with NO action modifier (super/meta) held.
+ * Match Ctrl+C without an action modifier such as Super or Meta.
  *
- * The busy-session interrupt anchors on this instead of a bare ctrl check so it
- * cannot swallow the VS Code/Cursor/Windsurf forwarded Cmd+C copy shape, which
- * arrives as `{ctrl:true, super:true}` (see `isCopyShortcut` in platform.ts and
- * its "accepts the VS Code/Cursor forwarded Cmd+C copy sequence on macOS" test).
- * Excluding super/meta keeps forwarded Cmd+C on the selection-copy path while a
- * genuine Ctrl+C still interrupts a running turn in every terminal.
+ * The busy-session interrupt uses this narrower predicate because
+ * `isCopyShortcut` also accepts forwarded Cmd+C events that carry Ctrl with an
+ * action modifier. Those events should continue to the selection-copy path.
  */
 export const isRawCtrlC = (key: { ctrl: boolean; meta: boolean; super?: boolean }, ch: string): boolean =>
   key.ctrl && !key.meta && key.super !== true && ch.toLowerCase() === 'c'
@@ -512,17 +509,9 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return
     }
 
-    // Ctrl+C while a turn is running ALWAYS interrupts, before any copy /
-    // selection / clear handling can swallow it. isCopyShortcut() intentionally
-    // also matches the VS Code/Cursor/Windsurf shape where Cmd+C arrives as
-    // super+ctrl; on those terminals a genuine Ctrl+C could otherwise be
-    // captured by the copy branch and consumed by its `if (isMac) return`
-    // early-out, so the running turn never stopped (only Ctrl+X did, because it
-    // sits above that early-out). Anchoring the busy-interrupt here, keyed on
-    // RAW Ctrl+C (isRawCtrlC excludes the super/meta action bits), makes Ctrl+C
-    // behave the same in every terminal WITHOUT stealing forwarded Cmd+C: that
-    // super+ctrl copy shape carries the super bit, so it skips this branch and
-    // reaches the selection-copy path below, preserving copy during a busy turn.
+    // Handle raw Ctrl+C during a busy turn before copy, selection, or composer
+    // handling can consume it. Forwarded Cmd+C events carry Super or Meta, so
+    // isRawCtrlC leaves those events for the selection-copy path below.
     if (isRawCtrlC(key, ch) && live.busy && live.sid) {
       return turnController.interruptTurn({
         appendMessage: actions.appendMessage,


### PR DESCRIPTION
## Problem

In the TUI, raw Ctrl+C could be consumed by copy shortcut handling before the busy turn interruption path ran. This was reported in macOS integrated terminals where Ctrl+X interrupted a turn but Ctrl+C did not.

## Root cause

The input handler checks `isCopyShortcut()` before its existing composer action branch. On macOS, that helper also accepts forwarded Cmd+C events that carry both the action modifier and a benign Ctrl bit. When the copy branch matched and there was no selection, its macOS early return prevented the later Ctrl+C branch from reaching `interruptTurn`.

## Fix

The handler now checks a narrow `isRawCtrlC` predicate before copy and composer handling while a session is busy. The predicate requires Ctrl+C without Meta or Super, so forwarded Cmd+C events remain available to the existing copy path.

The predicate is intentionally separate from `isCopyShortcut`: raw Ctrl+C interrupts the busy turn, while Ctrl+Super+C and Ctrl+Meta+C can still copy an active composer selection.

## Tests

Handler-level tests exercise the registered input callback and verify that:

* raw Ctrl+C during a busy turn calls `turnController.interruptTurn` with the active session;
* Ctrl+Super+C with an active composer selection calls copy and does not interrupt;
* Ctrl+Meta+C with an active composer selection calls copy and does not interrupt.

Predicate tests also cover uppercase C, forwarded action modifier shapes, bare action modifier copy, and unrelated Ctrl chords.

Local verification:

* focused input handler suites: 31 tests passed;
* full TUI suite: 1,721 tests passed across 160 files with `NODE_ENV=test`;
* TUI typecheck: passed;
* TUI lint: passed with two existing hook warnings;
* TUI build: passed.

This remains a draft until the updated commit is reviewed.
