### PR TITLE
fix(auth): expand ~ in CA bundle path before existence check

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4616,7 +4616,7 @@ def _resolve_verify(
     if effective_insecure:
         return False
     if effective_ca:
-        ca_path = str(effective_ca)
+        ca_path = os.path.expanduser(str(effective_ca))
         if not os.path.isfile(ca_path):
             logger.warning(
                 "CA bundle path does not exist: %s — falling back to default certificates",

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -122,6 +122,35 @@ class TestResolveVerifyFallback:
             f"Expected ssl.SSLContext but got {type(result).__name__}: {result!r}"
         )
 
+    def test_tilde_ca_bundle_path_is_expanded(self, tmp_path, monkeypatch):
+        import ssl
+        from hermes_cli.auth import _resolve_verify
+
+        # Make ~ resolve to tmp_path on both POSIX (HOME) and Windows (USERPROFILE).
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+        ca_file = tmp_path / "certs" / "ca.pem"
+        ca_file.parent.mkdir(parents=True)
+        ca_file.write_text("fake cert")
+
+        # Avoid loading actual PEM — just verify the return type
+        mock_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        monkeypatch.setattr(ssl, "create_default_context", lambda **kw: mock_ctx)
+
+        # --ca-bundle arg channel: a tilde path must expand to the real file.
+        result = _resolve_verify(ca_bundle="~/certs/ca.pem")
+        assert isinstance(result, ssl.SSLContext), (
+            f"Expected ssl.SSLContext but got {type(result).__name__}: {result!r}"
+        )
+
+        # HERMES_CA_BUNDLE env channel: same expansion must apply.
+        monkeypatch.setenv("HERMES_CA_BUNDLE", "~/certs/ca.pem")
+        result_env = _resolve_verify(auth_state={"tls": {}})
+        assert isinstance(result_env, ssl.SSLContext), (
+            f"Expected ssl.SSLContext but got {type(result_env).__name__}: {result_env!r}"
+        )
+
 
 def _setup_nous_auth(
     hermes_home: Path,


### PR DESCRIPTION
## What does this PR do?

`_resolve_verify` (in `hermes_cli/auth.py`) passes the resolved CA-bundle path straight to `os.path.isfile()` **without** `os.path.expanduser()`. A `~`-relative path — common when the value comes from persisted `auth.json` (`tls.ca_bundle`), from `HERMES_CA_BUNDLE` / `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE`, or from a quoted `--ca-bundle '~/certs/ca.pem'` — is never expanded, so `os.path.isfile()` is always `False`. The configured CA is then silently dropped and Hermes falls back to the system default trust store with only a `logger.warning` most users never see.

**Impact:** Operators in corporate / proxy / MITM-inspection environments who pin a private CA via a `~` path get the system default trust store instead — best case a confusing cert failure despite a "valid" configured bundle, worse case the intended pinned-CA verification is silently not applied.

The fix expands the path once with `os.path.expanduser` before the existence check (and before building the SSL context), matching the existing `hermes_cli` convention already used for user-supplied paths in `hermes_cli/web_server.py` (`Path(raw).expanduser()`) and `hermes_cli/session_recap.py` (`os.path.abspath(os.path.expanduser(path))`). Only the tilde expansion changes; the `isfile` guard, the default-trust fallback, and the env precedence chain are all unchanged.

## Related Issue

<!-- No filed issue; found via code review of the CA-bundle resolution path. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py` — in `_resolve_verify`, expand the resolved CA-bundle path with `os.path.expanduser(str(effective_ca))` before `os.path.isfile()` and before `ssl.create_default_context(cafile=...)`. One line changed.
- `tests/hermes_cli/test_auth_nous_provider.py` — add `test_tilde_ca_bundle_path_is_expanded` to `TestResolveVerifyFallback`, covering both the `--ca-bundle` arg and the `HERMES_CA_BUNDLE` env channel.

## How to Test

1. With unpatched code, set `HERMES_CA_BUNDLE='~/certs/ca.pem'` (file present at the expanded location) — Hermes logs `CA bundle path does not exist: ~/certs/ca.pem` and silently uses the default trust store.
2. Run `pytest tests/hermes_cli/test_auth_nous_provider.py -k ResolveVerify -v`.
3. Regression guard: the new `test_tilde_ca_bundle_path_is_expanded` **fails before** the fix (`os.path.isfile("~/certs/ca.pem")` is `False` → returns `_default_verify()` → `True`, so `isinstance(result, ssl.SSLContext)` fails) and **passes after** (`expanduser` resolves to the real file → `isfile` True → returns the SSL context). Verified both directions by stashing the production hunk.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_auth_nous_provider.py -q` and all tests pass (60 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (tests pin `sys.platform` to linux for the default-trust assertion)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `os.path.expanduser` honors `USERPROFILE` on Windows; the test sets both `HOME` and `USERPROFILE`.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A