### PR TITLE
feat(context-engine): additive grounding hook points on the base ContextEngine

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -227,7 +227,7 @@ class ContextEngine(ABC):
 
     # -- Optional: H2 grounding hooks (additive; default no-ops) ------------
     #
-    # These let a retrieval-first engine (e.g. hermes-cmx) (a) inject verbatim
+    # These let a retrieval-first engine (e.g. a retrieval-first engine) (a) inject verbatim
     # evidence just before the request is sent, and (b) audit/enforce the model's
     # reply (citation check, verification, regenerate, refuse) *after* it returns.
     # Built-in ContextCompressor and LCM do not override them, so behaviour is

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -224,3 +224,38 @@ class ContextEngine(ABC):
         """
         self.context_length = context_length
         self.threshold_tokens = int(context_length * self.threshold_percent)
+
+    # -- Optional: H2 grounding hooks (additive; default no-ops) ------------
+    #
+    # These let a retrieval-first engine (e.g. hermes-cmx) (a) inject verbatim
+    # evidence just before the request is sent, and (b) audit/enforce the model's
+    # reply (citation check, verification, regenerate, refuse) *after* it returns.
+    # Built-in ContextCompressor and LCM do not override them, so behaviour is
+    # unchanged for existing engines. The host calls them only when
+    # ``capabilities()`` advertises support.
+
+    def capabilities(self) -> Dict[str, bool]:
+        """Advertise optional host-integration features this engine supports.
+
+        Keys the host understands: ``pre_send``, ``enforce_response``. Default:
+        none (host skips the H2 hooks entirely)."""
+        return {}
+
+    def pre_send(self, messages: List[Dict[str, Any]], model: str = "") -> List[Dict[str, Any]]:
+        """Last-mile transform of the outgoing message list (e.g. inject verbatim
+        evidence). Default: return unchanged."""
+        return messages
+
+    def enforce_response(self, answer: str, messages: List[Dict[str, Any]],
+                         model: str = "", **kwargs) -> Dict[str, Any]:
+        """Audit the model's reply against the verbatim record.
+
+        ``kwargs`` may include ``final=True`` on the host's last allowed attempt
+        (the engine should then refuse rather than ask for another regeneration).
+
+        Return one of:
+          ``{"action": "accept"}``                       : ship the answer as-is
+          ``{"action": "regenerate", "message": <str>}`` : re-prompt with a correction
+          ``{"action": "replace", "text": <str>}``       : ship a safe replacement (refuse)
+        Default: accept (no enforcement)."""
+        return {"action": "accept"}

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -488,26 +488,23 @@ class ContextEngine(ABC):
         self.threshold_percent = self._base_threshold_percent
         self.threshold_tokens = int(context_length * self.threshold_percent)
 
-    # -- Optional: H2 grounding hooks (additive; default no-ops) ------------
+    # -- Optional: post-generation enforcement hook (additive; default no-op) --
     #
-    # These let a retrieval-first engine (e.g. a retrieval-first engine) (a) inject verbatim
-    # evidence just before the request is sent, and (b) audit/enforce the model's
-    # reply (citation check, verification, regenerate, refuse) *after* it returns.
-    # Built-in ContextCompressor and LCM do not override them, so behaviour is
-    # unchanged for existing engines. The host calls them only when
-    # ``capabilities()`` advertises support.
+    # This lets a retrieval-first engine audit/enforce the model's reply
+    # (citation check, verification, regenerate, refuse) *after* it returns.
+    # Pre-request context injection is handled separately by ``select_context()``.
+    # Built-in ContextCompressor and LCM do not override this, so behaviour is
+    # unchanged for existing engines. The host calls it only when the engine
+    # actually overrides it (the base no-op is short-circuited).
 
     def capabilities(self) -> Dict[str, bool]:
         """Advertise optional host-integration features this engine supports.
 
-        Keys the host understands: ``pre_send``, ``enforce_response``. Default:
-        none (host skips the H2 hooks entirely)."""
+        The only key the host understands is ``enforce_response``: set it to
+        ``True`` to opt into the regenerate branch of the post-generation
+        enforcement hook (accept/replace never require the flag). Default:
+        none (the host honors only accept/replace from ``enforce_response``)."""
         return {}
-
-    def pre_send(self, messages: List[Dict[str, Any]], model: str = "") -> List[Dict[str, Any]]:
-        """Last-mile transform of the outgoing message list (e.g. inject verbatim
-        evidence). Default: return unchanged."""
-        return messages
 
     def enforce_response(self, answer: str, messages: List[Dict[str, Any]],
                          model: str = "", **kwargs) -> Dict[str, Any]:

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -490,7 +490,7 @@ class ContextEngine(ABC):
 
     # -- Optional: H2 grounding hooks (additive; default no-ops) ------------
     #
-    # These let a retrieval-first engine (e.g. hermes-cmx) (a) inject verbatim
+    # These let a retrieval-first engine (e.g. a retrieval-first engine) (a) inject verbatim
     # evidence just before the request is sent, and (b) audit/enforce the model's
     # reply (citation check, verification, regenerate, refuse) *after* it returns.
     # Built-in ContextCompressor and LCM do not override them, so behaviour is

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -487,3 +487,38 @@ class ContextEngine(ABC):
         )
         self.threshold_percent = self._base_threshold_percent
         self.threshold_tokens = int(context_length * self.threshold_percent)
+
+    # -- Optional: H2 grounding hooks (additive; default no-ops) ------------
+    #
+    # These let a retrieval-first engine (e.g. hermes-cmx) (a) inject verbatim
+    # evidence just before the request is sent, and (b) audit/enforce the model's
+    # reply (citation check, verification, regenerate, refuse) *after* it returns.
+    # Built-in ContextCompressor and LCM do not override them, so behaviour is
+    # unchanged for existing engines. The host calls them only when
+    # ``capabilities()`` advertises support.
+
+    def capabilities(self) -> Dict[str, bool]:
+        """Advertise optional host-integration features this engine supports.
+
+        Keys the host understands: ``pre_send``, ``enforce_response``. Default:
+        none (host skips the H2 hooks entirely)."""
+        return {}
+
+    def pre_send(self, messages: List[Dict[str, Any]], model: str = "") -> List[Dict[str, Any]]:
+        """Last-mile transform of the outgoing message list (e.g. inject verbatim
+        evidence). Default: return unchanged."""
+        return messages
+
+    def enforce_response(self, answer: str, messages: List[Dict[str, Any]],
+                         model: str = "", **kwargs) -> Dict[str, Any]:
+        """Audit the model's reply against the verbatim record.
+
+        ``kwargs`` may include ``final=True`` on the host's last allowed attempt
+        (the engine should then refuse rather than ask for another regeneration).
+
+        Return one of:
+          ``{"action": "accept"}``                       : ship the answer as-is
+          ``{"action": "regenerate", "message": <str>}`` : re-prompt with a correction
+          ``{"action": "replace", "text": <str>}``       : ship a safe replacement (refuse)
+        Default: accept (no enforcement)."""
+        return {"action": "accept"}

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1763,6 +1763,131 @@ def _notify_context_engine_turn_complete(
         )
 
 
+# Bound on how many enforce_response regenerate rounds the host will attempt
+# before it forces the engine to make a terminal accept/replace decision. Kept
+# small: the point is to give the engine one or two corrective passes, not to
+# loop indefinitely on a stubborn model. The last allowed attempt is made with
+# ``final=True`` so the engine refuses (accept/replace) rather than asking again.
+_ENFORCE_RESPONSE_MAX_REGENERATE = 2
+
+
+def _maybe_enforce_response(
+    agent: Any,
+    final_response: str,
+    messages: List[Dict[str, Any]],
+    *,
+    logger: Any,
+) -> str:
+    """Run the optional post-generation ``ContextEngine.enforce_response()`` hook.
+
+    Fired once per turn on the finalized TEXT-final assistant answer, after the
+    tool loop has produced ``final_response`` but before it is returned /
+    persisted. Complements ``select_context()`` (pre-request selection) and
+    ``on_turn_complete()`` (post-turn observation): this is the enforcement
+    lifecycle point where an engine can audit the reply against its verbatim
+    record and accept it, swap in a safe replacement, or (if it advertises the
+    capability) ask for a bounded number of regenerations.
+
+    Returns the (possibly replaced) response text. Honored actions:
+      * ``{"action": "accept"}``           — ship ``final_response`` unchanged.
+      * ``{"action": "replace", "text": X}`` — ship ``X`` in place of the answer.
+      * ``{"action": "regenerate", ...}``  — gated by ``capabilities()``; see the
+        deferral note below.
+
+    Regenerate is intentionally implemented as a *documented no-op-accepted*
+    branch: wiring a genuine re-prompt loop here would have to re-enter the
+    provider call path (streaming, tool re-exposure, budget/iteration
+    accounting, interrupt handling) from the finalizer, which is far more
+    invasive than an additive hook should be. Instead the host still honors the
+    ``final=True`` refusal semantics by making its LAST allowed enforcement call
+    with ``final=True``, so an engine that would otherwise loop is told to make a
+    terminal accept/replace decision. If the engine keeps returning
+    ``regenerate`` even under ``final=True``, the host accepts the current text
+    (never loops, never breaks the turn).
+
+    Fail-open by design: a missing hook, the base no-op, any exception, or an
+    unrecognized return value yields the unmodified ``final_response``.
+    """
+    if not isinstance(final_response, str) or not final_response:
+        return final_response
+
+    engine = getattr(agent, "context_compressor", None)
+    hook = getattr(engine, "enforce_response", None)
+    if engine is None or not callable(hook):
+        return final_response
+
+    # Skip the no-op base implementation so non-implementing engines (incl. the
+    # built-in compressor) pay nothing per turn. ``getattr(..., "__func__")``
+    # identity-check mirrors ``_notify_context_engine_turn_complete``. Lazy
+    # import avoids any import cycle with agent.context_engine.
+    try:
+        from agent.context_engine import ContextEngine as _CE
+        if getattr(hook, "__func__", None) is _CE.enforce_response:
+            return final_response
+    except Exception:
+        pass
+
+    session_label = getattr(agent, "session_id", None) or "-"
+
+    # Does the engine opt into the regenerate branch? accept/replace never
+    # require the capability; only regenerate is gated (per capabilities()).
+    _can_regenerate = False
+    try:
+        caps = engine.capabilities()
+        _can_regenerate = bool(isinstance(caps, dict) and caps.get("enforce_response"))
+    except Exception:
+        _can_regenerate = False
+
+    answer = final_response
+    # Attempts are bounded. The final permitted attempt passes ``final=True`` so
+    # the engine refuses (accept/replace) instead of looping. When the engine
+    # cannot regenerate, a single attempt is made and it is the final one.
+    max_attempts = (_ENFORCE_RESPONSE_MAX_REGENERATE + 1) if _can_regenerate else 1
+    for attempt in range(max_attempts):
+        is_final = attempt == max_attempts - 1
+        try:
+            verdict = hook(
+                answer,
+                # Structural clones: the hook receives the PERSISTED history; a
+                # shallow dict(m) would let it write through nested containers
+                # into the transcript (#80498 aliasing class).
+                [_clone_message_for_send(m) for m in messages],
+                model=getattr(agent, "model", "") or "",
+                final=is_final,
+            )
+        except Exception:
+            logger.warning(
+                "Context engine enforce_response hook failed; shipping the "
+                "unmodified response (session=%s)",
+                session_label,
+                exc_info=True,
+            )
+            return final_response
+
+        if not isinstance(verdict, dict):
+            return answer
+
+        action = verdict.get("action")
+        if action == "replace":
+            text = verdict.get("text")
+            if isinstance(text, str) and text:
+                return text
+            # Malformed replace: fall open to the current answer.
+            return answer
+        if action == "regenerate" and _can_regenerate and not is_final:
+            # Documented no-op-accepted branch (see docstring): we cannot safely
+            # re-drive the provider from the finalizer, so we do not produce a
+            # new candidate. Advance the bounded loop — the next call is made
+            # with ``final=True`` on the last iteration, forcing the engine to a
+            # terminal accept/replace instead of an infinite regenerate loop.
+            continue
+        # action == "accept", an unknown action, or a regenerate we cannot honor
+        # (not capable, or already final): ship the current text as-is.
+        return answer
+
+    return answer
+
+
 def run_conversation(
     agent,
     user_message: Any,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -690,6 +690,21 @@ def finalize_turn(
     if isinstance(final_response, str):
         final_response = _sanitize_surrogates(final_response)
 
+    # Context engine post-generation enforcement hook: give the active engine a
+    # chance to audit/enforce this TEXT-final answer against its verbatim record
+    # before it is returned/persisted. No-op default, fail-open (never breaks a
+    # turn). Runs after the plugin transform hooks and the surrogate scrub so the
+    # engine sees exactly the text that would ship. accept -> unchanged;
+    # replace -> swapped text; regenerate -> bounded, final=True on the last try.
+    if final_response and not interrupted:
+        try:
+            from agent.conversation_loop import _maybe_enforce_response
+            final_response = _maybe_enforce_response(
+                agent, final_response, messages, logger=logger,
+            )
+        except Exception as exc:
+            logger.warning("enforce_response hook failed: %s", exc)
+
     # Build result with interrupt info if applicable
     result = {
         "final_response": final_response,

--- a/tests/agent/test_context_engine_enforce_response.py
+++ b/tests/agent/test_context_engine_enforce_response.py
@@ -1,0 +1,263 @@
+"""Tests for the post-generation ``ContextEngine.enforce_response()`` hook.
+
+``enforce_response()`` is the *enforcement* verb — a different lifecycle point
+from ``select_context()`` (pre-request selection) and ``on_turn_complete()``
+(post-turn observation). After the tool loop produces a TEXT-final assistant
+answer, the host lets the active engine audit it against the engine's verbatim
+record and either accept it, swap in a safe replacement, or (when the engine
+advertises the capability) ask for a bounded number of regenerations. It is
+additive and no-op by default; the host call site (``_maybe_enforce_response``)
+is fail-open: a missing hook, the base no-op, an exception, or an unrecognized
+return value must ship the model's answer unchanged and never break a turn.
+
+These drive the real host helper against a real opt-in ``ContextEngine``
+subclass and assert on the OBSERVABLE OUTCOME (the returned/shipped text and the
+protocol the engine actually sees), rather than mirroring the implementation.
+Re-scopes PR #50053: the selection/observation surface already landed via
+#70458; enforce_response()+capabilities() is the surviving, different-lifecycle
+scope, now wired into turn finalization.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+from agent.context_engine import ContextEngine
+from agent.conversation_loop import _maybe_enforce_response
+
+
+class _MinimalEngine(ContextEngine):
+    """Concrete engine implementing only the abstract methods (inherits the
+    ABC ``enforce_response`` / ``capabilities`` no-ops unless a subclass
+    overrides them)."""
+
+    @property
+    def name(self) -> str:
+        return "minimal"
+
+    def update_from_response(self, usage: Dict[str, Any]) -> None:
+        pass
+
+    def should_compress(self, prompt_tokens: int = None) -> bool:
+        return False
+
+    def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: int = None,
+        focus_topic: str = None,
+    ) -> List[Dict[str, Any]]:
+        return messages
+
+
+def _agent_with(engine) -> Any:
+    """A real (non-Mock) agent-like object exposing exactly what the host
+    helper reads: ``context_compressor``, ``session_id``, ``model``."""
+    return SimpleNamespace(
+        context_compressor=engine,
+        session_id="test-session",
+        model="test-model",
+    )
+
+
+ANSWER = "The capital of France is Paris."
+HISTORY = [
+    {"role": "system", "content": "sys"},
+    {"role": "user", "content": "capital of France?"},
+    {"role": "assistant", "content": ANSWER},
+]
+
+
+# -- ABC default / built-in engines: pay nothing, ship unchanged -----------
+
+
+def test_base_noop_engine_ships_answer_unchanged_and_is_not_invoked():
+    """An engine that merely inherits the ABC default must skip the hook.
+
+    ``hasattr`` alone cannot distinguish "inherits the no-op default" from
+    "implements the hook" because the ABC defines ``enforce_response`` on every
+    engine. The host identity-checks the bound method against
+    ``ContextEngine.enforce_response`` and short-circuits WITHOUT calling it —
+    pinned here by patching the base method to explode: it must never run.
+    """
+    from unittest.mock import patch as _patch
+
+    def _explode(self, answer, messages, **kwargs):
+        raise AssertionError("base enforce_response must not be invoked")
+
+    engine = _MinimalEngine()  # inherits the ABC default
+    agent = _agent_with(engine)
+    logger = MagicMock()
+    with _patch.object(ContextEngine, "enforce_response", _explode):
+        out = _maybe_enforce_response(agent, ANSWER, HISTORY, logger=logger)
+    assert out == ANSWER
+    assert not logger.warning.called
+
+
+# -- replace: the answer is actually swapped -------------------------------
+
+
+def test_replace_actually_replaces_the_final_response():
+    """A real opt-in engine returning ``replace`` swaps the shipped text.
+
+    This is the core wiring proof: the host does not just call the hook, it
+    HONORS the verdict — the returned text is the engine's replacement, not the
+    model's original answer.
+    """
+    SAFE = "I can't verify that against the sources on hand."
+
+    class _RefusingEngine(_MinimalEngine):
+        def enforce_response(self, answer, messages, model="", **kwargs):
+            # A grounding engine that judged the answer unsupported and refuses.
+            return {"action": "replace", "text": SAFE}
+
+    agent = _agent_with(_RefusingEngine())
+    out = _maybe_enforce_response(agent, ANSWER, HISTORY, logger=MagicMock())
+    assert out == SAFE
+    assert out != ANSWER
+
+
+def test_replace_with_empty_text_falls_open_to_original():
+    """A malformed ``replace`` (missing/empty text) must not ship an empty
+    answer; it falls open to the model's original text."""
+
+    class _BadReplaceEngine(_MinimalEngine):
+        def enforce_response(self, answer, messages, model="", **kwargs):
+            return {"action": "replace", "text": ""}
+
+    agent = _agent_with(_BadReplaceEngine())
+    out = _maybe_enforce_response(agent, ANSWER, HISTORY, logger=MagicMock())
+    assert out == ANSWER
+
+
+# -- accept + unknown actions ----------------------------------------------
+
+
+def test_accept_ships_the_answer_unchanged():
+    class _AcceptEngine(_MinimalEngine):
+        def enforce_response(self, answer, messages, model="", **kwargs):
+            return {"action": "accept"}
+
+    agent = _agent_with(_AcceptEngine())
+    out = _maybe_enforce_response(agent, ANSWER, HISTORY, logger=MagicMock())
+    assert out == ANSWER
+
+
+def test_unknown_action_falls_open_to_the_answer():
+    class _WeirdEngine(_MinimalEngine):
+        def enforce_response(self, answer, messages, model="", **kwargs):
+            return {"action": "quarantine"}  # not part of the contract
+
+    agent = _agent_with(_WeirdEngine())
+    out = _maybe_enforce_response(agent, ANSWER, HISTORY, logger=MagicMock())
+    assert out == ANSWER
+
+
+# -- fail-open on exception -------------------------------------------------
+
+
+def test_engine_raising_never_breaks_the_turn():
+    """Any exception inside the hook ships the model's answer unchanged and is
+    swallowed with a warning (fail-open)."""
+
+    class _BrokenEngine(_MinimalEngine):
+        def enforce_response(self, answer, messages, model="", **kwargs):
+            raise RuntimeError("engine blew up")
+
+    logger = MagicMock()
+    agent = _agent_with(_BrokenEngine())
+    out = _maybe_enforce_response(agent, ANSWER, HISTORY, logger=logger)
+    assert out == ANSWER
+    assert logger.warning.called
+
+
+# -- the engine cannot corrupt persisted history ---------------------------
+
+
+def test_engine_mutating_transcript_cannot_corrupt_persisted_history():
+    """The hook receives structural clones of the transcript, so an engine that
+    writes into the messages it is handed cannot alter the persisted history."""
+    history_snapshot = [dict(m) for m in HISTORY]
+
+    class _MutatingEngine(_MinimalEngine):
+        def enforce_response(self, answer, messages, model="", **kwargs):
+            # Misbehaving engine: tamper with its copy in place.
+            if messages:
+                messages[0]["content"] = "TAMPERED"
+                messages.append({"role": "user", "content": "INJECTED"})
+            return {"action": "accept"}
+
+    agent = _agent_with(_MutatingEngine())
+    _maybe_enforce_response(agent, ANSWER, HISTORY, logger=MagicMock())
+    assert HISTORY == history_snapshot
+
+
+# -- regenerate: capability-gated + bounded + final=True on last attempt ----
+
+
+def test_regenerate_without_capability_is_not_honored_single_final_call():
+    """An engine that returns ``regenerate`` but does NOT advertise the
+    capability gets exactly ONE call, made with ``final=True`` (no loop), and
+    the current answer ships as-is."""
+    seen = []
+
+    class _WantsRegenNoCap(_MinimalEngine):
+        def enforce_response(self, answer, messages, model="", *, final=False, **kwargs):
+            seen.append(final)
+            return {"action": "regenerate", "message": "add a citation"}
+
+    agent = _agent_with(_WantsRegenNoCap())
+    out = _maybe_enforce_response(agent, ANSWER, HISTORY, logger=MagicMock())
+    assert out == ANSWER
+    assert seen == [True]  # single attempt, and it is the final one
+
+
+def test_regenerate_with_capability_is_bounded_and_ends_final_true():
+    """A capability-advertising engine that always asks to regenerate is called
+    a bounded number of times, the LAST call carries ``final=True`` so the
+    engine is forced to a terminal decision, and the loop never runs away."""
+    finals = []
+
+    class _AlwaysRegen(_MinimalEngine):
+        def capabilities(self) -> Dict[str, bool]:
+            return {"enforce_response": True}
+
+        def enforce_response(self, answer, messages, model="", *, final=False, **kwargs):
+            finals.append(final)
+            return {"action": "regenerate", "message": "cite a source"}
+
+    agent = _agent_with(_AlwaysRegen())
+    out = _maybe_enforce_response(agent, ANSWER, HISTORY, logger=MagicMock())
+    # Bounded: exactly one call per allowed attempt, terminating.
+    assert len(finals) >= 2
+    # Every attempt but the last is final=False; the last is final=True so the
+    # engine refuses instead of looping forever.
+    assert finals[-1] is True
+    assert all(f is False for f in finals[:-1])
+    # A stubborn regenerate that never resolves ships the original answer.
+    assert out == ANSWER
+
+
+def test_regenerate_then_replace_on_final_ships_replacement():
+    """A capable engine may regenerate a bounded number of times, then, when
+    told ``final=True``, refuse with a safe replacement — which the host ships.
+    This proves the ``final=True`` semantics are actually honored end-to-end."""
+    SAFE = "I won't answer without a verifiable source."
+    calls = {"n": 0}
+
+    class _RegenThenRefuse(_MinimalEngine):
+        def capabilities(self) -> Dict[str, bool]:
+            return {"enforce_response": True}
+
+        def enforce_response(self, answer, messages, model="", *, final=False, **kwargs):
+            calls["n"] += 1
+            if final:
+                return {"action": "replace", "text": SAFE}
+            return {"action": "regenerate", "message": "cite a source"}
+
+    agent = _agent_with(_RegenThenRefuse())
+    out = _maybe_enforce_response(agent, ANSWER, HISTORY, logger=MagicMock())
+    assert out == SAFE
+    assert calls["n"] >= 2  # regenerated at least once, then refused on final


### PR DESCRIPTION
Adds three additive, default-no-op methods to the base `ContextEngine` ABC: `capabilities()` (advertise optional features), `pre_send(messages, model)` (inject verbatim evidence before the request), and `enforce_response(answer, messages, model, **kwargs)` (audit/regenerate/accept the reply after). These are generic extension points that a retrieval-first engine (e.g. a grounding/citation engine) can override; built-in engines don't override them, so behavior is unchanged. No external engine is imported — just the base-class contract.