### PR TITLE
fix(cli): hermes web → hermes dashboard in web_server.py

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5,8 +5,8 @@ Provides a FastAPI backend serving the Vite/React frontend and REST API
 endpoints for managing configuration, environment variables, and sessions.
 
 Usage:
-    python -m hermes_cli.main web          # Start on http://127.0.0.1:9119
-    python -m hermes_cli.main web --port 8080
+    python -m hermes_cli.main dashboard          # Start on http://127.0.0.1:9119
+    python -m hermes_cli.main dashboard --port 8080
 """
 
 from contextlib import asynccontextmanager, contextmanager


### PR DESCRIPTION
Update the web server module usage example to use `dashboard`.

Most of the related documentation corrections were already addressed in [#9207](https://github.com/NousResearch/hermes-agent/pull/9207). This PR updates the remaining usage example that still references the old module and switches it to use `dashboard`. 