### PR TITLE
feat(providers): add Groq/Cerebras catalogs and fix MiniMax model fetch

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -171,6 +171,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "xai-oauth": "xai",
     "xiaomi": "xiaomi",
     "nvidia": "nvidia",
+    "cerebras": "cerebras",
     "groq": "groq",
     "mistral": "mistral",
     "togetherai": "togetherai",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -287,6 +287,21 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-4.5-flash",
     ],
     "xai": _xai_curated_models(),
+    "groq": [
+        "llama-3.3-70b-versatile",
+        "llama-3.1-8b-instant",
+        "meta-llama/llama-4-scout-17b-16e-instruct",
+        "openai/gpt-oss-120b",
+        "openai/gpt-oss-20b",
+        "qwen/qwen3-32b",
+        "qwen/qwen3.6-27b",
+        "groq/compound",
+        "groq/compound-mini",
+    ],
+    "cerebras": [
+        "gpt-oss-120b",
+        "zai-glm-4.7",
+    ],
     "nvidia": [
         # NVIDIA flagship reasoning models
         "nvidia/nemotron-3-super-120b-a12b",
@@ -332,8 +347,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "minimax": [
         "MiniMax-M3",
         "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
+        "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
+        "MiniMax-M2.1-highspeed",
         "MiniMax-M2",
     ],
     "minimax-oauth": [
@@ -344,8 +362,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "minimax-cn": [
         "MiniMax-M3",
         "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
+        "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
+        "MiniMax-M2.1-highspeed",
         "MiniMax-M2",
     ],
     "anthropic": [
@@ -2133,6 +2154,8 @@ def _resolve_copilot_catalog_api_key() -> str:
 #     OpenRouter's 400+ catalog. Blindly merging would dump everything.
 #   - "nous": curated list and Portal /models endpoint are the source of
 #     truth for the subscription tier.
+#   - "groq": models.dev currently includes STT/safeguard/prompt-guard
+#     entries that are poor agent chat defaults; keep the curated list tight.
 # Also excluded: providers that already have dedicated live-endpoint
 # branches below (copilot, anthropic, ollama-cloud, custom,
 # stepfun, openai-codex) — those paths handle freshness themselves.
@@ -2146,7 +2169,7 @@ _MODELS_DEV_PREFERRED: frozenset[str] = frozenset({
     "togetherai",
     "cohere",
     "perplexity",
-    "groq",
+    "cerebras",
     "nvidia",
     "huggingface",
     "zai",

--- a/plugins/model-providers/cerebras/__init__.py
+++ b/plugins/model-providers/cerebras/__init__.py
@@ -1,0 +1,19 @@
+"""Cerebras provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+cerebras = ProviderProfile(
+    name="cerebras",
+    aliases=("cerebras-ai",),
+    api_mode="chat_completions",
+    env_vars=("CEREBRAS_API_KEY", "CEREBRAS_BASE_URL"),
+    display_name="Cerebras",
+    description="Cerebras Inference — OpenAI-compatible high-speed models",
+    signup_url="https://cloud.cerebras.ai/",
+    base_url="https://api.cerebras.ai/v1",
+    auth_type="api_key",
+)
+
+register_provider(cerebras)

--- a/plugins/model-providers/cerebras/plugin.yaml
+++ b/plugins/model-providers/cerebras/plugin.yaml
@@ -1,0 +1,4 @@
+name: cerebras
+kind: model-provider
+description: Cerebras OpenAI-compatible inference provider
+version: 1.0.0

--- a/plugins/model-providers/groq/__init__.py
+++ b/plugins/model-providers/groq/__init__.py
@@ -1,0 +1,38 @@
+"""Groq provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class GroqProfile(ProviderProfile):
+    """GroqCloud — curated picker catalog.
+
+    Groq's live ``/models`` endpoint includes STT, safeguard, prompt-guard,
+    and other non-agent chat entries. Returning ``None`` here makes
+    ``provider_model_ids('groq')`` fall back to Hermes' curated chat list
+    instead of appending noisy live-only entries.
+    """
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        return None
+
+
+groq = GroqProfile(
+    name="groq",
+    aliases=("groqcloud", "groq-cloud"),
+    api_mode="chat_completions",
+    env_vars=("GROQ_API_KEY", "GROQ_BASE_URL"),
+    display_name="Groq",
+    description="GroqCloud — fast OpenAI-compatible inference",
+    signup_url="https://console.groq.com/keys",
+    base_url="https://api.groq.com/openai/v1",
+    auth_type="api_key",
+)
+
+register_provider(groq)

--- a/plugins/model-providers/groq/plugin.yaml
+++ b/plugins/model-providers/groq/plugin.yaml
@@ -1,0 +1,4 @@
+name: groq
+kind: model-provider
+description: GroqCloud OpenAI-compatible inference provider
+version: 1.0.0

--- a/plugins/model-providers/minimax/__init__.py
+++ b/plugins/model-providers/minimax/__init__.py
@@ -29,6 +29,32 @@ def _is_minimax_m3(model: str | None) -> bool:
 class MiniMaxProfile(ProviderProfile):
     """MiniMax — M3 OpenAI-compatible reasoning controls."""
 
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch MiniMax's live catalog with the provider's auth semantics.
+
+        MiniMax's default Hermes route is the Anthropic-compatible endpoint,
+        which expects ``x-api-key`` rather than ``Authorization: Bearer``.
+        The base ``ProviderProfile`` fetcher is intentionally OpenAI-style, so
+        use the shared probing helper with ``api_mode='anthropic_messages'``.
+        """
+        try:
+            from hermes_cli.models import fetch_api_models
+
+            return fetch_api_models(
+                api_key,
+                base_url or self.base_url,
+                timeout=timeout,
+                api_mode="anthropic_messages",
+            )
+        except Exception:
+            return None
+
     def build_api_kwargs_extras(
         self,
         *,

--- a/tests/hermes_cli/test_provider_plugin_catalogs.py
+++ b/tests/hermes_cli/test_provider_plugin_catalogs.py
@@ -1,0 +1,90 @@
+"""Provider plugin and curated catalog regressions for smaller inference providers."""
+
+from unittest.mock import patch
+
+from agent.models_dev import PROVIDER_TO_MODELS_DEV
+from hermes_cli.auth import PROVIDER_REGISTRY
+from hermes_cli.models import _MODELS_DEV_PREFERRED, _PROVIDER_MODELS, provider_model_ids
+from providers import get_provider_profile
+
+
+def test_groq_plugin_registers_profile_and_auth_registry_entry():
+    profile = get_provider_profile("groq")
+    assert profile is not None
+    assert profile.base_url == "https://api.groq.com/openai/v1"
+
+    registry_entry = PROVIDER_REGISTRY["groq"]
+    assert registry_entry.api_key_env_vars == ("GROQ_API_KEY",)
+    assert registry_entry.base_url_env_var == "GROQ_BASE_URL"
+
+
+def test_cerebras_plugin_registers_profile_auth_registry_and_models_dev_mapping():
+    profile = get_provider_profile("cerebras")
+    assert profile is not None
+    assert profile.base_url == "https://api.cerebras.ai/v1"
+
+    registry_entry = PROVIDER_REGISTRY["cerebras"]
+    assert registry_entry.api_key_env_vars == ("CEREBRAS_API_KEY",)
+    assert registry_entry.base_url_env_var == "CEREBRAS_BASE_URL"
+    assert PROVIDER_TO_MODELS_DEV["cerebras"] == "cerebras"
+    assert "cerebras" in _MODELS_DEV_PREFERRED
+
+
+def test_minimax_fetch_models_uses_anthropic_messages_catalog_auth():
+    profile = get_provider_profile("minimax")
+    assert profile is not None
+    credential = "dummy-" + "key"
+
+    with patch("hermes_cli.models.fetch_api_models", return_value=["MiniMax-M3"]) as mocked_fetch:
+        result = profile.fetch_models(
+            api_key=credential,
+            base_url="https://api.minimax.io/anthropic",
+            timeout=3.0,
+        )
+
+    assert result == ["MiniMax-M3"]
+    assert mocked_fetch.call_args.kwargs["api_mode"] == "anthropic_messages"
+    assert mocked_fetch.call_args.kwargs["timeout"] == 3.0
+
+
+def test_groq_picker_uses_curated_chat_catalog_not_live_or_models_dev_noise():
+    assert "groq" not in _MODELS_DEV_PREFERRED
+    profile = get_provider_profile("groq")
+    assert profile is not None
+    credential = "dummy-" + "key"
+    assert profile.fetch_models(api_key=credential) is None
+
+    with (
+        patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": credential, "base_url": "https://api.groq.com/openai/v1"},
+        ),
+        patch(
+            "providers.base.ProviderProfile.fetch_models",
+            side_effect=AssertionError("groq should not use broad live /models"),
+        ),
+        patch(
+            "agent.models_dev.list_agentic_models",
+            side_effect=AssertionError("groq should not merge models.dev"),
+        ),
+    ):
+        models = provider_model_ids("groq", force_refresh=True)
+
+    assert models == _PROVIDER_MODELS["groq"]
+    joined = "\n".join(models).lower()
+    assert "whisper" not in joined
+    assert "safeguard" not in joined
+    assert "prompt-guard" not in joined
+
+
+def test_xiaomi_catalog_excludes_token_plan_rejected_ultraspeed_model():
+    assert "mimo-v2.5-pro-ultraspeed" not in _PROVIDER_MODELS["xiaomi"]
+
+    with patch(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        return_value={"api_key": "", "base_url": ""},
+    ):
+        models = provider_model_ids("xiaomi", force_refresh=True)
+
+    assert "mimo-v2.5-pro" in models
+    assert "mimo-v2.5-pro-ultraspeed" not in models

--- a/tests/test_minimax_model_validation.py
+++ b/tests/test_minimax_model_validation.py
@@ -56,20 +56,31 @@ class TestMiniMaxModelValidation:
         assert result["recognized"] is True
 
     # -------------------------------------------------------------------------
-    # Test 2: A near-match model on minimax-cn triggers a suggestion (not auto-correct)
+    # Test 2: Highspeed MiniMax variants are recognized catalog entries
     # -------------------------------------------------------------------------
-    def test_near_match_minimax_cn_suggests_similar(self):
-        # "MiniMax-M2.7-highspeed" is somewhat similar to "MiniMax-M2.7" (ratio ~0.71)
-        # but below the 0.9 auto-correct cutoff. It should be accepted with a
-        # recognized=False and a similar-models suggestion (ratio > 0.5).
+    def test_valid_minimax_cn_highspeed_model_accepted(self):
         result = validate_requested_model("MiniMax-M2.7-highspeed", "minimax-cn")
         assert result["accepted"] is True
         assert result["persist"] is True
+        assert result["recognized"] is True
+        assert result["message"] is None
+
+    # -------------------------------------------------------------------------
+    # Test 2b: A near-match model on minimax-cn triggers a suggestion (not auto-correct)
+    # -------------------------------------------------------------------------
+    def test_near_match_minimax_cn_suggests_similar(self):
+        # "MiniMax-M2.7-ultraspeed" is somewhat similar to the cataloged
+        # highspeed variant (ratio ~0.80) but below the 0.9 auto-correct cutoff.
+        # It should be accepted with recognized=False and a similar-models
+        # suggestion (ratio > 0.5).
+        result = validate_requested_model("MiniMax-M2.7-ultraspeed", "minimax-cn")
+        assert result["accepted"] is True
+        assert result["persist"] is True
         assert result["recognized"] is False
-        # Should NOT auto-correct (ratio 0.71 < 0.9)
+        # Should NOT auto-correct (ratio 0.80 < 0.9)
         assert "corrected_model" not in result
-        # But should suggest similar models (ratio 0.71 > 0.5)
-        assert "MiniMax-M2.7" in result["message"]
+        # But should suggest similar models (ratio 0.80 > 0.5)
+        assert "MiniMax-M2.7-highspeed" in result["message"]
 
     # -------------------------------------------------------------------------
     # Test 3: A completely unknown model is accepted (not rejected) with a warning


### PR DESCRIPTION
## Summary
- Adds bundled model-provider plugins for Groq and Cerebras with OpenAI-compatible profile metadata.
- Adds curated Groq/Cerebras picker catalogs and maps Cerebras into the models.dev provider metadata path.
- Fixes MiniMax live model fetching to use the provider's Anthropic-compatible auth semantics, and refreshes MiniMax highspeed catalog validation coverage.

## What changed
- `plugins/model-providers/groq/`: new Groq provider profile with aliases and a curated-chat catalog path that avoids broad `/models` noise such as STT/guard entries.
- `plugins/model-providers/cerebras/`: new Cerebras provider profile and plugin manifest.
- `hermes_cli/models.py`: static picker entries for Groq/Cerebras, MiniMax highspeed fallbacks, Cerebras models.dev merge preference, and Groq exclusion from models.dev noise merging.
- `agent/models_dev.py`: Cerebras provider ID mapping.
- `plugins/model-providers/minimax/__init__.py`: MiniMax `fetch_models()` now calls the shared catalog probe with `api_mode="anthropic_messages"`.
- Provider catalog regression tests for Groq, Cerebras, MiniMax, and Xiaomi token-plan model filtering.

## Why users benefit
- Users can choose Groq and Cerebras as first-class provider plugins instead of relying on custom endpoint setup.
- The `/model` picker stays focused on usable chat/agent models rather than surfacing non-chat Groq catalog entries.
- MiniMax users get a more accurate catalog path for Anthropic-compatible endpoints and highspeed variants.
- Xiaomi token-plan users avoid the rejected `mimo-v2.5-pro-ultraspeed` slug while retaining working MiMo models.

## Duplicate search / related work
- No existing PR was found for `Doji-Hammer:feat/provider-catalog-cleanup`.
- Related open provider PRs exist: #16642 adds Groq/Cerebras through older core-provider surfaces, and #31820 adds Groq with broader model discovery. This PR keeps the change on the current model-provider plugin/catalog path and also includes the MiniMax/Xiaomi catalog cleanup.
- Related Cerebras reasoning-content issues/PRs (#45655, #34716, #34760, #45661) are not addressed here; this PR is only provider registration/catalog behavior.

## Test plan
- [x] `git diff --check upstream/main..HEAD` — passed with no output.
- [x] committed-diff secret/privacy scan for private-key headers, token/PAT patterns, bearer literals, credential filenames, personal paths, and non-noreply emails — passed (`committed_changed_files: 9`, no findings).
- [x] `.venv/bin/python -m ruff check agent/models_dev.py hermes_cli/models.py plugins/model-providers/cerebras/__init__.py plugins/model-providers/groq/__init__.py plugins/model-providers/minimax/__init__.py tests/hermes_cli/test_provider_plugin_catalogs.py tests/test_minimax_model_validation.py` — `All checks passed!`
- [x] `scripts/run_tests.sh tests/hermes_cli/test_provider_plugin_catalogs.py tests/hermes_cli/test_models_dev_preferred_merge.py tests/test_minimax_model_validation.py tests/providers/test_fetch_models_base_url.py` — 33 passed, 0 failed.

## Platform tested
- macOS 26.4 (Build 25E246)
- Python 3.11.15

## Caveats
- Full `scripts/run_tests.sh` was not run; this PR was validated with targeted provider/model catalog tests plus ruff and diff/secret checks.
- Groq intentionally uses a curated picker catalog rather than broad live/model.dev merging to avoid non-agent chat entries.
- This PR does not fix provider-specific `reasoning_content` replay rejection for Cerebras or other strict providers.
