### PR TITLE
fix(doctor): skip operator-declared optional integrations instead of warning

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3336,6 +3336,27 @@ DEFAULT_CONFIG = {
         # Per-probe timeout (seconds) for the opt-in `hermes doctor --live`
         # real-call backend probes (Firecrawl/FAL/browser/MCP/TTS/STT).
         "live_probe_timeout": 10,
+        # Auth providers the operator has intentionally left unconfigured on
+        # this machine. Matching rows are NOT silently dropped: `hermes
+        # doctor` prints an explicit "skipped (declared optional)" line for
+        # each one and keeps them out of the blocking summary, so an operator
+        # who will never use, say, MiniMax or xAI still SEES that the row was
+        # deliberately skipped rather than missing. Case-insensitive; match by
+        # row label or a short alias. Accepted names:
+        #   "nous" / "nous portal"   -> Nous Portal auth
+        #   "codex" / "openai codex" -> OpenAI Codex auth
+        #   "minimax"                -> MiniMax OAuth
+        #   "xai"                    -> xAI OAuth
+        # Empty by default (every provider is checked).
+        "ignore_auth_providers": [],
+        # Toolsets the operator has intentionally left unconfigured on this
+        # machine. Matching entries are moved OUT of the "Tool Availability"
+        # missing-warnings and instead ENUMERATED under an explicit "skipped
+        # (declared optional)" line, so they are visible-but-not-nagged rather
+        # than hidden. Case-insensitive; match by toolset id/name as shown in
+        # the doctor output (e.g. "discord", "home-assistant", "spotify").
+        # Empty by default (every toolset is reported).
+        "ignore_toolsets": [],
     },
 
     # ``hermes update`` behaviour.

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -10,7 +10,7 @@ import subprocess
 import shutil
 from pathlib import Path
 
-from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
+from hermes_cli.config import get_project_root, get_hermes_home, get_env_path, load_config
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
 
@@ -75,6 +75,48 @@ def _safe_which(cmd: str) -> str | None:
         return shutil.which(cmd)
     except Exception:
         return None
+
+
+def _config_string_set(section: str, key: str) -> set[str]:
+    """Return a lowercase set from a config list/string at section.key.
+
+    Doctor uses this for operator-declared optional integrations that should
+    be skipped rather than warned about (for example machines that will never
+    use Discord, Home Assistant, or MiniMax OAuth). Unknown/missing config is
+    intentionally a no-op so doctor remains backwards compatible.
+    """
+    try:
+        cfg = load_config() or {}
+    except Exception:
+        return set()
+    raw_section = cfg.get(section) if isinstance(cfg, dict) else {}
+    if not isinstance(raw_section, dict):
+        return set()
+    raw_value = raw_section.get(key, [])
+    if isinstance(raw_value, str):
+        values = [raw_value]
+    elif isinstance(raw_value, (list, tuple, set)):
+        values = list(raw_value)
+    else:
+        return set()
+    return {str(v).strip().lower() for v in values if str(v).strip()}
+
+
+def _doctor_ignored_auth_providers() -> set[str]:
+    return _config_string_set("doctor", "ignore_auth_providers")
+
+
+def _doctor_ignored_toolsets() -> set[str]:
+    return _config_string_set("doctor", "ignore_toolsets")
+
+
+def _is_doctor_auth_ignored(*names: str) -> bool:
+    ignored = _doctor_ignored_auth_providers()
+    return any(str(name).strip().lower() in ignored for name in names)
+
+
+def _is_doctor_tool_ignored(name: str) -> bool:
+    return str(name or "").strip().lower() in _doctor_ignored_toolsets()
 
 
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
@@ -144,6 +186,8 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
         if name == "honcho" and _honcho_is_configured_for_doctor():
             if "honcho" not in updated_available:
                 updated_available.append("honcho")
+            continue
+        if _is_doctor_tool_ignored(str(name or "")):
             continue
         updated_unavailable.append(item)
     return updated_available, updated_unavailable
@@ -1074,11 +1118,14 @@ def run_doctor(args):
             get_minimax_oauth_auth_status,
         )
 
-        nous_status = get_nous_auth_status()
-        if nous_status.get("logged_in"):
-            check_ok("Nous Portal auth", "(logged in)")
+        if _is_doctor_auth_ignored("nous", "nous portal", "nous portal auth"):
+            check_info("Nous Portal auth skipped (disabled in doctor.ignore_auth_providers)")
         else:
-            check_warn("Nous Portal auth", "(not logged in)")
+            nous_status = get_nous_auth_status()
+            if nous_status.get("logged_in"):
+                check_ok("Nous Portal auth", "(logged in)")
+            else:
+                check_warn("Nous Portal auth", "(not logged in)")
 
         codex_status = get_codex_auth_status()
         if codex_status.get("logged_in"):
@@ -1098,12 +1145,15 @@ def run_doctor(args):
                     "from an existing Codex CLI login)"
                 )
 
-        minimax_status = get_minimax_oauth_auth_status()
-        if minimax_status.get("logged_in"):
-            region = minimax_status.get("region", "global")
-            check_ok("MiniMax OAuth", f"(logged in, region={region})")
+        if _is_doctor_auth_ignored("minimax", "minimax oauth"):
+            check_info("MiniMax OAuth skipped (disabled in doctor.ignore_auth_providers)")
         else:
-            check_warn("MiniMax OAuth", "(not logged in)")
+            minimax_status = get_minimax_oauth_auth_status()
+            if minimax_status.get("logged_in"):
+                region = minimax_status.get("region", "global")
+                check_ok("MiniMax OAuth", f"(logged in, region={region})")
+            else:
+                check_warn("MiniMax OAuth", "(not logged in)")
     except Exception as e:
         check_warn("Auth provider status", f"(could not check: {e})")
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -17,6 +17,7 @@ from hermes_cli.config import (
     get_hermes_home,
     get_project_root,
     is_nix_install_method,
+    load_config,
     recommended_update_command_for_method,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -349,10 +350,82 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
             )
     return rows
 
-def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
-    """Adjust runtime-gated tool availability for doctor diagnostics."""
+def _config_string_set(section: str, key: str) -> set[str]:
+    """Return a lowercase set from a config list/string at section.key.
+
+    Doctor uses this for operator-declared optional integrations. Rather
+    than silently skipping them, doctor ENUMERATES each skipped item with a
+    clear reason ("declared optional"). Unknown/missing config is a no-op so
+    doctor stays backwards compatible.
+    """
+    try:
+        cfg = load_config() or {}
+    except Exception:
+        return set()
+    raw_section = cfg.get(section) if isinstance(cfg, dict) else {}
+    if not isinstance(raw_section, dict):
+        return set()
+    raw_value = raw_section.get(key, [])
+    if isinstance(raw_value, str):
+        values = [raw_value]
+    elif isinstance(raw_value, (list, tuple, set)):
+        values = list(raw_value)
+    else:
+        return set()
+    return {str(v).strip().lower() for v in values if str(v).strip()}
+
+
+def _doctor_ignored_auth_providers() -> set[str]:
+    return _config_string_set("doctor", "ignore_auth_providers")
+
+
+def _doctor_ignored_toolsets() -> set[str]:
+    return _config_string_set("doctor", "ignore_toolsets")
+
+
+def _is_doctor_auth_ignored(*names: str) -> bool:
+    ignored = _doctor_ignored_auth_providers()
+    return any(str(name).strip().lower() in ignored for name in names)
+
+
+def _maybe_skip_auth_provider(label: str, *aliases: str) -> bool:
+    """Explicitly enumerate an auth-provider row the operator declared
+    optional, instead of silently hiding it.
+
+    Honors ``doctor.ignore_auth_providers`` for *every* auth row (Nous,
+    Codex, MiniMax, xAI, ...) rather than special-casing individual
+    providers. When the row is declared optional we print an explicit
+    enumerated skip line naming the provider AND the reason (operator
+    declared it optional), then return True so the caller skips its own
+    warning/summary handling. The operator SEES the skip; it is not hidden.
+    """
+    if _is_doctor_auth_ignored(label, *aliases):
+        check_info(
+            f"{label}: skipped (declared optional in "
+            f"doctor.ignore_auth_providers)"
+        )
+        return True
+    return False
+
+
+def _is_doctor_tool_ignored(name: str) -> bool:
+    return str(name or "").strip().lower() in _doctor_ignored_toolsets()
+
+
+def _apply_doctor_tool_availability_overrides(
+    available: list[str], unavailable: list[dict]
+) -> tuple[list[str], list[dict], list[dict]]:
+    """Adjust runtime-gated tool availability for doctor diagnostics.
+
+    Operator-declared optional toolsets (``doctor.ignore_toolsets``) are NOT
+    silently dropped: they are pulled out of the missing-warnings list into a
+    separate ``skipped`` list so ``run_doctor`` can ENUMERATE them under an
+    explicit "declared optional" line. Returns
+    (available, unavailable, skipped_optional).
+    """
     updated_available = list(available)
     updated_unavailable = []
+    skipped_optional: list[dict] = []
     for item in unavailable:
         name = item.get("name")
         if _is_kanban_worker_env_gate(item):
@@ -363,8 +436,11 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
             if "honcho" not in updated_available:
                 updated_available.append("honcho")
             continue
+        if _is_doctor_tool_ignored(str(name or "")):
+            skipped_optional.append(item)
+            continue
         updated_unavailable.append(item)
-    return updated_available, updated_unavailable
+    return updated_available, updated_unavailable, skipped_optional
 
 
 def _has_healthy_oauth_fallback_for_apikey_provider(provider_label: str) -> bool:
@@ -1941,52 +2017,61 @@ def run_doctor(args):
             get_minimax_oauth_auth_status,
         )
 
-        # Read-only display: refresh-free snapshot — doctor must never
+        # Read-only display: refresh-free snapshot, doctor must never
         # trigger an OAuth refresh as a side effect of a health check.
-        nous_status = get_nous_auth_status_local()
-        if nous_status.get("logged_in"):
-            check_ok("Nous Portal auth", "(logged in)")
-        else:
-            check_warn("Nous Portal auth", "(not logged in)")
+        if not _maybe_skip_auth_provider(
+            "Nous Portal auth", "nous", "nous portal"
+        ):
+            nous_status = get_nous_auth_status_local()
+            if nous_status.get("logged_in"):
+                check_ok("Nous Portal auth", "(logged in)")
+            else:
+                check_warn("Nous Portal auth", "(not logged in)")
 
-        codex_status = get_codex_auth_status()
-        if codex_status.get("logged_in"):
-            check_ok("OpenAI Codex auth", "(logged in)")
-        else:
-            check_warn("OpenAI Codex auth", "(not logged in)")
-            if codex_status.get("error"):
-                check_info(codex_status["error"])
-            # Native OAuth uses Hermes' own device-code flow — the Codex CLI is
-            # only needed to import existing tokens from ~/.codex/auth.json.
-            # Attach the hint to the Codex auth row so it doesn't read as
-            # remediation for whichever provider happens to print next (#27975).
-            if not _safe_which("codex"):
-                check_info(
-                    "codex CLI not installed "
-                    "(optional — only required to import tokens "
-                    "from an existing Codex CLI login)"
-                )
+        if not _maybe_skip_auth_provider(
+            "OpenAI Codex auth", "codex", "openai codex"
+        ):
+            codex_status = get_codex_auth_status()
+            if codex_status.get("logged_in"):
+                check_ok("OpenAI Codex auth", "(logged in)")
+            else:
+                check_warn("OpenAI Codex auth", "(not logged in)")
+                if codex_status.get("error"):
+                    check_info(codex_status["error"])
+                # Native OAuth uses Hermes' own device-code flow, the Codex
+                # CLI is only needed to import existing tokens from
+                # ~/.codex/auth.json. Attach the hint to the Codex auth row so
+                # it doesn't read as remediation for whichever provider prints
+                # next (#27975).
+                if not _safe_which("codex"):
+                    check_info(
+                        "codex CLI not installed "
+                        "(optional, only required to import tokens "
+                        "from an existing Codex CLI login)"
+                    )
 
-        minimax_status = get_minimax_oauth_auth_status()
-        if minimax_status.get("logged_in"):
-            region = minimax_status.get("region", "global")
-            check_ok("MiniMax OAuth", f"(logged in, region={region})")
-        else:
-            check_warn("MiniMax OAuth", "(not logged in)")
+        if not _maybe_skip_auth_provider("MiniMax OAuth", "minimax"):
+            minimax_status = get_minimax_oauth_auth_status()
+            if minimax_status.get("logged_in"):
+                region = minimax_status.get("region", "global")
+                check_ok("MiniMax OAuth", f"(logged in, region={region})")
+            else:
+                check_warn("MiniMax OAuth", "(not logged in)")
     except Exception as e:
         check_warn("Auth provider status", f"(could not check: {e})")
 
-    # xAI OAuth — separate try/except so an import failure here cannot
+    # xAI OAuth, separate try/except so an import failure here cannot
     # disrupt the already-printed Nous/Codex/Gemini/MiniMax rows above.
     try:
-        from hermes_cli.auth import get_xai_oauth_auth_status
-        xai_oauth_status = get_xai_oauth_auth_status() or {}
-        if xai_oauth_status.get("logged_in"):
-            check_ok("xAI OAuth", "(logged in)")
-        else:
-            check_warn("xAI OAuth", "(not logged in)")
-            if xai_oauth_status.get("error"):
-                check_info(xai_oauth_status["error"])
+        if not _maybe_skip_auth_provider("xAI OAuth", "xai"):
+            from hermes_cli.auth import get_xai_oauth_auth_status
+            xai_oauth_status = get_xai_oauth_auth_status() or {}
+            if xai_oauth_status.get("logged_in"):
+                check_ok("xAI OAuth", "(logged in)")
+            else:
+                check_warn("xAI OAuth", "(not logged in)")
+                if xai_oauth_status.get("error"):
+                    check_info(xai_oauth_status["error"])
     except Exception:
         pass
 
@@ -3153,7 +3238,11 @@ def run_doctor(args):
         from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
         
         available, unavailable = check_tool_availability()
-        available, unavailable = _apply_doctor_tool_availability_overrides(available, unavailable)
+        (
+            available,
+            unavailable,
+            skipped_optional,
+        ) = _apply_doctor_tool_availability_overrides(available, unavailable)
 
         # Web is split into search/extract readiness rows so an explicitly
         # selected but unconfigured backend cannot look healthy (#78412).
@@ -3181,6 +3270,21 @@ def run_doctor(args):
                 check_warn(item["name"], f"(missing {vars_str})")
             else:
                 check_warn(item["name"], "(system dependency not met)")
+
+        # Operator-declared optional toolsets are ENUMERATED here, not
+        # hidden. Each is listed by name with the reason it was skipped so
+        # the operator can see exactly what doctor left out and why.
+        if skipped_optional:
+            skipped_names = ", ".join(
+                sorted(
+                    str(item.get("name") or "?")
+                    for item in skipped_optional
+                )
+            )
+            check_info(
+                f"Skipped optional toolset(s): {skipped_names} "
+                f"(declared optional in doctor.ignore_toolsets)"
+            )
 
         # Count missing API-key requirements only for toolsets enabled in the
         # current CLI platform. Default-off or explicitly disabled toolsets may

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -162,6 +162,36 @@ class TestDoctorToolAvailabilityOverrides:
         assert available == []
         assert unavailable == [kanban_entry]
 
+    def test_drops_operator_ignored_toolsets_from_doctor_warnings(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor,
+            "load_config",
+            lambda: {"doctor": {"ignore_toolsets": ["discord", "browser-cdp"]}},
+        )
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [
+                {"name": "discord", "env_vars": ["DISCORD_BOT_TOKEN"]},
+                {"name": "browser-cdp", "env_vars": []},
+                {"name": "spotify", "env_vars": []},
+            ],
+        )
+
+        assert available == []
+        assert unavailable == [{"name": "spotify", "env_vars": []}]
+
+    def test_doctor_auth_ignore_matching_supports_aliases(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor,
+            "load_config",
+            lambda: {"doctor": {"ignore_auth_providers": ["nous", "minimax oauth"]}},
+        )
+
+        assert doctor._is_doctor_auth_ignored("Nous Portal", "nous")
+        assert doctor._is_doctor_auth_ignored("minimax oauth")
+        assert not doctor._is_doctor_auth_ignored("google gemini")
+
     def test_kanban_doctor_detail_explains_worker_gate(self, monkeypatch):
         monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -204,29 +204,248 @@ class TestDoctorToolAvailabilityOverrides:
 
     def test_marks_kanban_available_only_when_missing_worker_env_gate(self, monkeypatch):
         monkeypatch.setattr(doctor, "_honcho_is_configured_for_doctor", lambda: False)
+        monkeypatch.setattr(doctor, "load_config", lambda: {})
         monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
 
-        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
-            [],
-            [{"name": "kanban", "env_vars": [], "tools": ["kanban_show"]}],
+        available, unavailable, skipped = (
+            doctor._apply_doctor_tool_availability_overrides(
+                [],
+                [{"name": "kanban", "env_vars": [], "tools": ["kanban_show"]}],
+            )
         )
 
         assert available == ["kanban"]
         assert unavailable == []
+        assert skipped == []
 
     def test_leaves_kanban_unavailable_when_worker_env_is_set(self, monkeypatch):
         monkeypatch.setenv("HERMES_KANBAN_TASK", "probe")
+        monkeypatch.setattr(doctor, "load_config", lambda: {})
         kanban_entry = {"name": "kanban", "env_vars": [], "tools": ["kanban_show"]}
 
-        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
-            [],
-            [kanban_entry],
+        available, unavailable, skipped = (
+            doctor._apply_doctor_tool_availability_overrides(
+                [],
+                [kanban_entry],
+            )
         )
 
         assert available == []
         assert unavailable == [kanban_entry]
+        assert skipped == []
+
+    def test_enumerates_operator_ignored_toolsets_as_skipped(self, monkeypatch):
+        """Operator-declared optional toolsets are moved into the SKIPPED
+        list (for explicit enumeration), not silently dropped and not left
+        in the missing-warnings list."""
+        monkeypatch.setattr(
+            doctor,
+            "load_config",
+            lambda: {"doctor": {"ignore_toolsets": ["discord", "browser-cdp"]}},
+        )
+
+        available, unavailable, skipped = (
+            doctor._apply_doctor_tool_availability_overrides(
+                [],
+                [
+                    {"name": "discord", "env_vars": ["DISCORD_BOT_TOKEN"]},
+                    {"name": "browser-cdp", "env_vars": []},
+                    {"name": "spotify", "env_vars": []},
+                ],
+            )
+        )
+
+        assert available == []
+        # Only the non-ignored toolset stays a warning.
+        assert unavailable == [{"name": "spotify", "env_vars": []}]
+        # The two declared-optional toolsets are enumerated as skipped.
+        skipped_names = sorted(item["name"] for item in skipped)
+        assert skipped_names == ["browser-cdp", "discord"]
+
+    def test_doctor_auth_ignore_matching_supports_aliases(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor,
+            "load_config",
+            lambda: {
+                "doctor": {"ignore_auth_providers": ["nous", "minimax oauth"]}
+            },
+        )
+
+        assert doctor._is_doctor_auth_ignored("Nous Portal", "nous")
+        assert doctor._is_doctor_auth_ignored("minimax oauth")
+        assert not doctor._is_doctor_auth_ignored("google gemini")
 
 
+class TestDoctorAuthProviderEnumeratedSkip:
+    """End-to-end: doctor.ignore_auth_providers must ENUMERATE each skipped
+    provider with an explicit "declared optional" line (not silently drop
+    it), for EVERY auth provider including OpenAI Codex and xAI OAuth."""
+
+    def _run(self, monkeypatch, tmp_path, ignore_auth_providers=None,
+             ignore_toolsets=None):
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        import yaml
+        doctor_cfg = {}
+        if ignore_auth_providers is not None:
+            doctor_cfg["ignore_auth_providers"] = ignore_auth_providers
+        if ignore_toolsets is not None:
+            doctor_cfg["ignore_toolsets"] = ignore_toolsets
+        config = {"doctor": doctor_cfg} if doctor_cfg else {}
+        (home / "config.yaml").write_text(yaml.dump(config))
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        (tmp_path / "project").mkdir(exist_ok=True)
+
+        # The doctor helpers call load_config() directly; point at our file.
+        monkeypatch.setattr(doctor_mod, "load_config", lambda: config)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        # All providers report "not logged in" so, without the ignore config,
+        # each would emit a warning row.
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(
+                _auth_mod, "get_nous_auth_status_local",
+                lambda: {"logged_in": False},
+            )
+            monkeypatch.setattr(
+                _auth_mod, "get_codex_auth_status",
+                lambda: {"logged_in": False},
+            )
+            monkeypatch.setattr(
+                _auth_mod, "get_minimax_oauth_auth_status",
+                lambda: {"logged_in": False},
+            )
+            monkeypatch.setattr(
+                _auth_mod, "get_xai_oauth_auth_status",
+                lambda: {"logged_in": False},
+            )
+        except Exception:
+            pass
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    def test_all_auth_rows_warn_without_ignore(self, monkeypatch, tmp_path):
+        out = self._run(monkeypatch, tmp_path)
+        # Baseline: every provider prints its "not logged in" warning row.
+        assert "Nous Portal auth" in out
+        assert "OpenAI Codex auth" in out
+        assert "MiniMax OAuth" in out
+        assert "xAI OAuth" in out
+        assert "not logged in" in out
+        assert "declared optional" not in out
+
+    def test_codex_and_xai_rows_are_enumerated_as_skipped(
+        self, monkeypatch, tmp_path
+    ):
+        # Codex and xAI must honor ignore_auth_providers, enumerated clearly.
+        out = self._run(
+            monkeypatch, tmp_path,
+            ignore_auth_providers=["codex", "xai"],
+        )
+        assert "OpenAI Codex auth: skipped (declared optional" in out
+        assert "xAI OAuth: skipped (declared optional" in out
+        # Their "not logged in" warnings must be gone.
+        assert "OpenAI Codex auth (not logged in)" not in out
+        assert "xAI OAuth (not logged in)" not in out
+        # The providers NOT declared optional still warn.
+        assert "Nous Portal auth" in out
+        assert "MiniMax OAuth" in out
+
+    def test_nous_and_minimax_rows_are_enumerated_as_skipped(
+        self, monkeypatch, tmp_path
+    ):
+        out = self._run(
+            monkeypatch, tmp_path,
+            ignore_auth_providers=["nous portal", "minimax"],
+        )
+        assert "Nous Portal auth: skipped (declared optional" in out
+        assert "MiniMax OAuth: skipped (declared optional" in out
+        # Non-ignored providers still emit their real warning rows.
+        assert "OpenAI Codex auth" in out
+        assert "xAI OAuth" in out
+
+
+class TestDoctorToolsetEnumeratedSkip:
+    """End-to-end: doctor.ignore_toolsets must ENUMERATE the skipped toolset
+    under an explicit "declared optional" line, not merely drop it."""
+
+    def _run(self, monkeypatch, tmp_path, ignore_toolsets=None):
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        import yaml
+        config = {"doctor": {"ignore_toolsets": ignore_toolsets or []}}
+        (home / "config.yaml").write_text(yaml.dump(config))
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        (tmp_path / "project").mkdir(exist_ok=True)
+        monkeypatch.setattr(doctor_mod, "load_config", lambda: config)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: (
+                [],
+                [
+                    {"name": "discord", "env_vars": ["DISCORD_BOT_TOKEN"]},
+                    {"name": "spotify", "env_vars": ["SPOTIFY_CLIENT_ID"]},
+                ],
+            ),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(
+                _auth_mod, "get_nous_auth_status_local", lambda: {}
+            )
+            monkeypatch.setattr(
+                _auth_mod, "get_codex_auth_status", lambda: {}
+            )
+            monkeypatch.setattr(
+                _auth_mod, "get_minimax_oauth_auth_status", lambda: {}
+            )
+            monkeypatch.setattr(
+                _auth_mod, "get_xai_oauth_auth_status", lambda: {}
+            )
+        except Exception:
+            pass
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    def test_ignored_toolset_is_enumerated_not_warned(
+        self, monkeypatch, tmp_path
+    ):
+        out = self._run(monkeypatch, tmp_path, ignore_toolsets=["discord"])
+        # The ignored toolset's missing-var WARNING row must be gone.
+        assert "DISCORD_BOT_TOKEN" not in out
+        # But it must be ENUMERATED under the explicit skip line, by name.
+        assert "Skipped optional toolset(s):" in out
+        assert "discord" in out
+        assert "declared optional in doctor.ignore_toolsets" in out
+        # A non-ignored missing toolset still warns.
+        assert "SPOTIFY_CLIENT_ID" in out
+
+    def test_no_ignore_shows_all_toolset_warnings(self, monkeypatch, tmp_path):
+        out = self._run(monkeypatch, tmp_path, ignore_toolsets=[])
+        assert "DISCORD_BOT_TOKEN" in out
+        assert "SPOTIFY_CLIENT_ID" in out
+        assert "Skipped optional toolset(s):" not in out
 
 
 class TestHonchoDoctorConfigDetection:

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -818,6 +818,40 @@ hermes doctor [--fix]
 |--------|-------------|
 | `--fix` | Attempt automatic repairs where possible. |
 
+### Declaring optional integrations
+
+`hermes doctor` warns about integrations that are not configured. On a
+machine that intentionally never uses a given provider or toolset, those
+warnings are just noise. Two `doctor` config keys let an operator declare
+integrations optional. Declared-optional integrations are **not hidden**:
+doctor explicitly enumerates each skipped item by name with the reason
+(`declared optional`) and keeps it out of the blocking summary, so the
+operator always sees exactly what was skipped and why.
+
+```yaml
+doctor:
+  # Auth-provider rows to skip (case-insensitive; match by label or alias).
+  # Each skipped row prints an explicit "skipped (declared optional in
+  # doctor.ignore_auth_providers)" line and stays out of the final summary.
+  #   nous / nous portal   -> Nous Portal auth
+  #   codex / openai codex -> OpenAI Codex auth
+  #   minimax              -> MiniMax OAuth
+  #   xai                  -> xAI OAuth
+  ignore_auth_providers:
+    - minimax
+    - xai
+  # Toolset ids/names to move out of the "Tool Availability" missing
+  # warnings. Skipped toolsets are enumerated under an explicit "Skipped
+  # optional toolset(s): ... (declared optional in doctor.ignore_toolsets)"
+  # line (case-insensitive; use the id/name shown in doctor output).
+  ignore_toolsets:
+    - discord
+    - home-assistant
+```
+
+Both default to empty, so out of the box every provider and toolset is
+still reported.
+
 ## `hermes dump`
 
 ```bash


### PR DESCRIPTION
## Summary

This change lets operators declare unused doctor integrations optional without hiding them.

`doctor.ignore_auth_providers` accepts case insensitive provider labels and aliases for Nous Portal, OpenAI Codex, MiniMax OAuth, and xAI OAuth. Every matching provider path emits an explicit `skipped (declared optional)` row and avoids its normal warning and remediation detail. The default is an empty list, so every provider is still checked in an unchanged configuration.

`doctor.ignore_toolsets` moves matching unavailable toolsets out of the missing integration warnings and into an explicit skipped optional summary. Nonmatching toolsets continue to report their missing credentials or dependencies.

The CLI reference documents both settings, accepted auth aliases, output behavior, and defaults.

## Verification

The end to end doctor tests cover the default behavior, all four auth provider skip paths, provider aliases, mixed skipped and active providers, optional toolset enumeration, and unchanged warnings for nonignored toolsets.

`scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q`

Result: 72 passed.

`venv/bin/ruff check hermes_cli/config_defaults.py hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`

Result: all checks passed.
