### PR TITLE
fix(gateway): strip ANSI from text-only background watcher notifications (salvage of #13122 by @euyua9)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13186,7 +13186,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     or (notify_mode == "error" and session.exit_code not in {0, None})
                 )
                 if should_notify:
-                    new_output = session.output_buffer[-1000:] if session.output_buffer else ""
+                    from tools.ansi_strip import strip_ansi
+                    new_output = (
+                        strip_ansi(session.output_buffer[-1000:])
+                        if session.output_buffer
+                        else ""
+                    )
                     message_text = (
                         f"[Background process {session_id} finished with exit code {session.exit_code}~ "
                         f"Here's the final output:\n{new_output}]"
@@ -13211,7 +13216,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             elif has_new_output and notify_mode == "all" and not agent_notify:
                 # New output available -- deliver status update (only in "all" mode)
                 # Skip periodic updates for agent_notify watchers (they only care about completion)
-                new_output = session.output_buffer[-500:] if session.output_buffer else ""
+                from tools.ansi_strip import strip_ansi
+                new_output = (
+                    strip_ansi(session.output_buffer[-500:])
+                    if session.output_buffer
+                    else ""
+                )
                 message_text = (
                     f"[Background process {session_id} is still running~ "
                     f"New output:\n{new_output}]"

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -556,3 +556,80 @@ def test_parse_session_key_too_short():
 def test_parse_session_key_wrong_prefix():
     assert _parse_session_key("cron:main:telegram:dm:123") is None
     assert _parse_session_key("agent:cron:telegram:dm:123") is None
+
+
+@pytest.mark.asyncio
+async def test_finished_text_notification_strips_ansi(monkeypatch, tmp_path):
+    """The text-only 'finished with exit code' notification must strip ANSI.
+
+    Salvage of #13122 by @euyua9. The agent_notify completion branch already
+    strips ANSI; the plain text-only delivery branch (notify_mode in
+    all/result/error) still emitted raw output_buffer, leaking escape codes
+    into Telegram/Discord/etc. messages.
+    """
+    import tools.process_registry as pr_module
+
+    sessions = [
+        SimpleNamespace(
+            output_buffer="\x1b[31mFATAL\x1b[0m: \x1b[1mboom\x1b[0m\n",
+            exited=True,
+            exit_code=1,
+        )
+    ]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._run_process_watcher(_watcher_dict())
+
+    assert adapter.send.await_count == 1
+    sent_message = adapter.send.await_args.args[1]
+    assert "\x1b[" not in sent_message, f"ANSI leaked: {sent_message!r}"
+    assert "FATAL: boom" in sent_message
+
+
+@pytest.mark.asyncio
+async def test_still_running_text_notification_strips_ansi(monkeypatch, tmp_path):
+    """The periodic 'still running' status update must strip ANSI too."""
+    import tools.process_registry as pr_module
+
+    # First poll: not exited, has new colored output -> status update.
+    # Second poll: exited so the watcher loop terminates.
+    sessions = [
+        SimpleNamespace(
+            output_buffer="\x1b[32mprogress 50%\x1b[0m\n",
+            exited=False,
+            exit_code=None,
+        ),
+        SimpleNamespace(
+            output_buffer="\x1b[32mprogress 50%\x1b[0m\n",
+            exited=True,
+            exit_code=0,
+        ),
+    ]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._run_process_watcher(_watcher_dict())
+
+    # At least the "still running" status update was sent; none may contain ANSI.
+    assert adapter.send.await_count >= 1
+    running_msgs = [
+        c.args[1] for c in adapter.send.await_args_list
+        if "still running" in c.args[1]
+    ]
+    assert running_msgs, "expected a 'still running' status update"
+    for msg in running_msgs:
+        assert "\x1b[" not in msg, f"ANSI leaked: {msg!r}"
+        assert "progress 50%" in msg


### PR DESCRIPTION
## Summary

Salvages #13122 by @euyua9 onto current main.

`_run_process_watcher` delivers background-process output to the user's chat. The `agent_notify` completion branch already strips ANSI via `tools.ansi_strip.strip_ansi`, but the two **text-only** delivery branches still passed raw `session.output_buffer` straight into the message:

- `"[Background process N finished with exit code …~ Here's the final output:\n{raw}]"` (notify_mode `all`/`result`/`error`)
- `"[Background process N is still running~ New output:\n{raw}]"` (notify_mode `all`, periodic)

Raw escape codes (`\x1b[31m`, `\x1b[1m`, …) leak into Telegram/Discord/Slack messages and render as mojibake.

## What the original PR fixed

Wraps the watcher's text-notification output in `strip_ansi(...)`.

## Why it needed salvage

Since the Apr 22 original, the watcher grew an `agent_notify` completion path that *does* strip ANSI — but the two plain text-only branches were left untouched and remained the gap. Reapplied the strip to exactly those two branches on current main, preserving @euyua9's intent.

## Changes from original

- Rebased onto current main (line offsets + the new completion branch).
- Strip applied to both surviving raw branches (finished + still-running).
- 2 regression tests that **fail without the fix** (assert no `\x1b[` survives in the delivered message and the clean text remains).

## Real behavior proof

Captured on this branch:

```
OLD (raw):   "...final output:\n\x1b[31mFATAL\x1b[0m: \x1b[1mboom\x1b[0m\n]"
NEW (clean): "...final output:\nFATAL: boom\n]"
```

## Testing

```
$ python -m pytest tests/gateway/test_background_process_notifications.py::test_finished_text_notification_strips_ansi \
                   tests/gateway/test_background_process_notifications.py::test_still_running_text_notification_strips_ansi -q
2 passed

# Both FAIL on clean origin/main (44d552ea5) — confirmed regression coverage:
2 failed

$ python -m pytest tests/gateway/test_background_process_notifications.py -q
33 passed in 0.48s
```

## How to test

1. Start a background process that emits colored output (e.g. `ls --color=always`) under a watcher with `display.background_process_notifications: all`.
2. The completion/running notification arrives with clean text instead of raw escape sequences.

Credit to @euyua9 for the original fix (#13122).