### PR TITLE
fix(openviking): synchronous prefetch with timeout guard

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -70,6 +70,8 @@ _OPENVIKING_ENV_KEYS = (
 _TIMEOUT = 30.0
 _SESSION_DRAIN_TIMEOUT = 10.0
 _DEFERRED_COMMIT_TIMEOUT = (_TIMEOUT * 2) + 5.0
+_PREFETCH_TIMEOUT = 1.5        # Sync prefetch shouldn't block the turn loop
+_PREFETCH_MIN_SCORE = 0.35     # Noise filter (matches Claude Code plugin)
 _REMOTE_RESOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
 _SYNC_TRACE_ENV = "HERMES_OPENVIKING_SYNC_TRACE"
 
@@ -2046,15 +2048,52 @@ class OpenVikingMemoryProvider(MemoryProvider):
             )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
-        """Return prefetched results from the background thread."""
+        """Synchronous recall for the current turn.
+
+        Uses the *current* ``query`` to perform a synchronous OV search,
+        addressing the stale-context problem where background prefetch
+        results from the *previous* turn were injected into the current
+        turn. The old background cache is drained to avoid stale re-use.
+
+        A short timeout (``_PREFETCH_TIMEOUT``) prevents a slow or
+        unreachable OV server from blocking the agent turn loop.
+        ``queue_prefetch()`` continues to fire background searches at
+        turn-end for other potential consumers, but ``prefetch()`` no
+        longer consumes its output.
+        """
+        # ------------------------------------------------------------------
+        # 1. Drain stale background cache
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
-            result = self._prefetch_result
             self._prefetch_result = ""
-        if not result:
+
+        query = _derive_openviking_user_text(query)
+        if not self._client or not query:
             return ""
-        return f"## OpenViking Context\n{result}"
+
+        # ------------------------------------------------------------------
+        # 2. Synchronous search with the *current* query
+        try:
+            resp = self._client.post("/api/v1/search/find", {
+                "query": query,
+                "limit": 5,
+            }, timeout=_PREFETCH_TIMEOUT)
+            result = resp.get("result", {})
+            parts = []
+            for ctx_type in ("memories", "resources"):
+                items = result.get(ctx_type, [])
+                for item in items[:3]:
+                    uri = item.get("uri", "")
+                    score = item.get("score", 0)
+                    abstract = item.get("abstract", "")
+                    if abstract and score >= _PREFETCH_MIN_SCORE:
+                        parts.append(f"- [{score:.2f}] {abstract} ({uri})")
+            if parts:
+                return "## OpenViking Context\n" + "\n".join(parts)
+        except Exception as e:
+            logger.debug("OpenViking sync prefetch failed: %s", e)
+        return ""
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         """Fire a background search to pre-load relevant context."""


### PR DESCRIPTION
Superset of #33260 with additional hardening.

## Changes vs #33260

| Item | #33260 | This PR |
|------|--------|---------|
| Timeout | ❌ default 30s | ✅ `_PREFETCH_TIMEOUT = 1.5s` |
| Score threshold | ❌ hardcoded 0.35 | ✅ `_PREFETCH_MIN_SCORE` constant |
| Query processing | ❌ raw query | ✅ `_derive_openviking_user_text()` strips skill scaffolding |
| API field | `top_k` (deprecated?) | `limit` (matches queue_prefetch) |
| Client | `self._client` | `self._client` (same) |

## Why this matters

Without a timeout guard, the sync prefetch POST uses the 30s default `_TIMEOUT` — a slow OV server would block the agent turn loop for 30s before every response.

## Related

- Ref: https://github.com/volcengine/OpenViking/discussions/2253 (root cause analysis)
- Ref: https://github.com/NousResearch/hermes-agent/issues/5820