### PR TITLE
fix(gateway): read-only liveness probe + non-root-workspace root guard

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -527,7 +527,26 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
     if not resolved_lock_path.exists():
         return False
 
-    handle = open(resolved_lock_path, "a+", encoding="utf-8")
+    # Passive liveness probe only: we open the lock solely to test whether some
+    # OTHER process holds the flock, then release immediately. This NEVER writes,
+    # so open it read-only. Opening "a+" (read-write) here used to crash the whole
+    # gateway with PermissionError when the lock file was momentarily owned by a
+    # different user (e.g. a stray root-context start left a root-owned
+    # gateway.lock); the liveness check has no need for write access. The real
+    # owner still claims the lock read-write in acquire_gateway_runtime_lock().
+    try:
+        handle = open(resolved_lock_path, "r", encoding="utf-8")
+    except PermissionError:
+        # Can't even read it (alien-owned, no read bit). Fall back to a
+        # bytewise read-probe via os.open(O_RDONLY); if that also fails we
+        # conservatively report the lock as active (someone owns the file) so
+        # we don't spuriously declare the gateway dead and trigger a replace.
+        try:
+            fd = os.open(resolved_lock_path, os.O_RDONLY)
+        except OSError:
+            return True
+        os.close(fd)
+        return True
     try:
         if _try_acquire_file_lock(handle):
             _release_file_lock(handle)

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -818,6 +818,43 @@ def _try_acquire_file_lock(handle) -> bool:
         return False
 
 
+def _probe_file_lock_free(handle) -> bool:
+    """Write-free, non-blocking liveness probe for the runtime lock.
+
+    Returns True when the lock is FREE (no other process holds the exclusive
+    owner lock) and False when it is currently held. Unlike
+    :func:`_try_acquire_file_lock` (which takes the EXCLUSIVE owner lock and
+    seeds an empty file first), this takes a SHARED / READ lock and NEVER
+    writes, so it is safe to run on a READ-ONLY handle on every platform.
+
+    One shape on both platforms: take a non-blocking read lock, release it,
+    report free; contention with the owner's exclusive lock reports held.
+
+      * POSIX: ``fcntl.flock`` with ``LOCK_SH | LOCK_NB``. A shared lock is
+        refused while any process holds ``LOCK_EX`` (the owner), so it contends
+        exactly when the gateway is live.
+      * Windows: ``msvcrt.locking`` with ``LK_NBRLCK`` (non-blocking READ lock)
+        over the same reserved byte range the owner locks. A read lock needs
+        only read access to the handle, so no seed write is required here — the
+        "\\n" seed the owner writes is an owner-side concern, not a probe one.
+    """
+    try:
+        if _IS_WINDOWS:
+            handle.seek(_WINDOWS_LOCK_OFFSET)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBRLCK, 1)
+            try:
+                handle.seek(_WINDOWS_LOCK_OFFSET)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+        else:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB)
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        return True
+    except (BlockingIOError, OSError):
+        return False
+
+
 def _pid_exists(pid: int) -> bool:
     """Cross-platform "is this PID alive" check that does NOT kill the target.
 
@@ -1010,21 +1047,47 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
     if not resolved_lock_path.exists():
         return False
 
+    # Passive liveness probe only: we open the lock solely to test whether some
+    # OTHER process holds it, then release immediately. ONE unified code path on
+    # every platform:
+    #
+    #   * Open READ-ONLY ("r"). The probe never writes, so a read-only handle is
+    #     sufficient. This also means an alien/root-owned lock file (e.g. a stray
+    #     root-context start left a root-owned gateway.lock) no longer crashes
+    #     the gateway with PermissionError from opening "a+" (read-write) — the
+    #     historical bug this fixes.
+    #   * An EMPTY (zero-byte) lock file can NEVER be actively held: the real
+    #     owner in _try_acquire_file_lock() always seeds at least one byte
+    #     (writes "\n") BEFORE taking the OS lock, so a live lock is always
+    #     non-empty. We detect that empty-lock case explicitly and report FREE,
+    #     instead of relying on a probe-side seed write. That is what makes the
+    #     read-only path correct on Windows too: msvcrt.locking on a zero-length
+    #     range would otherwise be ambiguous, and a read-only handle cannot seed.
+    #   * Otherwise run the write-free _probe_file_lock_free() helper, which uses
+    #     fcntl on POSIX and msvcrt.locking on Windows — same shape, no writes.
     try:
-        handle = open(resolved_lock_path, "a+", encoding="utf-8")
+        handle = open(resolved_lock_path, "r", encoding="utf-8")
     except PermissionError:
-        # Stale root-owned lock file from a previous launchd Background
-        # session that ran as root.  The parent directory owner can unlink
-        # files even when they don't own them, so remove the stale lock
-        # and report inactive — the new process will create a fresh one.
+        # Alien-owned lock we cannot even open read-only. Fall back to a bare
+        # existence probe via os.open(O_RDONLY); if the file is present at all
+        # someone owns it, so conservatively report ACTIVE rather than
+        # spuriously declaring the gateway dead and triggering a --replace. The
+        # probe never mutates or unlinks the file.
         try:
-            resolved_lock_path.unlink()
+            fd = os.open(resolved_lock_path, os.O_RDONLY)
         except OSError:
-            pass
-        return False
+            return True
+        os.close(fd)
+        return True
     try:
-        if _try_acquire_file_lock(handle):
-            _release_file_lock(handle)
+        try:
+            is_empty = os.fstat(handle.fileno()).st_size == 0
+        except OSError:
+            is_empty = False
+        if is_empty:
+            # No owner can be holding a not-yet-seeded lock.
+            return False
+        if _probe_file_lock_free(handle):
             return False
         return True
     finally:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4026,7 +4026,30 @@ def _guard_official_docker_root_gateway() -> None:
     if _truthy_env(os.getenv("HERMES_ALLOW_ROOT_GATEWAY")):
         return
 
-    # Case 2: workspace owned by a non-root user. Check the resolved HERMES_HOME.
+    # Case 1 (legacy, most specific): official Docker checkout where the image
+    # entrypoint should have dropped privileges. Checked FIRST so that inside the
+    # official image the Docker-specific guidance wins over the general
+    # workspace-owner message below.
+    if _is_official_docker_checkout():
+        print_error(
+            "Refusing to run the Hermes gateway as root inside the official Docker image."
+        )
+        print(
+            "  The image entrypoint normally drops privileges to the 'hermes' user. "
+            "If you override entrypoint in Docker Compose, include "
+            "/opt/hermes/docker/entrypoint.sh before the Hermes command."
+        )
+        print(
+            "  Running the gateway as root can leave root-owned files in "
+            "$HERMES_HOME and break later non-root dashboard/gateway runs."
+        )
+        print(
+            "  Set HERMES_ALLOW_ROOT_GATEWAY=1 only if you intentionally accept this risk."
+        )
+        sys.exit(1)
+
+    # Case 2 (general): workspace owned by a non-root user. Check the resolved
+    # HERMES_HOME.
     home = None
     home_uid = 0
     try:
@@ -4064,28 +4087,6 @@ def _guard_official_docker_root_gateway() -> None:
             "root-owned workspace files."
         )
         sys.exit(1)
-
-    # Case 1 (legacy): official Docker checkout where entrypoint should have
-    # dropped privileges.
-    if not _is_official_docker_checkout():
-        return
-
-    print_error(
-        "Refusing to run the Hermes gateway as root inside the official Docker image."
-    )
-    print(
-        "  The image entrypoint normally drops privileges to the 'hermes' user. "
-        "If you override entrypoint in Docker Compose, include "
-        "/opt/hermes/docker/entrypoint.sh before the Hermes command."
-    )
-    print(
-        "  Running the gateway as root can leave root-owned files in "
-        "$HERMES_HOME and break later non-root dashboard/gateway runs."
-    )
-    print(
-        "  Set HERMES_ALLOW_ROOT_GATEWAY=1 only if you intentionally accept this risk."
-    )
-    sys.exit(1)
 
 
 def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, force: bool = False):

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4004,11 +4004,69 @@ def _guard_existing_gateway_process_conflict(replace: bool = False) -> None:
 
 
 def _guard_official_docker_root_gateway() -> None:
-    """Refuse gateway startup when the official Docker privilege drop was bypassed."""
+    """Refuse gateway startup when running as root would leave root-owned files.
+
+    Two cases, both fatal unless HERMES_ALLOW_ROOT_GATEWAY=1:
+
+      1. The official Docker image whose entrypoint normally drops privileges to
+         the 'hermes' user (legacy guard).
+      2. ANY host where $HERMES_HOME (the workspace) is owned by a NON-root user
+         but the gateway is being launched as root. This is the bindfs
+         dual-systemd-manager trap: when /root/.config is a bindfs view of a
+         user's ~/.config, root's `user@0.service` manager can pick up the user's
+         hermes-gateway.service unit and start it AS ROOT. That root process then
+         writes gateway.lock / gateway_state.json / processes.json /
+         channel_directory.json owned by root, which makes every subsequent
+         non-root gateway start crash with PermissionError. Refusing to start as
+         root here means the offending files are NEVER created as root in the
+         first place — the fix the workspace owner asked for.
+    """
     if not hasattr(os, "geteuid") or os.geteuid() != 0:
         return
     if _truthy_env(os.getenv("HERMES_ALLOW_ROOT_GATEWAY")):
         return
+
+    # Case 2: workspace owned by a non-root user. Check the resolved HERMES_HOME.
+    home = None
+    home_uid = 0
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = Path(get_hermes_home())
+        home_uid = home.stat().st_uid if home.exists() else 0
+    except Exception:
+        home_uid = 0
+    if home_uid != 0:
+        import pwd
+
+        try:
+            owner = pwd.getpwuid(home_uid).pw_name
+        except Exception:
+            owner = str(home_uid)
+        print_error(
+            "Refusing to run the Hermes gateway as root: the workspace "
+            f"({home}) is owned by '{owner}', not root."
+        )
+        print(
+            "  Running the gateway as root would create root-owned runtime "
+            "files (gateway.lock, gateway_state.json, processes.json, "
+            "channel_directory.json) that break the real non-root gateway with "
+            "PermissionError."
+        )
+        print(
+            "  This usually means root's systemd user-manager (user@0.service) "
+            "started a unit it sees via a bindfs view of the user's ~/.config. "
+            f"Start the gateway as '{owner}' instead "
+            f"(systemctl --user, or `sudo -u {owner} ...`)."
+        )
+        print(
+            "  Set HERMES_ALLOW_ROOT_GATEWAY=1 only if you intentionally accept "
+            "root-owned workspace files."
+        )
+        sys.exit(1)
+
+    # Case 1 (legacy): official Docker checkout where entrypoint should have
+    # dropped privileges.
     if not _is_official_docker_checkout():
         return
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5821,30 +5821,89 @@ def _guard_existing_gateway_process_conflict(replace: bool = False) -> None:
 
 
 def _guard_official_docker_root_gateway() -> None:
-    """Refuse gateway startup when the official Docker privilege drop was bypassed."""
+    """Refuse gateway startup when running as root would leave root-owned files.
+
+    Two cases, both fatal unless HERMES_ALLOW_ROOT_GATEWAY is truthy:
+
+      1. The official Docker image whose entrypoint normally drops privileges
+         to the 'hermes' user (legacy, most-specific guard).
+      2. ANY host where the resolved $HERMES_HOME workspace is owned by a
+         NON-root user but the gateway is being launched as root. This is the
+         bindfs dual-systemd-manager trap: root's ``user@0.service`` manager
+         can pick up a user's hermes-gateway.service unit (seen via a bindfs
+         view of the user's ~/.config) and start it AS ROOT. That root process
+         then writes gateway.lock / gateway_state.json / processes.json /
+         channel_directory.json owned by root, which makes every subsequent
+         non-root gateway start crash with PermissionError. Refusing to start
+         as root here means those files are never created as root in the first
+         place.
+    """
     if not hasattr(os, "geteuid") or os.geteuid() != 0:
         return
     if _truthy_env(os.getenv("HERMES_ALLOW_ROOT_GATEWAY")):
         return
-    if not _is_official_docker_checkout():
-        return
 
-    print_error(
-        "Refusing to run the Hermes gateway as root inside the official Docker image."
-    )
-    print(
-        "  The image entrypoint normally drops privileges to the 'hermes' user. "
-        "If you override entrypoint in Docker Compose, include "
-        "/opt/hermes/docker/entrypoint.sh before the Hermes command."
-    )
-    print(
-        "  Running the gateway as root can leave root-owned files in "
-        "$HERMES_HOME and break later non-root dashboard/gateway runs."
-    )
-    print(
-        "  Set HERMES_ALLOW_ROOT_GATEWAY=1 only if you intentionally accept this risk."
-    )
-    sys.exit(1)
+    # Case 1 (legacy, most specific): official Docker checkout. Checked FIRST so
+    # the Docker-specific guidance wins over the general message inside the
+    # official image.
+    if _is_official_docker_checkout():
+        print_error(
+            "Refusing to run the Hermes gateway as root inside the official "
+            "Docker image."
+        )
+        print(
+            "  The image entrypoint normally drops privileges to the 'hermes' "
+            "user. If you override entrypoint in Docker Compose, include "
+            "/opt/hermes/docker/entrypoint.sh before the Hermes command."
+        )
+        print(
+            "  Running the gateway as root can leave root-owned files in "
+            "$HERMES_HOME and break later non-root dashboard/gateway runs."
+        )
+        print(
+            "  Set HERMES_ALLOW_ROOT_GATEWAY=1 only if you intentionally "
+            "accept this risk."
+        )
+        sys.exit(1)
+
+    # Case 2 (general): workspace owned by a non-root user.
+    home = None
+    home_uid = 0
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = Path(get_hermes_home())
+        home_uid = home.stat().st_uid if home.exists() else 0
+    except Exception:
+        home_uid = 0
+    if home_uid != 0:
+        try:
+            import pwd
+
+            owner = pwd.getpwuid(home_uid).pw_name
+        except Exception:
+            owner = str(home_uid)
+        print_error(
+            "Refusing to run the Hermes gateway as root: the workspace "
+            f"({home}) is owned by '{owner}', not root."
+        )
+        print(
+            "  Running the gateway as root would create root-owned runtime "
+            "files (gateway.lock, gateway_state.json, processes.json, "
+            "channel_directory.json) that break the real non-root gateway "
+            "with PermissionError."
+        )
+        print(
+            "  This usually means root's systemd user-manager "
+            "(user@0.service) started a unit it sees via a bindfs view of the "
+            f"user's ~/.config. Start the gateway as '{owner}' instead "
+            f"(systemctl --user, or `sudo -u {owner} ...`)."
+        )
+        print(
+            "  Set HERMES_ALLOW_ROOT_GATEWAY=1 only if you intentionally "
+            "accept root-owned workspace files."
+        )
+        sys.exit(1)
 
 
 def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, force: bool = False):

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1150,13 +1150,18 @@ class TestLaunchdPlistRespawnGovernance:
 
 
 class TestPermissionErrorOnLockFile:
-    """Stale root-owned lock files from launchd Background sessions must not
-    crash the gateway on restart (issue #42685)."""
+    """A lock file the probe cannot open (alien/root-owned) must not crash the
+    gateway. The unified passive liveness probe reasons conservatively: an
+    unopenable-but-present lock is reported ACTIVE (someone owns it) so we never
+    spuriously declare the gateway dead and trigger a --replace, and the probe
+    never mutates or unlinks the file (issue #42685, PR #50047)."""
 
-    def test_permission_error_on_lock_file_returns_false_and_removes(self, tmp_path, monkeypatch):
-        """When the lock file is not writable (root-owned), the function should
-        remove the stale file and report the lock as inactive."""
+    def test_permission_error_on_lock_file_reports_active_and_preserves(self, tmp_path, monkeypatch):
+        """When the probe cannot open the lock (root-owned) but a read-only
+        O_RDONLY probe still succeeds, the lock is reported active and the file
+        is left untouched (the passive probe never mutates it)."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_gateway_lock_handle", None, raising=False)
         lock_path = tmp_path / "gateway.lock"
         lock_path.write_text("stale", encoding="utf-8")
 
@@ -1170,13 +1175,17 @@ class TestPermissionErrorOnLockFile:
         monkeypatch.setattr("builtins.open", deny_write)
 
         result = status.is_gateway_runtime_lock_active(lock_path)
-        assert result is False
-        assert not lock_path.exists(), "stale root-owned lock file should be removed"
+        assert result is True
+        assert lock_path.exists(), (
+            "passive liveness probe must not unlink the lock file"
+        )
 
-    def test_permission_error_unlink_failure_still_returns_false(self, tmp_path, monkeypatch):
-        """Even if unlinking the stale lock file fails (e.g. directory not writable),
-        the function should still return False to allow startup."""
+    def test_permission_error_with_unreadable_lock_still_reports_active(self, tmp_path, monkeypatch):
+        """Even when the fallback os.open(O_RDONLY) probe also fails, the
+        function conservatively reports the lock active (someone owns the file)
+        rather than declaring the gateway dead."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_gateway_lock_handle", None, raising=False)
         lock_path = tmp_path / "gateway.lock"
         lock_path.write_text("stale", encoding="utf-8")
 
@@ -1187,18 +1196,18 @@ class TestPermissionErrorOnLockFile:
                 raise PermissionError(13, "Permission denied", str(path))
             return real_open(path, *args, **kwargs)
 
-        real_unlink = Path.unlink
+        real_os_open = os.open
 
-        def deny_unlink(self, *args, **kwargs):
-            if str(self) == str(lock_path):
-                raise OSError(13, "Permission denied", str(self))
-            return real_unlink(self, *args, **kwargs)
+        def deny_os_open(path, *args, **kwargs):
+            if str(path) == str(lock_path):
+                raise PermissionError(13, "Permission denied", str(path))
+            return real_os_open(path, *args, **kwargs)
 
         monkeypatch.setattr("builtins.open", deny_write)
-        monkeypatch.setattr(Path, "unlink", deny_unlink)
+        monkeypatch.setattr(os, "open", deny_os_open)
 
         result = status.is_gateway_runtime_lock_active(lock_path)
-        assert result is False
+        assert result is True
 
     def test_acquire_gateway_runtime_lock_recovers_from_permission_error(self, tmp_path, monkeypatch):
         """acquire_gateway_runtime_lock must survive a stale root-owned lock
@@ -1228,6 +1237,191 @@ class TestPermissionErrorOnLockFile:
             assert status.acquire_gateway_runtime_lock() is True
         finally:
             status.release_gateway_runtime_lock()
+
+
+class TestLivenessProbeMode:
+    """The passive liveness probe in ``is_gateway_runtime_lock_active`` is a
+    SINGLE unified code path on every platform: it opens the lock READ-ONLY
+    ("r"), never writes/seeds/unlinks it, detects the empty-lock case
+    explicitly, then runs a write-free shared/read-lock probe (fcntl LOCK_SH on
+    POSIX, msvcrt LK_NBRLCK on Windows). PR #50047 (unified cross-platform)."""
+
+    def test_probe_opens_lock_read_only_on_this_host(self, tmp_path, monkeypatch):
+        """The lock is opened in read-only mode "r" (never "a+"), so an
+        alien/root-owned file can't crash the probe and the file is never
+        mutated. Capture the mode the probe passes to open()."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_gateway_lock_handle", None, raising=False)
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("held", encoding="utf-8")
+
+        seen_modes = []
+        real_open = open
+
+        def spy_open(path, mode="r", *args, **kwargs):
+            if str(path) == str(lock_path):
+                seen_modes.append(mode)
+            return real_open(path, mode, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", spy_open)
+        status.is_gateway_runtime_lock_active(lock_path)
+
+        assert seen_modes, "probe should have opened the lock file"
+        assert all(m == "r" for m in seen_modes), (
+            f"probe must open read-only, saw modes: {seen_modes}"
+        )
+
+    def test_empty_lock_reports_free_without_writing(self, tmp_path, monkeypatch):
+        """A zero-byte lock file can never be actively held (the owner seeds a
+        byte BEFORE locking), so the probe reports FREE by the explicit
+        empty-check and never writes to the file. Platform-agnostic."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_gateway_lock_handle", None, raising=False)
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("", encoding="utf-8")
+        assert lock_path.stat().st_size == 0
+
+        assert status.is_gateway_runtime_lock_active(lock_path) is False
+        # The read-only probe must not seed/rewrite the empty file.
+        assert lock_path.stat().st_size == 0
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX fcntl.flock path")
+    def test_free_lock_reports_not_active_and_is_unchanged(self, tmp_path, monkeypatch):
+        """An existing but UNHELD (non-empty) lock file is reported not active,
+        and the read-only probe leaves the file's contents untouched."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_gateway_lock_handle", None, raising=False)
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("free-content", encoding="utf-8")
+
+        assert status.is_gateway_runtime_lock_active(lock_path) is False
+        assert lock_path.read_text(encoding="utf-8") == "free-content"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX fcntl.flock path")
+    def test_held_lock_reports_active(self, tmp_path, monkeypatch):
+        """A lock held EXCLUSIVELY by another handle (simulating another live
+        gateway) is reported active: the probe's non-blocking shared-lock
+        attempt contends with the owner's LOCK_EX."""
+        import fcntl
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_gateway_lock_handle", None, raising=False)
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("held", encoding="utf-8")
+
+        holder = open(lock_path, "a+", encoding="utf-8")
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            assert status.is_gateway_runtime_lock_active(lock_path) is True
+        finally:
+            fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+            holder.close()
+        # Once released, the same file is reported free again.
+        assert status.is_gateway_runtime_lock_active(lock_path) is False
+
+    def test_windows_empty_unlocked_lock_reports_free(self, tmp_path, monkeypatch):
+        """Regression for the exact bug the sweeper flagged, now fixed in ONE
+        unified path: on Windows an EMPTY unlocked lock must report NOT active.
+
+        The original design opened the lock read-write on Windows so the
+        byte-seed write could run before ``msvcrt.locking``; a read-only handle
+        would raise on that write and falsely report the lock ACTIVE. The
+        unified fix instead opens read-only on EVERY platform and detects the
+        empty-lock case EXPLICITLY (an unseeded file cannot be held), so the
+        Windows path never needs a write and never even calls ``msvcrt.locking``
+        for the empty case.
+
+        We force the Windows branch on this POSIX host by patching
+        ``status._IS_WINDOWS`` and injecting a stub ``msvcrt`` (the real module
+        does not exist off Windows)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_gateway_lock_handle", None, raising=False)
+        monkeypatch.setattr(status, "_IS_WINDOWS", True)
+
+        locking_calls = []
+
+        def fake_locking(fd, mode, size):
+            locking_calls.append((mode, size))
+
+        fake_msvcrt = SimpleNamespace(
+            LK_NBRLCK=3, LK_NBLCK=1, LK_UNLCK=2, locking=fake_locking
+        )
+        monkeypatch.setattr(status, "msvcrt", fake_msvcrt, raising=False)
+
+        # Empty (zero-byte) UNLOCKED lock.
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("", encoding="utf-8")
+        assert lock_path.stat().st_size == 0
+
+        result = status.is_gateway_runtime_lock_active(lock_path)
+
+        assert result is False, (
+            "empty unlocked lock must be reported NOT active on the Windows "
+            "path without requiring any write to the read-only handle"
+        )
+        # The read-only probe must not have written a seed byte...
+        assert lock_path.stat().st_size == 0
+        # ...and must not even reach msvcrt.locking for the empty case.
+        assert locking_calls == []
+
+    def test_windows_nonempty_unlocked_lock_reports_free(self, tmp_path, monkeypatch):
+        """On Windows, a NON-empty but unlocked lock is probed with a write-free
+        read lock (``LK_NBRLCK``). When ``msvcrt.locking`` succeeds (no
+        contention) the lock is reported NOT active, and the file is never
+        written to."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_gateway_lock_handle", None, raising=False)
+        monkeypatch.setattr(status, "_IS_WINDOWS", True)
+
+        locking_calls = []
+
+        def fake_locking(fd, mode, size):
+            # Read-lock acquire and release both succeed -> unlocked.
+            locking_calls.append((mode, size))
+
+        fake_msvcrt = SimpleNamespace(
+            LK_NBRLCK=3, LK_NBLCK=1, LK_UNLCK=2, locking=fake_locking
+        )
+        monkeypatch.setattr(status, "msvcrt", fake_msvcrt, raising=False)
+
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("seeded\n", encoding="utf-8")
+
+        result = status.is_gateway_runtime_lock_active(lock_path)
+
+        assert result is False
+        # Write-free: the probe used the read lock, never re-seeded the file.
+        assert lock_path.read_text(encoding="utf-8") == "seeded\n"
+        assert (fake_msvcrt.LK_NBRLCK, 1) in locking_calls
+        assert (fake_msvcrt.LK_UNLCK, 1) in locking_calls
+
+    def test_windows_probe_reports_active_when_msvcrt_locking_contends(
+        self, tmp_path, monkeypatch
+    ):
+        """On Windows, if ``msvcrt.locking`` raises on the read-lock acquire
+        (byte range already exclusively locked by the live owner), the probe
+        reports the lock ACTIVE."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_gateway_lock_handle", None, raising=False)
+        monkeypatch.setattr(status, "_IS_WINDOWS", True)
+
+        def fake_locking(fd, mode, size):
+            if mode == 3:  # LK_NBRLCK acquire attempt -> contended
+                raise OSError(36, "Resource deadlock avoided")
+
+        monkeypatch.setattr(
+            status,
+            "msvcrt",
+            SimpleNamespace(
+                LK_NBRLCK=3, LK_NBLCK=1, LK_UNLCK=2, locking=fake_locking
+            ),
+            raising=False,
+        )
+
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("held\n", encoding="utf-8")
+
+        assert status.is_gateway_runtime_lock_active(lock_path) is True
 
 
 class TestNormalizeUpdatedAt:

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -878,6 +878,99 @@ def test_module_has_logger():
     assert gateway.logger.name == "hermes_cli.gateway"
 
 
+class TestGuardOfficialDockerRootGateway:
+    """``_guard_official_docker_root_gateway`` refuses to launch the gateway as
+    root when doing so would leave root-owned runtime files. Two cases, both
+    fatal unless ``HERMES_ALLOW_ROOT_GATEWAY`` is truthy:
+
+      1. inside the official Docker image (checked first, most specific), and
+      2. on ANY host where the resolved ``$HERMES_HOME`` workspace is owned by a
+         non-root user (the bindfs dual-systemd trap — PR #50047 generalized the
+         guard beyond the Docker-only case).
+    """
+
+    def _force_root(self, monkeypatch):
+        monkeypatch.setattr(gateway.os, "geteuid", lambda: 0, raising=False)
+
+    def test_non_root_euid_is_noop(self, monkeypatch, tmp_path):
+        """A normal (non-root) launch never trips the guard, regardless of who
+        owns the workspace."""
+        monkeypatch.setattr(gateway.os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(gateway, "_is_official_docker_checkout", lambda: True)
+        gateway._guard_official_docker_root_gateway()
+
+    def test_root_with_non_root_workspace_refuses(self, monkeypatch, tmp_path, capsys):
+        """Root launch + non-root-owned workspace (NOT the official Docker
+        image) is refused: the generalized Case 2 guard. This is the exact
+        scenario PR #50047 added beyond the Docker-only guard."""
+        pwd = pytest.importorskip("pwd")
+        self._force_root(monkeypatch)
+        monkeypatch.delenv("HERMES_ALLOW_ROOT_GATEWAY", raising=False)
+        monkeypatch.setattr(gateway, "_is_official_docker_checkout", lambda: False)
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: tmp_path, raising=False
+        )
+        monkeypatch.setattr(
+            gateway.Path,
+            "stat",
+            lambda self, *a, **k: SimpleNamespace(st_uid=1000),
+            raising=False,
+        )
+        monkeypatch.setattr(gateway.Path, "exists", lambda self: True, raising=False)
+        monkeypatch.setattr(
+            pwd, "getpwuid", lambda uid: SimpleNamespace(pw_name="alice")
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            gateway._guard_official_docker_root_gateway()
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "workspace" in out
+        assert "alice" in out
+
+    def test_root_with_root_owned_workspace_is_allowed(self, monkeypatch, tmp_path):
+        """Root launch is fine when the workspace itself is root-owned (nobody
+        else is broken by root-owned runtime files) and it is not the official
+        Docker image."""
+        self._force_root(monkeypatch)
+        monkeypatch.delenv("HERMES_ALLOW_ROOT_GATEWAY", raising=False)
+        monkeypatch.setattr(gateway, "_is_official_docker_checkout", lambda: False)
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: tmp_path, raising=False
+        )
+        monkeypatch.setattr(
+            gateway.Path,
+            "stat",
+            lambda self, *a, **k: SimpleNamespace(st_uid=0),
+            raising=False,
+        )
+        monkeypatch.setattr(gateway.Path, "exists", lambda self: True, raising=False)
+        gateway._guard_official_docker_root_gateway()
+
+    def test_allow_root_env_override_bypasses_guard(self, monkeypatch, tmp_path):
+        """``HERMES_ALLOW_ROOT_GATEWAY=1`` bypasses both cases even as root with
+        a non-root workspace inside the official image."""
+        self._force_root(monkeypatch)
+        monkeypatch.setenv("HERMES_ALLOW_ROOT_GATEWAY", "1")
+        monkeypatch.setattr(gateway, "_is_official_docker_checkout", lambda: True)
+        gateway._guard_official_docker_root_gateway()
+
+    def test_official_docker_case_wins_over_workspace_case(self, monkeypatch, tmp_path, capsys):
+        """Inside the official image the Docker-specific guidance is emitted,
+        not the general workspace-owner message (ordering: Docker checked
+        first)."""
+        self._force_root(monkeypatch)
+        monkeypatch.delenv("HERMES_ALLOW_ROOT_GATEWAY", raising=False)
+        monkeypatch.setattr(gateway, "_is_official_docker_checkout", lambda: True)
+
+        with pytest.raises(SystemExit) as exc:
+            gateway._guard_official_docker_root_gateway()
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "official Docker image" in out
+        assert "owned by" not in out
+
+
 class TestWindowsScheduledTaskSupervisorGuard:
     """The reaper must skip when the profile's scheduled task is still a
     supervisor — Running *or* Ready.


### PR DESCRIPTION
## Summary

This change makes gateway runtime lock liveness probing passive and read only on POSIX and Windows.

The probe opens an existing lock with mode `r`, treats a zero byte file as inactive because the owner seeds the lock byte before acquiring its operating system lock, and otherwise attempts a nonblocking shared or read lock over the owner's range. It never seeds, rewrites, or unlinks the lock file. A file that cannot be opened is treated conservatively as active instead of triggering replacement of a potentially live gateway.

The root startup guard now also rejects a root gateway outside the official Docker image when the resolved Hermes workspace belongs to a nonroot user. This prevents root owned runtime files from breaking later launches by the workspace owner. Root owned workspaces remain allowed, the existing official Docker guidance retains priority, and `HERMES_ALLOW_ROOT_GATEWAY=1` remains the explicit override.

## Verification

The lock tests cover read only open mode, empty and nonempty unlocked files, held files, no mutation, permission failures, mocked Windows `msvcrt` read lock success and contention, and the existing runtime status subsystem. Root guard tests cover nonroot execution, a nonroot owned workspace, a root owned workspace, the explicit override, and Docker message precedence.

`scripts/run_tests.sh tests/gateway/test_status.py tests/hermes_cli/test_gateway.py -q`

Result: 109 passed and 5 skipped across 2 files. The skipped tests are marked `windows_only` and run in the Windows CI lane. The Windows liveness regressions added here use a mocked Windows branch and passed on this host.

`venv/bin/ruff check gateway/status.py hermes_cli/gateway.py tests/gateway/test_status.py tests/hermes_cli/test_gateway.py`

Result: all checks passed.
