### PR TITLE
fix: DeepSeek Direct compatibility — proactive streaming disable + memory tools for minimal contexts

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -213,6 +213,7 @@ def init_agent(
     skip_context_files: bool = False,
     load_soul_identity: bool = False,
     skip_memory: bool = False,
+    expose_memory_tools_when_skipping: bool = False,
     session_db=None,
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
@@ -1147,9 +1148,15 @@ def init_agent(
     agent._memory_nudge_interval = 10
     agent._turns_since_memory = 0
     agent._iters_since_skill = 0
-    if not skip_memory:
+    agent._skip_memory_provider_prompt = bool(skip_memory and expose_memory_tools_when_skipping)
+    mem_config = {}
+    if not skip_memory or expose_memory_tools_when_skipping:
         try:
             mem_config = _agent_cfg.get("memory", {})
+        except Exception:
+            mem_config = {}
+    if not skip_memory:
+        try:
             agent._memory_enabled = mem_config.get("memory_enabled", False)
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
@@ -1168,7 +1175,7 @@ def init_agent(
     # Memory provider plugin (external — one at a time, alongside built-in)
     # Reads memory.provider from config to select which plugin to activate.
     agent._memory_manager = None
-    if not skip_memory:
+    if not skip_memory or expose_memory_tools_when_skipping:
         try:
             _mem_provider_name = mem_config.get("provider", "") if mem_config else ""
 

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1125,6 +1125,21 @@ def init_agent(
     # broad pseudo-public config object on the agent instance.
     agent._aux_compression_context_length_config = None
 
+    # Provider config may disable streaming proactively — some providers
+    # (e.g. DeepSeek Direct) accept streaming connections but stall without
+    # producing chunks, triggering the 180s stale detector.  Setting
+    # ``disable_streaming: true`` in the provider block avoids the hung-stream
+    # failure mode entirely instead of waiting for a reactive fallback.
+    agent._disable_streaming = False
+    if agent.provider:
+        try:
+            _providers_cfg = _agent_cfg.get("providers", {}) if isinstance(_agent_cfg, dict) else {}
+            _this_provider = _providers_cfg.get(agent.provider, {}) if isinstance(_providers_cfg, dict) else {}
+            if _this_provider.get("disable_streaming") is True:
+                agent._disable_streaming = True
+        except Exception:
+            pass
+
     # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
     agent._memory_store = None
     agent._memory_enabled = False

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -432,8 +432,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             if user_block:
                 volatile_parts.append(user_block)
 
-    # External memory provider system prompt block (additive to built-in)
-    if agent._memory_manager:
+    # External memory provider system prompt block (additive to built-in).
+    # Some system contexts (cron) need provider tools like fact_store without
+    # injecting provider memory into the prompt. They set
+    # _skip_memory_provider_prompt while still initialising _memory_manager.
+    if agent._memory_manager and not getattr(agent, "_skip_memory_provider_prompt", False):
         try:
             _ext_mem_block = agent._memory_manager.build_system_prompt()
             if _ext_mem_block:


### PR DESCRIPTION
## What

Two fixes for providers that don't support streaming (e.g. DeepSeek Direct) and for cron/minimal agent contexts that need structured memory tools without the full memory prompt payload.

### 1. Proactive streaming disable via provider config (4eb35a0)

DeepSeek Direct accepts streaming connections but stalls without producing chunks, triggering the 180s stale detector and forcing a reactive fallback that wastes a full API call and retry cycle.

The existing `_disable_streaming` attribute (checked in `conversation_loop.py:1118`) only gets set *reactively* after a streaming failure. This PR reads `disable_streaming: true` from the provider config block at agent init and sets it proactively — avoiding the hung-stream failure mode entirely.

**Config usage:**
```yaml
providers:
  deepseek:
    disable_streaming: true
```

### 2. Memory tools without full memory context (900e60c)

Cron jobs and other minimal contexts set `skip_memory=True` to avoid injecting multi-thousand-char MEMORY.md + USER.md blocks into the prompt. But this also prevents initialising the external memory manager, which means structured memory tools (`fact_store`, etc.) are unavailable.

New `expose_memory_tools_when_skipping` parameter: when set alongside `skip_memory=True`, the memory manager and its provider tools are still initialised, but:
- Built-in MEMORY.md/USER.md blocks are suppressed
- External provider's system prompt block is suppressed (via `_skip_memory_provider_prompt`)

## Testing

- [x] `disable_streaming: true` sets `_disable_streaming` on agent init
- [x] `disable_streaming` absent or false leaves streaming enabled
- [x] `expose_memory_tools_when_skipping=True` with `skip_memory=True` loads memory manager
- [x] Provider prompt is suppressed when `_skip_memory_provider_prompt` is set