### PR TITLE
fix(browser): prevent UnicodeDecodeError on Windows with non-UTF-8 subprocess output

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2110,9 +2110,9 @@ def _run_browser_command(
             result = {"success": False, "error": f"Command timed out after {timeout} seconds"}
             # Fall through to fallback check below
         else:
-            with open(stdout_path, "r", encoding="utf-8") as f:
+            with open(stdout_path, "r", encoding="utf-8", errors="replace") as f:
                 stdout = f.read()
-            with open(stderr_path, "r", encoding="utf-8") as f:
+            with open(stderr_path, "r", encoding="utf-8", errors="replace") as f:
                 stderr = f.read()
             returncode = proc.returncode
 


### PR DESCRIPTION
## Description

Fix `UnicodeDecodeError` in `browser_tool.py` when running on Windows with Chinese locale (GBK/CP936).

### Problem

When `agent-browser.cmd` fails on Windows with a Chinese locale, the error message from `cmd.exe` is encoded in the system default charset (GBK), not UTF-8. Reading stderr with strict `utf-8` codec raises:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb2 in position 9: invalid start byte
```

This masks the original error (e.g., node not found) and makes all browser tools completely unusable on Windows Chinese systems.

### Root Cause

In `_run_browser_command()` (lines 2113-2116), stdout and stderr temp files are read with `encoding="utf-8"` without error handling:

```python
with open(stdout_path, "r", encoding="utf-8") as f:
    stdout = f.read()
with open(stderr_path, "r", encoding="utf-8") as f:
    stderr = f.read()
```

When `agent-browser.cmd` fails (e.g., node not found), `cmd.exe` outputs the error in GBK encoding. Byte `0xB2` at position 9 is not a valid UTF-8 start byte, triggering `UnicodeDecodeError`.

### Fix

Add `errors="replace"` to the `open()` calls:

```python
with open(stdout_path, "r", encoding="utf-8", errors="replace") as f:
    stdout = f.read()
with open(stderr_path, "r", encoding="utf-8", errors="replace") as f:
    stderr = f.read()
```

This replaces non-UTF-8 bytes with the Unicode replacement character (U+FFFD) instead of crashing, so the actual subprocess error message is visible to users and agents.

### Impact

| Scenario | Before | After |
|----------|--------|-------|
| Normal UTF-8 output | Works | Works (unchanged) |
| GBK error on Windows | UnicodeDecodeError | Error message visible |
| Browser tools on Windows Chinese | All broken | All work |

### Other open(encoding="utf-8") calls in this file

- **Line 927**: Already wrapped in try/except Exception - safe
- **Line 1304**: open(..., "w") - write-only, no decoding risk
- **Line 2050**: Inside try/except OSError - safe
- **Line 3665**: Reads /proc/1/cgroup (Linux-only, always UTF-8) - safe
