### PR TITLE
fix(tools): fix discord tool schema type mismatch for Gemini

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -579,7 +579,9 @@ class TestRegistration:
         props = entry.schema["parameters"]["properties"]
         assert props["limit"]["minimum"] == 1
         assert props["limit"]["maximum"] == 100
-        assert props["auto_archive_duration"]["enum"] == [60, 1440, 4320, 10080]
+        # String enum (not integer) so Gemini accepts the schema; see #13486.
+        assert props["auto_archive_duration"]["type"] == "string"
+        assert props["auto_archive_duration"]["enum"] == ["60", "1440", "4320", "10080"]
 
     def test_core_schema_description(self):
         """Core schema description should mention core actions."""
@@ -1140,3 +1142,49 @@ class TestModelToolsIntegration:
         assert "discord" not in names
         assert "discord_admin" not in names
         assert "discord_server" not in names
+
+
+# ---------------------------------------------------------------------------
+# auto_archive_duration schema + coercion (Gemini compatibility)
+# Salvage of #13486 by @dirty-bun-ops.
+# ---------------------------------------------------------------------------
+
+class TestAutoArchiveDurationSchema:
+    """Gemini rejects integer-typed enums; auto_archive_duration must be a
+    string enum in the schema, and _create_thread must coerce it back to int
+    for the Discord REST API."""
+
+    def test_schema_auto_archive_duration_is_string_enum(self):
+        from tools.discord_tool import _build_schema
+
+        schema = _build_schema(["create_thread"])
+        prop = schema["parameters"]["properties"]["auto_archive_duration"]
+        assert prop["type"] == "string"
+        # All enum values must be strings (not ints) so Gemini accepts the schema.
+        assert prop["enum"] == ["60", "1440", "4320", "10080"]
+        assert all(isinstance(v, str) for v in prop["enum"])
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_thread_coerces_string_duration_to_int(self, mock_req):
+        from tools.discord_tool import _create_thread
+
+        mock_req.return_value = {"id": "999", "name": "t"}
+        _create_thread("tok", "chan123", "my thread", auto_archive_duration="4320")
+
+        body = mock_req.call_args.kwargs["body"]
+        assert body["auto_archive_duration"] == 4320
+        assert isinstance(body["auto_archive_duration"], int)
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_thread_from_message_coerces_string_duration(self, mock_req):
+        from tools.discord_tool import _create_thread
+
+        mock_req.return_value = {"id": "999", "name": "t"}
+        _create_thread(
+            "tok", "chan123", "my thread",
+            message_id="msg456", auto_archive_duration="1440",
+        )
+
+        body = mock_req.call_args.kwargs["body"]
+        assert body["auto_archive_duration"] == 1440
+        assert isinstance(body["auto_archive_duration"], int)

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -431,19 +431,22 @@ def _create_thread(
     **_kwargs: Any,
 ) -> str:
     """Create a thread in a channel."""
+    # The tool schema exposes auto_archive_duration as a string enum (Gemini
+    # rejects integer-typed enums), so coerce to the int Discord's API expects.
+    archive_minutes = int(auto_archive_duration)
     if message_id:
         # Create thread from an existing message
         path = f"/channels/{channel_id}/messages/{message_id}/threads"
         body: Dict[str, Any] = {
             "name": name,
-            "auto_archive_duration": auto_archive_duration,
+            "auto_archive_duration": archive_minutes,
         }
     else:
         # Create a standalone thread
         path = f"/channels/{channel_id}/threads"
         body = {
             "name": name,
-            "auto_archive_duration": auto_archive_duration,
+            "auto_archive_duration": archive_minutes,
             "type": 11,  # PUBLIC_THREAD
         }
     thread = _discord_request("POST", path, token, body=body)
@@ -708,8 +711,8 @@ def _build_schema(
             "description": "Snowflake ID for forward pagination (fetch_messages).",
         },
         "auto_archive_duration": {
-            "type": "integer",
-            "enum": [60, 1440, 4320, 10080],
+            "type": "string",
+            "enum": ["60", "1440", "4320", "10080"],
             "description": "Thread archive duration in minutes (create_thread, default 1440).",
         },
     }


### PR DESCRIPTION
## Summary
Make the `discord` tool schema Gemini-compatible by changing the `auto_archive_duration` parameter from an integer-typed enum to a string enum, with int coercion at the API call site.

Salvage of #13486 by @dirty-bun-ops (re-targeted to current `main` — `_build_schema`/`_create_thread` line offsets changed but the code is otherwise identical).

## Problem (root cause)
In `tools/discord_tool.py:_build_schema`, the parameter was declared as:

```python
"auto_archive_duration": {
    "type": "integer",
    "enum": [60, 1440, 4320, 10080],
    "description": "Thread archive duration in minutes (create_thread, default 1440).",
},
```

Gemini's function-calling API rejects integer-typed enums. Because this property is part of the single shared discord tool schema, the rejection makes the **entire** discord tool unregisterable under Gemini, not just `create_thread`.

## The fix
1. Schema: switch to a string enum so Gemini accepts it:
   ```python
   "type": "string",
   "enum": ["60", "1440", "4320", "10080"],
   ```
2. Coercion: `_create_thread` now does `int(auto_archive_duration)` before building the request body, since Discord's REST API expects an integer. This handles the now-string value from the model and the legacy int default.

## Testing
Added `TestAutoArchiveDurationSchema` (3 tests): schema is a string enum, and `_create_thread` coerces a string duration back to `int` in the request body (both standalone and from-message paths). Also updated the pre-existing `test_schema_parameter_bounds` which asserted the old integer enum.

With the fix (full discord tool suite):
```
$ python -m pytest tests/tools/test_discord_tool.py -q
93 passed in 1.55s
```

Without the fix (old integer-enum schema restored), the new tests fail as expected:
```
>       assert body["auto_archive_duration"] == 1440
E       AssertionError: assert '1440' == 1440
3 failed, 90 deselected in 0.17s
```
(`py_compile` clean on both changed files.)