### PR TITLE
fix(gateway): populate process start_time on Windows/macOS to fix stale per-token locks

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -109,17 +109,38 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
     return _get_lock_dir() / f"{scope}-{_scope_hash(identity)}.lock"
 
 
-def _get_process_start_time(pid: int) -> Optional[int]:
-    """Return the kernel start time for a process when available."""
+def _get_process_start_time(pid: int) -> Optional[float]:
+    """Return the start time for a process when available.
+
+    Linux: field 22 of ``/proc/<pid>/stat`` (start time in clock ticks since
+    boot) — a stable integer that, paired with the PID, uniquely identifies a
+    process generation and so detects PID reuse.
+
+    Windows / macOS have no ``/proc``.  Fall back to ``psutil.Process.create_time()``
+    (a float, seconds since the epoch).  psutil is a hard dependency and is
+    already used by ``_pid_exists`` below.  Without this fallback the PID-reuse
+    guard was silently disabled on those platforms: every gateway record stored
+    ``start_time: null``, so a stale per-token lock left behind by a crashed
+    gateway was never recognised as stale once the OS reused its PID, and
+    startup failed with a spurious "<platform> bot token already in use"
+    (e.g. Discord) until the lock file was deleted by hand.
+    """
     stat_path = Path(f"/proc/{pid}/stat")
     try:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
         return int(stat_path.read_text(encoding="utf-8").split()[21])
     except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        pass
+
+    # No /proc (Windows, macOS) or it was unreadable — ask psutil.
+    try:
+        import psutil  # type: ignore
+        return float(psutil.Process(int(pid)).create_time())
+    except Exception:
         return None
 
 
-def get_process_start_time(pid: int) -> Optional[int]:
+def get_process_start_time(pid: int) -> Optional[float]:
     """Public wrapper for retrieving a process start time when available."""
     return _get_process_start_time(pid)
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -531,6 +531,73 @@ class TestScopedLocks:
         assert acquired is False
         assert existing["pid"] == 99999
 
+    def test_get_process_start_time_falls_back_to_psutil_without_proc(self, monkeypatch):
+        """Windows/macOS have no /proc, but the PID-reuse guard still needs a
+        real start time. Without the psutil fallback every gateway record stored
+        ``start_time: null`` and a stale per-token lock left by a crashed gateway
+        was never recognised as stale once the OS reused its PID — startup then
+        failed with a spurious "bot token already in use" until the lock was
+        deleted by hand.
+        """
+        import sys
+
+        # PID with no /proc entry on Linux forces the psutil fallback; on
+        # Windows/macOS the /proc read fails for every PID anyway.
+        fake_proc = SimpleNamespace(create_time=lambda: 1717000000.5)
+        fake_psutil = SimpleNamespace(Process=lambda pid: fake_proc)
+        monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+        assert status._get_process_start_time(999999) == 1717000000.5
+
+    def test_get_process_start_time_returns_none_when_psutil_unavailable(self, monkeypatch):
+        """Stay defensive: an unreadable /proc and a failing psutil yield None,
+        and callers fall back to the cmdline-based staleness heuristics."""
+        import sys
+
+        def _raise(pid):
+            raise RuntimeError("no such process")
+
+        monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=_raise))
+
+        assert status._get_process_start_time(999999) is None
+
+    def test_acquire_scoped_lock_replaces_reused_pid_via_psutil_start_time(self, tmp_path, monkeypatch):
+        """End-to-end fix: on a no-/proc platform a lock whose owning PID has been
+        reused is recognised as stale because psutil reports a *different*
+        create_time than the one recorded in the lock — even when the live PID
+        also happens to look like a gateway. Before the psutil fallback this was
+        impossible (start_time was always None on Windows), which is what made
+        the Discord/Telegram "token already in use" error wedge restarts.
+        """
+        import sys
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 1000.0,  # written by the now-dead gateway
+            "kind": "hermes-gateway",
+            "argv": ["hermes_cli/main.py", "gateway", "run"],
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        # Worst case: the reused PID even looks like a gateway, so only the
+        # start_time mismatch can mark the lock stale.
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+        # No /proc: the real _get_process_start_time routes through psutil,
+        # which reports the *current* (different) process generation.
+        fake_proc = SimpleNamespace(create_time=lambda: 2000.0)
+        monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=lambda pid: fake_proc))
+
+        acquired, _existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"}
+        )
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+
     def test_acquire_scoped_lock_replaces_stale_record(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
         lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"


### PR DESCRIPTION
## Problem

On Windows (and macOS), the gateway can refuse to start with a spurious

> `<platform> bot token already in use (PID NNNNN). Stop the other gateway first.`

after an unclean shutdown (crash, hard kill, power loss, OS restart). Neither the GUI nor `hermes gateway restart` recovers — the only fix is deleting the per-token lock file under `…/state/hermes/gateway-locks/` by hand.

## Root cause

`gateway/status.py::_get_process_start_time` only reads `/proc/<pid>/stat`, so it returns `None` on any platform without `/proc` (Windows, macOS). Every gateway record therefore stores `start_time: null` on those platforms.

`acquire_scoped_lock` relies on `start_time` to detect PID reuse: a lock is stale when its owning PID is alive **but reports a different start_time** than the one recorded in the lock file (status.py, the `current_start != existing["start_time"]` branch). With `start_time` always `None`, that guard is silently disabled. Staleness then falls through to the cmdline heuristic, and in the common Windows case where the reused PID's cmdline is unreadable (access denied) while the lock record's own `argv` still "looks like a gateway", it **fails closed** and reports the token as in use.

The restart path doesn't rescue it either: `release_all_scoped_locks` only runs on the `--replace` takeover, which never fires when the runtime lock (`gateway.lock`/`gateway.pid`) shows no running gateway — exactly the post-crash state.

## Fix

Fall back to `psutil.Process(pid).create_time()` when `/proc` is unavailable. `psutil` is already a hard dependency (used right below in `_pid_exists`). This hands the existing, already-tested PID-reuse detection a real value to compare on every platform. The Linux `/proc` path is unchanged, so the integer jiffy semantics and the systemd boot-collision tests are unaffected.

## Tests

Adds three regression tests in `tests/gateway/test_status.py`:
- the psutil fallback returns a real start time when `/proc` is absent;
- it degrades to `None` (preserving the cmdline-heuristic fallback) when psutil also fails;
- end-to-end, a lock whose owning PID has been reused on a no-`/proc` platform is now recognised as stale via the differing `create_time`, even when the live PID also looks like a gateway.

Verified on a live Windows 11 install: pre-fix `_get_process_start_time(os.getpid())` returned `None`; post-fix it returns a concrete `create_time`, and a stale Discord token lock left by a dead PID is now reclaimed automatically instead of wedging startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)