### PR TITLE
fix: speed up profile alias scanning

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -34,6 +34,11 @@ from typing import List, Optional, Tuple
 from agent.skill_utils import is_excluded_skill_path
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_WRAPPER_PROFILE_RE = re.compile(
+    r"(?:^|[/\\\s])hermes(?:\.exe)?\s+-p\s+([a-z0-9][a-z0-9_-]{0,63})\b",
+    re.IGNORECASE,
+)
+_WRAPPER_SCAN_MAX_BYTES = 64 * 1024
 
 # Directories bootstrapped inside every new profile
 _PROFILE_DIRS = [
@@ -486,6 +491,82 @@ def _migrate_profile_config_if_outdated(profile_dir: Path) -> None:
         pass
 
 
+def _is_wrapper_candidate(entry: Path, *, is_windows: bool) -> bool:
+    """Return True when *entry* could be a Hermes profile wrapper."""
+    if not entry.is_file():
+        return False
+    if is_windows:
+        return entry.suffix.lower() == ".bat"
+    return not entry.suffix
+
+
+def _read_wrapper_candidate(entry: Path) -> Optional[str]:
+    """Read a small wrapper candidate, skipping binaries/large executables.
+
+    Hermes-created wrappers are tiny shell/batch scripts.  ``~/.local/bin`` also
+    commonly contains large extensionless binaries (node, claude, agy, etc.);
+    reading each of those for every profile turns ``profile list`` into a large
+    repeated I/O scan.  Oversized files cannot be wrappers we created, so skip
+    them before opening the file at all.
+    """
+    try:
+        if entry.stat().st_size > _WRAPPER_SCAN_MAX_BYTES:
+            return None
+        return entry.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _wrapper_target_profile(content: str) -> Optional[str]:
+    match = _WRAPPER_PROFILE_RE.search(content)
+    if not match:
+        return None
+    try:
+        return normalize_profile_name(match.group(1))
+    except ValueError:
+        return None
+
+
+def _scan_profile_aliases(profile_names: List[str]) -> dict[str, str]:
+    """Return ``profile_name -> alias_name`` for Hermes wrappers.
+
+    Scans ``~/.local/bin`` once for all requested profiles.  A custom alias is
+    preferred over the profile-named wrapper, matching the historical
+    ``find_alias_for_profile`` contract.
+    """
+    wanted = {normalize_profile_name(name) for name in profile_names}
+    if not wanted:
+        return {}
+
+    wrapper_dir = _get_wrapper_dir()
+    if not wrapper_dir.is_dir():
+        return {}
+
+    is_windows = sys.platform == "win32"
+    custom: dict[str, str] = {}
+    profile_named: dict[str, str] = {}
+
+    for entry in sorted(wrapper_dir.iterdir()):
+        if not _is_wrapper_candidate(entry, is_windows=is_windows):
+            continue
+        content = _read_wrapper_candidate(entry)
+        if not content:
+            continue
+        target = _wrapper_target_profile(content)
+        if target not in wanted:
+            continue
+        alias = entry.stem if is_windows else entry.name
+        if alias == target:
+            profile_named.setdefault(target, alias)
+        else:
+            custom.setdefault(target, alias)
+
+    aliases = dict(custom)
+    for profile, alias in profile_named.items():
+        aliases.setdefault(profile, alias)
+    return aliases
+
+
 def find_alias_for_profile(profile_name: str) -> Optional[str]:
     """Return the alias name of the wrapper that activates *profile_name*, or None.
 
@@ -499,35 +580,8 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
     so ``profile list``/``show`` surface the command the user actually typed.
     Results are sorted for deterministic output when several aliases match.
     """
-    wrapper_dir = _get_wrapper_dir()
-    if not wrapper_dir.is_dir():
-        return None
     canon = normalize_profile_name(profile_name)
-    is_windows = sys.platform == "win32"
-    needle = f"hermes -p {canon}"
-
-    custom: Optional[str] = None
-    profile_named: Optional[str] = None
-    for entry in sorted(wrapper_dir.iterdir()):
-        if not entry.is_file():
-            continue
-        # Only our own wrappers are named with the alias and (on Windows) .bat.
-        if is_windows and entry.suffix != ".bat":
-            continue
-        if not is_windows and entry.suffix:
-            continue
-        try:
-            content = entry.read_text()
-        except (OSError, UnicodeDecodeError):
-            continue
-        if needle not in content:
-            continue
-        alias = entry.stem if is_windows else entry.name
-        if alias == canon:
-            profile_named = alias
-        elif custom is None:
-            custom = alias
-    return custom if custom is not None else profile_named
+    return _scan_profile_aliases([canon]).get(canon)
 
 
 # ---------------------------------------------------------------------------
@@ -742,6 +796,7 @@ def list_profiles() -> List[ProfileInfo]:
 
     # Named profiles
     profiles_root = _get_profiles_root()
+    named_entries: List[Tuple[str, Path]] = []
     if profiles_root.is_dir():
         for entry in sorted(profiles_root.iterdir()):
             if not entry.is_dir():
@@ -751,32 +806,36 @@ def list_profiles() -> List[ProfileInfo]:
                 continue  # already added as the built-in default above
             if not _PROFILE_ID_RE.match(name):
                 continue
-            model, provider = _read_config_model(entry)
-            alias_name = find_alias_for_profile(name)
-            if alias_name:
-                is_windows = sys.platform == "win32"
-                alias_path = wrapper_dir / (f"{alias_name}.bat" if is_windows else alias_name)
-            else:
-                alias_path = None
-            dist_name, dist_version, dist_source = _read_distribution_meta(entry)
-            meta = read_profile_meta(entry)
-            profiles.append(ProfileInfo(
-                name=name,
-                path=entry,
-                is_default=False,
-                gateway_running=_check_gateway_running(entry),
-                model=model,
-                provider=provider,
-                has_env=(entry / ".env").exists(),
-                skill_count=_count_skills(entry),
-                alias_path=alias_path if (alias_path and alias_path.exists()) else None,
-                alias_name=alias_name,
-                distribution_name=dist_name,
-                distribution_version=dist_version,
-                distribution_source=dist_source,
-                description=meta.get("description", ""),
-                description_auto=meta.get("description_auto", False),
-            ))
+            named_entries.append((name, entry))
+
+    alias_by_profile = _scan_profile_aliases([name for name, _ in named_entries])
+    for name, entry in named_entries:
+        model, provider = _read_config_model(entry)
+        alias_name = alias_by_profile.get(name)
+        if alias_name:
+            is_windows = sys.platform == "win32"
+            alias_path = wrapper_dir / (f"{alias_name}.bat" if is_windows else alias_name)
+        else:
+            alias_path = None
+        dist_name, dist_version, dist_source = _read_distribution_meta(entry)
+        meta = read_profile_meta(entry)
+        profiles.append(ProfileInfo(
+            name=name,
+            path=entry,
+            is_default=False,
+            gateway_running=_check_gateway_running(entry),
+            model=model,
+            provider=provider,
+            has_env=(entry / ".env").exists(),
+            skill_count=_count_skills(entry),
+            alias_path=alias_path if (alias_path and alias_path.exists()) else None,
+            alias_name=alias_name,
+            distribution_name=dist_name,
+            distribution_version=dist_version,
+            distribution_source=dist_source,
+            description=meta.get("description", ""),
+            description_auto=meta.get("description_auto", False),
+        ))
 
     return profiles
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -617,6 +617,53 @@ class TestListProfiles:
         assert profiles[0].name == "default"
         assert profiles[0].is_default is True
 
+    def test_alias_lookup_scans_wrapper_dir_once(self, profile_env, monkeypatch):
+        create_profile("alpha", no_alias=True)
+        create_profile("beta", no_alias=True)
+        wrapper_dir = profile_env / ".local" / "bin"
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        (wrapper_dir / "alpha").write_text('#!/bin/sh\nexec hermes -p alpha "$@"\n')
+        (wrapper_dir / "custom-beta").write_text('#!/bin/sh\nexec hermes -p beta "$@"\n')
+
+        original_read_text = Path.read_text
+        reads = []
+
+        def counting_read_text(self, *args, **kwargs):
+            if self.parent == wrapper_dir:
+                reads.append(self.name)
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", counting_read_text)
+
+        profiles = list_profiles()
+        by_name = {profile.name: profile for profile in profiles}
+
+        assert by_name["alpha"].alias_name == "alpha"
+        assert by_name["beta"].alias_name == "custom-beta"
+        assert reads.count("alpha") == 1
+        assert reads.count("custom-beta") == 1
+
+    def test_alias_lookup_skips_oversized_wrapper_candidates(self, profile_env, monkeypatch):
+        create_profile("alpha", no_alias=True)
+        wrapper_dir = profile_env / ".local" / "bin"
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        (wrapper_dir / "alpha").write_text('#!/bin/sh\nexec hermes -p alpha "$@"\n')
+        oversized = wrapper_dir / "node"
+        oversized.write_bytes(b"not a hermes wrapper" * 8192)
+
+        original_open = Path.open
+
+        def guarded_open(self, *args, **kwargs):
+            if self == oversized:
+                raise AssertionError("profile list must not open oversized wrapper-dir entries")
+            return original_open(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "open", guarded_open)
+
+        profiles = list_profiles()
+        by_name = {profile.name: profile for profile in profiles}
+        assert by_name["alpha"].alias_name == "alpha"
+
 
 # ===================================================================
 # TestActiveProfile


### PR DESCRIPTION
## Summary
- Scan `~/.local/bin` once when listing profiles instead of once per profile.
- Skip oversized wrapper candidates before opening them, so large extensionless binaries are not read as text.
- Keep custom-alias preference over profile-named wrappers.

## Root cause
`list_profiles()` called `find_alias_for_profile()` for every named profile. Each call iterated every suffixless file in `~/.local/bin` and read it completely. On a machine with 35 named profiles and ~1 GB of binaries in `~/.local/bin`, `hermes profile list` repeatedly read the same large binaries and took ~6.4s; the desktop `/api/profiles` path uses the same function and can hit request timeouts.

## Verification
- RED: new regression tests failed on main:
  - `TestListProfiles::test_alias_lookup_scans_wrapper_dir_once`
  - `TestListProfiles::test_alias_lookup_skips_oversized_wrapper_candidates`
- GREEN: `uv run --extra dev python -m pytest tests/hermes_cli/test_profiles.py -q -o 'addopts='` → 140 passed
- `uv run --extra dev ruff check hermes_cli/profiles.py tests/hermes_cli/test_profiles.py` → passed
- Local benchmark with 36 profiles: `list_profiles()` ~6.1s before, ~0.76s after (unprofiled)
