### PR TITLE
fix(storage): improve error handling granularity + fix small file size display

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -101,6 +101,26 @@ class TestWriteToSandbox:
         result = _write_to_sandbox("content", "/tmp/hermes-results/abc.txt", env)
         assert result is False
 
+    def test_execute_exception_logs_warning(self, caplog):
+        env = MagicMock()
+        env.execute.side_effect = RuntimeError("connection lost")
+        with caplog.at_level("WARNING", logger="tools.tool_result_storage"):
+            result = _write_to_sandbox("content", "/tmp/hermes-results/abc.txt", env)
+
+        assert result is False
+        assert "env.execute() raised RuntimeError: connection lost" in caplog.text
+        assert "/tmp/hermes-results/abc.txt" in caplog.text
+
+    def test_nonzero_return_logs_exit_and_output(self, caplog):
+        env = MagicMock()
+        env.execute.return_value = {"output": "disk full", "returncode": 28}
+        with caplog.at_level("WARNING", logger="tools.tool_result_storage"):
+            result = _write_to_sandbox("content", "/tmp/hermes-results/abc.txt", env)
+
+        assert result is False
+        assert "exit code 28" in caplog.text
+        assert "disk full" in caplog.text
+
     def test_large_content_via_stdin(self):
         """Regression: 200 KB content exceeds Linux MAX_ARG_STRLEN (128 KB).
         It must travel via stdin, never inside the command string."""
@@ -202,6 +222,25 @@ class TestBuildPersistedMessage:
             file_path="/tmp/hermes-results/big.txt",
         )
         assert "MB" in msg
+
+    def test_sub_kb_size_shows_bytes(self):
+        msg = _build_persisted_message(
+            preview="x",
+            has_more=False,
+            original_size=16,
+            file_path="/tmp/hermes-results/tiny.txt",
+        )
+        assert "16 characters, 16 bytes" in msg
+        assert "0.0 KB" not in msg
+
+    def test_kb_boundary_shows_kb(self):
+        msg = _build_persisted_message(
+            preview="x",
+            has_more=False,
+            original_size=1024,
+            file_path="/tmp/hermes-results/one-kb.txt",
+        )
+        assert "1,024 characters, 1.0 KB" in msg
 
 
 # ── maybe_persist_tool_result ─────────────────────────────────────────

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -90,8 +90,28 @@ def _write_to_sandbox(content: str, remote_path: str, env) -> bool:
     """
     storage_dir = os.path.dirname(remote_path)
     cmd = f"mkdir -p {shlex.quote(storage_dir)} && cat > {shlex.quote(remote_path)}"
-    result = env.execute(cmd, timeout=30, stdin_data=content)
-    return result.get("returncode", 1) == 0
+    try:
+        result = env.execute(cmd, timeout=30, stdin_data=content)
+    except Exception as exc:
+        logger.warning(
+            "Sandbox write failed for %s — env.execute() raised %s: %s",
+            remote_path, type(exc).__name__, exc,
+        )
+        return False
+
+    returncode = result.get("returncode", 1)
+    if returncode != 0:
+        error_output = result.get("output", "")
+        # Truncate error output for logging (avoid flooding logs with huge error messages)
+        if len(error_output) > 500:
+            error_output = error_output[:500] + "... [truncated]"
+        logger.warning(
+            "Sandbox write failed for %s — exit code %d, output: %s",
+            remote_path, returncode, error_output,
+        )
+        return False
+
+    return True
 
 
 def _build_persisted_message(
@@ -101,11 +121,12 @@ def _build_persisted_message(
     file_path: str,
 ) -> str:
     """Build the <persisted-output> replacement block."""
-    size_kb = original_size / 1024
-    if size_kb >= 1024:
-        size_str = f"{size_kb / 1024:.1f} MB"
+    if original_size >= 1024 * 1024:
+        size_str = f"{original_size / 1024 / 1024:.1f} MB"
+    elif original_size >= 1024:
+        size_str = f"{original_size / 1024:.1f} KB"
     else:
-        size_str = f"{size_kb:.1f} KB"
+        size_str = f"{original_size} bytes"
 
     msg = f"{PERSISTED_OUTPUT_TAG}\n"
     msg += f"This tool result was too large ({original_size:,} characters, {size_str}).\n"


### PR DESCRIPTION
## Summary

This PR contains two improvements to tools/tool_result_storage.py:

1. Improved error handling granularity in _write_to_sandbox - catches env.execute() exceptions and logs returncode != 0 details
2. Fix size display for small files in _build_persisted_message - shows bytes instead of 0.0 KB when original_size < 1024

Synced with latest upstream/main.