### PR TITLE
fix(telegram): preserve newlines in rich slash-command output (#46070)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -356,9 +356,18 @@ def _wrap_markdown_tables(text: str) -> str:
 # Rich-message newline normalization
 # ---------------------------------------------------------------------------
 
-# Matches fenced code blocks (```...\n...\n```), used to protect their
-# content from newline normalization.
-_RICH_CODE_FENCE_RE = re.compile(r'(```[^\n]*\n[\s\S]*?```)', re.MULTILINE)
+# Matches a protected region whose internal newlines must stay bare in the
+# rich-message path: a fenced code block (```...```) OR a GFM pipe-table block
+# (a header row, a delimiter row of dashes/pipes, then any pipe data rows).
+# Telegram renders both natively, so injecting Markdown hard breaks inside them
+# would corrupt the code block / table.
+_RICH_PROTECTED_REGION_RE = re.compile(
+    r'(?:```[^\n]*\n[\s\S]*?```)'                       # fenced code block
+    r'|(?:^[^\n]*\|[^\n]*\n'                            # table header row (has a pipe)
+    r'[ \t]*\|?[ \t]*:?-+:?[ \t]*(?:\|[ \t]*:?-+:?[ \t]*)+\|?[ \t]*'  # delimiter
+    r'(?:\n[^\n]*\|[^\n]*)*)',                          # data rows (newline-led, trailing \n left for prose)
+    re.MULTILINE,
+)
 
 
 def _rich_normalize_linebreaks(text: str) -> str:
@@ -370,18 +379,26 @@ def _rich_normalize_linebreaks(text: str) -> str:
     paragraph.  Adding two trailing spaces before each single newline
     forces a hard line break (``<br>``) in the rendered output.
 
-    Paragraph breaks (``\\n\\n``) and fenced code blocks are left untouched.
+    Paragraph breaks (``\\n\\n``), fenced code blocks, and GFM pipe-table
+    blocks are left untouched: tables render natively in the rich path and a
+    hard break injected into a row separator would corrupt the table.
     """
     if not text or '\n' not in text:
         return text
 
-    parts = _RICH_CODE_FENCE_RE.split(text)
-    for i, part in enumerate(parts):
-        # Even indices are outside code fences; odd indices are fence content.
-        if i % 2 == 0:
-            # Convert single \n (not adjacent to another \n) to "  \n".
-            parts[i] = re.sub(r'(?<!\n)\n(?!\n)', '  \n', part)
-    return ''.join(parts)
+    out: list[str] = []
+    # Split off protected regions (fenced code OR table blocks) and only inject
+    # hard breaks in the prose between them. Boundary newlines are handled by
+    # the original single-\n regex, which sees each prose run as a whole string.
+    pos = 0
+    for m in _RICH_PROTECTED_REGION_RE.finditer(text):
+        prose = text[pos:m.start()]
+        out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', prose))
+        out.append(m.group(0))  # protected region kept verbatim
+        pos = m.end()
+    tail = text[pos:]
+    out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', tail))
+    return ''.join(out)
 
 
 class TelegramAdapter(BasePlatformAdapter):

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -352,6 +352,38 @@ def _wrap_markdown_tables(text: str) -> str:
     return '\n'.join(out)
 
 
+# ---------------------------------------------------------------------------
+# Rich-message newline normalization
+# ---------------------------------------------------------------------------
+
+# Matches fenced code blocks (```...\n...\n```), used to protect their
+# content from newline normalization.
+_RICH_CODE_FENCE_RE = re.compile(r'(```[^\n]*\n[\s\S]*?```)', re.MULTILINE)
+
+
+def _rich_normalize_linebreaks(text: str) -> str:
+    """Convert single ``\\n`` to Markdown hard breaks for the rich-message path.
+
+    Standard Markdown treats a lone ``\\n`` as whitespace (soft break), so
+    Bot API 10.1 ``sendRichMessage`` collapses multi-line content — e.g.
+    slash-command lists joined with ``"\\n".join(lines)`` — into a single
+    paragraph.  Adding two trailing spaces before each single newline
+    forces a hard line break (``<br>``) in the rendered output.
+
+    Paragraph breaks (``\\n\\n``) and fenced code blocks are left untouched.
+    """
+    if not text or '\n' not in text:
+        return text
+
+    parts = _RICH_CODE_FENCE_RE.split(text)
+    for i, part in enumerate(parts):
+        # Even indices are outside code fences; odd indices are fence content.
+        if i % 2 == 0:
+            # Convert single \n (not adjacent to another \n) to "  \n".
+            parts[i] = re.sub(r'(?<!\n)\n(?!\n)', '  \n', part)
+    return ''.join(parts)
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """
     Telegram bot adapter.
@@ -1107,8 +1139,12 @@ class TelegramAdapter(BasePlatformAdapter):
 
         Never pass ``format_message(content)`` here — that converts to
         MarkdownV2 and would escape/destroy rich syntax like table pipes.
+
+        Single newlines are normalized to Markdown hard breaks so that
+        multi-line content (slash-command lists, etc.) renders correctly
+        in the rich-message path.  See ``_rich_normalize_linebreaks``.
         """
-        payload: Dict[str, Any] = {"markdown": content}
+        payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(content)}
         if skip_entity_detection:
             payload["skip_entity_detection"] = True
         return payload

--- a/tests/gateway/test_telegram_rich_newlines.py
+++ b/tests/gateway/test_telegram_rich_newlines.py
@@ -116,3 +116,34 @@ class TestRichMessageNewlineNormalization:
         """The skip_entity_detection flag must still work after normalization."""
         payload = adapter._rich_message_payload("Line 1\nLine 2", skip_entity_detection=True)
         assert payload.get("skip_entity_detection") is True
+
+
+class TestRichMessageTableProtection:
+    """Hard-break injection must not corrupt GFM tables (rendered natively)."""
+
+    def test_table_rows_keep_bare_newlines(self, adapter):
+        """Table block newlines must stay bare — no '  \\n' inside the table."""
+        content = "| Col A | Col B |\n|-------|-------|\n| 1 | 2 |\n| 3 | 4 |"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert "  \n" not in md
+        assert md == content
+
+    def test_text_around_table_still_gets_hard_breaks(self, adapter):
+        """Prose lines outside the table keep getting hard breaks."""
+        content = (
+            "Intro line one\n"
+            "Intro line two\n"
+            "| H1 | H2 |\n"
+            "|----|----|\n"
+            "| a | b |\n"
+            "Outro line"
+        )
+        md = adapter._rich_message_payload(content)["markdown"]
+        # Prose-to-prose newline becomes a hard break.
+        assert "Intro line one  \nIntro line two" in md
+        # Table rows stay bare.
+        assert "| H1 | H2 |\n|----|----|\n| a | b |" in md
+        # Prose lines around the table still hard-break; only the table's own
+        # header/delimiter/data-row newlines stay bare.
+        assert "Intro line two  \n| H1 | H2 |" in md
+        assert "| a | b |  \nOutro line" in md

--- a/tests/gateway/test_telegram_rich_newlines.py
+++ b/tests/gateway/test_telegram_rich_newlines.py
@@ -1,0 +1,118 @@
+"""Tests for rich-message newline normalization (issue #46070).
+
+When Bot API 10.1 ``sendRichMessage`` is available, slash-command responses
+are sent through the rich path with RAW markdown.  Standard Markdown treats
+a lone ``\\n`` as a soft line break (renders as whitespace), so multi-line
+command output collapses into a single paragraph on Telegram.
+
+``_rich_message_payload`` must normalize single newlines to Markdown hard
+breaks (two trailing spaces + ``\\n``) so they render as visible line breaks.
+Paragraph breaks (``\\n\\n``) and fenced code blocks must be preserved.
+
+The ``telegram`` package is mocked by ``tests/gateway/conftest.py``, so these
+tests construct a real ``TelegramAdapter``.
+"""
+
+import pytest
+
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+@pytest.fixture()
+def adapter():
+    """Bare adapter instance — _rich_message_payload doesn't use self."""
+    return object.__new__(TelegramAdapter)
+
+
+class TestRichMessageNewlineNormalization:
+    """Verify _rich_message_payload normalizes single \\n to hard breaks."""
+
+    def test_single_newlines_become_hard_breaks(self, adapter):
+        """A lone \\n must gain two trailing spaces (Markdown hard break).
+
+        Standard Markdown soft-break rendering causes Bot API 10.1
+        ``sendRichMessage`` to collapse multi-line content into one paragraph.
+        """
+        content = "Line 1\nLine 2\nLine 3"
+        payload = adapter._rich_message_payload(content)
+        md = payload["markdown"]
+        # Each single \n should now be "  \n" (two spaces + newline)
+        assert "  \n" in md, f"Expected hard break '  \\n' in {md!r}"
+        assert "Line 1  \nLine 2  \nLine 3" == md
+
+    def test_paragraph_breaks_preserved(self, adapter):
+        """Double newlines (paragraph breaks) must NOT gain extra spaces."""
+        content = "Paragraph 1\n\nParagraph 2"
+        payload = adapter._rich_message_payload(content)
+        md = payload["markdown"]
+        # \n\n should remain as-is — no trailing spaces injected
+        assert "Paragraph 1\n\nParagraph 2" == md
+
+    def test_mixed_single_and_double_newlines(self, adapter):
+        """Content with both list items and paragraph breaks must be handled correctly."""
+        content = (
+            "Header\n\n"
+            "`/new` -- Start\n"
+            "`/model` -- Switch\n"
+            "`/reset` -- Reset\n\n"
+            "Footer"
+        )
+        payload = adapter._rich_message_payload(content)
+        md = payload["markdown"]
+        # Paragraph breaks preserved
+        assert "Header\n\n" in md
+        assert "\n\nFooter" in md
+        # Single newlines converted to hard breaks
+        assert "`/new` -- Start  \n`/model` -- Switch  \n`/reset` -- Reset" in md
+
+    def test_fenced_code_block_newlines_preserved(self, adapter):
+        """Newlines inside fenced code blocks must NOT gain trailing spaces."""
+        content = "Before\n```\ncode line 1\ncode line 2\n```\nAfter"
+        payload = adapter._rich_message_payload(content)
+        md = payload["markdown"]
+        # Code block content should be untouched
+        assert "```\ncode line 1\ncode line 2\n```" in md
+        # But the \n before ``` and after ``` should be hard breaks
+        assert "Before  \n```" in md
+        assert "```  \nAfter" in md
+
+    def test_realistic_command_output(self, adapter):
+        """Simulates /commands output: header + list items + nav line."""
+        lines = [
+            "📊 Commands (24 total, page 1/2)",
+            "",
+            "`/new` -- Start a new session",
+            "`/model` -- Switch model",
+            "`/stop` -- Stop the agent",
+            "",
+            "Use /commands 2 for next page | /commands 1 for prev",
+        ]
+        content = "\n".join(lines)
+        payload = adapter._rich_message_payload(content)
+        md = payload["markdown"]
+        # Header paragraph break preserved
+        assert "📊 Commands (24 total, page 1/2)\n\n" in md
+        # List items have hard breaks
+        assert "`/new` -- Start a new session  \n" in md
+        assert "`/model` -- Switch model  \n" in md
+        # Nav paragraph break preserved
+        assert "\n\nUse /commands 2" in md
+
+    def test_no_trailing_space_on_last_line(self, adapter):
+        """The final line should not get trailing spaces (no newline after it)."""
+        content = "Line 1\nLine 2"
+        payload = adapter._rich_message_payload(content)
+        md = payload["markdown"]
+        # No trailing spaces at end of string
+        assert md == "Line 1  \nLine 2"
+        assert not md.endswith("  ")
+
+    def test_empty_and_single_line_unchanged(self, adapter):
+        """Empty string and single-line content should pass through."""
+        assert adapter._rich_message_payload("")["markdown"] == ""
+        assert adapter._rich_message_payload("Single line")["markdown"] == "Single line"
+
+    def test_skip_entity_detection_flag_preserved(self, adapter):
+        """The skip_entity_detection flag must still work after normalization."""
+        payload = adapter._rich_message_payload("Line 1\nLine 2", skip_entity_detection=True)
+        assert payload.get("skip_entity_detection") is True


### PR DESCRIPTION
## Summary
Multi-line rich Telegram replies (slash-command lists, etc.) no longer collapse into a single paragraph. Bot API 10.1 `sendRichMessage` treats a lone `\n` as a soft break, so content joined with `"\n".join(lines)` rendered as one run-on line. The fix normalizes single newlines to Markdown hard breaks (two trailing spaces) in `_rich_message_payload`, leaving paragraph breaks, fenced code blocks, **and GFM tables** untouched.

Salvages #46129 by @Tranquil-Flow (fixes #46070), reconstructed onto current `main` (the Telegram adapter moved from `gateway/platforms/telegram.py` to `plugins/platforms/telegram/adapter.py`). Authorship preserved.

Closes #46070.

## Changes
- `plugins/platforms/telegram/adapter.py`:
  - `_rich_normalize_linebreaks()` — converts single `\n` → `  \n` outside protected regions. (@Tranquil-Flow)
  - **Follow-up:** `_rich_message_payload` is the shared chokepoint for *all three* rich call sites (send, draft, `editMessageText`). Injecting a hard break into a GFM table row separator corrupts the natively-rendered table — the rich path's headline feature. The protected-region matcher now exempts **pipe-table blocks** as well as fenced code, so only prose between them gets hard breaks. (Teknium)
- `tests/gateway/test_telegram_rich_newlines.py`: contributor's 8 list/paragraph/fence cases + table-protection cases.

## Validation
| Content | Behavior |
|---|---|
| Slash-command list | each line hard-breaks (renders multi-line) |
| GFM table | row newlines stay bare → table renders natively |
| Fenced code block | interior bare; boundaries hard-break |
| Paragraph breaks (`\n\n`) | preserved |

- 69 + 102 targeted tests pass; the three existing rich-table tests (`test_rich_happy_path_sends_raw_markdown`, `test_rich_draft_happy_path_sends_raw_markdown`, `test_finalize_edit_uses_rich_for_table_content`) stay byte-identical — the table guard is what keeps them green.
- E2E invariants verified: `RICH_CONTENT` unchanged, table-only unchanged, list hard-breaks, fence boundaries hard-break, paragraph breaks preserved.

## Infographic

![rich-newline-fix](https://v3b.fal.media/files/b/0a9f323e/pUhS1gOt5ILbflTj_5pPx_0sYOaMPp.png)
