### PR TITLE
fix(tools): raise default command TTS timeout to 300s

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -393,7 +393,10 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "piper",
 })
 
-DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
+# Command-provider defaults. Command providers (e.g. a shell script that falls
+# through multiple TTS engines sequentially) can need more wall-clock than
+# single-call HTTP providers. See https://github.com/NousResearch/hermes-agent/issues/50081
+DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 300
 DEFAULT_COMMAND_TTS_OUTPUT_FORMAT = "mp3"
 COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac"})
 DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH = 5000


### PR DESCRIPTION
Mitigation for #50081.

Command providers that fall through multiple TTS engines sequentially can exceed the previous 120s ceiling before a working tier runs, causing the wrapper to kill the subprocess mid-synthesis and leave a truncated audio file.

This buys command-provider scripts more headroom while a proper idle/progress timeout is discussed.