### PR TITLE
fix(agent_init): honor per-model providers.<p>.models.<m>.context_length in compressor

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1418,6 +1418,67 @@ def init_agent(
             )
             _config_context_length = None
 
+    # Per-model context_length override from the keyed
+    # `providers.<provider>.models.<model>.context_length` map.
+    #
+    # Historically agent_init only honored the FLAT top-level
+    # `model.context_length` (handled just above) and the legacy
+    # `custom_providers` list (handled just below). A per-model override
+    # parked under `providers.<provider>.models.<model>.context_length` was
+    # therefore invisible to the compressor, even though it is a documented
+    # place to pin a model's window.
+    #
+    # Concrete failure this fixes: a user pins a 1M window for a NON-default
+    # model via
+    #     providers:
+    #       copilot:
+    #         models:
+    #           claude-opus-4.8:
+    #             context_length: 1000000
+    # The top-level `model.context_length` is unset (their default model is a
+    # different one), so `_config_context_length` is None here and the
+    # compressor falls through to auto-detection, which can report a much
+    # smaller window (e.g. 200000). After the 32k output reserve is removed
+    # that yields a ~168000 compression window and premature, repeated
+    # compaction on what the user configured as a 1M model.
+    #
+    # Resolve the override from the live `(agent.provider, agent.model)` pair
+    # so the value is honored for non-default models too. Keep this BEFORE the
+    # custom_providers branch and the final `agent._config_context_length =`
+    # assignment so it persists across switch_model / fallback activation.
+    if _config_context_length is None:
+        try:
+            _prov_key = str(getattr(agent, "provider", "") or "").strip()
+            _providers_cfg = _agent_cfg.get("providers", {}) if isinstance(_agent_cfg, dict) else {}
+            if _prov_key and isinstance(_providers_cfg, dict):
+                _prov_block = _providers_cfg.get(_prov_key, {})
+                if isinstance(_prov_block, dict):
+                    _prov_models = _prov_block.get("models", {})
+                    if isinstance(_prov_models, dict):
+                        _pm_cfg = _prov_models.get(agent.model, {})
+                        if isinstance(_pm_cfg, dict):
+                            _pm_ctx = _pm_cfg.get("context_length")
+                            if _pm_ctx is not None:
+                                try:
+                                    if isinstance(_pm_ctx, bool):
+                                        raise ValueError
+                                    _pm_parsed = int(_pm_ctx)
+                                    if _pm_parsed <= 0:
+                                        raise ValueError
+                                    _config_context_length = _pm_parsed
+                                except (TypeError, ValueError):
+                                    _ra().logger.warning(
+                                        "Invalid context_length for model %r under "
+                                        "providers.%s.models in config.yaml: %r — must be a "
+                                        "positive integer (e.g. 1000000, not '1M'). "
+                                        "Falling back to auto-detection.",
+                                        agent.model, _prov_key, _pm_ctx,
+                                    )
+        except Exception:
+            # Never let an override-lookup error block agent init; fall
+            # through to custom_providers / auto-detection below.
+            pass
+
     # Resolve custom_providers list once for reuse below (startup
     # context-length override and plugin context-engine init).
     try:


### PR DESCRIPTION
## Problem

The context-length resolver in `init_agent` (`agent/agent_init.py`) only reads
two sources before falling through to auto-detection:

1. the flat top-level `model.context_length`
2. the legacy `custom_providers` list (matched by `base_url`)

A per-model override under
`providers.<provider>.models.<model>.context_length` is **never read**, so it is
invisible to the compressor that decides when to compact.

### Effect

Pinning a large window for a **non-default** model has no effect on compaction.
Example config:

```yaml
model:
  default: gpt-5.5        # a different model
  provider: copilot
providers:
  copilot:
    models:
      <configured-model>:
        context_length: 1000000
```

Because the top-level `model.context_length` is unset for the configured model,
`_config_context_length` stays `None`, and the compressor falls through to
auto-detection — which can report a much smaller window (e.g. `200000`). After
the 32k output reserve is subtracted, the compressor window becomes ~`168000`
and `threshold_tokens` ~`142800`, causing **premature, repeated context
compaction** on a model the user explicitly configured as 1M. The session JSON
shows the tell-tale `context_length=168000` / `threshold_tokens=142800` on a
"1M model".

## Fix

Add a resolution branch that reads
`providers.<agent.provider>.models.<agent.model>.context_length` from the live
`(provider, model)` pair, placed **after** the top-level override and
**before** the `custom_providers` fallback. Resulting precedence:

```
top-level model.context_length
  > per-model providers.<provider>.models.<model>.context_length   (NEW)
  > custom_providers list
  > auto-detection
```

Invalid values (non-int, `<= 0`, or `bool`) are ignored with a warning and fall
through to auto-detection, matching the existing top-level override's
robustness. The lookup is wrapped in a broad `try/except` so an unexpected
config shape can never block agent init.

## Verification

- `python -m py_compile agent/agent_init.py` — OK.
- Standalone logic test of the new branch against a representative config, all 9
  cases pass:

| case | result |
|---|---|
| non-default 1M model resolves override | `1000000` ✓ |
| 200k-capped model resolves its own value | `200000` ✓ |
| model with no per-model entry → None (auto-detect) | `None` ✓ |
| top-level override present → branch skipped | top-level wins ✓ |
| non-int `"1M"` string → None (warn + fallback) | `None` ✓ |
| `context_length: 0` → None | `None` ✓ |
| `bool True` → None (not coerced to 1) | `None` ✓ |
| unknown provider → None | `None` ✓ |
| empty provider → None | `None` ✓ |

After the fix, the configured model resolves to `ctx=1000000` → compressor
`window=968000` → `threshold_tokens=822800`, instead of `168000` / `142800`.

## Notes

- Pure addition (no existing lines changed), so behavior is unchanged when no
  per-model override is configured.
- This is the agent/compressor-side counterpart to per-model context-length
  resolution; it makes the documented `providers.<provider>.models.<model>.context_length`
  key actually affect compaction, not just any display surface.
