### PR TITLE
fix(state): periodically merge FTS5 segments to curb write-lock contention

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -677,6 +677,16 @@ class SessionDB:
     _WRITE_RETRY_MAX_S = 0.150   # 150ms
     # Attempt a PASSIVE WAL checkpoint every N successful writes.
     _CHECKPOINT_EVERY_N_WRITES = 50
+    # Merge fragmented FTS5 segments every N successful writes. The message
+    # triggers append one segment per insert; left unmaintained these grow
+    # into tens of thousands of segments, so every MATCH must scan them all
+    # and every insert pays a growing automerge cost — which lengthens the
+    # write-lock hold time and starves competing writers (gateway + cron
+    # processes share one state.db), surfacing as "database is locked".
+    # 'optimize' is a no-op once the index is already merged, so an idle DB
+    # pays almost nothing; the cadence is deliberately coarse so the one-off
+    # merge cost is amortised far below the checkpoint cadence.
+    _OPTIMIZE_EVERY_N_WRITES = 1000
 
     def __init__(self, db_path: Path = None, read_only: bool = False):
         self.db_path = db_path or DEFAULT_DB_PATH
@@ -945,10 +955,12 @@ class SessionDB:
                         except Exception:
                             pass
                         raise
-                # Success — periodic best-effort checkpoint.
+                # Success — periodic best-effort checkpoint + FTS merge.
                 self._write_count += 1
                 if self._write_count % self._CHECKPOINT_EVERY_N_WRITES == 0:
                     self._try_wal_checkpoint()
+                if self._write_count % self._OPTIMIZE_EVERY_N_WRITES == 0:
+                    self._try_optimize_fts()
                 return result
             except sqlite3.OperationalError as exc:
                 err_msg = str(exc).lower()
@@ -996,6 +1008,22 @@ class SessionDB:
                         "WAL checkpoint: %d/%d pages checkpointed",
                         result[2], result[1],
                     )
+        except Exception:
+            pass  # Best effort — never fatal.
+
+    def _try_optimize_fts(self) -> None:
+        """Best-effort FTS5 segment merge. Never raises.
+
+        Runs on the ``_OPTIMIZE_EVERY_N_WRITES`` cadence from the write hot
+        path (off the lock — ``optimize_fts`` re-acquires ``self._lock``
+        itself, mirroring ``_try_wal_checkpoint``). ``read_only`` connections
+        never reach the write path, so this is implicitly skipped for them.
+        Once the index is merged the 'optimize' command is close to free, so
+        the steady-state cost is negligible; the expensive case is only the
+        first merge of a long-neglected index.
+        """
+        try:
+            self.optimize_fts()
         except Exception:
             pass  # Best effort — never fatal.
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3656,6 +3656,40 @@ class TestOptimizeFts:
         # Search still works after repeated optimization.
         assert len(db.search_messages("repeat")) == 1
 
+    def test_write_path_optimizes_fts_on_cadence(self, db, monkeypatch):
+        """Writes periodically merge FTS segments so they never accumulate
+        into the tens-of-thousands that lengthen the write-lock hold and
+        starve competing writers ("database is locked")."""
+        db._OPTIMIZE_EVERY_N_WRITES = 5
+        calls = {"n": 0}
+        real_optimize = db.optimize_fts
+
+        def _counting_optimize():
+            calls["n"] += 1
+            return real_optimize()
+
+        monkeypatch.setattr(db, "optimize_fts", _counting_optimize)
+        # create_session is write #1; appends are #2.. -> #5 and #10 trigger.
+        db.create_session(session_id="s1", source="cli")
+        for i in range(9):
+            db.append_message(session_id="s1", role="user", content=f"needle {i}")
+        assert calls["n"] == 2
+        # The auto-merge is layout-only: search is unaffected.
+        assert len(db.search_messages("needle")) == 9
+
+    def test_write_path_optimize_failure_never_breaks_write(self, db, monkeypatch):
+        """A failing periodic optimize must not fail the surrounding write."""
+        db._OPTIMIZE_EVERY_N_WRITES = 2
+
+        def _boom():
+            raise sqlite3.OperationalError("simulated optimize failure")
+
+        monkeypatch.setattr(db, "optimize_fts", _boom)
+        db.create_session(session_id="s1", source="cli")  # write #1
+        # write #2 trips the cadence; the swallowed failure must not propagate.
+        db.append_message(session_id="s1", role="user", content="still persists")
+        assert len(db.get_messages("s1")) == 1
+
 
 class TestAutoMaintenance:
     def _make_old_ended(self, db, sid: str, days_old: int = 100):


### PR DESCRIPTION
## Problem

The `messages` table triggers append one FTS5 segment per insert into **both** the porter (`messages_fts`) and trigram (`messages_fts_trigram`) indexes. The `optimize_fts()` maintenance helper already exists but **nothing ever calls it**, so on a long-lived `state.db` these segments accumulate without bound.

Observed on a real instance: **~34k trigram segments for ~27k messages**. Consequences:
- Every `MATCH` query has to scan all segments (slower search).
- Every insert pays a growing automerge cost, which **lengthens the WAL write-lock hold time**.

Because the gateway and cron agents are **separate processes sharing one `state.db`**, those longer holds blow through the `1s timeout × 15 retry` budget in `_execute_write`, surfacing as repeated:

```
Session DB creation failed (will retry next turn): database is locked
Session DB append_message failed: database is locked
```

## Fix

Wire the existing `optimize_fts()` into the write path on a coarse cadence (`_OPTIMIZE_EVERY_N_WRITES = 1000`), right next to the existing every-50-writes WAL checkpoint.

- `'optimize'` is effectively a no-op once the index is already merged, so steady-state cost is negligible — only the **first** merge of a neglected index is expensive.
- The call is **best-effort** (`_try_optimize_fts`): it re-acquires `self._lock` (mirroring `_try_wal_checkpoint`) and never propagates failures into the surrounding write.
- `read_only` connections never reach the write path, so they're implicitly unaffected.

## Tests

- `test_write_path_optimizes_fts_on_cadence` — the cadence actually fires from the write path.
- `test_write_path_optimize_failure_never_breaks_write` — a failing optimize never fails the surrounding write.

Full `tests/test_hermes_state.py` suite passes (280 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)