### PR TITLE
docs(installation): add WSL2 path guidance and tips

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -152,9 +152,9 @@ The same pattern works on Arch (the installer uses pacman with the same sudo-det
 
 ### WSL2 Tips
 
-**Where does my data live?** On WSL2, `~/.hermes` is inside the WSL Linux filesystem (`\\wsl.localhost\Ubuntu\home\<user>\.hermes`). Do not move it to `/mnt/c/` — crossing the WSL/Windows filesystem boundary causes a 5-10x slowdown on git operations, npm installs, and database reads.
+**Where does my data live?** On WSL2, `~/.hermes` is inside the WSL Linux filesystem (`\\wsl.localhost\<distro>\home\<user>\.hermes`). Do not move it to `/mnt/c/` — crossing the WSL/Windows filesystem boundary causes a 5-10x slowdown on git operations, npm installs, and database reads.
 
-**How do I access Windows files?** Windows drives mount at `/mnt/c/`, `/mnt/d/`, etc. Use these paths in Hermes when the agent needs to read or write files visible from Windows (e.g., `C:\Users\prata\Downloads\file.pdf` becomes `/mnt/c/Users/prata/Downloads/file.pdf`).
+**How do I access Windows files?** Windows drives mount at `/mnt/c/`, `/mnt/d/`, etc. Use these paths in Hermes when the agent needs to read or write files visible from Windows (e.g., `C:\Users\user\Downloads\file.pdf` becomes `/mnt/c/Users/user/Downloads/file.pdf`).
 
 **Python note:** On WSL2, always use `python3` not `python`. The `python` command may not exist. The Hermes installer handles this automatically, but manual Python work should use `python3` explicitly.
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -150,6 +150,14 @@ The same pattern works on Arch (the installer uses pacman with the same sudo-det
 | `API key not set` | Run `hermes model` to configure your provider, or `hermes config set OPENROUTER_API_KEY your_key` |
 | Missing config after update | Run `hermes config check` then `hermes config migrate` |
 
+### WSL2 Tips
+
+**Where does my data live?** On WSL2, `~/.hermes` is inside the WSL Linux filesystem (`\\wsl.localhost\Ubuntu\home\<user>\.hermes`). Do not move it to `/mnt/c/` — crossing the WSL/Windows filesystem boundary causes a 5-10x slowdown on git operations, npm installs, and database reads.
+
+**How do I access Windows files?** Windows drives mount at `/mnt/c/`, `/mnt/d/`, etc. Use these paths in Hermes when the agent needs to read or write files visible from Windows (e.g., `C:\Users\prata\Downloads\file.pdf` becomes `/mnt/c/Users/prata/Downloads/file.pdf`).
+
+**Python note:** On WSL2, always use `python3` not `python`. The `python` command may not exist. The Hermes installer handles this automatically, but manual Python work should use `python3` explicitly.
+
 For more diagnostics, run `hermes doctor` — it will tell you exactly what's missing and how to fix it.
 
 ## Install method auto-detection


### PR DESCRIPTION
## What does this PR do?

Adds a **WSL2 Tips** section to the installation troubleshooting guide. Covers three things WSL users commonly trip over:

1. **Data directory location** — warns not to move `~/.hermes` to `/mnt/c/` (5-10x slowdown on git/npm/db operations across the WSL/Windows boundary)
2. **Accessing Windows files** — documents the `/mnt/c/` mapping with a concrete example
3. **Python `python3` vs `python`** — notes that WSL often lacks the bare `python` command

## Related Issue

N/A — discovered while running Hermes on WSL2.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've tested on my platform: WSL2 (Ubuntu), also cross-checked on Linux