### PR TITLE
fix(gateway): inject channel_prompt for Discord voice-channel input

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10792,11 +10792,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Use SimpleNamespace as raw_message so _get_guild_id() can extract
         # guild_id and _send_voice_reply() plays audio in the voice channel.
         from types import SimpleNamespace
+        # Inject the bound text channel's per-channel prompt so voice input
+        # receives the same ephemeral LLM instructions as text input in that
+        # channel. Mirrors the text path, which resolves this at event-build
+        # time; resolve the parent too so a thread inherits its parent's
+        # channel_prompts entry.
+        voice_channel = adapter._client.get_channel(text_ch_id)
+        voice_parent_id = str(getattr(voice_channel, "parent_id", "") or "") or None
         event = MessageEvent(
             source=source,
             text=transcript,
             message_type=MessageType.VOICE,
             raw_message=SimpleNamespace(guild_id=guild_id, guild=None),
+            channel_prompt=adapter._resolve_channel_prompt(str(text_ch_id), voice_parent_id),
         )
 
         await adapter.handle_message(event)

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -954,6 +954,7 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._resolve_channel_prompt = MagicMock(return_value=None)
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
         await runner._handle_voice_channel_input(111, 42, "Hello from VC")
@@ -984,6 +985,7 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._resolve_channel_prompt = MagicMock(return_value=None)
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
 
@@ -997,6 +999,32 @@ class TestVoiceChannelCommands:
         assert event.source.user_id == "42"
 
     @pytest.mark.asyncio
+    async def test_input_injects_channel_prompt(self, runner):
+        """Voice input carries the bound text channel's channel_prompt so
+        per-channel instructions reach the LLM, like the text path does. The
+        parent is resolved too, so a thread inherits its parent's prompt."""
+        from gateway.config import Platform
+
+        mock_adapter = AsyncMock()
+        mock_adapter._voice_text_channels = {111: 123}
+        mock_adapter._voice_sources = {}
+        # Bound channel is a thread → its parent's prompt must be considered.
+        mock_channel = MagicMock()
+        mock_channel.parent_id = 456
+        mock_adapter._client = MagicMock()
+        mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._resolve_channel_prompt = MagicMock(return_value="Always reply in French.")
+        mock_adapter.handle_message = AsyncMock()
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        await runner._handle_voice_channel_input(111, 42, "Bonjour")
+
+        mock_adapter._resolve_channel_prompt.assert_called_once_with("123", "456")
+        mock_adapter.handle_message.assert_called_once()
+        event = mock_adapter.handle_message.call_args[0][0]
+        assert event.channel_prompt == "Always reply in French."
+
+    @pytest.mark.asyncio
     async def test_input_posts_transcript_in_text_channel(self, runner):
         """Voice input sends transcript message to text channel."""
         from gateway.config import Platform
@@ -1006,6 +1034,7 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._resolve_channel_prompt = MagicMock(return_value=None)
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
         await runner._handle_voice_channel_input(111, 42, "Test transcript")
@@ -1025,6 +1054,7 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._resolve_channel_prompt = MagicMock(return_value=None)
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
 
@@ -1045,6 +1075,7 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._resolve_channel_prompt = MagicMock(return_value=None)
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
 


### PR DESCRIPTION
## What does this PR do?

Discord voice (STT) input ignored per-channel `channel_prompts`. The synthetic `MessageEvent` built in `GatewayRunner._handle_voice_channel_input` (`gateway/run.py`) was created without `channel_prompt`, so per-channel ephemeral prompts never reached the LLM for voice input — unlike the **text** path, which resolves and attaches the prompt at event-build time via `self._resolve_channel_prompt(channel_id, parent_id)`.

This resolves the bound text channel's prompt (and its parent, so a thread inherits its parent's `channel_prompts` entry) and passes it on the event, mirroring the text path. The function already holds the bound channel id (`adapter._voice_text_channels[guild_id]`), so the fix is local and minimal.

## Related Issue

Fixes #50149

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — in `_handle_voice_channel_input`, resolve `adapter._resolve_channel_prompt(str(text_ch_id), parent_id)` (parent derived from the bound channel) and set it as `MessageEvent(channel_prompt=...)`.
- `tests/gateway/test_voice_command.py` — add `test_input_injects_channel_prompt` asserting the synthetic voice event carries the resolved prompt and that the parent is passed through; stub the now-called sync `_resolve_channel_prompt` in the existing voice-input tests to keep them coroutine-warning-free.

## How to Test

1. `pytest tests/gateway/test_voice_command.py -q` — all pass (new test included).
2. Manual (Discord): set a `channel_prompts` entry for a channel, `/voice join` that channel, and speak. The reply now honors the channel prompt; before this change it was ignored for voice while text in the same channel respected it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/gateway/test_voice_command.py -q` and all tests pass
- [x] I've added a test for this fix
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] Docs — N/A (no user-facing config/behavior surface changed; voice now matches existing documented text behavior)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (no path/process/platform-specific code)
- [x] Tool descriptions/schemas — N/A
