### PR TITLE
Temporary workaround for typing Korean to hermes dashboard on an ipad

### DIFF
--- a/web/src/lib/hangul.ts
+++ b/web/src/lib/hangul.ts
@@ -1,0 +1,258 @@
+/**
+ * Hangul input automaton for the embedded dashboard chat.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * On iPad (all iPad browsers are WebKit) the virtual Korean keyboard does NOT
+ * drive IME composition inside xterm.js's hidden textarea — xterm constantly
+ * moves/clears that textarea, which resets WebKit's composition context. The
+ * result is that each *committed* compatibility jamo (ㅎ U+314E, ㅏ U+314F,
+ * ㄴ U+3134 …) arrives as its own `onData` event. Concatenating them yields
+ * the three-letter string "ㅎㅏㄴ", which renders as three loose letters — not
+ * the syllable "한" (U+D55C) a desktop OS IME would have composed before the
+ * terminal ever saw it.
+ *
+ * This module reimplements the standard 2-beolsik input automaton: it folds a
+ * stream of compatibility jamo into precomposed Hangul syllable blocks, exactly
+ * like an OS IME.
+ *
+ * COMMIT-BASED OUTPUT (no backspaces)
+ * -----------------------------------
+ * An earlier version rewrote the on-screen "composing" glyph by emitting
+ * backspaces (ㅎ → ⌫하 → ⌫한). That cannot work against the Hermes TUI: its
+ * input tokenizer (hermes-ink termio) only breaks text runs on ESC, so a
+ * backspace byte (0x7f) glued to the next syllable arrives as one token that
+ * `parseKeypress` recognizes as neither backspace nor printable text — and is
+ * dropped. So only the first jamo ever survived.
+ *
+ * Instead we do exactly what a desktop OS IME does: the terminal never sees an
+ * in-progress syllable. `feed()` emits a syllable only once it is *committed*
+ * (a following jamo starts a new syllable, or `flush()` is called on a space /
+ * enter / any non-jamo). The in-progress syllable is held internally until then.
+ * Trade-off: the syllable currently being typed isn't echoed until it commits —
+ * identical to how a desktop terminal only receives finished syllables.
+ */
+
+// Compatibility-jamo code points, indexed the way the syllable formula expects.
+//   syllable = 0xAC00 + (cho * 21 + jung) * 28 + jong
+// `cho` 0-18, `jung` 0-20, `jong` 0-27 (0 = no final consonant).
+const LEAD_CHARS = "ㄱㄲㄴㄷㄸㄹㅁㅂㅃㅅㅆㅇㅈㅉㅊㅋㅌㅍㅎ";
+const VOWEL_CHARS = "ㅏㅐㅑㅒㅓㅔㅕㅖㅗㅘㅙㅚㅛㅜㅝㅞㅟㅠㅡㅢㅣ";
+// Tail index 0 is "no tail"; the placeholder keeps the string 1-indexed.
+const TAIL_CHARS = "_ㄱㄲㄳㄴㄵㄶㄷㄹㄺㄻㄼㄽㄾㄿㅀㅁㅂㅄㅅㅆㅇㅈㅊㅋㅌㅍㅎ";
+
+const LEAD_IDX = new Map<string, number>(
+  [...LEAD_CHARS].map((c, i): [string, number] => [c, i]),
+);
+const VOWEL_IDX = new Map<string, number>(
+  [...VOWEL_CHARS].map((c, i): [string, number] => [c, i]),
+);
+const TAIL_IDX = new Map<string, number>(
+  [...TAIL_CHARS]
+    .map((c, i): [string, number] => [c, i])
+    .filter(([c]) => c !== "_"),
+);
+
+// Compound vowels formed by typing two simple vowels in sequence.
+//   key = `${jungIdx},${incomingVowelIdx}` -> resulting jung index
+const VOWEL_COMPOSE = new Map<string, number>([
+  ["8,0", 9], // ㅗ+ㅏ → ㅘ
+  ["8,1", 10], // ㅗ+ㅐ → ㅙ
+  ["8,20", 11], // ㅗ+ㅣ → ㅚ
+  ["13,4", 14], // ㅜ+ㅓ → ㅝ
+  ["13,5", 15], // ㅜ+ㅔ → ㅞ
+  ["13,20", 16], // ㅜ+ㅣ → ㅟ
+  ["18,20", 19], // ㅡ+ㅣ → ㅢ
+]);
+
+// Compound finals formed by typing two consonants while a final is pending.
+//   key = `${jongIdx},${incomingLeadIdx}` -> resulting jong index
+const TAIL_COMPOSE = new Map<string, number>([
+  ["1,9", 3], // ㄱ+ㅅ → ㄳ
+  ["4,12", 5], // ㄴ+ㅈ → ㄵ
+  ["4,18", 6], // ㄴ+ㅎ → ㄶ
+  ["8,0", 9], // ㄹ+ㄱ → ㄺ
+  ["8,6", 10], // ㄹ+ㅁ → ㄻ
+  ["8,7", 11], // ㄹ+ㅂ → ㄼ
+  ["8,9", 12], // ㄹ+ㅅ → ㄽ
+  ["8,16", 13], // ㄹ+ㅌ → ㄾ
+  ["8,17", 14], // ㄹ+ㅍ → ㄿ
+  ["8,18", 15], // ㄹ+ㅎ → ㅀ
+  ["17,9", 18], // ㅂ+ㅅ → ㅄ
+]);
+
+// When a vowel follows a final consonant, that final (or the last half of a
+// compound final) migrates to become the lead of the next syllable.
+//   jong index -> { baseJong, leadIdx }
+//   baseJong 0 means "the whole final migrated, nothing remains".
+const TAIL_SPLIT = new Map<number, { baseJong: number; leadIdx: number }>([
+  // simple finals: the entire final becomes the next lead
+  [1, { baseJong: 0, leadIdx: 0 }], // ㄱ → ㄱ
+  [2, { baseJong: 0, leadIdx: 1 }], // ㄲ → ㄲ
+  [4, { baseJong: 0, leadIdx: 2 }], // ㄴ → ㄴ
+  [7, { baseJong: 0, leadIdx: 3 }], // ㄷ → ㄷ
+  [8, { baseJong: 0, leadIdx: 5 }], // ㄹ → ㄹ
+  [16, { baseJong: 0, leadIdx: 6 }], // ㅁ → ㅁ
+  [17, { baseJong: 0, leadIdx: 7 }], // ㅂ → ㅂ
+  [19, { baseJong: 0, leadIdx: 9 }], // ㅅ → ㅅ
+  [20, { baseJong: 0, leadIdx: 10 }], // ㅆ → ㅆ
+  [21, { baseJong: 0, leadIdx: 11 }], // ㅇ → ㅇ
+  [22, { baseJong: 0, leadIdx: 12 }], // ㅈ → ㅈ
+  [23, { baseJong: 0, leadIdx: 14 }], // ㅊ → ㅊ
+  [24, { baseJong: 0, leadIdx: 15 }], // ㅋ → ㅋ
+  [25, { baseJong: 0, leadIdx: 16 }], // ㅌ → ㅌ
+  [26, { baseJong: 0, leadIdx: 17 }], // ㅍ → ㅍ
+  [27, { baseJong: 0, leadIdx: 18 }], // ㅎ → ㅎ
+  // compound finals: keep the first half, migrate the second
+  [3, { baseJong: 1, leadIdx: 9 }], // ㄳ → ㄱ + ㅅ
+  [5, { baseJong: 4, leadIdx: 12 }], // ㄵ → ㄴ + ㅈ
+  [6, { baseJong: 4, leadIdx: 18 }], // ㄶ → ㄴ + ㅎ
+  [9, { baseJong: 8, leadIdx: 0 }], // ㄺ → ㄹ + ㄱ
+  [10, { baseJong: 8, leadIdx: 6 }], // ㄻ → ㄹ + ㅁ
+  [11, { baseJong: 8, leadIdx: 7 }], // ㄼ → ㄹ + ㅂ
+  [12, { baseJong: 8, leadIdx: 9 }], // ㄽ → ㄹ + ㅅ
+  [13, { baseJong: 8, leadIdx: 16 }], // ㄾ → ㄹ + ㅌ
+  [14, { baseJong: 8, leadIdx: 17 }], // ㄿ → ㄹ + ㅍ
+  [15, { baseJong: 8, leadIdx: 18 }], // ㅀ → ㄹ + ㅎ
+  [18, { baseJong: 17, leadIdx: 9 }], // ㅄ → ㅂ + ㅅ
+]);
+
+/** True when `ch` is a single compatibility jamo (the only thing we compose). */
+export function isCompatJamo(ch: string): boolean {
+  if (ch.length !== 1) return false;
+  return LEAD_IDX.has(ch) || VOWEL_IDX.has(ch) || TAIL_IDX.has(ch);
+}
+
+interface Cluster {
+  cho: number; // -1 = empty
+  jung: number;
+  jong: number; // 0 or -1 = no final
+}
+
+function emptyCluster(): Cluster {
+  return { cho: -1, jung: -1, jong: -1 };
+}
+
+function isEmpty(c: Cluster): boolean {
+  return c.cho < 0 && c.jung < 0 && c.jong < 0;
+}
+
+/** Render a cluster to the single glyph it currently represents. */
+function display(c: Cluster): string {
+  if (c.cho >= 0 && c.jung >= 0) {
+    const jong = c.jong > 0 ? c.jong : 0;
+    return String.fromCharCode(0xac00 + (c.cho * 21 + c.jung) * 28 + jong);
+  }
+  if (c.cho >= 0) return LEAD_CHARS[c.cho]; // lone consonant
+  if (c.jung >= 0) return VOWEL_CHARS[c.jung]; // lone vowel
+  return "";
+}
+
+/**
+ * Stateful Hangul composer. Feed it one compatibility jamo at a time; `feed()`
+ * returns only text that has been *committed* (finalized syllables) and should
+ * be sent to the terminal now. The syllable still under construction is held
+ * internally until it commits or `flush()` is called — mirroring how a desktop
+ * OS IME only hands the terminal finished syllables.
+ */
+export class HangulComposer {
+  private cluster = emptyCluster();
+
+  /**
+   * Finalize and return the in-progress syllable (empty string if none), then
+   * reset. Call when a non-jamo (space, enter, ASCII, paste) arrives so the
+   * pending syllable is committed ahead of that input.
+   */
+  flush(): string {
+    const out = display(this.cluster);
+    this.cluster = emptyCluster();
+    return out;
+  }
+
+  /** Drop the in-progress syllable without emitting it (e.g. user backspace). */
+  discard(): void {
+    this.cluster = emptyCluster();
+  }
+
+  /** Whether a syllable is currently being composed. */
+  get composing(): boolean {
+    return !isEmpty(this.cluster);
+  }
+
+  /** Feed one compatibility jamo; returns committed text to send now (may be ""). */
+  feed(jamo: string): string {
+    let committed = "";
+    const c = this.cluster;
+
+    // Finalize the current cluster and begin a fresh one.
+    const startNew = (next: Cluster) => {
+      committed += display(c);
+      this.cluster = next;
+    };
+
+    if (VOWEL_IDX.has(jamo)) {
+      const v = VOWEL_IDX.get(jamo)!;
+      if (c.jung < 0) {
+        if (c.jong >= 0 && c.jong > 0) {
+          // LVT + V: the final migrates to a new syllable's lead.
+          const { baseJong, leadIdx } = TAIL_SPLIT.get(c.jong)!;
+          committed += display({ cho: c.cho, jung: c.jung, jong: baseJong });
+          this.cluster = { cho: leadIdx, jung: v, jong: -1 };
+        } else if (c.cho >= 0) {
+          c.jung = v; // L + V
+        } else {
+          startNew({ cho: -1, jung: v, jong: -1 }); // bare vowel
+        }
+      } else {
+        const compound =
+          c.jong <= 0 ? VOWEL_COMPOSE.get(`${c.jung},${v}`) : undefined;
+        if (compound !== undefined) {
+          c.jung = compound; // ㅗ+ㅏ → ㅘ etc.
+        } else if (c.jong > 0) {
+          // LVT + V: migrate the final, same as above.
+          const { baseJong, leadIdx } = TAIL_SPLIT.get(c.jong)!;
+          committed += display({ cho: c.cho, jung: c.jung, jong: baseJong });
+          this.cluster = { cho: leadIdx, jung: v, jong: -1 };
+        } else {
+          startNew({ cho: -1, jung: v, jong: -1 }); // LV + V, not combinable
+        }
+      }
+    } else {
+      // Consonant. A jamo may be valid as a lead, a final, or both.
+      const lead = LEAD_IDX.has(jamo) ? LEAD_IDX.get(jamo)! : -1;
+      const tail = TAIL_IDX.has(jamo) ? TAIL_IDX.get(jamo)! : -1;
+
+      if (isEmpty(c)) {
+        if (lead >= 0) this.cluster = { cho: lead, jung: -1, jong: -1 };
+        else committed += jamo; // compound consonant typed alone: pass through
+      } else if (c.jung < 0) {
+        // Consonant with no vowel yet: can't stack, start a new lead.
+        if (lead >= 0) startNew({ cho: lead, jung: -1, jong: -1 });
+        else {
+          startNew(emptyCluster());
+          committed += jamo;
+        }
+      } else if (c.jong <= 0) {
+        // LV + consonant → tentative final (if it can be one).
+        if (tail >= 0) c.jong = tail;
+        else if (lead >= 0) startNew({ cho: lead, jung: -1, jong: -1 });
+        else {
+          startNew(emptyCluster());
+          committed += jamo;
+        }
+      } else {
+        // LVT + consonant → try to form a compound final.
+        const compound =
+          lead >= 0 ? TAIL_COMPOSE.get(`${c.jong},${lead}`) : undefined;
+        if (compound !== undefined) c.jong = compound;
+        else if (lead >= 0) startNew({ cho: lead, jung: -1, jong: -1 });
+        else {
+          startNew(emptyCluster());
+          committed += jamo;
+        }
+      }
+    }
+
+    return committed;
+  }
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -25,6 +25,7 @@ import "@xterm/xterm/css/xterm.css";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@nous-research/ui/ui/components/typography/index";
 import { HERMES_BASE_PATH, buildWsAuthParam } from "@/lib/api";
+import { HangulComposer, isCompatJamo } from "@/lib/hangul";
 import { cn } from "@/lib/utils";
 import { Copy, PanelRight, RotateCcw, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -607,6 +608,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     let unmounting = false;
     let onDataDisposable: { dispose(): void } | null = null;
     let onResizeDisposable: { dispose(): void } | null = null;
+    // Hoisted composition-guard state so the cleanup can tear it down.
+    let compositionCleanup: (() => void) | null = null;
     void (async () => {
       const authParam = await buildWsAuthParam();
       if (unmounting) return;
@@ -705,14 +708,113 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // behave normally.
       // eslint-disable-next-line no-control-regex -- intentional ESC byte in xterm SGR mouse report parser
       const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
+
+      // ------------------------------------------------------------------
+      // Hangul IME bridge (iPad / touch-device fix)
+      // ------------------------------------------------------------------
+      // iPad WebKit (all iPad browsers use it) does not drive IME composition
+      // inside xterm.js's hidden textarea — xterm continuously moves/clears
+      // that textarea, which resets WebKit's composition context. So each
+      // *committed* compatibility jamo (ㅎ U+314E, ㅏ U+314F, ㄴ U+3134 …)
+      // arrives as its own onData event instead of the composed syllable 한
+      // that a desktop OS IME would have produced before the PTY ever saw it.
+      //
+      // We bridge by running the standard Hangul input automaton in the
+      // browser (lib/hangul.ts): jamo are folded into precomposed syllable
+      // blocks, and because a syllable grows in place (ㅎ → 하 → 한) we rewrite
+      // the on-screen composing glyph by sending backspaces over what we last
+      // emitted, then the new glyph — exactly what an OS IME does.
+      //
+      // When a browser DOES drive native composition (desktop, some Android),
+      // xterm emits finished syllables (U+AC00 block), never lone compat jamo,
+      // so the automaton below simply never engages and input passes through.
+      //
+      // Optional on-screen trace: append ?imedebug=1 to the dashboard URL.
+      const imeDebug =
+        typeof window !== "undefined" &&
+        new URLSearchParams(window.location.search).get("imedebug") === "1";
+      let debugPanel: HTMLDivElement | null = null;
+      const debugLog: string[] = [];
+      const dlog = (msg: string) => {
+        if (!debugPanel) return;
+        debugLog.push(`${Date.now() % 100000} ${msg}`);
+        if (debugLog.length > 40) debugLog.shift();
+        debugPanel.textContent = "🔬 " + debugLog.join(" | ");
+      };
+      if (imeDebug) {
+        debugPanel = document.createElement("div");
+        debugPanel.style.cssText = [
+          "position:fixed", "bottom:0", "left:0", "right:0",
+          "max-height:120px", "overflow-y:auto",
+          "background:rgba(0,0,0,0.85)", "color:#0f0",
+          "font-family:monospace", "font-size:11px", "padding:6px",
+          "z-index:9999", "pointer-events:none",
+          "border-top:1px solid #0f0",
+        ].join(";");
+        debugPanel.textContent = "🔬 IME debug — type Korean here → ";
+        document.body.appendChild(debugPanel);
+      }
+
+      const composer = new HangulComposer();
+
+      // If a browser fires real composition events we defer to xterm's native
+      // handling (it sends the composed text on compositionend); the automaton
+      // only owns the lone-jamo path. `nativeComposing` gates the two apart.
+      let nativeComposing = false;
+      const textarea = term.textarea;
+      const onCompStart = () => {
+        nativeComposing = true;
+        composer.flush();
+        dlog("compositionstart");
+      };
+      const onCompEnd = (e: Event) => {
+        nativeComposing = false;
+        dlog(`compositionend data="${(e as CompositionEvent).data ?? ""}"`);
+      };
+      textarea?.addEventListener("compositionstart", onCompStart);
+      textarea?.addEventListener("compositionend", onCompEnd);
+
+      compositionCleanup = () => {
+        textarea?.removeEventListener("compositionstart", onCompStart);
+        textarea?.removeEventListener("compositionend", onCompEnd);
+        debugPanel?.remove();
+        debugPanel = null;
+        compositionCleanup = null;
+      };
+
       onDataDisposable = term.onData((data) => {
         if (ws.readyState !== WebSocket.OPEN) return;
+        if (SGR_MOUSE_RE.test(data)) return;
 
-        if (SGR_MOUSE_RE.test(data)) {
+        if (imeDebug) {
+          const bytes = [...data]
+            .map((c) => c.charCodeAt(0).toString(16))
+            .join(" ");
+          dlog(`onData hex=${bytes} data="${data}"`);
+        }
+
+        // Lone compatibility jamo from the broken-IME path → fold into the
+        // automaton. We send only *committed* syllables (the TUI never sees the
+        // in-progress one); no backspaces, because the TUI's input tokenizer
+        // drops a 0x7f that's glued to following text. See lib/hangul.ts.
+        if (!nativeComposing && isCompatJamo(data)) {
+          const committed = composer.feed(data);
+          if (imeDebug) dlog(`compose committed="${committed}" hold="${composer.composing}"`);
+          if (committed) ws.send(committed);
           return;
         }
 
-        ws.send(data);
+        // User pressed backspace mid-syllable: the pending syllable isn't on
+        // screen yet, so just cancel it and swallow the keystroke.
+        if (composer.composing && (data === "\x7f" || data === "\b")) {
+          composer.discard();
+          return;
+        }
+
+        // Anything else (ASCII, space, enter, composed syllables, paste)
+        // commits the pending syllable first, then forwards the input.
+        const pending = composer.flush();
+        ws.send(pending + data);
       });
 
       onResizeDisposable = term.onResize(({ cols, rows }) => {
@@ -729,6 +831,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       syncMetricsRef.current = null;
       onDataDisposable?.dispose();
       onResizeDisposable?.dispose();
+      // Tear down the IME composition guard (textarea listeners + timer).
+      compositionCleanup?.();
       if (metricsDebounce) clearTimeout(metricsDebounce);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
       window.visualViewport?.removeEventListener(


### PR DESCRIPTION
## What does this PR do?
This is a workaround that allows users to type Korean when viewing the Hermes Dashboard from an ipad. Typing Korean to browsers from normal computers work fine, on the iPad produced disconnected jamo (ㅎ ㅏ ㄴ) instead of the composed syllable 한.
This PR includes a debug page to view the debug log. Just append `?imedebug=1` to the dashboard URL (e.g. `https://<host>/chat?imedebug=1`)

## Related Issue
To be created

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `web/src/lib/hangul.ts`
- Edited `web/src/pages/ChatPage.tsx`

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Open Hermes Dashboard from a browser in an ipad
2. Type Korean. Expect Korean to show up. 
3. One catch, and why it's a temporary workaround - the final character only shows up to the screen after the next keystroke is typed (space, period, start of another character). 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

