### PR TITLE
fix(gateway): fast-steer voice notes after STT

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4220,18 +4220,91 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         steered = False
         if effective_mode == "steer":
             steer_text = (event.text or "").strip()
+            media_urls = list(getattr(event, "media_urls", None) or [])
+            media_types = list(getattr(event, "media_types", None) or [])
+            has_media = bool(media_urls)
+            voice_paths: list[str] = []
+            for idx, path in enumerate(media_urls):
+                mtype = media_types[idx] if idx < len(media_types) else ""
+                is_audio_mime = mtype.startswith("audio/")
+                is_voice = (
+                    (event.message_type == MessageType.VOICE and (not mtype or is_audio_mime))
+                    or (
+                        is_audio_mime
+                        and event.message_type not in {MessageType.AUDIO, MessageType.DOCUMENT}
+                    )
+                )
+                if is_voice:
+                    voice_paths.append(path)
+            all_media_is_voice = has_media and len(voice_paths) == len(media_urls)
+
             can_steer = (
-                steer_text
-                and running_agent is not None
+                running_agent is not None
                 and running_agent is not _AGENT_PENDING_SENTINEL
                 and hasattr(running_agent, "steer")
             )
-            if can_steer:
+
+            # ``AIAgent.steer()`` is text-only, so media-bearing events cannot
+            # be passed through as raw MessageEvents.  Voice notes are the
+            # useful exception when every attachment is voice-like: transcribe
+            # it first, then steer the transcript into the current run.  Mixed
+            # media (voice + image/file) still queues so non-voice attachments
+            # cannot be dropped.  If transcription fails or the agent rejects
+            # the steer, queue the original event so cached media metadata is
+            # still preserved for the normal next-turn processing path.
+            if all_media_is_voice and can_steer:
                 try:
-                    steered = bool(running_agent.steer(steer_text))
+                    enriched_text, successful_transcripts = await self._enrich_message_with_transcription(
+                        steer_text,
+                        voice_paths,
+                    )
                 except Exception as exc:
-                    logger.warning("Gateway steer failed for session %s: %s", session_key, exc)
-                    steered = False
+                    logger.warning(
+                        "Gateway voice fast-steer transcription failed for session %s: %s",
+                        session_key,
+                        exc,
+                    )
+                    successful_transcripts = []
+                    enriched_text = steer_text
+
+                if successful_transcripts and enriched_text.strip():
+                    try:
+                        steered = bool(running_agent.steer(enriched_text.strip()))
+                    except Exception as exc:
+                        logger.warning("Gateway steer failed for session %s: %s", session_key, exc)
+                        steered = False
+
+                    if steered:
+                        # Match the fresh-message voice path: echo the raw STT
+                        # text so the user can verify what was injected.
+                        thread_meta = self._thread_metadata_for_source(
+                            event.source,
+                            self._reply_anchor_for_event(event),
+                        )
+                        for transcript in successful_transcripts:
+                            try:
+                                await adapter.send(
+                                    event.source.chat_id,
+                                    f'🎙️ "{transcript}"',
+                                    metadata=thread_meta,
+                                )
+                            except Exception as echo_exc:
+                                logger.debug(
+                                    "Transcript echo failed (non-fatal): %s",
+                                    echo_exc,
+                                )
+
+            elif has_media:
+                effective_mode = "queue"
+
+            if not steered and effective_mode == "steer" and not has_media:
+                can_text_steer = bool(steer_text) and can_steer
+                if can_text_steer:
+                    try:
+                        steered = bool(running_agent.steer(steer_text))
+                    except Exception as exc:
+                        logger.warning("Gateway steer failed for session %s: %s", session_key, exc)
+                        steered = False
             if not steered:
                 # Fall back to queue (merge into pending messages, no interrupt)
                 effective_mode = "queue"

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -83,6 +83,7 @@ def _make_adapter(platform_val="telegram"):
     adapter = MagicMock()
     adapter._pending_messages = {}
     adapter._send_with_retry = AsyncMock()
+    adapter.send = AsyncMock()
     adapter.config = MagicMock()
     adapter.config.extra = {}
     adapter.platform = MagicMock(value=platform_val)
@@ -296,6 +297,136 @@ class TestBusySessionAck:
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
         assert "Steered" in content or "steer" in content.lower()
         assert "Interrupting" not in content
+
+    @pytest.mark.asyncio
+    async def test_steer_mode_transcribes_voice_and_steers_transcript(self):
+        """Voice notes in steer mode should be timely when STT succeeds.
+
+        ``AIAgent.steer()`` cannot accept media metadata, but voice can be
+        lowered to text first.  Successful STT should steer the transcript into
+        the active run and avoid replaying the original media as a queued next
+        turn.
+        """
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="(The user sent a message with no text content)")
+        event.message_type = MessageType.VOICE
+        event.media_urls = ["/tmp/cached.ogg"]
+        event.media_types = ["audio/ogg"]
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        enriched = '[The user sent a voice message~ Here\'s what they said: "turn left"]'
+        runner._enrich_message_with_transcription = AsyncMock(
+            return_value=(enriched, ["turn left"])
+        )
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        runner._enrich_message_with_transcription.assert_awaited_once_with(
+            "(The user sent a message with no text content)",
+            ["/tmp/cached.ogg"],
+        )
+        agent.steer.assert_called_once_with(enriched)
+        agent.interrupt.assert_not_called()
+        assert adapter._pending_messages.get(sk) is None
+        adapter.send.assert_awaited_once()
+        assert '🎙️ "turn left"' in adapter.send.await_args.args
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Steered" in content
+        assert "Queued for the next turn" not in content
+
+    @pytest.mark.asyncio
+    async def test_steer_mode_queues_voice_when_transcription_fails(self):
+        """Failed voice STT must preserve the original media event for next turn."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="")
+        event.message_type = MessageType.VOICE
+        event.media_urls = ["/tmp/cached.ogg"]
+        event.media_types = ["audio/ogg"]
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner._enrich_message_with_transcription = AsyncMock(
+            return_value=("[voice failed]", [])
+        )
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.steer.assert_not_called()
+        agent.interrupt.assert_not_called()
+        assert adapter._pending_messages.get(sk) is event
+        adapter.send.assert_not_awaited()
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Queued for the next turn" in content
+
+    @pytest.mark.asyncio
+    async def test_steer_mode_queues_non_voice_media_to_preserve_attachment(self):
+        """Documents/images cannot be lowered to steer text without preprocessing."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="please read this pdf")
+        event.message_type = MessageType.DOCUMENT
+        event.media_urls = ["/tmp/cached.pdf"]
+        event.media_types = ["application/pdf"]
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner._enrich_message_with_transcription = AsyncMock()
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.steer.assert_not_called()
+        runner._enrich_message_with_transcription.assert_not_called()
+        assert adapter._pending_messages.get(sk) is event
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Queued for the next turn" in content
+        assert "Steered" not in content
+
+    @pytest.mark.asyncio
+    async def test_steer_mode_queues_mixed_voice_and_non_voice_media(self):
+        """Fast voice steer must not drop sibling image/document attachments."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="voice plus image")
+        event.message_type = MessageType.VOICE
+        event.media_urls = ["/tmp/cached.ogg", "/tmp/photo.png"]
+        event.media_types = ["audio/ogg", "image/png"]
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner._enrich_message_with_transcription = AsyncMock()
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.steer.assert_not_called()
+        runner._enrich_message_with_transcription.assert_not_called()
+        assert adapter._pending_messages.get(sk) is event
+        assert adapter._pending_messages[sk].media_urls == ["/tmp/cached.ogg", "/tmp/photo.png"]
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Queued for the next turn" in content
 
     @pytest.mark.asyncio
     async def test_steer_mode_falls_back_to_queue_when_agent_rejects(self):


### PR DESCRIPTION
## Summary

- Fast-steer voice-note follow-ups in `busy_input_mode: steer` by transcribing them first and injecting the enriched transcript text into the active run.
- Keep non-voice media (and mixed voice + non-voice media) on the queue path so cached attachment metadata is never silently dropped.
- Fall back to queueing the original voice `MessageEvent` when STT fails or the active agent rejects the steer.
- Echo successful STT text back to the user, matching the normal fresh voice-message path.

## Why

`AIAgent.steer()` is text-only. Queueing every media-bearing busy follow-up is safe, but voice notes are latency-sensitive and can be lowered to text before steering. This keeps the "don't drop attachments" invariant while making the common voice-note case timely.

This complements #47353: documents/images still queue, but voice notes can steer immediately after STT succeeds.

## Testing

- `scripts/run_tests.sh tests/gateway/test_busy_session_ack.py`
- `/home/the3asic/.hermes/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_busy_session_ack.py tests/gateway/test_queue_consumption.py tests/gateway/test_subagent_protection_30170.py -q -o 'addopts='`
- `/home/the3asic/.hermes/hermes-agent/.venv/bin/python scripts/check-windows-footguns.py --diff origin/main`
- `/home/the3asic/.hermes/hermes-agent/.venv/bin/python -m py_compile gateway/run.py tests/gateway/test_busy_session_ack.py`
