### PR TITLE
fix(update): resume Windows gateways after ZIP fallback

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10068,7 +10068,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print(f"⚠ Git update failed: {e}")
             print("→ Falling back to ZIP download...")
             print()
-            _update_via_zip(args)
+            try:
+                _update_via_zip(args)
+            finally:
+                _resume_windows_gateways_after_update(_windows_gateway_resume)
         else:
             print(f"✗ Update failed: {e}")
             sys.exit(1)

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -622,3 +623,63 @@ def test_cmd_update_force_bypasses_concurrent_check(_winp, tmp_path):
 
     # When --force is set, we should not have even consulted psutil.
     detect.assert_not_called()
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_cmd_update_resumes_windows_gateways_after_zip_fallback(
+    _winp,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setattr(sys, "platform", "win32")
+    project_root = tmp_path / "repo"
+    (project_root / ".git").mkdir(parents=True)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", project_root)
+
+    token = {"resume_needed": True, "profiles": {"default": 123}, "unmapped_pids": []}
+    resume = MagicMock()
+
+    args = SimpleNamespace(
+        check=False,
+        gateway=False,
+        yes=True,
+        force=True,
+        backup=False,
+        no_backup=True,
+        branch="main",
+    )
+
+    def fail_fetch(cmd, **_kwargs):
+        if cmd[:5] == [
+            "git",
+            "-c",
+            "windows.appendAtomically=false",
+            "config",
+            "windows.appendAtomically",
+        ]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise subprocess.CalledProcessError(1, cmd)
+
+    with patch.object(
+        cli_main, "_run_pre_update_backup"
+    ), patch.object(
+        cli_main, "_pause_windows_gateways_for_update", return_value=token
+    ), patch.object(
+        cli_main, "_resume_windows_gateways_after_update", resume
+    ), patch.object(
+        cli_main, "_resolve_update_branch", return_value="main"
+    ), patch.object(
+        cli_main, "_get_origin_url", return_value="https://github.com/NousResearch/hermes-agent.git"
+    ), patch.object(
+        cli_main, "_is_fork", return_value=False
+    ), patch.object(
+        cli_main, "_discard_lockfile_churn"
+    ), patch.object(
+        cli_main, "_update_via_zip"
+    ) as update_zip, patch.object(
+        cli_main.subprocess, "run", side_effect=fail_fetch
+    ):
+        cli_main._cmd_update_impl(args, gateway_mode=False)
+
+    update_zip.assert_called_once_with(args)
+    resume.assert_called_once_with(token)


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows update path where a git-based update fails, Hermes falls back to the ZIP updater, and paused Windows gateway profiles are not resumed afterward.

The direct ZIP update path already resumes paused gateways in a `finally` block. This PR applies the same behavior to the git-failure fallback path, so a successful ZIP fallback does not leave the user's gateway stopped.

## Related Issue

Fixes #49976

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Wrapped the Windows ZIP fallback call in `hermes_cli/main.py` with `try/finally`.
- Always calls `_resume_windows_gateways_after_update(...)` after the ZIP fallback path finishes.
- Added a regression test for the Windows git-failure-to-ZIP-fallback path.

## How to Test

1. Run `/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_update_concurrent_quarantine.py -q`
2. Run `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.0 local test run with Windows-specific code path mocked

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ /Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_update_concurrent_quarantine.py -q
.....................                                                    [100%]
21 passed in 0.30s

$ git diff --check
# no output
```
