### PR TITLE
fix(agent): repair missing tool call function names (#49968)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -285,6 +285,19 @@ def sanitize_tool_call_arguments(
             if not isinstance(function, dict):
                 continue
 
+            function_name = function.get("name")
+            if not isinstance(function_name, str) or not function_name.strip():
+                tool_call_id = tool_call.get("id")
+                function["name"] = "__unknown_tool__"
+                log.warning(
+                    "Missing tool_call function name repaired before request "
+                    "(session=%s, message_index=%s, tool_call_id=%s)",
+                    session_id or "-",
+                    message_index,
+                    tool_call_id or "-",
+                )
+                repaired += 1
+
             arguments = function.get("arguments")
             if arguments is None or arguments == "":
                 function["arguments"] = "{}"

--- a/tests/run_agent/test_tool_call_args_sanitizer.py
+++ b/tests/run_agent/test_tool_call_args_sanitizer.py
@@ -149,6 +149,41 @@ def test_empty_string_arguments_treated_as_empty_object(caplog):
     assert caplog.records == []
 
 
+def test_missing_function_name_repaired_before_provider_request(caplog):
+    messages = [
+        _assistant_message(_tool_call(name="read_file", arguments='{"query":"weather"}')),
+    ]
+    del messages[0]["tool_calls"][0]["function"]["name"]
+
+    with caplog.at_level(logging.WARNING, logger="run_agent"):
+        repaired = AIAgent._sanitize_tool_call_arguments(
+            messages,
+            logger=logging.getLogger("run_agent"),
+            session_id="session-123",
+        )
+
+    assert repaired == 1
+    assert messages[0]["tool_calls"][0]["function"]["name"] == "__unknown_tool__"
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == '{"query":"weather"}'
+    assert any(
+        "Missing tool_call function name repaired before request" in record.message
+        and "session=session-123" in record.message
+        and "tool_call_id=call_1" in record.message
+        for record in caplog.records
+    )
+
+
+def test_blank_function_name_repaired_before_provider_request():
+    messages = [
+        _assistant_message(_tool_call(name="   ", arguments='{"query":"weather"}')),
+    ]
+
+    repaired = AIAgent._sanitize_tool_call_arguments(messages)
+
+    assert repaired == 1
+    assert messages[0]["tool_calls"][0]["function"]["name"] == "__unknown_tool__"
+
+
 def test_non_assistant_messages_ignored():
     messages = [
         {"role": "user", "content": "hello", "tool_calls": [_tool_call(arguments='{"bad":')]},


### PR DESCRIPTION
## Summary

Fixes #49968.

Xiaomi MiMo can intermittently persist assistant `tool_calls` where `function.name` is missing or blank. OpenAI-compatible providers reject that history on the next request with `messages[X].tool_calls[0] is missing a function name`.

This patch extends the existing production `sanitize_tool_call_arguments` pass to:

- repair missing or whitespace-only `function.name` values before the provider request
- leave valid tool calls and valid JSON arguments unchanged
- log the repair with session/message/tool-call context
- count the repair so the existing accounting remains observable

## Verification

Regression proof captured in `.automation/runs/20260621T060732Z/49968/`.

Focused tests after rebasing onto current `upstream/main`:

```text
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/run_agent/test_tool_call_args_sanitizer.py -v -o "addopts=" --tb=short
9 passed, 3 warnings in 2.88s
```

Fail-without-fix proof from the build artifact:

```text
test_missing_function_name_repaired_before_provider_request FAILED: assert 0 == 1
test_blank_function_name_repaired_before_provider_request FAILED: assert 0 == 1
2 failed, 7 passed
```

## Duplicate / competitor check

Before publishing, I checked for open PRs referencing #49968, Tranquil-Flow branches for `fix/49968*`, and distinctive Xiaomi MiMo missing-function-name keywords. No focused open competitor PRs were found.

Auto-published by Moonsong via Path B automated pipeline.
