### PR TITLE
feat(tools): model_router proxy client tool

### DIFF
--- a/tools/model_router.py
+++ b/tools/model_router.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Hermes tool wrapper that forwards model calls to the local model-router proxy.
+Register this in tools/ and use it from skills/other modules.
+"""
+from tools.registry import registry
+import requests
+import os
+
+MODEL_ROUTER_URL = os.environ.get('MODEL_ROUTER_URL', 'http://127.0.0.1:6000')
+
+
+def model_router_call(prompt: str, task_type: str = 'minor', timeout_total: int = 30):
+    payload = {
+        'prompt': prompt,
+        'task_type': task_type,
+        'timeout_total': timeout_total,
+    }
+    r = requests.post(MODEL_ROUTER_URL + '/v1/chat', json=payload, timeout=timeout_total+2)
+    if r.status_code != 200:
+        raise RuntimeError(f"model-router error: {r.status_code} {r.text}")
+    return r.json()
+
+
+registry.register(
+    name='model_router',
+    toolset='model',
+    schema={
+        'name': 'model_router',
+        'description': 'Route model calls through local model-router proxy with fallback and rotation',
+        'parameters': {
+            'type': 'object',
+            'properties': {
+                'prompt': {'type': 'string'},
+                'task_type': {'type': 'string'},
+                'timeout_total': {'type': 'number'},
+            },
+            'required': ['prompt']
+        }
+    },
+    handler=lambda args, **kw: model_router_call(
+        args.get('prompt'), args.get('task_type', 'minor'), args.get('timeout_total', 30)
+    ),
+    check_fn=lambda: True,
+)


### PR DESCRIPTION
## What

A thin Hermes tool (`model_router`) that forwards model calls to a **local model-router proxy** (`MODEL_ROUTER_URL`, default `http://127.0.0.1:6000`) for fallback and model rotation.

## Status: DRAFT — depends on an external proxy service

This tool is a **client** for a separate `model-router` proxy that is **not part of this repo**. It is non-functional unless that proxy is running locally. Opened as a **draft** to preserve the integration shape for re-application; it is **not** ready for review/merge as-is (the proxy service would need to be defined/shipped first, or the tool generalized to a documented endpoint).

Single net-new file, registry-registered, no other code touched.
