### PR TITLE
fix: persist codex app-server final responses

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -180,6 +180,7 @@ def run_codex_app_server_turn(
     original_user_message: Any,
     messages: List[Dict[str, Any]],
     effective_task_id: str,
+    conversation_history: List[Dict[str, Any]] = None,
     should_review_memory: bool = False,
 ) -> Dict[str, Any]:
     """Codex app-server runtime path. Hands the entire turn to a `codex
@@ -257,6 +258,13 @@ def run_codex_app_server_turn(
     # is exactly what curator.py / sessions DB expect.
     if turn.projected_messages:
         messages.extend(turn.projected_messages)
+    if turn.final_text and not any(
+        isinstance(msg, dict)
+        and msg.get("role") == "assistant"
+        and msg.get("content") == turn.final_text
+        for msg in turn.projected_messages
+    ):
+        messages.append({"role": "assistant", "content": turn.final_text})
 
     # Counter ticks for the agent-improvement loop.
     # _turns_since_memory and _user_turn_count are ALREADY incremented
@@ -311,6 +319,56 @@ def run_codex_app_server_turn(
             )
         except Exception:
             logger.debug("background review spawn raised", exc_info=True)
+
+    try:
+        # The app-server path bypasses the normal turn finalizer, but the
+        # standard turn prologue has already crash-persisted the inbound user
+        # message in normal turns. Seed the DB flush de-dupe set only for user
+        # messages that are actually already present in the session DB so a
+        # failed turn-start flush can still be recovered by this final flush.
+        current_session_id = getattr(agent, "session_id", None)
+        if getattr(agent, "_flushed_db_message_session_id", None) != current_session_id:
+            agent._flushed_db_message_ids = set()
+            agent._flushed_db_message_session_id = current_session_id
+        flushed_ids = getattr(agent, "_flushed_db_message_ids", None)
+        if not isinstance(flushed_ids, set):
+            flushed_ids = set()
+            agent._flushed_db_message_ids = flushed_ids
+        existing_users = []
+        if getattr(agent, "_session_db", None) is not None and current_session_id:
+            try:
+                for row in agent._session_db.get_messages(current_session_id) or []:
+                    role = row["role"] if hasattr(row, "keys") else row.get("role")
+                    if role == "user":
+                        content = (
+                            row["content"]
+                            if hasattr(row, "keys")
+                            else row.get("content")
+                        )
+                        existing_users.append(content)
+            except Exception:
+                existing_users = []
+        seeded = 0
+        for msg in messages:
+            if not isinstance(msg, dict) or msg.get("role") != "user":
+                continue
+            content = msg.get("content")
+            try:
+                idx = existing_users.index(content)
+            except ValueError:
+                continue
+            existing_users.pop(idx)
+            flushed_ids.add(id(msg))
+            seeded += 1
+        if seeded and getattr(agent, "_last_flushed_db_idx", 0) == 0:
+            agent._last_flushed_db_idx = seeded
+        agent._persist_session(messages, conversation_history)
+    except Exception:
+        logger.warning(
+            "codex app-server session persistence failed (session=%s)",
+            getattr(agent, "session_id", None),
+            exc_info=True,
+        )
 
     return {
         "final_response": turn.final_text,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -582,6 +582,7 @@ def run_conversation(
             user_message=user_message,
             original_user_message=original_user_message,
             messages=messages,
+            conversation_history=conversation_history,
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
         )

--- a/run_agent.py
+++ b/run_agent.py
@@ -5325,11 +5325,20 @@ class AIAgent:
         original_user_message: Any,
         messages: List[Dict[str, Any]],
         effective_task_id: str,
+        conversation_history: List[Dict[str, Any]] = None,
         should_review_memory: bool = False,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
-        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+        return run_codex_app_server_turn(
+            self,
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            conversation_history=conversation_history,
+            should_review_memory=should_review_memory,
+        )
 
 def main(
     query: str = None,

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import run_agent
+from hermes_state import SessionDB
 from agent.transports.codex_app_server_session import CodexAppServerSession, TurnResult
 
 
@@ -190,6 +191,47 @@ class TestRunConversationCodexPath:
             if m.get("role") == "user" and m.get("content") == "ping unique 12345"
         )
         assert user_count == 1, f"user message appeared {user_count}× in {result['messages']}"
+
+    def test_final_text_without_projected_message_is_persisted_once(
+        self, monkeypatch, tmp_path
+    ):
+        """The app-server may return final_text without projecting a final
+        assistant message. Hermes must still persist that assistant response
+        and must not duplicate the crash-persisted user turn."""
+
+        def final_text_only_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text="persisted final",
+                projected_messages=[],
+                tool_iterations=0,
+                interrupted=False,
+                error=None,
+                turn_id="turn-final-only",
+                thread_id="thread-final-only",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", final_text_only_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-final-only"
+        )
+
+        agent = _make_codex_agent()
+        agent._session_db = SessionDB(db_path=tmp_path / "state.db")
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("persist me")
+
+        assert result["final_response"] == "persisted final"
+        assert result["messages"][-1] == {
+            "role": "assistant",
+            "content": "persisted final",
+        }
+
+        rows = agent._session_db.get_messages(agent.session_id)
+        transcript = [(row["role"], row["content"]) for row in rows]
+        assert transcript == [
+            ("user", "persist me"),
+            ("assistant", "persisted final"),
+        ]
 
     def test_background_review_NOT_invoked_below_threshold(self, fake_session):
         """A single turn shouldn't trigger background review — counters


### PR DESCRIPTION
## Summary
- Persist codex app-server turns before returning from the early runtime path so desktop/TUI sessions retain assistant replies after refresh.
- Add a fallback assistant message when the app-server returns `final_text` without projecting a final assistant message.
- Preserve session DB de-duplication for user turns that were already crash-persisted, while still allowing the final flush to recover if the early user flush failed.
- Add regression coverage for final-text-only app-server turns to verify one user row and one assistant row are stored.

## Validation
- `/path/to/python -m py_compile agent/codex_runtime.py agent/conversation_loop.py run_agent.py tests/run_agent/test_codex_app_server_integration.py`
- `PYTHONPATH=<temporary pytest target> /path/to/python -m pytest tests/run_agent/test_codex_app_server_integration.py -q`
  - Result: `18 passed, 8 warnings`

## Notes
- architecture impact: limited to the `codex_app_server` early-return runtime path and its session persistence handoff.
- stitch/design impact: none.
- follow-up: none.