### PR TITLE
fix(mcp): avoid replaying historical events on startup

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -217,6 +217,8 @@ class EventBridge:
         self._running = False
         self._thread: Optional[threading.Thread] = None
         self._last_poll_timestamps: Dict[str, float] = {}  # session_key -> unix timestamp
+        self._bridge_started_at = time.time()
+        self._initial_scan_complete = False
         # In-memory approval tracking (populated from events)
         self._pending_approvals: Dict[str, dict] = {}
         # mtime cache — skip expensive work when files haven't changed
@@ -356,7 +358,8 @@ class EventBridge:
         except OSError:
             sj_mtime = 0.0
 
-        if sj_mtime != self._sessions_json_mtime:
+        sessions_changed = sj_mtime != self._sessions_json_mtime
+        if sessions_changed:
             self._sessions_json_mtime = sj_mtime
             self._cached_sessions_index = _load_sessions_index()
 
@@ -372,7 +375,8 @@ class EventBridge:
         except OSError:
             db_mtime = 0.0
 
-        if db_mtime == self._state_db_mtime and sj_mtime == self._sessions_json_mtime:
+        db_changed = db_mtime != self._state_db_mtime
+        if not db_changed and not sessions_changed:
             return  # Nothing changed since last poll — skip entirely
 
         self._state_db_mtime = db_mtime
@@ -383,7 +387,11 @@ class EventBridge:
             if not session_id:
                 continue
 
-            last_seen = self._last_poll_timestamps.get(session_key, 0.0)
+            has_seen_session = session_key in self._last_poll_timestamps
+            if has_seen_session:
+                last_seen = self._last_poll_timestamps[session_key]
+            else:
+                last_seen = 0.0 if not self._initial_scan_complete else self._bridge_started_at
 
             try:
                 messages = db.get_messages(session_id)
@@ -391,6 +399,7 @@ class EventBridge:
                 continue
 
             if not messages:
+                self._last_poll_timestamps.setdefault(session_key, last_seen)
                 continue
 
             # Normalize timestamps to float for comparison
@@ -408,6 +417,16 @@ class EventBridge:
                         except Exception:
                             return 0.0
                 return 0.0
+
+            all_ts = [_ts_float(m.get("timestamp", 0)) for m in messages]
+            latest = max(all_ts) if all_ts else last_seen
+
+            # The first successful scan establishes a baseline. Without this,
+            # starting the MCP server replays every saved conversation message
+            # as a new live event.
+            if not has_seen_session and not self._initial_scan_complete:
+                self._last_poll_timestamps[session_key] = latest
+                continue
 
             # Find messages newer than our last seen timestamp
             new_messages = []
@@ -435,12 +454,10 @@ class EventBridge:
                     },
                 ))
 
-            # Update last seen to the most recent message timestamp
-            all_ts = [_ts_float(m.get("timestamp", 0)) for m in messages]
-            if all_ts:
-                latest = max(all_ts)
-                if latest > last_seen:
-                    self._last_poll_timestamps[session_key] = latest
+            # Update last seen to the most recent message timestamp.
+            self._last_poll_timestamps[session_key] = max(latest, last_seen)
+
+        self._initial_scan_complete = True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1058,8 +1058,8 @@ class TestEdgeCases:
 class TestEventBridgePollE2E:
     """End-to-end tests for the EventBridge polling loop with real files."""
 
-    def test_poll_detects_new_messages(self, tmp_path, monkeypatch):
-        """Write to SQLite + sessions.json, verify EventBridge picks it up."""
+    def test_initial_poll_baselines_existing_messages(self, tmp_path, monkeypatch):
+        """Existing transcript rows must not be replayed as live events."""
         import mcp_serve
         sessions_dir = tmp_path / "sessions"
         sessions_dir.mkdir()
@@ -1109,12 +1109,12 @@ class TestEventBridgePollE2E:
         # Run one poll cycle manually
         bridge._poll_once(TestDB())
 
-        # Should have found the messages
+        # Startup should establish the last-seen timestamp without replaying
+        # old conversation history as new MCP events.
         result = bridge.poll_events(after_cursor=0)
-        assert len(result["events"]) == 2
-        assert result["events"][0]["role"] == "user"
-        assert result["events"][0]["content"] == "First message"
-        assert result["events"][1]["role"] == "assistant"
+        assert result["events"] == []
+        assert result["next_cursor"] == 0
+        assert bridge._last_poll_timestamps["agent:main:telegram:dm:poll_test"] > 0
 
     def test_poll_skips_when_unchanged(self, tmp_path, monkeypatch):
         """Second poll with no file changes should be a no-op."""
@@ -1206,10 +1206,11 @@ class TestEventBridgePollE2E:
         db = TestDB()
         bridge = mcp_serve.EventBridge()
 
-        # First poll
+        # First poll establishes the baseline and should not replay history.
         bridge._poll_once(db)
         r1 = bridge.poll_events(after_cursor=0)
-        assert len(r1["events"]) == 1
+        assert r1["events"] == []
+        assert r1["next_cursor"] == 0
 
         # Add a new message to the DB
         conn = sqlite3.connect(str(db_path))


### PR DESCRIPTION
## Summary

Starting `hermes mcp serve` against a session store with existing conversation history replayed every saved transcript row to MCP clients as fresh `events_poll` events. This makes the first scan establish a per-session timestamp baseline so only genuinely-new messages are emitted as live events.

**Salvage of #13414 by @afurm** — re-targeted onto current main.

## Problem / root cause

`EventBridge` seeded each session with `last_seen = self._last_poll_timestamps.get(session_key, 0.0)`. With a baseline of `0.0`, the very first `_poll_once` treated **every** stored `user`/`assistant` message as newer-than-last-seen and enqueued it. On connect, MCP clients immediately received the whole historical transcript as if it were live traffic.

## The fix

- Add `_bridge_started_at` (capture time at construction) and `_initial_scan_complete` flag.
- On the first scan of a never-seen session (`not _initial_scan_complete`), record the latest message timestamp as the baseline and emit nothing.
- After the initial scan, newly-discovered sessions baseline at `_bridge_started_at` instead of `0.0`, so a session that appears mid-run doesn't dump its backlog either.
- Empty sessions still `setdefault` a baseline so they don't replay if messages arrive later.
- Replace the implicit mtime skip with explicit `sessions_changed`/`db_changed` flags (so a `sessions.json`-only change is still treated as poll work).

## Testing (real, captured)

Renamed/updated the two affected E2E tests to assert the new contract (no replay on first poll). Both **fail without the fix** and pass with it:

```
# Without the source fix (test changes only):
$ .venv/bin/python -m pytest tests/test_mcp_serve.py -q -k "initial_poll_baselines or detects_new_message_after_db_write"
>       assert r1["events"] == []
E       AssertionError: assert [{'content': ...'user', ...}] == []
E         Left contains one more item: {'content': 'First', 'cursor': 1, ...}
2 failed, 83 deselected in 0.14s

# With the fix (full file):
$ .venv/bin/python -m pytest tests/test_mcp_serve.py -q
45 passed, 40 skipped in 1.18s
```

`py_compile` clean on `mcp_serve.py` and `tests/test_mcp_serve.py`.

## Note on re-targeting

The repository restructured since the original PR, but `mcp_serve.py`'s `EventBridge` structure is unchanged, so the author's intended fix applied with only small offsets. The original PR's test renames were carried forward verbatim.