### PR TITLE
fix(kanban): add visible labels with tooltips to inline create form

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2680,38 +2680,60 @@
         rows: 2,
       }),
       h("div", { className: "flex gap-2" },
+        h("div", { className: "flex flex-col flex-1 min-w-0 gap-0.5" },
+          h(Label, {
+            className: "text-[10px] text-muted-foreground truncate",
+            title: props.columnName === "triage"
+              ? tx(t, "specifier", "Specifier")
+              : tx(t, "assignee", "Assignee"),
+          }, props.columnName === "triage"
+            ? tx(t, "specifier", "Specifier")
+            : tx(t, "assignee", "Assignee")),
+          h(Input, {
+            value: assignee,
+            onChange: function (e) { setAssignee(e.target.value); },
+            placeholder: props.columnName === "triage"
+              ? tx(t, "specifier", "specifier")
+              : tx(t, "assigneePlaceholder", "assignee"),
+            className: "h-7 text-xs w-full",
+            title: props.columnName === "triage"
+              ? "Hermes profile that will spec this task (default: the dispatcher's configured specifier). Leave blank to let the dispatcher pick."
+              : "Hermes profile to assign. Leave blank and the dispatcher will pick from available profiles when the task is Ready.",
+            style: { textTransform: "none" },
+            autoCapitalize: "none",
+            autoCorrect: "off",
+            spellCheck: false,
+          }),
+        ),
+        h("div", { className: "flex flex-col w-16 gap-0.5" },
+          h(Label, {
+            className: "text-[10px] text-muted-foreground truncate",
+            title: tx(t, "priority", "Priority"),
+          }, tx(t, "priority", "Priority")),
+          h(Input, {
+            type: "number",
+            value: priority,
+            onChange: function (e) { setPriority(e.target.value); },
+            placeholder: "pri",
+            className: "h-7 text-xs w-full",
+            title: "Priority. Higher-priority tasks are claimed first by the dispatcher. 0 = default.",
+          }),
+        ),
+      ),
+      h("div", { className: "flex flex-col gap-0.5" },
+        h(Label, {
+          className: "text-[10px] text-muted-foreground truncate",
+          title: tx(t, "skills", "Skills"),
+        }, tx(t, "skills", "Skills")),
         h(Input, {
-          value: assignee,
-          onChange: function (e) { setAssignee(e.target.value); },
-          placeholder: props.columnName === "triage"
-            ? tx(t, "specifier", "specifier")
-            : tx(t, "assigneePlaceholder", "assignee"),
-          className: "h-7 text-xs flex-1",
-          title: props.columnName === "triage"
-            ? "Hermes profile that will spec this task (default: the dispatcher's configured specifier). Leave blank to let the dispatcher pick."
-            : "Hermes profile to assign. Leave blank and the dispatcher will pick from available profiles when the task is Ready.",
-          style: { textTransform: "none" },
-          autoCapitalize: "none",
-          autoCorrect: "off",
-          spellCheck: false,
-        }),
-        h(Input, {
-          type: "number",
-          value: priority,
-          onChange: function (e) { setPriority(e.target.value); },
-          placeholder: "pri",
-          className: "h-7 text-xs w-16",
-          title: "Priority. Higher-priority tasks are claimed first by the dispatcher. 0 = default.",
+          value: skills,
+          onChange: function (e) { setSkills(e.target.value); },
+          placeholder: tx(t, "skillsPlaceholder",
+            "skills (optional, comma-separated): translation, github-code-review"),
+          title: "Force-load these skills into the worker (in addition to the built-in kanban-worker).",
+          className: "h-7 text-xs w-full",
         }),
       ),
-      h(Input, {
-        value: skills,
-        onChange: function (e) { setSkills(e.target.value); },
-        placeholder: tx(t, "skillsPlaceholder",
-          "skills (optional, comma-separated): translation, github-code-review"),
-        title: "Force-load these skills into the worker (in addition to the built-in kanban-worker).",
-        className: "h-7 text-xs",
-      }),
       h("div", { className: "flex gap-2 items-center" },
         h("label", {
           className: "flex items-center gap-1.5 text-xs cursor-pointer select-none",


### PR DESCRIPTION
## What

Adds visible labels above each input in the Kanban board's inline create form (the "+ New task" form in every column). Previously the form relied entirely on placeholder text inside narrow inputs, which truncated "specifier" → "specifi" and "assignee" → "assigne".

Fixes #49955

## Why

The inline create form had no `Label` elements — just `Input` components with placeholder text constrained by `flex-1` / `w-16` CSS. On typical viewport widths, the placeholder text was truncated with no way to see the full field name.

## How

`plugins/kanban/dashboard/dist/index.js` — wraps each input in a `flex-col` container with a `Label` component above it:

| Column | Field | Label |
|--------|-------|-------|
| Triage | assignee | Specifier |
| Other | assignee | Assignee |
| All | priority | Priority |
| All | skills | Skills |

- Labels use `truncate` CSS class — clips with ellipsis on very narrow viewports
- Each label has a `title` attribute — hover tooltip reveals full text as fallback
- Inputs changed from `flex-1` / `w-16` to `w-full` to fill their new flex containers
- Uses the existing `Label` component (already imported at line 22)

## Verification

- Lint passes
- No frontend test infrastructure exists for the dashboard plugin (raw `h()` React)
- Visual verification requires loading the Kanban dashboard and clicking "+ New task" in Triage and Todo columns
