### PR TITLE
fix(gateway): dedup the agent_visible_image path so it isn't re-attached after compression

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1157,11 +1157,18 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
             except Exception:
                 payload = None
             if isinstance(payload, dict) and payload.get("success"):
+                # Record EVERY path field, not just the first. The consumer
+                # (_collect_auto_append_media_tags) can emit any of host_image /
+                # image / agent_visible_image, so all delivered shapes must land
+                # in the dedup set. On remote terminal backends (Docker/Modal/
+                # SSH) image_generate carries a *distinct* agent_visible_image;
+                # stopping at host_image left that path undeduped, so it was
+                # re-attached every text-only turn after a compression boundary —
+                # the exact #46627 symptom this helper exists to prevent.
                 for field in _JSON_MEDIA_TOOL_PATH_FIELDS:
                     jp = payload.get(field)
                     if isinstance(jp, str) and jp:
                         paths.add(jp)
-                        break
     return paths
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -321,6 +321,41 @@ caption
         )
         assert tags == [], f"generated image re-emitted after compression: {tags}"
 
+    def test_image_generate_remote_backend_not_reemitted_after_compression(self):
+        """Remote terminal backends (Docker/Modal/SSH) make image_generate carry
+        a DISTINCT ``agent_visible_image`` alongside ``host_image``. The dedup
+        builder must record EVERY path field, not just the first — otherwise the
+        ``agent_visible_image`` path is never deduped and gets re-attached on
+        every text-only turn after a compression boundary (the #46627 symptom,
+        which the single-field regression above does not exercise)."""
+        from gateway.run import (
+            _collect_auto_append_media_tags,
+            _collect_history_media_paths,
+        )
+
+        history = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "c", "function": {"name": "image_generate"}}],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c",
+                "content": (
+                    '{"success": true, '
+                    '"host_image": "/host/.hermes/cache/cat.png", '
+                    '"image": "/host/.hermes/cache/cat.png", '
+                    '"agent_visible_image": "/root/.hermes/cache/cat.png"}'
+                ),
+            },
+        ]
+        history_paths = _collect_history_media_paths(history)
+
+        tags, _ = _collect_auto_append_media_tags(
+            history, history_offset=9999, history_media_paths=history_paths
+        )
+        assert tags == [], f"agent_visible_image re-emitted after compression: {tags}"
+
 
     def test_media_tags_not_extracted_from_history(self):
         """MEDIA tags from previous turns should NOT be extracted again."""


### PR DESCRIPTION
## Summary

Follow-up to `8ac5e90ec` ("dedup image_generate media across the compression boundary", #46627).

`_collect_history_media_paths` builds the media dedup set by iterating `_JSON_MEDIA_TOOL_PATH_FIELDS = ("host_image", "image", "agent_visible_image")` but **`break`s after the first non-empty field** — so an `image_generate` result records only `host_image`:

```python
if isinstance(payload, dict) and payload.get("success"):
    for field in _JSON_MEDIA_TOOL_PATH_FIELDS:
        jp = payload.get(field)
        if isinstance(jp, str) and jp:
            paths.add(jp)
            break   # ← stops at host_image; agent_visible_image never deduped
```

The consumer `_collect_auto_append_media_tags` iterates the **same three fields** and emits any path *not* in the dedup set, so once `host_image`/`image` are deduped it falls through to `agent_visible_image` (which the builder never stored) and re-emits it.

This reproduces the exact symptom #46627 set out to kill, on **remote terminal backends**: `_postprocess_image_generate_result` (`tools/image_generation_tool.py`) sets a *distinct* `agent_visible_image` alongside `host_image` whenever a different-filesystem backend is active (Docker/Modal/Singularity/SSH). After a compression boundary the auto-append fallback rescans full history (`history_offset` stale), so the already-delivered generated image is re-attached as `MEDIA:<agent_visible_image>` on **every text-only follow-up turn**.

Reproduced against the live module: builder dedup set = `{'/host/.hermes/cache/cat.png'}`; the compression-fallback consumer re-emits `['MEDIA:/root/.hermes/cache/cat.png']`. The committed regression test used a single-field local payload (`{"image": ...}`), so the multi-field remote shape went untested.

## Fix

Drop the early `break` so the builder records **every** delivered path field. The dedup set is a superset — adding more known-delivered paths is always safe, and it exactly mirrors the field set the consumer can emit.

## Tests

`tests/gateway/test_media_extraction.py::TestMediaExtraction::test_image_generate_remote_backend_not_reemitted_after_compression` — an `image_generate` result with a distinct `agent_visible_image`, run through the compression-fallback path; asserts no re-emission. **Fails without the fix** (`['MEDIA:/root/.hermes/cache/cat.png']`); the committed single-field test still passes.