### PR TITLE
fix(mcp): detect 'unknown method' phrasing in ping keepalive fallback (fix #50028)

### DIFF
--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -254,6 +254,12 @@ class TestMethodNotFoundDetection:
         from tools.mcp_tool import _is_method_not_found_error
         assert _is_method_not_found_error(Exception("Method not found")) is True
 
+    def test_unknown_method_phrasing_is_match(self):
+        # agentmemory's MCP server surfaces method-not-found as a plain
+        # "Unknown method: ping" string with no structural -32601 code (#50028).
+        from tools.mcp_tool import _is_method_not_found_error
+        assert _is_method_not_found_error(Exception("Unknown method: ping")) is True
+
     def test_unrelated_exception_is_not_match(self):
         from tools.mcp_tool import _is_method_not_found_error
         assert _is_method_not_found_error(TimeoutError()) is False
@@ -291,6 +297,23 @@ class TestKeepaliveProbeFallback:
         await task._keepalive_probe()
 
         # First cycle: ping tried, failed -32601, list_tools used as fallback.
+        task.session.send_ping.assert_awaited_once()
+        task.session.list_tools.assert_awaited_once()
+        assert task._ping_unsupported is True
+
+    async def test_falls_back_on_unknown_method_string(self):
+        """Regression for #50028: a server that surfaces method-not-found as a
+        plain "Unknown method: ping" string (no structural -32601 code) must
+        still latch the fallback and use list_tools, NOT reconnect-loop."""
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(tools=SimpleNamespace())
+        task.session = SimpleNamespace(
+            send_ping=AsyncMock(side_effect=Exception("Unknown method: ping")),
+            list_tools=AsyncMock(return_value=SimpleNamespace(tools=[])),
+        )
+
+        await task._keepalive_probe()
+
         task.session.send_ping.assert_awaited_once()
         task.session.list_tools.assert_awaited_once()
         assert task._ping_unsupported is True

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -415,6 +415,13 @@ def _is_method_not_found_error(exc: BaseException) -> bool:
     an empty result. Structurally inspect ``McpError.error.code`` first, then
     fall back to a substring match so detection survives SDK version drift and
     servers that surface the condition as a plain message.
+
+    The substring fallback matters when a server reports method-not-found
+    without a structural ``-32601`` code (e.g. surfaced as a plain exception
+    string). Besides the canonical "method not found", many JSON-RPC
+    implementations phrase it as "Unknown method: <name>" — agentmemory's MCP
+    server is one such case (#50028). Without matching that phrasing the
+    ping→list_tools fallback never latches and the keepalive reconnect-loops.
     """
     # Structural: mcp.shared.exceptions.McpError carries ErrorData.code.
     err = getattr(exc, "error", None)
@@ -427,6 +434,7 @@ def _is_method_not_found_error(exc: BaseException) -> bool:
     return (
         str(_JSONRPC_METHOD_NOT_FOUND) in msg
         or "method not found" in msg
+        or "unknown method" in msg
         or "not found: ping" in msg
     )
 


### PR DESCRIPTION
## Summary
Fixes the reconnect loop where MCP servers that don't implement the optional `ping` utility get torn down and restarted every keepalive cycle (~every 3 min), spamming the log with `keepalive failed, triggering reconnect: Unknown method: ping`.

## Root cause
The ping keepalive (commit `40722058e`) already has a capability-aware fallback: if `ping` returns JSON-RPC method-not-found, `_is_method_not_found_error` latches `_ping_unsupported` and the probe falls back to `list_tools` instead of reconnecting. But the substring fallback only matched `method not found` / `-32601` / `not found: ping`.

Some servers surface method-not-found as the common **`Unknown method: <name>`** phrasing **without** a structural `-32601` code (e.g. `@agentmemory/mcp`). That string matched none of the patterns, so:
1. `_is_method_not_found_error` returned `False`,
2. the -32601 fallback never latched,
3. `_keepalive_probe` re-raised → `_wait_for_lifecycle_event` triggered a reconnect **every cycle**.

The issue's suggested fix (`if "ping" in server_capabilities`) doesn't apply — MCP has no `capabilities.ping` advertisement; `ping` is a base-protocol utility detected via -32601, which is exactly what the existing fallback does. The real gap is the missing phrasing.

## Changes
- `tools/mcp_tool.py`: add `"unknown method"` to the `_is_method_not_found_error` substring fallback (one line + docstring note).
- `tests/tools/test_mcp_capability_gating.py`: two regression tests — the detector matches `"Unknown method: ping"`, and `_keepalive_probe` latches the fallback to `list_tools` (no reconnect) for that string.

## Validation
`scripts/run_tests.sh tests/tools/test_mcp_capability_gating.py` → 27/27 green (25 existing + 2 new).

Fixes #50028.
