### PR TITLE
fix(tui): use atomic config writes in tui gateway

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7890,3 +7890,37 @@ def test_start_agent_build_passes_session_model_override(monkeypatch):
         assert session["agent"].model == "claude-sonnet-4.6"
     finally:
         server._sessions.clear()
+
+
+def test_save_cfg_uses_atomic_write_and_preserves_config_on_failure(tmp_path, monkeypatch):
+    """_save_cfg must write config.yaml atomically: a mid-write failure must
+    leave the previous config intact rather than truncating it.
+
+    Salvage of #13357 by @Junass1.
+    """
+    import yaml
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"existing": True}), encoding="utf-8")
+
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setattr(server, "_cfg_cache", None, raising=False)
+    monkeypatch.setattr(server, "_cfg_mtime", None, raising=False)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("disk full")
+
+    # Patch the atomic helper at its source module so _save_cfg's
+    # `from utils import atomic_yaml_write` picks up the failing version.
+    monkeypatch.setattr("utils.atomic_yaml_write", _boom)
+
+    with patch.object(server, "_cfg_lock"):
+        try:
+            server._save_cfg({"new": True})
+        except RuntimeError as exc:
+            assert str(exc) == "disk full"
+        else:
+            raise AssertionError("expected _save_cfg to raise")
+
+    # The original config must survive untouched (no truncation).
+    assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == {"existing": True}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1385,11 +1385,12 @@ def _apply_managed(cfg: dict) -> dict:
 
 def _save_cfg(cfg: dict):
     global _cfg_cache, _cfg_mtime, _cfg_path
-    import yaml
+    from utils import atomic_yaml_write
 
     path = _hermes_home / "config.yaml"
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(cfg, f)
+    # Atomic write (temp file + fsync + os.replace): a crash or disk-full
+    # mid-write can never leave config.yaml truncated/half-written.
+    atomic_yaml_write(path, cfg)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
         _cfg_path = path


### PR DESCRIPTION
## Summary
Make `tui_gateway/server.py:_save_cfg` write `config.yaml` atomically so a crash or disk-full mid-write can never leave the user's config truncated or half-written.

Salvage of #13357 by @Junass1 (re-targeted to current `main` — `_save_cfg` is now at ~line 1386 and the repo already ships `utils.atomic_yaml_write`).

## Problem (root cause)
`_save_cfg` did:

```python
path = _hermes_home / "config.yaml"
with open(path, "w", encoding="utf-8") as f:
    yaml.safe_dump(cfg, f)
```

`open(path, "w")` truncates the target immediately. If serialization/write fails partway (crash, disk full, interrupt), `config.yaml` is left empty or partially written — the previous good config is gone. `_save_cfg` is the single write path used by every `config.set` RPC, so the whole TUI config is exposed to this.

## The fix
Use the repo's existing atomic-write helper, which writes to a temp file in the same directory, `fsync`s, then `os.replace`s into place (already used across `hermes_cli/auth.py` and `hermes_cli/config.py`):

```python
from utils import atomic_yaml_write
path = _hermes_home / "config.yaml"
atomic_yaml_write(path, cfg)
```

On any mid-write failure the previous `config.yaml` remains intact.

## Testing
Added `test_save_cfg_uses_atomic_write_and_preserves_config_on_failure`, which seeds a config, forces `utils.atomic_yaml_write` to raise mid-write, and asserts the original config survives untouched.

With the fix:
```
$ python -m pytest tests/test_tui_gateway_server.py -k test_save_cfg_uses_atomic_write_and_preserves_config_on_failure -x -q
.                                                                        [100%]
1 passed, 281 deselected in 0.39s
```

Without the fix (old non-atomic `_save_cfg` restored), the test fails as expected:
```
>               raise AssertionError("expected _save_cfg to raise")
E               AssertionError: expected _save_cfg to raise
1 failed, 281 deselected in 0.21s
```
(`py_compile` clean on both changed files.)