### PR TITLE
test(matrix): make voice-detection tests hermetic against mention gating

### DIFF
--- a/tests/gateway/test_matrix_voice.py
+++ b/tests/gateway/test_matrix_voice.py
@@ -26,7 +26,16 @@ from gateway.platforms.base import MessageType
 # ---------------------------------------------------------------------------
 
 def _make_adapter():
-    """Create a MatrixAdapter with mocked config."""
+    """Create a MatrixAdapter with mocked config.
+
+    Pins ``require_mention: False`` so these media-detection tests are NOT
+    gated by the mention requirement. The adapter defaults require_mention to
+    True (falling back to the MATRIX_REQUIRE_MENTION env var), so without this
+    a group-room audio event with no @mention is dropped by
+    _resolve_message_context before dispatch — making the tests pass or fail
+    depending on leaked env state from other tests in the same shard. These
+    tests exercise voice/audio TYPE detection, not mention gating.
+    """
     from plugins.platforms.matrix.adapter import MatrixAdapter
     from gateway.config import PlatformConfig
 
@@ -36,6 +45,7 @@ def _make_adapter():
         extra={
             "homeserver": "https://matrix.example.org",
             "user_id": "@bot:example.org",
+            "require_mention": False,
         },
     )
     adapter = MatrixAdapter(config)


### PR DESCRIPTION
## Summary
`tests/gateway/test_matrix_voice.py` flaked in CI — 6/7 failing on some shards, passing on others and on `main`. Makes the voice/audio-detection tests hermetic so they no longer depend on leaked `MATRIX_REQUIRE_MENTION` env state.

## Root cause
The Matrix adapter defaults `require_mention=True` (falling back to the `MATRIX_REQUIRE_MENTION` env var). These tests fire a **group-room** audio event with **no @mention**, so `_resolve_message_context` drops it before dispatch ("No event was captured") whenever `require_mention` resolves True — which is the case in a clean shard. An earlier test in another shard can leave `MATRIX_REQUIRE_MENTION=false` in `os.environ`, masking it. The recent adapter→bundled-plugin migration (`5600105478`) shifted shard composition and exposed the latent dependency.

## Fix
Pin `require_mention: False` in the test adapter's config `extra`, so these media-TYPE detection tests are not gated by the mention requirement regardless of ambient env. They test voice/audio detection, not mention gating.

## Validation
| Condition | Before | After |
|---|---|---|
| `MATRIX_REQUIRE_MENTION=true` (failing shard) | 6/7 fail | 7/7 pass |
| env unset (clean) | 7/7 pass | 7/7 pass |

Test-only change; no production code touched.

## Infographic
N/A — test-only flaky-fix, no behavioral/product change.
