### PR TITLE
fix(gateway): don't lazy-install SDKs for unconfigured platforms on startup (desktop stuck at 94%)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1907,12 +1907,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         from gateway.platform_registry import platform_registry
         for entry in platform_registry.plugin_entries():
             try:
-                if not entry.check_fn():
-                    continue
+                platform = Platform(entry.name)
             except Exception as e:
-                logger.debug("check_fn for %s raised: %s", entry.name, e)
+                logger.debug("unknown platform name %r: %s", entry.name, e)
                 continue
-            platform = Platform(entry.name)
             existing_cfg = config.platforms.get(platform)
             # Respect an explicit ``enabled: false`` (YAML / gateway.json /
             # dashboard PUT).  ``_enabled_explicit`` is set in
@@ -1996,6 +1994,22 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                             entry.name,
                         )
                         continue
+            # Verify dependencies LAST — only for platforms that are already
+            # enabled or passed the credential gate above.  For adapter plugins
+            # ``check_fn`` lazy-INSTALLS the platform SDK (pip) as a side
+            # effect, so running it as an unconditional sweep over every
+            # registered platform made ``load_gateway_config()`` pip-install
+            # Discord/Telegram/Slack/Feishu/Dingtalk on every call — including
+            # the desktop/dashboard readiness probe (``GET /api/status``, which
+            # awaits this synchronously) — even when the user configured none
+            # of them.  That blocked startup until every install finished and
+            # caused the desktop app to time out and boot-loop (stuck at 94%).
+            try:
+                if not entry.check_fn():
+                    continue
+            except Exception as e:
+                logger.debug("check_fn for %s raised: %s", entry.name, e)
+                continue
             if platform not in config.platforms:
                 config.platforms[platform] = PlatformConfig()
             config.platforms[platform].enabled = True

--- a/tests/gateway/test_startup_no_eager_platform_install.py
+++ b/tests/gateway/test_startup_no_eager_platform_install.py
@@ -1,0 +1,100 @@
+"""Regression tests: ``_apply_env_overrides`` must not lazy-install platform
+SDKs for platforms the user has not configured.
+
+For adapter plugins, ``PlatformEntry.check_fn`` doubles as the lazy-installer
+(it pip-installs the platform SDK as a side effect — see e.g.
+``plugins/platforms/discord/adapter.py::check_discord_requirements``).  The
+enablement sweep in ``_apply_env_overrides`` used to call ``check_fn`` for
+*every* registered plugin platform unconditionally, so a single
+``load_gateway_config()`` — which the desktop/dashboard readiness probe
+(``GET /api/status``) awaits synchronously — pip-installed Discord, Telegram,
+Slack, Feishu and Dingtalk even with ``platforms: none``.  That blocked
+startup until every install finished and made the desktop app time out and
+boot-loop (stuck at 94%).
+
+The fix consults the cheap ``is_connected`` credential check FIRST and only
+runs the install-triggering ``check_fn`` for platforms that are already
+enabled or actually configured.  These tests pin that contract.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+from gateway.platform_registry import PlatformEntry, platform_registry
+
+
+@pytest.fixture
+def isolated_registry():
+    """Run with a registry containing only the entries the test registers."""
+    original = dict(platform_registry._entries)
+    platform_registry._entries.clear()
+    try:
+        # ``_apply_env_overrides`` calls ``discover_plugins()`` (idempotent),
+        # which would re-register the real bundled platforms and clobber the
+        # fakes below.  Neutralize it so the test controls the registry.
+        with patch("hermes_cli.plugins.discover_plugins", lambda *a, **k: None):
+            yield platform_registry
+    finally:
+        platform_registry._entries.clear()
+        platform_registry._entries.update(original)
+
+
+def _register_fake_platform(name, *, check_fn, is_connected):
+    platform_registry.register(
+        PlatformEntry(
+            name=name,
+            label=name.title(),
+            adapter_factory=lambda cfg: MagicMock(),
+            check_fn=check_fn,
+            is_connected=is_connected,
+            source="plugin",
+        )
+    )
+
+
+def test_unconfigured_platform_is_not_probed_for_install(isolated_registry):
+    # is_connected reports "no credentials" → the platform must be skipped
+    # without ever calling check_fn (which would lazy-install the SDK).
+    check_fn = MagicMock(return_value=True)
+    _register_fake_platform(
+        "discord", check_fn=check_fn, is_connected=lambda cfg: False
+    )
+
+    config = GatewayConfig()
+    _apply_env_overrides(config)
+
+    check_fn.assert_not_called()
+    assert not config.platforms.get(Platform.DISCORD, PlatformConfig()).enabled
+
+
+def test_configured_platform_is_still_installed_and_enabled(isolated_registry):
+    # is_connected reports "credentials present" → check_fn must run (so the
+    # SDK is verified/installed) and the platform is auto-enabled, exactly as
+    # before the fix.
+    check_fn = MagicMock(return_value=True)
+    _register_fake_platform(
+        "discord", check_fn=check_fn, is_connected=lambda cfg: True
+    )
+
+    config = GatewayConfig()
+    _apply_env_overrides(config)
+
+    check_fn.assert_called_once()
+    assert config.platforms[Platform.DISCORD].enabled is True
+
+
+def test_failed_install_does_not_enable_configured_platform(isolated_registry):
+    # Credentials present but the SDK genuinely cannot be installed/imported
+    # (check_fn returns False) → platform must not be enabled.
+    check_fn = MagicMock(return_value=False)
+    _register_fake_platform(
+        "discord", check_fn=check_fn, is_connected=lambda cfg: True
+    )
+
+    config = GatewayConfig()
+    _apply_env_overrides(config)
+
+    check_fn.assert_called_once()
+    assert not config.platforms.get(Platform.DISCORD, PlatformConfig()).enabled


### PR DESCRIPTION
## Summary

Hermes Desktop on Windows frequently boot-loops and gets **stuck at 94%** ("Hermes backend is ready, finalizing desktop startup"). Debug logs show the backend repeatedly `lazy-installing` **every** messaging-platform SDK at startup — `dingtalk`, `discord`, `feishu`, `slack`, `telegram` — even though the user configured **no** platforms (`platforms: none`, `gateway: stopped`, no tokens). Each install takes 5–40s; on a slow/restricted network they run long enough to blow the desktop's readiness timeouts, so it kills and re-spawns the backend (multiple `HERMES_DASHBOARD_READY`, duplicate cron schedulers, `ConnectionResetError [WinError 10054]`) → boot loop.

## Root cause

For adapter plugins, `PlatformEntry.check_fn` doubles as a lazy installer — calling it pip-installs the platform SDK as a side effect (e.g. `plugins/platforms/discord/adapter.py::check_discord_requirements` → `tools.lazy_deps.ensure("platform.discord")`).

The enablement sweep in `gateway/config.py::_apply_env_overrides` called `check_fn()` for **every** registered plugin platform unconditionally, *before* consulting the cheap `is_connected` credential check:

```python
for entry in platform_registry.plugin_entries():
    if not entry.check_fn():   # <-- pip-installs the SDK here, for ALL platforms
        continue
    ...
    if entry.is_connected is not None and not entry.is_connected(probe_cfg):
        continue               # credential gate ran only AFTER the install
```

`load_gateway_config()` runs this sweep, and the desktop/dashboard readiness probe `GET /api/status` (`hermes_cli/web_server.py`) awaits `load_gateway_config()` **synchronously inside the async handler** — so every desktop launch installs all platform SDKs before `/api/status` can answer, blocking the event loop. (This is consistent with #24089, which the reporter closed after a VPN fixed their PyPI access.)

## Fix

Consult `is_connected` (a cheap env/credential check) **first** and only run the install-triggering `check_fn` for platforms that are already enabled or actually configured. All installing platforms (discord/telegram/slack/feishu/dingtalk) register `is_connected`, so with no platforms configured nothing is installed and the backend becomes ready immediately.

Auto-enable-by-credentials is unchanged: a platform with its token set still has its SDK installed and gets enabled. The explicit-`enabled: false` gate (#41112) and the `is_connected` enablement gate (#31116) are preserved; the only change is **ordering** so installs no longer happen for platforms the user never opted into.

## Test plan

- [x] New regression test `tests/gateway/test_startup_no_eager_platform_install.py`:
  - unconfigured platform → `check_fn` is **not** called (no install) and stays disabled (fails on pre-fix code)
  - configured platform (`is_connected` true) → `check_fn` runs and platform is enabled
  - configured but install fails (`check_fn` false) → not enabled
- [x] `scripts/run_tests.sh` green across affected suites: `test_plugin_platform_interface`, `test_platform_registry`, `test_platform_connected_checkers`, `test_discord_reply_mode`, `test_telegram_reply_mode`, `test_feishu`, `test_slack`, `test_unauthorized_dm_behavior`, `test_simplex_plugin`, `test_ntfy_plugin`, `test_discord_race_polish` (690 tests).