### PR TITLE
ci: fix save-durations JSONDecodeError from artifact name collision

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,14 +137,14 @@ jobs:
         with:
           pattern: test-durations-slice-*
           path: durations
-          merge-multiple: true
+          merge-multiple: false
 
       - name: Merge into single durations file
         run: |
           python3 -c "
           import json, glob, os
           merged = {}
-          for f in glob.glob('durations/*test_durations.json'):
+          for f in glob.glob('durations/**/test_durations.json', recursive=True):
             with open(f) as fh:
               merged.update(json.load(fh))
           with open('test_durations.json', 'w') as fh:


### PR DESCRIPTION
## Summary

Fixes a `save-durations` CI step failure caused by duration artifacts all containing the same filename (`test_durations.json`).

## Failure Mode

The `save-durations` job downloads all `test-durations-slice-*` artifacts into a single directory using `actions/download-artifact` with `merge-multiple: true`. Since each artifact contains a file named `test_durations.json`, the merge flattens them into one directory and the last artifact silently overwrites the others — or, depending on the runner version, produces corrupted output. The subsequent Python merge script then fails with `JSONDecodeError: Extra data` because it finds unexpected content in the merged file.

## Fix

Two changes in `.github/workflows/tests.yml`:

1. **`merge-multiple: false`** — keeps each slice artifact in its own subdirectory (`durations/test-durations-slice-0/`, `durations/test-durations-slice-1/`, etc.) instead of flattening them all into one directory.
2. **`durations/**/test_durations.json` with `recursive=True`** — the glob now searches recursively into each artifact subdirectory to find all `test_durations.json` files, regardless of how deep they sit.

This means each artifact remains isolated in its own directory, the glob finds all of them, and the merge script reads each one individually without name collisions.

## Scope

CI-only. No runtime code changes. Only `.github/workflows/tests.yml` is touched.

## Test Plan

- [x] Upstream workflow YAML parses without errors
- [x] Diff is exactly 2 lines changed in 1 file
- [x] No runtime code changes
- [ ] Verify `save-durations` succeeds on the next `main` push after merge

## Reproduction

Fork CI run demonstrating the failure: https://github.com/asimons81/hermes-agent/actions/runs/27891861592