### PR TITLE
[codex] Avoid gateway replay of Codex compaction notice

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1292,8 +1292,8 @@ def init_agent(
     # 85% (the Codex backend caps the window at 272K, so the default 50% would
     # compact at ~136K — half the usable context). Gated by an opt-out config
     # flag so the user can fall back to the global threshold; when the override
-    # fires we stash a one-time notification (replayed on the first turn) that
-    # tells the user what changed and how to revert.
+    # fires we record metadata for a CLI startup notice that tells the user what
+    # changed and how to revert.
     _codex_gpt55_autoraise = str(
         _compression_cfg.get("codex_gpt55_autoraise", True)
     ).lower() in {"true", "1", "yes"}
@@ -1709,23 +1709,16 @@ def init_agent(
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
         # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the
-        # exact opt-back-out command. Printed inline at startup for CLI users;
-        # gateway users get the same text replayed via _compression_warning on
-        # turn 1 (set below, after the warning slot is initialized).
+        # exact opt-back-out command. Printed inline at startup for CLI users.
         _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
         if _autoraise and compression_enabled:
             print(_build_codex_gpt55_autoraise_notice(_autoraise))
 
-    # Check immediately so CLI users see the warning at startup.
-    # Gateway status_callback is not yet wired, so any warning is stored
-    # in _compression_warning and replayed in the first run_conversation().
+    # Check immediately so CLI users see the warning at startup. Gateway
+    # platforms should not receive startup tuning notices as chat lifecycle
+    # messages; those can look like the agent's answer whenever the cached agent
+    # is rebuilt after idle eviction.
     agent._compression_warning = None
-    # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
-    # above only reaches the CLI, so stash the same text here to be replayed
-    # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
-    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
-        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -11,6 +11,8 @@ Arcee models like trinity-large-preview or trinity-mini.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from agent.auxiliary_client import (
@@ -19,6 +21,7 @@ from agent.auxiliary_client import (
     _is_arcee_trinity_thinking,
     _is_codex_gpt55,
 )
+from run_agent import AIAgent
 
 
 @pytest.mark.parametrize(
@@ -157,3 +160,48 @@ def test_compression_threshold_opt_out_does_not_disable_trinity() -> None:
         )
         == 0.75
     )
+
+
+def test_codex_gpt55_autoraise_does_not_queue_gateway_warning() -> None:
+    """Autoraise should tune compression without sending startup notices to chat."""
+
+    def fake_load_config():
+        return {
+            "agent": {},
+            "compression": {
+                "enabled": True,
+                "threshold": 0.70,
+                "target_ratio": 0.15,
+                "protect_last_n": 20,
+                "codex_gpt55_autoraise": True,
+            },
+        }
+
+    fake_client = type(
+        "FakeClient",
+        (),
+        {
+            "api_key": "test-token",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+    )()
+
+    with (
+        patch("hermes_cli.config.load_config", side_effect=fake_load_config),
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fake_client, "gpt-5.5"),
+        ),
+    ):
+        agent = AIAgent(
+            provider="openai-codex",
+            model="gpt-5.5",
+            quiet_mode=True,
+            enabled_toolsets=[],
+            skip_memory=True,
+            load_soul_identity=False,
+        )
+
+    assert agent.context_compressor.threshold_percent == 0.85
+    assert agent._compression_threshold_autoraised == {"from": 0.70, "to": 0.85}
+    assert agent._compression_warning is None


### PR DESCRIPTION
## Summary

- Keep the Codex gpt-5.5 compression threshold auto-raise behavior intact.
- Stop queuing that startup tuning notice for gateway chat replay, where it can appear as if it were an assistant response after an agent rebuild.
- Add a regression test that verifies the threshold still raises to 85% while no gateway compression warning is queued.

## Validation

- `uv run --extra dev pytest tests/agent/test_arcee_trinity_overrides.py tests/run_agent/test_compression_feasibility.py`