### PR TITLE
fix(cron): inherit runtime provider on gateway create

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -2,6 +2,7 @@
 
 import json
 import pytest
+from unittest.mock import MagicMock
 
 from tools.cronjob_tools import (
     _scan_cron_prompt,
@@ -263,6 +264,48 @@ class TestUnifiedCronjobTool:
         assert listing["count"] == 1
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
+
+    def test_create_inherits_runtime_provider_for_gateway_session(self, monkeypatch):
+        runtime = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.example.com/v1",
+            "api_key": "runtime-key",
+            "api_mode": "chat_completions",
+        }
+        resolve_runtime_provider = MagicMock(return_value=runtime)
+
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "weixin")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "wxid_home")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_NAME", "Home")
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            resolve_runtime_provider,
+        )
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                name="Gateway check",
+            )
+        )
+
+        assert created["success"] is True
+        resolve_runtime_provider.assert_called_once_with(
+            requested=None,
+            explicit_base_url=None,
+        )
+
+        from cron.jobs import get_job
+
+        job = get_job(created["job_id"])
+        assert job is not None
+        assert job["provider"] == "openrouter"
+        assert job["provider"] != "openai"
+        assert job["base_url"] == "https://openrouter.example.com/v1"
+        assert job["origin"]["platform"] == "weixin"
+        assert job["origin"]["chat_id"] == "wxid_home"
 
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -375,6 +375,41 @@ def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash:
     return text or None
 
 
+def _resolve_create_runtime_defaults(
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    """Fill in missing runtime fields from the active provider config.
+
+    Gateway/Weixin cron creation can arrive without an explicit model object.
+    In that case we still want to persist the same runtime provider settings
+    the gateway is actively using, rather than falling back to a stale or
+    invalid default.
+    """
+    normalized_provider = _normalize_optional_job_value(provider)
+    normalized_base_url = _normalize_optional_job_value(base_url, strip_trailing_slash=True)
+
+    if normalized_provider and normalized_base_url:
+        return normalized_provider, normalized_base_url
+
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(
+            requested=normalized_provider,
+            explicit_base_url=normalized_base_url,
+        )
+    except Exception:
+        runtime = {}
+
+    if not normalized_provider:
+        normalized_provider = _normalize_optional_job_value(runtime.get("provider"))
+    if not normalized_base_url:
+        normalized_base_url = _normalize_optional_job_value(runtime.get("base_url"), strip_trailing_slash=True)
+
+    return normalized_provider, normalized_base_url
+
+
 def _normalize_deliver_param(value: Any) -> Optional[str]:
     """Normalize a user-supplied ``deliver`` value to the canonical string form.
 
@@ -542,6 +577,7 @@ def cronjob(
                             success=False,
                         )
 
+            resolved_provider, resolved_base_url = _resolve_create_runtime_defaults(provider, base_url)
             job = create_job(
                 prompt=prompt or "",
                 schedule=schedule,
@@ -551,8 +587,8 @@ def cronjob(
                 origin=_origin_from_env(),
                 skills=canonical_skills,
                 model=_normalize_optional_job_value(model),
-                provider=_normalize_optional_job_value(provider),
-                base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
+                provider=resolved_provider,
+                base_url=resolved_base_url,
                 script=_normalize_optional_job_value(script),
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,


### PR DESCRIPTION
## Summary

Cron jobs created from a gateway-backed session (e.g. Weixin) without an explicit model/provider were persisted with `provider=None`, so at run time they fell back to a stale or invalid default rather than the provider the gateway is actively using. This wires the create path to inherit the active runtime provider settings.

**Salvage of #13337 by @sgaofen** — re-targeted onto current main.

## Problem / root cause

`cronjob(action="create")` passed `provider=_normalize_optional_job_value(provider)` and the matching `base_url` straight through to `create_job()`. When those came in empty (the common gateway/Weixin case, which has no explicit model object), the job stored `provider=None` / `base_url=None` and later resolved against whatever default was configured — typically `openai` — instead of the provider the gateway session was running on.

## The fix

- Add `_resolve_create_runtime_defaults(provider, base_url)`: if either field is missing, call `resolve_runtime_provider(requested=..., explicit_base_url=...)` from `hermes_cli.runtime_provider` (the same resolver the active runtime uses) and backfill the missing field from its result.
- Explicitly-supplied `provider`/`base_url` are returned untouched (no resolver call when both are present).
- Resolution failures degrade gracefully to `None` (prior behavior), so this never makes creation fail.
- Route the `create_job()` callsite through the helper.

## Testing (real, captured)

New test `test_create_inherits_runtime_provider_for_gateway_session` mocks `resolve_runtime_provider` to return an `openrouter` runtime and asserts the created job inherits it. It **fails without the fix** and passes with it:

```
# Without the source fix (test only):
$ .venv/bin/python -m pytest tests/tools/test_cronjob_tools.py -q -k inherits_runtime_provider
E   AssertionError: Expected 'mock' to be called once. Called 0 times.
1 failed, 62 deselected in 0.19s

# With the fix:
$ .venv/bin/python -m pytest tests/tools/test_cronjob_tools.py -q
63 passed in 0.86s
```

`py_compile` clean on both changed files.

## Note on re-targeting

`tools/cronjob_tools.py` is unchanged in shape on current main (helper added near `_normalize_optional_job_value`; callsite is the `create_job(...)` block). The `hermes_cli.runtime_provider.resolve_runtime_provider` import path and its `requested=` / `explicit_base_url=` keyword signature are unchanged, so the author's intended fix applied directly.