### PR TITLE
fix: reconnect stale MCP tool wrappers

### DIFF
--- a/tests/tools/test_mcp_stale_wrapper_reconnect.py
+++ b/tests/tools/test_mcp_stale_wrapper_reconnect.py
@@ -1,0 +1,42 @@
+import json
+from types import SimpleNamespace
+
+
+def test_tool_handler_reconnects_stale_wrapper_before_returning_not_connected(monkeypatch):
+    from tools import mcp_tool
+
+    calls = []
+    fake_server = SimpleNamespace(session=object())
+
+    with mcp_tool._lock:
+        mcp_tool._servers.pop("control-tower", None)
+        mcp_tool._server_error_counts.pop("control-tower", None)
+
+    def fake_reconnect(server_name):
+        calls.append(server_name)
+        return fake_server
+
+    monkeypatch.setattr(mcp_tool, "_try_reconnect_disconnected_server", fake_reconnect)
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", lambda _call, timeout: json.dumps({"result": "ok"}))
+
+    handler = mcp_tool._make_tool_handler("control-tower", "get_capabilities", 1)
+    result = json.loads(handler({}))
+
+    assert calls == ["control-tower"]
+    assert result == {"result": "ok"}
+
+
+def test_tool_handler_reports_not_connected_when_reconnect_fails(monkeypatch):
+    from tools import mcp_tool
+
+    with mcp_tool._lock:
+        mcp_tool._servers.pop("control-tower", None)
+        mcp_tool._server_error_counts.pop("control-tower", None)
+
+    monkeypatch.setattr(mcp_tool, "_try_reconnect_disconnected_server", lambda _name: None)
+
+    handler = mcp_tool._make_tool_handler("control-tower", "get_capabilities", 1)
+    result = json.loads(handler({}))
+
+    assert result == {"error": "MCP server 'control-tower' is not connected"}
+    assert mcp_tool._server_error_counts.get("control-tower") == 1

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3087,6 +3087,49 @@ def _load_mcp_config() -> Dict[str, dict]:
 # Server connection helper
 # ---------------------------------------------------------------------------
 
+def _try_reconnect_disconnected_server(server_name: str):
+    """Best-effort recovery for stale generated MCP wrappers.
+
+    A Hermes process can still have registered ``mcp_<server>_*`` tool schemas
+    after the long-lived client session for that server has disappeared or been
+    left half-closed.  Server-side watchdogs may prove the remote endpoint is
+    healthy, but these generated wrappers would previously return
+    ``MCP server '<name>' is not connected`` until the whole gateway/session was
+    reloaded.  When a wrapper is invoked in that state, attempt one in-process
+    rediscovery before surfacing the error.
+    """
+    with _lock:
+        existing = _servers.get(server_name)
+        if existing is not None and existing.session is not None:
+            return existing
+        if server_name in _server_connecting:
+            return None
+
+        configured = _load_mcp_config()
+        cfg = configured.get(server_name) if isinstance(configured, dict) else None
+        if not isinstance(cfg, dict):
+            return None
+        if not _parse_boolish(cfg.get("enabled", True), default=True):
+            return None
+
+        # Remove stale placeholders so register_mcp_servers()/discover_mcp_tools()
+        # treats this as a fresh connection attempt.  Registered tool wrappers stay
+        # in the registry; this only clears the dead client session state.
+        _servers.pop(server_name, None)
+        _server_connect_errors.pop(server_name, None)
+        _server_error_counts.pop(server_name, None)
+        _server_breaker_opened_at.pop(server_name, None)
+
+    logger.info("MCP server '%s' is disconnected; attempting in-process rediscovery", server_name)
+    try:
+        discover_mcp_tools()
+    except Exception as exc:
+        logger.warning("MCP rediscovery for '%s' failed: %s", server_name, exc)
+
+    with _lock:
+        recovered = _servers.get(server_name)
+        return recovered if recovered is not None and recovered.session is not None else None
+
 async def _connect_server(name: str, config: dict) -> MCPServerTask:
     """Create an MCPServerTask, start it, and return when ready.
 
@@ -3144,10 +3187,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         with _lock:
             server = _servers.get(server_name)
         if not server or not server.session:
-            _bump_server_error(server_name)
-            return json.dumps({
-                "error": f"MCP server '{server_name}' is not connected"
-            }, ensure_ascii=False)
+            server = _try_reconnect_disconnected_server(server_name)
+            if not server or not server.session:
+                _bump_server_error(server_name)
+                return json.dumps({
+                    "error": f"MCP server '{server_name}' is not connected"
+                }, ensure_ascii=False)
 
         async def _call():
             async with server._rpc_lock:


### PR DESCRIPTION
## Summary
- attempt in-process MCP rediscovery when a generated MCP tool wrapper has lost its server session
- preserve the existing `MCP server '<name>' is not connected` error when rediscovery cannot recover the session
- add regression coverage for stale wrapper recovery and failed reconnect behavior

## Test Plan
- `uv run pytest tests/cron/test_scheduler_mcp_init.py tests/tools/test_mcp_stale_wrapper_reconnect.py -q`

## Context
A long-running Hermes gateway can keep generated MCP tool wrappers after the underlying client session has gone stale/disconnected. Raw MCP endpoint health can be green while the active wrapper still returns not connected. This adds a best-effort reconnect path at wrapper invocation time before surfacing the error.