### PR TITLE
feat: add Unity editor bridge plugin

### DIFF
--- a/plugins/unity_vrchat_bridge/README.md
+++ b/plugins/unity_vrchat_bridge/README.md
@@ -1,0 +1,28 @@
+# Unity VRChat Bridge
+
+`unity-vrchat-bridge` is a Unity Editor bridge for Hermes with VRChat-first
+diagnostics layered on top. The MVP is read-only by default: it inspects Unity
+projects, reads live Editor state, checks VRChat/VCC/VPM package health, calls
+an explicitly trusted localhost Unity Editor bridge, and audits commercial model
+archives without extracting or redistributing them.
+
+The plugin deliberately blocks SDK upload, automatic package import, live menu
+execution, live generic operation execution, live plan apply, DRM or license
+bypass, and destructive project mutation in the MVP. Those operations belong
+behind explicit dry-run, backup, project trust, and operator gates.
+
+The Unity Editor package skeleton lives under:
+
+`unity_package/Packages/com.hermes.unity-vrchat-bridge`
+
+Install it into a Unity project when live Editor state is needed. Without the
+Editor package, the Hermes plugin still performs file-based project and archive
+diagnostics.
+
+The Editor bridge binds only to `127.0.0.1`, requires `X-Hermes-Bridge-Token`,
+stores the active session in `Library/HermesUnityBridge/session.json`, and only
+starts after the project is trusted in the EditorWindow.
+
+The generic Unity surface currently covers health, snapshot, selection, recent
+logs, package metadata, active scene hierarchy, asset search, asset metadata,
+dry-run menu plans, dry-run operation plans, and dry-run apply plans.

--- a/plugins/unity_vrchat_bridge/__init__.py
+++ b/plugins/unity_vrchat_bridge/__init__.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from . import core
+from .cli import register_cli, unity_vrchat_bridge_command
+
+_TOOLS = (
+    ("unity_bridge_status", core.STATUS_SCHEMA, core.handle_status, "U"),
+    ("unity_bridge_health", core.HEALTH_SCHEMA, core.handle_health, "U"),
+    ("unity_bridge_snapshot", core.SNAPSHOT_SCHEMA, core.handle_snapshot, "U"),
+    ("unity_bridge_selection_get", core.SELECTION_SCHEMA, core.handle_selection, "U"),
+    ("unity_bridge_capabilities", core.CAPABILITIES_SCHEMA, core.handle_capabilities, "U"),
+    ("unity_bridge_packages", core.PACKAGES_SCHEMA, core.handle_packages, "U"),
+    ("unity_bridge_scene_hierarchy", core.HIERARCHY_SCHEMA, core.handle_hierarchy, "U"),
+    ("unity_bridge_console_recent", core.CONSOLE_RECENT_SCHEMA, core.handle_console_recent, "U"),
+    ("unity_bridge_asset_search", core.ASSET_SEARCH_SCHEMA, core.handle_asset_search, "U"),
+    ("unity_bridge_asset_info", core.ASSET_INFO_SCHEMA, core.handle_asset_info, "U"),
+    ("unity_bridge_menu_execute", core.MENU_EXECUTE_SCHEMA, core.handle_menu_execute, "U"),
+    ("unity_bridge_operation_plan", core.OPERATION_PLAN_SCHEMA, core.handle_operation_plan, "U"),
+    ("unity_bridge_plan_apply", core.PLAN_APPLY_SCHEMA, core.handle_plan_apply, "U"),
+    ("unity_project_profile", core.PROJECT_PROFILE_SCHEMA, core.handle_project_profile, "U"),
+    ("vrchat_project_health", core.VRCHAT_PROJECT_HEALTH_SCHEMA, core.handle_vrchat_project_health, "V"),
+    (
+        "commercial_asset_inspect_archive",
+        core.COMMERCIAL_ASSET_INSPECT_SCHEMA,
+        core.handle_commercial_asset_inspect,
+        "A",
+    ),
+)
+
+
+def register(ctx) -> None:
+    for name, schema, handler, emoji in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="unity_vrchat_bridge",
+            schema=schema,
+            handler=handler,
+            check_fn=core.check_available,
+            description=schema.get("description", ""),
+            emoji=emoji,
+        )
+
+    ctx.register_command(
+        "unity-vrchat-bridge",
+        handler=core.handle_slash,
+        description="Run Unity/VRChat bridge diagnostics and read-only project audits.",
+        args_hint="[status|health|snapshot|selection|capabilities|packages|hierarchy|console|asset-search|asset-info|menu-execute|operation-plan|plan-apply|project-profile|vrchat-health|inspect-archive]",
+    )
+    ctx.register_cli_command(
+        name="unity-vrchat-bridge",
+        help="Unity/VRChat Editor bridge diagnostics",
+        setup_fn=register_cli,
+        handler_fn=unity_vrchat_bridge_command,
+        description=(
+            "Inspect Unity bridge sessions, VRChat/VCC project health, "
+            "and commercial model archives without mutating project files."
+        ),
+    )

--- a/plugins/unity_vrchat_bridge/cli.py
+++ b/plugins/unity_vrchat_bridge/cli.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from . import core
+
+
+def register_cli(subparsers) -> None:
+    parser = subparsers.add_parser(
+        "unity-vrchat-bridge",
+        help="Unity/VRChat Editor bridge diagnostics",
+    )
+    parser.add_argument("args", nargs="*")
+
+
+def unity_vrchat_bridge_command(args) -> int:
+    argv = list(getattr(args, "args", []) or [])
+    print(core.run_cli(argv))
+    return 0

--- a/plugins/unity_vrchat_bridge/core.py
+++ b/plugins/unity_vrchat_bridge/core.py
@@ -1,0 +1,1102 @@
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import tarfile
+import urllib.error
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:
+    def get_hermes_home() -> Path:  # type: ignore[no-redef]
+        return Path.home() / ".hermes"
+
+
+PLUGIN_ID = "unity-vrchat-bridge"
+PLUGIN_NAME = "unity-vrchat-bridge"
+SUPPORTED_VRCHAT_UNITY_VERSION = "2022.3.22f1"
+DEFAULT_PORT = 17751
+SESSION_RELATIVE_PATH = Path("Library") / "HermesUnityBridge" / "session.json"
+MAX_ARCHIVE_ENTRIES = 5000
+
+KNOWN_VPM_PACKAGES = {
+    "com.vrchat.base": "VRChat SDK Base",
+    "com.vrchat.avatars": "VRChat SDK Avatars",
+    "com.vrchat.worlds": "VRChat SDK Worlds",
+    "nadena.dev.modular-avatar": "Modular Avatar",
+    "nadena.dev.ndmf": "NDMF",
+    "jp.lilxyzw.liltoon": "lilToon",
+    "com.vrcfury.vrcfury": "VRCFury",
+    "com.anatawa12.avatar-optimizer": "Avatar Optimizer",
+    "com.poiyomi.toon": "Poiyomi Toon",
+    "com.poiyomi.shader": "Poiyomi Shader",
+}
+
+DEPENDENCY_HINTS = {
+    "liltoon": ("lilToon", "jp.lilxyzw.liltoon"),
+    "lil": ("lilToon", "jp.lilxyzw.liltoon"),
+    "modular avatar": ("Modular Avatar", "nadena.dev.modular-avatar"),
+    "modularavatar": ("Modular Avatar", "nadena.dev.modular-avatar"),
+    "ndmf": ("NDMF", "nadena.dev.ndmf"),
+    "vrcfury": ("VRCFury", "com.vrcfury.vrcfury"),
+    "poiyomi": ("Poiyomi", "com.poiyomi.toon"),
+}
+
+EDITOR_LOG_RULES = (
+    ("unity.compile.error", "error", re.compile(r"error CS\d+:|Assembly .* failed", re.I)),
+    ("vrc.sdk.validation", "error", re.compile(r"Validation failed|VRCSDK", re.I)),
+    (
+        "missing.script",
+        "error",
+        re.compile(r"The referenced script on this Behaviour is missing|Missing MonoBehaviour", re.I),
+    ),
+    ("shader.missing", "warning", re.compile(r"Shader .* not found|Hidden/InternalErrorShader", re.I)),
+    ("guid.meta.conflict", "error", re.compile(r"GUID \[.*\] for asset|meta file", re.I)),
+)
+
+
+STATUS_SCHEMA = {
+    "name": "unity_bridge_status",
+    "description": "Show Unity/VRChat bridge readiness without mutating Unity projects.",
+    "parameters": {"type": "object", "properties": {}},
+}
+
+HEALTH_SCHEMA = {
+    "name": "unity_bridge_health",
+    "description": "Call a trusted project-local Unity bridge /health endpoint.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {
+                "type": "string",
+                "description": "Unity project path containing Library/HermesUnityBridge/session.json.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": "HTTP timeout for the local bridge.",
+            },
+        },
+        "required": ["project_path"],
+    },
+}
+
+SNAPSHOT_SCHEMA = {
+    "name": "unity_bridge_snapshot",
+    "description": "Call a trusted project-local Unity bridge /snapshot endpoint.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": "HTTP timeout for the local bridge.",
+            },
+        },
+        "required": ["project_path"],
+    },
+}
+
+SELECTION_SCHEMA = {
+    "name": "unity_bridge_selection_get",
+    "description": "Call a trusted Unity bridge /selection endpoint.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": "HTTP timeout for the local bridge.",
+            },
+        },
+        "required": ["project_path"],
+    },
+}
+
+CAPABILITIES_SCHEMA = {
+    "name": "unity_bridge_capabilities",
+    "description": "List the trusted Unity Editor bridge capabilities and safety policy.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": "HTTP timeout for the local bridge.",
+            },
+        },
+        "required": ["project_path"],
+    },
+}
+
+PACKAGES_SCHEMA = {
+    "name": "unity_bridge_packages",
+    "description": "Read package metadata from a trusted live Unity Editor bridge.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": "HTTP timeout for the local bridge.",
+            },
+        },
+        "required": ["project_path"],
+    },
+}
+
+HIERARCHY_SCHEMA = {
+    "name": "unity_bridge_scene_hierarchy",
+    "description": "Read the active scene hierarchy from a trusted live Unity Editor bridge.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 500,
+                "description": "Maximum GameObjects to return.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": "HTTP timeout for the local bridge.",
+            },
+        },
+        "required": ["project_path"],
+    },
+}
+
+CONSOLE_RECENT_SCHEMA = {
+    "name": "unity_bridge_console_recent",
+    "description": "Call a trusted Unity bridge /logs/recent endpoint.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 500,
+                "description": "Maximum recent log entries.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": "HTTP timeout for the local bridge.",
+            },
+        },
+        "required": ["project_path"],
+    },
+}
+
+ASSET_SEARCH_SCHEMA = {
+    "name": "unity_bridge_asset_search",
+    "description": "Call a trusted Unity bridge /assets/search endpoint.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+            "filter": {"type": "string", "description": "Unity AssetDatabase filter, such as t:Prefab."},
+            "folders": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Asset folders to search. Defaults to Assets.",
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 500,
+                "description": "Maximum asset results.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": "HTTP timeout for the local bridge.",
+            },
+        },
+        "required": ["project_path", "filter"],
+    },
+}
+
+ASSET_INFO_SCHEMA = {
+    "name": "unity_bridge_asset_info",
+    "description": "Inspect Unity asset metadata and optional dependencies through the live Editor bridge.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+            "paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Unity asset paths, such as Assets/My.prefab.",
+            },
+            "include_dependencies": {
+                "type": "boolean",
+                "description": "Include direct Unity asset dependencies.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": "HTTP timeout for the local bridge.",
+            },
+        },
+        "required": ["project_path", "paths"],
+    },
+}
+
+MENU_EXECUTE_SCHEMA = {
+    "name": "unity_bridge_menu_execute",
+    "description": "Plan an allowlisted Unity menu command; MVP rejects live execution.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+            "menu_path": {"type": "string", "description": "Unity menu path."},
+            "dry_run": {
+                "type": "boolean",
+                "description": "Must be true in the MVP.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": "HTTP timeout for the local bridge.",
+            },
+        },
+        "required": ["project_path", "menu_path"],
+    },
+}
+
+OPERATION_PLAN_SCHEMA = {
+    "name": "unity_bridge_operation_plan",
+    "description": "Plan a generic Unity Editor operation; MVP rejects live execution.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+            "operation": {"type": "string", "description": "Operation name, such as asset_create."},
+            "target_path": {"type": "string", "description": "Optional target asset path under Assets."},
+            "dry_run": {
+                "type": "boolean",
+                "description": "Must be true in the MVP.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": "HTTP timeout for the local bridge.",
+            },
+        },
+        "required": ["project_path", "operation"],
+    },
+}
+
+PLAN_APPLY_SCHEMA = {
+    "name": "unity_bridge_plan_apply",
+    "description": "Submit a Unity bridge plan for dry-run review; MVP rejects live apply.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+            "operation": {"type": "string", "description": "Plan operation name."},
+            "dry_run": {
+                "type": "boolean",
+                "description": "Must be true in the MVP.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": "HTTP timeout for the local bridge.",
+            },
+        },
+        "required": ["project_path", "operation"],
+    },
+}
+
+PROJECT_PROFILE_SCHEMA = {
+    "name": "unity_project_profile",
+    "description": "Read Unity package and project metadata for a local project.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+        },
+        "required": ["project_path"],
+    },
+}
+
+VRCHAT_PROJECT_HEALTH_SCHEMA = {
+    "name": "vrchat_project_health",
+    "description": "Read-only VRChat/VCC/VPM project health check for a Unity project.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_path": {"type": "string", "description": "Unity project path."},
+        },
+        "required": ["project_path"],
+    },
+}
+
+COMMERCIAL_ASSET_INSPECT_SCHEMA = {
+    "name": "commercial_asset_inspect_archive",
+    "description": "Inspect a local zip or unitypackage for VRChat import risks without extracting it.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "archive_path": {"type": "string", "description": "Local .zip or .unitypackage path."},
+            "project_path": {
+                "type": "string",
+                "description": "Optional Unity project path used to compare installed dependencies.",
+            },
+        },
+        "required": ["archive_path"],
+    },
+}
+
+
+@dataclass(frozen=True)
+class BridgeSession:
+    project_path: Path
+    project_hash: str
+    port: int
+    token: str
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+
+class UnityBridgeError(RuntimeError):
+    pass
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _json(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def check_available() -> bool:
+    return True
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _read_project_version(project: Path) -> str:
+    version_file = project / "ProjectSettings" / "ProjectVersion.txt"
+    try:
+        text = version_file.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    match = re.search(r"m_EditorVersion:\s*(.+)", text)
+    return match.group(1).strip() if match else ""
+
+
+def _is_unity_project(project: Path) -> bool:
+    return (project / "Assets").is_dir() and (project / "ProjectSettings").is_dir()
+
+
+def _read_package_manifest(project: Path) -> dict[str, str]:
+    manifest = _read_json(project / "Packages" / "manifest.json")
+    deps = manifest.get("dependencies")
+    if not isinstance(deps, dict):
+        return {}
+    return {str(k): str(v) for k, v in deps.items()}
+
+
+def _read_vpm_manifest(project: Path) -> dict[str, str]:
+    for candidate in (project / "vpm-manifest.json", project / "Packages" / "vpm-manifest.json"):
+        data = _read_json(candidate)
+        locked = data.get("locked")
+        if isinstance(locked, dict):
+            return {
+                str(pkg): str(info.get("version", ""))
+                for pkg, info in locked.items()
+                if isinstance(info, dict)
+            }
+        deps = data.get("dependencies")
+        if isinstance(deps, dict):
+            return {
+                str(pkg): str(info.get("version", info))
+                for pkg, info in deps.items()
+            }
+    return {}
+
+
+def _read_packages_lock(project: Path) -> dict[str, str]:
+    data = _read_json(project / "Packages" / "packages-lock.json")
+    deps = data.get("dependencies")
+    if not isinstance(deps, dict):
+        return {}
+    result: dict[str, str] = {}
+    for package_id, info in deps.items():
+        if isinstance(info, dict):
+            result[str(package_id)] = str(info.get("version", ""))
+    return result
+
+
+def _detect_packages(packages: dict[str, str], vpm_locked: dict[str, str]) -> list[dict[str, str]]:
+    detected = []
+    for package_id in sorted(KNOWN_VPM_PACKAGES):
+        if package_id in packages or package_id in vpm_locked:
+            detected.append(
+                {
+                    "id": package_id,
+                    "name": KNOWN_VPM_PACKAGES[package_id],
+                    "version": vpm_locked.get(package_id) or packages.get(package_id, ""),
+                    "source": "vpm-lock" if package_id in vpm_locked else "manifest",
+                }
+            )
+    return detected
+
+
+def _project_hash(project: Path) -> str:
+    resolved = str(project.resolve()).replace("\\", "/").lower()
+    return "sha256:" + hashlib.sha256(resolved.encode("utf-8")).hexdigest()
+
+
+def project_profile(project_path: str) -> dict[str, Any]:
+    project = Path(project_path).expanduser()
+    packages = _read_package_manifest(project)
+    vpm_locked = _read_vpm_manifest(project)
+    packages_lock = _read_packages_lock(project)
+    sdk_avatar = "com.vrchat.avatars" in packages or "com.vrchat.avatars" in vpm_locked
+    sdk_world = "com.vrchat.worlds" in packages or "com.vrchat.worlds" in vpm_locked
+    sdk_base = "com.vrchat.base" in packages or "com.vrchat.base" in vpm_locked
+    risks: list[str] = []
+    if not project.exists():
+        risks.append("project path does not exist")
+    if project.exists() and not _is_unity_project(project):
+        risks.append("path is not a Unity project")
+    if not packages:
+        risks.append("Packages/manifest.json missing or unreadable")
+    if sdk_avatar and sdk_world:
+        risks.append("both VRChat Avatar and World SDK packages detected")
+    if (sdk_avatar or sdk_world or sdk_base) and not vpm_locked:
+        risks.append("VRChat SDK detected but VPM manifest lock is missing or unreadable")
+
+    unity_version = _read_project_version(project)
+    return {
+        "ok": True,
+        "scanned_at": _now_utc(),
+        "project_path": str(project),
+        "project_hash": _project_hash(project) if project.exists() else "",
+        "exists": project.exists(),
+        "unity_project": _is_unity_project(project),
+        "unity_version": unity_version,
+        "vrchat_supported_unity_version": SUPPORTED_VRCHAT_UNITY_VERSION,
+        "vrchat_unity_version_match": unity_version == SUPPORTED_VRCHAT_UNITY_VERSION,
+        "package_count": len(packages),
+        "packages_lock_count": len(packages_lock),
+        "vpm_locked_count": len(vpm_locked),
+        "detected_packages": _detect_packages(packages, vpm_locked),
+        "vrchat_project_kind": (
+            "avatar" if sdk_avatar and not sdk_world else
+            "world" if sdk_world and not sdk_avatar else
+            "mixed" if sdk_avatar and sdk_world else
+            "generic_unity"
+        ),
+        "risks": risks,
+    }
+
+
+def vrchat_project_health(project_path: str) -> dict[str, Any]:
+    profile = project_profile(project_path)
+    project = Path(project_path).expanduser()
+    packages = _read_package_manifest(project)
+    vpm_locked = _read_vpm_manifest(project)
+    risks = list(profile["risks"])
+    warnings: list[str] = []
+    if profile["unity_project"] and not profile["vrchat_unity_version_match"]:
+        warnings.append(
+            f"Unity version is {profile['unity_version'] or 'unknown'}, expected {SUPPORTED_VRCHAT_UNITY_VERSION}"
+        )
+    if not any(pkg in packages or pkg in vpm_locked for pkg in ("com.vrchat.avatars", "com.vrchat.worlds")):
+        warnings.append("VRChat SDK Avatars or Worlds package not detected")
+    if (project / "Assets" / "VRCSDK").exists():
+        risks.append("legacy Assets/VRCSDK folder detected")
+    editor_log = classify_editor_log(project)
+    return {
+        "ok": True,
+        "scanned_at": _now_utc(),
+        "project": profile,
+        "warnings": warnings,
+        "risks": risks,
+        "editor_log": editor_log,
+        "blocked_actions": [
+            "sdk_upload",
+            "package_import",
+            "destructive_project_mutation",
+        ],
+        "dry_run_required": True,
+    }
+
+
+def _editor_log_candidates(project: Path) -> list[Path]:
+    local = os.environ.get("LOCALAPPDATA")
+    candidates = [project / "Library" / "Editor.log"]
+    if local:
+        candidates.append(Path(local) / "Unity" / "Editor" / "Editor.log")
+    return candidates
+
+
+def classify_editor_log(project: Path, max_lines: int = 400) -> dict[str, Any]:
+    log_path = next((path for path in _editor_log_candidates(project) if path.is_file()), None)
+    if not log_path:
+        return {"available": False, "path": "", "findings": []}
+    try:
+        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()[-max_lines:]
+    except OSError:
+        return {"available": False, "path": str(log_path), "findings": []}
+    findings = []
+    for line in lines:
+        for rule_id, severity, pattern in EDITOR_LOG_RULES:
+            if pattern.search(line):
+                findings.append({"id": rule_id, "severity": severity, "line": line[:500]})
+                break
+    return {"available": True, "path": str(log_path), "findings": findings[:100]}
+
+
+def _session_path(project: Path) -> Path:
+    return project / SESSION_RELATIVE_PATH
+
+
+def read_bridge_session(project_path: str) -> BridgeSession:
+    project = Path(project_path).expanduser()
+    data = _read_json(_session_path(project))
+    token = str(data.get("token") or "")
+    port = int(data.get("port") or 0)
+    project_hash = str(data.get("projectHash") or data.get("project_hash") or "")
+    if not token or port <= 0:
+        raise UnityBridgeError(f"Unity bridge session is missing or incomplete at {_session_path(project)}")
+    if project_hash and project_hash != _project_hash(project):
+        raise UnityBridgeError("Unity bridge session project hash does not match project path")
+    return BridgeSession(project_path=project, project_hash=project_hash, port=port, token=token)
+
+
+def bridge_request(
+    project_path: str,
+    endpoint: str,
+    timeout_seconds: float = 5.0,
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    session = read_bridge_session(project_path)
+    if not endpoint.startswith("/"):
+        raise UnityBridgeError("Bridge endpoint must start with /")
+    body = None
+    headers = {
+        "X-Hermes-Bridge-Token": session.token,
+        "User-Agent": "HermesUnityVrchatBridge/0.1.0",
+    }
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    url = session.base_url + endpoint
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            body = response.read(1024 * 1024)
+    except urllib.error.HTTPError as exc:
+        raise UnityBridgeError(f"Unity bridge returned HTTP {exc.code}") from exc
+    except OSError as exc:
+        raise UnityBridgeError(f"Unity bridge request failed: {exc}") from exc
+    try:
+        return json.loads(body.decode("utf-8"))
+    except ValueError as exc:
+        raise UnityBridgeError("Unity bridge returned invalid JSON") from exc
+
+
+def status() -> dict[str, Any]:
+    package_root = Path(__file__).resolve().parent
+    unity_package = package_root / "unity_package" / "Packages" / "com.hermes.unity-vrchat-bridge"
+    return {
+        "ok": True,
+        "plugin": PLUGIN_ID,
+        "scanned_at": _now_utc(),
+        "hermes_home": str(get_hermes_home()),
+        "default_port": DEFAULT_PORT,
+        "supported_vrchat_unity_version": SUPPORTED_VRCHAT_UNITY_VERSION,
+        "unity_editor_package_present": unity_package.is_dir(),
+        "unity_editor_package_path": str(unity_package),
+        "mvp_policy": {
+            "read_only_first": True,
+            "sdk_upload_blocked": True,
+            "package_import_blocked": True,
+            "dangerous_mutations_require_dry_run": True,
+        },
+    }
+
+
+def _archive_entries(archive_path: Path) -> tuple[str, list[str]]:
+    suffix = archive_path.suffix.lower()
+    if suffix == ".zip":
+        with zipfile.ZipFile(archive_path) as archive:
+            return "zip", archive.namelist()[:MAX_ARCHIVE_ENTRIES]
+    if suffix == ".unitypackage":
+        with tarfile.open(archive_path) as archive:
+            return "unitypackage", archive.getnames()[:MAX_ARCHIVE_ENTRIES]
+    raise ValueError("archive_path must be a .zip or .unitypackage file")
+
+
+def _entry_kinds(entries: list[str]) -> dict[str, int]:
+    patterns = {
+        "prefab": "*.prefab",
+        "scene": "*.unity",
+        "fbx": "*.fbx",
+        "material": "*.mat",
+        "controller": "*.controller",
+        "animation": "*.anim",
+        "shader": "*.shader",
+        "texture": ("*.png", "*.jpg", "*.jpeg", "*.tga", "*.psd"),
+        "meta": "*.meta",
+        "readme": ("*readme*", "*license*", "*terms*", "*利用規約*"),
+    }
+    counts: dict[str, int] = {}
+    lower_entries = [entry.lower() for entry in entries]
+    for kind, raw_patterns in patterns.items():
+        pats = raw_patterns if isinstance(raw_patterns, tuple) else (raw_patterns,)
+        counts[kind] = sum(
+            1 for entry in lower_entries if any(fnmatch.fnmatch(entry, pattern.lower()) for pattern in pats)
+        )
+    return counts
+
+
+def _infer_dependencies(entries: list[str], installed: dict[str, str]) -> list[dict[str, Any]]:
+    haystack = "\n".join(entries).lower()
+    deps: dict[str, dict[str, Any]] = {}
+    for needle, (name, package_id) in DEPENDENCY_HINTS.items():
+        if needle in haystack:
+            deps[name] = {
+                "name": name,
+                "package_id": package_id,
+                "status": "installed" if package_id in installed else "missing_or_unknown",
+                "evidence": [f"archive path references {needle}"],
+            }
+    return list(deps.values())
+
+
+def inspect_commercial_asset_archive(archive_path: str, project_path: str | None = None) -> dict[str, Any]:
+    archive = Path(archive_path).expanduser()
+    if not archive.is_file():
+        return {"ok": False, "error": f"archive not found: {archive}"}
+    try:
+        archive_type, entries = _archive_entries(archive)
+    except (OSError, ValueError, tarfile.TarError, zipfile.BadZipFile) as exc:
+        return {"ok": False, "error": str(exc), "archive_path": str(archive)}
+    installed = _read_package_manifest(Path(project_path).expanduser()) if project_path else {}
+    kind_counts = _entry_kinds(entries)
+    root_candidates = sorted({entry.split("/")[0] for entry in entries if "/" in entry})[:20]
+    risks = []
+    if kind_counts.get("readme", 0) == 0:
+        risks.append("README/license/terms file not obvious from archive paths")
+    if archive_type == "unitypackage" and kind_counts.get("meta", 0) == 0:
+        risks.append("unitypackage contains no obvious .meta entries")
+    return {
+        "ok": True,
+        "scanned_at": _now_utc(),
+        "archive_path": str(archive),
+        "archive_type": archive_type,
+        "entry_count": len(entries),
+        "truncated": len(entries) >= MAX_ARCHIVE_ENTRIES,
+        "root_candidates": root_candidates,
+        "kinds": kind_counts,
+        "dependencies": _infer_dependencies(entries, installed),
+        "risks": risks,
+        "will_modify_files": False,
+        "blocked_actions": ["redistribution", "drm_bypass", "license_bypass", "automatic_import"],
+    }
+
+
+def _error_response(exc: Exception) -> str:
+    return _json({"ok": False, "error": str(exc)})
+
+
+def handle_status(args: dict[str, Any] | None = None, **_: Any) -> str:
+    return _json(status())
+
+
+def handle_health(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    try:
+        return _json(bridge_request(str(args.get("project_path") or ""), "/health", float(args.get("timeout_seconds") or 5)))
+    except Exception as exc:
+        return _error_response(exc)
+
+
+def handle_snapshot(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    try:
+        return _json(bridge_request(str(args.get("project_path") or ""), "/snapshot", float(args.get("timeout_seconds") or 5)))
+    except Exception as exc:
+        return _error_response(exc)
+
+
+def handle_selection(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    try:
+        return _json(bridge_request(str(args.get("project_path") or ""), "/selection", float(args.get("timeout_seconds") or 5)))
+    except Exception as exc:
+        return _error_response(exc)
+
+
+def handle_capabilities(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    try:
+        return _json(
+            bridge_request(
+                str(args.get("project_path") or ""),
+                "/editor/capabilities",
+                float(args.get("timeout_seconds") or 5),
+            )
+        )
+    except Exception as exc:
+        return _error_response(exc)
+
+
+def handle_packages(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    try:
+        return _json(
+            bridge_request(
+                str(args.get("project_path") or ""),
+                "/project/packages",
+                float(args.get("timeout_seconds") or 5),
+            )
+        )
+    except Exception as exc:
+        return _error_response(exc)
+
+
+def handle_hierarchy(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    limit = max(1, min(int(args.get("limit") or 200), 500))
+    try:
+        return _json(
+            bridge_request(
+                str(args.get("project_path") or ""),
+                f"/scene/hierarchy?limit={limit}",
+                float(args.get("timeout_seconds") or 5),
+            )
+        )
+    except Exception as exc:
+        return _error_response(exc)
+
+
+def handle_console_recent(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    limit = max(1, min(int(args.get("limit") or 100), 500))
+    try:
+        return _json(
+            bridge_request(
+                str(args.get("project_path") or ""),
+                f"/logs/recent?limit={limit}",
+                float(args.get("timeout_seconds") or 5),
+            )
+        )
+    except Exception as exc:
+        return _error_response(exc)
+
+
+def handle_asset_search(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    folders = args.get("folders")
+    if not isinstance(folders, list):
+        folders = ["Assets"]
+    limit = max(1, min(int(args.get("limit") or 100), 500))
+    try:
+        return _json(
+            bridge_request(
+                str(args.get("project_path") or ""),
+                "/assets/search",
+                float(args.get("timeout_seconds") or 5),
+                method="POST",
+                payload={
+                    "filter": str(args.get("filter") or ""),
+                    "folders": [str(folder) for folder in folders],
+                    "limit": limit,
+                },
+            )
+        )
+    except Exception as exc:
+        return _error_response(exc)
+
+
+def handle_asset_info(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    paths = args.get("paths")
+    if not isinstance(paths, list):
+        paths = []
+    try:
+        return _json(
+            bridge_request(
+                str(args.get("project_path") or ""),
+                "/assets/info",
+                float(args.get("timeout_seconds") or 5),
+                method="POST",
+                payload={
+                    "paths": [str(path) for path in paths],
+                    "includeDependencies": bool(args.get("include_dependencies", False)),
+                },
+            )
+        )
+    except Exception as exc:
+        return _error_response(exc)
+
+
+def handle_menu_execute(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    dry_run = bool(args.get("dry_run", True))
+    if not dry_run:
+        return _json(
+            {
+                "ok": False,
+                "error": "unity_bridge_menu_execute requires dry_run=true in the MVP",
+                "blocked_action": "menu_execute_live",
+            }
+        )
+    try:
+        return _json(
+            bridge_request(
+                str(args.get("project_path") or ""),
+                "/menu/execute",
+                float(args.get("timeout_seconds") or 5),
+                method="POST",
+                payload={"menuPath": str(args.get("menu_path") or ""), "dryRun": True},
+            )
+        )
+    except Exception as exc:
+        return _error_response(exc)
+
+
+def handle_operation_plan(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    dry_run = bool(args.get("dry_run", True))
+    if not dry_run:
+        return _json(
+            {
+                "ok": False,
+                "error": "unity_bridge_operation_plan requires dry_run=true in the MVP",
+                "blocked_action": "operation_execute_live",
+            }
+        )
+    try:
+        return _json(
+            bridge_request(
+                str(args.get("project_path") or ""),
+                "/operation/plan",
+                float(args.get("timeout_seconds") or 5),
+                method="POST",
+                payload={
+                    "operation": str(args.get("operation") or ""),
+                    "targetPath": str(args.get("target_path") or ""),
+                    "dryRun": True,
+                },
+            )
+        )
+    except Exception as exc:
+        return _error_response(exc)
+
+
+def handle_plan_apply(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    dry_run = bool(args.get("dry_run", True))
+    if not dry_run:
+        return _json(
+            {
+                "ok": False,
+                "error": "unity_bridge_plan_apply requires dry_run=true in the MVP",
+                "blocked_action": "plan_apply_live",
+            }
+        )
+    try:
+        return _json(
+            bridge_request(
+                str(args.get("project_path") or ""),
+                "/plan/apply",
+                float(args.get("timeout_seconds") or 5),
+                method="POST",
+                payload={"operation": str(args.get("operation") or ""), "dryRun": True},
+            )
+        )
+    except Exception as exc:
+        return _error_response(exc)
+
+
+def handle_project_profile(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    return _json(project_profile(str(args.get("project_path") or "")))
+
+
+def handle_vrchat_project_health(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    return _json(vrchat_project_health(str(args.get("project_path") or "")))
+
+
+def handle_commercial_asset_inspect(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    return _json(
+        inspect_commercial_asset_archive(
+            str(args.get("archive_path") or ""),
+            str(args.get("project_path") or "") or None,
+        )
+    )
+
+
+def handle_slash(command: str = "", **_: Any) -> str:
+    argv = command.split()
+    if argv and argv[0].lstrip("/") == "unity-vrchat-bridge":
+        argv = argv[1:]
+    return run_cli(argv)
+
+
+def run_cli(argv: list[str] | None = None) -> str:
+    parser = argparse.ArgumentParser(prog="hermes unity-vrchat-bridge")
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("status")
+    for name in (
+        "health",
+        "snapshot",
+        "selection",
+        "capabilities",
+        "packages",
+        "hierarchy",
+        "console",
+        "project-profile",
+        "vrchat-health",
+    ):
+        p = sub.add_parser(name)
+        p.add_argument("project_path")
+        if name == "hierarchy":
+            p.add_argument("--limit", type=int, default=200)
+    asset = sub.add_parser("asset-search")
+    asset.add_argument("project_path")
+    asset.add_argument("filter")
+    asset.add_argument("--folder", action="append", default=[])
+    asset.add_argument("--limit", type=int, default=100)
+    info = sub.add_parser("asset-info")
+    info.add_argument("project_path")
+    info.add_argument("paths", nargs="+")
+    info.add_argument("--include-dependencies", action="store_true")
+    menu = sub.add_parser("menu-execute")
+    menu.add_argument("project_path")
+    menu.add_argument("menu_path")
+    menu.add_argument("--live", action="store_true")
+    op = sub.add_parser("operation-plan")
+    op.add_argument("project_path")
+    op.add_argument("operation")
+    op.add_argument("--target-path", default="")
+    op.add_argument("--live", action="store_true")
+    plan = sub.add_parser("plan-apply")
+    plan.add_argument("project_path")
+    plan.add_argument("operation")
+    plan.add_argument("--live", action="store_true")
+    inspect = sub.add_parser("inspect-archive")
+    inspect.add_argument("archive_path")
+    inspect.add_argument("--project-path", default="")
+    ns = parser.parse_args(argv or ["status"])
+    if ns.command in (None, "status"):
+        return _json(status())
+    if ns.command == "health":
+        return handle_health({"project_path": ns.project_path})
+    if ns.command == "snapshot":
+        return handle_snapshot({"project_path": ns.project_path})
+    if ns.command == "selection":
+        return handle_selection({"project_path": ns.project_path})
+    if ns.command == "capabilities":
+        return handle_capabilities({"project_path": ns.project_path})
+    if ns.command == "packages":
+        return handle_packages({"project_path": ns.project_path})
+    if ns.command == "hierarchy":
+        return handle_hierarchy({"project_path": ns.project_path, "limit": ns.limit})
+    if ns.command == "console":
+        return handle_console_recent({"project_path": ns.project_path})
+    if ns.command == "asset-search":
+        return handle_asset_search(
+            {
+                "project_path": ns.project_path,
+                "filter": ns.filter,
+                "folders": ns.folder or ["Assets"],
+                "limit": ns.limit,
+            }
+        )
+    if ns.command == "asset-info":
+        return handle_asset_info(
+            {
+                "project_path": ns.project_path,
+                "paths": ns.paths,
+                "include_dependencies": ns.include_dependencies,
+            }
+        )
+    if ns.command == "menu-execute":
+        return handle_menu_execute(
+            {
+                "project_path": ns.project_path,
+                "menu_path": ns.menu_path,
+                "dry_run": not ns.live,
+            }
+        )
+    if ns.command == "operation-plan":
+        return handle_operation_plan(
+            {
+                "project_path": ns.project_path,
+                "operation": ns.operation,
+                "target_path": ns.target_path,
+                "dry_run": not ns.live,
+            }
+        )
+    if ns.command == "plan-apply":
+        return handle_plan_apply(
+            {
+                "project_path": ns.project_path,
+                "operation": ns.operation,
+                "dry_run": not ns.live,
+            }
+        )
+    if ns.command == "project-profile":
+        return handle_project_profile({"project_path": ns.project_path})
+    if ns.command == "vrchat-health":
+        return handle_vrchat_project_health({"project_path": ns.project_path})
+    if ns.command == "inspect-archive":
+        return handle_commercial_asset_inspect(
+            {"archive_path": ns.archive_path, "project_path": ns.project_path}
+        )
+    return _json({"ok": False, "error": f"unknown command: {ns.command}"})

--- a/plugins/unity_vrchat_bridge/plugin.yaml
+++ b/plugins/unity_vrchat_bridge/plugin.yaml
@@ -1,0 +1,28 @@
+name: unity-vrchat-bridge
+version: 0.1.0
+description: "VRChat-first Unity Editor bridge for read-only project health, local bridge status, and commercial asset import audits."
+author: "Hermes local plugin"
+kind: standalone
+platforms:
+  - windows
+  - linux
+  - macos
+provides_tools:
+  - unity_bridge_status
+  - unity_bridge_health
+  - unity_bridge_snapshot
+  - unity_bridge_selection_get
+  - unity_bridge_capabilities
+  - unity_bridge_packages
+  - unity_bridge_scene_hierarchy
+  - unity_bridge_console_recent
+  - unity_bridge_asset_search
+  - unity_bridge_asset_info
+  - unity_bridge_menu_execute
+  - unity_bridge_operation_plan
+  - unity_bridge_plan_apply
+  - unity_project_profile
+  - vrchat_project_health
+  - commercial_asset_inspect_archive
+provides_cli:
+  - unity-vrchat-bridge

--- a/plugins/unity_vrchat_bridge/unity_package/Packages/com.hermes.unity-vrchat-bridge/Editor/HermesUnityVrchatBridge.cs
+++ b/plugins/unity_vrchat_bridge/unity_package/Packages/com.hermes.unity-vrchat-bridge/Editor/HermesUnityVrchatBridge.cs
@@ -1,0 +1,865 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using UnityEditor;
+using UnityEngine;
+
+namespace Hermes.UnityVrchatBridge
+{
+    [InitializeOnLoad]
+    public sealed class HermesUnityVrchatBridgeWindow : EditorWindow
+    {
+        private const int DefaultPort = 17751;
+        private const int MaxRequestBytes = 1024 * 64;
+        private const string TrustedProjectsKey = "Hermes.UnityVrchatBridge.TrustedProjects";
+        private const string AutoStartPrefix = "Hermes.UnityVrchatBridge.AutoStart.";
+        private static readonly object LogsLock = new object();
+        private static readonly List<BridgeLogEntry> RecentLogs = new List<BridgeLogEntry>();
+        private static readonly object MainThreadLock = new object();
+        private static readonly Queue<Action> MainThreadQueue = new Queue<Action>();
+        private static HttpListener listener;
+        private static Thread listenerThread;
+        private static string token;
+        private static int port = DefaultPort;
+        private static bool running;
+        private static int mainThreadId;
+
+        static HermesUnityVrchatBridgeWindow()
+        {
+            mainThreadId = Thread.CurrentThread.ManagedThreadId;
+            Application.logMessageReceived -= CaptureLog;
+            Application.logMessageReceived += CaptureLog;
+            EditorApplication.update -= PumpMainThreadQueue;
+            EditorApplication.update += PumpMainThreadQueue;
+            EditorApplication.delayCall += () =>
+            {
+                if (IsCurrentProjectTrusted() && AutoStartForCurrentProject && !running)
+                {
+                    StartBridge();
+                }
+            };
+        }
+
+        [MenuItem("Hermes/Unity VRChat Bridge")]
+        public static void Open()
+        {
+            GetWindow<HermesUnityVrchatBridgeWindow>("Hermes Bridge");
+        }
+
+        public static void SelfTestForBatch()
+        {
+            TrustCurrentProject();
+            StartBridge();
+            try
+            {
+                Exception error = null;
+                using (var done = new ManualResetEvent(false))
+                {
+                    var client = new Thread(() =>
+                    {
+                        try
+                        {
+                            Thread.Sleep(1000);
+                            RequireContains(SelfTestRequest("GET", "/health", null, true, null), "\"ok\":true");
+                            RequireContains(SelfTestRequest("GET", "/snapshot", null, true, null), "\"unityVersion\"");
+                            RequireContains(SelfTestRequest("GET", "/selection", null, true, null), "\"ok\":true");
+                            RequireContains(SelfTestRequest("GET", "/editor/capabilities", null, true, null), "\"capabilities\"");
+                            RequireContains(SelfTestRequest("GET", "/project/packages", null, true, null), "\"packages\"");
+                            RequireContains(SelfTestRequest("GET", "/scene/hierarchy?limit=20", null, true, null), "\"objects\"");
+                            RequireContains(SelfTestRequest("GET", "/logs/recent?limit=5", null, true, null), "\"logs\"");
+                            RequireContains(SelfTestRequest("POST", "/assets/search", "{\"filter\":\"t:DefaultAsset\",\"folders\":[\"Assets\"],\"limit\":5}", true, null), "\"assets\"");
+                            RequireContains(SelfTestRequest("POST", "/assets/info", "{\"paths\":[\"Assets\"],\"includeDependencies\":true}", true, null), "\"assets\"");
+                            RequireContains(SelfTestRequest("POST", "/menu/execute", "{\"menuPath\":\"VRChat SDK/Show Control Panel\",\"dryRun\":true}", true, null), "\"willExecute\":false");
+                            RequireContains(SelfTestRequest("POST", "/menu/execute", "{\"menuPath\":\"VRChat SDK/Show Control Panel\",\"dryRun\":false}", true, null), "\"blockedAction\"");
+                            RequireContains(SelfTestRequest("POST", "/operation/plan", "{\"operation\":\"asset_create\",\"targetPath\":\"Assets/New.asset\",\"dryRun\":true}", true, null), "\"willExecute\":false");
+                            RequireContains(SelfTestRequest("POST", "/operation/plan", "{\"operation\":\"asset_create\",\"targetPath\":\"Assets/New.asset\",\"dryRun\":false}", true, null), "\"blockedAction\"");
+                            RequireContains(SelfTestRequest("POST", "/plan/apply", "{\"operation\":\"avatar_preflight\",\"dryRun\":true}", true, null), "\"willApply\":false");
+                            RequireContains(SelfTestRequest("POST", "/plan/apply", "{\"operation\":\"avatar_preflight\",\"dryRun\":false}", true, null), "\"blockedAction\"");
+                            RequireStatus("GET", "/health", null, false, null, 401);
+                            RequireStatus("GET", "/health", null, true, "http://example.com:80", 403);
+                        }
+                        catch (Exception ex)
+                        {
+                            error = ex;
+                        }
+                        finally
+                        {
+                            done.Set();
+                        }
+                    }) { IsBackground = true, Name = "HermesUnityVrchatBridgeSelfTest" };
+                    client.Start();
+
+                    var deadline = DateTime.UtcNow.AddSeconds(30);
+                    while (!done.WaitOne(10))
+                    {
+                        PumpMainThreadQueue();
+                        if (DateTime.UtcNow > deadline)
+                        {
+                            throw new TimeoutException("Unity bridge self-test timed out.");
+                        }
+                    }
+                    PumpMainThreadQueue();
+                }
+                if (error != null) throw error;
+                Debug.Log("HERMES_UNITY_VRCHAT_BRIDGE_SELFTEST_OK");
+            }
+            finally
+            {
+                StopBridge();
+            }
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.LabelField("Hermes Unity VRChat Bridge", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField("Status", running ? "Running" : "Stopped");
+            EditorGUILayout.LabelField("Port", port.ToString());
+            EditorGUILayout.LabelField("Project", ProjectPath());
+            EditorGUILayout.LabelField("Project Hash", ProjectHash());
+            EditorGUILayout.LabelField("Trusted", IsCurrentProjectTrusted() ? "Yes" : "No");
+
+            if (!IsCurrentProjectTrusted() && GUILayout.Button("Trust This Project"))
+            {
+                TrustCurrentProject();
+            }
+            if (IsCurrentProjectTrusted() && GUILayout.Button("Untrust This Project"))
+            {
+                UntrustCurrentProject();
+                StopBridge();
+            }
+
+            var autoStart = AutoStartForCurrentProject;
+            var nextAutoStart = EditorGUILayout.Toggle("Auto Start for This Project", autoStart);
+            if (nextAutoStart != autoStart)
+            {
+                AutoStartForCurrentProject = nextAutoStart;
+            }
+
+            using (new EditorGUI.DisabledScope(!IsCurrentProjectTrusted()))
+            {
+                if (!running && GUILayout.Button("Start Bridge"))
+                {
+                    StartBridge();
+                }
+            }
+            if (!running && !IsCurrentProjectTrusted())
+            {
+                EditorGUILayout.HelpBox("Trust this project before starting the localhost bridge.", MessageType.Warning);
+            }
+            if (running && GUILayout.Button("Stop Bridge"))
+            {
+                StopBridge();
+            }
+
+            EditorGUILayout.HelpBox(
+                "The MVP exposes read-only endpoints on 127.0.0.1. SDK upload, package import, live menu execution, and destructive mutation are unavailable.",
+                MessageType.Info);
+        }
+
+        private static void StartBridge()
+        {
+            if (running) return;
+            if (!IsCurrentProjectTrusted())
+            {
+                Debug.LogError("Hermes Unity VRChat Bridge refused to start because this project is not trusted.");
+                return;
+            }
+            token = GenerateToken();
+            listener = null;
+            for (var candidate = DefaultPort; candidate <= 17799; candidate++)
+            {
+                var next = new HttpListener();
+                next.Prefixes.Add("http://127.0.0.1:" + candidate + "/");
+                try
+                {
+                    next.Start();
+                    listener = next;
+                    port = candidate;
+                    break;
+                }
+                catch
+                {
+                    try { next.Close(); } catch { }
+                }
+            }
+            if (listener == null)
+            {
+                Debug.LogError("Hermes Unity VRChat Bridge could not bind a loopback port.");
+                return;
+            }
+            running = true;
+            WriteSession();
+            listenerThread = new Thread(ListenLoop) { IsBackground = true, Name = "HermesUnityVrchatBridge" };
+            listenerThread.Start();
+            Debug.Log("HERMES_UNITY_VRCHAT_BRIDGE_START port=" + port);
+        }
+
+        private static void StopBridge()
+        {
+            running = false;
+            try { listener?.Stop(); } catch { }
+            try { listener?.Close(); } catch { }
+            listener = null;
+        }
+
+        private static void ListenLoop()
+        {
+            while (running && listener != null)
+            {
+                try
+                {
+                    Handle(listener.GetContext());
+                }
+                catch
+                {
+                    if (!running) return;
+                }
+            }
+        }
+
+        private static void Handle(HttpListenerContext context)
+        {
+            try
+            {
+                if (!IsLoopback(context) || !IsOriginAllowed(context.Request.Headers["Origin"]))
+                {
+                    WriteJson(context, 403, "{\"ok\":false,\"error\":\"loopback origin required\"}");
+                    return;
+                }
+
+                if (context.Request.Headers["X-Hermes-Bridge-Token"] != token)
+                {
+                    WriteJson(context, 401, "{\"ok\":false,\"error\":\"token required\"}");
+                    return;
+                }
+
+                var path = context.Request.Url.AbsolutePath;
+                if (context.Request.HttpMethod == "GET" && path == "/health")
+                {
+                    WriteJson(context, 200, "{\"ok\":true,\"bridge\":\"unity-vrchat-bridge\",\"version\":\"0.1.0\"}");
+                    return;
+                }
+                if (context.Request.HttpMethod == "GET" && path == "/snapshot")
+                {
+                    WriteJson(context, 200, RunOnMainThread(BuildSnapshotJson));
+                    return;
+                }
+                if (context.Request.HttpMethod == "GET" && path == "/selection")
+                {
+                    WriteJson(context, 200, RunOnMainThread(BuildSelectionJson));
+                    return;
+                }
+                if (context.Request.HttpMethod == "GET" && path == "/editor/capabilities")
+                {
+                    WriteJson(context, 200, BuildCapabilitiesJson());
+                    return;
+                }
+                if (context.Request.HttpMethod == "GET" && path == "/project/packages")
+                {
+                    WriteJson(context, 200, RunOnMainThread(BuildPackagesJson));
+                    return;
+                }
+                if (context.Request.HttpMethod == "GET" && path == "/scene/hierarchy")
+                {
+                    WriteJson(context, 200, RunOnMainThread(() => BuildHierarchyJson(ReadLimit(context, 200))));
+                    return;
+                }
+                if (context.Request.HttpMethod == "GET" && path == "/logs/recent")
+                {
+                    WriteJson(context, 200, BuildLogsJson(ReadLimit(context, 100)));
+                    return;
+                }
+                if (context.Request.HttpMethod == "POST" && path == "/assets/search")
+                {
+                    var body = ReadBody(context);
+                    WriteJson(context, 200, RunOnMainThread(() => BuildAssetSearchJson(body)));
+                    return;
+                }
+                if (context.Request.HttpMethod == "POST" && path == "/assets/info")
+                {
+                    var body = ReadBody(context);
+                    WriteJson(context, 200, RunOnMainThread(() => BuildAssetInfoJson(body)));
+                    return;
+                }
+                if (context.Request.HttpMethod == "POST" && path == "/menu/execute")
+                {
+                    WriteJson(context, 200, BuildMenuPlanJson(ReadBody(context)));
+                    return;
+                }
+                if (context.Request.HttpMethod == "POST" && path == "/operation/plan")
+                {
+                    WriteJson(context, 200, BuildOperationPlanJson(ReadBody(context)));
+                    return;
+                }
+                if (context.Request.HttpMethod == "POST" && path == "/plan/apply")
+                {
+                    WriteJson(context, 200, BuildPlanApplyJson(ReadBody(context)));
+                    return;
+                }
+                WriteJson(context, 404, "{\"ok\":false,\"error\":\"not found\"}");
+            }
+            catch (Exception ex)
+            {
+                WriteJson(context, 500, "{\"ok\":false,\"error\":\"" + Escape(ex.GetType().Name + ": " + ex.Message) + "\"}");
+            }
+        }
+
+        private static bool IsLoopback(HttpListenerContext context)
+        {
+            return context.Request.RemoteEndPoint != null &&
+                   IPAddress.IsLoopback(context.Request.RemoteEndPoint.Address);
+        }
+
+        private static bool IsOriginAllowed(string origin)
+        {
+            if (string.IsNullOrEmpty(origin)) return true;
+            return origin.StartsWith("http://127.0.0.1:", StringComparison.OrdinalIgnoreCase) ||
+                   origin.StartsWith("http://localhost:", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string BuildSnapshotJson()
+        {
+            return "{"
+                + "\"ok\":true,"
+                + "\"unityVersion\":\"" + Escape(Application.unityVersion) + "\","
+                + "\"projectPath\":\"" + Escape(ProjectPath()) + "\","
+                + "\"dataPath\":\"" + Escape(Application.dataPath) + "\","
+                + "\"activeScene\":\"" + Escape(UnityEditor.SceneManagement.EditorSceneManager.GetActiveScene().path) + "\","
+                + "\"buildTarget\":\"" + Escape(EditorUserBuildSettings.activeBuildTarget.ToString()) + "\","
+                + "\"isCompiling\":" + Bool(EditorApplication.isCompiling) + ","
+                + "\"isPlaying\":" + Bool(EditorApplication.isPlaying)
+                + "}";
+        }
+
+        private static string BuildSelectionJson()
+        {
+            var obj = Selection.activeObject;
+            var path = obj == null ? "" : AssetDatabase.GetAssetPath(obj);
+            return "{"
+                + "\"ok\":true,"
+                + "\"name\":\"" + Escape(obj == null ? "" : obj.name) + "\","
+                + "\"type\":\"" + Escape(obj == null ? "" : obj.GetType().FullName) + "\","
+                + "\"assetPath\":\"" + Escape(path) + "\","
+                + "\"instanceId\":" + (obj == null ? 0 : obj.GetInstanceID())
+                + "}";
+        }
+
+        private static string BuildCapabilitiesJson()
+        {
+            return "{"
+                + "\"ok\":true,"
+                + "\"bridge\":\"unity-vrchat-bridge\","
+                + "\"capabilities\":["
+                + "\"health\",\"snapshot\",\"selection\",\"logs_recent\",\"asset_search\","
+                + "\"asset_info\",\"packages\",\"scene_hierarchy\",\"menu_execute_dry_run\","
+                + "\"operation_plan_dry_run\",\"plan_apply_dry_run\""
+                + "],"
+                + "\"blockedActions\":[\"sdk_upload\",\"package_import\",\"delete_asset\",\"overwrite_asset\",\"manifest_mutation\",\"live_menu_execute\",\"live_plan_apply\"],"
+                + "\"requiresProjectTrust\":true,"
+                + "\"requiresToken\":true,"
+                + "\"loopbackOnly\":true"
+                + "}";
+        }
+
+        private static string BuildPackagesJson()
+        {
+            var packages = UnityEditor.PackageManager.PackageInfo.GetAllRegisteredPackages();
+            var sb = new StringBuilder();
+            sb.Append("{\"ok\":true,\"packages\":[");
+            for (var i = 0; i < packages.Length; i++)
+            {
+                if (i > 0) sb.Append(",");
+                var pkg = packages[i];
+                sb.Append("{\"name\":\"").Append(Escape(pkg.name)).Append("\",");
+                sb.Append("\"displayName\":\"").Append(Escape(pkg.displayName)).Append("\",");
+                sb.Append("\"version\":\"").Append(Escape(pkg.version)).Append("\",");
+                sb.Append("\"source\":\"").Append(Escape(pkg.source.ToString())).Append("\",");
+                sb.Append("\"resolvedPath\":\"").Append(Escape(pkg.resolvedPath)).Append("\"}");
+            }
+            sb.Append("]}");
+            return sb.ToString();
+        }
+
+        private static string BuildHierarchyJson(int limit)
+        {
+            var scene = UnityEditor.SceneManagement.EditorSceneManager.GetActiveScene();
+            var roots = scene.GetRootGameObjects();
+            var sb = new StringBuilder();
+            var count = 0;
+            sb.Append("{\"ok\":true,\"scene\":\"").Append(Escape(scene.path)).Append("\",\"objects\":[");
+            for (var i = 0; i < roots.Length && count < limit; i++)
+            {
+                AppendHierarchyObject(sb, roots[i], roots[i].name, ref count, limit);
+            }
+            sb.Append("],\"truncated\":").Append(Bool(count >= limit)).Append("}");
+            return sb.ToString();
+        }
+
+        private static void AppendHierarchyObject(StringBuilder sb, GameObject obj, string path, ref int count, int limit)
+        {
+            if (count >= limit) return;
+            if (count > 0) sb.Append(",");
+            var components = obj.GetComponents<Component>();
+            sb.Append("{\"name\":\"").Append(Escape(obj.name)).Append("\",");
+            sb.Append("\"path\":\"").Append(Escape(path)).Append("\",");
+            sb.Append("\"activeSelf\":").Append(Bool(obj.activeSelf)).Append(",");
+            sb.Append("\"tag\":\"").Append(Escape(obj.tag)).Append("\",");
+            sb.Append("\"layer\":").Append(obj.layer).Append(",");
+            sb.Append("\"components\":[");
+            for (var i = 0; i < components.Length; i++)
+            {
+                if (i > 0) sb.Append(",");
+                sb.Append("\"").Append(Escape(components[i] == null ? "Missing Script" : components[i].GetType().FullName)).Append("\"");
+            }
+            sb.Append("]}");
+            count++;
+            for (var i = 0; i < obj.transform.childCount && count < limit; i++)
+            {
+                var child = obj.transform.GetChild(i).gameObject;
+                AppendHierarchyObject(sb, child, path + "/" + child.name, ref count, limit);
+            }
+        }
+
+        private static string BuildLogsJson(int limit)
+        {
+            BridgeLogEntry[] entries;
+            lock (LogsLock)
+            {
+                var count = Math.Min(Math.Max(limit, 1), RecentLogs.Count);
+                entries = RecentLogs.GetRange(RecentLogs.Count - count, count).ToArray();
+            }
+            var sb = new StringBuilder();
+            sb.Append("{\"ok\":true,\"logs\":[");
+            for (var i = 0; i < entries.Length; i++)
+            {
+                if (i > 0) sb.Append(",");
+                sb.Append(entries[i].ToJson());
+            }
+            sb.Append("]}");
+            return sb.ToString();
+        }
+
+        private static string BuildAssetSearchJson(string body)
+        {
+            var filter = ExtractString(body, "filter");
+            if (string.IsNullOrWhiteSpace(filter))
+            {
+                return "{\"ok\":false,\"error\":\"filter required\"}";
+            }
+            var limit = Math.Min(Math.Max(ExtractInt(body, "limit", 100), 1), 500);
+            var folders = ExtractStringArray(body, "folders");
+            if (folders.Length == 0) folders = new[] { "Assets" };
+            for (var i = 0; i < folders.Length; i++)
+            {
+                if (!folders[i].Replace("\\", "/").StartsWith("Assets", StringComparison.Ordinal))
+                {
+                    return "{\"ok\":false,\"error\":\"folder must be under Assets\"}";
+                }
+            }
+            var guids = AssetDatabase.FindAssets(filter, folders);
+            var sb = new StringBuilder();
+            sb.Append("{\"ok\":true,\"assets\":[");
+            var count = Math.Min(limit, guids.Length);
+            for (var i = 0; i < count; i++)
+            {
+                if (i > 0) sb.Append(",");
+                var path = AssetDatabase.GUIDToAssetPath(guids[i]);
+                sb.Append("{\"guid\":\"").Append(Escape(guids[i])).Append("\",");
+                sb.Append("\"path\":\"").Append(Escape(path)).Append("\",");
+                sb.Append("\"type\":\"").Append(Escape(AssetDatabase.GetMainAssetTypeAtPath(path)?.FullName ?? "")).Append("\"}");
+            }
+            sb.Append("],\"truncated\":").Append(Bool(guids.Length > count)).Append("}");
+            return sb.ToString();
+        }
+
+        private static string BuildAssetInfoJson(string body)
+        {
+            var paths = ExtractStringArray(body, "paths");
+            var includeDependencies = ExtractBool(body, "includeDependencies", false);
+            var sb = new StringBuilder();
+            sb.Append("{\"ok\":true,\"assets\":[");
+            for (var i = 0; i < paths.Length && i < 100; i++)
+            {
+                if (i > 0) sb.Append(",");
+                var path = paths[i].Replace("\\", "/");
+                var main = AssetDatabase.LoadMainAssetAtPath(path);
+                var type = AssetDatabase.GetMainAssetTypeAtPath(path);
+                sb.Append("{\"path\":\"").Append(Escape(path)).Append("\",");
+                sb.Append("\"exists\":").Append(Bool(main != null || AssetDatabase.IsValidFolder(path))).Append(",");
+                sb.Append("\"guid\":\"").Append(Escape(AssetDatabase.AssetPathToGUID(path))).Append("\",");
+                sb.Append("\"type\":\"").Append(Escape(type == null ? "" : type.FullName)).Append("\",");
+                sb.Append("\"labels\":[");
+                var labels = main == null ? new string[0] : AssetDatabase.GetLabels(main);
+                for (var j = 0; j < labels.Length; j++)
+                {
+                    if (j > 0) sb.Append(",");
+                    sb.Append("\"").Append(Escape(labels[j])).Append("\"");
+                }
+                sb.Append("],\"dependencies\":[");
+                var deps = includeDependencies ? AssetDatabase.GetDependencies(path, false) : new string[0];
+                for (var j = 0; j < deps.Length && j < 100; j++)
+                {
+                    if (j > 0) sb.Append(",");
+                    sb.Append("\"").Append(Escape(deps[j])).Append("\"");
+                }
+                sb.Append("]}");
+            }
+            sb.Append("]}");
+            return sb.ToString();
+        }
+
+        private static string BuildMenuPlanJson(string body)
+        {
+            var menuPath = ExtractString(body, "menuPath");
+            var dryRun = ExtractBool(body, "dryRun", true);
+            if (!dryRun)
+            {
+                return "{\"ok\":false,\"error\":\"menu execution is dry-run only in the MVP\",\"blockedAction\":\"menu_execute_live\"}";
+            }
+            return "{"
+                + "\"ok\":true,"
+                + "\"dryRun\":true,"
+                + "\"menuPath\":\"" + Escape(menuPath) + "\","
+                + "\"willExecute\":false,"
+                + "\"blockedActions\":[\"menu_execute_live\",\"sdk_upload\",\"package_import\",\"destructive_project_mutation\"]"
+                + "}";
+        }
+
+        private static string BuildPlanApplyJson(string body)
+        {
+            var operation = ExtractString(body, "operation");
+            var dryRun = ExtractBool(body, "dryRun", true);
+            if (!dryRun)
+            {
+                return "{\"ok\":false,\"error\":\"plan apply is dry-run only in the MVP\",\"blockedAction\":\"plan_apply_live\"}";
+            }
+            return "{"
+                + "\"ok\":true,"
+                + "\"dryRun\":true,"
+                + "\"operation\":\"" + Escape(operation) + "\","
+                + "\"willApply\":false,"
+                + "\"requiresBackup\":true,"
+                + "\"blockedActions\":[\"plan_apply_live\",\"sdk_upload\",\"package_import\",\"destructive_project_mutation\"]"
+                + "}";
+        }
+
+        private static string BuildOperationPlanJson(string body)
+        {
+            var operation = ExtractString(body, "operation");
+            var targetPath = ExtractString(body, "targetPath");
+            var dryRun = ExtractBool(body, "dryRun", true);
+            if (!dryRun)
+            {
+                return "{\"ok\":false,\"error\":\"operation execution is dry-run only in the MVP\",\"blockedAction\":\"operation_execute_live\"}";
+            }
+            if (!string.IsNullOrEmpty(targetPath) && !targetPath.Replace("\\", "/").StartsWith("Assets", StringComparison.Ordinal))
+            {
+                return "{\"ok\":false,\"error\":\"targetPath must be under Assets\",\"blockedAction\":\"path_outside_assets\"}";
+            }
+            return "{"
+                + "\"ok\":true,"
+                + "\"dryRun\":true,"
+                + "\"operation\":\"" + Escape(operation) + "\","
+                + "\"targetPath\":\"" + Escape(targetPath) + "\","
+                + "\"willExecute\":false,"
+                + "\"requiresBackup\":true,"
+                + "\"blockedActions\":[\"operation_execute_live\",\"delete_asset\",\"overwrite_asset\",\"manifest_mutation\",\"sdk_upload\",\"package_import\"]"
+                + "}";
+        }
+
+        private static int ReadLimit(HttpListenerContext context, int fallback)
+        {
+            var raw = context.Request.QueryString["limit"];
+            int parsed;
+            return int.TryParse(raw, out parsed) ? Math.Min(Math.Max(parsed, 1), 500) : fallback;
+        }
+
+        private static string ReadBody(HttpListenerContext context)
+        {
+            if (context.Request.ContentLength64 > MaxRequestBytes) return "";
+            using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding ?? Encoding.UTF8))
+            {
+                var body = reader.ReadToEnd();
+                return body.Length > MaxRequestBytes ? "" : body;
+            }
+        }
+
+        private static void WriteJson(HttpListenerContext context, int status, string json)
+        {
+            var bytes = Encoding.UTF8.GetBytes(json);
+            context.Response.StatusCode = status;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentEncoding = Encoding.UTF8;
+            context.Response.OutputStream.Write(bytes, 0, bytes.Length);
+            context.Response.Close();
+        }
+
+        private static void PumpMainThreadQueue()
+        {
+            while (true)
+            {
+                Action action = null;
+                lock (MainThreadLock)
+                {
+                    if (MainThreadQueue.Count == 0) return;
+                    action = MainThreadQueue.Dequeue();
+                }
+                action();
+            }
+        }
+
+        private static T RunOnMainThread<T>(Func<T> action)
+        {
+            if (Thread.CurrentThread.ManagedThreadId == mainThreadId)
+            {
+                return action();
+            }
+
+            T result = default(T);
+            Exception error = null;
+            using (var done = new ManualResetEvent(false))
+            {
+                lock (MainThreadLock)
+                {
+                    MainThreadQueue.Enqueue(() =>
+                    {
+                        try
+                        {
+                            result = action();
+                        }
+                        catch (Exception ex)
+                        {
+                            error = ex;
+                        }
+                        finally
+                        {
+                            done.Set();
+                        }
+                    });
+                }
+
+                if (!done.WaitOne(5000))
+                {
+                    throw new TimeoutException("Timed out waiting for Unity main thread.");
+                }
+            }
+
+            if (error != null) throw error;
+            return result;
+        }
+
+        private static string SelfTestRequest(string method, string path, string body, bool includeToken, string origin)
+        {
+            var request = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + port + path);
+            request.Method = method;
+            request.Timeout = 5000;
+            request.Proxy = null;
+            request.KeepAlive = false;
+            if (includeToken) request.Headers["X-Hermes-Bridge-Token"] = token;
+            if (!string.IsNullOrEmpty(origin)) request.Headers["Origin"] = origin;
+            if (body != null)
+            {
+                var bytes = Encoding.UTF8.GetBytes(body);
+                request.ContentType = "application/json";
+                request.ContentLength = bytes.Length;
+                using (var stream = request.GetRequestStream())
+                {
+                    stream.Write(bytes, 0, bytes.Length);
+                }
+            }
+            using (var response = (HttpWebResponse)request.GetResponse())
+            using (var reader = new StreamReader(response.GetResponseStream()))
+            {
+                return reader.ReadToEnd();
+            }
+        }
+
+        private static void RequireStatus(string method, string path, string body, bool includeToken, string origin, int status)
+        {
+            try
+            {
+                SelfTestRequest(method, path, body, includeToken, origin);
+            }
+            catch (WebException ex)
+            {
+                var response = ex.Response as HttpWebResponse;
+                if (response != null && (int)response.StatusCode == status) return;
+                throw;
+            }
+            throw new InvalidOperationException("Expected HTTP " + status + " for " + path);
+        }
+
+        private static void RequireContains(string value, string expected)
+        {
+            if (value == null || !value.Contains(expected))
+            {
+                throw new InvalidOperationException("Self-test response missing " + expected);
+            }
+        }
+
+        private static void CaptureLog(string condition, string stackTrace, LogType type)
+        {
+            lock (LogsLock)
+            {
+                RecentLogs.Add(new BridgeLogEntry(condition, stackTrace, type.ToString(), DateTime.UtcNow.ToString("o")));
+                if (RecentLogs.Count > 500) RecentLogs.RemoveRange(0, RecentLogs.Count - 500);
+            }
+        }
+
+        private static string GenerateToken()
+        {
+            var bytes = new byte[32];
+            RandomNumberGenerator.Fill(bytes);
+            return Convert.ToBase64String(bytes);
+        }
+
+        private static void WriteSession()
+        {
+            var project = ProjectPath();
+            var dir = Path.Combine(project, "Library", "HermesUnityBridge");
+            Directory.CreateDirectory(dir);
+            var json = "{"
+                + "\"port\":" + port + ","
+                + "\"token\":\"" + Escape(token) + "\","
+                + "\"projectHash\":\"" + Escape(ProjectHash()) + "\""
+                + "}";
+            File.WriteAllText(Path.Combine(dir, "session.json"), json, Encoding.UTF8);
+        }
+
+        private static string ProjectPath()
+        {
+            return Directory.GetParent(Application.dataPath).FullName;
+        }
+
+        private static string ProjectHash()
+        {
+            return Sha256("sha256:", ProjectPath().Replace("\\", "/").ToLowerInvariant());
+        }
+
+        private static bool IsCurrentProjectTrusted()
+        {
+            var hash = ProjectHash();
+            foreach (var entry in EditorPrefs.GetString(TrustedProjectsKey, "").Split('|'))
+            {
+                if (entry == hash) return true;
+            }
+            return false;
+        }
+
+        private static void TrustCurrentProject()
+        {
+            if (IsCurrentProjectTrusted()) return;
+            var current = EditorPrefs.GetString(TrustedProjectsKey, "");
+            var next = string.IsNullOrEmpty(current) ? ProjectHash() : current + "|" + ProjectHash();
+            EditorPrefs.SetString(TrustedProjectsKey, next);
+        }
+
+        private static void UntrustCurrentProject()
+        {
+            var hash = ProjectHash();
+            var kept = new List<string>();
+            foreach (var entry in EditorPrefs.GetString(TrustedProjectsKey, "").Split('|'))
+            {
+                if (!string.IsNullOrEmpty(entry) && entry != hash) kept.Add(entry);
+            }
+            EditorPrefs.SetString(TrustedProjectsKey, string.Join("|", kept.ToArray()));
+            AutoStartForCurrentProject = false;
+        }
+
+        private static bool AutoStartForCurrentProject
+        {
+            get { return EditorPrefs.GetBool(AutoStartPrefix + ProjectHash(), false); }
+            set { EditorPrefs.SetBool(AutoStartPrefix + ProjectHash(), value); }
+        }
+
+        private static string Sha256(string prefix, string text)
+        {
+            using (var sha = SHA256.Create())
+            {
+                var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(text));
+                var sb = new StringBuilder(prefix);
+                foreach (var b in bytes) sb.Append(b.ToString("x2"));
+                return sb.ToString();
+            }
+        }
+
+        private static string ExtractString(string json, string key)
+        {
+            var match = Regex.Match(json ?? "", "\"" + Regex.Escape(key) + "\"\\s*:\\s*\"((?:\\\\.|[^\"])*)\"");
+            return match.Success ? Unescape(match.Groups[1].Value) : "";
+        }
+
+        private static int ExtractInt(string json, string key, int fallback)
+        {
+            var match = Regex.Match(json ?? "", "\"" + Regex.Escape(key) + "\"\\s*:\\s*(\\d+)");
+            int parsed;
+            return match.Success && int.TryParse(match.Groups[1].Value, out parsed) ? parsed : fallback;
+        }
+
+        private static bool ExtractBool(string json, string key, bool fallback)
+        {
+            var match = Regex.Match(json ?? "", "\"" + Regex.Escape(key) + "\"\\s*:\\s*(true|false)", RegexOptions.IgnoreCase);
+            return match.Success ? string.Equals(match.Groups[1].Value, "true", StringComparison.OrdinalIgnoreCase) : fallback;
+        }
+
+        private static string[] ExtractStringArray(string json, string key)
+        {
+            var match = Regex.Match(json ?? "", "\"" + Regex.Escape(key) + "\"\\s*:\\s*\\[(.*?)\\]", RegexOptions.Singleline);
+            if (!match.Success) return new string[0];
+            var values = new List<string>();
+            foreach (Match item in Regex.Matches(match.Groups[1].Value, "\"((?:\\\\.|[^\"])*)\""))
+            {
+                values.Add(Unescape(item.Groups[1].Value));
+            }
+            return values.ToArray();
+        }
+
+        private static string Unescape(string value)
+        {
+            return (value ?? "").Replace("\\\"", "\"").Replace("\\\\", "\\");
+        }
+
+        private static string Escape(string value)
+        {
+            return (value ?? "").Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", "\\r").Replace("\n", "\\n");
+        }
+
+        private static string Bool(bool value)
+        {
+            return value ? "true" : "false";
+        }
+
+        private sealed class BridgeLogEntry
+        {
+            private readonly string condition;
+            private readonly string stackTrace;
+            private readonly string type;
+            private readonly string timeUtc;
+
+            public BridgeLogEntry(string condition, string stackTrace, string type, string timeUtc)
+            {
+                this.condition = condition;
+                this.stackTrace = stackTrace;
+                this.type = type;
+                this.timeUtc = timeUtc;
+            }
+
+            public string ToJson()
+            {
+                return "{"
+                    + "\"timeUtc\":\"" + Escape(timeUtc) + "\","
+                    + "\"type\":\"" + Escape(type) + "\","
+                    + "\"message\":\"" + Escape(condition) + "\","
+                    + "\"stackTrace\":\"" + Escape(stackTrace) + "\""
+                    + "}";
+            }
+        }
+    }
+}
+#endif

--- a/plugins/unity_vrchat_bridge/unity_package/Packages/com.hermes.unity-vrchat-bridge/package.json
+++ b/plugins/unity_vrchat_bridge/unity_package/Packages/com.hermes.unity-vrchat-bridge/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "com.hermes.unity-vrchat-bridge",
+  "version": "0.1.0",
+  "displayName": "Hermes Unity VRChat Bridge",
+  "description": "Localhost Unity Editor bridge for Hermes VRChat-first diagnostics.",
+  "unity": "2022.3",
+  "author": {
+    "name": "Hermes local plugin"
+  }
+}

--- a/tests/plugins/unity_vrchat_bridge/test_core.py
+++ b/tests/plugins/unity_vrchat_bridge/test_core.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import json
+import tarfile
+import threading
+import zipfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from plugins import unity_vrchat_bridge
+from plugins.unity_vrchat_bridge import core
+
+
+def make_unity_project(root: Path, unity_version: str = "2022.3.22f1") -> Path:
+    (root / "Assets").mkdir(parents=True)
+    (root / "ProjectSettings").mkdir()
+    (root / "Packages").mkdir()
+    (root / "ProjectSettings" / "ProjectVersion.txt").write_text(
+        f"m_EditorVersion: {unity_version}\n",
+        encoding="utf-8",
+    )
+    (root / "Packages" / "manifest.json").write_text(
+        json.dumps(
+            {
+                "dependencies": {
+                    "com.vrchat.base": "3.10.4",
+                    "com.vrchat.avatars": "3.10.4",
+                    "jp.lilxyzw.liltoon": "1.9.0",
+                    "nadena.dev.modular-avatar": "1.12.0",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "vpm-manifest.json").write_text(
+        json.dumps(
+            {
+                "locked": {
+                    "com.vrchat.avatars": {"version": "3.10.4"},
+                    "jp.lilxyzw.liltoon": {"version": "1.9.0"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_project_profile_detects_vrchat_avatar_project(tmp_path: Path) -> None:
+    project = make_unity_project(tmp_path / "AvatarProject")
+
+    profile = core.project_profile(str(project))
+
+    assert profile["ok"] is True
+    assert profile["unity_project"] is True
+    assert profile["vrchat_project_kind"] == "avatar"
+    assert profile["vrchat_unity_version_match"] is True
+    assert {pkg["id"] for pkg in profile["detected_packages"]} >= {
+        "com.vrchat.avatars",
+        "jp.lilxyzw.liltoon",
+        "nadena.dev.modular-avatar",
+    }
+
+
+def test_vrchat_project_health_blocks_upload_and_import(tmp_path: Path) -> None:
+    project = make_unity_project(tmp_path / "AvatarProject", unity_version="2021.3.1f1")
+
+    health = core.vrchat_project_health(str(project))
+
+    assert "sdk_upload" in health["blocked_actions"]
+    assert "package_import" in health["blocked_actions"]
+    assert health["dry_run_required"] is True
+    assert any("expected 2022.3.22f1" in warning for warning in health["warnings"])
+
+
+def test_plugin_register_exposes_plan_apply_tool() -> None:
+    calls: dict[str, list[str]] = {"tools": [], "commands": [], "cli": []}
+
+    class Context:
+        def register_tool(self, **kwargs: object) -> None:
+            calls["tools"].append(str(kwargs["name"]))
+
+        def register_command(self, name: str, **_: object) -> None:
+            calls["commands"].append(name)
+
+        def register_cli_command(self, name: str, **_: object) -> None:
+            calls["cli"].append(name)
+
+    unity_vrchat_bridge.register(Context())
+
+    assert "unity_bridge_plan_apply" in calls["tools"]
+    assert "unity_bridge_operation_plan" in calls["tools"]
+    assert "unity_bridge_asset_info" in calls["tools"]
+    assert "unity_bridge_scene_hierarchy" in calls["tools"]
+    assert "unity-vrchat-bridge" in calls["commands"]
+    assert "unity-vrchat-bridge" in calls["cli"]
+
+
+def test_bridge_health_reports_missing_session(tmp_path: Path) -> None:
+    project = make_unity_project(tmp_path / "AvatarProject")
+
+    payload = json.loads(core.handle_health({"project_path": str(project)}))
+
+    assert payload["ok"] is False
+    assert "session" in payload["error"]
+
+
+def test_menu_execute_rejects_live_before_http(tmp_path: Path) -> None:
+    project = make_unity_project(tmp_path / "AvatarProject")
+
+    payload = json.loads(
+        core.handle_menu_execute(
+            {
+                "project_path": str(project),
+                "menu_path": "VRChat SDK/Show Control Panel",
+                "dry_run": False,
+            }
+        )
+    )
+
+    assert payload["ok"] is False
+    assert payload["blocked_action"] == "menu_execute_live"
+
+
+def test_plan_apply_rejects_live_before_http(tmp_path: Path) -> None:
+    project = make_unity_project(tmp_path / "AvatarProject")
+
+    payload = json.loads(
+        core.handle_plan_apply(
+            {
+                "project_path": str(project),
+                "operation": "avatar_preflight",
+                "dry_run": False,
+            }
+        )
+    )
+
+    assert payload["ok"] is False
+    assert payload["blocked_action"] == "plan_apply_live"
+
+
+def test_asset_search_posts_json_to_bridge(tmp_path: Path) -> None:
+    project = make_unity_project(tmp_path / "AvatarProject")
+    seen: dict[str, object] = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            seen["path"] = self.path
+            seen["token"] = self.headers.get("X-Hermes-Bridge-Token")
+            size = int(self.headers.get("Content-Length") or "0")
+            seen["body"] = json.loads(self.rfile.read(size).decode("utf-8"))
+            data = b'{"ok":true,"assets":[{"path":"Assets/A.prefab"}],"truncated":false}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        session_dir = project / "Library" / "HermesUnityBridge"
+        session_dir.mkdir(parents=True)
+        (session_dir / "session.json").write_text(
+            json.dumps(
+                {
+                    "port": server.server_port,
+                    "token": "secret",
+                    "projectHash": core._project_hash(project),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        payload = json.loads(
+            core.handle_asset_search(
+                {
+                    "project_path": str(project),
+                    "filter": "t:Prefab",
+                    "folders": ["Assets"],
+                    "limit": 7,
+                }
+            )
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert payload["ok"] is True
+    assert seen["path"] == "/assets/search"
+    assert seen["token"] == "secret"
+    assert seen["body"] == {"filter": "t:Prefab", "folders": ["Assets"], "limit": 7}
+
+
+def test_asset_info_posts_paths_to_bridge(tmp_path: Path) -> None:
+    project = make_unity_project(tmp_path / "AvatarProject")
+    seen: dict[str, object] = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            seen["path"] = self.path
+            size = int(self.headers.get("Content-Length") or "0")
+            seen["body"] = json.loads(self.rfile.read(size).decode("utf-8"))
+            data = b'{"ok":true,"assets":[{"path":"Assets/A.prefab","exists":true}]}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        session_dir = project / "Library" / "HermesUnityBridge"
+        session_dir.mkdir(parents=True)
+        (session_dir / "session.json").write_text(
+            json.dumps(
+                {
+                    "port": server.server_port,
+                    "token": "secret",
+                    "projectHash": core._project_hash(project),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        payload = json.loads(
+            core.handle_asset_info(
+                {
+                    "project_path": str(project),
+                    "paths": ["Assets/A.prefab"],
+                    "include_dependencies": True,
+                }
+            )
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert payload["ok"] is True
+    assert seen["path"] == "/assets/info"
+    assert seen["body"] == {"paths": ["Assets/A.prefab"], "includeDependencies": True}
+
+
+def test_operation_plan_rejects_live_before_http(tmp_path: Path) -> None:
+    project = make_unity_project(tmp_path / "AvatarProject")
+
+    payload = json.loads(
+        core.handle_operation_plan(
+            {
+                "project_path": str(project),
+                "operation": "asset_create",
+                "target_path": "Assets/New.asset",
+                "dry_run": False,
+            }
+        )
+    )
+
+    assert payload["ok"] is False
+    assert payload["blocked_action"] == "operation_execute_live"
+
+
+def test_plan_apply_posts_dry_run_to_bridge(tmp_path: Path) -> None:
+    project = make_unity_project(tmp_path / "AvatarProject")
+    seen: dict[str, object] = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            seen["path"] = self.path
+            seen["token"] = self.headers.get("X-Hermes-Bridge-Token")
+            size = int(self.headers.get("Content-Length") or "0")
+            seen["body"] = json.loads(self.rfile.read(size).decode("utf-8"))
+            data = b'{"ok":true,"dryRun":true,"willApply":false}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        session_dir = project / "Library" / "HermesUnityBridge"
+        session_dir.mkdir(parents=True)
+        (session_dir / "session.json").write_text(
+            json.dumps(
+                {
+                    "port": server.server_port,
+                    "token": "secret",
+                    "projectHash": core._project_hash(project),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        payload = json.loads(
+            core.handle_plan_apply(
+                {
+                    "project_path": str(project),
+                    "operation": "avatar_preflight",
+                }
+            )
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert payload["ok"] is True
+    assert payload["willApply"] is False
+    assert seen["path"] == "/plan/apply"
+    assert seen["token"] == "secret"
+    assert seen["body"] == {"operation": "avatar_preflight", "dryRun": True}
+
+
+def test_commercial_asset_zip_inspection_is_read_only(tmp_path: Path) -> None:
+    project = make_unity_project(tmp_path / "AvatarProject")
+    archive = tmp_path / "booth_avatar.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("Avatar/README.txt", "local terms")
+        zf.writestr("Avatar/Materials/body_liltoon.mat", "%YAML")
+        zf.writestr("Avatar/Prefab/avatar.prefab", "%YAML")
+
+    payload = core.inspect_commercial_asset_archive(str(archive), str(project))
+
+    assert payload["ok"] is True
+    assert payload["archive_type"] == "zip"
+    assert payload["will_modify_files"] is False
+    assert "automatic_import" in payload["blocked_actions"]
+    assert payload["kinds"]["prefab"] == 1
+    assert any(dep["name"] == "lilToon" and dep["status"] == "installed" for dep in payload["dependencies"])
+
+
+def test_commercial_asset_unitypackage_without_meta_warns(tmp_path: Path) -> None:
+    archive = tmp_path / "outfit.unitypackage"
+    payload_file = tmp_path / "asset"
+    payload_file.write_text("payload", encoding="utf-8")
+    with tarfile.open(archive, "w") as tf:
+        tf.add(payload_file, arcname="guid/asset")
+        tf.add(payload_file, arcname="guid/pathname")
+
+    payload = core.inspect_commercial_asset_archive(str(archive))
+
+    assert payload["ok"] is True
+    assert payload["archive_type"] == "unitypackage"
+    assert any(".meta" in risk for risk in payload["risks"])


### PR DESCRIPTION
﻿## Summary

Adds a Unity Editor bridge as a Hermes plugin, with a Unity package that exposes local, token-gated Editor state over a loopback-only HTTP bridge. The bridge is intended for Unity workflows with VRChat-oriented health checks first, while keeping the surface general enough for ordinary Unity project inspection and dry-run planning.

The implementation adds:

- a `unity_vrchat_bridge` plugin toolset and CLI command family
- a Unity Editor package under `unity_package/Packages/com.hermes.unity-vrchat-bridge`
- local trust, token, origin, and request-size gates for the Editor bridge
- read-only project, scene, asset, package, selection, console, and capability inspection
- dry-run-only menu execution and operation/plan apply endpoints in this initial version
- VRChat/VPM project health checks and read-only commercial archive inspection
- Python coverage for bridge state handling, health analysis, archive inspection, and blocked mutating paths

## Safety and scope

This is plugin-only and does not add a core model tool. The Unity package binds only to `127.0.0.1`, requires a per-session token, and requires explicit project trust before serving requests. Mutating Unity operations are intentionally blocked unless they are dry-run checks, so the initial contribution is inspection and planning oriented.

Commercial asset inspection is read-only. It inventories `.zip` and `.unitypackage` archives without extracting, importing, or redistributing their contents.

No local `_docs` files or unrelated custom features are included in this PR.

## Validation

- `py -3 -m pytest tests\plugins\unity_vrchat_bridge\test_core.py -q` -> 12 passed
- `py -3 -m ruff check plugins\unity_vrchat_bridge tests\plugins\unity_vrchat_bridge` -> passed
- `py -3 -m compileall -q plugins\unity_vrchat_bridge` -> passed
- Unity 2022.3.22f1 batch self-test -> `HERMES_UNITY_VRCHAT_BRIDGE_SELFTEST_OK`, `UNITY_EXIT=0`, `UNITY_LOG_NO_REAL_ERRORS`

## Compatibility note

The bridge uses standard Unity Editor APIs and was validated locally on Unity 2022.3.22f1. I do not have a paid Unity seat for separate Pro/Enterprise validation, so the PR avoids paid-plan-only APIs and keeps the bridge behavior license-neutral.