### PR TITLE
feat(context-engine): post-response grounding-enforcement hook

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3624,6 +3624,30 @@ def run_conversation(
                 else:
                     assistant_message.content = str(raw)
 
+            # Post-response grounding enforcement. No-op unless the active context
+            # engine advertises an ``enforce_response`` capability via a
+            # ``capabilities()`` method returning a dict with that key set; the
+            # built-in ContextCompressor and LCM do not, so they are entirely
+            # unaffected. A grounding-aware engine can audit the final answer
+            # against its verbatim record and, if it is ungrounded, return a
+            # replacement. Duck-typed (getattr) so any engine lacking the API is
+            # silently skipped, and fully wrapped so enforcement can never break
+            # the turn.
+            try:
+                _eng = getattr(agent, "context_compressor", None)
+                _content = assistant_message.content
+                _has_tools = bool(getattr(assistant_message, "tool_calls", None))
+                _caps = getattr(_eng, "capabilities", None)
+                if (_eng is not None and not _has_tools
+                        and isinstance(_content, str) and _content.strip()
+                        and callable(_caps) and _caps().get("enforce_response")):
+                    _verdict = _eng.enforce_response(
+                        _content, messages, model=getattr(agent, "model", ""), final=True)
+                    if isinstance(_verdict, dict) and _verdict.get("action") == "replace":
+                        assistant_message.content = _verdict.get("text", _content)
+            except Exception:
+                pass  # enforcement must never break the turn
+
             try:
                 from hermes_cli.plugins import (
                     has_hook,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -8273,6 +8273,57 @@ def run_conversation(
                     final_response = None
                     continue
 
+                # Post-response grounding enforcement — the single host-side
+                # seam a grounding-aware context engine plugs into. This runs
+                # only here, past every continuation/nudge gate above
+                # (Codex ``incomplete`` ack-continuation, length-continuation
+                # join, dropped-tool-call recovery, verify-on-stop, pre_verify,
+                # kanban terminal-stop), so ``final_response`` is the TRULY
+                # FINAL assistant text about to be persisted and delivered —
+                # never an intermediate fragment or a turn that will continue.
+                #
+                # No-op unless the active context engine advertises an
+                # ``enforce_response`` capability via a ``capabilities()``
+                # method returning a dict with that key set; the built-in
+                # ContextCompressor and LCM do not, so they are entirely
+                # unaffected. A grounding-aware engine audits the final answer
+                # against its verbatim record and, if it is ungrounded, returns
+                # ``{"action": "replace", "text": ...}``. Duck-typed (getattr)
+                # so any engine lacking the API is silently skipped, and fully
+                # wrapped so enforcement can never break the turn. On replace we
+                # update both ``final_response`` (returned to the finalizer and
+                # delivered to the user) and ``final_msg["content"]`` (persisted
+                # to the durable transcript) so the two never diverge.
+                try:
+                    _eng = getattr(agent, "context_compressor", None)
+                    _caps = getattr(_eng, "capabilities", None)
+                    if (
+                        _eng is not None
+                        and not assistant_message.tool_calls
+                        and isinstance(final_response, str)
+                        and final_response.strip()
+                        and callable(_caps)
+                        and _caps().get("enforce_response")
+                    ):
+                        _verdict = _eng.enforce_response(
+                            final_response,
+                            messages,
+                            model=getattr(agent, "model", ""),
+                            final=True,
+                        )
+                        if (
+                            isinstance(_verdict, dict)
+                            and _verdict.get("action") == "replace"
+                        ):
+                            _replacement = _verdict.get("text", final_response)
+                            if isinstance(_replacement, str) and _replacement:
+                                final_response = _replacement
+                                final_msg["content"] = _replacement
+                except Exception:
+                    logger.debug(
+                        "grounding enforce_response hook failed", exc_info=True
+                    )  # enforcement must never break the turn
+
                 append_message(messages, final_msg)
                 # Make the completed answer durable before leaving the loop —
                 # a session torn down before finalize_turn's _persist_session

--- a/tests/agent/test_grounding_enforcement_hook.py
+++ b/tests/agent/test_grounding_enforcement_hook.py
@@ -1,0 +1,87 @@
+"""Tests for the post-response grounding-enforcement hook in conversation_loop.
+
+A context engine may advertise an ``enforce_response`` capability (via a
+``capabilities()`` method) to audit the final answer and, if ungrounded, return
+a replacement. The hook is duck-typed: engines lacking the API are skipped, and
+the built-in ContextCompressor/LCM (no ``capabilities``) are entirely unaffected.
+
+These tests exercise the hook's contract directly against the documented
+behavior, since the conversation_loop integration point is internal.
+"""
+import types
+
+
+def _apply_enforcement(agent, assistant_message, messages):
+    """Mirror of the conversation_loop grounding-enforcement block, so the
+    contract can be unit-tested without driving a full turn."""
+    try:
+        _eng = getattr(agent, "context_compressor", None)
+        _content = assistant_message.content
+        _has_tools = bool(getattr(assistant_message, "tool_calls", None))
+        _caps = getattr(_eng, "capabilities", None)
+        if (_eng is not None and not _has_tools
+                and isinstance(_content, str) and _content.strip()
+                and callable(_caps) and _caps().get("enforce_response")):
+            _verdict = _eng.enforce_response(
+                _content, messages, model=getattr(agent, "model", ""), final=True)
+            if isinstance(_verdict, dict) and _verdict.get("action") == "replace":
+                assistant_message.content = _verdict.get("text", _content)
+    except Exception:
+        pass
+    return assistant_message
+
+
+class _GroundingEngine:
+    def capabilities(self):
+        return {"enforce_response": True}
+
+    def enforce_response(self, content, messages, model="", final=True):
+        if "unsupported" in content:
+            return {"action": "replace", "text": "I can't verify that from the record."}
+        return {"action": "keep"}
+
+
+class _PlainEngine:
+    """No capabilities() — like the built-in ContextCompressor/LCM."""
+    pass
+
+
+def _msg(content, tool_calls=None):
+    return types.SimpleNamespace(content=content, tool_calls=tool_calls)
+
+
+def test_ungrounded_answer_is_replaced():
+    agent = types.SimpleNamespace(context_compressor=_GroundingEngine(), model="m")
+    m = _apply_enforcement(agent, _msg("here is an unsupported claim"), [])
+    assert m.content == "I can't verify that from the record."
+
+
+def test_grounded_answer_is_kept():
+    agent = types.SimpleNamespace(context_compressor=_GroundingEngine(), model="m")
+    m = _apply_enforcement(agent, _msg("a well-grounded answer"), [])
+    assert m.content == "a well-grounded answer"
+
+
+def test_plain_engine_without_capabilities_is_noop():
+    agent = types.SimpleNamespace(context_compressor=_PlainEngine(), model="m")
+    m = _apply_enforcement(agent, _msg("unsupported but engine has no caps"), [])
+    assert m.content == "unsupported but engine has no caps"
+
+
+def test_no_engine_is_noop():
+    agent = types.SimpleNamespace(context_compressor=None, model="m")
+    m = _apply_enforcement(agent, _msg("anything"), [])
+    assert m.content == "anything"
+
+
+def test_tool_call_turn_is_skipped():
+    # enforcement only applies to final text answers, not tool-call turns.
+    agent = types.SimpleNamespace(context_compressor=_GroundingEngine(), model="m")
+    m = _apply_enforcement(agent, _msg("unsupported", tool_calls=[{"id": "x"}]), [])
+    assert m.content == "unsupported"
+
+
+def test_empty_content_is_skipped():
+    agent = types.SimpleNamespace(context_compressor=_GroundingEngine(), model="m")
+    m = _apply_enforcement(agent, _msg("   "), [])
+    assert m.content == "   "

--- a/tests/agent/test_grounding_enforcement_hook.py
+++ b/tests/agent/test_grounding_enforcement_hook.py
@@ -1,0 +1,301 @@
+"""Integration tests for the post-response grounding-enforcement hook.
+
+A grounding-aware context engine may advertise an ``enforce_response``
+capability (via a ``capabilities()`` method) so the conversation loop lets it
+audit the TRULY FINAL assistant answer and, when ungrounded, return a
+replacement. The hook lives at the final-response assembly point in
+``agent.conversation_loop.run_conversation`` — past every continuation/nudge
+gate (Codex ``incomplete`` ack-continuation, length-continuation join,
+dropped-tool-call recovery, verify-on-stop, pre_verify, kanban) — so it only
+ever sees the delivered result, never an intermediate fragment.
+
+Unlike a unit test that mirrors the production block, these drive the real
+``AIAgent.run_conversation`` against an in-process mock provider and assert on
+the returned ``final_response`` and the persisted ``messages``, so they pin the
+integration placement AND persistence (the two concerns the sweeper flagged as
+unverified). The built-in ContextCompressor/LCM have no ``capabilities`` method,
+so the hook is a no-op for them; these tests opt in a fake engine explicitly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+# Repo root = three levels up from tests/agent/<file>.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+    # Set by the fixture before each request cycle.
+    captured_requests: list = []
+    response_queue: list = []
+
+    def do_POST(self):  # noqa: N802 (http.server API)
+        length = int(self.headers.get("Content-Length", 0))
+        req = json.loads(self.rfile.read(length).decode())
+        type(self).captured_requests.append(req)
+        is_stream = req.get("stream") is True
+        if type(self).response_queue:
+            resp = type(self).response_queue.pop(0)
+        else:
+            resp = _text_resp("DONE")
+        msg = resp["choices"][0]["message"]
+        if is_stream:
+            content = msg.get("content") or ""
+            tcs = msg.get("tool_calls")
+            fr = resp["choices"][0].get("finish_reason") or ("tool_calls" if tcs else "stop")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            chunks = [{"id": "m", "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}]}]
+            if content:
+                chunks.append({"id": "m", "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None}]})
+            if tcs:
+                for ti, tc in enumerate(tcs):
+                    chunks.append({"id": "m", "choices": [{"index": 0, "delta": {"tool_calls": [{
+                        "index": ti, "id": tc["id"], "type": "function",
+                        "function": {"name": tc["function"]["name"], "arguments": tc["function"]["arguments"]}}]}, "finish_reason": None}]})
+            chunks.append({"id": "m", "choices": [{"index": 0, "delta": {}, "finish_reason": fr}]})
+            for c in chunks:
+                self.wfile.write(f"data: {json.dumps(c)}\n\n".encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+        else:
+            body = json.dumps(resp).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    def log_message(self, *a, **kw):  # silence the default stderr logging
+        pass
+
+
+def _text_resp(text: str) -> dict:
+    return {
+        "id": "m",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+
+def _tc_resp(name: str, args: str = "{}") -> dict:
+    return {
+        "id": "m",
+        "choices": [{"index": 0, "message": {
+            "role": "assistant", "content": "",
+            "tool_calls": [{"id": "call_1", "type": "function",
+                            "function": {"name": name, "arguments": args}}]},
+            "finish_reason": "tool_calls"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+    }
+
+
+def _length_resp(text: str) -> dict:
+    """A truncated (finish_reason=length) partial that triggers a continuation."""
+    return {
+        "id": "m",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "length"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+
+class _GroundingProbe:
+    """Opt-in grounding behavior grafted onto the REAL ContextCompressor.
+
+    We attach ``capabilities`` and ``enforce_response`` onto the live
+    ``agent.context_compressor`` rather than replacing it, so the rest of the
+    conversation loop (``protect_first_n``, ``update_from_response``, etc.)
+    keeps working while the hook still sees an engine that advertises the
+    capability. Records every call so tests can assert the hook fired exactly
+    once, on the final text only.
+    """
+
+    def __init__(self):
+        self.calls: list = []
+
+    def capabilities(self):
+        return {"enforce_response": True}
+
+    def enforce_response(self, content, messages, model="", final=True):
+        self.calls.append({"content": content, "model": model, "final": final})
+        if "unsupported" in content:
+            return {"action": "replace", "text": "I can't verify that from the record."}
+        return {"action": "keep"}
+
+
+def _graft_engine(agent, probe):
+    """Bind a probe's grounding methods onto the agent's real compressor."""
+    agent.context_compressor.capabilities = probe.capabilities
+    agent.context_compressor.enforce_response = probe.enforce_response
+
+
+def _graft_broken(agent):
+    """Advertise the capability but raise inside enforce_response."""
+    agent.context_compressor.capabilities = lambda: {"enforce_response": True}
+
+    def _boom(*a, **k):
+        raise RuntimeError("engine blew up")
+
+    agent.context_compressor.enforce_response = _boom
+
+
+@pytest.fixture()
+def agent_env():
+    """Spin up the mock provider + an isolated HERMES_HOME, yield (agent, helpers)."""
+    _MockHandler.captured_requests = []
+    _MockHandler.response_queue = []
+    srv = HTTPServer(("127.0.0.1", 0), _MockHandler)
+    port = srv.server_address[1]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+
+    test_home = tempfile.mkdtemp(prefix="hermes_grounding_")
+    os.makedirs(os.path.join(test_home, ".hermes"))
+    prev_home = os.environ.get("HERMES_HOME")
+    os.environ["HERMES_HOME"] = os.path.join(test_home, ".hermes")
+
+    # Import fresh so the patched conversation_loop is exercised even when the
+    # module was imported earlier in the same worker.
+    for mod in list(sys.modules):
+        if mod == "run_agent" or mod.startswith("agent.") or mod.startswith("tools.") or mod.startswith("hermes_"):
+            del sys.modules[mod]
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key", base_url=f"http://127.0.0.1:{port}/v1",
+        provider="openai-compat", model="test-model",
+        max_iterations=10, enabled_toolsets=[],
+        quiet_mode=True, skip_context_files=True, skip_memory=True,
+        save_trajectories=False, platform="cli",
+    )
+    agent.valid_tool_names = {"terminal", "read_file", "write_file"}
+
+    try:
+        yield agent, _MockHandler
+    finally:
+        srv.shutdown()
+        shutil.rmtree(test_home, ignore_errors=True)
+        if prev_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = prev_home
+
+
+def _final_assistant_content(result) -> str:
+    msgs = result.get("messages") or []
+    for m in reversed(msgs):
+        if isinstance(m, dict) and m.get("role") == "assistant" and not m.get("tool_calls"):
+            return m.get("content") or ""
+    return ""
+
+
+def test_ungrounded_final_answer_is_replaced_and_persisted(agent_env):
+    """An ungrounded final answer is swapped for the engine's replacement in
+    BOTH the returned ``final_response`` and the persisted transcript."""
+    agent, handler = agent_env
+    probe = _GroundingProbe()
+    _graft_engine(agent, probe)
+    handler.response_queue.append(_text_resp("here is an unsupported claim"))
+
+    result = agent.run_conversation("what is X?", conversation_history=[], task_id="t")
+
+    assert result["final_response"] == "I can't verify that from the record."
+    assert _final_assistant_content(result) == "I can't verify that from the record."
+    # The hook fired exactly once, on the final text, with final=True.
+    assert len(probe.calls) == 1
+    assert probe.calls[0]["content"] == "here is an unsupported claim"
+    assert probe.calls[0]["final"] is True
+
+
+def test_grounded_final_answer_is_kept(agent_env):
+    """A grounded answer passes through untouched (keep verdict)."""
+    agent, handler = agent_env
+    probe = _GroundingProbe()
+    _graft_engine(agent, probe)
+    handler.response_queue.append(_text_resp("a well-grounded answer"))
+
+    result = agent.run_conversation("what is X?", conversation_history=[], task_id="t")
+
+    assert result["final_response"] == "a well-grounded answer"
+    assert _final_assistant_content(result) == "a well-grounded answer"
+    assert len(probe.calls) == 1
+
+
+def test_engine_without_capabilities_is_noop(agent_env):
+    """The built-in-style engine (no capabilities()) never triggers the hook.
+
+    The stock ContextCompressor ships no ``capabilities`` method, so the hook
+    stays dormant and the answer is delivered verbatim.
+    """
+    agent, handler = agent_env
+    assert not hasattr(agent.context_compressor, "capabilities")
+    handler.response_queue.append(_text_resp("unsupported but engine has no caps"))
+
+    result = agent.run_conversation("what is X?", conversation_history=[], task_id="t")
+
+    assert result["final_response"] == "unsupported but engine has no caps"
+
+
+def test_broken_engine_never_breaks_the_turn(agent_env):
+    """An engine that raises inside enforce_response must not fail the turn;
+    the original answer is delivered unchanged."""
+    agent, handler = agent_env
+    _graft_broken(agent)
+    handler.response_queue.append(_text_resp("original answer stands"))
+
+    result = agent.run_conversation("what is X?", conversation_history=[], task_id="t")
+
+    assert result["final_response"] == "original answer stands"
+    assert not result.get("failed")
+
+
+def test_tool_call_turns_are_not_audited(agent_env):
+    """A turn that dispatches a tool then finishes must only audit the FINAL
+    text response, never the intermediate tool-call turn."""
+    agent, handler = agent_env
+    probe = _GroundingProbe()
+    _graft_engine(agent, probe)
+    # Turn 1: a tool call (intermediate, must be skipped by the hook).
+    handler.response_queue.append(_tc_resp("read_file", '{"path": "x"}'))
+    # Turn 2: the final text answer (audited).
+    handler.response_queue.append(_text_resp("final grounded summary"))
+
+    result = agent.run_conversation("read x and summarize", conversation_history=[], task_id="t")
+
+    assert result["final_response"] == "final grounded summary"
+    # Exactly one audit — the final text — despite the earlier tool-call turn.
+    assert len(probe.calls) == 1
+    assert probe.calls[0]["content"] == "final grounded summary"
+
+
+def test_length_continuation_audits_only_the_joined_final(agent_env):
+    """A length-truncated response that continues must be audited only ONCE,
+    on the fully joined final text — not on the intermediate fragment."""
+    agent, handler = agent_env
+    probe = _GroundingProbe()
+    _graft_engine(agent, probe)
+    # First response is truncated (finish_reason=length); the loop continues.
+    handler.response_queue.append(_length_resp("first part "))
+    # Continuation completes the answer.
+    handler.response_queue.append(_text_resp("second part"))
+
+    result = agent.run_conversation("write a long answer", conversation_history=[], task_id="t")
+
+    # The engine saw exactly one final audit, and its content includes both
+    # joined parts — i.e. it ran on the assembled final text, not the fragment.
+    assert len(probe.calls) == 1
+    audited = probe.calls[0]["content"]
+    assert "first part" in audited and "second part" in audited
+    assert probe.calls[0]["final"] is True


### PR DESCRIPTION
## Summary

Adds the host-side **grounding-enforcement seam** that a grounding-aware context
engine plugs into. After the assistant message is normalized in the conversation
loop, if the active context engine advertises an `enforce_response` capability
(via a `capabilities()` method returning `{"enforce_response": True, ...}`), the
engine may audit the final answer against its record and return a replacement
when the answer is ungrounded.

## Design

- **No-op by default.** The built-in `ContextCompressor` and LCM have no
  `capabilities()` method, so they are entirely unaffected.
- **Duck-typed.** Uses `getattr(_eng, "capabilities", None)` + a `callable` check,
  so any engine lacking the API is silently skipped — no hard dependency on a
  particular engine being installed.
- **Crash-safe.** The whole block is wrapped; enforcement can never break a turn.
- **Final text only.** Skips tool-call turns and empty content.

This is the single host-side seam for a verbatim-memory / grounding context engine.
The engine implementation itself lives in its own component; this PR is just the
provider-agnostic hook in the conversation loop.

## Tests

`tests/agent/test_grounding_enforcement_hook.py` (6 cases): replace verdict,
keep verdict, engine without `capabilities()` (no-op), no engine (no-op),
tool-call turn (skipped), empty content (skipped). All pass; ruff clean.

Built on `origin/main`; applies onto v0.17.0.
