### PR TITLE
fix(desktop): keep plain-text fences copyable

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -70,6 +70,36 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('const value = 1;')
   })
 
+  it('keeps explicit text fences copyable instead of leaking the language label into prose', () => {
+    const fence = '```'
+    const input = [
+      'Send this:',
+      '',
+      `${fence}text`,
+      'Hallo Nicholas, das Teakbett gefällt mir sehr gut.',
+      '',
+      'Wenn alles passt, würde ich es gern nehmen.',
+      '',
+      'Viele Grüße',
+      'Justin',
+      fence
+    ].join('\n')
+
+    const output = preprocessMarkdown(input)
+
+    expect(output).toContain('```text')
+    expect(output).toContain('Hallo Nicholas')
+    expect(output).not.toContain('\ntext\nHallo Nicholas')
+  })
+
+  it('keeps dangling explicit text fences copyable during streaming', () => {
+    const input = ['```text', 'Hallo Nicholas,', '', 'Viele Grüße', 'Justin'].join('\n')
+    const output = preprocessMarkdown(input)
+
+    expect(output.startsWith('```text')).toBe(true)
+    expect(output).toContain('Hallo Nicholas')
+  })
+
   it('keeps dangling real code fences during streaming', () => {
     const input = ['```ts', 'const value = 1;'].join('\n')
     const output = preprocessMarkdown(input)

--- a/apps/desktop/src/lib/markdown-code.ts
+++ b/apps/desktop/src/lib/markdown-code.ts
@@ -1,5 +1,6 @@
 const VALID_LANGUAGE_RE = /^[a-z0-9][a-z0-9+#-]*$/i
 const NON_CODE_FENCE_LANGUAGES = new Set(['', 'text', 'plain', 'plaintext', 'md', 'markdown'])
+const COPYABLE_TEXT_FENCE_LANGUAGES = new Set(['text', 'plain', 'plaintext'])
 
 const COMMON_CODE_LANGUAGES = new Set([
   'bash',
@@ -157,6 +158,14 @@ export function isLikelyProseFence(info: string, body: string): boolean {
     return false
   }
 
+  // Explicit plain-text fences are usually intentional copy surfaces: message
+  // drafts, emails, prompts, snippets to paste elsewhere. Do not flatten them
+  // into prose, because that leaks the language tag ("text") into the visible
+  // body and removes the per-block copy button.
+  if (COPYABLE_TEXT_FENCE_LANGUAGES.has(language) && !hasInfoTail) {
+    return false
+  }
+
   if (
     hasInfoTail &&
     signals.codeSignals <= 2 &&
@@ -180,6 +189,10 @@ export function isLikelyProseCodeBlock(language: string | undefined, code: strin
   const signals = codeSignals(code || '')
 
   if (!signals.trimmed || signals.codeSignals >= 3) {
+    return false
+  }
+
+  if (COPYABLE_TEXT_FENCE_LANGUAGES.has(cleanLanguage)) {
     return false
   }
 


### PR DESCRIPTION
## Summary
- Preserve explicit `text`, `plain`, and `plaintext` fenced blocks in the desktop markdown pipeline.
- Prevent the language tag from leaking into visible prose as `text Hallo...`.
- Keep seller-message/email/prompt drafts in code-card style blocks with per-block copy buttons.

## Verification
- `npm exec vitest run src/components/assistant-ui/markdown-text.test.ts -- --environment node`
- `npm run typecheck`

## Note
- `npm run test:ui -- src/components/assistant-ui/markdown-text.test.ts` is currently blocked in this checkout by a jsdom dependency ESM/CJS incompatibility in `html-encoding-sniffer` requiring `@exodus/bytes/encoding-lite.js`; the focused test passes under the node environment because this preprocessor test does not need jsdom.
