### PR TITLE
fix(desktop): reopen preview panel after closing when setting new target

### DIFF
--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -2,6 +2,7 @@ import { atom, computed } from 'nanostores'
 
 import { $rightRailActiveTabId, RIGHT_RAIL_PREVIEW_TAB_ID, type RightRailTabId, selectRightRailTab } from './layout'
 import { $activeSessionId, $selectedStoredSessionId } from './session'
+import { setPaneOpen } from './panes'
 
 export interface PreviewTarget {
   binary?: boolean
@@ -100,6 +101,7 @@ export function setPreviewTarget(target: PreviewTarget | null) {
   $previewTarget.set(target)
 
   if (target) {
+    setPaneOpen('preview', true)
     selectRightRailTab(RIGHT_RAIL_PREVIEW_TAB_ID)
   }
 }


### PR DESCRIPTION
  What does this PR do?
  
💾 Self-improvement review: Patched SKILL.md in skill 'hermes-agent' (1 replacement). · Patched SKILL.md in skill 'github-repo-management' (1 replacement).
  Call setPaneOpen('preview', true) in setPreviewTarget() so the preview panel reopens when a new preview target is set. Previously the function only set the target and selected the right rail tab, but did not restore the pane open state — so after closing the preview panel, subsequent browser_navigate calls loaded content but the panel stayed hidden.
  
  Related Issue
  
  Fixes #49985
  
  Type of Change
  
  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests
  - [ ] ♻️ Refactor
  - [ ] 🎯 New skill
  
  Changes Made
  
  File: apps/desktop/src/store/preview.ts (+2 lines)
  
  - Import setPaneOpen from ./panes
  - In setPreviewTarget(): when target is non-null, call setPaneOpen('preview', true) before selectRightRailTab()
  
  How to Test
  
  1. Launch Hermes Desktop
  2. Call browser_navigate with any URL — preview panel opens ✅
  3. Click the close (X) button on the preview panel
  4. Call browser_navigate again — preview panel reopens and displays the URL content ✅
  
  Checklist
  
  - [x] Commit messages follow Conventional Commits
  - [x] Searched for existing PRs — no duplicates
  - [x] Only changes related to this fix
  - [ ] N/A — no tests (pure store change, tested manually)
  - [x] Tested on Ubuntu 24.04