### PR TITLE
feat: add turn-scoped smart model routing

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -19,6 +19,7 @@ preserved.
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import re
@@ -47,7 +48,7 @@ from agent.tool_guardrails import (
     ToolCallGuardrailController,
     ToolGuardrailDecision,
 )
-from hermes_cli.config import cfg_get
+from hermes_cli.config import cfg_get, load_config
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
 from utils import base_url_host_matches, is_truthy_value
@@ -443,6 +444,10 @@ def init_agent(
     agent._execution_thread_id: int | None = None  # Set at run_conversation() start
     agent._interrupt_thread_signal_pending = False
     agent._client_lock = threading.RLock()
+    agent._smart_model_routing = copy.deepcopy(cfg_get(load_config(), "smart_model_routing", default={}) or {})
+    agent._smart_model_route_snapshot = None
+    agent._smart_model_route_activated = False
+    agent._smart_model_route_reason = None
 
     # /steer mechanism — inject a user note into the next tool result
     # without interrupting the agent. Unlike interrupt(), steer() does

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -973,6 +973,63 @@ def drop_thinking_only_and_merge_users(
 
 
 
+def _restore_runtime_snapshot(agent, rt: dict, *, reason: str) -> bool:
+    """Restore a previously captured runtime snapshot onto the live agent."""
+    try:
+        # ── Core runtime state ──
+        agent.model = rt["model"]
+        agent.provider = rt["provider"]
+        agent.base_url = rt["base_url"]           # setter updates _base_url_lower
+        agent.api_mode = rt["api_mode"]
+        if hasattr(agent, "_transport_cache"):
+            agent._transport_cache.clear()
+        agent.api_key = rt["api_key"]
+        agent._client_kwargs = dict(rt["client_kwargs"])
+        agent._use_prompt_caching = rt["use_prompt_caching"]
+        # Default to native layout when the restored snapshot predates the
+        # native-vs-proxy split (older sessions saved before this PR).
+        agent._use_native_cache_layout = rt.get(
+            "use_native_cache_layout",
+            agent.api_mode == "anthropic_messages" and agent.provider == "anthropic",
+        )
+
+        # ── Rebuild client for the restored provider ──
+        if agent.api_mode == "anthropic_messages":
+            from agent.anthropic_adapter import build_anthropic_client
+            agent._anthropic_api_key = rt.get("anthropic_api_key", rt["api_key"])
+            agent._anthropic_base_url = rt.get("anthropic_base_url", rt["base_url"])
+            agent._anthropic_client = build_anthropic_client(
+                agent._anthropic_api_key,
+                agent._anthropic_base_url,
+                timeout=get_provider_request_timeout(agent.provider, agent.model) or 1800.0,
+            )
+            agent._is_anthropic_oauth = rt.get("is_anthropic_oauth", False)
+            agent.client = None
+        else:
+            agent.client = agent._create_openai_client(
+                dict(rt["client_kwargs"]),
+                reason=reason,
+                shared=True,
+            )
+
+        # ── Restore context engine state ──
+        cc = agent.context_compressor
+        cc.update_model(
+            model=rt["compressor_model"],
+            context_length=rt["compressor_context_length"],
+            base_url=rt["compressor_base_url"],
+            api_key=rt["compressor_api_key"],
+            provider=rt["compressor_provider"],
+            api_mode=rt.get("compressor_api_mode", ""),
+        )
+        if rt.get("compressor_threshold_tokens"):
+            cc.threshold_tokens = rt["compressor_threshold_tokens"]
+        return True
+    except Exception as e:
+        logger.warning("Failed to restore runtime snapshot: %s", e)
+        return False
+
+
 def restore_primary_runtime(agent) -> bool:
     """Restore the primary runtime at the start of a new turn.
 
@@ -998,71 +1055,142 @@ def restore_primary_runtime(agent) -> bool:
     if getattr(agent, "_rate_limited_until", 0) > time.monotonic():
         return False  # primary still in rate-limit cooldown, stay on fallback
 
-    rt = agent._primary_runtime
-    try:
-        # ── Core runtime state ──
-        agent.model = rt["model"]
-        agent.provider = rt["provider"]
-        agent.base_url = rt["base_url"]           # setter updates _base_url_lower
-        agent.api_mode = rt["api_mode"]
-        if hasattr(agent, "_transport_cache"):
-            agent._transport_cache.clear()
-        agent.api_key = rt["api_key"]
-        agent._client_kwargs = dict(rt["client_kwargs"])
-        agent._use_prompt_caching = rt["use_prompt_caching"]
-        # Default to native layout when the restored snapshot predates the
-        # native-vs-proxy split (older sessions saved before this PR).
-        agent._use_native_cache_layout = rt.get(
-            "use_native_cache_layout",
-            agent.api_mode == "anthropic_messages" and agent.provider == "anthropic",
-        )
-
-        # ── Rebuild client for the primary provider ──
-        if agent.api_mode == "anthropic_messages":
-            from agent.anthropic_adapter import build_anthropic_client
-            agent._anthropic_api_key = rt["anthropic_api_key"]
-            agent._anthropic_base_url = rt["anthropic_base_url"]
-            agent._anthropic_client = build_anthropic_client(
-                rt["anthropic_api_key"], rt["anthropic_base_url"],
-                timeout=get_provider_request_timeout(agent.provider, agent.model),
-            )
-            agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
-            agent.client = None
-        else:
-            agent.client = agent._create_openai_client(
-                dict(rt["client_kwargs"]),
-                reason="restore_primary",
-                shared=True,
-            )
-
-        # ── Restore context engine state ──
-        cc = agent.context_compressor
-        cc.update_model(
-            model=rt["compressor_model"],
-            context_length=rt["compressor_context_length"],
-            base_url=rt["compressor_base_url"],
-            api_key=rt["compressor_api_key"],
-            provider=rt["compressor_provider"],
-            api_mode=rt.get("compressor_api_mode", ""),
-        )
-
-        # ── Reset fallback chain for the new turn ──
+    restored = _restore_runtime_snapshot(agent, agent._primary_runtime, reason="restore_primary")
+    if restored:
         agent._fallback_activated = False
         agent._fallback_index = 0
 
         # Undo the fallback's identity rewrite so the prompt is
         # byte-identical to the stored copy again (prefix cache match).
         from agent.chat_completion_helpers import rewrite_prompt_model_identity
-        rewrite_prompt_model_identity(agent, rt["model"], rt["provider"])
+        rewrite_prompt_model_identity(
+            agent,
+            agent._primary_runtime["model"],
+            agent._primary_runtime["provider"],
+        )
 
         logger.info(
             "Primary runtime restored for new turn: %s (%s)",
             agent.model, agent.provider,
         )
-        return True
-    except Exception as e:
-        logger.warning("Failed to restore primary runtime: %s", e)
+    return restored
+
+
+def restore_turn_model_route(agent) -> bool:
+    """Undo the previous turn's smart-route so the next turn starts on primary."""
+    if not getattr(agent, "_smart_model_route_activated", False):
         return False
+
+    rt = getattr(agent, "_smart_model_route_snapshot", None)
+    restored = _restore_runtime_snapshot(agent, rt, reason="restore_turn_route") if rt else False
+    agent._smart_model_route_snapshot = None
+    agent._smart_model_route_activated = False
+    agent._smart_model_route_reason = None
+    return restored
+
+
+_SMART_COMPLEX_PATTERNS = (
+    r"\b(debug|bug|fix|refactor|implement|architecture|migration|deploy|deployment|ci/cd|test|tests|failing|error|traceback|stack trace|performance|optimi[sz]e)\b",
+    r"\b(api|database|schema|sql|python|javascript|typescript|react|vite|node|supabase|vercel|docker|git)\b",
+    r"(코드|코딩|디버깅|버그|에러|오류|리팩터링|구현|배포|설정|마이그레이션|성능|테스트|서버|DB|데이터베이스|스키마|깃|도커|수정해|고쳐줘)",
+)
+
+_SMART_SIMPLE_PATTERNS = (
+    r"(요약|정리|번역|맞춤법|짧게|한줄|한 줄|아이디어|브레인스토밍|제목|카피)",
+    r"\b(summary|summarize|translate|rewrite|brainstorm|idea|headline|title|copy)\b",
+)
+
+
+def _smart_route_decision(agent, user_message: str) -> tuple[str, str]:
+    cfg = getattr(agent, "_smart_model_routing", {}) or {}
+    text = (user_message or "").strip()
+    short_threshold = int(cfg.get("short_prompt_threshold") or 180)
+    long_threshold = int(cfg.get("long_prompt_threshold") or 500)
+
+    if not text:
+        return "primary", "empty_prompt"
+
+    text_lower = text.lower()
+    length = len(text)
+    complex_hit = any(re.search(p, text_lower, re.I) for p in _SMART_COMPLEX_PATTERNS)
+    simple_hit = any(re.search(p, text_lower, re.I) for p in _SMART_SIMPLE_PATTERNS)
+
+    if "```" in text or ("\n" in text and length >= short_threshold):
+        return "primary", "multiline_prompt"
+    if length >= long_threshold:
+        return "primary", f"long_prompt:{length}"
+    if complex_hit:
+        return "primary", "complex_keywords"
+    if simple_hit and length <= max(short_threshold + 120, 300):
+        return "cheap", "simple_keywords"
+    if length <= short_threshold:
+        return "cheap", f"short_prompt:{length}"
+    return "primary", f"mid_prompt:{length}"
+
+
+def maybe_route_turn_model(agent, user_message: str) -> bool:
+    """Route obviously simple turns to the configured cheap model."""
+    cfg = getattr(agent, "_smart_model_routing", {}) or {}
+    if not cfg.get("enabled"):
+        return False
+
+    cheap_model = str(cfg.get("cheap_model") or "").strip()
+    if not cheap_model:
+        return False
+
+    primary = getattr(agent, "_primary_runtime", None) or {}
+    if not primary.get("model"):
+        return False
+
+    decision, reason = _smart_route_decision(agent, user_message)
+    if decision != "cheap":
+        return False
+
+    cheap_provider = str(cfg.get("cheap_provider") or primary.get("provider") or agent.provider or "").strip().lower()
+    cheap_base_url = str(cfg.get("cheap_base_url") or primary.get("base_url") or agent.base_url or "").strip()
+    cheap_api_mode = str(cfg.get("cheap_api_mode") or "").strip()
+    current_provider = (agent.provider or "").strip().lower()
+    current_base_url = str(agent.base_url or "").strip()
+
+    if (
+        cheap_model == (agent.model or "")
+        and cheap_provider == current_provider
+        and cheap_base_url == current_base_url
+    ):
+        return False
+
+    primary_snapshot = copy.deepcopy(primary)
+    fallback_chain_snapshot = copy.deepcopy(getattr(agent, "_fallback_chain", []) or [])
+    fallback_model_snapshot = copy.deepcopy(getattr(agent, "_fallback_model", None))
+    fallback_index_snapshot = getattr(agent, "_fallback_index", 0)
+    fallback_activated_snapshot = getattr(agent, "_fallback_activated", False)
+
+    switch_model(
+        agent,
+        cheap_model,
+        cheap_provider,
+        api_key=primary_snapshot.get("api_key", getattr(agent, "api_key", "")),
+        base_url=cheap_base_url,
+        api_mode=cheap_api_mode,
+    )
+    agent._primary_runtime = primary_snapshot
+    agent._fallback_chain = fallback_chain_snapshot
+    agent._fallback_model = fallback_model_snapshot
+    agent._fallback_index = fallback_index_snapshot
+    agent._fallback_activated = fallback_activated_snapshot
+    agent._smart_model_route_snapshot = primary_snapshot
+    agent._smart_model_route_activated = True
+    agent._smart_model_route_reason = reason
+
+    logger.info(
+        "Turn smart-routing activated: %s (%s) -> %s (%s) reason=%s",
+        primary_snapshot.get("model"),
+        primary_snapshot.get("provider"),
+        cheap_model,
+        cheap_provider,
+        reason,
+    )
+    return True
 
 # Which error types indicate a transient transport failure worth
 # one more attempt with a rebuilt client / connection pool.

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -90,7 +90,22 @@ def build_turn_context(
 
     agent._ensure_db_session()
 
+    # Tag log records on this thread with the session ID for ``hermes logs``.
+    set_session_context(agent.session_id)
+
+    # Bind the skill write-origin ContextVar for this thread.
+    set_current_write_origin(getattr(agent, "_memory_write_origin", "assistant_tool"))
+
+    # Start each new turn back on the primary runtime, then optionally route
+    # obviously simple prompts to a cheap model. The cheap route is turn-scoped
+    # and gets undone at the beginning of the next turn.
+    agent._restore_turn_model_route()
+    agent._restore_primary_runtime()
+    agent._maybe_route_turn_model(user_message)
+
     # Tell auxiliary_client what the live main provider/model are for this turn.
+    # This happens *after* restore/routing so tool behavior sees the effective
+    # runtime actually answering the turn, not the stale pre-restore state.
     try:
         from agent.auxiliary_client import set_runtime_main
         set_runtime_main(
@@ -102,15 +117,6 @@ def build_turn_context(
         )
     except Exception:
         pass
-
-    # Tag log records on this thread with the session ID for ``hermes logs``.
-    set_session_context(agent.session_id)
-
-    # Bind the skill write-origin ContextVar for this thread.
-    set_current_write_origin(getattr(agent, "_memory_write_origin", "assistant_tool"))
-
-    # Restore the primary runtime if the previous turn activated fallback.
-    agent._restore_primary_runtime()
 
     # Between-turns MCP refresh: an MCP server that finished connecting since
     # the previous turn (slow HTTP/OAuth servers routinely take 2-6s on a cold

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -883,6 +883,19 @@ def _ensure_hermes_home_managed(home: Path):
 DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
+    # Route obviously light-weight prompts to a cheaper/faster model while
+    # keeping the configured primary model for harder turns. Disabled by
+    # default; when enabled the primary runtime remains the session's source
+    # of truth and the cheap route is turn-scoped.
+    "smart_model_routing": {
+        "enabled": False,
+        "cheap_model": "",
+        "cheap_provider": "",
+        "cheap_base_url": "",
+        "cheap_api_mode": "",
+        "short_prompt_threshold": 180,
+        "long_prompt_threshold": 500,
+    },
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
@@ -4376,7 +4389,7 @@ def check_config_version() -> Tuple[int, int]:
 
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
-    "_config_version", "model", "providers", "fallback_model",
+    "_config_version", "model", "providers", "smart_model_routing", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",

--- a/run_agent.py
+++ b/run_agent.py
@@ -4325,6 +4325,16 @@ class AIAgent:
         from agent.agent_runtime_helpers import restore_primary_runtime
         return restore_primary_runtime(self)
 
+    def _restore_turn_model_route(self) -> bool:
+        """Forwarder — see ``agent.agent_runtime_helpers.restore_turn_model_route``."""
+        from agent.agent_runtime_helpers import restore_turn_model_route
+        return restore_turn_model_route(self)
+
+    def _maybe_route_turn_model(self, user_message: str) -> bool:
+        """Forwarder — see ``agent.agent_runtime_helpers.maybe_route_turn_model``."""
+        from agent.agent_runtime_helpers import maybe_route_turn_model
+        return maybe_route_turn_model(self, user_message)
+
     def _try_recover_primary_transport(
         self, api_error: Exception, *, retry_count: int, max_retries: int,
     ) -> bool:

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -76,8 +76,14 @@ class _FakeAgent:
     def _ensure_db_session(self):
         pass
 
+    def _restore_turn_model_route(self):
+        return False
+
     def _restore_primary_runtime(self):
-        pass
+        return False
+
+    def _maybe_route_turn_model(self, _user_message):
+        return False
 
     def _cleanup_dead_connections(self):
         return False

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -10,7 +10,11 @@ Verifies that:
 """
 
 import time
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
 
 
 from run_agent import AIAgent
@@ -210,6 +214,60 @@ class TestRestorePrimaryRuntime:
             result = agent._restore_primary_runtime()
 
         assert result is False
+
+
+# =============================================================================
+# smart_model_routing turn restore
+# =============================================================================
+
+class TestSmartModelRouting:
+    def test_turn_scoped_route_restores_primary_and_can_reroute(self):
+        agent = cast(Any, _make_agent(provider="openai-codex", base_url="https://api.openai.com/v1"))
+        agent.model = "gpt-5.4"
+        agent._primary_runtime["model"] = "gpt-5.4"
+        original_model = agent.model
+        original_provider = agent.provider
+        original_base_url = agent.base_url
+
+        agent._smart_model_routing = {
+            "enabled": True,
+            "cheap_model": "gpt-5.3-codex-spark",
+            "cheap_provider": original_provider,
+            "cheap_base_url": original_base_url,
+            "short_prompt_threshold": 180,
+            "long_prompt_threshold": 500,
+        }
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            # Turn 1: a simple summary prompt should route to the cheap model.
+            assert agent._maybe_route_turn_model("이 문장을 한 줄로 요약해줘") is True
+            assert agent.model == "gpt-5.3-codex-spark"
+            assert agent._smart_model_route_activated is True
+            assert agent._smart_model_route_reason == "simple_keywords"
+
+            # Turn 2 start: the prior cheap route must be undone before routing again.
+            assert agent._restore_turn_model_route() is True
+            assert agent._restore_primary_runtime() is False
+            assert agent.model == original_model
+            assert agent.provider == original_provider
+            assert agent.base_url == original_base_url
+            assert agent._smart_model_route_snapshot is None
+            assert agent._smart_model_route_activated is False
+            assert agent._smart_model_route_reason is None
+
+            # A complex coding/debugging prompt must stay on the primary model.
+            assert agent._maybe_route_turn_model("파이썬 traceback 에러를 디버깅해줘") is False
+            assert agent.model == original_model
+            assert agent.provider == original_provider
+            assert agent.base_url == original_base_url
+
+            # Turn 3: after a primary-only turn, a new simple prompt can route cheap again.
+            assert agent._restore_turn_model_route() is False
+            assert agent._restore_primary_runtime() is False
+            assert agent._maybe_route_turn_model("한 줄로 다듬어줘") is True
+            assert agent.model == "gpt-5.3-codex-spark"
+            assert agent._smart_model_route_activated is True
+            assert agent._smart_model_route_reason == "simple_keywords"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- add turn-scoped smart model routing config and runtime state
- restore the primary runtime before each turn and re-route simple prompts to the cheap model
- extend regression coverage for runtime restore, turn context, and cheap → primary → cheap rerouting

## Test Plan
- /Users/aion/Projects/hermes-agent/venv/bin/python -m py_compile agent/agent_init.py agent/agent_runtime_helpers.py agent/conversation_loop.py agent/turn_context.py hermes_cli/config.py run_agent.py
- /Users/aion/Projects/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_primary_runtime_restore.py -q -o addopts=
- /Users/aion/Projects/hermes-agent/venv/bin/python -m pytest tests/agent/test_turn_context.py -q -o addopts=
- direct 3-turn runtime smoke test in clean worktree: cheap → primary → cheap verified in agent.log