### PR TITLE
fix: back off goal continuations on provider rate limits

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -35,6 +35,7 @@ import atexit
 import errno
 import tempfile
 import time
+import threading
 import uuid
 import textwrap
 from collections import deque
@@ -8083,6 +8084,62 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._goal_manager = mgr
         return mgr
 
+    @staticmethod
+    def _is_goal_continuation_prompt_text(text: Any) -> bool:
+        return str(text or "").startswith("[Continuing toward your standing goal]\nGoal:")
+
+    def _pending_input_has_goal_continuation(self) -> bool:
+        """Return True if a synthetic /goal continuation is already queued."""
+        pending = getattr(self, "_pending_input", None)
+        if pending is None:
+            return False
+        try:
+            for entry in list(pending.queue):
+                if isinstance(entry, tuple) and entry:
+                    entry = entry[0]
+                if self._is_goal_continuation_prompt_text(entry):
+                    return True
+        except Exception:
+            return False
+        return False
+
+    def _enqueue_goal_continuation_prompt(self, prompt: str, *, delay_seconds: int = 0) -> None:
+        """Queue a synthetic /goal continuation once, optionally after backoff."""
+        if not prompt:
+            return
+        if self._pending_input_has_goal_continuation():
+            logging.debug("goal continuation enqueue skipped: prompt already pending")
+            return
+        delay_seconds = max(0, int(delay_seconds or 0))
+        if delay_seconds <= 0:
+            self._pending_input.put(prompt)
+            return
+
+        existing = getattr(self, "_goal_retry_timer", None)
+        if existing is not None and existing.is_alive():
+            logging.debug("goal continuation retry already scheduled")
+            return
+
+        session_id = getattr(self, "session_id", None)
+
+        def _delayed_enqueue() -> None:
+            try:
+                if getattr(self, "session_id", None) != session_id:
+                    return
+                mgr = self._get_goal_manager()
+                if mgr is None or not mgr.is_active():
+                    return
+                if self._pending_input_has_goal_continuation():
+                    return
+                self._pending_input.put(prompt)
+            except Exception as exc:
+                logging.debug("delayed goal continuation enqueue failed: %s", exc)
+
+        timer = threading.Timer(delay_seconds, _delayed_enqueue)
+        timer.daemon = True
+        self._goal_retry_timer = timer
+        timer.start()
+
 
 
     def _maybe_continue_goal_after_turn(self) -> None:
@@ -8197,7 +8254,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             prompt = decision.get("continuation_prompt")
             if prompt:
                 try:
-                    self._pending_input.put(prompt)
+                    self._enqueue_goal_continuation_prompt(
+                        prompt,
+                        delay_seconds=int(decision.get("retry_after_seconds") or 0),
+                    )
                 except Exception as exc:
                     logging.debug("goal continuation enqueue failed: %s", exc)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3642,6 +3642,73 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     queued_events.pop(session_key, None)
         return removed
 
+    def _has_pending_goal_continuation(self, session_key: str, adapter: Any) -> bool:
+        """Return True if a synthetic /goal continuation is already queued."""
+        if not session_key:
+            return False
+        pending_slot = getattr(adapter, "_pending_messages", None) if adapter is not None else None
+        if isinstance(pending_slot, dict) and self._is_goal_continuation_event(pending_slot.get(session_key)):
+            return True
+        queued_events = getattr(self, "_queued_events", None)
+        if isinstance(queued_events, dict):
+            for queued_event in queued_events.get(session_key) or []:
+                if self._is_goal_continuation_event(queued_event):
+                    return True
+        return False
+
+    def _enqueue_goal_continuation_once(self, session_key: str, cont_event: Any, adapter: Any) -> bool:
+        """Enqueue a synthetic /goal continuation only if one is not pending."""
+        if not session_key or adapter is None:
+            return False
+        if self._has_pending_goal_continuation(session_key, adapter):
+            logger.info("goal continuation: skipped duplicate pending continuation for %s", session_key)
+            return False
+        self._enqueue_fifo(session_key, cont_event, adapter)
+        return True
+
+    def _schedule_goal_continuation_retry(
+        self,
+        *,
+        session_key: str,
+        session_id: str,
+        cont_event: Any,
+        adapter: Any,
+        delay_seconds: int,
+    ) -> None:
+        """Schedule a delayed /goal continuation after provider backoff."""
+        delay_seconds = max(0, int(delay_seconds or 0))
+        if delay_seconds <= 0:
+            self._enqueue_goal_continuation_once(session_key, cont_event, adapter)
+            return
+        tasks = getattr(self, "_goal_retry_tasks", None)
+        if not isinstance(tasks, dict):
+            tasks = {}
+            self._goal_retry_tasks = tasks
+        existing = tasks.get(session_key)
+        if existing is not None and not existing.done():
+            logger.info("goal continuation: retry already scheduled for %s", session_key)
+            return
+
+        async def _delayed_enqueue() -> None:
+            try:
+                await asyncio.sleep(delay_seconds)
+                if not self._goal_still_active_for_session(session_id):
+                    return
+                self._enqueue_goal_continuation_once(session_key, cont_event, adapter)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("goal continuation: delayed enqueue failed: %s", exc)
+            finally:
+                try:
+                    current = getattr(self, "_goal_retry_tasks", {}).get(session_key)
+                    if current is asyncio.current_task():
+                        self._goal_retry_tasks.pop(session_key, None)
+                except Exception:
+                    pass
+
+        tasks[session_key] = asyncio.create_task(_delayed_enqueue())
+
     def _goal_still_active_for_session(self, session_id: str) -> bool:
         """Best-effort fresh DB check before running a queued continuation."""
         if not session_id:
@@ -9922,6 +9989,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                         )
+                    # The normal post-turn /goal hook lives in the caller and
+                    # only sees this method's return value.  For streamed turns
+                    # we return None below to avoid duplicate delivery, so run
+                    # the hook here while the final response text is still
+                    # available.  Without this, streamed gateway sessions keep
+                    # showing an active goal at 0/N turns but never enqueue the
+                    # next continuation.
+                    try:
+                        await self._post_turn_goal_continuation(
+                            session_entry=session_entry,
+                            source=source,
+                            final_response=response,
+                        )
+                    except Exception as _goal_exc:
+                        logger.debug("goal continuation hook failed after streamed delivery: %s", _goal_exc)
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
                 # Send it now as a small trailing message so Telegram/Discord/etc.
@@ -10557,7 +10639,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message_id=None,
                     channel_prompt=None,
                 )
-                self._enqueue_fifo(_quick_key, cont_event, adapter)
+                self._schedule_goal_continuation_retry(
+                    session_key=_quick_key,
+                    session_id=sid,
+                    cont_event=cont_event,
+                    adapter=adapter,
+                    delay_seconds=int(decision.get("retry_after_seconds") or 0),
+                )
         except Exception as exc:
             logger.debug("goal continuation: enqueue failed: %s", exc)
 

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -66,6 +66,11 @@ _JUDGE_RESPONSE_SNIPPET_CHARS = 4000
 # exhausted with every reply shaped like `judge returned empty response` or
 # `judge reply was not JSON`.
 DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES = 3
+# Transient provider failures (rate limits, overloads, timeouts) should never
+# satisfy a standing goal. Back off before retrying so two long-running goals do
+# not hammer the same provider/credential pool into a feedback loop.
+DEFAULT_TRANSIENT_RETRY_BASE_SECONDS = 5 * 60
+DEFAULT_TRANSIENT_RETRY_MAX_SECONDS = 60 * 60
 
 
 CONTINUATION_PROMPT_TEMPLATE = (
@@ -102,6 +107,9 @@ JUDGE_SYSTEM_PROMPT = (
     "- The response clearly shows the final deliverable was produced, OR\n"
     "- The response explains the goal is unachievable / blocked / needs "
     "user input (treat this as DONE with reason describing the block).\n\n"
+    "Transient model-provider/API failures are NOT goal completion. If the "
+    "response only says the provider is rate-limiting, overloaded, timed out, "
+    "or failed after retries, return done=false so the caller can retry later.\n\n"
     "Otherwise the goal is NOT done — CONTINUE.\n\n"
     "Reply ONLY with a single JSON object on one line:\n"
     '{\"done\": <true|false>, \"reason\": \"<one-sentence rationale>\"}'
@@ -153,6 +161,8 @@ class GoalState:
     last_reason: Optional[str] = None
     paused_reason: Optional[str] = None       # why we auto-paused (budget, etc.)
     consecutive_parse_failures: int = 0       # judge-output parse failures in a row
+    transient_error_failures: int = 0         # consecutive provider/rate-limit failures
+    retry_after_until: float = 0.0            # epoch seconds; advisory retry backoff
     # User-added criteria appended mid-loop via the /subgoal command.
     # When non-empty the judge prompt and continuation prompt both
     # include them so the agent works toward them and the judge factors
@@ -181,6 +191,8 @@ class GoalState:
             last_reason=data.get("last_reason"),
             paused_reason=data.get("paused_reason"),
             consecutive_parse_failures=int(data.get("consecutive_parse_failures", 0) or 0),
+            transient_error_failures=int(data.get("transient_error_failures", 0) or 0),
+            retry_after_until=float(data.get("retry_after_until", 0.0) or 0.0),
             subgoals=subgoals,
         )
 
@@ -315,6 +327,7 @@ def migrate_goal_to_session(old_session_id: str, new_session_id: str, *, reason:
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("GoalManager: goal migration failed: %s", exc)
         return False
+        return False
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -331,6 +344,129 @@ def _truncate(text: str, limit: int) -> str:
 
 
 _JSON_OBJECT_RE = re.compile(r"\{.*?\}", re.DOTALL)
+_TRANSIENT_PROVIDER_RESPONSE_RE = re.compile(
+    r"("
+    r"rate[-\s]?limit(?:ed|ing)?"
+    r"|too\s+many\s+requests"
+    r"|\b(?:http\s*)?429\b"
+    r"|temporar(?:y|ily)\s+(?:overloaded|unavailable)"
+    r"|overloaded"
+    r"|failed\s+after\s+retries"
+    r"|timeout|timed\s*out"
+    r"|try\s+again\s+(?:shortly|later|in\s+a\s+moment)"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def classify_transient_provider_response(text: str) -> Optional[str]:
+    """Return a normalized transient-provider failure reason, if detected.
+
+    Gateway replies deliberately sanitize raw provider failures into short
+    user-safe messages such as "The model provider is rate-limiting requests".
+    The normal judge prompt can misread those as a completed/blocked goal. This
+    classifier runs before the judge so infrastructure failures stay active and
+    get retried with backoff instead of becoming DONE.
+    """
+    body = str(text or "").strip()
+    if not body:
+        return None
+    # Keep this conservative: only short provider-error envelopes should match,
+    # not a long assistant explanation about how to handle HTTP 429s.
+    if len(body) > 800 or body.count("\n") > 8:
+        return None
+    if not _TRANSIENT_PROVIDER_RESPONSE_RE.search(body):
+        return None
+    lowered = body.lower()
+    if "rate" in lowered or "429" in lowered or "too many requests" in lowered:
+        return "model provider rate limited the request"
+    if "overload" in lowered or "temporar" in lowered:
+        return "model provider is temporarily overloaded"
+    if "timeout" in lowered or "timed out" in lowered:
+        return "model provider timed out"
+    return "model provider failed transiently"
+
+
+def _transient_retry_delay_seconds(failures: int) -> int:
+    """Exponential retry backoff for consecutive transient provider failures."""
+    attempts = max(1, int(failures or 1))
+    delay = DEFAULT_TRANSIENT_RETRY_BASE_SECONDS * (2 ** (attempts - 1))
+    return int(min(delay, DEFAULT_TRANSIENT_RETRY_MAX_SECONDS))
+
+
+def _format_delay(delay_seconds: int) -> str:
+    delay_seconds = max(0, int(delay_seconds or 0))
+    if delay_seconds < 60:
+        return f"{delay_seconds}s"
+    minutes = delay_seconds // 60
+    if minutes < 60:
+        return f"{minutes}m"
+    hours = minutes // 60
+    rem = minutes % 60
+    return f"{hours}h{rem}m" if rem else f"{hours}h"
+
+
+def _goal_pause_decision(state: GoalState, reason: str) -> Dict[str, Any]:
+    """Shared budget-exhaustion decision shape."""
+    state.status = "paused"
+    state.paused_reason = f"turn budget exhausted ({state.turns_used}/{state.max_turns})"
+    return {
+        "status": "paused",
+        "should_continue": False,
+        "continuation_prompt": None,
+        "verdict": "continue",
+        "reason": reason,
+        "message": (
+            f"⏸ Goal paused — {state.turns_used}/{state.max_turns} turns used. "
+            "Use /goal resume to keep going, or /goal clear to stop."
+        ),
+    }
+
+
+def _goal_continue_decision(
+    state: GoalState,
+    prompt: Optional[str],
+    reason: str,
+    *,
+    retry_after_seconds: int = 0,
+) -> Dict[str, Any]:
+    message = f"↻ Continuing toward goal ({state.turns_used}/{state.max_turns}): {reason}"
+    if retry_after_seconds > 0:
+        message = (
+            f"↻ Goal still active; provider failure detected. Retrying in "
+            f"{_format_delay(retry_after_seconds)} ({state.turns_used}/{state.max_turns}): {reason}"
+        )
+    return {
+        "status": "active",
+        "should_continue": True,
+        "continuation_prompt": prompt,
+        "verdict": "continue",
+        "reason": reason,
+        "message": message,
+        "retry_after_seconds": retry_after_seconds,
+    }
+
+
+def _goal_done_decision(reason: str) -> Dict[str, Any]:
+    return {
+        "status": "done",
+        "should_continue": False,
+        "continuation_prompt": None,
+        "verdict": "done",
+        "reason": reason,
+        "message": f"✓ Goal achieved: {reason}",
+    }
+
+
+def _goal_inactive_decision(state: Optional[GoalState]) -> Dict[str, Any]:
+    return {
+        "status": state.status if state else None,
+        "should_continue": False,
+        "continuation_prompt": None,
+        "verdict": "inactive",
+        "reason": "no active goal",
+        "message": "",
+    }
 
 
 def _goal_judge_max_tokens() -> int:
@@ -677,24 +813,43 @@ class GoalManager:
         """
         state = self._state
         if state is None or state.status != "active":
-            return {
-                "status": state.status if state else None,
-                "should_continue": False,
-                "continuation_prompt": None,
-                "verdict": "inactive",
-                "reason": "no active goal",
-                "message": "",
-            }
+            return _goal_inactive_decision(state)
 
         # Count the turn that just finished.
         state.turns_used += 1
-        state.last_turn_at = time.time()
+        now = time.time()
+        state.last_turn_at = now
+
+        transient_reason = classify_transient_provider_response(last_response)
+        if transient_reason:
+            # Do not ask the judge to interpret infrastructure errors. The judge
+            # is allowed to treat "blocked" as DONE for real task blockers, but
+            # provider rate limits/overloads are retryable execution failures.
+            state.last_verdict = "continue"
+            state.last_reason = transient_reason
+            state.consecutive_parse_failures = 0
+            state.transient_error_failures += 1
+            retry_after = _transient_retry_delay_seconds(state.transient_error_failures)
+            state.retry_after_until = now + retry_after
+            if state.turns_used >= state.max_turns:
+                decision = _goal_pause_decision(state, transient_reason)
+                save_goal(self.session_id, state)
+                return decision
+            save_goal(self.session_id, state)
+            return _goal_continue_decision(
+                state,
+                self.next_continuation_prompt(),
+                transient_reason,
+                retry_after_seconds=retry_after,
+            )
 
         verdict, reason, parse_failed = judge_goal(
             state.goal, last_response, subgoals=state.subgoals or None
         )
         state.last_verdict = verdict
         state.last_reason = reason
+        state.transient_error_failures = 0
+        state.retry_after_until = 0.0
 
         # Track consecutive judge parse failures. Reset on any usable reply,
         # including API / transport errors (parse_failed=False) so a flaky
@@ -707,14 +862,7 @@ class GoalManager:
         if verdict == "done":
             state.status = "done"
             save_goal(self.session_id, state)
-            return {
-                "status": "done",
-                "should_continue": False,
-                "continuation_prompt": None,
-                "verdict": "done",
-                "reason": reason,
-                "message": f"✓ Goal achieved: {reason}",
-            }
+            return _goal_done_decision(reason)
 
         # Auto-pause when the judge model can't produce the expected JSON
         # verdict N turns in a row. Points the user at the goal_judge config
@@ -747,32 +895,12 @@ class GoalManager:
             }
 
         if state.turns_used >= state.max_turns:
-            state.status = "paused"
-            state.paused_reason = f"turn budget exhausted ({state.turns_used}/{state.max_turns})"
+            decision = _goal_pause_decision(state, reason)
             save_goal(self.session_id, state)
-            return {
-                "status": "paused",
-                "should_continue": False,
-                "continuation_prompt": None,
-                "verdict": "continue",
-                "reason": reason,
-                "message": (
-                    f"⏸ Goal paused — {state.turns_used}/{state.max_turns} turns used. "
-                    "Use /goal resume to keep going, or /goal clear to stop."
-                ),
-            }
+            return decision
 
         save_goal(self.session_id, state)
-        return {
-            "status": "active",
-            "should_continue": True,
-            "continuation_prompt": self.next_continuation_prompt(),
-            "verdict": "continue",
-            "reason": reason,
-            "message": (
-                f"↻ Continuing toward goal ({state.turns_used}/{state.max_turns}): {reason}"
-            ),
-        }
+        return _goal_continue_decision(state, self.next_continuation_prompt(), reason)
 
     def next_continuation_prompt(self) -> Optional[str]:
         if not self._state or self._state.status != "active":
@@ -942,10 +1070,13 @@ __all__ = [
     "KANBAN_GOAL_CONTINUATION_TEMPLATE",
     "KANBAN_GOAL_FINALIZE_TEMPLATE",
     "DEFAULT_MAX_TURNS",
+    "DEFAULT_TRANSIENT_RETRY_BASE_SECONDS",
+    "DEFAULT_TRANSIENT_RETRY_MAX_SECONDS",
     "load_goal",
     "save_goal",
     "clear_goal",
     "migrate_goal_to_session",
+    "classify_transient_provider_response",
     "judge_goal",
     "run_kanban_goal_loop",
 ]

--- a/tests/cli/test_cli_goal_interrupt.py
+++ b/tests/cli/test_cli_goal_interrupt.py
@@ -179,6 +179,46 @@ class TestHealthyTurnStillRuns:
         assert "Continuing toward your standing goal" in queued
         assert mgr.state.status == "active"
 
+    def test_duplicate_goal_continuation_is_not_enqueued(self, hermes_home):
+        sid = f"sid-dedup-{uuid.uuid4().hex}"
+        cli, mgr = _make_cli_with_goal(sid)
+        existing = mgr.next_continuation_prompt()
+        assert existing is not None
+        cli._pending_input.put(existing)
+        cli.conversation_history = [
+            {"role": "assistant", "content": "more work remains"},
+        ]
+
+        with patch(
+            "hermes_cli.goals.judge_goal",
+            return_value=("continue", "needs more steps", False),
+        ):
+            cli._maybe_continue_goal_after_turn()
+
+        assert cli._pending_input.qsize() == 1
+
+    def test_rate_limit_response_schedules_retry_instead_of_immediate_enqueue(self, hermes_home):
+        sid = f"sid-rate-limit-{uuid.uuid4().hex}"
+        cli, mgr = _make_cli_with_goal(sid)
+        cli.conversation_history = [
+            {
+                "role": "assistant",
+                "content": "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.",
+            },
+        ]
+
+        with patch("hermes_cli.goals.judge_goal") as judge_mock:
+            judge_mock.side_effect = AssertionError("rate-limit response should bypass judge")
+            cli._maybe_continue_goal_after_turn()
+
+        assert cli._pending_input.empty()
+        timer = getattr(cli, "_goal_retry_timer", None)
+        assert timer is not None and timer.is_alive()
+        timer.cancel()
+        state = mgr.state
+        assert state is not None
+        assert state.status == "active"
+
     def test_clean_response_marks_done_when_judge_says_done(self, hermes_home):
         sid = f"sid-done-{uuid.uuid4().hex}"
         cli, mgr = _make_cli_with_goal(sid)

--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -73,6 +73,7 @@ def _make_runner_with_adapter(session_id: str = None):
     runner._running_agents = {}
     runner._running_agents_ts = {}
     runner._queued_events = {}
+    runner._goal_retry_tasks = {}
 
     src = _make_source()
     # Default to a unique session_id so xdist parallel runs on the same worker
@@ -149,6 +150,61 @@ async def test_goal_verdict_continue_enqueues_continuation(hermes_home):
     assert "Continuing toward goal" in adapter.sends[0]["content"]
     # Continuation prompt enqueued for next turn
     assert adapter._pending_messages, "continuation prompt must be enqueued in pending_messages"
+
+
+@pytest.mark.asyncio
+async def test_goal_continuation_dedup_skips_duplicate_pending_prompt(hermes_home):
+    """A second judge pass must not stack duplicate synthetic continuations."""
+    runner, adapter, session_entry, src = _make_runner_with_adapter()
+
+    from hermes_cli.goals import GoalManager
+
+    GoalManager(session_entry.session_id).set("polish the docs")
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "still needs work", False)):
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="partial edit one",
+        )
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="partial edit two",
+        )
+        await asyncio.sleep(0.05)
+
+    assert len(adapter._pending_messages) == 1
+    assert not runner._queued_events.get(build_session_key(src)), "duplicate continuation leaked into overflow queue"
+
+
+@pytest.mark.asyncio
+async def test_goal_rate_limit_schedules_delayed_retry_without_immediate_enqueue(hermes_home):
+    """Provider rate limits should back off instead of immediately re-queuing."""
+    runner, adapter, session_entry, src = _make_runner_with_adapter()
+
+    from hermes_cli.goals import GoalManager
+
+    GoalManager(session_entry.session_id).set("ship the backend")
+
+    with patch("hermes_cli.goals.judge_goal") as judge_mock:
+        judge_mock.side_effect = AssertionError("rate-limit response should bypass judge")
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="⏱️ The model provider is rate-limiting requests. Please wait a moment and try again.",
+        )
+        await asyncio.sleep(0.05)
+
+    assert len(adapter.sends) == 1
+    assert "Retrying in" in adapter.sends[0]["content"]
+    assert not adapter._pending_messages
+    key = build_session_key(src)
+    task = runner._goal_retry_tasks.get(key)
+    assert task is not None and not task.done()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -286,6 +286,69 @@ class TestGoalManager:
         assert mgr.state.status == "active"
         assert mgr.state.turns_used == 1
 
+    def test_provider_rate_limit_response_stays_active_and_backs_off(self, hermes_home):
+        """A sanitized provider 429 is infrastructure failure, not goal completion."""
+        from hermes_cli import goals
+        from hermes_cli.goals import (
+            DEFAULT_TRANSIENT_RETRY_BASE_SECONDS,
+            GoalManager,
+        )
+
+        mgr = GoalManager(session_id="eval-rate-limit", default_max_turns=5)
+        mgr.set("ship the backend")
+
+        with patch.object(goals, "judge_goal") as judge_mock:
+            judge_mock.side_effect = AssertionError("rate-limit responses must bypass the judge")
+            decision = mgr.evaluate_after_turn(
+                "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+            )
+
+        assert decision["verdict"] == "continue"
+        assert decision["should_continue"] is True
+        assert decision["retry_after_seconds"] == DEFAULT_TRANSIENT_RETRY_BASE_SECONDS
+        assert "provider" in decision["message"].lower()
+        state = mgr.state
+        assert state is not None
+        assert state.status == "active"
+        assert state.last_verdict == "continue"
+        assert state.last_reason is not None and "rate limited" in state.last_reason
+        assert state.transient_error_failures == 1
+        assert state.retry_after_until > 0
+
+    def test_provider_transient_backoff_is_exponential_and_resets_on_progress(self, hermes_home):
+        from hermes_cli import goals
+        from hermes_cli.goals import DEFAULT_TRANSIENT_RETRY_BASE_SECONDS, GoalManager
+
+        mgr = GoalManager(session_id="eval-rate-limit-reset", default_max_turns=10)
+        mgr.set("ship the backend")
+
+        with patch.object(goals, "judge_goal") as judge_mock:
+            judge_mock.side_effect = AssertionError("transient failures bypass judge")
+            d1 = mgr.evaluate_after_turn("HTTP 429 Too Many Requests")
+            d2 = mgr.evaluate_after_turn("rate limited after 3 retries")
+
+        assert d1["retry_after_seconds"] == DEFAULT_TRANSIENT_RETRY_BASE_SECONDS
+        assert d2["retry_after_seconds"] == DEFAULT_TRANSIENT_RETRY_BASE_SECONDS * 2
+        state = mgr.state
+        assert state is not None
+        assert state.transient_error_failures == 2
+
+        with patch.object(goals, "judge_goal", return_value=("continue", "made progress", False)):
+            d3 = mgr.evaluate_after_turn("implemented part of it")
+
+        assert d3["should_continue"] is True
+        state = mgr.state
+        assert state is not None
+        assert state.transient_error_failures == 0
+        assert state.retry_after_until == 0.0
+
+    def test_provider_error_text_classifier_is_conservative(self):
+        from hermes_cli.goals import classify_transient_provider_response
+
+        assert classify_transient_provider_response("HTTP 429 Too Many Requests")
+        assert classify_transient_provider_response("The model provider is temporarily overloaded")
+        assert classify_transient_provider_response("normal progress: wrote tests and pushed code") is None
+
     def test_evaluate_after_turn_budget_exhausted(self, hermes_home):
         """When turn budget hits ceiling, auto-pause instead of continuing."""
         from hermes_cli import goals


### PR DESCRIPTION
## Summary
- Treat transient provider failures (429/rate limits, overloads, timeouts, failed-after-retries envelopes) as retryable `/goal` continuations, not goal completion.
- Add exponential backoff state to persisted goal metadata and schedule delayed retries in both CLI and gateway paths.
- Deduplicate synthetic `/goal` continuation prompts so repeated judge hooks cannot flood a session queue.
- Tighten the goal judge prompt so provider/API failures are explicitly not considered DONE.

## Test Plan
- `PYTHONPATH=. /Users/mrr/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_goals.py tests/gateway/test_goal_verdict_send.py tests/cli/test_cli_goal_interrupt.py -q -o 'addopts='`
  - `74 passed in 1.62s`

## Deployment note
This fixes a production failure mode observed on a Telegram gateway where simultaneous long-running `/goal` sessions hit provider rate limits and then re-enqueued hundreds of duplicate continuations. A temporary hotpatch with the same behavior has been deployed to the affected operator.
