### PR TITLE
fix: matrix being dropped from get_connected_platforms() with password auth

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -467,6 +467,7 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
         cfg.extra.get("phone_number_id") and cfg.extra.get("access_token")
     ),
     Platform.SIGNAL: lambda cfg: bool(cfg.extra.get("http_url")),
+    Platform.MATRIX: lambda cfg: bool(cfg.token or cfg.extra.get("homeserver")),
     Platform.API_SERVER: lambda cfg: True,
     Platform.WEBHOOK: lambda cfg: True,
     Platform.MSGRAPH_WEBHOOK: lambda cfg: bool(

--- a/tests/gateway/test_platform_connected_checkers.py
+++ b/tests/gateway/test_platform_connected_checkers.py
@@ -93,6 +93,8 @@ def test_checker_returns_true_when_configured(platform, checker, monkeypatch):
         mock_config.extra = {"account_id": "123", "token": "***"}
     elif platform == Platform.SIGNAL:
         mock_config.extra = {"http_url": "http://signal:8080"}
+    elif platform == Platform.MATRIX:
+        mock_config.extra = {"homeserver": "https://matrix.org"}
     elif platform == Platform.EMAIL:
         mock_config.extra = {"address": "hermes@example.com"}
     elif platform == Platform.SMS:


### PR DESCRIPTION
## What does this PR do?

Fixes Matrix being silently excluded from `get_connected_platforms()` when it is
authenticated with a password (`MATRIX_PASSWORD`) instead of an access token
(`MATRIX_ACCESS_TOKEN`).

Matrix supports both auth methods. With password auth, `PlatformConfig.token`
is never populated, so the generic `config.token or config.api_key` branch in
`_is_platform_connected()` returns `False`, and there is no Matrix entry in
`_PLATFORM_CONNECTED_CHECKERS` to fall back to. The net effect: the Matrix
adapter connects and serves chat normally, but the platform does not appear in
`get_connected_platforms()`.

That function gates several user-visible features, so a fully working Matrix
connection is invisible to:

- the dashboard's **Connected Platforms** panel (`hermes_cli/web_server.py`),
- **cron / scheduled delivery targets** (`cron/scheduler.py` → `cron_delivery_targets()`),
- **home-channel startup notifications** (`gateway/run.py`).

In practice, with Matrix on password auth and (say) Signal also configured, the
dashboard shows only Signal and all notifications route to Signal, even though
Matrix is the user's intended home channel.

The fix adds a bespoke Matrix checker keyed on the homeserver, which is always
populated from `MATRIX_HOMESERVER` whenever the platform is configured (token
**or** password). Token-based auth continues to work through the same
`cfg.token` check, so this is purely additive — it just stops dropping the
password-auth case.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `gateway/config.py`: add a `Platform.MATRIX` entry to `_PLATFORM_CONNECTED_CHECKERS`:
  `lambda cfg: bool(cfg.token or cfg.extra.get("homeserver"))`. This recognizes
  password-auth Matrix (no token, homeserver always set) as connected, while
  leaving the token path unchanged.
- `tests/gateway/test_platform_connected_checkers.py`: add a `Platform.MATRIX`
  case to `test_checker_returns_true_when_configured` so the new checker is
  exercised (homeserver-only config) rather than skipped.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Configure Matrix with **password** auth and no access token:
   `MATRIX_HOMESERVER=https://matrix.org`, `MATRIX_USER_ID=@bot:matrix.org`,
   `MATRIX_PASSWORD=...` (and optionally `MATRIX_HOME_ROOM=...`). Configure a
   second platform such as Signal as well.
2. Start the gateway and confirm Matrix actually connects and you can chat with
   the bot over Matrix.
3. **Before this change:** the dashboard's Connected Platforms panel lists only
   Signal, and cron / home-channel notifications go to Signal. **After this
   change:** Matrix also appears as connected and is a valid delivery target.
4. Unit coverage: `pytest tests/gateway/test_platform_connected_checkers.py -q`.
   The parametrized suite now includes Matrix and asserts the checker returns
   `True` for a homeserver-only config and `False` for an empty one.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
