### PR TITLE
fix(ssl_guard): tolerate truststore SSLContext.get_ca_certs() NotImplementedError on Windows

### DIFF
--- a/agent/ssl_guard.py
+++ b/agent/ssl_guard.py
@@ -54,7 +54,20 @@ def _validate_bundle_path(label: str, value: str, *, require_substantial: bool =
         ctx = ssl.create_default_context(cafile=str(path))
     except Exception as exc:
         raise _ssl_err(f"{label} CA bundle at {value} cannot be loaded: {exc}") from exc
-    if not ctx.get_ca_certs():
+    try:
+        loaded_certs = ctx.get_ca_certs()
+    except NotImplementedError:
+        # A truststore-backed SSLContext (Windows OS trust store, installed via
+        # truststore.inject_into_ssl() — pip does this on Windows, and Hermes
+        # venvs ship a sitecustomize.py that injects it) does not implement
+        # get_ca_certs(); it raises NotImplementedError with an empty message.
+        # create_default_context(cafile=...) above already validated that the
+        # bundle is parseable/loadable, so accept it instead of failing on an
+        # introspection call we cannot run. Without this, every fresh agent
+        # init dies with "Failed to initialize OpenAI client:" (no detail,
+        # because str(NotImplementedError()) == "").
+        return
+    if not loaded_certs:
         raise _ssl_err(f"{label} CA bundle at {value} did not load any certificates")
 
 

--- a/tests/agent/test_ssl_ca_guard.py
+++ b/tests/agent/test_ssl_ca_guard.py
@@ -80,3 +80,35 @@ def test_skip_env_var_bypasses_guard(monkeypatch, tmp_path, value):
     monkeypatch.setenv("SSL_CERT_FILE", str(fake))
     verify_ca_bundle()
     verify_ca_bundle_with_fallback()
+
+
+def test_truststore_get_ca_certs_not_implemented_is_accepted(monkeypatch, tmp_path):
+    """A truststore-backed SSLContext (Windows OS trust store) raises
+    NotImplementedError from get_ca_certs(). The guard must accept the
+    already-loaded bundle rather than fail.
+
+    Regression for the empty-message ``Failed to initialize OpenAI client:``
+    seen on every fresh agent init on Windows (str(NotImplementedError()) == "").
+    """
+    from agent import ssl_guard
+
+    bundle = tmp_path / "bundle.pem"
+    bundle.write_text(
+        "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n",
+        encoding="utf-8",
+    )
+
+    class _TruststoreLikeContext:
+        def get_ca_certs(self, binary_form=False):  # noqa: ARG002 - mirror ssl API
+            raise NotImplementedError()
+
+    # create_default_context(cafile=...) loads the bundle fine; only the
+    # post-load introspection is unsupported under truststore.
+    monkeypatch.setattr(
+        ssl_guard.ssl, "create_default_context", lambda *a, **k: _TruststoreLikeContext()
+    )
+    monkeypatch.setenv("SSL_CERT_FILE", str(bundle))
+
+    # Must not raise on the explicit env bundle nor the certifi check.
+    verify_ca_bundle()
+    verify_ca_bundle_with_fallback()


### PR DESCRIPTION
## Problem

On Windows, every **freshly-created** agent fails at OpenAI-client construction with an empty-detail error:

```
RuntimeError: Failed to initialize OpenAI client:
```

(note the trailing nothing — `str(e)` is empty). This hits the CLI one-shot (`hermes -z`), the `gateway/platforms/api_server.py` chat-completions path (one fresh `AIAgent` per request), and the Hermes Desktop app. Only the gateway's long-lived startup-warmed agent survives, which is why Telegram/Discord keep working while "send a message in Desktop" fails.

This is the root cause behind #49937 and implements the fix proposed in #49014.

## Root cause

1. On Windows, pip installs [`truststore`](https://github.com/sethmlarson/truststore), and Hermes venvs ship a `sitecustomize.py` that calls `truststore.inject_into_ssl()`. That globally replaces `ssl.SSLContext` with an OS-trust-store-backed context whose `get_ca_certs()` raises `NotImplementedError()` — **with an empty message** (`truststore/_api.py`).
2. The gateway sets `SSL_CERT_FILE = certifi.where()` in-process at startup (`gateway/run.py:_ensure_ssl_cert_file`), so `agent/ssl_guard.py:verify_ca_bundle()` enters its env-var loop and calls `_validate_bundle_path("SSL_CERT_FILE", ...)`.
3. `_validate_bundle_path` did `if not ctx.get_ca_certs():` unguarded → `NotImplementedError` → wrapped by `agent/agent_init.py` into `RuntimeError("Failed to initialize OpenAI client: ")` with no detail.

Full traceback (Hermes v0.17.0, Win11 26200, Python 3.11.15, `openai-codex`/`gpt-5.5`):

```
File ".../agent/agent_init.py", line 916, in init_agent
    verify_ca_bundle_with_fallback()
File ".../agent/ssl_guard.py", line 94, in verify_ca_bundle_with_fallback
    verify_ca_bundle()
File ".../agent/ssl_guard.py", line 76, in verify_ca_bundle
    _validate_bundle_path(env_var, value)
File ".../agent/ssl_guard.py", line 57, in _validate_bundle_path
    if not ctx.get_ca_certs():
File ".../venv/Lib/site-packages/truststore/_api.py", line 212, in get_ca_certs
    raise NotImplementedError()
NotImplementedError
```

## Fix

`ssl.create_default_context(cafile=...)` already validates that the bundle is parseable/loadable (it raises on a bad PEM). The `get_ca_certs()` call was only a secondary "did anything actually load?" check. Under truststore there is no way to enumerate certs, so we **skip** that introspection rather than treat the `NotImplementedError` as a failure (or as "zero certs loaded").

Note this is intentionally not the bare one-liner from #49014: catching `NotImplementedError` and falling through would still hit `if not loaded_certs:` with an undefined/empty value, so the `return` on the truststore path is required.

## Verification

Deterministic repro of just the guard, reproducing the gateway's runtime conditions:

```python
import os, certifi, truststore; truststore.inject_into_ssl()
os.environ["SSL_CERT_FILE"] = certifi.where()
from agent.ssl_guard import verify_ca_bundle_with_fallback
verify_ca_bundle_with_fallback()   # before: NotImplementedError | after: passes
```

- Adds a regression test (`test_truststore_get_ca_certs_not_implemented_is_accepted`) that simulates a truststore-backed context.
- `pytest tests/agent/test_ssl_ca_guard.py` → **15 passed**.

## User-side workaround (for anyone hitting this before the fix ships)

Set `HERMES_SKIP_SSL_GUARD=1` (env var or in `%LOCALAPPDATA%\hermes\.env`) and restart the gateway/Desktop. Unlike switching to an API-key provider, this keeps the Codex/Gemini OAuth providers working.