### PR TITLE
fix(agent): omit tools from API requests when tool_use_enforcement is never/false

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -554,7 +554,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
-    tools_for_api = agent.tools
+    tools_for_api = agent._tools_for_api()
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -916,11 +916,14 @@ DEFAULT_CONFIG = {
         # provider hiccups on a single provider.
         "api_max_retries": 3,
         "service_tier": "",
-        # Tool-use enforcement: injects system prompt guidance that tells the
-        # model to actually call tools instead of describing intended actions.
-        # Values: "auto" (default — applies to gpt/codex models), true/false
-        # (force on/off for all models), or a list of model-name substrings
-        # to match (e.g. ["gpt", "codex", "gemini", "qwen"]).
+        # Tool-use enforcement: controls prompt injection AND whether tools are
+        # sent in API requests.
+        # Values: "auto" (default — injects guidance for known gpt/codex models,
+        # sends tools normally), true/always/yes/on (always inject + send tools),
+        # false/never/no/off (suppress guidance AND omit tools from API requests
+        # — needed for models that reject the tools parameter, e.g. deepseek-r1),
+        # or a list of model-name substrings to match (e.g. ["gpt", "codex",
+        # "gemini", "qwen"]).
         "tool_use_enforcement": "auto",
         # Universal "finish the job" guidance — short prompt block applied to
         # all models that targets two cross-family failure modes: (1) stopping

--- a/run_agent.py
+++ b/run_agent.py
@@ -4834,6 +4834,20 @@ class AIAgent:
                     content[-1]["cache_control"] = {"type": "ephemeral"}
                 break
 
+    def _tools_for_api(self):
+        """Return self.tools unless tool_use_enforcement is explicitly disabled.
+
+        When enforcement is set to false/never/no/off, tools are omitted from
+        API requests entirely — needed for models that reject the tools
+        parameter (e.g. deepseek-r1 via Ollama).
+        """
+        _enforce = getattr(self, "_tool_use_enforcement", "auto")
+        if _enforce is False or (
+            isinstance(_enforce, str) and _enforce.lower() in ("false", "never", "no", "off")
+        ):
+            return None
+        return self.tools
+
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Forwarder — see ``agent.chat_completion_helpers.build_api_kwargs``."""
         from agent.chat_completion_helpers import build_api_kwargs

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1351,6 +1351,34 @@ class TestToolUseEnforcementConfig:
             prompt = a._build_system_prompt()
             assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
 
+    def test_never_omits_tools_from_api_kwargs(self):
+        """When enforcement='never', tools should NOT be in API kwargs."""
+        agent = self._make_agent(tool_use_enforcement="never")
+        assert agent.tools  # tools are still loaded internally
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "tools" not in kwargs
+
+    def test_false_omits_tools_from_api_kwargs(self):
+        """When enforcement=False, tools should NOT be in API kwargs."""
+        agent = self._make_agent(tool_use_enforcement=False)
+        assert agent.tools
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "tools" not in kwargs
+
+    def test_auto_includes_tools_in_api_kwargs(self):
+        """When enforcement='auto', tools should be included normally."""
+        agent = self._make_agent(tool_use_enforcement="auto")
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "tools" in kwargs
+
+    def test_tools_for_api_defaults_to_tools_when_attr_missing(self):
+        """Partially-initialized agents (object.__new__, no agent_init) lack
+        _tool_use_enforcement. _tools_for_api() must default to sending tools
+        instead of raising AttributeError."""
+        agent = object.__new__(AIAgent)
+        agent.tools = [{"type": "function", "function": {"name": "x"}}]
+        assert agent._tools_for_api() == agent.tools
+
 
 class TestTaskCompletionGuidance:
     """Tests for the universal task-completion / no-fabrication guidance


### PR DESCRIPTION
## Summary

`build_api_kwargs` always sent `tools=agent.tools` regardless of `tool_use_enforcement`. Models that reject the `tools` parameter (e.g. deepseek-r1 via Ollama) errored out even when the operator explicitly disabled enforcement. This omits `tools` from the request when enforcement is `false`/`never`/`no`/`off`.

**Salvage of #13950 by @ennian001** — re-targeted onto the restructured tree.

## Problem / root cause

`tool_use_enforcement` only gated *system-prompt* injection. The API request always carried the full tool list, so disabling enforcement did nothing for providers that 400 on `tools`. There was no way to actually stop sending tools short of unloading them.

## The fix

- Add `Agent._tools_for_api()`: returns `None` when `_tool_use_enforcement` is `False` or a string in `{"false","never","no","off"}`; otherwise returns `self.tools`.
- Route the single `tools_for_api = agent.tools` assignment in `build_api_kwargs` through it. That one change covers all four `api_mode` branches (`anthropic_messages`, `bedrock_converse`, `codex_responses`, `chat_completions`) since they all read `tools_for_api`. Transports drop the key when `tools is None`, so `tools` is omitted from the request body.
- Update the `tool_use_enforcement` config doc-comment in `hermes_cli/config.py` to document the new send/omit semantics.

Tools stay loaded internally (`agent.tools` is unchanged) — only the outbound request is affected.

## Testing (real, captured)

Three new tests in `TestToolUseEnforcementConfig` (tools still loaded, but omitted from kwargs when disabled / included on auto). The two omit-tests **fail without the fix**; `auto` correctly passes both ways:

```
# Without the source fix (tests + config only):
$ .venv/bin/python -m pytest tests/run_agent/test_run_agent.py -q -k "omits_tools_from_api_kwargs or auto_includes_tools_in_api_kwargs"
>       assert "tools" not in kwargs
E       AssertionError: assert 'tools' not in {... 'tools': [...]}
2 failed, 1 passed, 384 deselected in 1.44s

# With the fix (whole enforcement suite):
$ .venv/bin/python -m pytest tests/run_agent/test_run_agent.py -q -k TestToolUseEnforcementConfig
21 passed, 366 deselected in 8.57s
```

`py_compile` clean on all four changed files.

## Note on re-targeting

`build_api_kwargs` moved from `run_agent.py` to `agent/chat_completion_helpers.py` and now sets `tools_for_api` once at the top, so a single callsite edit replaces the four separate `tools=self.tools` edits in the original PR. The `_tools_for_api` method lives on the `Agent` class in `run_agent.py` (next to `_qwen_prepare_chat_messages_inplace`); the `hermes_cli/config.py` doc change applies unchanged. The xAI schema-sanitize branch already guards against a `None` tool list via try/except.