### PR TITLE
fix(terminal): stop cross-session HERMES_SESSION_* leak into subprocess env

### DIFF
--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -44,6 +44,30 @@ from typing import Any
 # When it holds "" (after clear_session_vars resets it), we return "" — no fallback.
 _UNSET: Any = object()
 
+# Process-level flag: has any code in this process bound a session via
+# set_session_vars()? Concurrent multi-session hosts (the messaging gateway, the
+# ACP adapter, the API server, the TUI, cron) all do. A pure single-process
+# CLI/one-shot that never engages the session-context system does not.
+#
+# Consumers that bridge session vars into a child process env (see
+# tools/environments/local.py) use this to decide their leak policy: when the
+# session-context machinery is engaged, the ContextVars are authoritative and an
+# _UNSET var means "no session bound in THIS context" — so a process-global
+# os.environ mirror (written last-writer-wins by whatever concurrent session ran
+# most recently) must NOT be inherited. When it was never engaged, the os.environ
+# fallback is preserved (there is no concurrency to leak across). This is a
+# monotonic latch — once any host binds a session, the process is "engaged" for
+# its lifetime; it never flips back.
+_session_context_engaged: bool = False
+
+
+def session_context_engaged() -> bool:
+    """True if any session has been bound via set_session_vars in this process.
+
+    See the _session_context_engaged docstring for the leak-policy rationale.
+    """
+    return _session_context_engaged
+
 # ---------------------------------------------------------------------------
 # Per-task session variables
 # ---------------------------------------------------------------------------
@@ -123,6 +147,12 @@ def set_session_vars(
 
     ``cwd`` pins the logical working directory for this context.
     """
+    # Mark the session-context machinery as engaged for this process. Consumers
+    # (e.g. the subprocess-env bridge) use this to switch from "os.environ
+    # fallback" to "ContextVar-authoritative, strip on _UNSET" — see the
+    # _session_context_engaged docstring.
+    global _session_context_engaged
+    _session_context_engaged = True
     tokens = [
         _SESSION_PLATFORM.set(platform),
         _SESSION_SOURCE.set(source),

--- a/tests/tools/test_local_env_session_leak.py
+++ b/tests/tools/test_local_env_session_leak.py
@@ -1,0 +1,254 @@
+"""Cross-session HERMES_SESSION_* leak guard for the local terminal backend.
+
+Regression coverage for the bug where a terminal subprocess could observe a
+*different concurrent session's* ``HERMES_SESSION_KEY`` (and the other
+``HERMES_SESSION_*`` vars).
+
+Root cause: the session vars have a process-global ``os.environ`` mirror (written
+last-writer-wins as a CLI/cron fallback, never cleared), while the
+concurrency-safe source of truth is a task-local ``ContextVar``. The subprocess
+env was built from ``os.environ`` and only *overrode* the session vars when the
+ContextVar was set+truthy. When the subprocess was spawned from a thread/context
+that never inherited the agent's copied context (ContextVar ``_UNSET``), the
+override no-op'd and the stale, foreign ``os.environ`` value leaked into the
+child — so e.g. ``bug_thread.py whoami`` read another session's thread id.
+
+The fix: once the session-context machinery is engaged in this process (any
+concurrent host — gateway, ACP, API server, TUI, cron — has called
+``set_session_vars``), the session vars are ContextVar-authoritative. The
+subprocess-env bridge resolves each ``HERMES_SESSION_*`` from the ContextVar and,
+when it is ``_UNSET``, STRIPS the var from the child env rather than inheriting
+the process-global value that may belong to another session. A pure
+single-process CLI/one-shot that never engaged the session-context system keeps
+the ``os.environ`` fallback.
+"""
+
+import os
+
+import pytest
+
+import gateway.session_context as sc
+from gateway.session_context import _VAR_MAP, clear_session_vars, set_session_vars
+from tools.environments.local import _make_run_env, _sanitize_subprocess_env
+
+# The full set of session vars the bridge owns.
+SESSION_VARS = list(_VAR_MAP.keys())
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_context():
+    """Clean ContextVar + os.environ + engaged-latch slate per test, restored."""
+    saved_env = {k: os.environ.get(k) for k in SESSION_VARS}
+    saved_ctx = {name: var.get() for name, var in _VAR_MAP.items()}
+    saved_engaged = sc._session_context_engaged
+    for var in _VAR_MAP.values():
+        var.set(sc._UNSET)
+    sc._session_context_engaged = False
+    try:
+        yield
+    finally:
+        for var, val in zip(_VAR_MAP.values(), saved_ctx.values()):
+            var.set(val)
+        sc._session_context_engaged = saved_engaged
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _engage():
+    """Mark the session-context machinery engaged, like a concurrent host would."""
+    sc._session_context_engaged = True
+
+
+# --------------------------------------------------------------------------- #
+# Foreground path (_make_run_env)
+# --------------------------------------------------------------------------- #
+
+def test_engaged_unset_contextvar_strips_foreign_session_key(monkeypatch):
+    """Engaged host + UNSET ContextVar must NOT inherit a foreign global.
+
+    This is the production hijack: a concurrent session wrote
+    os.environ["HERMES_SESSION_KEY"], this task's ContextVar is unset, and the
+    subprocess must see NO key rather than the foreign one.
+    """
+    _engage()
+    monkeypatch.setenv(
+        "HERMES_SESSION_KEY",
+        "agent:main:discord:thread:FOREIGN_CONCURRENT:FOREIGN_CONCURRENT",
+    )
+
+    env = _make_run_env({})
+
+    assert "HERMES_SESSION_KEY" not in env, (
+        "Foreign concurrent session key leaked into subprocess env: "
+        f"{env.get('HERMES_SESSION_KEY')!r}"
+    )
+
+
+def test_set_session_vars_engages_and_overrides_foreign_global(monkeypatch):
+    """set_session_vars itself engages the latch and the bound value wins.
+
+    Mirrors a real host: calling set_session_vars both marks the process engaged
+    and binds the ContextVar, so the bound value overrides the foreign global.
+    """
+    monkeypatch.setenv(
+        "HERMES_SESSION_KEY",
+        "agent:main:discord:thread:FOREIGN:FOREIGN",
+    )
+
+    tokens = set_session_vars(
+        session_key="agent:main:discord:group:MY_BUGS_ROOT:111",
+        platform="discord",
+        chat_id="MY_BUGS_ROOT",
+    )
+    try:
+        assert sc.session_context_engaged() is True
+        env = _make_run_env({})
+    finally:
+        clear_session_vars(tokens)
+
+    assert env.get("HERMES_SESSION_KEY") == "agent:main:discord:group:MY_BUGS_ROOT:111"
+
+
+def test_engaged_strips_all_session_vars_when_unset(monkeypatch):
+    """The strip covers every HERMES_SESSION_* mirror, not just the key."""
+    _engage()
+    monkeypatch.setenv("HERMES_SESSION_KEY", "foreign-key")
+    monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "foreign-thread")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "foreign-chat")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "foreign-user")
+
+    env = _make_run_env({})
+
+    for var in (
+        "HERMES_SESSION_KEY",
+        "HERMES_SESSION_THREAD_ID",
+        "HERMES_SESSION_CHAT_ID",
+        "HERMES_SESSION_USER_ID",
+    ):
+        assert var not in env, f"{var} leaked from a foreign global: {env.get(var)!r}"
+
+
+def test_unengaged_process_preserves_os_environ_fallback(monkeypatch):
+    """A process that never engaged the session-context system keeps the fallback.
+
+    Pure single-process CLI/one-shot sets HERMES_SESSION_* directly in os.environ
+    and relies on the subprocess inheriting them; there is no concurrency to leak
+    across, so the strip must NOT apply.
+    """
+    # _isolate_session_context already forced engaged=False.
+    monkeypatch.setenv("HERMES_SESSION_KEY", "cli-session-key")
+    monkeypatch.setenv("HERMES_SESSION_ID", "cli-session-id")
+
+    env = _make_run_env({})
+
+    assert env.get("HERMES_SESSION_KEY") == "cli-session-key"
+    assert env.get("HERMES_SESSION_ID") == "cli-session-id"
+
+
+def test_engaged_explicit_empty_contextvar_clears(monkeypatch):
+    """An explicitly-cleared ContextVar ("" via clear_session_vars) clears the var.
+
+    After a handler finishes it calls clear_session_vars which sets each var to
+    "" (distinct from _UNSET). A subprocess spawned in that window must see the
+    empty value (which overrides the foreign global), NOT the foreign global —
+    an empty key is safe (whoami reads "" → no thread).
+    """
+    monkeypatch.setenv("HERMES_SESSION_KEY", "foreign-after-clear")
+
+    tokens = set_session_vars(session_key="real-key", platform="discord", chat_id="c")
+    clear_session_vars(tokens)  # sets vars to "" (explicitly cleared); stays engaged
+
+    env = _make_run_env({})
+
+    # Explicit-empty wins over the foreign global: either stripped or "" — never
+    # the foreign value. Both outcomes are safe for the consumer.
+    assert env.get("HERMES_SESSION_KEY", "") == "", (
+        f"Foreign key survived an explicit clear: {env.get('HERMES_SESSION_KEY')!r}"
+    )
+
+
+def test_explicit_empty_thread_id_overrides_stale_value(monkeypatch):
+    """A bound-but-empty thread id must override a stale inherited value.
+
+    This is the complementary case (the #38507 scenario): a top-level post with
+    no thread id binds HERMES_SESSION_THREAD_ID="" and that empty value must win
+    over an older non-empty value left in os.environ.
+    """
+    monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "stale-thread-from-prior-turn")
+
+    tokens = set_session_vars(
+        session_key="mm:chan",
+        platform="mattermost",
+        chat_id="chan",
+        thread_id="",  # explicitly no thread
+    )
+    try:
+        env = _make_run_env({})
+    finally:
+        clear_session_vars(tokens)
+
+    assert env.get("HERMES_SESSION_THREAD_ID") == "", (
+        "Bound-empty thread id did not override the stale value: "
+        f"{env.get('HERMES_SESSION_THREAD_ID')!r}"
+    )
+    assert env.get("HERMES_SESSION_KEY") == "mm:chan"
+
+
+# --------------------------------------------------------------------------- #
+# Background / PTY path (_sanitize_subprocess_env via process_registry)
+# --------------------------------------------------------------------------- #
+
+def test_sanitize_subprocess_env_strips_foreign_session_key_when_engaged(monkeypatch):
+    """The background/PTY spawn path gets the same cross-session strip.
+
+    process_registry.spawn_local() builds its env via _sanitize_subprocess_env(
+    os.environ, env_vars). A background subprocess spawned with an UNSET
+    ContextVar in an engaged process must not inherit a foreign session key.
+    """
+    _engage()
+    stale_base = {
+        "PATH": "/usr/bin:/bin",
+        "HERMES_SESSION_KEY": "agent:main:discord:thread:FOREIGN_BG:FOREIGN_BG",
+        "HERMES_SESSION_THREAD_ID": "FOREIGN_BG",
+    }
+
+    sanitized = _sanitize_subprocess_env(stale_base)
+
+    assert "HERMES_SESSION_KEY" not in sanitized, (
+        f"Background subprocess inherited foreign key: {sanitized.get('HERMES_SESSION_KEY')!r}"
+    )
+    assert "HERMES_SESSION_THREAD_ID" not in sanitized
+
+
+def test_sanitize_subprocess_env_set_contextvar_wins_when_engaged():
+    """Background path: a SET ContextVar overrides the foreign global base."""
+    stale_base = {
+        "PATH": "/usr/bin:/bin",
+        "HERMES_SESSION_KEY": "agent:main:discord:thread:FOREIGN_BG:FOREIGN_BG",
+    }
+    tokens = set_session_vars(
+        session_key="agent:main:discord:group:REAL_BG:222",
+        platform="discord",
+        chat_id="REAL_BG",
+    )
+    try:
+        sanitized = _sanitize_subprocess_env(stale_base)
+    finally:
+        clear_session_vars(tokens)
+
+    assert sanitized.get("HERMES_SESSION_KEY") == "agent:main:discord:group:REAL_BG:222"
+
+
+def test_sanitize_subprocess_env_unengaged_preserves_fallback(monkeypatch):
+    """Background path in an unengaged process keeps the inherited value."""
+    stale_base = {
+        "PATH": "/usr/bin:/bin",
+        "HERMES_SESSION_KEY": "cli-bg-key",
+    }
+
+    sanitized = _sanitize_subprocess_env(stale_base)
+
+    assert sanitized.get("HERMES_SESSION_KEY") == "cli-bg-key"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -203,6 +203,54 @@ def _inject_context_hermes_home(env: dict) -> None:
         pass
 
 
+def _inject_session_context_env(env: dict) -> None:
+    """Bridge gateway session ContextVars into a subprocess environment.
+
+    ContextVars don't propagate to child processes, so the live session vars
+    (HERMES_SESSION_*) are bridged onto the child env here.
+
+    🔴 Cross-session leak guard. The session vars also have a process-global
+    os.environ mirror (written last-writer-wins as a CLI/cron fallback, never
+    cleared). Under a concurrent multi-session host (messaging gateway, ACP
+    adapter, API server, TUI) that global belongs to *whichever turn wrote it
+    last* — NOT necessarily this task. A subprocess spawned from a thread/context
+    whose ContextVar is _UNSET (e.g. a worker thread that never inherited the
+    agent's copied context) would otherwise inherit the FOREIGN global and act on
+    another session's identity (verified 2026: a /bug subprocess read a
+    concurrent session's thread id and renamed an unrelated Discord thread).
+
+    So once the session-context machinery is engaged in this process (any host
+    has called set_session_vars), the session vars are ContextVar-authoritative:
+    - ContextVar set (incl. explicitly-empty "") → that value wins, overriding
+      any stale snapshot/global value.
+    - ContextVar _UNSET → STRIP the var from the child env rather than inherit
+      the possibly-foreign process-global.
+    In a pure single-process CLI/one-shot that never engaged the session-context
+    system there is no concurrency to leak across and callers legitimately set
+    HERMES_SESSION_* directly in os.environ, so the inherited fallback is kept.
+    """
+    try:
+        from gateway.session_context import (
+            _UNSET,
+            _VAR_MAP,
+            session_context_engaged,
+        )
+    except Exception:
+        return
+
+    _engaged = session_context_engaged()
+    for var_name, var in _VAR_MAP.items():
+        value = var.get()
+        if value is not _UNSET:
+            # Explicitly bound (including "") — authoritative for this task.
+            env[var_name] = "" if value is None else str(value)
+        elif _engaged:
+            # Unset for THIS task while the session-context system is engaged:
+            # drop any inherited global so a concurrent session's value can't
+            # leak into this subprocess.
+            env.pop(var_name, None)
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -226,6 +274,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             sanitized[key] = value
 
     _inject_context_hermes_home(sanitized)
+    _inject_session_context_env(sanitized)
 
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(sanitized)
@@ -387,16 +436,10 @@ def _make_run_env(env: dict) -> dict:
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(run_env)
 
-    # Inject ContextVar-based session vars into subprocess env.
-    # ContextVars don't propagate to child processes, so we bridge them here.
-    try:
-        from gateway.session_context import _UNSET, _VAR_MAP
-        for var_name, var in _VAR_MAP.items():
-            value = var.get()
-            if value is not _UNSET and value:
-                run_env[var_name] = value
-    except Exception:
-        pass
+    # ContextVars don't propagate to child processes, so bridge the gateway
+    # session vars here. Strips foreign-concurrent-session values under the
+    # gateway; see _inject_session_context_env for the cross-session leak guard.
+    _inject_session_context_env(run_env)
 
     return run_env
 


### PR DESCRIPTION
## Summary

Under any concurrent multi-session host (the messaging **gateway**, the **ACP** adapter, the **API server**), a terminal subprocess could observe a *different concurrent session's* `HERMES_SESSION_KEY` (and the other `HERMES_SESSION_*` vars). In production this caused a Discord `/bug` subprocess to read a **foreign concurrent session's** `thread_id` and act on the wrong thread.

### Root cause

The session vars have two storage paths:
- the concurrency-safe source of truth — a task-local `ContextVar` (per `gateway/session_context.py`);
- a process-global `os.environ` mirror written as a CLI/cron fallback (e.g. `gateway/run.py`: `os.environ["HERMES_SESSION_KEY"] = session_key`), last-writer-wins and never cleared.

The subprocess env is built from `os.environ`, and the existing ContextVar→subprocess bridge in `_make_run_env` only **overrode** the session vars when the ContextVar was set+truthy. When a subprocess is spawned from a thread/context that never inherited the agent's `copy_context()` — so the ContextVar is `_UNSET` — the bridge no-ops and the stale, **foreign** `os.environ` value leaks into the child. Because the global is shared across all concurrent sessions in the process, the child can inherit a *different* session's identity.

Two spawn paths were affected:
- foreground — `_make_run_env()`
- background / PTY — `_sanitize_subprocess_env()` via `process_registry.spawn_local()`

### Fix

When the **session-context machinery is engaged in this process** (i.e. any concurrent host has called `set_session_vars` — gateway, ACP, API server, TUI, cron), the session vars are ContextVar-authoritative:

- ContextVar set (incl. explicitly-empty `""`) → that value wins, overriding any stale `os.environ`/snapshot value;
- ContextVar `_UNSET` → **strip** the var from the child env rather than inherit a possibly-foreign process-global.

A pure single-process CLI/one-shot that never engaged the session-context system keeps the `os.environ` fallback (no concurrency to leak across). Factored into a shared `_inject_session_context_env()` helper wired into both spawn paths.

> Note: this is intentionally **not** gated on the gateway-only `_HERMES_GATEWAY` marker — the ACP adapter and API server are *also* concurrent multi-session hosts and don't set it. The discriminator is "has any code in this process bound a session via `set_session_vars`?", which covers every concurrent host (current and future) without per-host markers. The ACP adapter already hand-patches a narrower version of this same hazard per-var (`os.environ["HERMES_SESSION_ID"]` save/restore around the agent call, `acp_adapter/server.py`) — this generalizes that defense to the whole `HERMES_SESSION_*` set.

### Minimal repro (pre-fix)

```python
import os, threading
from gateway.session_context import set_session_vars
from tools.environments.local import _make_run_env

os.environ["HERMES_SESSION_KEY"] = "agent:main:discord:thread:FOREIGN:X"  # concurrent writer
set_session_vars(session_key="agent:main:discord:group:CORRECT:1", platform="discord", chat_id="c")

def worker():  # fresh thread -> ContextVar _UNSET here
    print(_make_run_env({}).get("HERMES_SESSION_KEY"))
threading.Thread(target=worker).start()
# pre-fix:  agent:main:discord:thread:FOREIGN:X   (foreign session leaked in)
# post-fix: None                                  (stripped — safe)
```

## Tests

`tests/tools/test_local_env_session_leak.py` (new): the production hijack on both the foreground and background paths, set-ContextVar override (both paths), the all-vars strip, the explicit-empty override, the engaged-host strip, and the un-engaged single-process fallback.

```
python -m pytest tests/tools/test_local_env_session_leak.py \
  tests/gateway/test_session_api.py tests/gateway/test_session_env.py \
  tests/test_subprocess_home_isolation.py tests/tools/test_local_env_blocklist.py \
  tests/tools/test_env_passthrough.py tests/gateway/test_raft_adapter.py \
  tests/tools/test_process_registry.py tests/run_agent/test_session_id_env.py -q
ruff check tools/environments/local.py gateway/session_context.py tests/tools/test_local_env_session_leak.py
```

## Related

Overlaps with #38507 (shared session-overlay helper across fg/bg + explicit-empty-overrides-stale), which intentionally skips the `_UNSET` case this closes. The two are compatible; whichever lands first, the other reduces to its non-overlapping parts.