### PR TITLE
test: bedrock EU-region fallback + sessions pagination total

### DIFF
--- a/tests/hermes_cli/test_bedrock_model_picker.py
+++ b/tests/hermes_cli/test_bedrock_model_picker.py
@@ -280,9 +280,15 @@ class TestBedrockRegionRouting:
     """End-to-end: region from botocore profile is used for discovery, so EU/AP
     users get eu.*/ap.* model IDs rather than the hardcoded us-east-1 list."""
 
-    def test_eu_region_from_botocore_profile_yields_eu_models(self):
+    def test_eu_region_from_botocore_profile_yields_eu_models(self, monkeypatch):
         """When botocore resolves eu-central-1, picker shows eu.* model IDs."""
         from hermes_cli.model_switch import list_authenticated_providers
+
+        # The code intentionally gives AWS_REGION/AWS_DEFAULT_REGION priority
+        # over botocore profile config.  Clear host-level AWS region variables
+        # so this test actually exercises the botocore-profile fallback path.
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
 
         mock_session = MagicMock()
         mock_session.get_config_variable.return_value = "eu-central-1"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -483,6 +483,34 @@ class TestWebServerEndpoints:
         assert config["dashboard"]["theme"] == "ember"
         assert config["dashboard"]["font"] == "jetbrains-mono"
 
+    def test_get_sessions_total_matches_visible_default_rows(self):
+        """Pagination total must count rows the endpoint can actually return.
+
+        Child delegate sessions are intentionally hidden from the default
+        list_sessions_rich view. If /api/sessions reports the raw session table
+        count instead, the frontend enables phantom pages whose offsets return
+        no rows.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("root", "cli")
+            db.append_message("root", "user", "root request")
+            for i in range(25):
+                sid = f"delegate-{i}"
+                db.create_session(sid, "cli", parent_session_id="root")
+                db.append_message(sid, "user", f"delegate request {i}")
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions?limit=20&offset=0")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert [s["id"] for s in data["sessions"]] == ["root"]
+        assert data["total"] == 1
+
     def test_get_sessions_uses_only_persisted_cwd(self, monkeypatch):
         """Session rows without persisted cwd must not inherit TERMINAL_CWD.
 


### PR DESCRIPTION
Two test-only additions covering behavior already present on main: a bedrock EU-region botocore-profile fallback test (clears AWS_REGION/AWS_DEFAULT_REGION to exercise the fallback) and a sessions-pagination total test (asserts /api/sessions total counts only visible rows, not hidden child delegate sessions). No source changes.
---

### ℹ️ Note on `tests/hermes_cli/test_web_server.py` failures (pre-existing upstream)

6 tests in `test_web_server.py` (cron-blueprints / desktop-ticker) FAIL on a **pristine
v0.17.0 checkout with ZERO PRs applied** — they are pre-existing upstream failures
(a `cron.scheduler` module-resolution issue + one timing-flaky test), NOT introduced by
this PR. Evidence: `#50111:verification/pristine-v017-web_server-FAILURES.log`. This PR's
OWN tests pass. Do not treat these as a regression from this PR.
