### PR TITLE
fix(cli): normalize Hermes home display separators

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -327,7 +327,7 @@ def display_hermes_home() -> str:
     """
     home = get_hermes_home()
     try:
-        return "~/" + str(home.relative_to(Path.home()))
+        return "~/" + home.relative_to(Path.home()).as_posix()
     except ValueError:
         return str(home)
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -1,7 +1,7 @@
 """Tests for hermes_constants module."""
 
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -106,6 +106,22 @@ class TestGetHermesHome:
         monkeypatch.setattr(hermes_constants, "_profile_fallback_warned", False)
 
         assert get_hermes_home() == local_appdata / "hermes"
+
+
+class TestDisplayHermesHome:
+    def test_windows_home_relative_path_uses_consistent_placeholder_separators(
+        self, monkeypatch
+    ):
+        home = PureWindowsPath("C:/Users/bryan")
+        hermes_home = home / "AppData" / "Local" / "hermes"
+
+        monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(hermes_constants.Path, "home", lambda: home)
+
+        display = hermes_constants.display_hermes_home()
+
+        assert display == "~/AppData/Local/hermes"
+        assert f"{display}/.env" == "~/AppData/Local/hermes/.env"
 
 
 class TestHermesManagedNode:


### PR DESCRIPTION
Normalizes home-relative Hermes display paths with forward slashes before applying the `~/` placeholder. That keeps `hermes doctor` from printing mixed separators like `~/AppData\Local\hermes/.env` on Windows.

Changes:
- Use `as_posix()` when formatting home-relative display paths.
- Add a regression test using `PureWindowsPath` to cover the doctor `.env` suffix path.

Testing:
- `scripts/run_tests.sh tests/test_hermes_constants.py`
- `scripts/run_tests.sh tests/hermes_cli/test_doctor.py`
- `.venv/bin/python -m ruff check hermes_constants.py tests/test_hermes_constants.py`
- `.venv/bin/python scripts/check-windows-footguns.py hermes_constants.py tests/test_hermes_constants.py`

Fixes #49500
