### PR TITLE
fix(pool): serialize openai-codex oauth refresh

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -892,13 +892,16 @@ class CredentialPool:
                     except Exception as wexc:
                         logger.debug("Failed to write refreshed token to credentials file: %s", wexc)
             elif self.provider == "openai-codex":
-                # Adopt fresher tokens from auth.json before spending the
-                # refresh_token — single-use tokens consumed by another Hermes
-                # process sharing the same auth.json singleton would otherwise
-                # trigger ``refresh_token_reused`` on the next POST.
-                synced = self._sync_codex_entry_from_auth_store(entry)
-                if synced is not entry:
-                    entry = synced
+                if entry.source == "device_code":
+                    auth_mod.resolve_codex_runtime_credentials(
+                        force_refresh=force,
+                        refresh_if_expiring=True,
+                    )
+                    return self._sync_codex_entry_from_auth_store(entry)
+
+                # Independent manual OAuth entries are not singleton mirrors.
+                # They keep their own refresh-token chain until the targeted
+                # pool-entry CAS path lands.
                 refreshed = auth_mod.refresh_codex_oauth_pure(
                     entry.access_token,
                     entry.refresh_token,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1055,7 +1055,7 @@ class CredentialPool:
             # may have consumed the refresh token between our proactive sync
             # and the HTTP call.  Re-check auth.json and adopt the fresh tokens
             # if they have rotated since.
-            if self.provider == "openai-codex":
+            if self.provider == "openai-codex" and entry.source == "device_code":
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced.refresh_token != entry.refresh_token:
                     logger.debug(
@@ -1074,10 +1074,11 @@ class CredentialPool:
                     self._persist()
                     return updated
                 # Terminal error: auth.json has no newer tokens — the stored
-                # refresh_token is dead.  Clear it from auth.json so the next
-                # session does not re-seed the same revoked credentials, and
-                # remove all singleton-seeded (device_code) entries from the
-                # in-memory pool.  Mirrors the xAI and Nous quarantine paths.
+                # singleton refresh_token is dead.  Clear it from auth.json so
+                # the next session does not re-seed the same revoked
+                # credentials, and remove all singleton-seeded (device_code)
+                # entries from the in-memory pool.  Independent manual OAuth
+                # entries are handled by the generic exhausted/dead path below.
                 if auth_mod._is_terminal_codex_oauth_refresh_error(exc):
                     logger.debug(
                         "Codex OAuth refresh token is terminally invalid; clearing local token state"

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -11,7 +11,8 @@ import uuid
 import re
 from dataclasses import dataclass, fields, replace
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Set, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
@@ -485,6 +486,112 @@ class CredentialPool:
             [entry.to_dict() for entry in self._entries],
         )
 
+    @staticmethod
+    def _pool_entry_version_payload(payload: Dict[str, Any]) -> Tuple[str, str, str]:
+        return (
+            str(payload.get("access_token") or ""),
+            str(payload.get("refresh_token") or ""),
+            str(payload.get("last_refresh") or ""),
+        )
+
+    @classmethod
+    def _pool_entry_version(cls, entry: PooledCredential) -> Tuple[str, str, str]:
+        return cls._pool_entry_version_payload(entry.to_dict())
+
+    def _exact_pool_auth_path_for_entry(self, entry: PooledCredential) -> Path:
+        """Return the auth.json path that currently owns this pool entry."""
+        profile_path = auth_mod._auth_file_path()
+        with auth_mod._auth_store_lock_for_path(profile_path):
+            profile_store = _load_auth_store(profile_path)
+            profile_pool = profile_store.get("credential_pool")
+            profile_entries = profile_pool.get(self.provider) if isinstance(profile_pool, dict) else None
+            if isinstance(profile_entries, list) and any(
+                isinstance(item, dict) and item.get("id") == entry.id
+                for item in profile_entries
+            ):
+                return profile_path
+            if isinstance(profile_entries, list) and profile_entries:
+                return profile_path
+
+        root_path = auth_mod._global_auth_file_path()
+        if root_path is not None:
+            with auth_mod._auth_store_lock_for_path(root_path):
+                root_store = _load_auth_store(root_path)
+                root_pool = root_store.get("credential_pool")
+                root_entries = root_pool.get(self.provider) if isinstance(root_pool, dict) else None
+                if isinstance(root_entries, list) and any(
+                    isinstance(item, dict) and item.get("id") == entry.id
+                    for item in root_entries
+                ):
+                    return root_path
+
+        return profile_path
+
+    def _read_pool_entry_exact(self, auth_path: Path, entry_id: str) -> Optional[PooledCredential]:
+        with auth_mod._auth_store_lock_for_path(auth_path):
+            auth_store = _load_auth_store(auth_path)
+            pool = auth_store.get("credential_pool")
+            entries = pool.get(self.provider) if isinstance(pool, dict) else None
+            if not isinstance(entries, list):
+                return None
+            for item in entries:
+                if isinstance(item, dict) and item.get("id") == entry_id:
+                    return PooledCredential.from_dict(self.provider, item)
+        return None
+
+    @staticmethod
+    def _codex_pool_refresh_lock_key(auth_path: Path, entry_id: str) -> str:
+        return "\0".join(
+            (
+                "openai-codex",
+                "pool",
+                str(auth_path.expanduser().resolve(strict=False)),
+                str(entry_id),
+            )
+        )
+
+    def _update_pool_entry_exact(
+        self,
+        entry: PooledCredential,
+        *,
+        expected_version: Tuple[str, str, str],
+        updater: Callable[[Dict[str, Any]], Dict[str, Any]],
+        auth_path: Optional[Path] = None,
+    ) -> PooledCredential:
+        """Read-modify-write exactly one pool entry without rewriting siblings."""
+        auth_path = auth_path or self._exact_pool_auth_path_for_entry(entry)
+        with auth_mod._auth_store_lock_for_path(auth_path):
+            auth_store = _load_auth_store(auth_path)
+            pool = auth_store.get("credential_pool")
+            if not isinstance(pool, dict):
+                pool = {}
+                auth_store["credential_pool"] = pool
+            entries = pool.get(self.provider)
+            if not isinstance(entries, list):
+                entries = []
+                pool[self.provider] = entries
+
+            target_index: Optional[int] = None
+            current_payload: Optional[Dict[str, Any]] = None
+            for index, item in enumerate(entries):
+                if isinstance(item, dict) and item.get("id") == entry.id:
+                    target_index = index
+                    current_payload = dict(item)
+                    break
+
+            if current_payload is None or target_index is None:
+                current_payload = entry.to_dict()
+                entries.append(current_payload)
+                target_index = len(entries) - 1
+
+            if self._pool_entry_version_payload(current_payload) != expected_version:
+                return PooledCredential.from_dict(self.provider, current_payload)
+
+            updated_payload = updater(dict(current_payload))
+            entries[target_index] = updated_payload
+            _save_auth_store(auth_store, auth_path)
+            return PooledCredential.from_dict(self.provider, updated_payload)
+
     def _is_terminal_auth_failure(
         self,
         status_code: Optional[int],
@@ -900,18 +1007,53 @@ class CredentialPool:
                     return self._sync_codex_entry_from_auth_store(entry)
 
                 # Independent manual OAuth entries are not singleton mirrors.
-                # They keep their own refresh-token chain until the targeted
-                # pool-entry CAS path lands.
-                refreshed = auth_mod.refresh_codex_oauth_pure(
-                    entry.access_token,
-                    entry.refresh_token,
-                )
-                updated = replace(
-                    entry,
-                    access_token=refreshed["access_token"],
-                    refresh_token=refreshed["refresh_token"],
-                    last_refresh=refreshed.get("last_refresh"),
-                )
+                # Serialize per entry and persist only the targeted item so a
+                # stale in-memory pool cannot revert a sibling refreshed by
+                # another process.
+                auth_path = self._exact_pool_auth_path_for_entry(entry)
+                lock_key = self._codex_pool_refresh_lock_key(auth_path, entry.id)
+                lock_timeout = float(getattr(auth_mod, "AUTH_LOCK_TIMEOUT_SECONDS", 30.0))
+                with auth_mod._timed_codex_process_lock(lock_key, lock_timeout):
+                    with auth_mod._codex_refresh_file_lock(
+                        auth_path=auth_path,
+                        lock_key=lock_key,
+                        timeout_seconds=lock_timeout,
+                    ):
+                        current = self._read_pool_entry_exact(auth_path, entry.id) or entry
+                        if self._pool_entry_version(current) != self._pool_entry_version(entry):
+                            if not self._entry_needs_refresh(current):
+                                self._replace_entry(entry, current)
+                                return current
+                            entry = current
+
+                        attempted_version = self._pool_entry_version(entry)
+                        refresh_token = str(entry.refresh_token or "").strip()
+                        if not refresh_token:
+                            return None
+                        refreshed = auth_mod.refresh_codex_oauth_pure(
+                            entry.access_token,
+                            refresh_token,
+                        )
+                        updated = replace(
+                            entry,
+                            access_token=refreshed["access_token"],
+                            refresh_token=refreshed["refresh_token"],
+                            last_refresh=refreshed.get("last_refresh"),
+                            last_status=STATUS_OK,
+                            last_status_at=None,
+                            last_error_code=None,
+                            last_error_reason=None,
+                            last_error_message=None,
+                            last_error_reset_at=None,
+                        )
+                        persisted = self._update_pool_entry_exact(
+                            entry,
+                            expected_version=attempted_version,
+                            updater=lambda _current: updated.to_dict(),
+                            auth_path=auth_path,
+                        )
+                        self._replace_entry(entry, persisted)
+                        return persisted
             elif self.provider == "xai-oauth":
                 # Adopt fresher tokens from auth.json before spending the
                 # refresh_token — single-use tokens consumed by another
@@ -1181,6 +1323,23 @@ class CredentialPool:
                         self._current_id = None
                     self._persist()
                     return None
+            if self.provider == "openai-codex" and _is_manual_source(entry.source):
+                failed = replace(
+                    entry,
+                    last_status=STATUS_EXHAUSTED,
+                    last_status_at=time.time(),
+                    last_error_code=None,
+                    last_error_reason=getattr(exc, "code", None),
+                    last_error_message=str(exc) or None,
+                    last_error_reset_at=None,
+                )
+                persisted = self._update_pool_entry_exact(
+                    entry,
+                    expected_version=self._pool_entry_version(entry),
+                    updater=lambda _current: failed.to_dict(),
+                )
+                self._replace_entry(entry, persisted)
+                return None
             self._mark_exhausted(entry, None)
             return None
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Callable, Dict, FrozenSet, List, Optional, Tuple
+from typing import Any, Callable, Dict, FrozenSet, List, Literal, Optional, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
@@ -948,10 +948,23 @@ def _load_global_auth_store() -> Dict[str, Any]:
 
 
 def _auth_lock_path() -> Path:
-    return _auth_file_path().with_suffix(".lock")
+    return _auth_lock_path_for(_auth_file_path())
+
+
+def _auth_lock_path_for(auth_path: Path) -> Path:
+    """Return the auth-store lock path for an explicit auth.json path."""
+    return auth_path.expanduser().resolve(strict=False).with_suffix(".lock")
 
 
 _auth_lock_holder = threading.local()
+_AUTH_PATH_LOCK_HOLDERS: Dict[str, threading.local] = {}
+_AUTH_PATH_LOCK_HOLDERS_GUARD = threading.Lock()
+
+
+def _auth_lock_holder_for_path(auth_path: Path) -> threading.local:
+    key = str(auth_path.expanduser().resolve(strict=False))
+    with _AUTH_PATH_LOCK_HOLDERS_GUARD:
+        return _AUTH_PATH_LOCK_HOLDERS.setdefault(key, threading.local())
 
 
 @contextmanager
@@ -1041,6 +1054,22 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
         _auth_lock_holder,
         timeout_seconds,
         "Timed out waiting for auth store lock",
+    ):
+        yield
+
+
+@contextmanager
+def _auth_store_lock_for_path(
+    auth_path: Path,
+    timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS,
+):
+    """Cross-process advisory lock for a specific auth.json path."""
+    canonical = auth_path.expanduser().resolve(strict=False)
+    with _file_lock(
+        _auth_lock_path_for(canonical),
+        _auth_lock_holder_for_path(canonical),
+        timeout_seconds,
+        f"Timed out waiting for auth store lock: {canonical}",
     ):
         yield
 
@@ -3357,6 +3386,267 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
+
+@dataclass(frozen=True)
+class CodexStoreRef:
+    auth_path: Path
+    source: Literal["classic", "profile", "root_fallback"]
+
+    @property
+    def is_root_fallback(self) -> bool:
+        return self.source == "root_fallback"
+
+
+@dataclass(frozen=True)
+class CodexOAuthIdentity:
+    account_id: Optional[str] = None
+    subject: Optional[str] = None
+    email: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CodexTokenSnapshot:
+    ref: CodexStoreRef
+    tokens: Dict[str, str]
+    last_refresh: Optional[str]
+    identity: CodexOAuthIdentity
+
+
+def _profile_has_own_codex_state(auth_store: Dict[str, Any]) -> bool:
+    providers = auth_store.get("providers")
+    return isinstance(providers, dict) and isinstance(providers.get("openai-codex"), dict)
+
+
+def _codex_state_has_usable_tokens(state: Any) -> bool:
+    if not isinstance(state, dict):
+        return False
+    tokens = state.get("tokens")
+    return (
+        isinstance(tokens, dict)
+        and bool(str(tokens.get("access_token") or "").strip())
+        and bool(str(tokens.get("refresh_token") or "").strip())
+    )
+
+
+def _resolve_codex_store_ref() -> CodexStoreRef:
+    """Resolve the exact store authoritative for the Codex singleton."""
+    profile_path = _auth_file_path()
+    with _auth_store_lock_for_path(profile_path):
+        profile_store = _load_auth_store(profile_path)
+        if _profile_has_own_codex_state(profile_store):
+            return CodexStoreRef(profile_path, "profile")
+
+    root_path = _global_auth_file_path()
+    if root_path is None:
+        return CodexStoreRef(profile_path, "classic")
+
+    with _auth_store_lock_for_path(root_path):
+        root_store = _load_auth_store(root_path)
+        root_providers = root_store.get("providers")
+        if isinstance(root_providers, dict) and isinstance(root_providers.get("openai-codex"), dict):
+            return CodexStoreRef(root_path, "root_fallback")
+
+    return CodexStoreRef(profile_path, "profile")
+
+
+def _load_codex_state_exact(ref: CodexStoreRef) -> Dict[str, Any]:
+    store = _load_auth_store(ref.auth_path)
+    providers = store.get("providers")
+    state = providers.get("openai-codex") if isinstance(providers, dict) else None
+    if not isinstance(state, dict):
+        raise AuthError(
+            "No Codex credentials stored. Run `hermes auth` to authenticate.",
+            provider="openai-codex",
+            code="codex_auth_missing",
+            relogin_required=True,
+        )
+    return dict(state)
+
+
+def _codex_oauth_identity_from_tokens(tokens: Dict[str, str]) -> CodexOAuthIdentity:
+    claims = _decode_jwt_claims(tokens.get("access_token"))
+
+    def _claim(*names: str) -> Optional[str]:
+        for name in names:
+            value = claims.get(name)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    account_id = _claim(
+        "account_id",
+        "chatgpt_account_id",
+        "https://api.openai.com/auth.chatgpt_account_id",
+        "https://api.openai.com/auth.account_id",
+    )
+    subject = _claim("sub")
+    email = _claim("email", "preferred_username", "upn")
+    if email:
+        email = email.strip().lower()
+    return CodexOAuthIdentity(account_id=account_id, subject=subject, email=email)
+
+
+def _snapshot_from_codex_state(ref: CodexStoreRef, state: Dict[str, Any]) -> CodexTokenSnapshot:
+    tokens = state.get("tokens")
+    if not isinstance(tokens, dict):
+        raise AuthError(
+            "Codex auth state is missing tokens. Run `hermes auth` to re-authenticate.",
+            provider="openai-codex",
+            code="codex_auth_invalid_shape",
+            relogin_required=True,
+        )
+    access_token = tokens.get("access_token")
+    refresh_token = tokens.get("refresh_token")
+    if not isinstance(access_token, str) or not access_token.strip():
+        raise AuthError(
+            "Codex auth is missing access_token. Run `hermes auth` to re-authenticate.",
+            provider="openai-codex",
+            code="codex_auth_missing_access_token",
+            relogin_required=True,
+        )
+    if not isinstance(refresh_token, str) or not refresh_token.strip():
+        raise AuthError(
+            "Codex auth is missing refresh_token. Run `hermes auth` to re-authenticate.",
+            provider="openai-codex",
+            code="codex_auth_missing_refresh_token",
+            relogin_required=True,
+        )
+    copied = {str(k): str(v) for k, v in tokens.items() if isinstance(k, str) and isinstance(v, str)}
+    return CodexTokenSnapshot(
+        ref=ref,
+        tokens=copied,
+        last_refresh=state.get("last_refresh") if isinstance(state.get("last_refresh"), str) else None,
+        identity=_codex_oauth_identity_from_tokens(copied),
+    )
+
+
+def _read_codex_snapshot_exact(ref: CodexStoreRef) -> CodexTokenSnapshot:
+    with _auth_store_lock_for_path(ref.auth_path):
+        state = _load_codex_state_exact(ref)
+        return _snapshot_from_codex_state(ref, state)
+
+
+def _codex_token_version(snapshot: CodexTokenSnapshot) -> Tuple[str, str, str]:
+    return (
+        str(snapshot.tokens.get("access_token") or ""),
+        str(snapshot.tokens.get("refresh_token") or ""),
+        str(snapshot.last_refresh or ""),
+    )
+
+
+def _codex_access_token_expiry(access_token: str) -> Optional[float]:
+    claims = _decode_jwt_claims(access_token)
+    exp = claims.get("exp")
+    return float(exp) if isinstance(exp, (int, float)) else None
+
+
+def _codex_tokens_strictly_fresh(snapshot: CodexTokenSnapshot, skew_seconds: int) -> bool:
+    access = str(snapshot.tokens.get("access_token") or "").strip()
+    expiry = _codex_access_token_expiry(access)
+    return bool(access) and expiry is not None and expiry > time.time() + max(0, int(skew_seconds))
+
+
+def _codex_identity_compatible(
+    existing: CodexOAuthIdentity,
+    candidate: CodexOAuthIdentity,
+) -> bool:
+    if existing.account_id and candidate.account_id:
+        return existing.account_id == candidate.account_id
+    if existing.subject and candidate.subject:
+        return existing.subject == candidate.subject
+    if existing.email and candidate.email:
+        return existing.email == candidate.email
+    return True
+
+
+def _codex_identity_changed_error() -> AuthError:
+    return AuthError(
+        "Codex credential identity changed during refresh.",
+        provider="openai-codex",
+        code="codex_identity_changed_during_refresh",
+        relogin_required=False,
+    )
+
+
+_CODEX_PROCESS_LOCKS: Dict[str, threading.Lock] = {}
+_CODEX_PROCESS_LOCKS_GUARD = threading.Lock()
+_CODEX_FILE_LOCK_HOLDERS: Dict[str, threading.local] = {}
+_CODEX_FILE_LOCK_HOLDERS_GUARD = threading.Lock()
+
+
+def _codex_process_lock_for_key(lock_key: str) -> threading.Lock:
+    with _CODEX_PROCESS_LOCKS_GUARD:
+        return _CODEX_PROCESS_LOCKS.setdefault(lock_key, threading.Lock())
+
+
+@contextmanager
+def _timed_codex_process_lock(lock_key: str, timeout_seconds: float):
+    lock = _codex_process_lock_for_key(lock_key)
+    acquired = lock.acquire(timeout=max(1.0, float(timeout_seconds)))
+    if not acquired:
+        raise AuthError(
+            "Timed out waiting for Codex OAuth refresh lock.",
+            provider="openai-codex",
+            code="codex_refresh_contention",
+            relogin_required=False,
+        )
+    try:
+        yield
+    finally:
+        lock.release()
+
+
+def _codex_file_lock_holder_for_path(lock_path: Path) -> threading.local:
+    key = str(lock_path.expanduser().resolve(strict=False))
+    with _CODEX_FILE_LOCK_HOLDERS_GUARD:
+        return _CODEX_FILE_LOCK_HOLDERS.setdefault(key, threading.local())
+
+
+def _codex_singleton_refresh_lock_key(ref: CodexStoreRef) -> str:
+    return "\0".join(
+        (
+            "openai-codex",
+            "singleton",
+            str(ref.auth_path.expanduser().resolve(strict=False)),
+        )
+    )
+
+
+def _codex_refresh_lock_path(auth_path: Path, lock_key: str) -> Path:
+    digest = hashlib.sha256(lock_key.encode("utf-8")).hexdigest()
+    return (
+        auth_path.expanduser().resolve(strict=False).parent
+        / "locks"
+        / "oauth-refresh"
+        / f"openai-codex-{digest}.lock"
+    )
+
+
+@contextmanager
+def _codex_refresh_file_lock(
+    *,
+    auth_path: Path,
+    lock_key: str,
+    timeout_seconds: float,
+):
+    lock_path = _codex_refresh_lock_path(auth_path, lock_key)
+    try:
+        with _file_lock(
+            lock_path,
+            _codex_file_lock_holder_for_path(lock_path),
+            timeout_seconds,
+            "Timed out waiting for Codex OAuth refresh lock",
+        ):
+            yield
+    except TimeoutError as exc:
+        raise AuthError(
+            "Timed out waiting for Codex OAuth refresh lock.",
+            provider="openai-codex",
+            code="codex_refresh_contention",
+            relogin_required=False,
+        ) from exc
+
+
 def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
     
@@ -3679,6 +3969,161 @@ def refresh_codex_oauth_pure(
     return updated
 
 
+def _try_adopt_changed_codex_snapshot(
+    *,
+    ref: CodexStoreRef,
+    attempted: CodexTokenSnapshot,
+    refresh_skew_seconds: int,
+) -> Optional[CodexTokenSnapshot]:
+    latest = _read_codex_snapshot_exact(ref)
+    if _codex_token_version(latest) == _codex_token_version(attempted):
+        return None
+    if not _codex_identity_compatible(attempted.identity, latest.identity):
+        raise _codex_identity_changed_error()
+    if not _codex_tokens_strictly_fresh(latest, refresh_skew_seconds):
+        return None
+    logger.info(
+        "Codex OAuth refresh did not complete locally, but a newer persisted "
+        "credential was found and adopted"
+    )
+    return latest
+
+
+def _persist_codex_refresh_result_cas(
+    *,
+    ref: CodexStoreRef,
+    attempted: CodexTokenSnapshot,
+    refreshed: Dict[str, Any],
+    refresh_skew_seconds: int,
+) -> CodexTokenSnapshot:
+    with _auth_store_lock_for_path(ref.auth_path):
+        store = _load_auth_store(ref.auth_path)
+        latest_state = _load_codex_state_exact(ref)
+        latest = _snapshot_from_codex_state(ref, latest_state)
+        if _codex_token_version(latest) != _codex_token_version(attempted):
+            if not _codex_identity_compatible(attempted.identity, latest.identity):
+                raise _codex_identity_changed_error()
+            if _codex_tokens_strictly_fresh(latest, refresh_skew_seconds):
+                return latest
+            raise AuthError(
+                "Codex credential changed during refresh and could not be safely adopted.",
+                provider="openai-codex",
+                code="codex_refresh_concurrent_mutation",
+                relogin_required=False,
+            )
+
+        access_token = str(refreshed.get("access_token") or "").strip()
+        if not access_token:
+            raise AuthError(
+                "Codex token refresh response was missing access_token.",
+                provider="openai-codex",
+                code="codex_refresh_missing_access_token",
+                relogin_required=True,
+            )
+        refresh_token = str(refreshed.get("refresh_token") or "").strip() or str(
+            attempted.tokens.get("refresh_token") or ""
+        ).strip()
+        last_refresh = str(refreshed.get("last_refresh") or "").strip() or datetime.now(
+            timezone.utc
+        ).isoformat().replace("+00:00", "Z")
+
+        updated_state = dict(latest_state)
+        updated_state["tokens"] = {
+            **dict(attempted.tokens),
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        }
+        updated_state["last_refresh"] = last_refresh
+        updated_state["auth_mode"] = "chatgpt"
+        _store_provider_state(store, "openai-codex", updated_state, set_active=False)
+        try:
+            _save_auth_store(store, ref.auth_path)
+        except Exception as exc:
+            raise AuthError(
+                "Codex token refresh succeeded, but the rotated credential could not be persisted. "
+                "The OAuth refresh will not be repeated automatically.",
+                provider="openai-codex",
+                code="codex_refresh_persist_failed",
+                relogin_required=False,
+            ) from exc
+
+        return _snapshot_from_codex_state(ref, updated_state)
+
+
+def _refresh_codex_singleton_serialized(
+    observed: CodexTokenSnapshot,
+    *,
+    timeout_seconds: float,
+    refresh_skew_seconds: int = CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+    force_refresh: bool = False,
+) -> CodexTokenSnapshot:
+    max_origin_retries = 3
+    for _ in range(max_origin_retries):
+        initial_ref = _resolve_codex_store_ref()
+        lock_key = _codex_singleton_refresh_lock_key(initial_ref)
+        lock_timeout = max(float(AUTH_LOCK_TIMEOUT_SECONDS), float(timeout_seconds) + 10.0)
+        with _timed_codex_process_lock(lock_key, lock_timeout):
+            with _codex_refresh_file_lock(
+                auth_path=initial_ref.auth_path,
+                lock_key=lock_key,
+                timeout_seconds=lock_timeout,
+            ):
+                stable_ref = _resolve_codex_store_ref()
+                stable_key = _codex_singleton_refresh_lock_key(stable_ref)
+                if stable_key != lock_key:
+                    continue
+
+                current = _read_codex_snapshot_exact(stable_ref)
+                if _codex_token_version(current) != _codex_token_version(observed):
+                    if not _codex_identity_compatible(observed.identity, current.identity):
+                        raise _codex_identity_changed_error()
+                    if _codex_tokens_strictly_fresh(current, refresh_skew_seconds):
+                        return current
+
+                if not force_refresh and _codex_tokens_strictly_fresh(current, refresh_skew_seconds):
+                    return current
+
+                attempted = current
+                refresh_token = str(attempted.tokens.get("refresh_token") or "").strip()
+                if not refresh_token:
+                    raise AuthError(
+                        "Codex auth is missing refresh_token. Run `hermes auth` to re-authenticate.",
+                        provider="openai-codex",
+                        code="codex_auth_missing_refresh_token",
+                        relogin_required=True,
+                    )
+
+                try:
+                    refreshed = refresh_codex_oauth_pure(
+                        str(attempted.tokens.get("access_token") or ""),
+                        refresh_token,
+                        timeout_seconds=timeout_seconds,
+                    )
+                except Exception:
+                    recovered = _try_adopt_changed_codex_snapshot(
+                        ref=stable_ref,
+                        attempted=attempted,
+                        refresh_skew_seconds=refresh_skew_seconds,
+                    )
+                    if recovered is not None:
+                        return recovered
+                    raise
+
+                return _persist_codex_refresh_result_cas(
+                    ref=stable_ref,
+                    attempted=attempted,
+                    refreshed=refreshed,
+                    refresh_skew_seconds=refresh_skew_seconds,
+                )
+
+    raise AuthError(
+        "Codex credential origin changed repeatedly during refresh.",
+        provider="openai-codex",
+        code="codex_refresh_origin_unstable",
+        relogin_required=False,
+    )
+
+
 def _refresh_codex_auth_tokens(
     tokens: Dict[str, str],
     timeout_seconds: float,
@@ -3779,18 +4224,7 @@ def resolve_codex_runtime_credentials(
         data = _read_codex_tokens()
     except AuthError as exc:
         read_error = exc
-        if getattr(exc, "relogin_required", False) and getattr(exc, "code", None) in {
-            "codex_auth_missing_access_token",
-            "codex_auth_missing_refresh_token",
-            "codex_auth_invalid_shape",
-        }:
-            imported = _recover_codex_tokens_from_cli(str(getattr(exc, "code", None) or "auth_error"))
-            if imported:
-                data = {"tokens": imported, "last_refresh": imported.get("last_refresh")}
-            else:
-                data = None
-        else:
-            data = None
+        data = None
 
     if data is None:
         pool_token = _pool_codex_access_token()
@@ -3844,19 +4278,17 @@ def resolve_codex_runtime_credentials(
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
     if should_refresh:
-        # Re-read under lock to avoid racing with other Hermes processes
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
-            data = _read_codex_tokens(_lock=False)
-            tokens = dict(data["tokens"])
-            access_token = str(tokens.get("access_token", "") or "").strip()
-
-            should_refresh = bool(force_refresh)
-            if (not should_refresh) and refresh_if_expiring:
-                should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
-
-            if should_refresh:
-                tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
-                access_token = str(tokens.get("access_token", "") or "").strip()
+        observed_ref = _resolve_codex_store_ref()
+        observed = _read_codex_snapshot_exact(observed_ref)
+        refreshed_snapshot = _refresh_codex_singleton_serialized(
+            observed,
+            timeout_seconds=refresh_timeout_seconds,
+            refresh_skew_seconds=refresh_skew_seconds,
+            force_refresh=force_refresh,
+        )
+        tokens = dict(refreshed_snapshot.tokens)
+        access_token = str(tokens.get("access_token", "") or "").strip()
+        data = {"tokens": tokens, "last_refresh": refreshed_snapshot.last_refresh}
 
     base_url = (
         os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2641,6 +2641,51 @@ def test_sync_codex_entry_noop_when_tokens_match(tmp_path, monkeypatch):
     assert synced is entry
 
 
+def test_codex_device_code_refresh_delegates_to_singleton_resolver(tmp_path, monkeypatch):
+    """device_code mirrors must not spend refresh tokens outside auth.py's singleton transaction."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_auth_store("access-OLD", "refresh-OLD"))
+
+    from agent.credential_pool import load_pool
+    import hermes_cli.auth as auth_mod
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    assert entry is not None
+    assert entry.source == "device_code"
+
+    resolver_calls = {"count": 0}
+    low_level_calls = {"count": 0}
+
+    def _resolver(*, force_refresh=False, refresh_if_expiring=True, refresh_skew_seconds=None):
+        resolver_calls["count"] += 1
+        assert force_refresh is True
+        assert refresh_if_expiring is True
+        _write_auth_store(tmp_path, _codex_auth_store("access-NEW", "refresh-NEW"))
+        return {
+            "provider": "openai-codex",
+            "api_key": "access-NEW",
+            "source": "hermes-auth-store",
+            "last_refresh": "2026-04-28T00:00:00Z",
+            "auth_mode": "chatgpt",
+        }
+
+    def _low_level_refresh(*_args, **_kwargs):
+        low_level_calls["count"] += 1
+        raise RuntimeError("credential_pool called low-level Codex refresh")
+
+    monkeypatch.setattr(auth_mod, "resolve_codex_runtime_credentials", _resolver)
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _low_level_refresh)
+
+    refreshed = pool.try_refresh_current()
+
+    assert resolver_calls["count"] == 1
+    assert low_level_calls["count"] == 0
+    assert refreshed is not None
+    assert refreshed.access_token == "access-NEW"
+    assert refreshed.refresh_token == "refresh-NEW"
+
+
 def test_codex_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatch):
     """An exhausted Codex entry should recover when auth.json has newer tokens.
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -3012,6 +3012,84 @@ def test_codex_oauth_terminal_refresh_clears_auth_json_and_removes_pool_entries(
     assert refresh_calls["count"] == 1
 
 
+def test_codex_manual_device_code_terminal_failure_does_not_clear_singleton(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CODEX_OAUTH_ACCESS_TOKEN", raising=False)
+
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "active_provider": "openai-codex",
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "singleton-access",
+                        "refresh_token": "singleton-refresh",
+                    },
+                }
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "manual-oauth",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "access_token": "manual-access",
+                        "refresh_token": "manual-refresh",
+                    },
+                    {
+                        "id": "singleton-mirror",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "access_token": "singleton-access",
+                        "refresh_token": "singleton-refresh",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool, STATUS_EXHAUSTED
+    import hermes_cli.auth as auth_mod
+    from hermes_cli.auth import AuthError
+
+    pool = load_pool("openai-codex")
+    selected = pool.select()
+    assert selected is not None
+    assert selected.id == "manual-oauth"
+    assert selected.source == "manual:device_code"
+
+    def _terminal_refresh_failure(*_args, **_kwargs):
+        raise AuthError(
+            "Refresh session has been revoked",
+            provider="openai-codex",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _terminal_refresh_failure)
+
+    assert pool.try_refresh_current() is None
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    tokens = auth_payload["providers"]["openai-codex"]["tokens"]
+    assert tokens["access_token"] == "singleton-access"
+    assert tokens["refresh_token"] == "singleton-refresh"
+
+    persisted = auth_payload["credential_pool"]["openai-codex"]
+    by_id = {entry["id"]: entry for entry in persisted}
+    assert set(by_id) == {"manual-oauth", "singleton-mirror"}
+    assert by_id["manual-oauth"]["last_status"] == STATUS_EXHAUSTED
+    assert by_id["singleton-mirror"].get("last_status") in {None, "ok"}
+    assert by_id["singleton-mirror"]["refresh_token"] == "singleton-refresh"
+
+
 def test_codex_oauth_nonterminal_refresh_does_not_quarantine(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -3012,6 +3012,148 @@ def test_codex_oauth_terminal_refresh_clears_auth_json_and_removes_pool_entries(
     assert refresh_calls["count"] == 1
 
 
+def test_codex_manual_device_code_refresh_adopts_rotated_entry_without_second_http(
+    tmp_path, monkeypatch
+):
+    """A stale waiter for the same manual entry should reread and skip HTTP refresh."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CODEX_OAUTH_ACCESS_TOKEN", raising=False)
+    old_access = _jwt_with_claims({"exp": int(time.time()) + 3600})
+    new_access = _jwt_with_claims({"exp": int(time.time()) + 7200})
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "manual-one",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "access_token": old_access,
+                        "refresh_token": "refresh-old",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+    import hermes_cli.auth as auth_mod
+
+    pool_one = load_pool("openai-codex")
+    pool_two_stale = load_pool("openai-codex")
+    assert pool_one.select() is not None
+    assert pool_two_stale.select() is not None
+
+    refresh_calls = {"count": 0}
+
+    def _manual_refresh(access_token, refresh_token, *_args, **_kwargs):
+        refresh_calls["count"] += 1
+        assert refresh_token == "refresh-old"
+        return {
+            "access_token": new_access,
+            "refresh_token": "refresh-new",
+            "last_refresh": "2026-06-21T01:00:00Z",
+        }
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _manual_refresh)
+
+    refreshed_one = pool_one.try_refresh_current()
+    refreshed_two = pool_two_stale.try_refresh_current()
+
+    assert refreshed_one is not None
+    assert refreshed_two is not None
+    assert refreshed_one.access_token == new_access
+    assert refreshed_two.access_token == new_access
+    assert refreshed_two.refresh_token == "refresh-new"
+    assert refresh_calls["count"] == 1
+
+
+def test_codex_manual_device_code_refresh_preserves_unrelated_updates(tmp_path, monkeypatch):
+    """Refreshing one manual entry must not rewrite a stale full pool snapshot."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CODEX_OAUTH_ACCESS_TOKEN", raising=False)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "manual-one",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "access_token": "access-one-old",
+                        "refresh_token": "refresh-one-old",
+                    },
+                    {
+                        "id": "manual-two",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "access_token": "access-two-old",
+                        "refresh_token": "refresh-two-old",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+    import hermes_cli.auth as auth_mod
+
+    pool_one = load_pool("openai-codex")
+    pool_two_stale = load_pool("openai-codex")
+    selected_one = pool_one.select()
+    assert selected_one is not None
+    assert selected_one.id == "manual-one"
+    pool_two_stale._current_id = "manual-two"
+
+    refresh_calls = []
+
+    def _manual_refresh(access_token, refresh_token, *_args, **_kwargs):
+        refresh_calls.append(refresh_token)
+        if refresh_token == "refresh-one-old":
+            return {
+                "access_token": "access-one-new",
+                "refresh_token": "refresh-one-new",
+                "last_refresh": "2026-06-21T01:00:00Z",
+            }
+        if refresh_token == "refresh-two-old":
+            return {
+                "access_token": "access-two-new",
+                "refresh_token": "refresh-two-new",
+                "last_refresh": "2026-06-21T02:00:00Z",
+            }
+        raise AssertionError(f"unexpected refresh token {refresh_token}")
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _manual_refresh)
+
+    refreshed_one = pool_one.try_refresh_current()
+    refreshed_two = pool_two_stale.try_refresh_current()
+
+    assert refreshed_one is not None
+    assert refreshed_two is not None
+    assert refreshed_one.access_token == "access-one-new"
+    assert refreshed_two.access_token == "access-two-new"
+    assert refresh_calls == ["refresh-one-old", "refresh-two-old"]
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    by_id = {
+        entry["id"]: entry
+        for entry in auth_payload["credential_pool"]["openai-codex"]
+    }
+    assert by_id["manual-one"]["access_token"] == "access-one-new"
+    assert by_id["manual-one"]["refresh_token"] == "refresh-one-new"
+    assert by_id["manual-two"]["access_token"] == "access-two-new"
+    assert by_id["manual-two"]["refresh_token"] == "refresh-two-new"
+
+
 def test_codex_manual_device_code_terminal_failure_does_not_clear_singleton(
     tmp_path, monkeypatch
 ):

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -92,11 +92,13 @@ def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, mo
 
     called = {"count": 0}
 
-    def _fake_refresh(tokens, timeout_seconds):
+    def _fake_refresh(access_token, refresh_token, *, timeout_seconds=20.0):
         called["count"] += 1
+        assert access_token == expiring_token
+        assert refresh_token == "refresh-old"
         return {"access_token": "access-new", "refresh_token": "refresh-new"}
 
-    monkeypatch.setattr("hermes_cli.auth._refresh_codex_auth_tokens", _fake_refresh)
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", _fake_refresh)
 
     resolved = resolve_codex_runtime_credentials()
 
@@ -111,11 +113,13 @@ def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
 
     called = {"count": 0}
 
-    def _fake_refresh(tokens, timeout_seconds):
+    def _fake_refresh(access_token, refresh_token, *, timeout_seconds=20.0):
         called["count"] += 1
+        assert access_token == "access-current"
+        assert refresh_token == "refresh-old"
         return {"access_token": "access-forced", "refresh_token": "refresh-new"}
 
-    monkeypatch.setattr("hermes_cli.auth._refresh_codex_auth_tokens", _fake_refresh)
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", _fake_refresh)
 
     resolved = resolve_codex_runtime_credentials(force_refresh=True, refresh_if_expiring=False)
 

--- a/tests/hermes_cli/test_auth_codex_self_heal.py
+++ b/tests/hermes_cli/test_auth_codex_self_heal.py
@@ -146,8 +146,8 @@ def test_reraises_when_imported_token_lacks_refresh_token(monkeypatch):
     assert saved == {}  # nothing was persisted
 
 
-def test_self_heals_missing_singleton_access_token_from_codex_cli(tmp_path, monkeypatch):
-    """Exact cron failure path: Hermes auth has refresh_token but missing access_token."""
+def test_runtime_missing_singleton_access_token_does_not_import_codex_cli(tmp_path, monkeypatch):
+    """Runtime resolution no longer auto-imports ~/.codex after malformed Hermes state."""
     hermes_home = tmp_path / "hermes"
     codex_home = tmp_path / "codex"
     hermes_home.mkdir()
@@ -171,14 +171,14 @@ def test_self_heals_missing_singleton_access_token_from_codex_cli(tmp_path, monk
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
 
-    resolved = resolve_codex_runtime_credentials()
+    with pytest.raises(AuthError) as ei:
+        resolve_codex_runtime_credentials()
 
-    assert resolved["api_key"] == "fresh-access"
-    assert resolved["source"] == "hermes-auth-store"
+    assert ei.value.code == "codex_auth_missing_access_token"
     stored = json.loads((hermes_home / "auth.json").read_text())
     tokens = stored["providers"]["openai-codex"]["tokens"]
-    assert tokens["access_token"] == "fresh-access"
-    assert tokens["refresh_token"] == "fresh-refresh"
+    assert "access_token" not in tokens
+    assert tokens["refresh_token"] == "stale-refresh"
 
 
 def test_missing_singleton_access_token_reraises_when_codex_cli_half_token(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_codex_oauth_refresh_serialization.py
+++ b/tests/hermes_cli/test_codex_oauth_refresh_serialization.py
@@ -1,0 +1,438 @@
+"""Focused tests for serializing OpenAI Codex OAuth refreshes.
+
+These tests describe the first phase of the focused auth race fix:
+
+* a profile using root fallback must refresh the root canonical store, not
+  create a profile-owned provider block;
+* an explicit profile provider block, even an empty one, shadows root;
+* concurrent in-process callers should single-flight one rotating refresh.
+"""
+
+import base64
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import auth
+from hermes_cli.auth import AuthError, resolve_codex_runtime_credentials
+
+
+def _jwt_with_exp(exp_epoch: int) -> str:
+    payload = {"exp": exp_epoch}
+    encoded = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8"))
+        .rstrip(b"=")
+        .decode("utf-8")
+    )
+    return f"h.{encoded}.s"
+
+
+def _write_store(path: Path, store: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(store, indent=2), encoding="utf-8")
+
+
+def _read_store(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def profile_and_root_auth_paths(tmp_path, monkeypatch):
+    """Wire distinct profile and root auth stores without touching real auth."""
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    root_path = tmp_path / "root" / "auth.json"
+
+    monkeypatch.setattr(auth, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-real-home"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
+    return profile_path, root_path
+
+
+def test_root_fallback_refresh_persists_to_root_without_profile_shadow(
+    profile_and_root_auth_paths,
+    monkeypatch,
+):
+    """A root-fallback refresh must update root and not create profile state."""
+    profile_path, root_path = profile_and_root_auth_paths
+    old_access = _jwt_with_exp(int(time.time()) - 60)
+    new_access = _jwt_with_exp(int(time.time()) + 3600)
+
+    _write_store(
+        profile_path,
+        {
+            "version": 1,
+            "active_provider": "anthropic",
+            "providers": {},
+        },
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "active_provider": "anthropic",
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": old_access,
+                        "refresh_token": "root-refresh-old",
+                    },
+                    "last_refresh": "2026-01-01T00:00:00Z",
+                    "auth_mode": "chatgpt",
+                }
+            },
+        },
+    )
+
+    refresh_calls = {"count": 0}
+
+    def _fake_refresh(access_token, refresh_token, *, timeout_seconds=20.0):
+        refresh_calls["count"] += 1
+        assert access_token == old_access
+        assert refresh_token == "root-refresh-old"
+        return {
+            "access_token": new_access,
+            "refresh_token": "root-refresh-new",
+            "last_refresh": "2026-06-21T00:00:00Z",
+        }
+
+    monkeypatch.setattr(auth, "refresh_codex_oauth_pure", _fake_refresh)
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert refresh_calls["count"] == 1
+    assert resolved["api_key"] == new_access
+
+    root = _read_store(root_path)
+    root_state = root["providers"]["openai-codex"]
+    assert root_state["tokens"]["access_token"] == new_access
+    assert root_state["tokens"]["refresh_token"] == "root-refresh-new"
+    assert root_state["last_refresh"] == "2026-06-21T00:00:00Z"
+    assert root["active_provider"] == "anthropic"
+
+    profile = _read_store(profile_path)
+    assert "openai-codex" not in profile.get("providers", {})
+    assert profile["active_provider"] == "anthropic"
+
+
+def test_profile_owned_empty_codex_block_shadows_root(profile_and_root_auth_paths):
+    """An empty profile block is own state and must not fall back to root."""
+    profile_path, root_path = profile_and_root_auth_paths
+    root_access = _jwt_with_exp(int(time.time()) + 3600)
+
+    _write_store(
+        profile_path,
+        {
+            "version": 1,
+            "active_provider": "anthropic",
+            "providers": {"openai-codex": {}},
+        },
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "active_provider": "openai-codex",
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": root_access,
+                        "refresh_token": "root-refresh",
+                    },
+                    "auth_mode": "chatgpt",
+                }
+            },
+        },
+    )
+
+    with pytest.raises(AuthError) as exc:
+        resolve_codex_runtime_credentials()
+
+    assert exc.value.code in {"codex_auth_missing", "codex_auth_invalid_shape"}
+    profile = _read_store(profile_path)
+    assert profile["providers"]["openai-codex"] == {}
+    root = _read_store(root_path)
+    assert root["providers"]["openai-codex"]["tokens"]["refresh_token"] == "root-refresh"
+
+
+def test_same_process_concurrent_codex_refresh_single_flights(tmp_path, monkeypatch):
+    """Concurrent callers with the same expired chain should spend it once."""
+    hermes_home = tmp_path / "hermes"
+    auth_path = hermes_home / "auth.json"
+    old_access = _jwt_with_exp(int(time.time()) - 60)
+    new_access = _jwt_with_exp(int(time.time()) + 3600)
+    _write_store(
+        auth_path,
+        {
+            "version": 1,
+            "active_provider": "anthropic",
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": old_access,
+                        "refresh_token": "refresh-old",
+                    },
+                    "last_refresh": "2026-01-01T00:00:00Z",
+                    "auth_mode": "chatgpt",
+                }
+            },
+        },
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
+    monkeypatch.setenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "5")
+
+    refresh_calls = {"count": 0}
+    refresh_lock = threading.Lock()
+    start = threading.Barrier(10)
+
+    def _fake_refresh(access_token, refresh_token, *, timeout_seconds=20.0):
+        assert access_token == old_access
+        assert refresh_token == "refresh-old"
+        with refresh_lock:
+            refresh_calls["count"] += 1
+        time.sleep(0.05)
+        return {
+            "access_token": new_access,
+            "refresh_token": "refresh-new",
+            "last_refresh": "2026-06-21T00:00:00Z",
+        }
+
+    monkeypatch.setattr(auth, "refresh_codex_oauth_pure", _fake_refresh)
+
+    results = []
+    errors = []
+
+    def _worker():
+        try:
+            start.wait(timeout=5)
+            results.append(resolve_codex_runtime_credentials()["api_key"])
+        except Exception as exc:  # pragma: no cover - assertion reports details below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_worker) for _ in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert not errors
+    assert len(results) == 10
+    assert set(results) == {new_access}
+    assert refresh_calls["count"] == 1
+
+    store = _read_store(auth_path)
+    state = store["providers"]["openai-codex"]
+    assert state["tokens"]["access_token"] == new_access
+    assert state["tokens"]["refresh_token"] == "refresh-new"
+    assert store["active_provider"] == "anthropic"
+
+
+def test_refresh_failure_adopts_newer_fresh_canonical_store(tmp_path, monkeypatch):
+    """Any refresh exception should reread and adopt a fresh changed store."""
+    hermes_home = tmp_path / "hermes"
+    auth_path = hermes_home / "auth.json"
+    old_access = _jwt_with_exp(int(time.time()) - 60)
+    new_access = _jwt_with_exp(int(time.time()) + 3600)
+    _write_store(
+        auth_path,
+        {
+            "version": 1,
+            "active_provider": "anthropic",
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": old_access,
+                        "refresh_token": "refresh-old",
+                    },
+                    "last_refresh": "2026-01-01T00:00:00Z",
+                    "auth_mode": "chatgpt",
+                }
+            },
+        },
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
+
+    def _fake_refresh(access_token, refresh_token, *, timeout_seconds=20.0):
+        assert access_token == old_access
+        assert refresh_token == "refresh-old"
+        _write_store(
+            auth_path,
+            {
+                "version": 1,
+                "active_provider": "anthropic",
+                "providers": {
+                    "openai-codex": {
+                        "tokens": {
+                            "access_token": new_access,
+                            "refresh_token": "refresh-new",
+                        },
+                        "last_refresh": "2026-06-21T00:00:00Z",
+                        "auth_mode": "chatgpt",
+                    }
+                },
+            },
+        )
+        raise AuthError(
+            "refresh token reused",
+            provider="openai-codex",
+            code="refresh_token_reused",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth, "refresh_codex_oauth_pure", _fake_refresh)
+    monkeypatch.setattr(
+        auth,
+        "_recover_codex_tokens_from_cli",
+        lambda reason: pytest.fail("runtime refresh must not import Codex CLI tokens"),
+    )
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert resolved["api_key"] == new_access
+    assert resolved["last_refresh"] == "2026-06-21T00:00:00Z"
+    assert _read_store(auth_path)["providers"]["openai-codex"]["tokens"]["refresh_token"] == "refresh-new"
+
+
+def test_changed_unknown_exp_token_is_not_adopted_after_refresh_failure(tmp_path, monkeypatch):
+    """Recovery adoption requires a parseable future exp claim."""
+    hermes_home = tmp_path / "hermes"
+    auth_path = hermes_home / "auth.json"
+    old_access = _jwt_with_exp(int(time.time()) - 60)
+    _write_store(
+        auth_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": old_access,
+                        "refresh_token": "refresh-old",
+                    },
+                    "last_refresh": "2026-01-01T00:00:00Z",
+                    "auth_mode": "chatgpt",
+                }
+            },
+        },
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
+
+    def _fake_refresh(access_token, refresh_token, *, timeout_seconds=20.0):
+        _write_store(
+            auth_path,
+            {
+                "version": 1,
+                "providers": {
+                    "openai-codex": {
+                        "tokens": {
+                            "access_token": "not-a-jwt",
+                            "refresh_token": "refresh-new",
+                        },
+                        "last_refresh": "2026-06-21T00:00:00Z",
+                        "auth_mode": "chatgpt",
+                    }
+                },
+            },
+        )
+        raise AuthError(
+            "refresh token reused",
+            provider="openai-codex",
+            code="refresh_token_reused",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth, "refresh_codex_oauth_pure", _fake_refresh)
+
+    with pytest.raises(AuthError) as exc:
+        resolve_codex_runtime_credentials()
+
+    assert exc.value.code == "refresh_token_reused"
+
+
+def test_persist_failure_after_http_success_is_terminal_and_not_retried(tmp_path, monkeypatch):
+    """Once refresh succeeds, save failure must not trigger a second refresh."""
+    hermes_home = tmp_path / "hermes"
+    auth_path = hermes_home / "auth.json"
+    old_access = _jwt_with_exp(int(time.time()) - 60)
+    new_access = _jwt_with_exp(int(time.time()) + 3600)
+    _write_store(
+        auth_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": old_access,
+                        "refresh_token": "refresh-old",
+                    },
+                    "last_refresh": "2026-01-01T00:00:00Z",
+                    "auth_mode": "chatgpt",
+                }
+            },
+        },
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
+
+    refresh_calls = {"count": 0}
+
+    def _fake_refresh(access_token, refresh_token, *, timeout_seconds=20.0):
+        refresh_calls["count"] += 1
+        return {
+            "access_token": new_access,
+            "refresh_token": "refresh-new",
+            "last_refresh": "2026-06-21T00:00:00Z",
+        }
+
+    def _failing_save(store, target_path=None):
+        if target_path == auth_path:
+            raise OSError("simulated save failure")
+        return auth._save_auth_store(store, target_path)
+
+    monkeypatch.setattr(auth, "refresh_codex_oauth_pure", _fake_refresh)
+    monkeypatch.setattr(auth, "_save_auth_store", _failing_save)
+
+    with pytest.raises(AuthError) as exc:
+        resolve_codex_runtime_credentials()
+
+    assert exc.value.code == "codex_refresh_persist_failed"
+    assert exc.value.relogin_required is False
+    assert refresh_calls["count"] == 1
+
+
+def test_runtime_missing_access_token_does_not_auto_import_codex_cli(tmp_path, monkeypatch):
+    """Runtime recovery must not silently switch to ~/.codex/auth.json."""
+    hermes_home = tmp_path / "hermes"
+    _write_store(
+        hermes_home / "auth.json",
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {"refresh_token": "stale-refresh"},
+                    "last_refresh": "2026-01-01T00:00:00Z",
+                    "auth_mode": "chatgpt",
+                }
+            },
+        },
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    recover_calls = {"count": 0}
+
+    def _recover_spy(reason):
+        recover_calls["count"] += 1
+        return {"access_token": _jwt_with_exp(int(time.time()) + 3600), "refresh_token": "cli-refresh"}
+
+    monkeypatch.setattr(auth, "_recover_codex_tokens_from_cli", _recover_spy)
+
+    with pytest.raises(AuthError) as exc:
+        resolve_codex_runtime_credentials()
+
+    assert exc.value.code == "codex_auth_missing_access_token"
+    assert recover_calls["count"] == 0


### PR DESCRIPTION
## Problem
OpenAI Codex OAuth refreshes could race across gateway/cron/parallel agent processes. A second process could refresh from stale state, overwrite newer tokens, or mark the wrong credential exhausted after another process had already repaired the singleton or manual pool entry.

## Solution
- Add path-scoped auth-store locking so profile/root fallback auth files serialize independently.
- Serialize OpenAI Codex singleton refreshes with a process lock plus file lock.
- Add compare-and-swap persistence for refreshed Codex tokens so changed snapshots are adopted safely instead of overwritten.
- Extend the credential pool refresh path to refresh exact Codex pool entries under the same lock discipline.
- Isolate manual device-code entry failures so one bad manual Codex credential does not poison unrelated singleton-derived credentials.

## Tests
- `python3 -m pytest tests/agent/test_credential_pool.py tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_codex_self_heal.py tests/hermes_cli/test_codex_oauth_refresh_serialization.py -o 'addopts=' -q` → 128 passed
- `python3 -m pytest tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_manual_paste.py tests/hermes_cli/test_auth_profile_fallback.py tests/hermes_cli/test_auth_toctou_file_modes.py -o 'addopts=' -q` → 103 passed
- `python3 -m pytest tests/hermes_cli/test_auth*.py tests/hermes_cli/test_codex_oauth_refresh_serialization.py tests/agent/test_credential_pool.py -o 'addopts=' -q` → 435 passed
- `git diff --check origin/main...HEAD` → passed
- `python3 -m py_compile` on changed Python files → passed

## Notes
No new user-facing `.env` knobs were added; the branch keeps behavioral OAuth refresh coordination in code and persisted auth state rather than adding environment configuration.
