### PR TITLE
feat(desktop): add polished cmux theme

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1176,7 +1176,7 @@ export function ChatSidebar({
   return (
     <Sidebar
       className={cn(
-        'relative h-full min-w-0 overflow-hidden border-t-0 border-b-0 text-foreground transition-none',
+        'relative h-full min-w-0 overflow-hidden border-t-0 border-b-0 text-sidebar-foreground transition-none',
         panesFlipped ? 'border-l border-r-0' : 'border-r border-l-0',
         sidebarOpen
           ? 'border-(--sidebar-edge-border) bg-(--ui-sidebar-surface-background) opacity-100'
@@ -1214,9 +1214,9 @@ export function ChatSidebar({
                         // resolved region has been observed to swallow clicks on the
                         // top rows. Same carve-out as USER_BUBBLE_BASE_CLASS in
                         // thread.tsx.
-                        'flex h-7 w-full justify-start gap-2 rounded-md border border-transparent px-2 text-left text-[0.8125rem] font-medium text-(--ui-text-secondary) transition-colors duration-100 ease-out [-webkit-app-region:no-drag] hover:bg-(--ui-control-hover-background) hover:text-foreground hover:transition-none',
+                        'flex h-7 w-full justify-start gap-2 rounded-md border border-transparent px-2 text-left text-[0.8125rem] font-semibold text-(--ui-sidebar-nav-foreground) transition-colors duration-100 ease-out [-webkit-app-region:no-drag] hover:bg-(--ui-control-hover-background) hover:text-(--ui-sidebar-heading) hover:transition-none',
                         active &&
-                          'border-(--ui-stroke-tertiary) bg-(--ui-control-active-background) text-foreground shadow-none hover:border-(--ui-stroke-tertiary)!',
+                          'border-(--ui-stroke-tertiary) bg-(--ui-control-active-background) text-(--ui-sidebar-heading) shadow-none hover:border-(--ui-stroke-tertiary)!',
                         !isInteractive &&
                           'cursor-default hover:border-transparent hover:bg-transparent hover:text-inherit'
                       )}

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -215,7 +215,12 @@ export function SidebarSessionRow({
               />
             </Tip>
           ) : null}
-          <SidebarRowLabel className="flex-1 font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90">
+          <SidebarRowLabel
+            className={cn(
+              'flex-1 font-normal text-(--ui-sidebar-session-foreground) group-hover:text-sidebar-foreground group-data-[working=true]:text-sidebar-foreground',
+              isSelected && 'text-sidebar-foreground'
+            )}
+          >
             {title}
           </SidebarRowLabel>
         </SidebarRowBody>

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -210,6 +210,7 @@ export function useStatusbarItems({
       label,
       onSelect: () => openUpdateOverlayFor('client'),
       title: tooltip || undefined,
+      tone: 'version',
       variant: 'action'
     }
   }, [
@@ -259,6 +260,7 @@ export function useStatusbarItems({
       label,
       onSelect: () => openUpdateOverlayFor('backend'),
       title: tooltip || undefined,
+      tone: 'version',
       variant: 'action'
     }
   }, [
@@ -297,6 +299,7 @@ export function useStatusbarItems({
         menuClassName: 'w-72',
         menuContent: gatewayMenuContent,
         title: inferenceStatus?.reason || copy.gatewayTitle,
+        tone: inferenceReady || gatewayRestarting ? 'gateway' : undefined,
         variant: 'menu'
       },
       {
@@ -322,6 +325,7 @@ export function useStatusbarItems({
         label: copy.agents,
         onSelect: openAgents,
         title: agentsOpen ? copy.closeAgents : copy.openAgents,
+        tone: subagentsFailed > 0 ? undefined : 'agents',
         variant: 'action'
       },
       {
@@ -329,6 +333,7 @@ export function useStatusbarItems({
         id: 'cron',
         label: copy.cron,
         title: copy.openCron,
+        tone: 'cron',
         to: CRON_ROUTE,
         variant: 'action'
       }
@@ -367,6 +372,7 @@ export function useStatusbarItems({
         id: 'context-usage',
         label: contextUsage,
         title: copy.contextUsage,
+        tone: 'context',
         variant: 'text'
       },
       {
@@ -375,6 +381,7 @@ export function useStatusbarItems({
         id: 'session-timer',
         label: copy.session,
         title: copy.runtimeSessionElapsed,
+        tone: 'session',
         variant: 'text'
       },
       {
@@ -388,6 +395,7 @@ export function useStatusbarItems({
         id: 'yolo',
         onSelect: modifiers => void toggleYolo(modifiers),
         title: yoloActive ? copy.yoloOn : copy.yoloOff,
+        tone: 'yolo',
         variant: 'action'
       },
       {
@@ -397,6 +405,7 @@ export function useStatusbarItems({
         id: 'terminal',
         onSelect: () => setTerminalTakeover(!$terminalTakeover.get()),
         title: terminalTakeover ? copy.hideTerminal : copy.showTerminal,
+        tone: 'terminal',
         variant: 'action'
       },
       clientVersionItem,

--- a/apps/desktop/src/app/shell/sidebar-label.tsx
+++ b/apps/desktop/src/app/shell/sidebar-label.tsx
@@ -10,7 +10,7 @@ export function SidebarPanelLabel({ children, className, dotClassName, ...props 
   return (
     <span
       className={cn(
-        'flex min-w-0 items-center gap-2 pl-2 text-[0.64rem] font-semibold uppercase tracking-[0.16em] text-(--theme-primary)',
+        'flex min-w-0 items-center gap-2 pl-2 text-[0.64rem] font-semibold uppercase tracking-[0.16em] text-(--ui-sidebar-heading)',
         className
       )}
       {...props}

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -39,6 +39,7 @@ export interface StatusbarItem {
   onSelect?: (modifiers: StatusbarSelectModifiers) => void
   title?: string
   to?: string
+  tone?: 'agents' | 'context' | 'cron' | 'gateway' | 'session' | 'terminal' | 'version' | 'yolo'
   variant?: 'action' | 'link' | 'menu' | 'text'
 }
 
@@ -92,7 +93,11 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
     <>
       {item.icon}
       {item.label && <span className="truncate">{item.label}</span>}
-      {item.detail && <span className="truncate text-muted-foreground/80">{item.detail}</span>}
+      {item.detail && (
+        <span className="truncate text-muted-foreground/80" data-slot="statusbar-detail">
+          {item.detail}
+        </span>
+      )}
     </>
   )
 
@@ -101,7 +106,12 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
       <Tip label={item.title}>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} type="button">
+            <button
+              className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+              data-statusbar-tone={item.tone}
+              disabled={item.disabled}
+              type="button"
+            >
               {content}
             </button>
           </DropdownMenuTrigger>
@@ -160,6 +170,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
             'inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
             item.className
           )}
+          data-statusbar-tone={item.tone}
         >
           {content}
         </div>
@@ -170,7 +181,13 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
   if (item.href || item.variant === 'link') {
     return (
       <Tip label={item.title}>
-        <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
+        <a
+          className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+          data-statusbar-tone={item.tone}
+          href={item.href}
+          rel="noreferrer"
+          target="_blank"
+        >
           {content}
         </a>
       </Tip>
@@ -181,6 +198,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
     <Tip label={item.title}>
       <button
         className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+        data-statusbar-tone={item.tone}
         disabled={item.disabled}
         onClick={event => {
           if (item.to) {

--- a/apps/desktop/src/components/Backdrop.tsx
+++ b/apps/desktop/src/components/Backdrop.tsx
@@ -93,7 +93,7 @@ export function Backdrop() {
           className="pointer-events-none absolute inset-0 z-2"
           style={{
             mixBlendMode: statue.blendMode as CSSProperties['mixBlendMode'],
-            opacity: statue.opacity
+            opacity: `calc(${statue.opacity} * var(--ui-backdrop-opacity, 1))`
           }}
         >
           <img

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -464,7 +464,7 @@ const HEADING_SIZES: Record<'h1' | 'h2' | 'h3' | 'h4', string> = {
 const MARKDOWN_CONTAINER_CLASS_NAME = cn(
   'aui-md prose w-full max-w-none overflow-hidden text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground',
   'prose-p:leading-(--dt-line-height) prose-li:leading-(--dt-line-height)',
-  'prose-headings:text-foreground prose-strong:text-foreground',
+  'prose-headings:text-(--ui-emphasis-foreground) prose-strong:text-(--ui-emphasis-foreground)',
   'prose-a:break-words prose-p:[overflow-wrap:anywhere]',
   'prose-li:marker:text-muted-foreground/70',
   'prose-code:rounded-[0.25rem] prose-code:px-[0.1875rem] prose-code:py-px prose-code:font-mono prose-code:text-[0.9em] prose-code:font-normal prose-code:before:content-none prose-code:after:content-none',

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -16,6 +16,7 @@ import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { CopyButton } from '@/components/ui/copy-button'
 import { useI18n } from '@/i18n'
 import { codiconForLanguage, isLikelyProseCodeBlock, sanitizeLanguageTag } from '@/lib/markdown-code'
+import { useTheme } from '@/themes/context'
 
 /**
  * Streamdown's code adapter renders header + body as inline siblings, so we
@@ -122,7 +123,17 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
   defer = false
 }) => {
   const { t } = useI18n()
+  const { theme } = useTheme()
   const trimmed = (code ?? '').replace(/^\n+/, '').trimEnd()
+
+  // Resolve the Shiki theme: the active skin may override either mode; each
+  // missing side falls back to the app default. `defaultColor="light-dark()"`
+  // then picks the right side from the document's color-scheme. Omitting
+  // `shikiTheme` (every built-in today) keeps the exact GitHub defaults.
+  const shikiTheme = {
+    dark: theme.shikiTheme?.dark ?? SHIKI_THEME.dark,
+    light: theme.shikiTheme?.light ?? SHIKI_THEME.light
+  }
 
   // Streaming may hand us empty/incomplete fences — render nothing rather
   // than a transient empty card.
@@ -169,7 +180,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
                 delay={120}
                 language={language || 'text'}
                 showLanguage={false}
-                theme={SHIKI_THEME}
+                theme={shikiTheme}
               >
                 {trimmed}
               </ShikiHighlighter>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -266,6 +266,27 @@
     --ui-inline-code-background: color-mix(in srgb, #141414 5%, transparent);
     --ui-inline-code-foreground: color-mix(in srgb, #141414 88%, transparent);
     --ui-selection-background: color-mix(in srgb, #ffd24a 55%, transparent);
+    /* Emphasis (chat markdown headings + bold). Defaults to the body foreground
+       so existing themes render identically; a theme can set it (via
+       `emphasisForeground`) to make headings/bold a brighter/separate color —
+       e.g. terminal-style "bold brightens". */
+    --ui-emphasis-foreground: var(--dt-foreground);
+    /* Sidebar section headers ("PINNED", "SESSIONS"). Defaults to the brand
+       accent (prior behavior); a theme can override (via
+       `sidebarHeadingForeground`) for e.g. white headers. */
+    --ui-sidebar-heading: var(--theme-primary);
+    --ui-sidebar-nav-foreground: var(--sidebar-foreground);
+    --ui-sidebar-workspace-foreground: var(--ui-text-secondary);
+    --ui-sidebar-session-foreground: var(--ui-text-secondary);
+    --ui-backdrop-opacity: 1;
+    --ui-status-gateway-foreground: var(--ui-text-tertiary);
+    --ui-status-agents-foreground: var(--ui-text-tertiary);
+    --ui-status-cron-foreground: var(--ui-text-tertiary);
+    --ui-status-context-foreground: var(--ui-text-tertiary);
+    --ui-status-session-foreground: var(--ui-text-tertiary);
+    --ui-status-yolo-foreground: var(--ui-text-tertiary);
+    --ui-status-terminal-foreground: var(--ui-text-tertiary);
+    --ui-status-version-foreground: var(--ui-text-tertiary);
 
     --dt-background: var(--ui-bg-chrome);
     --dt-foreground: var(--ui-text-primary);
@@ -478,11 +499,11 @@
    pointer-transparent. Auto-resets on mouse-out, no JS.
 
    - data-suppress-pane-reveal       → kills BOTH edges (use for small regions
-                                         like the thread timeline).
+                                        like the thread timeline).
    - data-suppress-pane-reveal-side  → kills only the hovered region's OWN side
-                                         (side read from its [data-pane-side]
-                                         pane ancestor), so the opposite sidebar
-                                         stays summonable while you work a pane. */
+                                        (side read from its [data-pane-side]
+                                        pane ancestor), so the opposite sidebar
+                                        stays summonable while you work a pane. */
 [data-pane-shell]:has([data-suppress-pane-reveal]:hover) [data-pane-reveal-trigger] {
   pointer-events: none;
 }
@@ -494,6 +515,43 @@
   [data-pane-side='right']
   [data-pane-reveal-trigger] {
   pointer-events: none;
+}
+
+[data-statusbar-tone='gateway'] {
+  color: var(--ui-status-gateway-foreground) !important;
+}
+
+[data-statusbar-tone='agents'] {
+  color: var(--ui-status-agents-foreground) !important;
+}
+
+[data-statusbar-tone='cron'] {
+  color: var(--ui-status-cron-foreground) !important;
+}
+
+[data-statusbar-tone='context'] {
+  color: var(--ui-status-context-foreground) !important;
+}
+
+[data-statusbar-tone='session'] {
+  color: var(--ui-status-session-foreground) !important;
+}
+
+[data-statusbar-tone='yolo'] {
+  color: var(--ui-status-yolo-foreground) !important;
+}
+
+[data-statusbar-tone='terminal'] {
+  color: var(--ui-status-terminal-foreground) !important;
+}
+
+[data-statusbar-tone='version'] {
+  color: var(--ui-status-version-foreground) !important;
+}
+
+[data-statusbar-tone] [data-slot='statusbar-detail'] {
+  color: currentColor;
+  opacity: 0.82;
 }
 
 :root:not([style*='--theme-asset-bg:']) .theme-default-filler {

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -228,6 +228,40 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
     root.style.setProperty(k, v)
   }
 
+  // Inline-code tokens are opt-in per theme. Set when present, REMOVE when not,
+  // so switching from a theme that customizes them back to one that doesn't
+  // restores the styles.css :root / :root.dark default instead of leaking the
+  // previous skin's values. Same pattern for emphasis (chat headings/bold) and
+  // the two sidebar tokens (section headers + entry text).
+  const optionalTokens: Record<string, string | undefined> = {
+    '--ui-inline-code-foreground': c.inlineCodeForeground,
+    '--ui-inline-code-background': c.inlineCodeBackground,
+    '--ui-inline-code-border': c.inlineCodeBorder,
+    '--ui-emphasis-foreground': c.emphasisForeground,
+    '--ui-sidebar-heading': c.sidebarHeadingForeground,
+    '--sidebar-foreground': c.sidebarForeground,
+    '--ui-sidebar-nav-foreground': c.sidebarNavForeground,
+    '--ui-sidebar-workspace-foreground': c.sidebarWorkspaceForeground,
+    '--ui-sidebar-session-foreground': c.sidebarSessionForeground,
+    '--ui-backdrop-opacity': c.backdropOpacity,
+    '--ui-status-gateway-foreground': c.statusGatewayForeground,
+    '--ui-status-agents-foreground': c.statusAgentsForeground,
+    '--ui-status-cron-foreground': c.statusCronForeground,
+    '--ui-status-context-foreground': c.statusContextForeground,
+    '--ui-status-session-foreground': c.statusSessionForeground,
+    '--ui-status-yolo-foreground': c.statusYoloForeground,
+    '--ui-status-terminal-foreground': c.statusTerminalForeground,
+    '--ui-status-version-foreground': c.statusVersionForeground
+  }
+
+  for (const [k, v] of Object.entries(optionalTokens)) {
+    if (v) {
+      root.style.setProperty(k, v)
+    } else {
+      root.style.removeProperty(k)
+    }
+  }
+
   const chromeBg = chromeBackground(c.background, isDark)
 
   window.hermesDesktop?.setTitleBarTheme?.({

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -277,12 +277,108 @@ export const slateTheme: DesktopTheme = {
   }
 }
 
+/**
+ * cmux — terminal-IDE dark theme. Tuned to Jeff's cmux screenshots: true black
+ * chat surface, terminal-green prose, brighter-green bold/headings, white/blue
+ * sidebar structure, lavender inline-code identifiers, and a colored statusbar.
+ */
+export const cmuxTheme: DesktopTheme = {
+  name: 'cmux',
+  label: 'cmux',
+  description: 'Homebrew-green terminal on black — cmux vibes',
+  colors: {
+    // Main chat surface is true black; only the sidebar carries a green tint.
+    background: '#000000',
+    // Body text stays green — this is the soul of the cmux look. Headings/bold
+    // brighten via emphasisForeground below; scaffolding/hints stay gray-white.
+    foreground: '#33d96a',
+    card: '#070b07',
+    cardForeground: '#33d96a',
+    muted: '#0d140d',
+    // Scaffolding / hint text ("Ran N commands", timestamps) is dim white,
+    // not green, so it doesn't compete with bold/heading emphasis.
+    mutedForeground: '#aab4aa',
+    popover: '#0a100a',
+    popoverForeground: '#33d96a',
+    primary: '#7dffae',
+    primaryForeground: '#04130a',
+    secondary: '#13231a',
+    secondaryForeground: '#9be8b5',
+    accent: '#102018',
+    accentForeground: '#9bf6bd',
+    border: '#1c2c20',
+    input: '#1c2c20',
+    ring: '#7dffae',
+    midground: '#7dffae',
+    composerRing: '#33d96a',
+    destructive: '#f0635a',
+    destructiveForeground: '#000000',
+    // Sidebar: dark olive-green surface (not black), white-bold top nav +
+    // section headers, blue profile/workspace names, dim-white child rows.
+    sidebarBackground: '#0d170d',
+    sidebarBorder: '#1f2d1f',
+    sidebarHeadingForeground: '#ffffff',
+    sidebarForeground: '#f2f4f2',
+    sidebarNavForeground: '#ffffff',
+    sidebarWorkspaceForeground: '#7dcfff',
+    sidebarSessionForeground: '#b7c1b7',
+    userBubble: '#0e1a12',
+    userBubbleBorder: '#28402f',
+    // Headings + bold brighten to a lighter green than the body.
+    emphasisForeground: '#7dffae',
+    backdropOpacity: '0',
+    statusGatewayForeground: '#7dffae',
+    statusAgentsForeground: '#bb9af7',
+    statusCronForeground: '#7dcfff',
+    statusContextForeground: '#7dcfff',
+    statusSessionForeground: '#e0af68',
+    statusYoloForeground: '#f7768e',
+    statusTerminalForeground: '#7aa2f7',
+    statusVersionForeground: '#bb9af7',
+    // Inline code reads lavender against the green body (the cmux identifier
+    // look). Tints derive from the same lavender.
+    inlineCodeForeground: '#b0b9f9',
+    inlineCodeBackground: 'rgba(176, 185, 249, 0.10)',
+    inlineCodeBorder: 'rgba(176, 185, 249, 0.22)'
+  },
+  typography: {
+    fontSans: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`
+  },
+  // Fenced code blocks: everforest-dark is green-tinted with lavender/aqua
+  // identifiers, so syntax highlighting sits in the cmux palette instead of
+  // GitHub-dark blue. Same theme for both modes (cmux is dark-only).
+  shikiTheme: { dark: 'everforest-dark', light: 'everforest-dark' },
+  terminal: {
+    foreground: '#33d96a',
+    cursor: '#6dfca0',
+    selectionBackground: '#28402f',
+    black: '#000000',
+    red: '#f0635a',
+    green: '#41d97d',
+    yellow: '#d4b758',
+    blue: '#6ab0f3',
+    magenta: '#c3b0f0',
+    cyan: '#5fc9c9',
+    white: '#cfe6d6',
+    brightBlack: '#6f8f70',
+    brightRed: '#ff7a70',
+    brightGreen: '#86efac',
+    brightYellow: '#e6cf7a',
+    brightBlue: '#8cc6ff',
+    brightMagenta: '#cbb6f0',
+    brightCyan: '#7fdede',
+    brightWhite: '#e8f5e9'
+  }
+}
+
 export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
   nous: nousTheme,
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
+  cmux: cmuxTheme,
   slate: slateTheme
 }
 

--- a/apps/desktop/src/themes/types.ts
+++ b/apps/desktop/src/themes/types.ts
@@ -45,6 +45,52 @@ export interface DesktopThemeColors {
   sidebarBorder?: string
   userBubble?: string
   userBubbleBorder?: string
+  /**
+   * Inline code (`` `like this` ``) foreground / fill / hairline. All optional:
+   * when a theme omits them the styles.css `:root` / `:root.dark` defaults win,
+   * so existing themes render byte-identically. A theme that wants code tokens
+   * to read in its own palette (e.g. lavender identifiers on a green body) sets
+   * these and `applyTheme` paints them over the defaults.
+   */
+  inlineCodeForeground?: string
+  inlineCodeBackground?: string
+  inlineCodeBorder?: string
+  /**
+   * Chat markdown headings + bold (`<strong>`). Optional: when omitted the body
+   * foreground is used (styles.css `--ui-emphasis-foreground` default), so
+   * existing themes are unchanged. A terminal-style skin can set this brighter
+   * than `foreground` so bold/headings "brighten" against the body.
+   */
+  emphasisForeground?: string
+  /**
+   * Sidebar section headers ("PINNED", "SESSIONS"). Optional: defaults to the
+   * brand accent (`--ui-sidebar-heading` → `--theme-primary`). Set e.g. white
+   * for a terminal look where headers read as bold white over a tinted sidebar.
+   */
+  sidebarHeadingForeground?: string
+  /**
+   * Sidebar entry text (session rows, nav labels). Optional: defaults to the
+   * body foreground (`--sidebar-foreground`). Set to decouple sidebar text from
+   * chat body text — e.g. near-white rows over a dark-green sidebar.
+   */
+  sidebarForeground?: string
+  /** Top navigation rows in the left sidebar (New session, Skills, Messaging). */
+  sidebarNavForeground?: string
+  /** Profile/workspace group headings in the left sidebar. */
+  sidebarWorkspaceForeground?: string
+  /** Child session row text under a profile/workspace group. */
+  sidebarSessionForeground?: string
+  /** Multiplier for the decorative backdrop image/statue; `0` disables it. */
+  backdropOpacity?: string
+  /** Optional colored statusbar tones. Defaults preserve the original muted chrome. */
+  statusGatewayForeground?: string
+  statusAgentsForeground?: string
+  statusCronForeground?: string
+  statusContextForeground?: string
+  statusSessionForeground?: string
+  statusYoloForeground?: string
+  statusTerminalForeground?: string
+  statusVersionForeground?: string
 }
 
 export interface DesktopThemeTypography {
@@ -94,6 +140,14 @@ export interface DesktopTheme {
   /** Hand-tuned dark palette. Skins like `nous` ship one. */
   darkColors?: DesktopThemeColors
   typography?: Partial<DesktopThemeTypography>
+  /**
+   * Shiki syntax-highlighting theme for fenced code blocks, per color mode.
+   * Optional — omitted means the app default (`github-dark-default` /
+   * `github-light-default`). Each side is a bundled Shiki theme name; a missing
+   * side falls back to the default for that mode. Lets a skin ship code blocks
+   * that match its surface instead of always GitHub-dark.
+   */
+  shikiTheme?: { light?: string; dark?: string }
   /** Light-variant terminal ANSI palette (also the fallback for dark). */
   terminal?: DesktopTerminalPalette
   /** Dark-variant terminal ANSI palette. Falls back to `terminal`. */


### PR DESCRIPTION
## Summary
- add a built-in `cmux` desktop theme with black chat surface, terminal-green prose, brighter green emphasis, lavender inline code, dark olive sidebars, and colored statusbar tones
- add fallback-safe optional theme tokens for emphasis text, sidebar nav/group/session colors, backdrop opacity, and statusbar item tones
- make Shiki code highlighting theme-aware so cmux fenced code blocks use an everforest-dark palette instead of the default blue-heavy theme

## Validation
- `cd apps/desktop && npx tsc -p . --noEmit`
- `cd apps/desktop && npx eslint src/components/chat/shiki-highlighter.tsx src/themes/context.tsx src/themes/presets.ts src/themes/types.ts src/app/chat/sidebar/index.tsx src/app/shell/sidebar-label.tsx src/components/assistant-ui/markdown-text.tsx src/app/chat/sidebar/session-row.tsx src/app/shell/hooks/use-statusbar-items.tsx src/app/shell/statusbar-controls.tsx src/components/Backdrop.tsx` (passes; pre-existing warning at `src/app/chat/sidebar/index.tsx:536`)
- `cd apps/desktop && npx vitest run --environment jsdom src/themes/`
- `hermes desktop --build-only --force-build`
- extracted packed `app.asar` and verified cmux/token markers are present

Stack note: this is intentionally separate from #49902 (text size + chat width). This PR is only theme/chrome polish.