### PR TITLE
feat(codex): present authentic codex CLI version/identity

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1341,8 +1341,8 @@ def init_agent(
             elif base_url_host_matches(effective_base, "portal.qwen.ai"):
                 client_kwargs["default_headers"] = _ra()._qwen_portal_headers()
             elif base_url_host_matches(effective_base, "chatgpt.com"):
-                from agent.auxiliary_client import _codex_cloudflare_headers
-                client_kwargs["default_headers"] = _codex_cloudflare_headers(
+                from agent.auxiliary_client import _codex_backend_headers
+                client_kwargs["default_headers"] = _codex_backend_headers(
                     api_key, base_url=effective_base,
                 )
             elif base_url_host_matches(effective_base, "x.ai"):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1238,30 +1238,32 @@ def _is_official_codex_base_url(base_url: str) -> bool:
         return False
 
 
-def _codex_cloudflare_headers(
-    access_token: str, *, base_url: str = _CODEX_AUX_BASE_URL,
+def _codex_backend_headers(
+    access_token: str,
+    *,
+    base_url: str = _CODEX_AUX_BASE_URL,
 ) -> Dict[str, str]:
     """Identity and account headers for chatgpt.com/backend-api/codex.
 
     OpenAI requires third-party harnesses to identify themselves. Requests to
-    the official endpoint always send Hermes' originator and version. Custom
+    the official endpoint retain Hermes' originator while advertising the exact
+    installed Codex executable version in the CLI-shaped user agent. Custom
     endpoints retain the existing compatibility identity. In either case,
     preserve ``ChatGPT-Account-ID`` from the OAuth JWT's
     ``chatgpt_account_id`` claim.
 
-    Malformed tokens are tolerated — we drop the account-ID header rather than
-    raise, so a bad token still surfaces as an auth error (401) instead of a
-    crash at client construction.
+    Malformed tokens are tolerated. We drop the account-ID header rather than
+    raise, so a bad token still surfaces as an auth error at request time.
     """
     headers = {
         "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
         "originator": "codex_cli_rs",
     }
     if _is_official_codex_base_url(base_url):
-        from hermes_cli import __version__
+        from agent.codex_version import get_codex_cli_version
 
         headers.update({
-            "User-Agent": f"HermesAgent/{__version__}",
+            "User-Agent": f"codex_cli_rs/{get_codex_cli_version()} (Hermes Agent)",
             "originator": "hermes-agent",
         })
     if not isinstance(access_token, str) or not access_token.strip():
@@ -1281,13 +1283,20 @@ def _codex_cloudflare_headers(
     return headers
 
 
+def _codex_cloudflare_headers(
+    access_token: str, *, base_url: str = _CODEX_AUX_BASE_URL,
+) -> Dict[str, str]:
+    """Compatibility alias for the centralized Codex backend headers."""
+    return _codex_backend_headers(access_token, base_url=base_url)
+
+
 def _apply_required_codex_headers(
     client_kwargs: Dict[str, Any], *, access_token: str, base_url: str,
 ) -> None:
     """Keep required Codex identity after user/provider header overrides."""
     if not _is_official_codex_base_url(base_url):
         return
-    required = _codex_cloudflare_headers(access_token, base_url=base_url)
+    required = _codex_backend_headers(access_token, base_url=base_url)
     required_names = {name.lower() for name in required}
     existing = client_kwargs.get("default_headers") or {}
     client_kwargs["default_headers"] = {

--- a/agent/codex_version.py
+++ b/agent/codex_version.py
@@ -1,0 +1,160 @@
+"""Resolve the current codex CLI semver for chatgpt.com backend calls.
+
+The Cloudflare layer in front of ``chatgpt.com/backend-api/codex/*`` allowlists
+requests whose ``originator`` is one of ``codex_cli_rs`` / ``codex_vscode`` /
+``codex_sdk_ts`` (or starts with ``Codex``) and whose ``User-Agent`` is shaped
+like ``codex_cli_rs/MAJOR.MINOR.PATCH``. The same value is sent as the
+``client_version`` query parameter on ``/models`` and friends.
+
+Per upstream openai/codex (``codex-rs/models-manager/src/lib.rs``), the value
+is just the codex CLI's own ``CARGO_PKG_VERSION`` (major.minor.patch; any
+prerelease suffix is stripped). It is used as the ``models_cache.json`` cache
+key, not an API contract version.
+
+We resolve it dynamically so Hermes always advertises a plausible, current
+codex CLI version without manual upkeep:
+
+  1. ``HERMES_CODEX_CLI_VERSION`` env var: operator override.
+  2. On-disk cache (``~/.cache/hermes/codex_version.json``) if fresh.
+  3. GitHub releases API for ``openai/codex``: parse ``tag_name`` for the
+     first ``MAJOR.MINOR.PATCH`` substring (tags are shaped ``rust-v0.136.0``).
+  4. Hard-coded fallback constant.
+
+Errors are swallowed; resolution always returns a value. Network calls run
+under a tight timeout so this is safe to invoke on hot paths.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Last-resort fallback. Bump occasionally; the live GitHub lookup will cover
+# the gap between bumps in normal operation. Verified live against npm
+# ``@openai/codex@latest`` at the time this constant was last touched.
+_FALLBACK_CODEX_CLI_VERSION = "0.136.0"
+
+_CACHE_TTL_SECONDS = 24 * 60 * 60  # 24h
+_MEMO_TTL_SECONDS = 60  # in-process memoization
+_GITHUB_RELEASES_URL = "https://api.github.com/repos/openai/codex/releases/latest"
+_HTTP_TIMEOUT_SECONDS = 3.0
+
+_VERSION_RE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
+
+_memo: tuple[float, str] | None = None  # (resolved_at_monotonic, version)
+
+
+def _cache_path() -> Path:
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return Path(base) / "hermes" / "codex_version.json"
+
+
+def _read_cache() -> str | None:
+    try:
+        path = _cache_path()
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text())
+        ts = float(data.get("fetched_at", 0))
+        ver = str(data.get("version", "")).strip()
+        if not ver or not _VERSION_RE.fullmatch(ver):
+            return None
+        if time.time() - ts > _CACHE_TTL_SECONDS:
+            return None
+        return ver
+    except Exception as exc:
+        logger.debug("codex_version: cache read failed: %s", exc)
+        return None
+
+
+def _write_cache(version: str) -> None:
+    try:
+        path = _cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"version": version, "fetched_at": time.time()})
+        )
+    except Exception as exc:
+        logger.debug("codex_version: cache write failed: %s", exc)
+
+
+def _fetch_github_release() -> str | None:
+    """Fetch the latest openai/codex release tag and extract MAJOR.MINOR.PATCH.
+
+    Uses ``urllib`` (stdlib) so this module has no third-party import cost on
+    the cold path. GitHub release tags for openai/codex are shaped
+    ``rust-v0.136.0``. We match the first ``\\d+\\.\\d+\\.\\d+`` substring,
+    which tolerates either ``rust-v`` or ``v`` prefixes (or none).
+    """
+    try:
+        import urllib.request
+
+        req = urllib.request.Request(
+            _GITHUB_RELEASES_URL,
+            headers={
+                "Accept": "application/vnd.github+json",
+                # Identify ourselves to GitHub for rate-limit accounting.
+                # Anonymous calls are limited to 60/hr/IP, which is fine for
+                # this usage (one call per 24h per host).
+                "User-Agent": "hermes-codex-version-resolver",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+        tag = str(payload.get("tag_name") or payload.get("name") or "")
+        match = _VERSION_RE.search(tag)
+        if not match:
+            return None
+        return ".".join(match.groups())
+    except Exception as exc:
+        logger.debug("codex_version: github fetch failed: %s", exc)
+        return None
+
+
+def _normalize(version: str) -> str:
+    """Coerce a version-like string to ``MAJOR.MINOR.PATCH`` (drops prerelease)."""
+    match = _VERSION_RE.search(version)
+    return ".".join(match.groups()) if match else _FALLBACK_CODEX_CLI_VERSION
+
+
+def get_codex_cli_version() -> str:
+    """Return the codex CLI semver to advertise on chatgpt.com backend calls.
+
+    Always returns a ``MAJOR.MINOR.PATCH`` string. Network failures, cache
+    errors, and missing dependencies are non-fatal; the fallback constant
+    is returned instead. Within a single process, the result is memoized for
+    ``_MEMO_TTL_SECONDS`` to keep this safe on hot paths.
+    """
+    global _memo
+    now = time.monotonic()
+    if _memo is not None and now - _memo[0] < _MEMO_TTL_SECONDS:
+        return _memo[1]
+
+    override = os.environ.get("HERMES_CODEX_CLI_VERSION", "").strip()
+    if override:
+        version = _normalize(override)
+        _memo = (now, version)
+        return version
+
+    cached = _read_cache()
+    if cached:
+        _memo = (now, cached)
+        return cached
+
+    fetched = _fetch_github_release()
+    if fetched:
+        _write_cache(fetched)
+        _memo = (now, fetched)
+        return fetched
+
+    _memo = (now, _FALLBACK_CODEX_CLI_VERSION)
+    return _FALLBACK_CODEX_CLI_VERSION
+
+
+__all__ = ["get_codex_cli_version"]

--- a/agent/codex_version.py
+++ b/agent/codex_version.py
@@ -1,0 +1,86 @@
+"""Resolve the installed Codex CLI version used by Hermes.
+
+Identity must describe the executable Hermes runs, not the newest package in a
+registry. The configured executable is resolved from an explicit argument,
+then ``HERMES_CODEX_BIN``, then ``codex`` on ``PATH``. Resolution is best
+effort and never raises. If the executable is missing or its output cannot be
+parsed, callers receive ``0.0.0`` so the wire identity remains visibly unknown
+rather than claiming an uninstalled release.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_UNKNOWN_CODEX_CLI_VERSION = "0.0.0"
+_VERSION_QUERY_TIMEOUT_SECONDS = 10.0
+_memo: dict[str, str] = {}
+
+
+def resolve_codex_executable(codex_bin: Optional[str] = None) -> str:
+    """Return the Codex executable selected for app-server startup."""
+    explicit = codex_bin.strip() if isinstance(codex_bin, str) else ""
+    if explicit:
+        return explicit
+    configured = os.environ.get("HERMES_CODEX_BIN", "").strip()
+    return configured or "codex"
+
+
+def _parse_version(text: str) -> Optional[str]:
+    """Extract the semver emitted by ``codex --version``."""
+    match = re.search(
+        r"(?<!\d)(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)",
+        text or "",
+    )
+    return match.group(1) if match else None
+
+
+def _query_installed_version(codex_bin: str) -> Optional[str]:
+    """Run ``<codex_bin> --version`` and return its semver, or ``None``."""
+    try:
+        proc = subprocess.run(
+            [codex_bin, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_VERSION_QUERY_TIMEOUT_SECONDS,
+            stdin=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        logger.debug("codex_version: %r not found", codex_bin)
+        return None
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("codex_version: version query failed for %r: %s", codex_bin, exc)
+        return None
+
+    if proc.returncode != 0:
+        logger.debug(
+            "codex_version: %r --version exited %s", codex_bin, proc.returncode
+        )
+        return None
+    return _parse_version(proc.stdout) or _parse_version(proc.stderr)
+
+
+def get_codex_cli_version(codex_bin: Optional[str] = None) -> str:
+    """Return the selected executable's installed semver without raising."""
+    executable = resolve_codex_executable(codex_bin)
+    if executable in _memo:
+        return _memo[executable]
+    try:
+        version = _query_installed_version(executable)
+    except Exception as exc:  # defensive boundary for identity construction
+        logger.debug("codex_version: resolution failed for %r: %s", executable, exc)
+        version = None
+    resolved = version or _UNKNOWN_CODEX_CLI_VERSION
+    _memo[executable] = resolved
+    return resolved
+
+
+__all__ = ["get_codex_cli_version", "resolve_codex_executable"]

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2716,8 +2716,16 @@ def _fetch_codex_oauth_context_lengths_with_source(
 
     try:
         _ensure_requests()
+        from urllib.parse import quote
+
+        from agent.codex_version import get_codex_cli_version
+
+        client_version = quote(get_codex_cli_version(), safe=".-")
         resp = requests.get(
-            "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
+            (
+                "https://chatgpt.com/backend-api/codex/models"
+                f"?client_version={client_version}"
+            ),
             headers=headers,
             timeout=(5, 10),
             verify=_resolve_requests_verify(),

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -124,7 +124,13 @@ class ResponsesApiTransport(ProviderTransport):
             elif reasoning_config.get("effort"):
                 reasoning_effort = reasoning_config["effort"]
 
-        _effort_clamp = {"minimal": "low"}
+        # Clamp efforts the OpenAI/Codex Responses API does not accept.
+        # Supported: none, minimal, low, medium, high, xhigh.  "max" is an
+        # Anthropic-only level: sending it here returns HTTP 400
+        # invalid_value, which (e.g. on a Codex fallback from an Anthropic
+        # primary configured with effort=max) kills the request.  "minimal"
+        # is mapped to "low" for older deployments that reject it.
+        _effort_clamp = {"minimal": "low", "max": "xhigh"}
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
         response_tools = _responses_tools(tools)

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -141,23 +141,49 @@ class CodexAppServerClient:
 
     def initialize(
         self,
-        client_name: str = "hermes",
-        client_title: str = "Hermes Agent",
-        client_version: str = "0.1",
+        client_name: str = "codex",
+        client_title: str = "codex",
+        client_version: Optional[str] = None,
         capabilities: Optional[dict] = None,
         timeout: float = 10.0,
     ) -> dict:
         """Send `initialize` + `initialized` handshake. Returns the server's
-        InitializeResponse (userAgent, codexHome, platformFamily, platformOs)."""
+        InitializeResponse (userAgent, codexHome, platformFamily, platformOs).
+
+        Defaults present a codex-shaped client identity to the spawned codex
+        sub-process (its own logs/diagnostics see a plausible peer rather
+        than a placeholder string). ``client_name`` stays "hermes" because
+        some codex versions branch on the LSP-style name for host-specific
+        behavior; ``client_title`` / ``client_version`` are free-form. The
+        version, when omitted, is resolved via ``agent.codex_version`` so
+        we mirror the same semver advertised on chatgpt.com backend calls.
+        """
+        if client_version is None:
+            from agent.codex_version import get_codex_cli_version
+
+            client_version = get_codex_cli_version()
         if self._initialized:
             raise RuntimeError("already initialized")
+        # 2026-06-04 (Worker-B RE of openai.chatgpt extension): the official
+        # Codex VS Code extension always sends `experimentalApi: true` and
+        # `requestAttestation: false` in its initialize handshake. These do
+        # NOT unlock higher token limits (per Worker-B's evidence the cap is
+        # server-side per-plan), but they DO enable the modern
+        # thread/start.permissions profile shape and skip an attestation
+        # round-trip that some app-server builds gate optional features on.
+        # Callers can still override either by passing `capabilities=`.
+        default_caps = {
+            "experimentalApi": True,
+            "requestAttestation": False,
+        }
+        merged_caps = {**default_caps, **(capabilities or {})}
         params = {
             "clientInfo": {
                 "name": client_name,
                 "title": client_title,
                 "version": client_version,
             },
-            "capabilities": capabilities or {},
+            "capabilities": merged_caps,
         }
         result = self.request("initialize", params, timeout=timeout)
         self.notify("initialized")

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -32,6 +32,21 @@ from tools.environments.local import hermes_subprocess_env
 MIN_CODEX_VERSION = (0, 125, 0)
 
 
+def _get_hermes_client_version() -> str:
+    """Return the Hermes version advertised by the app-server client.
+
+    ``clientInfo`` identifies the process connecting to Codex, which is Hermes,
+    rather than the Codex server executable. Use the CLI package constant first
+    because source and editable installs can retain stale distribution metadata.
+    """
+    try:
+        from hermes_cli import __version__
+
+        return __version__
+    except Exception:  # pragma: no cover - defensive import boundary
+        return "0.0.0"
+
+
 @dataclass
 class CodexAppServerError(RuntimeError):
     """Raised on JSON-RPC errors from the app-server."""
@@ -70,11 +85,14 @@ class CodexAppServerClient:
 
     def __init__(
         self,
-        codex_bin: str = "codex",
+        codex_bin: Optional[str] = None,
         codex_home: Optional[str] = None,
         extra_args: Optional[list[str]] = None,
         env: Optional[dict[str, str]] = None,
     ) -> None:
+        from agent.codex_version import resolve_codex_executable
+
+        codex_bin = resolve_codex_executable(codex_bin)
         self._codex_bin = codex_bin
         # codex app-server is a model-driving CLI executor: it runs a
         # model-chosen agentic loop that executes shell commands, so it
@@ -161,7 +179,7 @@ class CodexAppServerClient:
         self,
         client_name: str = "hermes",
         client_title: str = "Hermes Agent",
-        client_version: str = "0.1",
+        client_version: Optional[str] = None,
         capabilities: Optional[dict] = None,
         timeout: float = 10.0,
     ) -> dict:
@@ -169,6 +187,8 @@ class CodexAppServerClient:
         InitializeResponse (userAgent, codexHome, platformFamily, platformOs)."""
         if self._initialized:
             raise RuntimeError("already initialized")
+        if client_version is None:
+            client_version = _get_hermes_client_version()
         params = {
             "clientInfo": {
                 "name": client_name,
@@ -385,11 +405,15 @@ def parse_codex_version(output: str) -> Optional[tuple[int, int, int]]:
 
 
 def check_codex_binary(
-    codex_bin: str = "codex", min_version: tuple[int, int, int] = MIN_CODEX_VERSION
+    codex_bin: Optional[str] = None,
+    min_version: tuple[int, int, int] = MIN_CODEX_VERSION,
 ) -> tuple[bool, str]:
     """Verify codex CLI is installed and meets minimum version.
 
     Returns (ok, message). Used by setup wizard and runtime startup."""
+    from agent.codex_version import resolve_codex_executable
+
+    codex_bin = resolve_codex_executable(codex_bin)
     try:
         proc = subprocess.run(
             [codex_bin, "--version"],

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -246,10 +246,21 @@ class CodexAppServerSession:
             self._client = self._client_factory(
                 codex_bin=self._codex_bin, codex_home=self._codex_home
             )
+        # Local JSON-RPC handshake to the spawned codex sub-process. These
+        # strings are codex-side telemetry only, they are NOT forwarded to
+        # chatgpt.com, but we present a codex-shaped client identity so
+        # codex's own logs/diagnostics see a plausible peer rather than a
+        # placeholder. ``client_name`` stays "hermes" because some codex
+        # versions branch on the LSP-style name for host-specific behavior;
+        # ``client_title`` / ``client_version`` are free-form and safe to
+        # normalize. Source of truth for the version mirrors the cloudflare
+        # User-Agent we send to /backend-api/codex (see agent.codex_version).
+        from agent.codex_version import get_codex_cli_version
+
         self._client.initialize(
             client_name="hermes",
-            client_title="Hermes Agent",
-            client_version=_get_hermes_version(),
+            client_title="codex",
+            client_version=get_codex_cli_version(),
         )
         # Permission selection is intentionally NOT sent on thread/start.
         # Two reasons (live-tested against codex 0.130.0):
@@ -864,13 +875,3 @@ def _has_turn_aborted_marker(text: str) -> bool:
         if marker in text:
             return True
     return False
-
-
-def _get_hermes_version() -> str:
-    """Best-effort Hermes version string for codex's userAgent line."""
-    try:
-        from importlib.metadata import version
-
-        return version("hermes-agent")
-    except Exception:  # pragma: no cover
-        return "0.0.0"

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -32,10 +32,12 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Optional
 
 from agent.codex_responses_adapter import _format_responses_error
+from agent.codex_version import resolve_codex_executable
 from agent.redact import redact_sensitive_text
 from agent.transports.codex_app_server import (
     CodexAppServerClient,
     CodexAppServerError,
+    _get_hermes_client_version,
 )
 from agent.transports.codex_event_projector import CodexEventProjector
 
@@ -275,7 +277,7 @@ class CodexAppServerSession:
         self,
         *,
         cwd: Optional[str] = None,
-        codex_bin: str = "codex",
+        codex_bin: Optional[str] = None,
         codex_home: Optional[str] = None,
         permission_profile: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
@@ -284,7 +286,7 @@ class CodexAppServerSession:
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
-        self._codex_bin = codex_bin
+        self._codex_bin = resolve_codex_executable(codex_bin)
         self._codex_home = codex_home
         self._permission_profile = (
             permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(
@@ -325,7 +327,7 @@ class CodexAppServerSession:
         self._client.initialize(
             client_name="hermes",
             client_title="Hermes Agent",
-            client_version=_get_hermes_version(),
+            client_version=_get_hermes_client_version(),
         )
         # Permission selection is intentionally NOT sent on thread/start.
         # Two reasons (live-tested against codex 0.130.0):
@@ -1280,13 +1282,3 @@ def _has_turn_aborted_marker(text: str) -> bool:
         if marker in text:
             return True
     return False
-
-
-def _get_hermes_version() -> str:
-    """Best-effort Hermes version string for codex's userAgent line."""
-    try:
-        from importlib.metadata import version
-
-        return version("hermes-agent")
-    except Exception:  # pragma: no cover
-        return "0.0.0"

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -83,8 +83,11 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
     """Fetch available models from the Codex API. Returns visible models sorted by priority."""
     try:
         import httpx
+
+        from agent.codex_version import get_codex_cli_version
+
         resp = httpx.get(
-            "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
+            f"https://chatgpt.com/backend-api/codex/models?client_version={get_codex_cli_version()}",
             headers={"Authorization": f"Bearer {access_token}"},
             timeout=10,
         )

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -154,13 +154,22 @@ def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:
 def _fetch_models_from_api(access_token: str) -> List[str]:
     """Fetch available models from the Codex API. Returns visible models sorted by priority."""
     try:
+        from urllib.parse import quote
+
         import httpx
+
+        from agent.codex_version import get_codex_cli_version
+
+        client_version = quote(get_codex_cli_version(), safe=".-")
         headers = {"Authorization": f"Bearer {access_token}"}
         acct_id = _extract_chatgpt_account_id(access_token)
         if acct_id:
             headers["ChatGPT-Account-Id"] = acct_id
         resp = httpx.get(
-            "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
+            (
+                "https://chatgpt.com/backend-api/codex/models"
+                f"?client_version={client_version}"
+            ),
             headers=headers,
             timeout=10,
         )

--- a/run_agent.py
+++ b/run_agent.py
@@ -6354,8 +6354,8 @@ class AIAgent:
         elif base_url_host_matches(base_url, "portal.qwen.ai"):
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         elif base_url_host_matches(base_url, "chatgpt.com"):
-            from agent.auxiliary_client import _codex_cloudflare_headers
-            self._client_kwargs["default_headers"] = _codex_cloudflare_headers(
+            from agent.auxiliary_client import _codex_backend_headers
+            self._client_kwargs["default_headers"] = _codex_backend_headers(
                 self._client_kwargs.get("api_key", ""), base_url=base_url,
             )
         elif base_url_host_matches(base_url, "x.ai"):

--- a/tests/agent/test_codex_cloudflare_headers.py
+++ b/tests/agent/test_codex_cloudflare_headers.py
@@ -26,7 +26,14 @@ import base64
 import json
 from unittest.mock import MagicMock, patch
 
-from hermes_cli import __version__
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _installed_codex_version(monkeypatch):
+    import agent.codex_version as cv
+
+    monkeypatch.setattr(cv, "get_codex_cli_version", lambda *_args: "0.222.3")
 
 
 # ---------------------------------------------------------------------------
@@ -60,7 +67,7 @@ class TestCodexCloudflareHeaders:
     def test_user_agent_advertises_hermes_version(self):
         from agent.auxiliary_client import _codex_cloudflare_headers
         headers = _codex_cloudflare_headers(_make_codex_jwt())
-        assert headers["User-Agent"] == f"HermesAgent/{__version__}"
+        assert headers["User-Agent"] == "codex_cli_rs/0.222.3 (Hermes Agent)"
         assert headers["originator"] == "hermes-agent"
 
 
@@ -118,7 +125,7 @@ class TestPrimaryClientWiring:
             headers = agent._client_kwargs.get("default_headers") or {}
             assert headers.get("originator") == "hermes-agent"
             assert headers.get("ChatGPT-Account-ID") == "acct-rotation"
-            assert headers.get("User-Agent") == f"HermesAgent/{__version__}"
+            assert headers.get("User-Agent") == "codex_cli_rs/0.222.3 (Hermes Agent)"
 
     def test_apply_client_headers_clears_codex_headers_off_chatgpt(self):
         """Switching AWAY from chatgpt.com must drop the codex headers."""
@@ -174,7 +181,7 @@ class TestAuxiliaryClientWiring:
             headers = mock_openai.call_args.kwargs.get("default_headers") or {}
             assert headers.get("originator") == "hermes-agent"
             assert headers.get("ChatGPT-Account-ID") == "acct-aux-try-codex"
-            assert headers.get("User-Agent") == f"HermesAgent/{__version__}"
+            assert headers.get("User-Agent") == "codex_cli_rs/0.222.3 (Hermes Agent)"
 
     def test_resolve_provider_client_raw_codex_passes_codex_headers(self, monkeypatch):
         """The ``raw_codex=True`` branch (used by the main agent loop for direct
@@ -194,4 +201,4 @@ class TestAuxiliaryClientWiring:
             headers = mock_openai.call_args.kwargs.get("default_headers") or {}
             assert headers.get("originator") == "hermes-agent"
             assert headers.get("ChatGPT-Account-ID") == "acct-aux-raw-codex"
-            assert headers.get("User-Agent") == f"HermesAgent/{__version__}"
+            assert headers.get("User-Agent") == "codex_cli_rs/0.222.3 (Hermes Agent)"

--- a/tests/agent/test_codex_usage_attribution.py
+++ b/tests/agent/test_codex_usage_attribution.py
@@ -12,8 +12,14 @@ import httpx
 import pytest
 import yaml
 
-from hermes_cli import __version__
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture(autouse=True)
+def _installed_codex_version(monkeypatch):
+    import agent.codex_version as cv
+
+    monkeypatch.setattr(cv, "get_codex_cli_version", lambda *_args: "0.222.3")
 
 
 CODEX_URL = "https://chatgpt.com/backend-api/codex"
@@ -109,7 +115,7 @@ def wire(profile, monkeypatch):
 
 def _assert_identity(request, account_id="acct-attribution-test"):
     assert request.headers["originator"] == "hermes-agent"
-    assert request.headers["user-agent"] == f"HermesAgent/{__version__}"
+    assert request.headers["user-agent"] == "codex_cli_rs/0.222.3 (Hermes Agent)"
     assert request.headers["chatgpt-account-id"] == account_id
     assert "extra_headers" not in json.loads(request.content)
 
@@ -122,7 +128,7 @@ def test_required_identity_preserves_account_id(profile, legacy_enabled):
     headers = _codex_cloudflare_headers(_jwt())
 
     assert headers["originator"] == "hermes-agent"
-    assert headers["User-Agent"] == f"HermesAgent/{__version__}"
+    assert headers["User-Agent"] == "codex_cli_rs/0.222.3 (Hermes Agent)"
     assert headers["ChatGPT-Account-ID"] == "acct-attribution-test"
     assert "ChatGPT-Account-ID" not in _codex_cloudflare_headers("not-a-jwt")
 
@@ -152,7 +158,7 @@ def test_new_identity_is_limited_to_the_official_endpoint(base_url, attributed):
 
     assert headers["originator"] == ("hermes-agent" if attributed else "codex_cli_rs")
     assert headers["User-Agent"] == (
-        f"HermesAgent/{__version__}"
+        "codex_cli_rs/0.222.3 (Hermes Agent)"
         if attributed else "codex_cli_rs/0.0.0 (Hermes Agent)"
     )
 

--- a/tests/agent/test_codex_version.py
+++ b/tests/agent/test_codex_version.py
@@ -1,0 +1,171 @@
+"""Regression tests for installed Codex executable identity resolution."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import agent.codex_version as cv
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    monkeypatch.setattr(cv, "_memo", {})
+    monkeypatch.delenv("HERMES_CODEX_BIN", raising=False)
+
+
+def _fake_codex(tmp_path, version: str):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path = tmp_path / "configured-codex"
+    path.write_text(
+        f"#!/bin/sh\nprintf '%s\\n' 'codex-cli {version}'\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
+def test_configured_binary_version_is_queried(tmp_path, monkeypatch):
+    binary = _fake_codex(tmp_path, "0.222.3")
+    monkeypatch.setenv("HERMES_CODEX_BIN", str(binary))
+
+    assert cv.resolve_codex_executable() == str(binary)
+    assert cv.get_codex_cli_version() == "0.222.3"
+
+
+def test_backend_headers_advertise_configured_binary(tmp_path, monkeypatch):
+    from agent.auxiliary_client import _codex_backend_headers
+
+    binary = _fake_codex(tmp_path, "0.228.1")
+    monkeypatch.setenv("HERMES_CODEX_BIN", str(binary))
+
+    headers = _codex_backend_headers("")
+    assert headers["originator"] == "hermes-agent"
+    assert headers["User-Agent"] == "codex_cli_rs/0.228.1 (Hermes Agent)"
+
+
+def test_backend_headers_do_not_claim_an_uninstalled_version(monkeypatch):
+    from agent.auxiliary_client import _codex_backend_headers
+
+    monkeypatch.setenv("HERMES_CODEX_BIN", "/does/not/exist/codex")
+    headers = _codex_backend_headers("")
+    assert headers["User-Agent"] == "codex_cli_rs/0.0.0 (Hermes Agent)"
+
+
+def test_model_metadata_catalog_advertises_configured_binary(tmp_path, monkeypatch):
+    from agent import model_metadata
+
+    binary = _fake_codex(tmp_path, "0.228.2")
+    monkeypatch.setenv("HERMES_CODEX_BIN", str(binary))
+    captured = {}
+
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"models": [{"slug": "gpt-test", "context_window": 1234}]}
+
+    class Requests:
+        @staticmethod
+        def get(url, **kwargs):
+            captured["url"] = url
+            return Response()
+
+    monkeypatch.setattr(model_metadata, "requests", Requests())
+    monkeypatch.setattr(model_metadata, "_ensure_requests", lambda: None)
+    monkeypatch.setattr(model_metadata, "_codex_oauth_context_cache", {})
+
+    models, fresh = model_metadata._fetch_codex_oauth_context_lengths_with_source(
+        "test-token"
+    )
+    assert fresh is True
+    assert models == {"gpt-test": 1234}
+    assert captured["url"].endswith("?client_version=0.228.2")
+
+
+def test_explicit_binary_wins_over_environment(tmp_path, monkeypatch):
+    configured = _fake_codex(tmp_path, "0.222.3")
+    explicit = _fake_codex(tmp_path / "explicit", "0.223.4")
+    monkeypatch.setenv("HERMES_CODEX_BIN", str(configured))
+
+    assert cv.resolve_codex_executable(str(explicit)) == str(explicit)
+    assert cv.get_codex_cli_version(str(explicit)) == "0.223.4"
+
+
+def test_default_executable_is_codex():
+    assert cv.resolve_codex_executable() == "codex"
+
+
+def test_missing_binary_returns_truthful_unknown(monkeypatch):
+    monkeypatch.setenv("HERMES_CODEX_BIN", "/does/not/exist/codex")
+    assert cv.get_codex_cli_version() == "0.0.0"
+
+
+def test_nonzero_binary_returns_truthful_unknown(monkeypatch):
+    monkeypatch.setattr(
+        cv.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 1, "", "bad"),
+    )
+    assert cv.get_codex_cli_version("broken-codex") == "0.0.0"
+
+
+def test_unparseable_binary_returns_truthful_unknown(monkeypatch):
+    monkeypatch.setattr(
+        cv.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "codex unknown", ""),
+    )
+    assert cv.get_codex_cli_version("odd-codex") == "0.0.0"
+
+
+def test_version_on_stderr_is_accepted(monkeypatch):
+    monkeypatch.setattr(
+        cv.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 0, "", "codex-cli 0.224.5"
+        ),
+    )
+    assert cv.get_codex_cli_version("stderr-codex") == "0.224.5"
+
+
+def test_prerelease_version_is_preserved(monkeypatch):
+    monkeypatch.setattr(
+        cv.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 0, "codex-cli 0.225.0-beta.2+build.7", ""
+        ),
+    )
+    assert cv.get_codex_cli_version("preview-codex") == "0.225.0-beta.2+build.7"
+
+
+def test_result_is_memoized_per_executable(monkeypatch):
+    calls = []
+
+    def query(executable):
+        calls.append(executable)
+        return "0.226.0"
+
+    monkeypatch.setattr(cv, "_query_installed_version", query)
+    assert cv.get_codex_cli_version("codex-a") == "0.226.0"
+    assert cv.get_codex_cli_version("codex-a") == "0.226.0"
+    assert cv.get_codex_cli_version("codex-b") == "0.226.0"
+    assert calls == ["codex-a", "codex-b"]
+
+
+def test_subprocess_contract_disables_stdin(monkeypatch):
+    captured = {}
+
+    def run(command, **kwargs):
+        captured.update(command=command, **kwargs)
+        return subprocess.CompletedProcess(command, 0, "codex-cli 0.227.0", "")
+
+    monkeypatch.setattr(cv.subprocess, "run", run)
+    assert cv.get_codex_cli_version("/opt/codex") == "0.227.0"
+    assert captured["command"] == ["/opt/codex", "--version"]
+    assert captured["stdin"] is subprocess.DEVNULL
+    assert captured["timeout"] == cv._VERSION_QUERY_TIMEOUT_SECONDS

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -92,6 +92,51 @@ class TestMaybeApplyCodexAppServerRuntime:
 class TestCodexAppServerModule:
     """Module-surface tests for the JSON-RPC speaker. Don't require codex CLI."""
 
+    def test_initialize_default_client_info_uses_hermes_version(self, monkeypatch):
+        from agent.transports import codex_app_server as cas
+
+        calls = []
+        client = object.__new__(cas.CodexAppServerClient)
+        client._initialized = False
+        monkeypatch.setattr(
+            client,
+            "request",
+            lambda method, params, timeout: (
+                calls.append((method, params, timeout))
+                or {"userAgent": "codex_cli_rs/0.229.2"}
+            ),
+        )
+        monkeypatch.setattr(
+            client, "notify", lambda method: calls.append((method,))
+        )
+        monkeypatch.setattr(cas, "_get_hermes_client_version", lambda: "0.20.5")
+
+        result = client.initialize()
+
+        assert result == {"userAgent": "codex_cli_rs/0.229.2"}
+        assert calls == [
+            (
+                "initialize",
+                {
+                    "clientInfo": {
+                        "name": "hermes",
+                        "title": "Hermes Agent",
+                        "version": "0.20.5",
+                    },
+                    "capabilities": {},
+                },
+                10.0,
+            ),
+            ("initialized",),
+        ]
+        assert client._initialized is True
+
+    def test_client_version_comes_from_hermes_package_constant(self, monkeypatch):
+        import hermes_cli
+        from agent.transports import codex_app_server as cas
+
+        monkeypatch.setattr(hermes_cli, "__version__", "9.8.7")
+        assert cas._get_hermes_client_version() == "9.8.7"
 
 
 

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -6,6 +6,7 @@ deadline timeouts. These tests pin all of that without spawning real codex.
 """
 
 from __future__ import annotations
+import itertools
 
 import time
 from unittest.mock import patch
@@ -769,7 +770,7 @@ class TestSessionRetirement:
             threadId="t", turnId="tu1",
         )
         s = make_session(client)
-        monotonic_values = iter([1000.0, 999.0, 999.0, 999.0, 1000.2])
+        monotonic_values = itertools.chain([1000.0, 999.0, 999.0, 999.0, 1000.2], itertools.repeat(1000.3))
         with patch.object(
             session_mod.time,
             "monotonic",

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -38,10 +38,12 @@ class FakeClient:
         self._notifications: list[dict] = []
         self._server_requests: list[dict] = []
         self._request_handler = None  # Optional[Callable[[str, dict], dict]]
+        self.initialize_kwargs: dict[str, Any] = {}
 
     # API matching CodexAppServerClient
     def initialize(self, **kwargs):
         self._initialized = True
+        self.initialize_kwargs = kwargs
         return {"userAgent": "fake/0.0.0", "codexHome": "/tmp",
                 "platformOs": "linux", "platformFamily": "unix"}
 
@@ -173,6 +175,49 @@ class TestLifecycle:
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
+
+    def test_initialize_identity_describes_hermes_not_backend(
+        self, monkeypatch, tmp_path
+    ):
+        from agent.codex_version import get_codex_cli_version
+
+        binary = tmp_path / "codex"
+        binary.write_text(
+            "#!/bin/sh\nprintf '%s\\n' 'codex-cli 0.229.2'\n",
+            encoding="utf-8",
+        )
+        binary.chmod(0o755)
+        client = FakeClient()
+        monkeypatch.setattr(
+            session_mod, "_get_hermes_client_version", lambda: "0.20.5"
+        )
+        session = make_session(client, codex_bin=str(binary))
+        session.ensure_started()
+
+        assert get_codex_cli_version(str(binary)) == "0.229.2"
+        assert client.initialize_kwargs == {
+            "client_name": "hermes",
+            "client_title": "Hermes Agent",
+            "client_version": "0.20.5",
+        }
+
+    def test_configured_executable_reaches_app_server_factory(self, monkeypatch):
+        client = FakeClient()
+        factory_kwargs = []
+        monkeypatch.setenv("HERMES_CODEX_BIN", "/opt/configured/codex")
+        monkeypatch.setattr(
+            session_mod, "_get_hermes_client_version", lambda: "0.20.5"
+        )
+        session = CodexAppServerSession(
+            cwd="/tmp",
+            client_factory=lambda **kwargs: factory_kwargs.append(kwargs) or client,
+        )
+        session.ensure_started()
+
+        assert factory_kwargs == [
+            {"codex_bin": "/opt/configured/codex", "codex_home": None}
+        ]
+        assert client.initialize_kwargs["client_version"] == "0.20.5"
 
     def test_close_idempotent(self):
         client = FakeClient()

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -98,14 +98,22 @@ def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
                 ]
             }
 
+    captured = {}
+
     class _FakeHttpx:
         @staticmethod
         def get(url, headers=None, timeout=None):
+            captured["url"] = url
             return _FakeResp()
 
     monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+    monkeypatch.setattr(
+        "agent.codex_version.get_codex_cli_version", lambda: "0.231.4"
+    )
 
     models = codex_models._fetch_models_from_api(access_token="tok")
+
+    assert captured["url"].endswith("?client_version=0.231.4")
 
     assert "gpt-5.5" in models
     assert "gpt-5.3-codex-spark" in models


### PR DESCRIPTION
## Summary

This change derives Codex backend identity from the executable Hermes will run instead of a hard-coded or registry version. `HERMES_CODEX_BIN`, an explicit executable, and the `codex` path fallback all use the same resolver. Version lookup is bounded, cached per executable, preserves prerelease versions, and falls back to `0.0.0` rather than claiming an uninstalled release.

The installed Codex version now supplies the `codex_cli_rs/<version> (Hermes Agent)` user agent on the official Codex backend and the `client_version` query parameter on both model catalog paths. Hermes remains the truthful `originator` on official backend requests. Custom endpoints retain the compatibility identity.

The app-server handshake has a separate identity contract. Its required `clientInfo` describes the connecting client, so it sends `name: hermes`, `title: Hermes Agent`, and the Hermes package version from `hermes_cli.__version__`. It does not reuse the backend executable version. The generated Codex 0.149.0 protocol schema requires `clientInfo.name` and `clientInfo.version`, so the version cannot be omitted.

## Verification

Regression coverage distinguishes a fake Codex executable at version `0.229.2` from Hermes `clientInfo.version` `0.20.5`. It also covers executable precedence, missing and malformed version output, memoization, official and custom backend headers, both catalog call sites, direct app-server initialization, and session initialization.

`scripts/run_tests.sh <all 38 Codex-named test files> tests/cli/test_cli_provider_resolution.py tests/hermes_cli/test_config.py -q`

Result: 636 passed across 40 files.

`venv/bin/ruff check <all 14 changed Python files>`

Result: all checks passed.

`venv/bin/python -m compileall -q <all 14 changed Python files>`

Result: passed.

`git diff --check && git diff HEAD^ --check`

Result: passed. The stray blank line at the end of `agent/transports/codex_app_server_session.py` was removed.
