### PR TITLE
fix(cli): detect gh auth via hosts JSON in doctor

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2165,11 +2165,22 @@ def run_doctor(args):
         """Check if gh CLI is authenticated via token file or device flow."""
         try:
             result = subprocess.run(
-                ["gh", "auth", "status", "--json", "authenticated"],
-                capture_output=True, timeout=10,
+                ["gh", "auth", "status", "--json", "hosts", "--hostname", "github.com"],
+                capture_output=True, timeout=10, text=True,
             )
-            return result.returncode == 0
-        except (FileNotFoundError, subprocess.TimeoutExpired):
+            if result.returncode != 0:
+                return False
+
+            import json
+
+            payload = json.loads(result.stdout or "{}")
+            hosts = payload.get("hosts", {})
+            github_accounts = hosts.get("github.com", [])
+            return any(
+                account.get("state") == "success"
+                for account in github_accounts
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError, ValueError, AttributeError):
             return False
 
     github_token = get_env_value("GITHUB_TOKEN") or get_env_value("GH_TOKEN")

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -886,9 +886,10 @@ class TestGitHubTokenCheck:
 
         call_log = []
         def mock_run(cmd, **kwargs):
-            call_log.append(cmd)
-            if cmd[:2] == ["gh", "auth"]:
-                result = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+            call_log.append((cmd, kwargs))
+            if cmd[:4] == ["gh", "auth", "status", "--json"]:
+                stdout = '{"hosts":{"github.com":[{"state":"success","active":true}]}}'
+                result = types.SimpleNamespace(returncode=0, stdout=stdout, stderr="")
             else:
                 result = types.SimpleNamespace(returncode=1, stdout="", stderr="")
             return result
@@ -904,7 +905,7 @@ class TestGitHubTokenCheck:
             run_doctor(Namespace(fix=False))
         out = buf.getvalue()
 
-        assert "gh auth" in str(call_log) or any(c[0] == "gh" for c in call_log), f"gh not called: {call_log}"
+        assert any(c[0][:4] == ["gh", "auth", "status", "--json"] for c in call_log), f"gh not called: {call_log}"
         assert "GitHub authenticated via gh CLI" in out or "token configured" in out
 
 


### PR DESCRIPTION
## Problem

`hermes doctor` prints `No GITHUB_TOKEN` even when GitHub CLI authentication is already present via `gh auth login`.

On the current `gh` version, `gh auth status --json authenticated` is no longer a valid JSON field, so the doctor’s auth probe always falls through to the warning path.

## Root Cause

`hermes_cli/doctor.py` still used the removed/unsupported `authenticated` JSON field. The command exits non-zero, so the check is treated as unauthenticated even though `gh auth status --json hosts` reports a healthy active account.

## Fix

- Switch the doctor probe to `gh auth status --json hosts --hostname github.com`
- Parse the returned host/account payload and treat any `state == "success"` entry as authenticated
- Keep the non-fatal fallback behavior for exec/timeout/OSError failures
- Update the test to mock the current JSON schema

## Testing

- `python -m pytest tests/hermes_cli/test_doctor.py -q -k 'GitHubTokenCheck or permission_error_from_gh'`
- `python - <<'PY' ... hermes doctor --fix ... PY` verified that `No GITHUB_TOKEN` is no longer present while `GitHub authenticated via gh CLI` is present

## Related

I searched the repo for an existing issue matching this exact `authenticated`-field regression and did not find one.
