### PR TITLE
fix(mcp): rediscover dead cached servers on session startup

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -3875,6 +3875,71 @@ class TestRegisterMcpServers:
         finally:
             _servers.pop("existing", None)
 
+    def test_reconnects_server_entry_that_exists_but_is_not_connected(self):
+        """A stale server record with ``session is None`` must NOT block a fresh
+        connection attempt for a new session.
+
+        Regression for #50170: after keepalive/reconnect failure, the dead
+        ``MCPServerTask`` can remain parked in ``_servers``.  The old
+        name-only gate treated that as "already connected", so later session
+        startup skipped rediscovery entirely and the session inherited no MCP
+        tools.
+        """
+        from tools.mcp_tool import register_mcp_servers, _servers, _ensure_mcp_loop
+
+        stale = _make_mock_server("existing", session=None)
+        stale._registered_tool_names = ["mcp_existing_old_tool"]
+        _servers["existing"] = stale
+
+        fake_config = {"existing": {"command": "npx", "args": ["test"]}}
+        calls = []
+
+        async def fake_register(name, cfg):
+            calls.append((name, cfg))
+            fresh = _make_mock_server(name, session=MagicMock())
+            fresh._registered_tool_names = ["mcp_existing_fresh_tool"]
+            _servers[name] = fresh
+            return ["mcp_existing_fresh_tool"]
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._discover_and_register_server", side_effect=fake_register), \
+                 patch("tools.mcp_tool._existing_tool_names", return_value=["mcp_existing_fresh_tool"]):
+                _ensure_mcp_loop()
+                result = register_mcp_servers(fake_config)
+
+            assert calls == [("existing", fake_config["existing"])]
+            assert result == ["mcp_existing_fresh_tool"]
+            assert _servers["existing"].session is not None
+        finally:
+            _servers.pop("existing", None)
+
+    def test_skips_server_that_is_mid_reconnect_with_live_background_task(self):
+        """An in-flight reconnect keeps ownership of the server name.
+
+        ``session`` can legitimately be None during an in-place reconnect. That
+        alone must not trigger a second startup connect while the original
+        ``MCPServerTask`` background loop is still alive and recovering.
+        """
+        from tools.mcp_tool import register_mcp_servers, _servers
+
+        recovering = _make_mock_server("existing", session=None)
+        recovering._registered_tool_names = ["mcp_existing_old_tool"]
+        recovering._task = MagicMock()
+        recovering._task.done.return_value = False
+        _servers["existing"] = recovering
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._discover_and_register_server") as discover, \
+                 patch("tools.mcp_tool._existing_tool_names", return_value=["mcp_existing_old_tool"]):
+                result = register_mcp_servers({"existing": {"command": "test"}})
+
+            discover.assert_not_called()
+            assert result == ["mcp_existing_old_tool"]
+        finally:
+            _servers.pop("existing", None)
+
     def test_skips_disabled_servers(self):
         from tools.mcp_tool import register_mcp_servers, _servers
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3883,6 +3883,23 @@ def _existing_tool_names() -> List[str]:
     return names
 
 
+def _server_is_connected(server: "MCPServerTask | None") -> bool:
+    """Return True when a cached MCP server entry is still live or recovering.
+
+    ``_servers`` can retain a named ``MCPServerTask`` after its reconnect loop
+    gives up or during an in-flight reconnect window.  Treat an entry with a
+    live ``session`` as connected, and also treat an entry whose background task
+    is still running as self-recovering. Only a dead/absent task should stop
+    blocking fresh startup discovery for a new session.
+    """
+    if server is None:
+        return False
+    if getattr(server, "session", None) is not None:
+        return True
+    task = getattr(server, "_task", None)
+    return bool(task is not None and not task.done())
+
+
 def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> List[str]:
     """Register tools from an already-connected server into the registry.
 
@@ -4051,7 +4068,10 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         new_servers = {
             k: v
             for k, v in servers.items()
-            if k not in _servers and _parse_boolish(v.get("enabled", True), default=True)
+            if (
+                not _server_is_connected(_servers.get(k))
+                and _parse_boolish(v.get("enabled", True), default=True)
+            )
         }
         _server_connecting.update(new_servers)
         for srv_name in new_servers:
@@ -4156,7 +4176,10 @@ def discover_mcp_tools() -> List[str]:
         new_server_names = [
             name
             for name, cfg in servers.items()
-            if name not in _servers and _parse_boolish(cfg.get("enabled", True), default=True)
+            if (
+                not _server_is_connected(_servers.get(name))
+                and _parse_boolish(cfg.get("enabled", True), default=True)
+            )
         ]
 
     tool_names = register_mcp_servers(servers)


### PR DESCRIPTION
## What does this PR do?

Fixes a stale-MCP startup bug where a dead `MCPServerTask` could remain parked in `tools.mcp_tool._servers` after keepalive/reconnect failure. Later session startup only checked `name in _servers`, so it skipped fresh MCP discovery and the new session silently lost that server's tools.

This change only treats a cached MCP server as already connected when it still has a live `session` or a live background reconnect task. If the cached task is dead and detached, startup rediscovery reconnects it and re-registers its tools.

## Related Issue

Fixes #50170

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_server_is_connected(...)` in `tools/mcp_tool.py` so startup gating distinguishes live/recovering MCP tasks from dead cached entries.
- Updated `register_mcp_servers()` and `discover_mcp_tools()` to rediscover only dead cached servers, while preserving legitimate in-flight reconnect ownership.
- Added regression tests in `tests/tools/test_mcp_tool.py` for both:
  - dead cached server entry must be rediscovered on new session startup
  - live background reconnect must still suppress duplicate startup connects

## How to Test

1. Reproduce the pre-fix state by leaving a stale MCP server entry in `_servers` with `session=None` and no live background task.
2. Run `./.venv/bin/pytest -q tests/tools/test_mcp_tool.py -k "reconnects_server_entry_that_exists_but_is_not_connected or skips_server_that_is_mid_reconnect_with_live_background_task or skips_already_connected_servers or connects_new_servers or logs_summary_on_success"`.
3. Confirm the new-session startup path now reconnects dead cached servers, while existing connected servers and in-flight reconnects still follow the old idempotent behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation:

- `./.venv/bin/pytest -q tests/tools/test_mcp_tool.py -k "reconnects_server_entry_that_exists_but_is_not_connected or skips_server_that_is_mid_reconnect_with_live_background_task or skips_already_connected_servers or connects_new_servers or logs_summary_on_success"`
- `./.venv/bin/pytest -q tests/agent/test_turn_context.py -k "between_turns_refresh"`
- `./.venv/bin/pytest -q tests/test_get_tool_definitions_cache_isolation.py`
