### PR TITLE
fix(auxiliary): preserve explicit caps for compatible routes

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4452,7 +4452,13 @@ def get_auxiliary_extra_body() -> dict:
     return _nous_extra_body() if auxiliary_is_nous else {}
 
 
-def auxiliary_max_tokens_param(value: int, *, model: Optional[str] = None) -> dict:
+def auxiliary_max_tokens_param(
+    value: int,
+    *,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> dict:
     """Return the correct max tokens kwarg for the auxiliary client's provider.
 
     OpenRouter and local models use 'max_tokens'. Direct OpenAI with newer
@@ -4462,13 +4468,19 @@ def auxiliary_max_tokens_param(value: int, *, model: Optional[str] = None) -> di
     fronting the newer families are also recognised — URL-only detection
     misses the case where a custom base URL serves e.g. ``gpt-5.4``.
     """
-    custom_base = _current_custom_base_url()
+    custom_base = base_url if base_url is not None else _current_custom_base_url()
+    if _is_anthropic_compat_endpoint(provider, custom_base):
+        return {"max_tokens": value}
+
     or_key = os.getenv("OPENROUTER_API_KEY")
+    direct_route = base_url is not None or provider is not None
     # Use max_completion_tokens for direct OpenAI-compatible providers that reject
     # max_tokens on newer GPT-4o/o-series/GPT-5-style models.
-    if (not or_key
-            and _read_nous_auth() is None
-            and base_url_hostname(custom_base) in {"api.openai.com", "api.githubcopilot.com"}):
+    if (
+        (direct_route or not or_key)
+        and _read_nous_auth() is None
+        and base_url_hostname(custom_base) in {"api.openai.com", "api.githubcopilot.com"}
+    ):
         return {"max_completion_tokens": value}
     # ...and for any caller serving a newer OpenAI-family model by name.
     if model_forces_max_completion_tokens(model):
@@ -5121,24 +5133,21 @@ def _build_call_kwargs(
         kwargs["temperature"] = temperature
 
     if max_tokens is not None:
-        # We do NOT cap output by default. Most chat-completions providers treat
-        # an omitted max_tokens as "use the model's max output", which is what we
-        # want for auxiliary tasks (compression summaries, titles, vision, etc.) —
-        # an explicit cap only risks truncating a summary or 400-ing on providers
-        # that reject the parameter outright (e.g. GitHub Copilot / newer OpenAI
-        # GPT-5 models require max_completion_tokens, not max_tokens; ZAI vision
-        # models reject it entirely with error 1210). Omitting it sidesteps all of
-        # those wire-format quirks at once.
-        #
-        # The one exception is the Anthropic Messages wire (MiniMax and any
-        # ``/anthropic`` endpoint reached through the OpenAI SDK wrapper), where
-        # max_tokens is a MANDATORY field — omitting it is a hard 400. Keep it only
-        # there.
+        # We still avoid capping output by default — this branch only runs when
+        # the caller explicitly requested a limit. Preserve that intent using
+        # the provider/model-specific wire key, then let the retry path below
+        # strip it if the endpoint rejects the parameter outright.
         _effective_base = base_url or (
             _current_custom_base_url() if provider == "custom" else ""
         )
-        if _is_anthropic_compat_endpoint(provider, _effective_base):
-            kwargs["max_tokens"] = max_tokens
+        kwargs.update(
+            auxiliary_max_tokens_param(
+                max_tokens,
+                model=model,
+                provider=provider,
+                base_url=_effective_base,
+            )
+        )
 
     if tools:
         # Defensive dedup: providers like Google Vertex, Azure, and Bedrock

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -105,13 +105,12 @@ class TestAuxiliaryMaxTokensParam:
 
 
 class TestBuildCallKwargsMaxTokens:
-    """_build_call_kwargs should not cap output by default (#34530).
+    """_build_call_kwargs should preserve explicit max_tokens intent.
 
-    Most chat-completions providers treat an omitted max_tokens as "use the
-    model max", which is what we want for auxiliary tasks. An explicit cap only
-    risks truncation or a wire-format 400 (GitHub Copilot / GPT-5 reject
-    max_tokens; ZAI vision rejects it entirely). The Anthropic Messages wire is
-    the one exception — max_tokens is a mandatory field there.
+    Auxiliary callers still omit max_tokens by default, but once a caller
+    explicitly computes a budget (for example compression's dynamic summary
+    limit) the wire kwargs should preserve that cap using the provider/model
+    specific parameter name. Retry logic covers endpoints that reject it.
     """
 
     @pytest.mark.parametrize(
@@ -126,7 +125,27 @@ class TestBuildCallKwargsMaxTokens:
             ("zai", "glm-4v-flash", "https://open.bigmodel.cn/api/paas/v4"),
         ],
     )
-    def test_omits_max_tokens_for_openai_compatible(self, provider, model, base_url):
+    def test_omits_max_tokens_when_no_cap_is_requested(self, provider, model, base_url):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            base_url=base_url,
+        )
+        assert "max_tokens" not in kwargs
+        assert "max_completion_tokens" not in kwargs
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            ("custom", "qwen", "http://localhost:8080/v1"),
+            ("openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1"),
+            ("nous", "hermes-4", "https://inference-api.nousresearch.com/v1"),
+        ],
+    )
+    def test_keeps_explicit_max_tokens_for_openai_compatible(self, provider, model, base_url):
         from agent.auxiliary_client import _build_call_kwargs
 
         kwargs = _build_call_kwargs(
@@ -136,8 +155,28 @@ class TestBuildCallKwargsMaxTokens:
             max_tokens=1234,
             base_url=base_url,
         )
-        assert "max_tokens" not in kwargs
+        assert kwargs["max_tokens"] == 1234
         assert "max_completion_tokens" not in kwargs
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            ("copilot", "gpt-5.4", "https://api.githubcopilot.com"),
+            ("custom", "gpt-5", "https://api.openai.com/v1"),
+        ],
+    )
+    def test_uses_max_completion_tokens_for_explicit_cap_on_openai_family(self, provider, model, base_url):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=1234,
+            base_url=base_url,
+        )
+        assert kwargs["max_completion_tokens"] == 1234
+        assert "max_tokens" not in kwargs
 
     @pytest.mark.parametrize(
         "provider,model,base_url",


### PR DESCRIPTION
## What does this PR do?

This PR preserves explicit auxiliary output caps using the correct wire parameter for the active provider/model route.

`_build_call_kwargs()` currently drops explicit caps for most non-Anthropic routes, and even when a compatible route should preserve the cap, OpenAI-family endpoints may need `max_completion_tokens` instead of `max_tokens`.

This change routes explicit auxiliary caps through `auxiliary_max_tokens_param()` so:
- local / OpenAI-compatible backends that expect `max_tokens` keep the explicit cap
- OpenAI-family GPT-5 / Copilot-style routes use `max_completion_tokens`
- Anthropic-compatible routes continue using `max_tokens`

## Related Issue

Fixes #50132

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `agent/auxiliary_client.py` so `_build_call_kwargs()` preserves explicit caps through `auxiliary_max_tokens_param()`
- Extended `auxiliary_max_tokens_param()` to accept the active `provider` and `base_url`
- Updated `tests/agent/test_auxiliary_client.py` to cover:
  - no-cap requests still omitting max token fields
  - explicit caps on local / compatible routes preserving `max_tokens`
  - explicit caps on GPT-5 / Copilot-style routes using `max_completion_tokens`

## How to Test

1. Activate the repo venv.
2. Run:
   `pytest tests/agent/test_auxiliary_client.py -k 'test_uses_max_completion_tokens_for_explicit_cap_on_openai_family or TestBuildCallKwargsMaxTokens or TestAuxiliaryMaxTokensParam'`
3. Confirm the selected regression tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
