### PR TITLE
fix(delegation): correct _adjust_thread_count worker args to match stdlib signature

### DIFF
--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -72,9 +72,8 @@ class _DaemonThreadPoolExecutor(ThreadPoolExecutor):
                 target=_worker,
                 args=(
                     weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
                     self._work_queue,
-                    self._initializer,
-                    self._initargs,
                 ),
                 daemon=True,
             )


### PR DESCRIPTION
## Problem

`_DaemonThreadPoolExecutor._adjust_thread_count` passes `(weakref, queue, initializer, initargs)` to the stdlib `_worker` function, but the stdlib signature is `(executor_ref, ctx, queue)` where `ctx` is a worker context object from `_create_worker_context()`.

`initializer` and `initargs` are not attributes of `ThreadPoolExecutor` — the stdlib never sets them. This causes `AttributeError: '_DaemonThreadPoolExecutor' object has no attribute '_initializer'` when `_adjust_thread_count` is called to spawn additional workers beyond the initial pool.

## Trigger

The bug surfaces when background delegation dispatches more concurrent subagents than the initial worker pool size, triggering `_adjust_thread_count` to create new worker threads. The first N dispatches succeed; subsequent ones crash.

## Fix

Replace the incorrect positional args with `self._create_worker_context()`, matching the pattern used by the stdlib's own `_adjust_thread_count`.

## Testing

Verified that worker threads now spawn correctly beyond the initial pool size. Existing async delegation tests continue to pass.