### PR TITLE
fix(web): stream dashboard file downloads

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,13 +5,16 @@
 // incoming ``X-Forwarded-Prefix`` header so the SPA can address its own
 // ``/api/...`` and ``/dashboard-plugins/...`` URLs correctly without a
 // rebuild. Empty string means "served at root".
-function readBasePath(): string {
-  if (typeof window === "undefined") return "";
-  const raw = window.__HERMES_BASE_PATH__ ?? "";
+function normalizeBasePath(raw: string | null | undefined): string {
   if (!raw) return "";
   // Normalise: ensure leading slash, strip trailing slash.
   const withLead = raw.startsWith("/") ? raw : `/${raw}`;
   return withLead.replace(/\/+$/, "");
+}
+
+function readBasePath(): string {
+  if (typeof window === "undefined") return "";
+  return normalizeBasePath(window.__HERMES_BASE_PATH__ ?? "");
 }
 
 export const HERMES_BASE_PATH = readBasePath();
@@ -186,6 +189,17 @@ export async function fetchJSON<T>(
     throw new Error(`${res.status}: ${text}`);
   }
   return res.json();
+}
+
+export function buildManagedFileDownloadUrl(
+  path: string,
+  options: { basePath?: string; token?: string | null } = {},
+): string {
+  const params = new URLSearchParams({ path });
+  if (options.token) {
+    params.set("token", options.token);
+  }
+  return `${normalizeBasePath(options.basePath ?? HERMES_BASE_PATH)}/api/files/download?${params.toString()}`;
 }
 
 /** Encode a plugin registry key for URL paths (preserves `/` segment separators). */
@@ -419,6 +433,10 @@ export const api = {
     fetchJSON<ManagedFileReadResponse>(
       `/api/files/read?path=${encodeURIComponent(path)}`,
     ),
+  fileDownloadUrl: (path: string) =>
+    buildManagedFileDownloadUrl(path, {
+      token: typeof window === "undefined" ? null : window.__HERMES_SESSION_TOKEN__ ?? null,
+    }),
   uploadFile: (path: string, file: File, overwrite = true) => {
     // Stream the raw bytes as multipart/form-data. Do NOT set Content-Type —
     // the browser adds the multipart boundary automatically. Sending the file

--- a/web/src/lib/managed-file-download.test.ts
+++ b/web/src/lib/managed-file-download.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { buildManagedFileDownloadUrl } from "./api";
+
+describe("buildManagedFileDownloadUrl", () => {
+  it("targets the streaming download endpoint with encoded path and token", () => {
+    expect(
+      buildManagedFileDownloadUrl("/tmp/Hermes files/report 1.mp3", {
+        basePath: "/hermes/",
+        token: "session token",
+      }),
+    ).toBe(
+      "/hermes/api/files/download?path=%2Ftmp%2FHermes+files%2Freport+1.mp3&token=session+token",
+    );
+  });
+
+  it("omits the token query parameter when no token is available", () => {
+    expect(
+      buildManagedFileDownloadUrl("relative/file.txt", {
+        basePath: "",
+        token: null,
+      }),
+    ).toBe("/api/files/download?path=relative%2Ffile.txt");
+  });
+});

--- a/web/src/pages/FilesPage.tsx
+++ b/web/src/pages/FilesPage.tsx
@@ -58,9 +58,9 @@ function formatBytes(size: number | null): string {
   return `${(size / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
-function downloadDataUrl(dataUrl: string, name: string) {
+function downloadUrl(url: string, name: string) {
   const link = document.createElement("a");
-  link.href = dataUrl;
+  link.href = url;
   link.download = name || "download";
   document.body.appendChild(link);
   link.click();
@@ -235,11 +235,10 @@ export default function FilesPage() {
     void uploadFiles(event.dataTransfer.files);
   };
 
-  const downloadFile = async (entry: ManagedFileEntry) => {
+  const downloadFile = (entry: ManagedFileEntry) => {
     if (entry.is_directory) return;
     try {
-      const file = await api.readFile(entry.path);
-      downloadDataUrl(file.data_url, file.name);
+      downloadUrl(api.fileDownloadUrl(entry.path), entry.name);
     } catch (e) {
       showToast(`Download failed: ${e}`, "error");
     }


### PR DESCRIPTION
## What does this PR do?

The Dashboard Files page currently downloads files by calling `/api/files/read`, waiting for a JSON response with a base64 `data_url`, then synthesizing a client-side data URL. That works for small files but forces larger downloads to be fully buffered and inflated in JavaScript.

This switches the Files page download action to the existing streaming attachment endpoint:

`GET /api/files/download?path=...`

The helper also carries the dashboard base path and optional session token so prefixed deployments and auth-gated browser downloads keep working.

## Related Issue

Fixes #50152

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/lib/api.ts`
  - Added `buildManagedFileDownloadUrl()` and `api.fileDownloadUrl()` for `/api/files/download`.
  - Reused the dashboard base-path normalization for prefixed deployments.
- `web/src/pages/FilesPage.tsx`
  - Changed file downloads from `api.readFile()` + base64 data URL to a direct streaming download link.
- `web/src/lib/managed-file-download.test.ts`
  - Added URL construction coverage for encoded paths, base paths, and optional query token auth.

## How to Test

1. `npm --workspace web test`
2. `npm --workspace web run typecheck`
3. `npx eslint src/lib/api.ts src/pages/FilesPage.tsx src/lib/managed-file-download.test.ts` from `web/`
4. `python3 -m pytest tests/hermes_cli/test_web_server_files.py -q`
5. `npm --workspace web run build`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Duplicate gate: PASS
Artifact: `.context/pre-pr-gates/NousResearch-hermes-agent-50152-20260621T135158Z.md`

Manual duplicate review:
- #46895 is the merged backend `/api/files/download` endpoint this PR builds on.
- #46663 is the superseded desktop remote-artifact PR.
- #43772 covers attachment/static file serving, not Dashboard Files downloads.
- Gate REVIEW candidates #26354, #28853, #35331, #36669, and #37545 were unrelated by files/topic.

Verification:

```text
npm --workspace web test
Test Files 3 passed; Tests 12 passed

npm --workspace web run typecheck
passed

npx eslint src/lib/api.ts src/pages/FilesPage.tsx src/lib/managed-file-download.test.ts
passed

python3 -m pytest tests/hermes_cli/test_web_server_files.py -q
16 passed

npm --workspace web run build
passed
```

Note: full `npm --workspace web run lint` currently fails on pre-existing unrelated React Compiler / refs lint violations outside this PR's changed files; the changed-file ESLint command above passes.
