### PR TITLE
fix(agent): emit only extracted reasoning progress

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3689,11 +3689,8 @@ def run_conversation(
                         agent.tool_progress_callback("_thinking", first_line)
                     except Exception:
                         pass
-                elif _think_text:
-                    try:
-                        agent.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
-                    except Exception:
-                        pass
+                else:
+                    agent._fire_reasoning_available(assistant_message)
             
             # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
             # This means the model ran out of output tokens mid-reasoning — retry up to 2 times

--- a/run_agent.py
+++ b/run_agent.py
@@ -4272,6 +4272,26 @@ class AIAgent:
             except Exception:
                 pass
 
+    def _fire_reasoning_available(self, assistant_message) -> None:
+        """Fire structured reasoning progress if registered.
+
+        This reuses the existing reasoning extractor so the callback only
+        receives tagged/structured reasoning, never ordinary assistant reply
+        text.
+        """
+        cb = self.tool_progress_callback
+        if cb is None:
+            return
+
+        reasoning_text = self._extract_reasoning(assistant_message)
+        if not reasoning_text:
+            return
+
+        try:
+            cb("reasoning.available", "_thinking", reasoning_text[:500], None)
+        except Exception:
+            pass
+
     def _fire_tool_gen_started(self, tool_name: str) -> None:
         """Notify display layer that the model is generating tool call arguments.
 

--- a/tests/agent/test_subagent_progress.py
+++ b/tests/agent/test_subagent_progress.py
@@ -320,6 +320,18 @@ class TestThinkingCallback:
         )
         assert len(calls) == 0
 
+    def test_thinking_callback_keeps_stripped_preview(self):
+        """Subagent thinking relay should still expose the stripped preview."""
+        calls = []
+        self._simulate_thinking_callback(
+            "<think>internal reasoning</think> visible summary",
+            lambda name, preview=None: calls.append((name, preview))
+        )
+        assert len(calls) == 1
+        assert calls[0][0] == "_thinking"
+        assert "internal reasoning" in calls[0][1]
+        assert "visible summary" in calls[0][1]
+
 
 # =========================================================================
 # Gateway batch flush tests

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2039,6 +2039,30 @@ class TestBuildAssistantMessage:
         assert result["content"] == ""
 
 
+class TestReasoningAvailableProgress:
+    def test_emits_only_extracted_reasoning(self, agent):
+        calls = []
+        agent.tool_progress_callback = lambda *args, **kwargs: calls.append(args)
+
+        msg = _mock_assistant_msg(
+            content="<think>internal analysis</think>The actual answer."
+        )
+
+        agent._fire_reasoning_available(msg)
+
+        assert calls == [("reasoning.available", "_thinking", "internal analysis", None)]
+
+    def test_skips_plain_answer_text(self, agent):
+        calls = []
+        agent.tool_progress_callback = lambda *args, **kwargs: calls.append(args)
+
+        msg = _mock_assistant_msg(content="The actual answer only.")
+
+        agent._fire_reasoning_available(msg)
+
+        assert calls == []
+
+
 class TestFormatToolsForSystemMessage:
     def test_no_tools_returns_empty_array(self, agent):
         agent.tools = []


### PR DESCRIPTION
## Summary

The conversation loop emitted the entire stripped assistant message content as a `reasoning.available` progress event. For models that don't wrap their reasoning in tags, this leaked the plain answer text to the display layer as if it were reasoning. This routes the event through the existing reasoning extractor so only genuinely tagged/structured reasoning is emitted.

**Salvage of #13326 by @sgaofen** — re-targeted onto the restructured tree.

## Problem / root cause

In the post-response progress block:

```python
_think_text = assistant_message.content.strip()
_think_text = re.sub(r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text).strip()
...
elif _think_text:
    agent.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
```

`_think_text` is just the assistant content with a few tag names stripped — not extracted reasoning. So a model that returns a plain answer (no `<think>`/structured reasoning) still fired `reasoning.available` carrying the answer text.

## The fix

- Add `Agent._fire_reasoning_available(assistant_message)` (next to `_fire_reasoning_delta` in `run_agent.py`). It calls the existing `self._extract_reasoning(...)` — which forwards to `agent.agent_runtime_helpers.extract_reasoning` — and only fires `reasoning.available` when real reasoning is found.
- Replace the `elif _think_text:` branch in the loop with `agent._fire_reasoning_available(assistant_message)`.
- The first-line subagent relay path (`_delegate_depth > 0`) is untouched.

## Testing (real, captured)

New `TestReasoningAvailableProgress` asserts reasoning is emitted only when tagged and that plain answers emit nothing. Both **fail without the fix** (method absent) and pass with it; plus a subagent-relay preview test:

```
# Without the source fix:
$ .venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestReasoningAvailableProgress -q
tests/run_agent/test_run_agent.py:2061: AttributeError
2 failed in 1.65s

# With the fix:
$ .venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestReasoningAvailableProgress -q
2 passed in 1.45s
$ .venv/bin/python -m pytest tests/agent/test_subagent_progress.py -q
22 passed in 0.34s
```

`py_compile` clean on all four changed files.

## Note on re-targeting

The emit logic moved out of `run_agent.py` into `agent/conversation_loop.py` (~line 3692) in the restructure. The new `_fire_reasoning_available` method lives on the `Agent` class in `run_agent.py`; the module-level loop invokes it via `agent._fire_reasoning_available(...)`. 4 files, ~50 lines — kept surgical.