### PR TITLE
fix(dashboard): dedupe symlinked/templated state.db in cross-profile session list

### DIFF
--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -18,6 +18,7 @@ import functools
 import inspect
 import json
 import logging
+import os
 import re
 import subprocess  # noqa: F401
 import sys  # noqa: F401
@@ -107,6 +108,60 @@ def _sidebar_db_fingerprint(db_path: Path):
     """Track SQLite content changes through the main DB and its WAL."""
     wal_path = Path(f"{db_path}-wal")
     return (_stat_fingerprint(db_path), _stat_fingerprint(wal_path))
+
+
+# Windows reports ``st_ino == 0`` (and an unstable ``st_dev``) on many
+# filesystems, so the POSIX inode identity used to collapse symlinked state.db
+# aliases is meaningless there. ``os.name == "nt"`` mirrors the guard idiom
+# already used across hermes_cli (active_sessions.py, backup.py, agent_plugins).
+_IS_WINDOWS = os.name == "nt"
+
+
+def _db_identity_key(db_path: Path):
+    """Return a stable identity for the *physical* state.db behind ``db_path``.
+
+    Cross-profile session aggregation must scan each underlying database once,
+    even when several profiles reach the same file through different links:
+
+    * A **symlinked** state.db (the gsd-* worker fleet links its DB back to the
+      canonical workspace DB).
+    * A **profile-template** clone that shares its base's DB. ``create_profile``
+      copies the source tree with ``symlinks=True``, so a template whose
+      ``state.db`` is itself a symlink is preserved as a symlink in every
+      derived profile; all of them, and the template, resolve to one real path.
+      A template that instead ships its own real ``state.db`` resolves to a
+      *distinct* path and is (correctly) scanned separately.
+
+    Resolving the real path first is what makes template + derived collapse
+    (or stay separate) correctly regardless of how the share was set up.
+
+    Identity strategy:
+
+    * POSIX: ``(st_dev, st_ino)`` of the resolved target. Inodes also fold
+      hardlinked copies of the same DB, which realpath alone would miss.
+    * Windows / inode-less hosts: ``st_ino`` is unreliable (often ``0``), so
+      fall back to the case-normalized real path. ``os.path.normcase`` matches
+      the repo's existing path-identity idiom (``_startup_fast``,
+      ``gateway_windows``) and makes the key case-insensitive, as NTFS is.
+
+    Never raises: a resolution/stat failure degrades to the normalized path
+    string so a single unreadable profile can't abort the whole scan.
+    """
+    try:
+        real = os.path.realpath(str(db_path))
+    except Exception:
+        real = str(db_path)
+    normalized = os.path.normcase(real)
+    if not _IS_WINDOWS:
+        try:
+            stat = os.stat(real)
+            if stat.st_ino:
+                return (stat.st_dev, stat.st_ino)
+        except OSError:
+            pass
+    # Windows, or a host where inodes are unavailable/zero: the normalized
+    # real path is the most reliable identity we can form without crashing.
+    return normalized
 
 
 def _sidebar_profile_cache_get(key):
@@ -289,18 +344,23 @@ def get_profiles_sessions(
     now = time.time()
     # Dedupe targets that point at the SAME physical state.db. Main-linked
     # profiles (e.g. the gsd-* worker fleet) symlink their state.db back to the
-    # canonical workspace DB, so a naive loop opens and scans that one large file
-    # once per profile -- on a host with N such links the cost is O(N) full
-    # scans of the same rows for zero new data, which pushes the sidebar's
-    # session-list request past the desktop's connect timeout. Resolving each
-    # db_path to its real inode and scanning each distinct DB exactly once makes
-    # profile=all O(distinct DBs) instead of O(profiles), and prevents the same
-    # rows being counted N times into ``total``/``profile_totals``.
+    # canonical workspace DB, and profile-template clones share their base's DB
+    # the same way (create_profile copies with symlinks=True), so a naive loop
+    # opens and scans that one large file once per profile -- on a host with N
+    # such links the cost is O(N) full scans of the same rows for zero new data,
+    # which pushes the sidebar's session-list request past the desktop's connect
+    # timeout. Resolving each db_path to a physical-DB identity and scanning each
+    # distinct DB exactly once makes profile=all O(distinct DBs) instead of
+    # O(profiles), and prevents the same rows being counted N times into
+    # ``total``/``profile_totals``. See ``_db_identity_key`` for how a template
+    # and its derivatives collapse to one key while a template shipping its own
+    # real DB stays separate, and for the Windows/inode-less fallback.
     #
     # Order so a profile owning a REAL state.db file is scanned before any
     # profile that merely symlinks to it -- that way the shared canonical DB is
     # claimed (and its rows tagged) under its real owner (e.g. "default") rather
-    # than an arbitrary symlink alias.
+    # than an arbitrary symlink alias. This also tags a template's shared rows
+    # to the template/base rather than to a derived profile.
     def _is_symlink_db(home: Path) -> bool:
         try:
             return (Path(home) / "state.db").is_symlink()
@@ -313,14 +373,10 @@ def get_profiles_sessions(
         db_path = Path(home) / "state.db"
         if not db_path.exists():
             continue
-        try:
-            real = db_path.resolve()
-            stat = real.stat()
-            db_key = (stat.st_dev, stat.st_ino)
-        except Exception:
-            db_key = str(db_path)
+        db_key = _db_identity_key(db_path)
         if db_key in seen_db_keys:
-            # Already scanned this physical DB under another profile name.
+            # Already scanned this physical DB under another profile name
+            # (symlink alias, hardlink, or template/derived share).
             continue
         seen_db_keys.add(db_key)
         try:

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -287,10 +287,42 @@ def get_profiles_sessions(
     profile_totals: Dict[str, int] = {}
     errors: List[Dict[str, str]] = []
     now = time.time()
-    for name, home in targets:
+    # Dedupe targets that point at the SAME physical state.db. Main-linked
+    # profiles (e.g. the gsd-* worker fleet) symlink their state.db back to the
+    # canonical workspace DB, so a naive loop opens and scans that one large file
+    # once per profile -- on a host with N such links the cost is O(N) full
+    # scans of the same rows for zero new data, which pushes the sidebar's
+    # session-list request past the desktop's connect timeout. Resolving each
+    # db_path to its real inode and scanning each distinct DB exactly once makes
+    # profile=all O(distinct DBs) instead of O(profiles), and prevents the same
+    # rows being counted N times into ``total``/``profile_totals``.
+    #
+    # Order so a profile owning a REAL state.db file is scanned before any
+    # profile that merely symlinks to it -- that way the shared canonical DB is
+    # claimed (and its rows tagged) under its real owner (e.g. "default") rather
+    # than an arbitrary symlink alias.
+    def _is_symlink_db(home: Path) -> bool:
+        try:
+            return (Path(home) / "state.db").is_symlink()
+        except Exception:
+            return False
+
+    ordered_targets = sorted(targets, key=lambda t: _is_symlink_db(t[1]))
+    seen_db_keys: set = set()
+    for name, home in ordered_targets:
         db_path = Path(home) / "state.db"
         if not db_path.exists():
             continue
+        try:
+            real = db_path.resolve()
+            stat = real.stat()
+            db_key = (stat.st_dev, stat.st_ino)
+        except Exception:
+            db_key = str(db_path)
+        if db_key in seen_db_keys:
+            # Already scanned this physical DB under another profile name.
+            continue
+        seen_db_keys.add(db_key)
         try:
             # Read-only on the healthy path: this loop runs on every sidebar
             # refresh, so it must not routinely DDL/write-lock another

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2988,10 +2988,42 @@ async def get_profiles_sessions(
     profile_totals: Dict[str, int] = {}
     errors: List[Dict[str, str]] = []
     now = time.time()
-    for name, home in targets:
+    # Dedupe targets that point at the SAME physical state.db. Main-linked
+    # profiles (e.g. the gsd-* worker fleet) symlink their state.db back to the
+    # canonical workspace DB, so a naive loop opens and scans that one large file
+    # once per profile -- on a host with N such links the cost is O(N) full
+    # scans of the same rows for zero new data, which pushes the sidebar's
+    # session-list request past the desktop's connect timeout. Resolving each
+    # db_path to its real inode and scanning each distinct DB exactly once makes
+    # profile=all O(distinct DBs) instead of O(profiles), and prevents the same
+    # rows being counted N times into ``total``/``profile_totals``.
+    #
+    # Order so a profile owning a REAL state.db file is scanned before any
+    # profile that merely symlinks to it -- that way the shared canonical DB is
+    # claimed (and its rows tagged) under its real owner (e.g. "default") rather
+    # than an arbitrary symlink alias.
+    def _is_symlink_db(home: Path) -> bool:
+        try:
+            return (Path(home) / "state.db").is_symlink()
+        except Exception:
+            return False
+
+    ordered_targets = sorted(targets, key=lambda t: _is_symlink_db(t[1]))
+    seen_db_keys: set = set()
+    for name, home in ordered_targets:
         db_path = Path(home) / "state.db"
         if not db_path.exists():
             continue
+        try:
+            real = db_path.resolve()
+            stat = real.stat()
+            db_key = (stat.st_dev, stat.st_ino)
+        except Exception:
+            db_key = str(db_path)
+        if db_key in seen_db_keys:
+            # Already scanned this physical DB under another profile name.
+            continue
+        seen_db_keys.add(db_key)
         try:
             # Read-only: this loop runs on every sidebar refresh, so it must
             # never DDL/write-lock another profile's live DB (see SessionDB

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -641,6 +641,45 @@ class TestWebServerEndpoints:
         assert row["is_default_profile"] is True
         assert isinstance(data.get("errors"), list)
 
+    def test_profiles_sessions_dedupes_symlinked_state_db(self):
+        """A profile whose state.db is a symlink to the canonical DB must not
+        cause its rows to be scanned/counted twice. Main-linked profiles (e.g.
+        the gsd-* worker fleet) symlink state.db back to the workspace DB; the
+        aggregator dedupes by physical inode so profile=all stays O(distinct DBs)
+        and ``total`` is not inflated N times for N aliases."""
+        from hermes_state import SessionDB
+        from hermes_cli import profiles as profiles_mod
+
+        # One real row in the default (canonical) DB.
+        default_db = SessionDB()
+        try:
+            default_db.create_session(session_id="shared-row", source="cli")
+            default_db.append_message(session_id="shared-row", role="user", content="hi")
+        finally:
+            default_db.close()
+
+        # A second profile whose state.db is a SYMLINK to the canonical DB.
+        canonical = profiles_mod.get_profile_dir("default") / "state.db"
+        alias_home = profiles_mod.get_profile_dir("worker-alias")
+        alias_home.mkdir(parents=True, exist_ok=True)
+        alias_db = alias_home / "state.db"
+        if alias_db.exists() or alias_db.is_symlink():
+            alias_db.unlink()
+        alias_db.symlink_to(canonical)
+
+        resp = self.client.get("/api/profiles/sessions?profile=all&limit=20&min_messages=0")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # The shared session appears exactly ONCE, not once per aliasing profile.
+        shared = [s for s in data["sessions"] if s["id"] == "shared-row"]
+        assert len(shared) == 1, f"shared row double-counted: {len(shared)} copies"
+        # And it is tagged to the REAL owner (default), not the symlink alias,
+        # because real-DB owners are scanned before symlink aliases.
+        assert shared[0]["profile"] == "default"
+        # Total must not be inflated by the duplicate physical DB.
+        assert data["total"] == 1
+
     def test_profiles_sessions_rejects_unknown_archived_value(self):
         resp = self.client.get("/api/profiles/sessions?archived=bogus")
         assert resp.status_code == 400

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2031,6 +2031,109 @@ class TestWebServerEndpoints:
         # Total must not be inflated by the duplicate physical DB.
         assert data["total"] == 1
 
+    def test_profiles_sessions_dedupes_template_derived_share(self):
+        """A profile-template whose state.db is shared by derived profiles must
+        contribute its rows exactly once, tagged to the template (scanned first
+        as the real-DB owner), not to each derivative.
+
+        ``create_profile`` clones with ``symlinks=True``, so a template whose
+        derivatives link back to one physical DB is the same shape as the
+        gsd-* fleet: three profile dirs (template + 2 derived) reach one file.
+        The aggregator must collapse all three to a single physical DB.
+        """
+        import pytest
+
+        from hermes_state import SessionDB
+        from hermes_cli import profiles as profiles_mod
+
+        # The template ("base") profile owns the REAL state.db with one row.
+        base_home = profiles_mod.get_profile_dir("tmpl-base")
+        base_home.mkdir(parents=True, exist_ok=True)
+        base_db_path = base_home / "state.db"
+        base_db = SessionDB(db_path=base_db_path)
+        try:
+            base_db.create_session(session_id="tmpl-row", source="cli")
+            base_db.append_message(session_id="tmpl-row", role="user", content="hi")
+        finally:
+            base_db.close()
+
+        # Two derived profiles that symlink their state.db back to the base's
+        # DB (what a symlink-preserving clone of a template produces).
+        derived_homes = []
+        for derived in ("tmpl-child-a", "tmpl-child-b"):
+            home = profiles_mod.get_profile_dir(derived)
+            home.mkdir(parents=True, exist_ok=True)
+            link = home / "state.db"
+            if link.exists() or link.is_symlink():
+                link.unlink()
+            try:
+                link.symlink_to(base_db_path)
+            except (OSError, NotImplementedError) as exc:
+                pytest.skip(f"symlinks unavailable in test environment: {exc}")
+            derived_homes.append(home)
+
+        resp = self.client.get(
+            "/api/profiles/sessions?profile=all&limit=20&min_messages=0"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Template row appears exactly once across template + 2 derivatives.
+        matched = [s for s in data["sessions"] if s["id"] == "tmpl-row"]
+        assert len(matched) == 1, (
+            f"template row scanned {len(matched)} times across derivatives"
+        )
+        # And it is owned by the template (the real-DB owner), because real DBs
+        # are scanned before symlink aliases.
+        assert matched[0]["profile"] == "tmpl-base"
+        # No derived profile double-counted into the aggregate total.
+        assert data["total"] == 1
+
+    def test_db_identity_key_windows_and_posix_semantics(self):
+        """``_db_identity_key`` collapses aliases to one physical DB on POSIX
+        (inode identity) and degrades to a case-normalized real path on Windows
+        / inode-less hosts without crashing.
+
+        This guards the Windows path directly (POSIX CI can't exercise
+        ``os.name == 'nt'`` at runtime) by patching the module flag, which is
+        the branch that turns off inode keys where ``st_ino`` is unreliable.
+        """
+        import pytest
+
+        from hermes_cli.web_routers import profiles as web_profiles
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            real_db = root / "real" / "state.db"
+            real_db.parent.mkdir(parents=True)
+            real_db.write_bytes(b"sqlite")
+
+            alias_dir = root / "alias"
+            alias_dir.mkdir()
+            alias_db = alias_dir / "state.db"
+            try:
+                alias_db.symlink_to(real_db)
+            except (OSError, NotImplementedError) as exc:
+                pytest.skip(f"symlinks unavailable: {exc}")
+
+            # POSIX branch: the alias and the real file share one identity.
+            key_real = web_profiles._db_identity_key(real_db)
+            key_alias = web_profiles._db_identity_key(alias_db)
+            assert key_real == key_alias
+
+            # Windows branch: force the nt guard on. Identity degrades to the
+            # normalized real path; the alias still resolves to the same
+            # physical file, so the two keys still match (dedupe still works),
+            # and neither call raises.
+            with patch.object(web_profiles, "_IS_WINDOWS", True):
+                wkey_real = web_profiles._db_identity_key(real_db)
+                wkey_alias = web_profiles._db_identity_key(alias_db)
+            assert isinstance(wkey_real, str)
+            assert wkey_real == wkey_alias
+            assert wkey_real == os.path.normcase(os.path.realpath(str(real_db)))
+
     def test_get_session_messages_rejects_negative_limit(self):
         """limit=-1 previously bypassed the documented 500-row clamp because
         min(-1, 500) == -1, which SQLite treats as 'no limit'."""

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1981,6 +1981,56 @@ class TestWebServerEndpoints:
         assert payload["limit"] == 3
         assert len(payload["sessions"]) == 3
 
+    def test_profiles_sessions_dedupes_symlinked_state_db(self):
+        """A profile whose state.db is a symlink to the canonical DB must not
+        cause its rows to be scanned/counted twice. Main-linked profiles (e.g.
+        the gsd-* worker fleet) symlink state.db back to the workspace DB; the
+        aggregator dedupes by physical inode so profile=all stays O(distinct DBs)
+        and ``total`` is not inflated N times for N aliases."""
+        import pytest
+
+        from hermes_state import SessionDB
+        from hermes_cli import profiles as profiles_mod
+
+        # One real row in the default (canonical) DB.
+        default_db = SessionDB()
+        try:
+            default_db.create_session(session_id="shared-row", source="cli")
+            default_db.append_message(session_id="shared-row", role="user", content="hi")
+        finally:
+            default_db.close()
+
+        # A second profile whose state.db is a SYMLINK to the canonical DB.
+        canonical = profiles_mod.get_profile_dir("default") / "state.db"
+        alias_home = profiles_mod.get_profile_dir("worker-alias")
+        alias_home.mkdir(parents=True, exist_ok=True)
+        alias_db = alias_home / "state.db"
+        if alias_db.exists() or alias_db.is_symlink():
+            alias_db.unlink()
+        # Guard symlink creation: native Windows without the developer/elevated
+        # privilege (and some restricted filesystems) raise OSError or
+        # NotImplementedError from Path.symlink_to(). Skip gracefully there,
+        # mirroring the repo's _symlink_file_or_skip helper in test_backup.py.
+        # On POSIX (this CI box) the guard is a no-op and the full inode-dedupe
+        # regression below still runs and asserts.
+        try:
+            alias_db.symlink_to(canonical)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        resp = self.client.get("/api/profiles/sessions?profile=all&limit=20&min_messages=0")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # The shared session appears exactly ONCE, not once per aliasing profile.
+        shared = [s for s in data["sessions"] if s["id"] == "shared-row"]
+        assert len(shared) == 1, f"shared row double-counted: {len(shared)} copies"
+        # And it is tagged to the REAL owner (default), not the symlink alias,
+        # because real-DB owners are scanned before symlink aliases.
+        assert shared[0]["profile"] == "default"
+        # Total must not be inflated by the duplicate physical DB.
+        assert data["total"] == 1
+
     def test_get_session_messages_rejects_negative_limit(self):
         """limit=-1 previously bypassed the documented 500-row clamp because
         min(-1, 500) == -1, which SQLite treats as 'no limit'."""


### PR DESCRIPTION
## What does this PR do?

The dashboard profile session aggregator can encounter several profile paths that refer to one physical `state.db`. This happens with symlinked worker profiles and templates whose derived profiles preserve a shared database link. Scanning every alias duplicates rows and repeats the cost of reading the same database.

This PR assigns each database a physical identity before scanning it. POSIX uses the resolved target's device and inode, which also collapses hard links. Windows and inode free filesystems use the normalized resolved path. Real database owners are considered before symlink aliases so shared rows retain the canonical profile label.

## Type of change

Bug fix with cross platform regression coverage.

## Changes made

`hermes_cli/web_routers/profiles.py` deduplicates profile databases by physical identity while preserving distinct template databases.

`tests/hermes_cli/test_web_server.py` covers a direct symlink alias, a template with two derived aliases, POSIX identity, and the Windows fallback branch.

## Verification

The three new identity and aggregation regressions pass through `scripts/run_tests.sh`. An additional 84 profile, sidebar, and gateway tests pass, with two Windows only tests skipped on Linux. Ruff passes on both changed files.

The complete web server file reports 167 passing tests and one skip on this host. Five unrelated schema migration tests require SQLite `DROP COLUMN`; the host SQLite 3.26 rejects that syntax before application code runs.
