### PR TITLE
fix(tools): use idle timeout for command TTS

### DIFF
--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -14,6 +14,8 @@ differences) Windows.
 
 import json
 import os
+import shlex
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -37,6 +39,7 @@ from tools.tts_tool import (
     _render_command_tts_template,
     _resolve_command_provider_config,
     _resolve_max_text_length,
+    _run_command_tts,
     _shell_quote_context,
     check_tts_requirements,
     text_to_speech_tool,
@@ -55,6 +58,13 @@ def _python_copy_command(output_placeholder: str = "{output_path}") -> str:
         f'shutil.copyfile(sys.argv[1], sys.argv[2])" '
         f'{{input_path}} {output_placeholder}'
     )
+
+
+def _shell_command(*args: str) -> str:
+    """Return a shell command string for subprocess.Popen(shell=True)."""
+    if os.name == "nt":
+        return subprocess.list2cmdline(list(args))
+    return " ".join(shlex.quote(str(arg)) for arg in args)
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +356,53 @@ class TestRenderCommandTtsTemplate:
             placeholders,
         )
         assert '"bob\'s voice"' in rendered
+
+
+# ---------------------------------------------------------------------------
+# _run_command_tts idle/progress timeout behavior
+# ---------------------------------------------------------------------------
+
+class TestRunCommandTts:
+    def test_stderr_progress_extends_beyond_timeout(self, tmp_path):
+        script = tmp_path / "progress_then_exit.py"
+        script.write_text(
+            "\n".join([
+                "import sys, time",
+                "for idx in range(4):",
+                "    print(f'tick {idx}', file=sys.stderr, flush=True)",
+                "    time.sleep(0.15)",
+                "print('done', flush=True)",
+            ]),
+            encoding="utf-8",
+        )
+
+        result = _run_command_tts(
+            _shell_command(sys.executable, "-u", str(script)),
+            timeout=0.25,
+        )
+
+        assert result.returncode == 0
+        assert "tick 3" in result.stderr
+        assert "done" in result.stdout
+
+    def test_silent_after_progress_still_times_out_with_stderr(self, tmp_path):
+        script = tmp_path / "progress_then_hang.py"
+        script.write_text(
+            "\n".join([
+                "import sys, time",
+                "print('starting tier 1', file=sys.stderr, flush=True)",
+                "time.sleep(1.0)",
+            ]),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+            _run_command_tts(
+                _shell_command(sys.executable, "-u", str(script)),
+                timeout=0.2,
+            )
+
+        assert "starting tier 1" in (excinfo.value.stderr or "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -363,6 +363,39 @@ class TestRenderCommandTtsTemplate:
 # ---------------------------------------------------------------------------
 
 class TestRunCommandTts:
+    def test_reads_process_output_in_large_chunks(self):
+        read_sizes: dict[str, list[int]] = {"stdout": [], "stderr": []}
+
+        class FakeStream:
+            def __init__(self, name: str, chunks: list[str]):
+                self.name = name
+                self.chunks = chunks
+
+            def read(self, size: int) -> str:
+                read_sizes[self.name].append(size)
+                if self.chunks:
+                    return self.chunks.pop(0)
+                return ""
+
+        class FakeProcess:
+            def __init__(self):
+                self.pid = 12345
+                self.returncode = 0
+                self.stdout = FakeStream("stdout", ["done"])
+                self.stderr = FakeStream("stderr", ["tick"])
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+        with patch("tools.tts_tool.subprocess.Popen", return_value=FakeProcess()):
+            result = _run_command_tts("fake tts", timeout=0.25)
+
+        assert result.returncode == 0
+        assert result.stdout == "done"
+        assert result.stderr == "tick"
+        assert read_sizes["stdout"][0] == 65536
+        assert read_sizes["stderr"][0] == 65536
+
     def test_stderr_progress_extends_beyond_timeout(self, tmp_path):
         script = tmp_path / "progress_then_exit.py"
         script.write_text(
@@ -403,6 +436,7 @@ class TestRunCommandTts:
             )
 
         assert "starting tier 1" in (excinfo.value.stderr or "")
+        assert isinstance(excinfo.value.__cause__, subprocess.TimeoutExpired)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -396,6 +396,32 @@ class TestRunCommandTts:
         assert read_sizes["stdout"][0] == 65536
         assert read_sizes["stderr"][0] == 65536
 
+    def test_closed_pipes_still_running_honors_idle_timeout(self):
+        class ClosedStream:
+            def read(self, size: int) -> str:
+                return ""
+
+        class FakeProcess:
+            def __init__(self):
+                self.pid = 12345
+                self.returncode = None
+                self.stdout = ClosedStream()
+                self.stderr = ClosedStream()
+
+            def wait(self, timeout=None):
+                if timeout is None:
+                    self.returncode = 0
+                    return self.returncode
+                raise subprocess.TimeoutExpired("fake tts", timeout)
+
+        process = FakeProcess()
+        with (
+            patch("tools.tts_tool.subprocess.Popen", return_value=process),
+            patch("tools.tts_tool._terminate_command_tts_process_tree"),
+        ):
+            with pytest.raises(subprocess.TimeoutExpired):
+                _run_command_tts("fake tts", timeout=0.25)
+
     def test_stderr_progress_extends_beyond_timeout(self, tmp_path):
         script = tmp_path / "progress_then_exit.py"
         script.write_text(

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -47,6 +47,7 @@ import shutil
 import subprocess
 import tempfile
 import threading
+import time
 import uuid
 from pathlib import Path
 from typing import Callable, Dict, Any, Optional
@@ -760,7 +761,7 @@ def _terminate_command_tts_process_tree(proc: subprocess.Popen) -> None:
 
 
 def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProcess:
-    """Run a command-provider shell command with process-tree timeout cleanup."""
+    """Run a command-provider shell command with process-tree idle cleanup."""
     popen_kwargs: Dict[str, Any] = {
         "shell": True,
         "stdout": subprocess.PIPE,
@@ -773,21 +774,75 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
         popen_kwargs["start_new_session"] = True
 
     proc = subprocess.Popen(command, **popen_kwargs, stdin=subprocess.DEVNULL)
-    try:
-        stdout, stderr = proc.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired as exc:
-        _terminate_command_tts_process_tree(proc)
+    output_queue: "queue.Queue[tuple[str, Optional[str]]]" = queue.Queue()
+    chunks: Dict[str, list[str]] = {"stdout": [], "stderr": []}
+    open_streams = {"stdout", "stderr"}
+
+    def read_stream(name: str, stream: Any) -> None:
         try:
-            stdout, stderr = proc.communicate(timeout=1)
-        except Exception:
-            stdout = getattr(exc, "output", None)
-            stderr = getattr(exc, "stderr", None)
+            while True:
+                chunk = stream.read(1)
+                if not chunk:
+                    break
+                output_queue.put((name, chunk))
+        finally:
+            output_queue.put((name, None))
+
+    readers = [
+        threading.Thread(
+            target=read_stream,
+            args=("stdout", proc.stdout),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=read_stream,
+            args=("stderr", proc.stderr),
+            daemon=True,
+        ),
+    ]
+    for reader in readers:
+        reader.start()
+
+    deadline = time.monotonic() + timeout
+    timed_out = False
+    while open_streams:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            timed_out = True
+            break
+        try:
+            name, chunk = output_queue.get(timeout=min(0.05, remaining))
+        except queue.Empty:
+            continue
+        if chunk is None:
+            open_streams.discard(name)
+            continue
+        chunks[name].append(chunk)
+        deadline = time.monotonic() + timeout
+
+    if timed_out:
+        _terminate_command_tts_process_tree(proc)
+        for reader in readers:
+            reader.join(timeout=0.5)
+        while True:
+            try:
+                name, chunk = output_queue.get_nowait()
+            except queue.Empty:
+                break
+            if chunk:
+                chunks[name].append(chunk)
+        stdout = "".join(chunks["stdout"])
+        stderr = "".join(chunks["stderr"])
         raise subprocess.TimeoutExpired(
             command,
             timeout,
             output=stdout,
             stderr=stderr,
-        ) from exc
+        )
+
+    stdout = "".join(chunks["stdout"])
+    stderr = "".join(chunks["stderr"])
+    proc.wait()
 
     if proc.returncode:
         raise subprocess.CalledProcessError(

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -779,9 +779,19 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
     open_streams = {"stdout", "stderr"}
 
     def read_stream(name: str, stream: Any) -> None:
+        encoding = getattr(stream, "encoding", None) or "utf-8"
         try:
             while True:
-                chunk = stream.read(1)
+                try:
+                    fd = stream.fileno()
+                except (AttributeError, OSError):
+                    fd = None
+
+                if fd is None:
+                    chunk = stream.read(65536)
+                else:
+                    data = os.read(fd, 65536)
+                    chunk = data.decode(encoding, errors="replace")
                 if not chunk:
                     break
                 output_queue.put((name, chunk))
@@ -833,12 +843,15 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
                 chunks[name].append(chunk)
         stdout = "".join(chunks["stdout"])
         stderr = "".join(chunks["stderr"])
-        raise subprocess.TimeoutExpired(
-            command,
-            timeout,
-            output=stdout,
-            stderr=stderr,
-        )
+        try:
+            raise subprocess.TimeoutExpired(command, timeout)
+        except subprocess.TimeoutExpired as exc:
+            raise subprocess.TimeoutExpired(
+                command,
+                timeout,
+                output=stdout,
+                stderr=stderr,
+            ) from exc
 
     stdout = "".join(chunks["stdout"])
     stderr = "".join(chunks["stderr"])

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -780,17 +780,13 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
 
     def read_stream(name: str, stream: Any) -> None:
         encoding = getattr(stream, "encoding", None) or "utf-8"
+        read1 = getattr(getattr(stream, "buffer", None), "read1", None)
         try:
             while True:
-                try:
-                    fd = stream.fileno()
-                except (AttributeError, OSError):
-                    fd = None
-
-                if fd is None:
+                if read1 is None:
                     chunk = stream.read(65536)
                 else:
-                    data = os.read(fd, 65536)
+                    data = read1(65536)
                     chunk = data.decode(encoding, errors="replace")
                 if not chunk:
                     break
@@ -830,6 +826,12 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
         chunks[name].append(chunk)
         deadline = time.monotonic() + timeout
 
+    if not timed_out:
+        try:
+            proc.wait(timeout=max(0.0, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            timed_out = True
+
     if timed_out:
         _terminate_command_tts_process_tree(proc)
         for reader in readers:
@@ -855,7 +857,6 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
 
     stdout = "".join(chunks["stdout"])
     stderr = "".join(chunks["stderr"])
-    proc.wait()
 
     if proc.returncode:
         raise subprocess.CalledProcessError(

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -310,7 +310,7 @@ Use `{{` and `}}` for literal braces.
 
 | Key                | Default | Meaning                                                                                                    |
 |--------------------|---------|------------------------------------------------------------------------------------------------------------|
-| `timeout`          | `120`   | Seconds; the process tree is killed on expiry (Unix `killpg`, Windows `taskkill /T`).                       |
+| `timeout`          | `120`   | Idle seconds; stdout or stderr output resets the deadline. The process tree is killed after inactivity (Unix `killpg`, Windows `taskkill /T`). |
 | `output_format`    | `mp3`   | One of `mp3` / `wav` / `ogg` / `flac`. Auto-inferred from the output extension if Hermes picks a path.      |
 | `voice_compatible` | `false` | When `true`, Hermes converts MP3/WAV output to Opus/OGG via ffmpeg so Telegram renders a voice bubble.      |
 | `max_text_length`  | `5000`  | Input is truncated to this length before rendering the command.                                             |


### PR DESCRIPTION
## Summary

Fixes command TTS providers being killed by a hard wall-clock subprocess timeout while they are still making progress. `_run_command_tts()` now treats the configured timeout as an idle/progress timeout: stdout or stderr activity extends the deadline, while a silent subprocess is still terminated with the existing process-tree cleanup.

This is the follow-up shape discussed in #50081 rather than only raising the default timeout.

## Changes

- Replace `proc.communicate(timeout=timeout)` in `tools/tts_tool.py` with a small stdout/stderr reader loop that resets the deadline on command output.
- Preserve captured stdout/stderr for non-zero exits and timeout diagnostics.
- Keep the existing POSIX/Windows process setup and timeout cleanup behavior.
- Add command-provider regression tests for active stderr progress and silent-after-progress timeout behavior.

## Testing/Verification

- `python -m pytest -q -o addopts='' tests/tools/test_tts_command_providers.py` -> `53 passed, 1 skipped`
- `python -m pytest -q -o addopts='' tests/tools/test_tts_command_providers.py tests/tools/test_tts_max_text_length.py tests/tools/test_tts_plugin_dispatch.py` -> `115 passed, 1 skipped`
- `python -m py_compile tools/tts_tool.py tests/tools/test_tts_command_providers.py` -> passed
- `python -m ruff check tools/tts_tool.py tests/tools/test_tts_command_providers.py` -> passed
- `git diff --check` -> passed

Note: `scripts/run_tests.sh tests/tools/test_tts_command_providers.py -q` could not run in this Windows hot-runner session because launching bash failed immediately with `The requested operation requires elevation.` I used direct pytest with `addopts` disabled as the practical local fallback.

## Related Issue

Fixes #50081