### PR TITLE
fix(tui): gracefully shut down MCP servers on exit

### DIFF
--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -252,6 +252,41 @@ def test_main_top_level_tui_accepts_toolsets(monkeypatch, main_mod):
     assert captured == {"toolsets": "web,terminal", "tui": True}
 
 
+def test_prepare_agent_startup_top_level_tui_skips_mcp_discovery(monkeypatch, main_mod):
+    calls = {"hooks": 0, "mcp": 0, "plugins": 0}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(
+            discover_plugins=lambda: calls.__setitem__("plugins", calls["plugins"] + 1)
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(
+            discover_mcp_tools=lambda: calls.__setitem__("mcp", calls["mcp"] + 1)
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(
+            register_from_config=lambda _cfg, accept_hooks=False: calls.__setitem__(
+                "hooks", calls["hooks"] + 1
+            )
+        ),
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+
+    main_mod._prepare_agent_startup(
+        Namespace(command=None, tui=True, accept_hooks=False)
+    )
+
+    assert calls == {"hooks": 1, "mcp": 0, "plugins": 1}
+
+
 def test_termux_fast_tui_launch_uses_light_parser(monkeypatch, main_mod):
     captured = {}
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1684,6 +1684,41 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_shutdown_for_exit_shuts_down_sessions_before_mcp(monkeypatch):
+    events = []
+
+    class _FakeWorker:
+        def close(self):
+            events.append("worker")
+
+    fake_mcp = types.ModuleType("tools.mcp_tool")
+    fake_mcp.shutdown_mcp_servers = lambda: events.append("mcp")
+    monkeypatch.setitem(sys.modules, "tools.mcp_tool", fake_mcp)
+    monkeypatch.setattr(server, "_sessions_shutdown_done", False)
+    monkeypatch.setattr(server, "_mcp_shutdown_done", False)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(
+        server,
+        "_notify_session_boundary",
+        lambda hook, session_id: events.append(f"hook:{hook}:{session_id}"),
+    )
+
+    server._sessions["shutdown-sid"] = _session(
+        session_key="shutdown-sid",
+        slash_worker=_FakeWorker(),
+    )
+
+    try:
+        server._shutdown_for_exit()
+        server._shutdown_for_exit()
+    finally:
+        server._sessions.pop("shutdown-sid", None)
+        server._sessions_shutdown_done = False
+        server._mcp_shutdown_done = False
+
+    assert events == ["hook:on_session_finalize:shutdown-sid", "worker", "mcp"]
+
+
 def test_ws_orphan_reap_closes_worker_when_session_stays_detached(monkeypatch):
     """A detached WS session past its grace window has its slash_worker closed.
 

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -50,13 +50,12 @@ def _install_sidecar_publisher() -> None:
 
 # How long to wait for orderly shutdown (atexit + finalisers) before
 # falling back to ``os._exit(0)`` so a wedged worker mid-flush can't
-# strand the process.  1s covers the gateway's own shutdown work
-# (thread-pool drain + session finalize) on every machine we've
-# tested; override via ``HERMES_TUI_GATEWAY_SHUTDOWN_GRACE_S`` if a
-# slower environment needs more headroom (e.g. encrypted disks
-# flushing checkpoints) and accept that a longer grace also means a
-# longer wait when shutdown actually deadlocks.
-_DEFAULT_SHUTDOWN_GRACE_S = 1.0
+# strand the process.  MCP stdio children such as lark-mcp and NotebookLM
+# can need a few seconds to receive EOF/SIGTERM and exit cleanly, so keep
+# the default long enough for normal sidecar shutdown before the hard-exit
+# safety net fires. Override via ``HERMES_TUI_GATEWAY_SHUTDOWN_GRACE_S`` if
+# a slower environment needs more headroom.
+_DEFAULT_SHUTDOWN_GRACE_S = 25.0
 
 
 def _shutdown_grace_seconds() -> float:
@@ -129,6 +128,11 @@ def _log_signal(signum: int, frame) -> None:
     timer = _threading.Timer(_shutdown_grace_seconds(), _hard_exit)
     timer.daemon = True
     timer.start()
+
+    try:
+        server._shutdown_for_exit()
+    except Exception:
+        pass
 
     try:
         sys.exit(0)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -127,6 +127,8 @@ _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}
 _answers: dict[str, str] = {}
+_sessions_shutdown_done = False
+_mcp_shutdown_done = False
 _db = None
 _db_error: str | None = None
 _stdout_lock = threading.Lock()
@@ -575,10 +577,32 @@ def _close_sessions_for_transport(
 
 
 def _shutdown_sessions() -> None:
+    global _sessions_shutdown_done
+    if _sessions_shutdown_done:
+        return
+    _sessions_shutdown_done = True
     with _sessions_lock:
         sids = list(_sessions)
     for sid in sids:
         _close_session_by_id(sid, end_reason="tui_shutdown")
+
+
+def _shutdown_mcp_servers() -> None:
+    global _mcp_shutdown_done
+    if _mcp_shutdown_done:
+        return
+    _mcp_shutdown_done = True
+    try:
+        from tools.mcp_tool import shutdown_mcp_servers
+
+        shutdown_mcp_servers()
+    except Exception:
+        logger.debug("MCP shutdown failed during TUI gateway exit", exc_info=True)
+
+
+def _shutdown_for_exit() -> None:
+    _shutdown_sessions()
+    _shutdown_mcp_servers()
 
 
 # Last-resort net for any disconnect path that slips past the WS finally. TTL is
@@ -637,6 +661,7 @@ def _start_idle_reaper() -> None:
     threading.Thread(target=_loop, daemon=True).start()
 
 
+atexit.register(_shutdown_mcp_servers)
 atexit.register(_shutdown_sessions)
 _start_idle_reaper()
 

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -16,6 +16,8 @@ const MAX_BUFFERED_EVENTS = 2000
 const MAX_LOG_PREVIEW = 240
 const STARTUP_TIMEOUT_MS = Math.max(5000, parseInt(process.env.HERMES_TUI_STARTUP_TIMEOUT_MS ?? '15000', 10) || 15000)
 const REQUEST_TIMEOUT_MS = Math.max(30000, parseInt(process.env.HERMES_TUI_RPC_TIMEOUT_MS ?? '120000', 10) || 120000)
+const SHUTDOWN_GRACE_MS = Math.max(1000, parseInt(process.env.HERMES_TUI_SHUTDOWN_GRACE_MS ?? '8000', 10) || 8000)
+const SHUTDOWN_KILL_GRACE_MS = Math.max(1000, parseInt(process.env.HERMES_TUI_SHUTDOWN_KILL_GRACE_MS ?? '30000', 10) || 30000)
 const WS_CONNECTING = 0
 const WS_OPEN = 1
 const WS_CLOSING = 2
@@ -510,6 +512,48 @@ export class GatewayClient extends EventEmitter {
     }
   }
 
+  private stopProcess(reason = 'requested') {
+    const proc = this.proc
+
+    if (!proc || proc.exitCode !== null || proc.signalCode !== null) {
+      this.pushLog(`[lifecycle] stopProcess reason=${reason} ${describeChild(proc)} stopResult=none`)
+      return false
+    }
+
+    this.pushLog(`[lifecycle] stopProcess reason=${reason} ${describeChild(proc)} stopResult=stdin-close`)
+
+    try {
+      proc.stdin?.end()
+    } catch (e) {
+      this.pushLog(`[lifecycle] stdin close failed during ${reason}: ${e instanceof Error ? e.message : String(e)}`)
+    }
+
+    const termTimer = setTimeout(() => {
+      if (proc.exitCode === null && proc.signalCode === null) {
+        this.pushLog(`[lifecycle] stopProcess reason=${reason} ${describeChild(proc)} stopResult=SIGTERM`)
+        proc.kill('SIGTERM')
+      }
+    }, SHUTDOWN_GRACE_MS)
+
+    termTimer.unref?.()
+
+    const killTimer = setTimeout(() => {
+      if (proc.exitCode === null && proc.signalCode === null) {
+        this.pushLog(`[lifecycle] stopProcess reason=${reason} ${describeChild(proc)} stopResult=SIGKILL`)
+        proc.kill('SIGKILL')
+      }
+    }, SHUTDOWN_GRACE_MS + SHUTDOWN_KILL_GRACE_MS)
+
+    killTimer.unref?.()
+
+    proc.once('exit', () => {
+      clearTimeout(termTimer)
+      clearTimeout(killTimer)
+    })
+
+    return true
+  }
+
   start() {
     const root = process.env.HERMES_PYTHON_SRC_ROOT ?? resolve(import.meta.dirname, '../../')
     const attachUrl = resolveGatewayAttachUrl()
@@ -519,9 +563,9 @@ export class GatewayClient extends EventEmitter {
     this.sidecarUrl = sidecarUrl
     this.resetStartupState()
 
-    if (this.proc && !this.proc.killed && this.proc.exitCode === null) {
+    if (this.proc && this.proc.exitCode === null && this.proc.signalCode === null) {
       this.lifecycle(`[lifecycle] replacing live gateway child ${describeChild(this.proc)}`)
-      this.proc.kill()
+      this.stopProcess('replace')
     }
 
     this.proc = null
@@ -736,9 +780,9 @@ export class GatewayClient extends EventEmitter {
 
   kill(reason = 'requested') {
     const proc = this.proc
-    const killed = proc?.kill()
+    const stopped = this.stopProcess(reason)
 
-    this.lifecycle(`[lifecycle] GatewayClient.kill reason=${reason} ${describeChild(proc)} killResult=${killed ?? 'none'}`)
+    this.pushLog(`[lifecycle] GatewayClient.kill reason=${reason} ${describeChild(proc)} stopResult=${stopped ? 'requested' : 'none'}`)
     this.closeGatewaySocket()
     this.closeSidecarSocket()
     this.clearReadyTimer()


### PR DESCRIPTION
## Summary

Gracefully shut down TUI gateway-owned MCP servers when the TUI exits.

This keeps the TUI sidecar teardown order explicit:

- finalize TUI sessions first
- close slash workers through the session finalize path
- then call `shutdown_mcp_servers()` so stdio MCP children receive normal teardown
- let the Node TUI close the Python sidecar stdin before escalating to SIGTERM/SIGKILL

## Why

The top-level TUI launcher no longer starts its own MCP discovery, but the
stdio TUI sidecar can still own MCP server processes. If the TUI exits by
closing/killing the sidecar process directly, stdio MCP children can survive
past the TUI lifetime.

This is especially visible with long-lived stdio MCP servers such as Lark or
NotebookLM: after leaving `hermes --tui`, those child processes can remain
running unless the sidecar gets enough time to run its normal shutdown path.

## Changes

- Add idempotent TUI gateway shutdown guards for sessions and MCP servers.
- Add `_shutdown_for_exit()` so signal and atexit paths share the same order.
- Increase the TUI sidecar hard-exit grace default to 25 seconds.
- Change `GatewayClient.kill()` from immediate `proc.kill()` to:
  1. close sidecar stdin
  2. send SIGTERM after a short grace window
  3. send SIGKILL only if the process still has not exited
- Add regression coverage for top-level TUI MCP discovery and shutdown order.

## Validation

- `python -m py_compile tui_gateway/entry.py tui_gateway/server.py hermes_cli/main.py`
- `python -m pytest tests/test_tui_gateway_server.py::test_shutdown_for_exit_shuts_down_sessions_before_mcp tests/hermes_cli/test_tui_resume_flow.py::test_prepare_agent_startup_top_level_tui_skips_mcp_discovery`
- `npm test -- src/lib/memory.test.ts src/__tests__/gatewayClient.test.ts`
