### PR TITLE
fix(packaging): ship NeuTTS default voice samples in the wheel and sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,12 @@ graft locales
 # built from the sdist (e.g. Homebrew, downstream packagers). package-data
 # below covers the wheel; this covers the sdist. See #34034 / #28149.
 recursive-include plugins plugin.yaml plugin.yml
+# Bundled NeuTTS default-voice reference sample (jo.wav / jo.txt). tools/ is a
+# real package so the wheel ships its .py files, but these data files in the
+# bare tools/neutts_samples/ subdir are otherwise dropped from the sdist
+# (Homebrew, downstream packagers build from it). package-data in pyproject
+# covers the wheel; this graft covers the sdist. Without both, default-config
+# NeuTTS synthesis fails on a sealed install with "reference audio not found".
+graft tools/neutts_samples
 global-exclude __pycache__
 global-exclude *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,6 +327,15 @@ locales = ["locales/*.yaml"]
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
 gateway = ["assets/**/*"]
+# NeuTTS bundled default-voice reference sample. tools/ is a real package, but
+# tools/neutts_samples/ is a bare data subdir, so its non-Python files are
+# dropped from the wheel unless declared here. The runtime resolver
+# (tools/tts_tool.py::_default_neutts_ref_audio) reads them __file__-relative at
+# site-packages/tools/neutts_samples/, which is exactly where package-data lands
+# them — data-files (prefix-relative) would not satisfy that resolution. Without
+# this, every default-config NeuTTS synthesis fails on a sealed install with
+# "reference audio not found".
+tools = ["neutts_samples/*.wav", "neutts_samples/*.txt"]
 plugins = [
   "*/dashboard/manifest.json",
   "*/dashboard/dist/*",

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -265,3 +265,56 @@ def test_locale_catalogs_ship_in_both_wheel_and_sdist():
     on_disk = list((REPO_ROOT / "locales").glob("*.yaml"))
     assert on_disk, "expected locales/*.yaml catalogs on disk"
 
+
+def test_neutts_voice_samples_ship_in_both_wheel_and_sdist():
+    """Regression for the bundled NeuTTS default-voice reference sample.
+
+    ``tools/`` is a real package (``tools/__init__.py`` exists, and it is in
+    ``packages.find``), so the wheel ships ``tools/*.py``. But
+    ``tools/neutts_samples/`` is a bare data subdir whose contents (``jo.wav`` /
+    ``jo.txt``) are non-Python files, so they are globbed out of the wheel
+    unless declared as package-data, and dropped from the sdist unless grafted
+    in MANIFEST.in.
+
+    These samples are the default voice reference for the built-in NeuTTS local
+    TTS provider: ``tools/tts_tool.py::_default_neutts_ref_audio`` /
+    ``_default_neutts_ref_text`` resolve them ``__file__``-relative at
+    ``site-packages/tools/neutts_samples/``, and ``tools/neutts_synth.py``
+    exits 1 if either is absent. So a packaged install (pip wheel, Nix venv,
+    Homebrew sdist) using NeuTTS with default config hits a 100% synthesis
+    failure ("reference audio not found"). Source/editable checkouts have the
+    files present, so it escapes CI.
+
+    package-data (NOT data-files) is required here: the resolver reads the
+    samples inside the installed package dir, which is where package-data lands
+    them; data-files would install prefix-relative and not satisfy the
+    ``Path(__file__).parent`` resolution. Mirrors the locales / optional-mcps /
+    plugin-manifest "bare data dropped from the build" fixes.
+    """
+    # The samples must actually exist on disk for the globs to match.
+    on_disk_wav = list((REPO_ROOT / "tools" / "neutts_samples").glob("*.wav"))
+    on_disk_txt = list((REPO_ROOT / "tools" / "neutts_samples").glob("*.txt"))
+    assert on_disk_wav, "expected tools/neutts_samples/*.wav default voice sample on disk"
+    assert on_disk_txt, "expected tools/neutts_samples/*.txt default voice reference on disk"
+
+    # Wheel channel: package-data on the `tools` package must ship both the
+    # wav and txt globs so they land at site-packages/tools/neutts_samples/.
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    tools_pkg_data = data["tool"]["setuptools"]["package-data"].get("tools", [])
+    assert any(g.endswith("neutts_samples/*.wav") for g in tools_pkg_data), (
+        "pyproject [tool.setuptools.package-data] 'tools' must ship "
+        "neutts_samples/*.wav so the wheel carries the NeuTTS default voice audio"
+    )
+    assert any(g.endswith("neutts_samples/*.txt") for g in tools_pkg_data), (
+        "pyproject [tool.setuptools.package-data] 'tools' must ship "
+        "neutts_samples/*.txt so the wheel carries the NeuTTS reference text"
+    )
+
+    # Sdist channel: MANIFEST.in must graft the dir so downstream packagers
+    # building from the sdist also get the samples.
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    assert "graft tools/neutts_samples" in manifest, (
+        "MANIFEST.in must `graft tools/neutts_samples` so the sdist ships the "
+        "NeuTTS default voice reference samples"
+    )
+


### PR DESCRIPTION
## This is a sibling follow-up to the locales / optional-mcps / plugin-manifest packaging fixes

- `locales = ["locales/*.yaml"]` (data-files) + `graft locales`, the `optional-mcps/<name>` data-files entries, and the `plugins **/plugin.yaml` package-data glob fixed the same "bare data dir dropped from the build" class for i18n catalogs, the MCP catalog, and plugin manifests (#27632 / #34034 / #28149).
- None of them covered `tools/neutts_samples/` — the bundled default-voice reference for the built-in NeuTTS local TTS provider. `tools` is a real package, so the wheel ships `tools/*.py`, but `jo.wav` / `jo.txt` are non-Python files in a bare subdir and are silently globbed out of the wheel (and, without a graft, the sdist).
- This adds the wheel package-data entry + the sdist graft + a regression test.

## What does this PR do?

Declares `tools/neutts_samples/{*.wav,*.txt}` as package-data of the `tools` package (wheel) and grafts the dir in `MANIFEST.in` (sdist), so sealed installs ship the default voice reference. Uses **package-data, not data-files**, because the runtime resolver (`tools/tts_tool.py::_default_neutts_ref_audio` / `_default_neutts_ref_text`) reads the samples `__file__`-relative inside `site-packages/tools/neutts_samples/`, which is exactly where package-data lands them. data-files would install them prefix-relative (`<prefix>/tools/neutts_samples/`) and would NOT satisfy the `Path(__file__).parent` resolution.

**Why:** On a packaged install (`pip install`, Nix store venv, Homebrew sdist) a user who selects NeuTTS with default config hits `_default_neutts_ref_audio()` → `tools/neutts_samples/jo.wav`, which is absent, so `tools/neutts_synth.py` exits 1 and `_generate_neutts` raises `RuntimeError: NeuTTS synthesis failed: ... reference audio not found`. That is a 100% failure on the documented free / on-device TTS path. Source / editable checkouts have the files present, so it escapes dev and CI.

## Related Issue

N/A (packaging completeness, found by audit)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `pyproject.toml` — add a `tools = ["neutts_samples/*.wav", "neutts_samples/*.txt"]` entry under `[tool.setuptools.package-data]` so the wheel carries the NeuTTS default voice reference inside the installed `tools` package dir.
- `MANIFEST.in` — `graft tools/neutts_samples` so the sdist (Homebrew / downstream packagers) ships the samples too.
- `tests/test_packaging_metadata.py` — `test_neutts_voice_samples_ship_in_both_wheel_and_sdist`: asserts the wheel package-data globs, the sdist graft, and the on-disk samples.

## How to Test

1. `git stash` the prod hunk → `pytest tests/test_packaging_metadata.py::test_neutts_voice_samples_ship_in_both_wheel_and_sdist` fails (no `tools` package-data entry, no graft). Restore → passes. Verified both directions.
2. End-to-end build proof: `uv build --wheel` then `unzip -l dist/*.whl | grep neutts_samples` lists `tools/neutts_samples/jo.wav` and `jo.txt` (post-fix). `uv build --sdist` then `tar tzf dist/*.tar.gz | grep neutts_samples` lists them too. Both were absent before this change.
3. `pytest tests/test_packaging_metadata.py -q` — all packaging tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — packaging metadata is platform-independent; verified wheel + sdist build on macOS
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A