### PR TITLE
fix(send_message): verbatim target_ref fallback for plugin platforms

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -313,16 +313,13 @@ def _handle_send(args):
             resolved = resolve_channel_name(platform_name, target_ref)
             if resolved:
                 chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
-            else:
-                return json.dumps({
-                    "error": f"Could not resolve '{target_ref}' on {platform_name}. "
-                    f"Use send_message(action='list') to see available targets."
-                })
         except Exception:
-            return json.dumps({
-                "error": f"Could not resolve '{target_ref}' on {platform_name}. "
-                f"Try using a numeric channel ID instead."
-            })
+            pass  # fall through to verbatim fallback
+
+    # Plugin platforms and opaque IDs: pass target_ref through verbatim;
+    # the adapter validates (same pattern as _handle_react, line 234).
+    if not chat_id and target_ref:
+        chat_id = target_ref
 
     from tools.interrupt import is_interrupted
     if is_interrupted():


### PR DESCRIPTION
## Summary

`_handle_send` previously returned an error when `resolve_channel_name` could not resolve a `target_ref`. Plugin platforms (e.g. tuitui) are not known to `_parse_target_ref` or the channel directory, so `send_message` invariably failed for them with:

```
Could not resolve 'dm:panyaozhen' on tuitui
No home channel set for tuitui
```

## Root Cause

`_handle_send` had no verbatim fallback when both `_parse_target_ref` and `channel_directory` resolution failed. Contrast with `_handle_react` (line 234) which already has:

```python
chat_id = resolved or target_ref
```

## Fix

Align `_handle_send` with `_handle_react`: when `_parse_target_ref` returns None and `channel_directory` resolution also fails, pass `target_ref` through verbatim as `chat_id`. The adapter validates on the other side — same pattern that already works for photon space GUIDs and other opaque IDs in `_handle_react`.

**Change:** 6 insertions, 9 deletions in `tools/send_message_tool.py`

## Test Plan

- [x] 26 existing send_message tests pass
- [ ] Real-world: `send_message(target="tuitui:dm:panyaozhen", ...)` routes to tuitui adapter

## Related

- hermes-tuitui-connector: BUG-019 — send_message plugin target resolution blocks image/file delivery to tuitui