### PR TITLE
fix(model_metadata): correct GLM-5.2 context window to 1M

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -201,7 +201,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     # MiniMax — official docs: 204,800 context for all models
     # https://platform.minimax.io/docs/api-reference/text-anthropic-api
     "minimax": 204800,
-    # GLM
+    # GLM — only 5.2 has 1M context; older models (GLM-4, GLM-5-turbo, etc.) are ~200k
+    "glm-5.2": 1000000,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to


### PR DESCRIPTION
## Problem

GLM-5.2 supports a **1M token context window**, but the only entry in `DEFAULT_CONTEXT_LENGTHS` was a generic `"glm"` catch-all at **202 752 tokens**. Since matching is longest-substring-first, `glm-5.2` was incorrectly matched by the generic `"glm"` key and capped at ~202k instead of 1M.

This meant Hermes would compress/truncate the context far earlier than necessary when using GLM-5.2 via the `zai` provider (`https://api.z.ai`).

## Fix

Add a specific `"glm-5.2": 1000000` entry **before** the generic `"glm": 202752` catch-all:

```python
"glm-5.2": 1000000,
"glm": 202752,
```

Older GLM models (GLM-4, GLM-5-turbo, etc.) remain unchanged at 202 752 via the existing fallback.

## Source

GLM-5.2 official context: 1M tokens, max output 128K.
https://z.ai/