### PR TITLE
fix(delegation): recover from stale _shutdown flag in long-running processes

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -1015,3 +1015,22 @@ def test_gateway_cli_origin_event_left_unrouted():
     runner._enrich_async_delegation_routing(evt)
     assert "platform" not in evt
 
+
+def test_get_executor_recovers_from_shutdown_executor():
+    """When the shared singleton executor is shut down, _get_executor must
+    transparently return a fresh, usable replacement (instance-level recovery).
+
+    Regression guard for the stale-shutdown recovery path: a returned executor
+    that has been .shutdown() must not be handed back to the next caller.
+    """
+    e1 = ad._get_executor(4)
+    e1.shutdown(wait=False)
+    assert getattr(e1, "_shutdown", False) is True
+
+    e2 = ad._get_executor(4)
+    assert e2 is not e1
+    assert getattr(e2, "_shutdown", False) is False
+
+    # The replacement must actually accept and run new work.
+    future = e2.submit(lambda: 42)
+    assert future.result(timeout=5) == 42

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -491,23 +491,6 @@ def _get_executor(max_workers: int) -> ThreadPoolExecutor:
     futures keep running on the old pool until it's garbage collected.
     """
     global _executor, _executor_max_workers
-    # Reset the module-level _shutdown flag in concurrent.futures.thread when
-    # it has been set to True by atexit handlers. In a long-running Hermes
-    # process this flag can be left set after interpreter shutdown begins
-    # (e.g. during cron session cleanup), which then prevents ALL subsequent
-    # ThreadPoolExecutor.submit() calls across the process — even in
-    # unrelated sessions — with "cannot schedule new futures after
-    # interpreter shutdown". Resetting it here is safe because we only
-    # reach this point when we are about to submit real work.
-    try:
-        from concurrent.futures.thread import _shutdown as _cf_shutdown
-        if _cf_shutdown:
-            from concurrent.futures.thread import _global_shutdown_lock as _cf_lock
-            with _cf_lock:
-                import concurrent.futures.thread as _cft
-                _cft._shutdown = False
-    except Exception:  # noqa: BLE001 — must never block executor creation
-        pass
     with _executor_lock:
         if (
             _executor is None

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -491,8 +491,29 @@ def _get_executor(max_workers: int) -> ThreadPoolExecutor:
     futures keep running on the old pool until it's garbage collected.
     """
     global _executor, _executor_max_workers
+    # Reset the module-level _shutdown flag in concurrent.futures.thread when
+    # it has been set to True by atexit handlers. In a long-running Hermes
+    # process this flag can be left set after interpreter shutdown begins
+    # (e.g. during cron session cleanup), which then prevents ALL subsequent
+    # ThreadPoolExecutor.submit() calls across the process — even in
+    # unrelated sessions — with "cannot schedule new futures after
+    # interpreter shutdown". Resetting it here is safe because we only
+    # reach this point when we are about to submit real work.
+    try:
+        from concurrent.futures.thread import _shutdown as _cf_shutdown
+        if _cf_shutdown:
+            from concurrent.futures.thread import _global_shutdown_lock as _cf_lock
+            with _cf_lock:
+                import concurrent.futures.thread as _cft
+                _cft._shutdown = False
+    except Exception:  # noqa: BLE001 — must never block executor creation
+        pass
     with _executor_lock:
-        if _executor is None or max_workers > _executor_max_workers:
+        if (
+            _executor is None
+            or max_workers > _executor_max_workers
+            or getattr(_executor, "_shutdown", False)
+        ):
             # Daemon threads: thread_name_prefix aids debugging in stack dumps.
             _executor = _DaemonThreadPoolExecutor(
                 max_workers=max_workers,


### PR DESCRIPTION
## Problem

Two shutdown flags can permanently break background delegation in long-running Hermes processes:

1. **Module-level** `concurrent.futures.thread._shutdown` — set to `True` by Python's atexit handlers. In a long-running Hermes process, this flag can be left set after interpreter-level cleanup during cron session teardown, preventing ALL subsequent `ThreadPoolExecutor.submit()` calls across the process.

2. **Instance-level** `ThreadPoolExecutor._shutdown` — set to `True` when `executor.shutdown()` is called. Since the delegation executor is a module-level singleton, any code path that calls `shutdown()` permanently breaks all future background delegations.

## Error

RuntimeError: cannot schedule new futures after interpreter shutdown

This kills every delegate_task(background=True) call until the process is restarted.

## Fix

Two defensive recoveries in _get_executor:

1. **Reset module-level flag** — when the concurrent.futures.thread module-level _shutdown is True, reset it back to False under the global lock. Safe because we only reach this point when about to submit real work.

2. **Check instance-level flag** — when the singleton executor's _shutdown attribute is True, replace it with a fresh instance instead of permanently losing background delegation capacity.

Both resets are best-effort and never raise. A failure here must not block agent operation.

## Context

The existing _reset_for_tests() path already calls executor.shutdown() + sets _executor = None, so the instance check also guards against any future code that calls shutdown() on the singleton. The module-level reset handles the case where atexit handlers fire during cron session cleanup in a long-running gateway process.