### PR TITLE
fix(config): warn on incomplete model sub-keys when custom_providers is configured

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4535,6 +4535,24 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             "    base_url: https://...",
         ))
 
+    # ── model section sub-key completeness (when custom_providers present) ──
+    if cp and isinstance(model_cfg, dict):
+        if not model_cfg.get("provider"):
+            issues.append(ConfigIssue(
+                "warning",
+                "model section is missing 'provider' — Hermes will fall through to auto-detection",
+                "Add: model:\n"
+                "  provider: custom\n"
+                "  (or the name of your custom_providers entry)",
+            ))
+        if not model_cfg.get("default") and not model_cfg.get("model"):
+            issues.append(ConfigIssue(
+                "warning",
+                "model section is missing 'default' — Hermes won't know which model to use",
+                "Add: model:\n"
+                "  default: your-model-name",
+            ))
+
     # ── Root-level keys that look misplaced ──────────────────────────────
     for key in config:
         if key.startswith("_"):

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -205,3 +205,69 @@ class TestConfigIssueDataclass:
         a = ConfigIssue("error", "msg", "hint")
         b = ConfigIssue("error", "msg", "hint")
         assert a == b
+
+
+class TestModelSubKeyValidation:
+    """When custom_providers is configured and model section exists as a dict,
+    warn about missing essential sub-keys (provider, default)."""
+
+    def test_missing_provider_subkey(self):
+        """model dict without 'provider' should warn about auto-detection fallback."""
+        issues = validate_config_structure({
+            "custom_providers": [
+                {"name": "test", "base_url": "https://example.com/v1"},
+            ],
+            "model": {"default": "test-model"},
+        })
+        assert any("missing 'provider'" in i.message for i in issues)
+
+    def test_missing_default_subkey(self):
+        """model dict without 'default' or 'model' should warn."""
+        issues = validate_config_structure({
+            "custom_providers": [
+                {"name": "test", "base_url": "https://example.com/v1"},
+            ],
+            "model": {"provider": "custom"},
+        })
+        assert any("missing 'default'" in i.message for i in issues)
+
+    def test_model_key_accepted_as_default(self):
+        """model dict with 'model' sub-key (instead of 'default') should not warn."""
+        issues = validate_config_structure({
+            "custom_providers": [
+                {"name": "test", "base_url": "https://example.com/v1"},
+            ],
+            "model": {"provider": "custom", "model": "test-model"},
+        })
+        default_issues = [i for i in issues if "missing 'default'" in i.message]
+        assert len(default_issues) == 0
+
+    def test_complete_model_no_issues(self):
+        """Fully configured model section should produce no model-related warnings."""
+        issues = validate_config_structure({
+            "custom_providers": [
+                {"name": "test", "base_url": "https://example.com/v1"},
+            ],
+            "model": {"provider": "custom", "default": "test-model"},
+        })
+        model_issues = [i for i in issues if "model" in i.message.lower() and "missing" in i.message.lower()]
+        assert len(model_issues) == 0
+
+    def test_no_custom_providers_skips_subkey_check(self):
+        """Without custom_providers, model sub-key check should be skipped."""
+        issues = validate_config_structure({
+            "model": {},
+        })
+        subkey_issues = [i for i in issues if "missing 'provider'" in i.message]
+        assert len(subkey_issues) == 0
+
+    def test_model_as_string_skips_subkey_check(self):
+        """model as a string (shorthand) should not trigger sub-key validation."""
+        issues = validate_config_structure({
+            "custom_providers": [
+                {"name": "test", "base_url": "https://example.com/v1"},
+            ],
+            "model": "openrouter/claude-sonnet-4",
+        })
+        subkey_issues = [i for i in issues if "missing 'provider'" in i.message]
+        assert len(subkey_issues) == 0


### PR DESCRIPTION
## What does this PR do?

Adds sub-key completeness validation for the `model:` config section when `custom_providers` is configured. Previously, `validate_config_structure()` only checked whether the `model:` section existed — if it existed but was missing essential sub-keys (`provider`, `default`), validation passed silently, causing Hermes to fall through to provider auto-detection and potentially route to an unintended provider with unexpected billing.

## Related Issue

Fixes #50105

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: Added sub-key completeness checks in `validate_config_structure()` — when `custom_providers` is configured and `model:` is a dict, warn if `provider` is missing (triggers auto-detection fallback) and if neither `default` nor `model` sub-key is present (no model selected). String shorthand (`model: "openrouter/claude-sonnet-4"`) is unaffected.
- `tests/hermes_cli/test_config_validation.py`: Added `TestModelSubKeyValidation` class with 6 tests covering: missing provider, missing default, `model` sub-key as alternative to `default`, complete config, no custom_providers skip, and string shorthand skip.

## How to Test

1. Create a `config.yaml` with `custom_providers` but `model:` missing the `provider` sub-key:
   ```yaml
   custom_providers:
     - name: test
       base_url: https://example.com/v1
   model:
     default: test-model
   ```
2. Run `hermes config check` — should warn about missing `provider`
3. Run `pytest tests/hermes_cli/test_config_validation.py -q` — all 27 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_config_validation.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `hermes_cli/config.py` `validate_config_structure()` (line 4408), callers: `print_config_warnings()`, `run_config_check()`
- Blast radius: LOW — additive validation only, no existing behavior changed
- Related patterns: existing `custom_providers` validation (lines 4424-4467), `fallback_model` validation (lines 4469-4515)
