### PR TITLE
fix(terminal): bypass Git Bash wrapper to prevent console flashes on Windows

### DIFF
--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -1007,3 +1007,38 @@ class TestGatewayDetachedWatcherWindowsFlags:
             "CreateProcess and retry without the breakaway bit, matching "
             "gateway_windows._spawn_detached's fallback pattern."
         )
+
+
+class TestGitBashWrapperRedirection:
+    """Verify that _find_bash on Windows redirects bin/bash.exe to usr/bin/bash.exe."""
+
+    def test_redirects_bin_to_usr_bin_when_exists(self, monkeypatch):
+        from tools.environments import local
+        
+        # Force IS_WINDOWS to True for the test
+        monkeypatch.setattr(local, "_IS_WINDOWS", True)
+        
+        # Mock shutil.which to return a path ending in bin/bash.exe
+        monkeypatch.setattr(local.shutil, "which", lambda cmd: r"C:\Program Files\Git\bin\bash.exe")
+        
+        # Mock os.path.isfile to return True when checking the usr/bin/bash.exe path,
+        # but False for others (to avoid infinite recursion or matching other candidates)
+        def mock_isfile(path):
+            if path.lower() == r"c:\program files\git\usr\bin\bash.exe".lower():
+                return True
+            return False
+            
+        monkeypatch.setattr(local.os.path, "isfile", mock_isfile)
+        
+        resolved = local._find_bash()
+        assert resolved == r"C:\Program Files\Git\usr\bin\bash.exe"
+
+    def test_falls_back_to_bin_when_usr_bin_missing(self, monkeypatch):
+        from tools.environments import local
+        
+        monkeypatch.setattr(local, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local.shutil, "which", lambda cmd: r"C:\Program Files\Git\bin\bash.exe")
+        monkeypatch.setattr(local.os.path, "isfile", lambda path: False)
+        
+        resolved = local._find_bash()
+        assert resolved == r"C:\Program Files\Git\bin\bash.exe"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -244,9 +244,21 @@ def _find_bash() -> str:
             or "/bin/sh"
         )
 
+    def _to_real_bash(path: str) -> str:
+        if not path:
+            return path
+        lower_path = path.lower()
+        for pattern, replacement in [("\\bin\\bash.exe", "\\usr\\bin\\bash.exe"), ("/bin/bash.exe", "/usr/bin/bash.exe")]:
+            idx = lower_path.find(pattern)
+            if idx != -1:
+                candidate = path[:idx] + replacement + path[idx + len(pattern):]
+                if os.path.isfile(candidate):
+                    return candidate
+        return path
+
     custom = os.environ.get("HERMES_GIT_BASH_PATH")
     if custom and os.path.isfile(custom):
-        return custom
+        return _to_real_bash(custom)
 
     # Prefer our own portable Git install first — this way a broken or
     # partially-uninstalled system Git can't hijack the bash lookup.  The
@@ -265,11 +277,11 @@ def _find_bash() -> str:
             os.path.join(_hermes_portable_git, "usr", "bin", "bash.exe"), # MinGit fallback
         ):
             if os.path.isfile(candidate):
-                return candidate
+                return _to_real_bash(candidate)
 
     found = shutil.which("bash")
     if found:
-        return found
+        return _to_real_bash(found)
 
     for candidate in (
         os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
@@ -277,7 +289,7 @@ def _find_bash() -> str:
         os.path.join(_local_appdata, "Programs", "Git", "bin", "bash.exe"),
     ):
         if candidate and os.path.isfile(candidate):
-            return candidate
+            return _to_real_bash(candidate)
 
     raise RuntimeError(
         "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"


### PR DESCRIPTION
### Summary
Bypasses the Git Bash wrapper launcher (`bin/bash.exe`) on Windows and executes the real shell binary (`usr/bin/bash.exe`) directly. This allows the `CREATE_NO_WINDOW` process flag to be respected and permanently prevents console flashing (`conhost.exe`) and input focus stealing when spawning foreground or background terminal tools in Hermes.

Fixes #49851

### Rationale
- **The Issue:** Spawning Git Bash on Windows via standard PATH resolves to the wrapper `bin/bash.exe` (a console helper utility). While the wrapper itself is spawned with `CREATE_NO_WINDOW`, it spawns the real shell (`usr/bin/bash.exe`) internally without forwarding the hide flag, forcing a visible `conhost.exe` command window to flash on screen.
- **The Fix:** Resolves the real `usr/bin/bash.exe` binary path when locating `bash.exe` on Windows (if it exists). Since the real binary is spawned directly under the parent process with `CREATE_NO_WINDOW` creation flags, it executes 100% invisibly.
- **Other processes:** Verified via manual and automated tests that standard command line tools, batch files (`.cmd`/`.bat` like `npm.cmd`), and direct executables do not cause flashes when spawned with the `CREATE_NO_WINDOW` flag.

### Verification & Tests
- Added unit tests to `tests/tools/test_windows_native_support.py` (`TestGitBashWrapperRedirection`) to ensure the wrapper redirection and fallback behavior work correctly on all platforms.
- Ran tests locally on Windows: `pytest tests/tools/test_windows_native_support.py -k TestGitBashWrapperRedirection` (Passed).
- Verified manually that terminal tool runs (foreground and background) do not trigger visible console window popups or steal input focus.
