### PR TITLE
fix(cli): honor config terminal settings in /config

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5918,10 +5918,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
     def show_config(self):
         """Display current configuration with kawaii ASCII art."""
-        # Get terminal config from environment (which was set from cli-config.yaml)
-        terminal_env = os.getenv("TERMINAL_ENV", "local")
-        terminal_cwd = os.getenv("TERMINAL_CWD", os.getcwd())
-        terminal_timeout = os.getenv("TERMINAL_TIMEOUT", "60")
+        # config.yaml is the source of truth for terminal settings. Environment
+        # variables are only a fallback for legacy/default-only setups.
+        terminal_cfg = self.config.get("terminal", {}) if isinstance(self.config, dict) else {}
+        if not isinstance(terminal_cfg, dict):
+            terminal_cfg = {}
+        terminal_env = (
+            terminal_cfg.get("backend")
+            or terminal_cfg.get("env_type")
+            or os.getenv("TERMINAL_ENV", "local")
+        )
+        terminal_cwd = terminal_cfg.get("cwd") or os.getenv("TERMINAL_CWD", os.getcwd())
+        terminal_timeout = terminal_cfg.get("timeout")
+        if terminal_timeout in (None, ""):
+            terminal_timeout = os.getenv("TERMINAL_TIMEOUT", "60")
         
         user_config_path = _hermes_home / 'config.yaml'
         project_config_path = Path(__file__).parent / 'cli-config.yaml'

--- a/tests/cli/test_cli_show_config.py
+++ b/tests/cli/test_cli_show_config.py
@@ -1,0 +1,106 @@
+"""Tests for CLI /config display using config.yaml terminal settings.
+
+Salvage of #13651 by @LeonSGP43.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
+    """Create a HermesCLI instance with minimal mocking."""
+    import importlib
+
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local", "cwd": "/from/config", "timeout": 60},
+    }
+    if config_overrides:
+        _clean_config.update(config_overrides)
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    if env_overrides:
+        clean_env.update(env_overrides)
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), \
+         patch.dict("os.environ", clean_env, clear=False):
+        import cli as _cli_mod
+        _cli_mod = importlib.reload(_cli_mod)
+        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), \
+             patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}):
+            return _cli_mod.HermesCLI(**kwargs)
+
+
+def test_show_config_uses_terminal_settings_from_config(capsys):
+    """show_config() must read terminal settings from config.yaml, not just env.
+
+    With config.yaml present, the env vars (TERMINAL_ENV/_CWD/_TIMEOUT) must be
+    ignored in favor of the config block.
+    """
+    cli = _make_cli(
+        env_overrides={
+            "TERMINAL_ENV": "docker",
+            "TERMINAL_CWD": "/from/env",
+            "TERMINAL_TIMEOUT": "999",
+        },
+        config_overrides={
+            "terminal": {
+                "backend": "local",
+                "env_type": "local",
+                "cwd": "/from/config",
+                "timeout": 60,
+            },
+        },
+    )
+
+    cli.show_config()
+    output = capsys.readouterr().out
+
+    assert "Environment:  local" in output
+    assert "Working Dir:  /from/config" in output
+    assert "Timeout:      60s" in output
+    assert "Environment:  docker" not in output
+    assert "/from/env" not in output
+
+
+def test_show_config_falls_back_to_env_when_config_missing(capsys):
+    """When config.yaml has no terminal block, env vars remain the fallback."""
+    cli = _make_cli(config_overrides={"terminal": {}})
+
+    env = {
+        "TERMINAL_ENV": "docker",
+        "TERMINAL_CWD": "/from/env",
+        "TERMINAL_TIMEOUT": "120",
+    }
+    with patch.dict("os.environ", env, clear=False):
+        cli.show_config()
+    output = capsys.readouterr().out
+
+    assert "Environment:  docker" in output
+    assert "Working Dir:  /from/env" in output
+    assert "Timeout:      120s" in output


### PR DESCRIPTION
## Summary
Make the CLI `/config` display (`HermesCLI.show_config`) read terminal settings from `config.yaml`'s `terminal:` block instead of relying solely on environment variables.

Salvage of #13651 by @LeonSGP43 (re-targeted to current `main` — `show_config` is now at ~line 5919 in `cli.py`).

## Problem (root cause)
`show_config` did:

```python
# Get terminal config from environment (which was set from cli-config.yaml)
terminal_env = os.getenv("TERMINAL_ENV", "local")
terminal_cwd = os.getenv("TERMINAL_CWD", os.getcwd())
terminal_timeout = os.getenv("TERMINAL_TIMEOUT", "60")
```

This only reflects the env vars. When a user configures `terminal:` (backend/env_type/cwd/timeout) in `config.yaml` and those env vars aren't bridged (or were overridden elsewhere), `/config` shows stale/default values that don't match the running configuration — misleading for debugging.

## The fix
Treat `config.yaml` as the source of truth, with env vars as fallback:

```python
terminal_cfg = self.config.get("terminal", {}) if isinstance(self.config, dict) else {}
terminal_env = (
    terminal_cfg.get("backend")
    or terminal_cfg.get("env_type")
    or os.getenv("TERMINAL_ENV", "local")
)
terminal_cwd = terminal_cfg.get("cwd") or os.getenv("TERMINAL_CWD", os.getcwd())
terminal_timeout = terminal_cfg.get("timeout")
if terminal_timeout in (None, ""):
    terminal_timeout = os.getenv("TERMINAL_TIMEOUT", "60")
```

## Testing
Added `tests/cli/test_cli_show_config.py` (using the established `_make_cli` harness from `test_cli_init.py`):
- `test_show_config_uses_terminal_settings_from_config` — config block wins over conflicting env vars.
- `test_show_config_falls_back_to_env_when_config_missing` — env fallback still works when no `terminal:` block.

With the fix:
```
$ python -m pytest tests/cli/test_cli_show_config.py -q
..                                                                       [100%]
2 passed in 0.18s
```

Without the fix (old env-only `show_config` restored), the config-wins test fails as expected:
```
>       assert "Working Dir:  /from/config" in output
E       AssertionError: assert 'Working Dir:  /from/config' in '...'
1 failed, 1 passed in 0.23s
```
(`py_compile` clean on both changed files.)