### PR TITLE
fix(auxiliary): preserve explicit max_tokens caps (#50132)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5121,24 +5121,12 @@ def _build_call_kwargs(
         kwargs["temperature"] = temperature
 
     if max_tokens is not None:
-        # We do NOT cap output by default. Most chat-completions providers treat
-        # an omitted max_tokens as "use the model's max output", which is what we
-        # want for auxiliary tasks (compression summaries, titles, vision, etc.) —
-        # an explicit cap only risks truncating a summary or 400-ing on providers
-        # that reject the parameter outright (e.g. GitHub Copilot / newer OpenAI
-        # GPT-5 models require max_completion_tokens, not max_tokens; ZAI vision
-        # models reject it entirely with error 1210). Omitting it sidesteps all of
-        # those wire-format quirks at once.
-        #
-        # The one exception is the Anthropic Messages wire (MiniMax and any
-        # ``/anthropic`` endpoint reached through the OpenAI SDK wrapper), where
-        # max_tokens is a MANDATORY field — omitting it is a hard 400. Keep it only
-        # there.
-        _effective_base = base_url or (
-            _current_custom_base_url() if provider == "custom" else ""
-        )
-        if _is_anthropic_compat_endpoint(provider, _effective_base):
-            kwargs["max_tokens"] = max_tokens
+        # Preserve explicit caller caps.  Omitting max_tokens is still the
+        # default when callers do not request a limit, but compression and other
+        # budgeted auxiliary paths pass a deliberate cap that local
+        # OpenAI-compatible servers must see.  Providers that reject the field
+        # are handled by the existing unsupported-parameter retry path below.
+        kwargs["max_tokens"] = max_tokens
 
     if tools:
         # Defensive dedup: providers like Google Vertex, Azure, and Bedrock

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -105,13 +105,14 @@ class TestAuxiliaryMaxTokensParam:
 
 
 class TestBuildCallKwargsMaxTokens:
-    """_build_call_kwargs should not cap output by default (#34530).
+    """_build_call_kwargs preserves caller-requested output caps (#50132).
 
-    Most chat-completions providers treat an omitted max_tokens as "use the
-    model max", which is what we want for auxiliary tasks. An explicit cap only
-    risks truncation or a wire-format 400 (GitHub Copilot / GPT-5 reject
-    max_tokens; ZAI vision rejects it entirely). The Anthropic Messages wire is
-    the one exception — max_tokens is a mandatory field there.
+    The helper still omits max_tokens when callers do not request a cap, keeping
+    the historic "use provider default/max output" behavior. When a caller does
+    pass an explicit cap (for example context compression's summary budget), the
+    cap must reach OpenAI-compatible local endpoints instead of silently falling
+    back to their oversized server default. Providers that reject the field are
+    handled by the existing unsupported-parameter retry path.
     """
 
     @pytest.mark.parametrize(
@@ -126,7 +127,27 @@ class TestBuildCallKwargsMaxTokens:
             ("zai", "glm-4v-flash", "https://open.bigmodel.cn/api/paas/v4"),
         ],
     )
-    def test_omits_max_tokens_for_openai_compatible(self, provider, model, base_url):
+    def test_omits_max_tokens_when_no_cap_is_requested(self, provider, model, base_url):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            base_url=base_url,
+        )
+        assert "max_tokens" not in kwargs
+        assert "max_completion_tokens" not in kwargs
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            ("custom", "qwen", "http://localhost:8080/v1"),
+            ("openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1"),
+            ("nous", "hermes-4", "https://inference-api.nousresearch.com/v1"),
+        ],
+    )
+    def test_keeps_explicit_max_tokens_for_openai_compatible(self, provider, model, base_url):
         from agent.auxiliary_client import _build_call_kwargs
 
         kwargs = _build_call_kwargs(
@@ -136,7 +157,7 @@ class TestBuildCallKwargsMaxTokens:
             max_tokens=1234,
             base_url=base_url,
         )
-        assert "max_tokens" not in kwargs
+        assert kwargs["max_tokens"] == 1234
         assert "max_completion_tokens" not in kwargs
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #50132.

`_build_call_kwargs()` was silently dropping explicit `max_tokens` values for every non-Anthropic chat-completions endpoint. That made local OpenAI-compatible backends (oMLX/llama.cpp/Ollama/LM Studio-style servers) fall back to oversized server defaults during context compression, producing runaway summaries that finish by length.

This PR preserves explicit caller caps while keeping the old default behavior when no cap is requested:

- if callers omit `max_tokens`, the request still omits both `max_tokens` and `max_completion_tokens`
- if callers pass an explicit cap, OpenAI-compatible/local endpoints receive `max_tokens`
- Anthropic-compatible endpoints still receive explicit `max_tokens`
- providers that reject `max_tokens` continue to rely on the existing unsupported-parameter retry path

## Verification

Focused regression suite after rebasing onto current `upstream/main`:

```text
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/agent/test_auxiliary_client.py::TestBuildCallKwargsMaxTokens -v -o "addopts=" --tb=short
12 passed in 0.86s
```

Builder also ran the nearby suite:

```text
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/agent/test_auxiliary_client.py -v -o "addopts=" --tb=short
225 passed, 1 failed in 12.09s
```

The single failure was the pre-existing/timing-sensitive `TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events` elapsed-time assertion; an immediate isolated rerun passed.

## Duplicate / competitor checks

Before publishing, I checked:

- issue-number PR search for `50132 in:title,body state:open`
- same-author Tranquil-Flow PR search for issue #50132
- same-author branch-head search for `fix/50132*`
- topic keyword search for `build_call_kwargs max_tokens compression`

No open competing PRs were found.

Auto-published by Moonsong via Path B automated pipeline.
