### PR TITLE
fix(agent): pass max_tokens unconditionally in _build_call_kwargs

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5121,24 +5121,19 @@ def _build_call_kwargs(
         kwargs["temperature"] = temperature
 
     if max_tokens is not None:
-        # We do NOT cap output by default. Most chat-completions providers treat
-        # an omitted max_tokens as "use the model's max output", which is what we
-        # want for auxiliary tasks (compression summaries, titles, vision, etc.) —
-        # an explicit cap only risks truncating a summary or 400-ing on providers
-        # that reject the parameter outright (e.g. GitHub Copilot / newer OpenAI
-        # GPT-5 models require max_completion_tokens, not max_tokens; ZAI vision
-        # models reject it entirely with error 1210). Omitting it sidesteps all of
-        # those wire-format quirks at once.
+        # Pass max_tokens unconditionally.  Previously this was gated to
+        # Anthropic-compatible endpoints only, but local OpenAI-compatible
+        # backends (oMLX, llama.cpp, Ollama, LM Studio) interpret an omitted
+        # max_tokens as "use server default" (typically 4096-8192), NOT
+        # "generate until EOS".  This caused compression summaries to fill the
+        # entire server default, hit finish_reason=length, and retry 4+ times
+        # (~18 minutes per compression cycle).  See #50132.
         #
-        # The one exception is the Anthropic Messages wire (MiniMax and any
-        # ``/anthropic`` endpoint reached through the OpenAI SDK wrapper), where
-        # max_tokens is a MANDATORY field — omitting it is a hard 400. Keep it only
-        # there.
-        _effective_base = base_url or (
-            _current_custom_base_url() if provider == "custom" else ""
-        )
-        if _is_anthropic_compat_endpoint(provider, _effective_base):
-            kwargs["max_tokens"] = max_tokens
+        # Providers that reject max_tokens outright (ZAI vision, GPT-5-style
+        # models needing max_completion_tokens, GitHub Copilot) are already
+        # handled by the retry logic at lines ~5394-5410, which strips
+        # max_tokens and retries on "unsupported_parameter" errors.
+        kwargs["max_tokens"] = max_tokens
 
     if tools:
         # Defensive dedup: providers like Google Vertex, Azure, and Bedrock

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -105,13 +105,13 @@ class TestAuxiliaryMaxTokensParam:
 
 
 class TestBuildCallKwargsMaxTokens:
-    """_build_call_kwargs should not cap output by default (#34530).
+    """_build_call_kwargs should pass max_tokens unconditionally (#50132).
 
-    Most chat-completions providers treat an omitted max_tokens as "use the
-    model max", which is what we want for auxiliary tasks. An explicit cap only
-    risks truncation or a wire-format 400 (GitHub Copilot / GPT-5 reject
-    max_tokens; ZAI vision rejects it entirely). The Anthropic Messages wire is
-    the one exception — max_tokens is a mandatory field there.
+    Previously, max_tokens was only included for Anthropic-compatible
+    endpoints.  Local OpenAI-compatible backends (oMLX, llama.cpp, Ollama)
+    interpret an omitted max_tokens as "use server default" (4096-8192),
+    NOT "generate until EOS", causing compression summaries to never
+    converge.  Providers that reject max_tokens are handled by retry logic.
     """
 
     @pytest.mark.parametrize(
@@ -126,7 +126,7 @@ class TestBuildCallKwargsMaxTokens:
             ("zai", "glm-4v-flash", "https://open.bigmodel.cn/api/paas/v4"),
         ],
     )
-    def test_omits_max_tokens_for_openai_compatible(self, provider, model, base_url):
+    def test_passes_max_tokens_unconditionally(self, provider, model, base_url):
         from agent.auxiliary_client import _build_call_kwargs
 
         kwargs = _build_call_kwargs(
@@ -136,7 +136,7 @@ class TestBuildCallKwargsMaxTokens:
             max_tokens=1234,
             base_url=base_url,
         )
-        assert "max_tokens" not in kwargs
+        assert kwargs["max_tokens"] == 1234
         assert "max_completion_tokens" not in kwargs
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`_build_call_kwargs()` previously only included `max_tokens` for Anthropic-compatible endpoints. For OpenAI-compatible backends (oMLX, llama.cpp, Ollama, LM Studio), `max_tokens` was silently dropped.

This caused:
- Compression summaries filling the entire server default (4096-8192), hitting `finish_reason=length`
- 4+ retries per compression cycle (~18 minutes total)
- Subsequent compressions only removing 6% of messages

## Fix

Pass `max_tokens` unconditionally. Providers that reject the parameter (ZAI vision, GPT-5-style models, GitHub Copilot) are already handled by the existing retry logic that strips `max_tokens` on `unsupported_parameter` errors.

## Test Plan

- [x] Updated `TestBuildCallKwargsMaxTokens` test class
- [x] All 9 test cases pass
- [x] 2 files changed, +20 -25 lines

Fixes #50132