### PR TITLE
feat(tools): browser-export redaction + bounded oversized-read preview

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -172,7 +172,7 @@ class TestCharacterCountGuard(unittest.TestCase):
     @patch("tools.file_tools._get_file_ops")
     @patch("tools.file_tools._get_max_read_chars", return_value=_DEFAULT_MAX_READ_CHARS)
     def test_oversized_read_rejected(self, _mock_limit, mock_ops):
-        """A read that returns >max chars is rejected."""
+        """An oversized read returns a bounded safe preview with guidance."""
         big_content = "x" * (_DEFAULT_MAX_READ_CHARS + 1)
         mock_ops.return_value = _make_fake_ops(
             content=big_content,
@@ -180,9 +180,13 @@ class TestCharacterCountGuard(unittest.TestCase):
             file_size=len(big_content) + 100,  # bigger than content
         )
         result = json.loads(read_file_tool("/tmp/huge.txt", task_id="big"))
-        self.assertIn("error", result)
-        self.assertIn("safety limit", result["error"])
-        self.assertIn("offset and limit", result["error"])
+        self.assertNotIn("error", result)
+        self.assertTrue(result.get("oversized"))
+        self.assertTrue(result.get("truncated"))
+        self.assertTrue(result.get("content_returned"))
+        self.assertEqual(result.get("original_content_chars"), len(big_content))
+        self.assertIn("safety limit", result.get("_warning", ""))
+        self.assertIn("offset and limit", result.get("_warning", ""))
         self.assertIn("total_lines", result)
 
     @patch("tools.file_tools._get_file_ops")
@@ -646,12 +650,15 @@ class TestConfigOverride(unittest.TestCase):
     @patch("tools.file_tools._get_file_ops")
     @patch("hermes_cli.config.load_config", return_value={"file_read_max_chars": 50})
     def test_custom_config_lowers_limit(self, _mock_cfg, mock_ops):
-        """A config value of 50 should reject reads over 50 chars."""
+        """A config value of 50 should truncate oversized previews at 50 chars."""
         mock_ops.return_value = _make_fake_ops(content="x" * 60, file_size=60)
         result = json.loads(read_file_tool("/tmp/cfgtest.txt", task_id="cfg1"))
-        self.assertIn("error", result)
-        self.assertIn("safety limit", result["error"])
-        self.assertIn("50", result["error"])  # should show the configured limit
+        self.assertNotIn("error", result)
+        self.assertTrue(result.get("oversized"))
+        self.assertTrue(result.get("truncated"))
+        self.assertEqual(result.get("max_chars"), 50)
+        self.assertIn("safety limit", result.get("_warning", ""))
+        self.assertIn("50", result.get("_warning", ""))  # should show the configured limit
 
     @patch("tools.file_tools._get_file_ops")
     @patch("hermes_cli.config.load_config", return_value={"file_read_max_chars": 500_000})

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -64,6 +64,46 @@ class TestReadFileHandler:
         assert "error" in result
         assert "terminal not available" in result["error"]
 
+    @patch("tools.file_tools._get_max_read_chars", return_value=1000)
+    @patch("tools.file_tools._get_file_ops")
+    def test_oversized_read_returns_preview_not_error(self, mock_get, mock_max):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = "x" * 3000
+        result_obj.to_dict.return_value = {
+            "content": result_obj.content,
+            "total_lines": 1,
+            "file_size": 3000,
+        }
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+        result = json.loads(read_file_tool("/tmp/long.txt"))
+        assert "error" not in result
+        assert result["oversized"] is True
+        assert result["content_returned"] is True
+        assert "read_file truncated oversized output" in result["content"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_browser_export_values_are_force_redacted(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = '{"name":"session","value":"super-secret-cookie-value"}\n.example.com\tTRUE\t/\tFALSE\t0\tsid\tplain-cookie-value'
+        result_obj.to_dict.return_value = {
+            "content": result_obj.content,
+            "total_lines": 2,
+            "file_size": len(result_obj.content),
+        }
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+        result = json.loads(read_file_tool("/tmp/LocalStorage_export.json"))
+        assert "super-secret-cookie-value" not in result["content"]
+        assert "plain-cookie-value" not in result["content"]
+        assert result["content"].count("[REDACTED]") >= 2
+
 
 class TestWriteFileHandler:
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -41,6 +41,106 @@ class TestReadFileHandler:
         assert "error" in result
         assert "terminal not available" in result["error"]
 
+    @patch("tools.file_tools._get_max_read_chars", return_value=1000)
+    @patch("tools.file_tools._get_file_ops")
+    def test_oversized_read_truncated_within_cap(self, mock_get, mock_max):
+        """An oversized read is truncated to a bounded, continuation-friendly
+        result rather than erroring, and the returned content never exceeds the
+        configured cap (sweeper concern #1: honor file_read_max_chars)."""
+        cap = 1000
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        # Many short lines so line-boundary truncation kicks in well over the cap.
+        result_obj.content = "\n".join(f"{i}|" + "z" * 40 for i in range(1, 200))
+        result_obj.to_dict.return_value = {
+            "content": result_obj.content,
+            "total_lines": 199,
+            "file_size": len(result_obj.content),
+        }
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+        result = json.loads(read_file_tool("/tmp/long.txt"))
+        assert "error" not in result
+        assert result["truncated"] is True
+        assert result["truncated_by"] == "bytes"
+        assert "next_offset" in result
+        # Core sweeper assertion: content must honor the configured cap.
+        assert len(result["content"]) <= cap
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_browser_export_values_are_force_redacted(self, mock_get):
+        """Browser cookie/localStorage exports get the extra opaque-value pass:
+        JSON "value" fields and the Netscape TSV cookie column are scrubbed even
+        though the built-in code-file patterns intentionally leave them alone."""
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = (
+            '{"name":"session","value":"super-secret-cookie-value"}\n'
+            ".example.com\tTRUE\t/\tFALSE\t0\tsid\tplain-cookie-value"
+        )
+        result_obj.to_dict.return_value = {
+            "content": result_obj.content,
+            "total_lines": 2,
+            "file_size": len(result_obj.content),
+        }
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+        result = json.loads(read_file_tool("/tmp/LocalStorage_export.json"))
+        assert "super-secret-cookie-value" not in result["content"]
+        assert "plain-cookie-value" not in result["content"]
+        assert result["content"].count("[REDACTED]") >= 2
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_browser_export_prefix_cred_uses_nonreusable_sentinel(self, mock_get):
+        """File-read redaction of a recognized prefix credential in a browser
+        export must emit the NON-REUSABLE sentinel (sweeper concern #2:
+        file_read=True contract), never a head/tail mask that looks like a
+        truncated-but-usable key."""
+        secret = "ghp_" + "A" * 36
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = f'{{"name":"token","value":"{secret}"}}'
+        result_obj.to_dict.return_value = {
+            "content": result_obj.content,
+            "total_lines": 1,
+            "file_size": len(result_obj.content),
+        }
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+        result = json.loads(read_file_tool("/tmp/cookies.json"))
+        # Raw secret gone; the value key is force-redacted to the opaque marker.
+        assert secret not in result["content"]
+        # Non-reusable sentinel guarantee: no head/tail-preserving mask that
+        # still starts with the real prefix + a truncated body.
+        assert "ghp_A" not in result["content"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_ordinary_file_prefix_cred_uses_nonreusable_sentinel(self, mock_get):
+        """Non-browser file reads keep main's file_read=True contract: a prefix
+        credential becomes the non-reusable sentinel, not a reusable mask."""
+        secret = "ghp_" + "B" * 36
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = f"token = {secret}\n"
+        result_obj.to_dict.return_value = {
+            "content": result_obj.content,
+            "total_lines": 1,
+            "file_size": len(result_obj.content),
+        }
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+        result = json.loads(read_file_tool("/tmp/config.txt"))
+        assert secret not in result["content"]
+        assert "ghp_B" not in result["content"]
+
 
 class TestWriteFileHandler:
     @patch("tools.file_tools._get_file_ops")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import re
 import threading
 from pathlib import Path
 
@@ -61,6 +62,66 @@ def _get_max_read_chars() -> int:
 # If the total file size exceeds this AND the caller didn't specify a narrow
 # range (limit <= 200), we include a hint encouraging targeted reads.
 _LARGE_FILE_HINT_BYTES = 512_000  # 512 KB
+_OVERSIZED_READ_PREVIEW_CHARS = 8_000
+
+# Browser exports and storage dumps commonly place opaque cookie/localStorage
+# values under generic keys like "value", which the global code-file redactor
+# intentionally skips to avoid false positives in source code.  File reads for
+# these dump names are never source-code reads, so force a narrower extra pass.
+_BROWSER_EXPORT_NAME_RE = re.compile(
+    r"(?:cookie|localstorage|sessionstorage|conversationdb|indexeddb|browser[-_]?storage|^general[_-])",
+    re.IGNORECASE,
+)
+_BROWSER_EXPORT_JSON_VALUE_RE = re.compile(
+    r'("(?:value|cookie|cookies|localStorage|sessionStorage|auth|authorization)"\s*:\s*")([^"\\]*(?:\\.[^"\\]*)*)(")',
+    re.IGNORECASE,
+)
+
+
+def _looks_like_sensitive_browser_export(path: str) -> bool:
+    """Return True for browser cookie/storage/conversation export filenames."""
+    try:
+        return bool(_BROWSER_EXPORT_NAME_RE.search(Path(path).name))
+    except Exception:
+        return False
+
+
+def _redact_cookie_tsv_lines(content: str) -> str:
+    """Redact Netscape/browser-cookie TSV value columns in text exports."""
+    redacted_lines = []
+    for line in content.splitlines(keepends=True):
+        newline = ""
+        body = line
+        if line.endswith("\r\n"):
+            body, newline = line[:-2], "\r\n"
+        elif line.endswith("\n"):
+            body, newline = line[:-1], "\n"
+        elif line.endswith("\r"):
+            body, newline = line[:-1], "\r"
+
+        parts = body.split("\t")
+        # Netscape cookie rows have at least 7 columns; the final column is the
+        # cookie value.  Preserve metadata while removing the secret payload.
+        if len(parts) >= 7 and ("." in parts[0] or parts[0].startswith("http")):
+            parts[-1] = "[REDACTED]"
+            body = "\t".join(parts)
+        redacted_lines.append(body + newline)
+    return "".join(redacted_lines)
+
+
+def _redact_read_content(path: str, content: str) -> str:
+    """Redact read_file content, with stricter handling for browser exports."""
+    if not content:
+        return content
+    if _looks_like_sensitive_browser_export(path):
+        content = redact_sensitive_text(content, force=True, code_file=False)
+        content = _BROWSER_EXPORT_JSON_VALUE_RE.sub(
+            lambda m: f"{m.group(1)}[REDACTED]{m.group(3)}",
+            content,
+        )
+        return _redact_cookie_tsv_lines(content)
+    return redact_sensitive_text(content, code_file=True)
+
 
 # ---------------------------------------------------------------------------
 # Device path blocklist — reading these hangs the process (infinite output
@@ -932,34 +993,46 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         result = file_ops.read_file(path, offset, limit)
         result_dict = result.to_dict()
 
-        # ── Character-count guard ─────────────────────────────────────
-        # We're model-agnostic so we can't count tokens; characters are
-        # the best proxy we have.  If the read produced an unreasonable
-        # amount of content, reject it and tell the model to narrow down.
-        # Note: we check the formatted content (with line-number prefixes),
-        # not the raw file size, because that's what actually enters context.
-        # Check BEFORE redaction to avoid expensive regex on huge content.
+        # ── Redact secrets before size handling ───────────────────────
+        # Browser cookie/localStorage exports often have few very long lines;
+        # if we reject before redaction the UI shows a generic [error] and the
+        # user gets no safe preview.  Redact first, then return a bounded
+        # preview for oversized reads.
+        if result.content:
+            result.content = _redact_read_content(path, result.content)
+            result_dict["content"] = result.content
+
         content_len = len(result.content or "")
         file_size = result_dict.get("file_size", 0)
         max_chars = _get_max_read_chars()
         if content_len > max_chars:
             total_lines = result_dict.get("total_lines", "unknown")
-            return json.dumps({
-                "error": (
+            preview_chars = max(1_000, min(max_chars - 1_000, _OVERSIZED_READ_PREVIEW_CHARS))
+            preview = (result.content or "")[:preview_chars].rstrip()
+            omitted = max(0, content_len - len(preview))
+            result_dict.update({
+                "content": (
+                    f"{preview}\n\n"
+                    f"[read_file truncated oversized output: omitted {omitted:,} "
+                    f"characters after a safe redacted preview. Use offset and "
+                    f"limit to read a narrower range.]"
+                ),
+                "oversized": True,
+                "truncated": True,
+                "content_returned": True,
+                "original_content_chars": content_len,
+                "max_chars": max_chars,
+                "suggested_offset": offset,
+                "suggested_limit": min(limit, 100),
+                "_warning": (
                     f"Read produced {content_len:,} characters which exceeds "
-                    f"the safety limit ({max_chars:,} chars). "
-                    "Use offset and limit to read a smaller range. "
+                    f"the safety limit ({max_chars:,} chars). Returned a safe "
+                    "redacted preview instead of failing the tool call. Use "
+                    "offset and limit for the exact section you need. "
                     f"The file has {total_lines} lines total."
                 ),
-                "path": path,
-                "total_lines": total_lines,
-                "file_size": file_size,
-            }, ensure_ascii=False)
-
-        # ── Redact secrets (after guard check to skip oversized content) ──
-        if result.content:
-            result.content = redact_sensitive_text(result.content, code_file=True)
-            result_dict["content"] = result.content
+            })
+            return json.dumps(result_dict, ensure_ascii=False)
 
         # Large-file hint: if the file is big and the caller didn't ask
         # for a narrow window, nudge toward targeted reads.

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import posixpath
+import re
 import sys
 import threading
 from pathlib import Path, PurePosixPath
@@ -136,6 +137,78 @@ def _truncate_to_char_budget(content: str, max_chars: int) -> tuple[str, int, bo
 # If the total file size exceeds this AND the caller didn't specify a narrow
 # range (limit <= 200), we include a hint encouraging targeted reads.
 _LARGE_FILE_HINT_BYTES = 512_000  # 512 KB
+
+# Browser exports and storage dumps commonly place opaque cookie/localStorage
+# values under generic keys like "value", which the global code-file redactor
+# intentionally skips to avoid false positives in source code.  File reads for
+# these dump names are never source-code reads, so force a narrower extra pass.
+_BROWSER_EXPORT_NAME_RE = re.compile(
+    r"(?:cookie|localstorage|sessionstorage|conversationdb|indexeddb|browser[-_]?storage|^general[_-])",
+    re.IGNORECASE,
+)
+_BROWSER_EXPORT_JSON_VALUE_RE = re.compile(
+    r'("(?:value|cookie|cookies|localStorage|sessionStorage|auth|authorization)"\s*:\s*")([^"\\]*(?:\\.[^"\\]*)*)(")',
+    re.IGNORECASE,
+)
+
+
+def _looks_like_sensitive_browser_export(path: str) -> bool:
+    """Return True for browser cookie/storage/conversation export filenames."""
+    try:
+        return bool(_BROWSER_EXPORT_NAME_RE.search(Path(path).name))
+    except Exception:
+        return False
+
+
+def _redact_cookie_tsv_lines(content: str) -> str:
+    """Redact Netscape/browser-cookie TSV value columns in text exports."""
+    redacted_lines = []
+    for line in content.splitlines(keepends=True):
+        newline = ""
+        body = line
+        if line.endswith("\r\n"):
+            body, newline = line[:-2], "\r\n"
+        elif line.endswith("\n"):
+            body, newline = line[:-1], "\n"
+        elif line.endswith("\r"):
+            body, newline = line[:-1], "\r"
+
+        parts = body.split("\t")
+        # Netscape cookie rows have at least 7 columns; the final column is the
+        # cookie value.  Preserve metadata while removing the secret payload.
+        if len(parts) >= 7 and ("." in parts[0] or parts[0].startswith("http")):
+            parts[-1] = "[REDACTED]"
+            body = "\t".join(parts)
+        redacted_lines.append(body + newline)
+    return "".join(redacted_lines)
+
+
+def _redact_read_content(path: str, content: str) -> str:
+    """Redact read_file content, with stricter handling for browser exports.
+
+    Both branches use ``file_read=True`` so prefix-matched credentials become
+    the non-reusable ``«redacted:ghp_…»`` sentinel rather than a head/tail mask
+    (see ``agent.redact.redact_sensitive_text``): a file read must never hand
+    back a string that looks like a truncated-but-usable key.  Browser exports
+    additionally get an opaque-value pass because cookie/localStorage dumps
+    stash secrets under generic keys (``"value"``) or in the final TSV column,
+    which the built-in patterns intentionally leave alone to avoid false
+    positives in ordinary source code.
+    """
+    if not content:
+        return content
+    if _looks_like_sensitive_browser_export(path):
+        # force=True: browser dumps must be scrubbed even when the operator
+        # disabled global log redaction; file_read=True keeps the
+        # non-reusable-sentinel guarantee for recognized credential prefixes.
+        content = redact_sensitive_text(content, force=True, file_read=True)
+        content = _BROWSER_EXPORT_JSON_VALUE_RE.sub(
+            lambda m: f"{m.group(1)}[REDACTED]{m.group(3)}",
+            content,
+        )
+        return _redact_cookie_tsv_lines(content)
+    return redact_sensitive_text(content, file_read=True)
+
 
 # ---------------------------------------------------------------------------
 # Device path blocklist — reading these hangs the process (infinite output
@@ -1906,8 +1979,12 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
             content_len = len(trimmed)
 
         # ── Redact secrets (after guard check to skip oversized content) ──
+        # Browser cookie/localStorage/IndexedDB exports get an extra opaque-value
+        # pass on top of the standard file_read redaction (see
+        # _redact_read_content); ordinary files fall through to the same
+        # file_read=True contract main already uses.
         if result.content:
-            result.content = redact_sensitive_text(result.content, file_read=True)
+            result.content = _redact_read_content(path, result.content)
             result_dict["content"] = result.content
 
         # Large-file hint: if the file is big and the caller didn't ask


### PR DESCRIPTION
Hardens `read_file`: (1) browser-storage exports (cookie/localStorage/IndexedDB/conversation DBs etc., matched by `_BROWSER_EXPORT_NAME_RE`) are redacted on read to avoid leaking captured secrets into context; (2) oversized reads return a bounded `_OVERSIZED_READ_PREVIEW_CHARS` preview instead of erroring. `tools/file_tools.py` + 2 tests. Draft for review.