### PR TITLE
test(tools): make env_passthrough blocklist probe deterministic

### DIFF
--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -165,8 +165,10 @@ class TestTerminalIntegration:
     def test_blocklisted_var_blocked_by_default(self):
         from tools.environments.local import _sanitize_subprocess_env, _HERMES_PROVIDER_ENV_BLOCKLIST
 
-        # Pick a var we know is in the blocklist
-        blocked_var = next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST))
+        # Pick a var we know is in the blocklist. sorted() so the probed
+        # var is deterministic across runs (frozenset iteration order
+        # varies with PYTHONHASHSEED). See 2d978bf44.
+        blocked_var = sorted(_HERMES_PROVIDER_ENV_BLOCKLIST)[0]
         env = {blocked_var: "secret_value", "PATH": "/usr/bin"}
         result = _sanitize_subprocess_env(env)
         assert blocked_var not in result
@@ -182,7 +184,9 @@ class TestTerminalIntegration:
             _HERMES_PROVIDER_ENV_BLOCKLIST,
         )
 
-        blocked_var = next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST))
+        # sorted() so the probed var is deterministic across runs
+        # (frozenset iteration order varies with PYTHONHASHSEED).
+        blocked_var = sorted(_HERMES_PROVIDER_ENV_BLOCKLIST)[0]
         # Attempt to register — must be silently refused (logged warning).
         register_env_passthrough([blocked_var])
 
@@ -203,7 +207,9 @@ class TestTerminalIntegration:
             _HERMES_PROVIDER_ENV_BLOCKLIST,
         )
 
-        blocked_var = next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST))
+        # sorted() so the probed var is deterministic across runs
+        # (frozenset iteration order varies with PYTHONHASHSEED).
+        blocked_var = sorted(_HERMES_PROVIDER_ENV_BLOCKLIST)[0]
         os.environ[blocked_var] = "secret_value"
         try:
             # Without passthrough — blocked


### PR DESCRIPTION
## What does this PR do?

Fixes non deterministic test behavior in `tests/tools/test_env_passthrough.py`. Three tests in `TestTerminalIntegration` (`test_blocklisted_var_blocked_by_default`, `test_passthrough_cannot_override_provider_blocklist`, `test_make_run_env_blocklist_override_rejected`) pick a probe variable from `_HERMES_PROVIDER_ENV_BLOCKLIST` using `next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST))`.

`_HERMES_PROVIDER_ENV_BLOCKLIST` is a `frozenset`, and Python's set iteration order depends on `PYTHONHASHSEED`, which varies per process. This means `next(iter())` returns a different variable on every run depending on the hash seed. I confirmed this directly on a real Mac: the same blocklist returns `LINE_ALLOWED_USERS`, `DISCORD_FREE_RESPONSE_CHANNELS`, `MINIMAX_BASE_URL`, `WECOM_CALLBACK_CORP_ID`, and `MATTERMOST_ALLOWED_USERS` across five different `PYTHONHASHSEED` values for the exact same expression.

This doesn't cause false failures today since the test logic is correct for any blocklisted variable, but it makes any future failure hard to reproduce, since the probed variable changes between runs and machines.

This follows the exact same fix pattern a maintainer already applied earlier today in `tests/cron/test_cron_script.py` (commit `2d978bf44`) for the same `_HERMES_PROVIDER_ENV_BLOCKLIST` frozenset, just in a sibling test file that had the same three remaining occurrences of the pattern.

I checked the other two files in the repo that reference `_HERMES_PROVIDER_ENV_BLOCKLIST` (`tests/tools/test_local_env_blocklist.py`, `tests/tools/test_docker_environment.py`) and confirmed neither has the `next(iter())` pattern, so this is the only remaining file affected.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non breaking change that fixes an issue)
- [ ] ✨ New feature (non breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/tools/test_env_passthrough.py`: replaced `next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST))` with `sorted(_HERMES_PROVIDER_ENV_BLOCKLIST)[0]` in three tests in `TestTerminalIntegration`, matching the precedent set in `tests/cron/test_cron_script.py` (commit `2d978bf44`).

## How to Test

1. On any machine, run the following to confirm the old expression is non deterministic across hash seeds, while the new one is stable. Replace `next(iter(...))` with the old expression to reproduce the original behavior:
   `for seed in 0 1 2 42 100; do PYTHONHASHSEED=$seed python -c "from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST; print(next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST)))"; done`
2. Before this fix, each `PYTHONHASHSEED` value above prints a different variable name. After this fix, `sorted(_HERMES_PROVIDER_ENV_BLOCKLIST)[0]` prints the same variable (`AGENT_BROWSER_ENGINE`) every time, regardless of hash seed.
3. Run `scripts/run_tests.sh tests/tools/test_env_passthrough.py`, all 17 tests pass. Also ran `scripts/run_tests.sh tests/tools/test_local_env_blocklist.py tests/tools/test_docker_environment.py tests/cron/test_cron_script.py` to confirm no sibling test files were affected, all 134 tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Sequoia), Python 3.12.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A, this fix only affects Python hash seed behavior in test code, not platform specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

### Demonstrating the bug and the fix side by side

<img width="632" height="344" alt="demo" src="https://github.com/user-attachments/assets/18d4cd6a-3686-4594-8015-5d1ae3bcf62b" />


### After fix, official test runner

<img width="830" height="244" alt="Screenshot 2026-06-20 at 10 17 00 PM" src="https://github.com/user-attachments/assets/eef15c16-a1fc-4a51-aa0e-00bec850e8ac" />
