### PR TITLE
docs: align contributor test checklist with run_tests wrapper

### DIFF
--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -223,9 +223,9 @@ refactor/description   # Code restructuring
 
 ### Before Submitting
 
-1. **Run tests**: `pytest tests/ -v`
+1. **Run tests**: `scripts/run_tests.sh` for CI-parity. Use direct `python -m pytest ...` only when the wrapper is unavailable or you are intentionally debugging outside the wrapper.
 2. **Test manually**: Run `hermes` and exercise the code path you changed
-3. **Check cross-platform impact**: Consider macOS and different Linux distros
+3. **Check cross-platform impact**: Consider macOS, Linux, WSL2, and native Windows. If you touch file I/O, process management, terminal handling, subprocesses, or signals, run `scripts/check-windows-footguns.py`.
 4. **Keep PRs focused**: One logical change per PR
 
 ### PR Description

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/contributing.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/contributing.md
@@ -212,9 +212,9 @@ refactor/description   # 代码重构
 
 ### 提交前检查
 
-1. **运行测试**：`pytest tests/ -v`
+1. **运行测试**：`scripts/run_tests.sh` 以确保 CI 一致性。仅当 wrapper 不可用或您有意在 wrapper 之外调试时，才使用直接 `python -m pytest ...`。
 2. **手动测试**：运行 `hermes` 并验证您修改的代码路径
-3. **检查跨平台影响**：考虑 macOS 和不同 Linux 发行版
+3. **检查跨平台影响**：考虑 macOS、Linux、WSL2 和原生 Windows。如果您修改了文件 I/O、进程管理、终端处理、子进程或信号相关代码，请运行 `scripts/check-windows-footguns.py`。
 4. **保持 PR 聚焦**：每个 PR 只包含一个逻辑变更
 
 ### PR 描述


### PR DESCRIPTION
## Summary
- Updates the website contributor checklist to recommend `scripts/run_tests.sh` for CI-parity test runs.
- Adds native Windows / WSL2 to the cross-platform impact checklist.
- Mirrors the same checklist update in the zh-Hans translation.

## Why
`AGENTS.md` documents `scripts/run_tests.sh` as the canonical test entry point because it enforces the hermetic CI-like environment. The website contributor guide still used `pytest tests/ -v` in the final PR checklist.

## Test Plan
- [x] `python3 website/scripts/extract-skills.py` — passed
- [x] `python3 website/scripts/generate-skill-docs.py` — passed
- [x] `npm run lint:diagrams` — passed (355 files, 0 errors)
- [x] `npm run build` — passed (SUCCESS for both en and zh-Hans; broken links are pre-existing)

## Risk
Low. Docs-only change.