### PR TITLE
fix(whatsapp): resolve default bridge dir to repo root, not plugins/

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -261,8 +261,17 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     share it. Only transport-specific code lives here.
     """
 
-    # Default bridge location relative to the hermes-agent install
-    _DEFAULT_BRIDGE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "whatsapp-bridge"
+    # Default bridge location relative to the hermes-agent install.
+    # This file lives at plugins/platforms/whatsapp/adapter.py, so the repo
+    # root is parents[3] (whatsapp -> platforms -> plugins -> <root>). The
+    # installer (hermes_cli/main.py) writes the bridge to <root>/scripts/
+    # whatsapp-bridge/, so this MUST resolve to the same place. parents[2]
+    # (== plugins/) was a relocation off-by-one left over from when this
+    # adapter lived at gateway/platforms/whatsapp.py; it pointed at the
+    # nonexistent plugins/scripts/whatsapp-bridge/ and broke every gateway
+    # start with "Bridge script not found" until a manual symlink papered
+    # over it.
+    _DEFAULT_BRIDGE_DIR = Path(__file__).resolve().parents[3] / "scripts" / "whatsapp-bridge"
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WHATSAPP)

--- a/tests/gateway/test_whatsapp_bridge_path.py
+++ b/tests/gateway/test_whatsapp_bridge_path.py
@@ -1,0 +1,72 @@
+"""Regression test for the WhatsApp default bridge path resolution.
+
+The bug: ``WhatsAppAdapter._DEFAULT_BRIDGE_DIR`` used ``parents[2]`` from
+``plugins/platforms/whatsapp/adapter.py``, which resolves to
+``<repo>/plugins/scripts/whatsapp-bridge`` — a directory that does not
+exist. The installer (``hermes_cli/main.py``) writes the bridge to
+``<repo>/scripts/whatsapp-bridge``. The mismatch made every gateway start
+log ``Bridge script not found`` and fail to connect WhatsApp until a manual
+symlink papered over it. The line was correct when the adapter lived at
+``gateway/platforms/whatsapp.py`` (one directory shallower); relocating it
+into ``plugins/platforms/whatsapp/`` deepened it by one without bumping the
+index.
+
+These tests pin the invariant so a future relocation that breaks the index
+again fails loudly in CI instead of silently in production.
+"""
+
+from pathlib import Path
+
+
+# Repo root: this file is at <repo>/tests/gateway/test_whatsapp_bridge_path.py
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _installer_bridge_dir() -> Path:
+    """Mirror the path the installer writes the bridge to.
+
+    See ``hermes_cli/main.py``::
+
+        project_root = Path(__file__).resolve().parents[1]
+        bridge_dir = project_root / "scripts" / "whatsapp-bridge"
+    """
+    return _REPO_ROOT / "scripts" / "whatsapp-bridge"
+
+
+def test_default_bridge_dir_matches_installer_path():
+    """The adapter's default bridge dir must equal the installer's bridge dir.
+
+    This is the load-bearing invariant: if the adapter looks somewhere the
+    installer never writes, the gateway can never find the bridge after a
+    clean ``hermes update``.
+    """
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    assert WhatsAppAdapter._DEFAULT_BRIDGE_DIR == _installer_bridge_dir()
+
+
+def test_default_bridge_js_exists_on_disk():
+    """The resolved default bridge.js must actually exist in the repo tree.
+
+    Guards against the path drifting away from the committed bridge source.
+    """
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    bridge_js = WhatsAppAdapter._DEFAULT_BRIDGE_DIR / "bridge.js"
+    assert bridge_js.exists(), f"bridge.js missing at {bridge_js}"
+
+
+def test_default_bridge_dir_is_not_under_plugins():
+    """Negative guard: the old ``parents[2]`` bug pointed under plugins/.
+
+    The bridge lives at the repo root's ``scripts/``, never inside
+    ``plugins/``. If this ever resolves under ``plugins/`` again, the
+    off-by-one has regressed.
+    """
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    parts = WhatsAppAdapter._DEFAULT_BRIDGE_DIR.parts
+    assert "plugins" not in parts, (
+        f"bridge dir wrongly resolved under plugins/: "
+        f"{WhatsAppAdapter._DEFAULT_BRIDGE_DIR}"
+    )


### PR DESCRIPTION
## Summary

The WhatsApp adapter resolved its default bridge directory with `parents[2]` from `plugins/platforms/whatsapp/adapter.py`, which points at `<repo>/plugins/scripts/whatsapp-bridge` — a directory that never exists. The installer (`hermes_cli/main.py`) writes the bridge to `<repo>/scripts/whatsapp-bridge`. Every gateway start therefore logged `Bridge script not found` and WhatsApp failed to connect until a manual symlink papered over it; a clean `hermes update` re-breaks it.

## Root cause

The line was correct when the adapter lived at `gateway/platforms/whatsapp.py` (`parents[2]` == repo root). Relocating it into `plugins/platforms/whatsapp/` deepened the path by one directory without bumping the index. A `git log -L` on the line confirms it was introduced at the original shallower location and carried verbatim through the move.

```
plugins/platforms/whatsapp/adapter.py
  parents[2]  ->  <repo>/plugins/scripts/whatsapp-bridge   (nonexistent)
  parents[3]  ->  <repo>/scripts/whatsapp-bridge           (installer's path)  ✓
```

## Fix

Bump the index to `parents[3]` so the adapter's default bridge dir matches the installer's canonical path. No symlink, survives `hermes update`.

## Tests

Adds `tests/gateway/test_whatsapp_bridge_path.py` pinning the invariant:
- the adapter's default bridge dir must equal the installer's bridge dir (the load-bearing relationship, not a frozen literal)
- the resolved `bridge.js` must exist on disk
- the path must never resolve under `plugins/` again (negative guard against the off-by-one regressing)

## Test plan

- [x] `pytest tests/gateway/test_whatsapp_bridge_path.py tests/gateway/test_whatsapp_stale_bridge.py` → 14 passed
- [x] Removed the manual symlink crutch, restarted the gateway: the adapter passes the bridge-script-exists check and advances to the pairing check, instead of dying with `Bridge script not found`. Log shows the `Bridge script not found` warnings stop entirely after the fix.
