### PR TITLE
fix(model-metadata): normalize LM Studio native model URL (#50157)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -538,6 +538,17 @@ def is_local_endpoint(base_url: str) -> bool:
     return False
 
 
+def _lmstudio_server_root_url(base_url: str) -> str:
+    """Return the HTTP origin/root to use for LM Studio native API probes."""
+
+    normalized = _normalize_base_url(base_url)
+    lowered = normalized.lower()
+    for suffix in ("/api/v1", "/v1"):
+        if lowered.endswith(suffix):
+            return normalized[: -len(suffix)].rstrip("/")
+    return normalized.rstrip("/")
+
+
 def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
     """Detect which local server is running at base_url by probing known endpoints.
 
@@ -546,9 +557,7 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
     import httpx
 
     normalized = _normalize_base_url(base_url)
-    server_url = normalized
-    if server_url.endswith("/v1"):
-        server_url = server_url[:-3]
+    server_url = _lmstudio_server_root_url(normalized)
 
     headers = _auth_headers(api_key)
 
@@ -774,7 +783,7 @@ def fetch_endpoint_model_metadata(
     if is_local_endpoint(normalized):
         try:
             if detect_local_server_type(normalized, api_key=api_key) == "lm-studio":
-                server_url = normalized[:-3].rstrip("/") if normalized.endswith("/v1") else normalized
+                server_url = _lmstudio_server_root_url(normalized)
                 response = requests.get(
                     server_url.rstrip("/") + "/api/v1/models",
                     headers=headers,

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -519,6 +519,101 @@ class TestCodexOAuthContextLength:
 
 
 # =========================================================================
+# Local endpoint model metadata
+# =========================================================================
+
+class _EndpointMetadataResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class TestLocalEndpointModelMetadata:
+    def setup_method(self):
+        import agent.model_metadata as mm
+
+        mm._endpoint_model_metadata_cache.clear()
+        mm._endpoint_model_metadata_cache_time.clear()
+
+    def test_lmstudio_metadata_strips_api_v1_before_native_models_probe(self, monkeypatch):
+        """LM Studio configs may store the native `/api/v1` endpoint directly."""
+        import agent.model_metadata as mm
+
+        requested_urls: list[str] = []
+        expected_url = "http://127.0.0.1:1234/api/v1/models"
+
+        monkeypatch.setattr(
+            mm,
+            "detect_local_server_type",
+            lambda base_url, api_key="": "lm-studio",
+        )
+
+        def fake_get(url: str, **kwargs):
+            requested_urls.append(url)
+            if url != expected_url:
+                raise RuntimeError(f"unexpected URL: {url}")
+            return _EndpointMetadataResponse(
+                {
+                    "models": [
+                        {
+                            "key": "local-model",
+                            "name": "Local Model",
+                            "loaded_instances": [
+                                {"config": {"context_length": 8192}}
+                            ],
+                        }
+                    ]
+                }
+            )
+
+        monkeypatch.setattr(mm.requests, "get", fake_get)
+
+        metadata = mm.fetch_endpoint_model_metadata(
+            "http://127.0.0.1:1234/api/v1",
+            force_refresh=True,
+        )
+
+        assert requested_urls == [expected_url]
+        assert metadata["local-model"]["context_length"] == 8192
+
+    def test_lmstudio_metadata_keeps_plain_v1_endpoint_compatible(self, monkeypatch):
+        """Plain OpenAI-compatible `/v1` URLs should continue to resolve normally."""
+        import agent.model_metadata as mm
+
+        requested_urls: list[str] = []
+        expected_url = "http://127.0.0.1:1234/api/v1/models"
+
+        monkeypatch.setattr(
+            mm,
+            "detect_local_server_type",
+            lambda base_url, api_key="": "lm-studio",
+        )
+
+        def fake_get(url: str, **kwargs):
+            requested_urls.append(url)
+            if url != expected_url:
+                raise RuntimeError(f"unexpected URL: {url}")
+            return _EndpointMetadataResponse(
+                {"models": [{"key": "plain-v1-model", "name": "Plain V1"}]}
+            )
+
+        monkeypatch.setattr(mm.requests, "get", fake_get)
+
+        metadata = mm.fetch_endpoint_model_metadata(
+            "http://127.0.0.1:1234/v1",
+            force_refresh=True,
+        )
+
+        assert requested_urls == [expected_url]
+        assert "plain-v1-model" in metadata
+
+
+# =========================================================================
 # Nous Portal context-window resolution (provider="nous")
 # =========================================================================
 


### PR DESCRIPTION
## Summary

Fixes LM Studio local endpoint model refresh when the configured custom endpoint already includes the native `/api/v1` path.

Previously, `fetch_endpoint_model_metadata()` stripped only a trailing `/v1` before appending `/api/v1/models`. For an LM Studio endpoint such as `http://127.0.0.1:1234/api/v1`, Hermes Desktop model refresh probed `http://127.0.0.1:1234/api/api/v1/models` before falling back.

This patch adds a small LM Studio root-normalization helper and uses it for both local-server detection and native model metadata fetches, preserving the existing plain `/v1` behavior.

## Verification

- RED proof on upstream/main with the regression tests applied: `1 failed, 1 passed`; failing request was `http://127.0.0.1:1234/api/api/v1/models` instead of `http://127.0.0.1:1234/api/v1/models`.
- Green after fix:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/agent/test_model_metadata.py::TestLocalEndpointModelMetadata tests/agent/test_model_metadata_local_ctx.py -v -o "addopts=" --tb=short`
  - Result: `24 passed in 1.36s`

## Competitor / duplicate check

Checked open PRs before publication:

- Same-author PRs referencing `50157`: none
- Same-author branch `Tranquil-Flow:fix/50157*`: none
- Open PR search for `50157`: none
- Keyword search for `LM Studio api/api models refresh`: none

Auto-published by Moonsong via Path B automated pipeline.
