### PR TITLE
fix(gateway): route priority-path text follow-ups through FIFO instead of merge

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7758,17 +7758,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     time.time() - _started_at,
                     _quick_key,
                 )
-                adapter = self.adapters.get(source.platform)
-                if adapter:
-                    if self._busy_input_mode == "queue":
-                        self._enqueue_fifo(_quick_key, event, adapter)
-                    else:
-                        merge_pending_message_event(
-                            adapter._pending_messages,
-                            _quick_key,
-                            event,
-                            merge_text=True,
-                        )
+                self._queue_or_replace_pending_event(_quick_key, event)
                 return None
 
             running_agent = self._running_agents.get(_quick_key)
@@ -7781,14 +7771,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return EphemeralReply("⚡ Force-stopped. The agent was still starting — session unlocked.")
                 # Queue the message so it will be picked up after the
                 # agent starts.
-                adapter = self.adapters.get(source.platform)
-                if adapter:
-                    merge_pending_message_event(
-                        adapter._pending_messages,
-                        _quick_key,
-                        event,
-                        merge_text=True,
-                    )
+                self._queue_or_replace_pending_event(_quick_key, event)
                 return None
             if self._draining:
                 if self._queue_during_drain_enabled():

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -297,7 +297,10 @@ async def test_recent_telegram_followups_append_in_pending_queue():
 
     fake_agent.interrupt.assert_not_called()
     adapter = runner.adapters[Platform.TELEGRAM]
-    assert adapter._pending_messages[session_key].text == "part one\npart two"
+    assert adapter._pending_messages[session_key].text == "part one"
+    overflow = getattr(runner, "_queued_events", {}).get(session_key, [])
+    assert len(overflow) == 1
+    assert overflow[0].text == "part two"
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The Telegram follow-up grace window (non-queue mode) and the agent-pending sentinel path still called `merge_pending_message_event` with `merge_text=True`, newline-joining consecutive TEXT messages into a single pending turn and destroying message boundaries.
- Replace both call sites with `_queue_or_replace_pending_event`, matching the fix applied in #49776 for `_handle_active_session_busy_message`. Each text follow-up now gets its own turn in arrival order while photo-burst / album merge semantics are preserved.

Sibling of #49776.

## Test plan

- [x] Updated `test_recent_telegram_followups_append_in_pending_queue` to assert FIFO semantics (head slot + overflow) instead of newline-merged text
- [x] All 19 `test_session_race_guard` tests pass
- [x] All 19 `test_busy_session_ack` tests pass
- [x] All 31 `test_queue_consumption` + `test_subagent_protection` tests pass