### PR TITLE
fix(agent): explicitly set tool_choice=auto in chat_completions transport

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -315,6 +315,15 @@ class ChatCompletionsTransport(ProviderTransport):
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools
+            # Explicitly request tool_choice="auto". Without this, some
+            # providers/models (observed: NVIDIA NIM and OpenRouter routes
+            # for qwen3-next and mistral-nemotron) default to never invoking
+            # any tool even though `tools` is present and a direct API call
+            # with tool_choice="auto" correctly returns tool_calls for the
+            # same prompt (issue #49961). The OpenAI SDK does not set this
+            # itself when omitted.
+            existing_tool_choice = params.get("tool_choice")
+            api_kwargs["tool_choice"] = existing_tool_choice if existing_tool_choice else "auto"
 
         # max_tokens resolution — priority: ephemeral > user > provider default
         max_tokens_fn = params.get("max_tokens_param_fn")


### PR DESCRIPTION
## Problem

Chat Completions transport built api_kwargs[tools] but never set tool_choice. Direct curl to NVIDIA NIM with same model+tools but explicit tool_choice=auto correctly returns tool_calls, while Hermes gets tool_turns=0/finish_reason=stop on identical prompt. Reproduced with qwen3-next-80b and mistral-nemotron across NVIDIA NIM and OpenRouter (issue #49961).

## Fix

When tools present, explicitly set tool_choice (default auto, or honor explicit override).

## Verification

81/81 existing tests pass. 3 new runtime checks pass.

Not verified against live NIM/OpenRouter call in this sandbox (no API key/network access) -- fix based on static analysis matching the issues curl comparison. Requester verification welcome.

Fixes #49961