### PR TITLE
fix(update): preserve desktop dashboard during background updates

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5658,27 +5658,49 @@ def _find_stale_dashboard_pids(
             # with `hermes_cli.gateway._scan_gateway_pids` and avoids the
             # greedy regex matching unrelated cmdlines that merely contain
             # both words (e.g. a chat session discussing "dashboard").
+            #
+            # Include PPID so we can protect Hermes Desktop-managed dashboard
+            # children even if the update command was launched from a context
+            # that did not inherit HERMES_DESKTOP_CHILD_PID. Killing that child
+            # is visible to the user as "all desktop sessions crashed"; the
+            # Electron app owns restarting/reloading it safely.
             result = subprocess.run(
-                ["ps", "-A", "-o", "pid=,command="],
+                ["ps", "-A", "-o", "pid=,ppid=,command="],
                 capture_output=True,
                 text=True,
                 timeout=10,
             )
             if result.returncode == 0:
+                rows: list[tuple[int, int, str]] = []
+                desktop_parent_pids: set[int] = set()
                 for line in getattr(result, "stdout", "").split("\n"):
                     stripped = line.strip()
                     if not stripped or "grep" in stripped:
                         continue
-                    parts = stripped.split(None, 1)
-                    if len(parts) != 2:
+                    parts = stripped.split(None, 2)
+                    if len(parts) != 3:
                         continue
                     try:
                         pid = int(parts[0])
+                        ppid = int(parts[1])
                     except ValueError:
                         continue
-                    command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
-                        dashboard_pids.append(pid)
+                    command = parts[2]
+                    rows.append((pid, ppid, command))
+                    if (
+                        "Hermes.app/Contents/MacOS/Hermes" in command
+                        and "Hermes Helper" not in command
+                    ):
+                        desktop_parent_pids.add(pid)
+
+                for pid, ppid, command in rows:
+                    if pid == self_pid:
+                        continue
+                    if not any(p in command for p in patterns):
+                        continue
+                    if ppid in desktop_parent_pids:
+                        continue
+                    dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []
 

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -59,9 +59,9 @@ def _refresh_bindings_against_live_module():
     yield
 
 
-def _ps_line(pid: int, cmd: str) -> str:
-    """Format a line as it would appear in ``ps -A -o pid=,command=`` output."""
-    return f"{pid:>7} {cmd}"
+def _ps_line(pid: int, cmd: str, ppid: int = 1) -> str:
+    """Format a line as it would appear in ``ps -A -o pid=,ppid=,command=`` output."""
+    return f"{pid:>7} {ppid:>7} {cmd}"
 
 
 def _ps_runner(stdout: str):
@@ -204,6 +204,63 @@ class TestFindStaleDashboardPids:
         assert 11111 in pids
         assert 22222 not in pids
         assert 33333 in pids
+
+    def test_desktop_managed_dashboard_child_is_protected_by_ppid(self):
+        """Cron/chat updates may not inherit HERMES_DESKTOP_CHILD_PID.
+
+        On macOS/Linux the desktop backend still has Hermes.app as its direct
+        parent. Detect that lineage from ps and do not reap it; otherwise a
+        successful background update drops every active desktop conversation.
+        """
+        desktop_pid = 44444
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(
+                        desktop_pid,
+                        "/Users/u/.hermes/hermes-agent/apps/desktop/release/mac-arm64/Hermes.app/Contents/MacOS/Hermes",
+                        ppid=1,
+                    ),
+                    _ps_line(
+                        55555,
+                        "/Users/u/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main dashboard --no-open --host 127.0.0.1 --port 0",
+                        ppid=desktop_pid,
+                    ),
+                    _ps_line(66666, "hermes dashboard --port 9119", ppid=1),
+                ]) + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        assert 55555 not in pids
+        assert pids == [66666]
+
+    def test_desktop_helper_is_not_treated_as_dashboard_parent(self):
+        """Electron helper processes also contain Hermes.app in their path.
+
+        Only the main Hermes.app process owns dashboard children; helper
+        processes must not accidentally protect unrelated dashboard PIDs.
+        """
+        helper_pid = 44445
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(
+                        helper_pid,
+                        "/Users/u/.hermes/hermes-agent/apps/desktop/release/mac-arm64/Hermes.app/Contents/Frameworks/Hermes Helper.app/Contents/MacOS/Hermes Helper",
+                        ppid=1,
+                    ),
+                    _ps_line(
+                        55556,
+                        "/Users/u/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main dashboard --no-open",
+                        ppid=helper_pid,
+                    ),
+                ]) + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        assert pids == [55556]
 
     def test_exclude_pids_none_is_noop(self):
         """Passing exclude_pids=None (the default) changes nothing."""


### PR DESCRIPTION
## Summary
- Protect Hermes Desktop-managed dashboard backends during `hermes update` even when cron/chat-triggered updates do not inherit `HERMES_DESKTOP_CHILD_PID`.
- Detect the Hermes.app main process from `ps` PPID lineage and skip reaping its dashboard child.
- Add regression tests proving cron/background updates preserve desktop-managed conversations while helper processes do not accidentally protect unrelated dashboards.

## Test Plan
- `venv/bin/python -m pytest tests/hermes_cli/test_update_stale_dashboard.py tests/gateway/test_clean_shutdown_marker.py -q -o 'addopts='`
