### PR TITLE
fix(kanban-dashboard): add close button and click-outside dismiss to OrchestrationPanel

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -86,8 +86,6 @@
     return body || raw;
   }
 
-  // Order matches BOARD_COLUMNS in plugin_api.py.
-  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "done"];
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
@@ -106,6 +104,8 @@
     ready: "Dependencies satisfied; assign a profile to dispatch",
     running: "Claimed by a worker — in-flight",
     blocked: "Worker asked for human input",
+    scheduled: "Waiting on a scheduled time or follow-up",
+    review: "Awaiting human review before moving to done",
     done: "Completed",
     archived: "Archived",
   };

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1561,8 +1561,11 @@
 
     useEffect(function () {
       // Collapse the panel when the user clicks or taps outside it.
+      // Skip clicks inside portal content (SelectOption dropdowns rendered
+      // by Radix popper) — they live outside the panel's DOM hierarchy.
       function onPointerDown(event) {
         if (!expanded || !panelRef.current) return;
+        if (event.target.closest("[data-radix-popper-content-wrapper]")) return;
         if (!panelRef.current.contains(event.target)) {
           setExpanded(false);
         }

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1538,6 +1538,7 @@
     const [profiles, setProfiles] = useState([]);
     const [busy, setBusy] = useState({});
     const [msg, setMsg] = useState(null);
+    const panelRef = useRef(null);
 
     const loadAll = useCallback(function () {
       Promise.all([
@@ -1557,6 +1558,20 @@
       // requiring the user to expand the panel first.
       if (settings === null) loadAll();
     }, [settings, loadAll]);
+
+    useEffect(function () {
+      // Collapse the panel when the user clicks or taps outside it.
+      function onPointerDown(event) {
+        if (!expanded || !panelRef.current) return;
+        if (!panelRef.current.contains(event.target)) {
+          setExpanded(false);
+        }
+      }
+      document.addEventListener("pointerdown", onPointerDown);
+      return function () {
+        document.removeEventListener("pointerdown", onPointerDown);
+      };
+    }, [expanded]);
 
     const saveSettings = function (patch) {
       setMsg(null);
@@ -1667,7 +1682,7 @@
       return h(SelectOption, { key: p.name, value: p.name }, p.name + tag);
     });
 
-    return h(Card, { className: "p-3" },
+    return h(Card, { ref: panelRef, className: "p-3" },
       h(CardContent, { className: "p-2 flex flex-col gap-3" },
         h("div", { className: "flex items-center justify-between" },
           h("button", {
@@ -1675,8 +1690,17 @@
             onClick: function () { setExpanded(false); },
             className: "text-sm font-medium underline-offset-2 hover:underline",
           }, headerLabel),
-          modePill,
-          h(Button, { onClick: loadAll, size: "sm" }, "Reload"),
+          h("div", { className: "flex items-center gap-2" },
+            modePill,
+            h(Button, { onClick: loadAll, size: "sm" }, "Reload"),
+            h(Button, {
+              type: "button",
+              onClick: function () { setExpanded(false); },
+              size: "sm",
+              title: "Collapse orchestration settings",
+              className: "px-2",
+            }, "✕"),
+          ),
         ),
         msg ? h("div", {
           className: msg.ok ? "hermes-kanban-msg-ok" : "hermes-kanban-msg-err",

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1682,7 +1682,8 @@
       return h(SelectOption, { key: p.name, value: p.name }, p.name + tag);
     });
 
-    return h(Card, { ref: panelRef, className: "p-3" },
+    return h("div", { ref: panelRef },
+      h(Card, { className: "p-3" },
       h(CardContent, { className: "p-2 flex flex-col gap-3" },
         h("div", { className: "flex items-center justify-between" },
           h("button", {
@@ -1781,7 +1782,7 @@
               ),
         ),
       ),
-    );
+    ));
   }
 
   function ProfileDescriptionRow(props) {

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -254,9 +254,9 @@ AUTHOR_MAP = {
     "ahmad@madsgency.com": "ahmadashfq",
     "182213728+yinkev@users.noreply.github.com": "yinkev",  # scratch artifact preservation salvage
     "rratmansky@gmail.com": "rratmansky",
+    "dmetcalfe@users.noreply.github.com": "DavidMetcalfe",
     "lkz-de@users.noreply.github.com": "lkz-de",
     "charles@salesondemand.io": "salesondemandio",
-    "80915+DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",
     "DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",
     "IamSanchoPanza@users.noreply.github.com": "IamSanchoPanza",
     "victor@rocketfueldev.com": "victor-kyriazakos",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -256,6 +256,8 @@ AUTHOR_MAP = {
     "rratmansky@gmail.com": "rratmansky",
     "lkz-de@users.noreply.github.com": "lkz-de",
     "charles@salesondemand.io": "salesondemandio",
+    "80915+DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",
+    "DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",
     "IamSanchoPanza@users.noreply.github.com": "IamSanchoPanza",
     "victor@rocketfueldev.com": "victor-kyriazakos",
     "87440198+JoaoMarcos44@users.noreply.github.com": "JoaoMarcos44",


### PR DESCRIPTION
## What

The Orchestration settings panel in the Kanban dashboard expanded via "▸ Orchestration settings" but could only be collapsed by clicking the header label text — a subtle toggle with no visual affordance. Users had to navigate away and return to close it.

Closes #49939

## Changes

- Add `useRef(panelRef)` attached to the expanded `Card` element
- Add `pointerdown` listener on `document` that collapses when clicking outside the panel (with proper cleanup on unmount and when `expanded` changes)
- Add a visible ✕ close button in the expanded header alongside Reload, grouped in a flex container with the modePill
- Keep the header label toggle for keyboard/consistency access

## How to test

1. Open `/kanban` in the dashboard
2. Click "▸ Orchestration settings" — panel expands
3. Click the ✕ button — panel collapses ✓
4. Expand again, click anywhere outside the panel (e.g. a task card) — panel collapses ✓
5. Expand again, click the header label text — panel collapses ✓
6. Verify the panel can be re-expanded repeatedly without view switches
7. Verify the modePill (Auto/Manual toggle), Reload button, and all settings controls still work inside the expanded panel