### PR TITLE
feat(delegate_task): per-call model/provider overrides

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5220,6 +5220,8 @@ class AIAgent:
             role=function_args.get("role"),
             background=(not _is_subagent),
             parent_agent=self,
+            model=function_args.get("model"),
+            provider=function_args.get("provider"),
         )
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2797,3 +2797,166 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPerCallModelOverride(unittest.TestCase):
+    """Tests for per-call model/provider overrides in delegate_task."""
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_top_level_model_override(self, mock_creds, mock_cfg):
+        """Top-level model override passes through to _build_child_agent."""
+        mock_creds.return_value = {
+            "provider": None, "base_url": None,
+            "api_key": None, "api_mode": None, "model": None,
+        }
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True,
+                "api_calls": 1, "messages": [],
+            }
+            mock_child._delegate_saved_tool_names = []
+            mock_child._credential_pool = None
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.model = "test"
+            mock_build.return_value = mock_child
+
+            delegate_task(
+                goal="test",
+                model="deepseek/deepseek-v4-pro",
+                parent_agent=parent,
+            )
+            _, kwargs = mock_build.call_args
+            self.assertEqual(kwargs["model"], "deepseek/deepseek-v4-pro")
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_top_level_provider_override(self, mock_creds, mock_cfg):
+        """Top-level provider override passes through to _build_child_agent."""
+        mock_creds.return_value = {
+            "provider": None, "base_url": None,
+            "api_key": None, "api_mode": None, "model": None,
+        }
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True,
+                "api_calls": 1, "messages": [],
+            }
+            mock_child._delegate_saved_tool_names = []
+            mock_child._credential_pool = None
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.model = "test"
+            mock_build.return_value = mock_child
+
+            delegate_task(
+                goal="test",
+                model="deepseek/deepseek-v4-pro",
+                provider="openrouter",
+                parent_agent=parent,
+            )
+            _, kwargs = mock_build.call_args
+            self.assertEqual(kwargs["override_provider"], "openrouter")
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_model_overrides_top_level(self, mock_creds, mock_cfg):
+        """Per-task model overrides top-level model."""
+        mock_creds.return_value = {
+            "provider": None, "base_url": None,
+            "api_key": None, "api_mode": None, "model": None,
+        }
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True,
+                "api_calls": 1, "messages": [],
+            }
+            mock_child._delegate_saved_tool_names = []
+            mock_child._credential_pool = None
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.model = "test"
+            mock_build.return_value = mock_child
+
+            delegate_task(
+                model="deepseek/deepseek-v4-pro",
+                tasks=[
+                    {"goal": "task1", "model": "z-ai/glm-5.2"},
+                    {"goal": "task2"},
+                ],
+                parent_agent=parent,
+            )
+            calls = mock_build.call_args_list
+            self.assertEqual(calls[0][1]["model"], "z-ai/glm-5.2")  # task1: per-task wins
+            self.assertEqual(calls[1][1]["model"], "deepseek/deepseek-v4-pro")  # task2: falls back to top-level
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_no_override_uses_config(self, mock_creds, mock_cfg):
+        """Without per-call overrides, config credentials are used."""
+        mock_creds.return_value = {
+            "provider": "openrouter", "base_url": None,
+            "api_key": "sk-test", "api_mode": "chat_completions",
+            "model": "xiaomi/mimo-v2.5",
+        }
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True,
+                "api_calls": 1, "messages": [],
+            }
+            mock_child._delegate_saved_tool_names = []
+            mock_child._credential_pool = None
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.model = "test"
+            mock_build.return_value = mock_child
+
+            delegate_task(goal="test", parent_agent=parent)
+            _, kwargs = mock_build.call_args
+            # Config model should be used, not any override
+            self.assertEqual(kwargs["model"], "xiaomi/mimo-v2.5")
+            self.assertEqual(kwargs["override_provider"], "openrouter")
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_provider_overrides_top_level(self, mock_creds, mock_cfg):
+        """Per-task provider overrides top-level provider."""
+        mock_creds.return_value = {
+            "provider": None, "base_url": None,
+            "api_key": None, "api_mode": None, "model": None,
+        }
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True,
+                "api_calls": 1, "messages": [],
+            }
+            mock_child._delegate_saved_tool_names = []
+            mock_child._credential_pool = None
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.model = "test"
+            mock_build.return_value = mock_child
+
+            delegate_task(
+                model="deepseek/deepseek-v4-pro",
+                provider="openrouter",
+                tasks=[
+                    {"goal": "task1", "provider": "omlx"},
+                    {"goal": "task2"},
+                ],
+                parent_agent=parent,
+            )
+            calls = mock_build.call_args_list
+            self.assertEqual(calls[0][1]["override_provider"], "omlx")  # task1: per-task wins
+            self.assertEqual(calls[1][1]["override_provider"], "openrouter")  # task2: falls back to top-level

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2073,6 +2073,8 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
@@ -2129,6 +2131,11 @@ def delegate_task(
 
     # Load config
     cfg = _load_config()
+    # Per-call model/provider overrides beat config-level delegation settings
+    if model:
+        cfg["model"] = model
+    if provider:
+        cfg["provider"] = provider
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     # Model-supplied max_iterations is ignored — the config value is authoritative
     # so users get predictable budgets. The kwarg is retained for internal callers
@@ -2173,7 +2180,8 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role,
+             "model": model, "provider": provider}
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2214,16 +2222,19 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task model/provider override top-level creds
+            task_model = t.get("model") or creds["model"]
+            task_provider = t.get("provider") or creds["provider"]
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_model,
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
+                override_provider=task_provider,
                 override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
                 override_api_mode=creds["api_mode"],
@@ -2898,7 +2909,7 @@ def _build_top_level_description() -> str:
         f"Orchestrators are bounded by max_spawn_depth={max_depth} for this "
         f"user and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
-        "- Subagent model is NOT selectable per call: children inherit the parent model (plus its fallback chain) unless you pin all subagents to a model via delegation.provider / delegation.model in config.yaml.\n"
+        "- Subagent model IS selectable per call: pass 'model' and/or 'provider' to override delegation.config for that specific call. Without these, children inherit the parent model (plus its fallback chain) unless pinned via delegation.provider / delegation.model in config.yaml.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
         "- Results are always returned as an array, one entry per task."
     )
@@ -3056,6 +3067,14 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "model": {
+                            "type": "string",
+                            "description": "Per-task model override. Overrides delegation.model for this task only.",
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": "Per-task provider override. Overrides delegation.provider for this task only.",
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3103,6 +3122,22 @@ DELEGATE_TASK_SCHEMA = {
                     "Leave empty unless acp_command is explicitly provided."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Per-call model override (e.g. 'deepseek/deepseek-v4-pro', "
+                    "'z-ai/glm-5.2'). Overrides delegation.model for this specific "
+                    "call only. Leave empty to use the delegation config default."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Per-call provider override (e.g. 'openrouter'). Overrides "
+                    "delegation.provider for this specific call only. Leave empty "
+                    "to use the delegation config default."
+                ),
+            },
         },
         "required": [],
     },
@@ -3144,6 +3179,8 @@ registry.register(
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
         parent_agent=kw.get("parent_agent"),
+        model=args.get("model"),
+        provider=args.get("provider"),
     ),
     check_fn=check_delegate_requirements,
     emoji="🔀",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2223,8 +2223,8 @@ def delegate_task(
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
             # Per-task model/provider override top-level creds
-            task_model = t.get("model") or creds["model"]
-            task_provider = t.get("provider") or creds["provider"]
+            task_model = t.get("model") or model or creds["model"]
+            task_provider = t.get("provider") or provider or creds["provider"]
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -142,6 +142,20 @@ delegation:
 
 If omitted, subagents use the same model as the parent.
 
+### Per-Call Overrides
+
+You can override the model and provider for individual delegation calls without changing the global config:
+
+
+
+This is useful when different tasks need different models — a cheap model for simple lookups, an expensive model for deep reasoning — without needing to change  globally.
+
+Per-task overrides are also supported in batch mode:
+
+
+
+**Precedence:**  > top-level  >  from config. When no per-call override is specified, the existing config-based behavior is used.
+
 ## Toolset Selection Tips
 
 The `toolsets` parameter controls what tools the subagent has access to. Choose based on the task:


### PR DESCRIPTION
## Summary

Adds optional `model` and `provider` parameters to `delegate_task` that override `delegation.model`/`delegation.provider` for a specific call.

## Motivation

Different subtasks need different models — code reviews on Claude, research on Gemini, cheap lookups on Flash — but `delegate_task` currently only uses the single `delegation.model` from config. Users must either change config globally, spawn full Hermes subprocesses, or create/switch profiles.

Closes #15789 (canonical issue). Related: #47014, #47295, #46880, #32711.

## What Changed

**Single task:**
```python
delegate_task(
    goal='Review code for security issues',
    model='deepseek/deepseek-v4-pro',
    provider='openrouter'
)
```

**Batch mode (per-task overrides):**
```python
delegate_task(tasks=[
    {'goal': 'Simple lookup', 'model': 'deepseek/deepseek-v4-flash'},
    {'goal': 'Hard reasoning', 'model': 'z-ai/glm-5.2', 'provider': 'openrouter'},
])
```

## Implementation

- Added `model` and `provider` optional params to `DELEGATE_TASK_SCHEMA` (top-level + per-task)
- Added `model` and `provider` to `delegate_task()` function signature
- Per-call values override config-level `delegation.model`/`delegation.provider` after config load
- Per-task values in batch mode override top-level creds
- Updated registry handler to pass new params
- Updated tool description (was: 'NOT selectable per call' → now: 'IS selectable per call')

## Backward Compatibility

Fully backward-compatible. When `model`/`provider` are not specified, behavior is identical to current — inherits from `delegation.*` config. No breaking changes to existing tool schemas or calling patterns.

## Files Changed

- `tools/delegate_tool.py`: +41/-4 lines (1 file)