### PR TITLE
feat(chat): touch-friendly transcript copy on phones & tablets

### DIFF
--- a/web/src/lib/terminal-transcript.test.ts
+++ b/web/src/lib/terminal-transcript.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { reassembleWrappedLines, type TranscriptRow } from "./terminal-transcript";
+
+const rows = (...specs: Array<[string, boolean]>): TranscriptRow[] =>
+  specs.map(([text, isWrapped]) => ({ text, isWrapped }));
+
+describe("reassembleWrappedLines", () => {
+  it("returns empty string for no rows", () => {
+    expect(reassembleWrappedLines([])).toBe("");
+  });
+
+  it("keeps unwrapped rows on separate lines", () => {
+    expect(
+      reassembleWrappedLines(rows(["first", false], ["second", false])),
+    ).toBe("first\nsecond");
+  });
+
+  it("joins a wrapped continuation onto the previous logical line", () => {
+    // A long path soft-wrapped across two physical rows must copy as one line.
+    expect(
+      reassembleWrappedLines(
+        rows(["/very/long/path/that/", false], ["wraps/here", true]),
+      ),
+    ).toBe("/very/long/path/that/wraps/here");
+  });
+
+  it("joins a run of several wrapped rows with no separators", () => {
+    expect(
+      reassembleWrappedLines(
+        rows(["aaa", false], ["bbb", true], ["ccc", true], ["ddd", true]),
+      ),
+    ).toBe("aaabbbcccddd");
+  });
+
+  it("mixes wrapped and unwrapped rows correctly", () => {
+    expect(
+      reassembleWrappedLines(
+        rows(
+          ["cmd --flag ", false],
+          ["value", true],
+          ["$ next", false],
+          ["output", false],
+        ),
+      ),
+    ).toBe("cmd --flag value\n$ next\noutput");
+  });
+
+  it("treats a leading wrapped row as the start of the transcript", () => {
+    // Defensive: nothing precedes row 0, so it can only start a logical line.
+    expect(reassembleWrappedLines(rows(["orphan", true]))).toBe("orphan");
+  });
+
+  it("trims trailing whitespace and blank rows", () => {
+    expect(
+      reassembleWrappedLines(
+        rows(["line", false], ["   ", false], ["", false]),
+      ),
+    ).toBe("line");
+  });
+
+  it("preserves interior blank lines", () => {
+    expect(
+      reassembleWrappedLines(
+        rows(["a", false], ["", false], ["b", false]),
+      ),
+    ).toBe("a\n\nb");
+  });
+});

--- a/web/src/lib/terminal-transcript.ts
+++ b/web/src/lib/terminal-transcript.ts
@@ -1,0 +1,36 @@
+/** One physical terminal row, as read from xterm's active buffer. */
+export interface TranscriptRow {
+  /** The row's text (typically `line.translateToString(true)`, trailing whitespace trimmed). */
+  text: string;
+  /** True when this physical row is a soft-wrap continuation of the row above it. */
+  isWrapped: boolean;
+}
+
+/**
+ * Reassemble xterm *physical* rows into *logical* lines.
+ *
+ * xterm stores each visual row separately, and a row that soft-wraps from the
+ * one above has `isWrapped === true`. Joining every physical row with "\n"
+ * would break a wrapped command, path, or URL across lines when copied — worst
+ * on the narrow phones the touch-copy sheet exists for. A newline is inserted
+ * only at a real line break: a row that is *not* a wrap continuation starts a
+ * fresh logical line; a wrapped row is appended to the current one with no
+ * separator. Trailing whitespace across the whole transcript is trimmed to
+ * match the copied-buffer behaviour.
+ */
+export function reassembleWrappedLines(rows: TranscriptRow[]): string {
+  const out: string[] = [];
+  let logical = "";
+  let started = false;
+  for (const row of rows) {
+    if (row.isWrapped && started) {
+      logical += row.text;
+    } else {
+      if (started) out.push(logical);
+      logical = row.text;
+      started = true;
+    }
+  }
+  if (started) out.push(logical);
+  return out.join("\n").replace(/\s+$/, "");
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -36,6 +36,11 @@ import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
 import { normalizeSessionTitle } from "@/lib/chat-title";
+import { copyTextToClipboard } from "@/lib/clipboard";
+import {
+  reassembleWrappedLines,
+  type TranscriptRow,
+} from "@/lib/terminal-transcript";
 import {
   PTY_CONNECTING_TIMEOUT_MS,
   PTY_RECONNECT_INPUT_MESSAGE,
@@ -191,6 +196,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     useState<PtyConnectionState>("connecting");
   const ptyStateRef = useRef<PtyConnectionState>("connecting");
   const [lastCloseCode, setLastCloseCode] = useState<number | null>(null);
+  // Touch copy: on a phone the inner Ink TUI runs xterm in mouse-events mode,
+  // so a press-and-hold can only word-select and never drag-extends — leaving
+  // you stranded on one word. A long-press instead opens this read-only sheet
+  // with the full transcript, where native OS selection works on any range.
+  // null = closed; a string = the captured transcript text.
+  const [textSheet, setTextSheet] = useState<string | null>(null);
   // NS-504: when the agent process exits cleanly (the user typed `/exit`, or
   // started a new session that ended the current PTY child), the PTY socket
   // closes with a normal code. Before this fix the terminal just printed
@@ -1270,6 +1281,82 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     term.options.theme = terminalTheme;
   }, [terminalTheme]);
 
+  // Touch long-press → open the selectable transcript sheet. A single finger
+  // held still for ~500ms captures the full xterm buffer as plain text. We use
+  // raw touch events (not xterm's pointer handling) so the inner TUI's
+  // mouse-events mode can't swallow the gesture; the listeners stay passive and
+  // only read scroll/position, so normal touch-scrolling is unaffected.
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const MOVE_TOLERANCE = 12; // px before we treat it as a scroll, not a hold
+    const HOLD_MS = 500;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let startX = 0;
+    let startY = 0;
+    const clear = () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+    const bufferText = (): string => {
+      const term = termRef.current;
+      if (!term) return "";
+      const buf = term.buffer.active;
+      // Collect physical rows, then let the tested helper reassemble them into
+      // logical lines (wrap-aware, so a soft-wrapped command/path/URL copies as
+      // one line instead of being split — worst on the narrow phones this sheet
+      // exists for). See lib/terminal-transcript.ts.
+      const rows: TranscriptRow[] = [];
+      for (let i = 0; i < buf.length; i++) {
+        const line = buf.getLine(i);
+        if (!line) continue;
+        rows.push({
+          text: line.translateToString(true),
+          isWrapped: line.isWrapped,
+        });
+      }
+      return reassembleWrappedLines(rows);
+    };
+    const onStart = (e: TouchEvent) => {
+      if (e.touches.length !== 1) {
+        clear();
+        return;
+      }
+      const t = e.touches[0];
+      startX = t.clientX;
+      startY = t.clientY;
+      clear();
+      timer = setTimeout(() => {
+        timer = null;
+        const text = bufferText();
+        if (text) setTextSheet(text);
+      }, HOLD_MS);
+    };
+    const onMove = (e: TouchEvent) => {
+      if (!timer) return;
+      const t = e.touches[0];
+      if (
+        Math.abs(t.clientX - startX) > MOVE_TOLERANCE ||
+        Math.abs(t.clientY - startY) > MOVE_TOLERANCE
+      ) {
+        clear();
+      }
+    };
+    host.addEventListener("touchstart", onStart, { passive: true });
+    host.addEventListener("touchmove", onMove, { passive: true });
+    host.addEventListener("touchend", clear, { passive: true });
+    host.addEventListener("touchcancel", clear, { passive: true });
+    return () => {
+      clear();
+      host.removeEventListener("touchstart", onStart);
+      host.removeEventListener("touchmove", onMove);
+      host.removeEventListener("touchend", clear);
+      host.removeEventListener("touchcancel", clear);
+    };
+  }, []);
+
   // Layout:
   //   outer flex column — sits inside the dashboard's content area
   //   row split — terminal pane (flex-1) + sidebar (fixed width, lg+)
@@ -1470,6 +1557,50 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               </span>
             </span>
           </Button>
+
+          {/* Touch transcript sheet (long-press the terminal). A real
+              OS-selectable <textarea> with the full conversation — the reliable
+              way to copy an arbitrary range on a phone, where xterm's own
+              selection only grabs one word. */}
+          {textSheet !== null && (
+            <div className="absolute inset-0 z-30 flex flex-col bg-black/85 backdrop-blur-sm">
+              <div className="flex items-center gap-2 px-3 py-2 text-xs text-white/80">
+                <span className="tracking-wide">Select any text to copy, or</span>
+                <button
+                  type="button"
+                  className="rounded border border-current/40 px-2 py-0.5 hover:border-current/70"
+                  onClick={() => {
+                    // Shared helper: prefers the async Clipboard API on secure
+                    // origins and falls back to a hidden-textarea execCommand
+                    // copy otherwise — the reliable path on the insecure-origin
+                    // LAN dashboards this sheet is meant for.
+                    void copyTextToClipboard(textSheet ?? "");
+                    setTextSheet(null);
+                  }}
+                >
+                  Copy all
+                </button>
+                <span className="flex-1" />
+                <button
+                  type="button"
+                  className="rounded px-2 py-0.5 hover:bg-white/10"
+                  aria-label="Close transcript"
+                  onClick={() => setTextSheet(null)}
+                >
+                  ✕
+                </button>
+              </div>
+              {/* No auto-select-on-focus: it highlights the whole transcript
+                  and fights a press-and-hold range selection. Tap/long-press to
+                  place and drag your own selection; "Copy all" covers the rest. */}
+              <textarea
+                readOnly
+                value={textSheet}
+                className="min-h-0 w-full flex-1 resize-none bg-transparent px-3 pb-3 font-mono text-xs leading-relaxed text-white/90 outline-none"
+                style={{ WebkitUserSelect: "text", userSelect: "text" }}
+              />
+            </div>
+          )}
         </div>
 
         {!narrow && (


### PR DESCRIPTION
## What does this PR do?

Makes the dashboard chat **copyable on touch devices** (phones and tablets).

The chat renders into an xterm **canvas/WebGL** surface that the OS can't text-select, and the inline Hermes TUI holds xterm in mouse-events mode. So on a touch device a press-and-hold can only *word*-select and never drag-extends — you're stranded on a single word with no way to copy a range (a code block, an error, a command the agent printed). There's no keyboard `Ctrl/Cmd-C` path on a phone/tablet either.

This adds a **long-press** (~500 ms, stationary) on the terminal that opens a read-only `<textarea>` holding the full xterm transcript, where **native OS selection works on any range**, plus a **Copy all** button. The touch listeners are passive (scrolling unaffected) and bypass xterm's pointer handling so the TUI's mouse-events mode can't swallow the gesture. Desktop is untouched — mouse selection and `Ctrl/Cmd-C` work exactly as before.

## Related Issue

Fixes #50075

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `web/src/pages/ChatPage.tsx`:
  - A `textSheet` state + a touch long-press effect on the terminal host that captures the xterm buffer (`buffer.active` → plain text) and opens it in a selectable overlay.
  - The overlay: a read-only `<textarea>` (native touch selection) with a "Copy all" button (`navigator.clipboard.writeText` + an `execCommand("copy")` fallback for insecure-origin LAN access) and a close button.
  - Listeners are passive and movement-tolerant (>12 px ⇒ treated as a scroll, not a long-press), so normal touch scrolling is preserved.

## How to Test

1. Open `/chat` on a phone or tablet.
2. **Press and hold** (~½ s) on the chat text → a panel covers the terminal with the full transcript.
3. Finger-select any range and copy, or tap **Copy all**.
4. Desktop regression: mouse-drag select + `Ctrl/Cmd-C` still copy; normal touch scrolling still works.

## Checklist

- [x] Read the Contributing Guide
- [x] Commit message follows Conventional Commits (`feat(chat):`)
- [x] Searched existing PRs for duplicates
- [x] PR contains **only** this touch-copy change (keep-alive is a separate PR)
- [x] Ran tests — no Python touched; frontend `tsc -b && vite build` passes
- [ ] Added tests — N/A / manual: a touch-gesture + canvas-selection behavior with no DOM/browser test harness in `web/`; verified by hand on device. Happy to add a Playwright test if wanted.
- [x] Tested on my platform: Chrome on Android (phone) over the LAN; desktop Chrome regression
- [x] Docs: code comments explain the gesture/why; N/A config + tool schemas
- [x] Cross-platform: pure client-side touch handling, no server/Python change
