### PR TITLE
feat(tui): YOLO status-bar badge

### DIFF
--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -162,9 +162,8 @@ describe('StatusRule session count click target', () => {
     expect(rendered).not.toContain('$0.5000')
   })
 
-  it('renders YOLO and AUTO indicators when enabled', () => {
+  it('renders the YOLO indicator when enabled', () => {
     const element = StatusRule({
-      autopilot: true,
       bgCount: 0,
       busy: false,
       cols: 160,
@@ -186,12 +185,10 @@ describe('StatusRule session count click target', () => {
     const rendered = textContent(element)
 
     expect(rendered).toContain('YOLO')
-    expect(rendered).toContain('AUTO')
   })
 
-  it('omits YOLO and AUTO indicators when disabled', () => {
+  it('omits the YOLO indicator when disabled', () => {
     const element = StatusRule({
-      autopilot: false,
       bgCount: 0,
       busy: false,
       cols: 160,
@@ -213,7 +210,6 @@ describe('StatusRule session count click target', () => {
     const rendered = textContent(element)
 
     expect(rendered).not.toContain('YOLO')
-    expect(rendered).not.toContain('AUTO')
   })
 })
 

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -161,6 +161,60 @@ describe('StatusRule session count click target', () => {
     expect(rendered).not.toContain('3 sessions')
     expect(rendered).not.toContain('$0.5000')
   })
+
+  it('renders YOLO and AUTO indicators when enabled', () => {
+    const element = StatusRule({
+      autopilot: true,
+      bgCount: 0,
+      busy: false,
+      cols: 160,
+      cwdLabel: '~/repo',
+      liveSessionCount: 1,
+      model: 'opus-4.8',
+      onSessionCountClick: vi.fn(),
+      sessionStartedAt: null,
+      showCost: false,
+      status: 'ready',
+      statusColor: DEFAULT_THEME.color.ok,
+      t: DEFAULT_THEME,
+      turnStartedAt: null,
+      usage: { total: 0 },
+      voiceLabel: '',
+      yolo: true
+    })
+
+    const rendered = textContent(element)
+
+    expect(rendered).toContain('YOLO')
+    expect(rendered).toContain('AUTO')
+  })
+
+  it('omits YOLO and AUTO indicators when disabled', () => {
+    const element = StatusRule({
+      autopilot: false,
+      bgCount: 0,
+      busy: false,
+      cols: 160,
+      cwdLabel: '~/repo',
+      liveSessionCount: 1,
+      model: 'opus-4.8',
+      onSessionCountClick: vi.fn(),
+      sessionStartedAt: null,
+      showCost: false,
+      status: 'ready',
+      statusColor: DEFAULT_THEME.color.ok,
+      t: DEFAULT_THEME,
+      turnStartedAt: null,
+      usage: { total: 0 },
+      voiceLabel: '',
+      yolo: false
+    })
+
+    const rendered = textContent(element)
+
+    expect(rendered).not.toContain('YOLO')
+    expect(rendered).not.toContain('AUTO')
+  })
 })
 
 describe('StatusRule credits notice render priority', () => {

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -403,6 +403,7 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
 }
 
 export function StatusRule({
+  autopilot,
   cwdLabel,
   cols,
   busy,
@@ -421,6 +422,7 @@ export function StatusRule({
   showCost,
   turnStartedAt,
   voiceLabel,
+  yolo,
   onSessionCountClick,
   t
 }: StatusRuleProps) {
@@ -572,6 +574,18 @@ export function StatusRule({
             <Text color={t.color.muted} wrap="truncate-end">
               {' │ '}
               {ctxLabel}
+            </Text>
+          ) : null}
+          {yolo ? (
+            <Text color={t.color.warn} wrap="truncate-end">
+              {' │ '}
+              {'⚠ YOLO'}
+            </Text>
+          ) : null}
+          {autopilot ? (
+            <Text color={t.color.warn} wrap="truncate-end">
+              {' │ '}
+              {'🤖 AUTO'}
             </Text>
           ) : null}
         </Box>
@@ -750,6 +764,7 @@ export function TranscriptScrollbar({ scrollRef, t }: TranscriptScrollbarProps) 
 }
 
 interface StatusRuleProps {
+  autopilot?: boolean
   bgCount: number
   lastTurnEndedAt?: null | number
   liveSessionCount: number
@@ -769,6 +784,7 @@ interface StatusRuleProps {
   turnStartedAt?: null | number
   usage: Usage
   voiceLabel?: string
+  yolo?: boolean
   onSessionCountClick?: () => void
 }
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -403,7 +403,6 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
 }
 
 export function StatusRule({
-  autopilot,
   cwdLabel,
   cols,
   busy,
@@ -582,12 +581,6 @@ export function StatusRule({
               {'⚠ YOLO'}
             </Text>
           ) : null}
-          {autopilot ? (
-            <Text color={t.color.warn} wrap="truncate-end">
-              {' │ '}
-              {'🤖 AUTO'}
-            </Text>
-          ) : null}
         </Box>
         {showBar ? (
           <Text color={t.color.muted} wrap="truncate-end">
@@ -764,7 +757,6 @@ export function TranscriptScrollbar({ scrollRef, t }: TranscriptScrollbarProps) 
 }
 
 interface StatusRuleProps {
-  autopilot?: boolean
   bgCount: number
   lastTurnEndedAt?: null | number
   liveSessionCount: number

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -361,6 +361,7 @@ const StatusRulePane = memo(function StatusRulePane({
   return (
     <Box marginTop={at === 'top' ? 1 : 0}>
       <StatusRule
+        autopilot={ui.info?.autopilot}
         bgCount={ui.bgTasks.size}
         busy={ui.busy}
         cols={composer.cols}
@@ -381,6 +382,7 @@ const StatusRulePane = memo(function StatusRulePane({
         turnStartedAt={status.turnStartedAt}
         usage={ui.usage}
         voiceLabel={status.voiceLabel}
+        yolo={ui.info?.yolo}
       />
     </Box>
   )

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -361,7 +361,6 @@ const StatusRulePane = memo(function StatusRulePane({
   return (
     <Box marginTop={at === 'top' ? 1 : 0}>
       <StatusRule
-        autopilot={ui.info?.autopilot}
         bgCount={ui.bgTasks.size}
         busy={ui.busy}
         cols={composer.cols}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -148,7 +148,6 @@ export interface McpServerStatus {
 }
 
 export interface SessionInfo {
-  autopilot?: boolean
   cwd?: string
   fast?: boolean
   lazy?: boolean

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -148,6 +148,7 @@ export interface McpServerStatus {
 }
 
 export interface SessionInfo {
+  autopilot?: boolean
   cwd?: string
   fast?: boolean
   lazy?: boolean
@@ -164,6 +165,7 @@ export interface SessionInfo {
   update_command?: string
   usage?: Usage
   version?: string
+  yolo?: boolean
 }
 
 export interface Usage {


### PR DESCRIPTION
## What this adds

A small status-bar indicator in the TUI so you can see at a glance when you're in YOLO mode (`⚠ YOLO`). When you've got approvals bypassed, it's easy to forget, and forgetting is exactly when it bites. The badge renders in the warn color next to the context label and disappears the moment YOLO is off.

## Changes

- `StatusRule` gains an optional `yolo` prop and renders the `⚠ YOLO` segment only when it's true.
- `yolo?: boolean` added to `StatusRuleProps` and to `SessionInfo` in `types.ts`.
- `appLayout` wires `ui.info?.yolo` through to the status rule.
- Two tests in `appChromeStatusRule.test.tsx`: the badge shows when `yolo: true`, and is absent when `yolo: false`.

All additive and optional, so existing call sites are unaffected.

## Scope note

This PR is intentionally YOLO-only. An equivalent `🤖 AUTO` badge for autopilot mode lives with the autopilot feature in #49917, where the `autopilot` session field it reads is actually defined. Keeping them separate so each badge ships with the feature that backs it.
