### PR TITLE
fix(desktop): re-seed composer when profile default model changes externally

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -79,6 +79,7 @@ import { useCwdActions } from '../session/hooks/use-cwd-actions'
 import { useHermesConfig } from '../session/hooks/use-hermes-config'
 import { useMessageStream } from '../session/hooks/use-message-stream'
 import { useModelControls } from '../session/hooks/use-model-controls'
+import { useModelProfileSync } from '../session/hooks/use-model-profile-sync'
 import { usePreviewRouting } from '../session/hooks/use-preview-routing'
 import { usePromptActions } from '../session/hooks/use-prompt-actions'
 import { useRouteResume } from '../session/hooks/use-route-resume'
@@ -630,6 +631,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     refreshSessions,
     requestGateway
   })
+
+  // Keep the composer in sync with the profile's model.default after the
+  // initial seed from refreshCurrentModel (above). Polls every 30 s while the
+  // gateway is open — catches Dashboard edits, hermes model, hermes config set,
+  // and other clients on the same profile.
+  useModelProfileSync({ gatewayOpen: gatewayState === 'open' })
 
   // Electron-main / OS / cross-window integrations: update polling, ⌘W close,
   // deep links, native-notification nav, preview-shortcut enablement,

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -55,7 +55,7 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
       }
 
       if (force) {
-        $currentModelExplicitlySet.set(false)
+        setCurrentModelExplicitlySet(false)
       }
 
       if (!force && $currentModel.get()) {
@@ -96,7 +96,7 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
 
       setCurrentModel(selection.model)
       setCurrentProvider(selection.provider)
-      $currentModelExplicitlySet.set(true)
+      setCurrentModelExplicitlySet(true)
       updateModelOptionsCache(selection.provider, selection.model, !activeSessionId)
 
       // No live session yet: the pick is pure UI state. session.create reads

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -4,7 +4,15 @@ import { useCallback } from 'react'
 import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { notifyError } from '@/store/notifications'
-import { $activeSessionId, $currentModel, $currentProvider, setCurrentModel, setCurrentProvider } from '@/store/session'
+import {
+  $activeSessionId,
+  $currentModel,
+  $currentModelExplicitlySet,
+  $currentProvider,
+  setCurrentModel,
+  setCurrentModelExplicitlySet,
+  setCurrentProvider
+} from '@/store/session'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
 interface ModelSelection {
@@ -46,6 +54,10 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
         return
       }
 
+      if (force) {
+        $currentModelExplicitlySet.set(false)
+      }
+
       if (!force && $currentModel.get()) {
         return
       }
@@ -84,6 +96,7 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
 
       setCurrentModel(selection.model)
       setCurrentProvider(selection.provider)
+      $currentModelExplicitlySet.set(true)
       updateModelOptionsCache(selection.provider, selection.model, !activeSessionId)
 
       // No live session yet: the pick is pure UI state. session.create reads

--- a/apps/desktop/src/app/session/hooks/use-model-profile-sync.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-profile-sync.test.tsx
@@ -1,0 +1,224 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getGlobalModelInfo } from '@/hermes'
+import {
+  $activeSessionId,
+  $currentModel,
+  $currentModelExplicitlySet,
+  $currentProvider,
+  setCurrentModel,
+  setCurrentProvider
+} from '@/store/session'
+
+import { syncProfileDefaultTick, useModelProfileSync } from './use-model-profile-sync'
+
+vi.mock('@/hermes', () => ({
+  getGlobalModelInfo: vi.fn()
+}))
+
+describe('syncProfileDefaultTick', () => {
+  beforeEach(() => {
+    $activeSessionId.set(null)
+    $currentModelExplicitlySet.set(false)
+    setCurrentModel('')
+    setCurrentProvider('')
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    $activeSessionId.set(null)
+    $currentModelExplicitlySet.set(false)
+    setCurrentModel('')
+    setCurrentProvider('')
+  })
+
+  it('takes a baseline on the first call and does not write to the composer', async () => {
+    setCurrentModel('') // empty — first-run seed path is refreshCurrentModel, not us
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'openai/gpt-5.5',
+      provider: 'openai-codex'
+    })
+
+    const next = await syncProfileDefaultTick({ model: '', provider: '' })
+
+    expect(next).toEqual({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+    // First-run seed is NOT this hook's job — empty stays empty.
+    expect($currentModel.get()).toBe('')
+  })
+
+  it('re-seeds the composer when the server default drifts and the composer was following the previous default', async () => {
+    // Simulate post-boot state: composer holding the previously-seen default.
+    setCurrentModel('openai/gpt-5.5')
+    setCurrentProvider('openai-codex')
+
+    // Server changes (Dashboard Models page, `hermes model`, `hermes config set`).
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'anthropic/claude-sonnet-4.7',
+      provider: 'anthropic'
+    })
+
+    const next = await syncProfileDefaultTick({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+
+    expect(next).toEqual({ model: 'anthropic/claude-sonnet-4.7', provider: 'anthropic' })
+    expect($currentModel.get()).toBe('anthropic/claude-sonnet-4.7')
+    expect($currentProvider.get()).toBe('anthropic')
+  })
+
+  it('never overwrites an explicit user pick, even after the server default drifts', async () => {
+    // Composer was auto-seeded, then the user explicitly picked something else.
+    setCurrentModel('deepseek/deepseek-v4-pro')
+    setCurrentProvider('deepseek')
+
+    // Server's default also changes (independent event).
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'anthropic/claude-sonnet-4.7',
+      provider: 'anthropic'
+    })
+
+    const next = await syncProfileDefaultTick({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+
+    // The pick survives — that's the test contract in use-model-controls.test.tsx.
+    expect($currentModel.get()).toBe('deepseek/deepseek-v4-pro')
+    expect($currentProvider.get()).toBe('deepseek')
+    // Baseline still advances so a future composer-following default would
+    // compare against the new server value.
+    expect(next).toEqual({ model: 'anthropic/claude-sonnet-4.7', provider: 'anthropic' })
+  })
+
+  it('does nothing while a live session is active (footer owns the model label)', async () => {
+    setCurrentModel('openai/gpt-5.5')
+    setCurrentProvider('openai-codex')
+
+    // A session starts — composer is now driven by the active-session footer.
+    $activeSessionId.set('runtime-1')
+
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'anthropic/claude-sonnet-4.7',
+      provider: 'anthropic'
+    })
+
+    const next = await syncProfileDefaultTick({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+
+    expect($currentModel.get()).toBe('openai/gpt-5.5')
+    expect($currentProvider.get()).toBe('openai-codex')
+    // Baseline unchanged — we'll re-evaluate when the session ends.
+    expect(next).toEqual({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+  })
+
+  it('keeps the previous baseline when the backend call fails', async () => {
+    setCurrentModel('openai/gpt-5.5')
+    setCurrentProvider('openai-codex')
+
+    vi.mocked(getGlobalModelInfo).mockRejectedValue(new Error('network'))
+
+    const next = await syncProfileDefaultTick({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+
+    expect(next).toEqual({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+    expect($currentModel.get()).toBe('openai/gpt-5.5')
+  })
+
+  it('skips writes when the server value did not change', async () => {
+    setCurrentModel('openai/gpt-5.5')
+    setCurrentProvider('openai-codex')
+
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'openai/gpt-5.5',
+      provider: 'openai-codex'
+    })
+
+    const next = await syncProfileDefaultTick({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+
+    expect(next).toEqual({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+    expect($currentModel.get()).toBe('openai/gpt-5.5')
+  })
+
+  it('records an empty server value as the new baseline without clobbering the composer', async () => {
+    // Composer holding a previous default; server has no default configured.
+    setCurrentModel('openai/gpt-5.5')
+    setCurrentProvider('openai-codex')
+
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({ model: '', provider: '' })
+
+    const next = await syncProfileDefaultTick({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+
+    expect(next).toEqual({ model: '', provider: '' })
+    // Composer untouched — empty server value is treated as "nothing to seed".
+    expect($currentModel.get()).toBe('openai/gpt-5.5')
+    expect($currentProvider.get()).toBe('openai-codex')
+  })
+
+  it('does not overwrite a picker selection equal to the previous default', async () => {
+    // Simulate the edge case from the maintainer review: user explicitly picked
+    // the same model as the current default (e.g. opened the picker, selected
+    // the default entry). selectModel calls setCurrentModel + sets the flag.
+    setCurrentModel('openai/gpt-5.5')
+    setCurrentProvider('openai-codex')
+    $currentModelExplicitlySet.set(true)
+
+    // External change (Dashboard, `hermes model`, another client on the same profile).
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'anthropic/claude-sonnet-4.7',
+      provider: 'anthropic'
+    })
+
+    const next = await syncProfileDefaultTick({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+
+    // The picker selection survives — provenance overrides the value comparison.
+    expect($currentModel.get()).toBe('openai/gpt-5.5')
+    expect($currentProvider.get()).toBe('openai-codex')
+    // Baseline advances so a future tick (after the user clears the pick, or the
+    // profile is swapped) compares against the current server value.
+    expect(next).toEqual({ model: 'anthropic/claude-sonnet-4.7', provider: 'anthropic' })
+  })
+
+  it('writes an empty provider from the server when the model is non-empty', async () => {
+    // Composer following the previous baseline (provider populated).
+    setCurrentModel('openai/gpt-5.5')
+    setCurrentProvider('openai-codex')
+
+    // Server drifts — new model with an empty provider (e.g. a model that
+    // doesn't need an explicit provider override).
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'anthropic/claude-sonnet-4.7',
+      provider: ''
+    })
+
+    const next = await syncProfileDefaultTick({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+
+    // Both model AND provider are written — matches refreshCurrentModel's
+    // unconditional write (use-model-controls.ts:69). The empty provider is
+    // the server's answer; leaving the stale provider produces a mismatch.
+    expect($currentModel.get()).toBe('anthropic/claude-sonnet-4.7')
+    expect($currentProvider.get()).toBe('')
+    expect(next).toEqual({ model: 'anthropic/claude-sonnet-4.7', provider: '' })
+  })
+})
+
+describe('useModelProfileSync', () => {
+  beforeEach(() => {
+    $activeSessionId.set(null)
+    setCurrentModel('')
+    setCurrentProvider('')
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    $activeSessionId.set(null)
+    setCurrentModel('')
+    setCurrentProvider('')
+  })
+
+  it('mounts without crashing in a real component (smoke)', () => {
+    function Harness() {
+      useModelProfileSync({ gatewayOpen: true })
+
+      return null
+    }
+
+    const { unmount } = render(<Harness />)
+    expect(() => unmount()).not.toThrow()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-model-profile-sync.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-profile-sync.ts
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+import { getGlobalModelInfo } from '@/hermes'
+import {
+  $activeSessionId,
+  $currentModel,
+  $currentModelExplicitlySet,
+  $currentProvider,
+  setCurrentModel,
+  setCurrentProvider
+} from '@/store/session'
+
+// Same cadence as the cron-jobs polling block in desktop-controller.tsx —
+// 30 s while the app is open + visible. Cheap (single GET against a backend
+// that already has the config in memory), and rare enough that a Dashboard
+// edit / `hermes model` / `hermes config set` round-trip shows up within a
+// polling interval without flooding the backend.
+const MODEL_POLL_INTERVAL_MS = 30_000
+
+export interface ProfileDefaultSnapshot {
+  model: string
+  provider: string
+}
+
+interface UseModelProfileSyncOptions {
+  /** True only after the gateway is open (web_server is up + serving). */
+  gatewayOpen: boolean
+}
+
+/**
+ * Run one sync tick against the server. Exported for tests so the timing
+ * machinery (setInterval + visibilitychange) doesn't have to be driven
+ * through fake timers — call this directly with the previous baseline.
+ *
+ * Returns the *next* baseline snapshot — caller writes it back to its ref.
+ *
+ * Contract:
+ *  - Returns immediately if a live session is active.
+ *  - On the first call (lastSeenDefault empty), records the server value
+ *    and writes nothing to the composer — first-run seed is
+ *    `refreshCurrentModel`'s job.
+ *  - On subsequent calls, if the server value matches the previous baseline
+ *    OR the user explicitly picked via the picker (`$currentModelExplicitlySet`)
+ *    OR the composer diverges from the previous baseline, returns the new
+ *    server value as the baseline without writing. The user pick (explicit or
+ *    divergent composer) is sacred.
+ *  - Otherwise (server drifted AND composer was still showing the previous
+ *    baseline AND the user didn't explicitly pick), writes the new value to
+ *    the composer AND returns it as the new baseline.
+ */
+export async function syncProfileDefaultTick(
+  lastSeenDefault: ProfileDefaultSnapshot
+): Promise<ProfileDefaultSnapshot> {
+  if ($activeSessionId.get()) {
+    return lastSeenDefault
+  }
+
+  let result: { model?: unknown; provider?: unknown }
+
+  try {
+    result = await getGlobalModelInfo()
+  } catch {
+    return lastSeenDefault
+  }
+
+  const serverModel = typeof result.model === 'string' ? result.model : ''
+  const serverProvider = typeof result.provider === 'string' ? result.provider : ''
+
+  // No baseline yet → record and stop.
+  if (!lastSeenDefault.model) {
+    return { model: serverModel, provider: serverProvider }
+  }
+
+  // Server value unchanged → no-op.
+  if (lastSeenDefault.model === serverModel && lastSeenDefault.provider === serverProvider) {
+    return lastSeenDefault
+  }
+
+  // Server drifted. Skip if the user explicitly picked — a picker selection
+  // equal to the previous default is still an explicit pick (selectModel
+  // persists it), and we must not overwrite it on the next external change.
+  if ($currentModelExplicitlySet.get()) {
+    return { model: serverModel, provider: serverProvider }
+  }
+
+  // Did the composer follow the previous baseline?
+  const composerModel = $currentModel.get()
+  const composerProvider = $currentProvider.get()
+
+  const composerFollowedBaseline =
+    composerModel === lastSeenDefault.model && composerProvider === lastSeenDefault.provider
+
+  // Only re-seed when the composer is still showing the old default.
+  if (composerFollowedBaseline && serverModel) {
+    setCurrentModel(serverModel)
+    // Always write provider — even empty — to match refreshCurrentModel's seed
+    // behaviour (use-model-controls.ts:69). An empty provider is the server's
+    // answer; leaving a stale provider produces a model/provider mismatch.
+    setCurrentProvider(serverProvider)
+  }
+
+  return { model: serverModel, provider: serverProvider }
+}
+
+/**
+ * Keep the composer ($currentModel / $currentProvider) in sync with the
+ * profile's `model.default` after the initial seed. The empty-composer
+ * first-run path lives in `useModelControls.refreshCurrentModel`; this hook
+ * picks up the case where the user *did* seed from the default but never
+ * made an explicit pick, so the composer is just holding the last-seen
+ * default. If that default changes externally — Dashboard Models page,
+ * `hermes model`, `hermes config set`, another Hermes client on the same
+ * profile — the composer should follow.
+ *
+ * The invariant the existing test contract pins: **a user pick is sacred**.
+ * We never overwrite a pick. The mechanism is to compare the server's
+ * current value against the server's last-seen value, not against the
+ * composer's current value. If they match, the composer is already showing
+ * what the server thinks; if they diverge, the user (or something else)
+ * picked, and we stay out of the way.
+ *
+ * Skipped while a live session is active — the in-flight footer owns the
+ * model label for that session.
+ */
+export function useModelProfileSync({ gatewayOpen }: UseModelProfileSyncOptions): void {
+  const lastSeenDefault = useRef<ProfileDefaultSnapshot>({ model: '', provider: '' })
+
+  const tick = useCallback(async () => {
+    lastSeenDefault.current = await syncProfileDefaultTick(lastSeenDefault.current)
+  }, [])
+
+  useEffect(() => {
+    if (!gatewayOpen) {
+      // Reset on disconnect so a reconnect takes a fresh baseline (the
+      // server may have been replaced with a different profile's backend).
+      lastSeenDefault.current = { model: '', provider: '' }
+
+      return
+    }
+
+    let cancelled = false
+
+    const onVisible = () => {
+      if (document.visibilityState === 'visible' && !cancelled) {
+        void tick()
+      }
+    }
+
+    const intervalId = window.setInterval(() => {
+      if (document.visibilityState === 'visible' && !cancelled) {
+        void tick()
+      }
+    }, MODEL_POLL_INTERVAL_MS)
+
+    document.addEventListener('visibilitychange', onVisible)
+    // Take an initial baseline immediately so the next real tick (or a
+    // Dashboard-driven change) compares against something current rather
+    // than waiting 30 s.
+    void tick()
+
+    return () => {
+      cancelled = true
+      window.clearInterval(intervalId)
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [gatewayOpen, tick])
+}

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -278,6 +278,11 @@ export const $resumeFailedSessionId = atom<string | null>(null)
 export const $resumeExhaustedSessionId = atom<string | null>(null)
 export const $currentModel = atom(storedString(COMPOSER_MODEL_KEY) ?? '')
 export const $currentProvider = atom(storedString(COMPOSER_PROVIDER_KEY) ?? '')
+// True when the user explicitly picked a model via selectModel (the picker UI).
+// A picker selection equal to the current default is still an explicit pick —
+// the next external default change must not overwrite it. Reset to false when
+// refreshCurrentModel(force=true) reseeds from the new profile's default.
+export const $currentModelExplicitlySet = atom(false)
 export const $currentReasoningEffort = atom(storedString(COMPOSER_EFFORT_KEY) ?? '')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(storedBoolean(COMPOSER_FAST_KEY, false))

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -20,6 +20,10 @@ const COMPOSER_MODEL_KEY = 'hermes.desktop.composer.model'
 const COMPOSER_PROVIDER_KEY = 'hermes.desktop.composer.provider'
 const COMPOSER_EFFORT_KEY = 'hermes.desktop.composer.reasoning-effort'
 const COMPOSER_FAST_KEY = 'hermes.desktop.composer.fast'
+// Persisted provenance: did the user explicitly pick the model (picker UI) vs.
+// was it auto-seeded from the profile default? Persisted so a page reload
+// doesn't forget a picker selection equal to the default.
+const COMPOSER_MODEL_EXPLICITLY_SET_KEY = 'hermes.desktop.composer.model-explicit'
 
 // The last chat the user had open, so a relaunch lands back on it instead of an
 // empty new-chat. Stored (not runtime) id — the route is keyed by stored id.
@@ -280,9 +284,10 @@ export const $currentModel = atom(storedString(COMPOSER_MODEL_KEY) ?? '')
 export const $currentProvider = atom(storedString(COMPOSER_PROVIDER_KEY) ?? '')
 // True when the user explicitly picked a model via selectModel (the picker UI).
 // A picker selection equal to the current default is still an explicit pick —
-// the next external default change must not overwrite it. Reset to false when
-// refreshCurrentModel(force=true) reseeds from the new profile's default.
-export const $currentModelExplicitlySet = atom(false)
+// the next external default change must not overwrite it. Persisted so a page
+// reload doesn't forget a picker selection equal to the default. Reset to
+// false when refreshCurrentModel(force=true) reseeds from a new profile's default.
+export const $currentModelExplicitlySet = atom(storedBoolean(COMPOSER_MODEL_EXPLICITLY_SET_KEY, false))
 export const $currentReasoningEffort = atom(storedString(COMPOSER_EFFORT_KEY) ?? '')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(storedBoolean(COMPOSER_FAST_KEY, false))
@@ -355,6 +360,13 @@ export const setCurrentProvider = (next: Updater<string>) => {
 export const setCurrentReasoningEffort = (next: Updater<string>) => {
   updateAtom($currentReasoningEffort, next)
   persistString(COMPOSER_EFFORT_KEY, $currentReasoningEffort.get() || null)
+}
+
+// Persisted so a page reload doesn't forget a picker selection equal to the
+// default. Set to true in selectModel, false in refreshCurrentModel(force=true).
+export const setCurrentModelExplicitlySet = (next: Updater<boolean>) => {
+  updateAtom($currentModelExplicitlySet, next)
+  persistBoolean(COMPOSER_MODEL_EXPLICITLY_SET_KEY, $currentModelExplicitlySet.get())
 }
 
 export const setCurrentServiceTier = (next: Updater<string>) => updateAtom($currentServiceTier, next)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",  # PR #50198: desktop composer sync fix
     "Burgunthy@users.noreply.github.com": "Burgunthy",  # PR #20096 salvage (gateway: profile-based routing for inbound messages)
     "75556242+webtecnica@users.noreply.github.com": "webtecnica",  # PR #63360 salvage (nous: restore inference-api base_url)
     "skosarevivan@yandex.ru": "Epoxidex",  # PR #29820 salvage (ollama: top-level reasoning_effort=none; #25758)


### PR DESCRIPTION
## Summary

Fixes the user-visible symptom in #50013: the Desktop composer's model label silently desynchronises from `model.default` in the active profile's `~/.hermes/profiles/<name>/config.yaml`. After this lands, a Dashboard Models page edit, `hermes model`, `hermes config set`, or another Hermes client on the same profile will reach the Desktop composer within one polling interval.

## Root cause

`apps/desktop/src/store/session.ts:238-239` hydrates `$currentModel` from `localStorage["hermes.desktop.composer.model"]` at module load. `apps/desktop/src/app/session/hooks/use-model-controls.ts:55-57` only re-seeds from `/api/model/info` when localStorage is empty — so once the user picks anything, that pick sticks forever, even if `config.yaml` is rewritten on the same profile by any other surface. No config-file watcher exists in `apps/desktop/src` (`grep -r 'chokidar\|fs.watch' apps/desktop/src` returns 0 hits).

## Fix

New hook `apps/desktop/src/app/session/hooks/use-model-profile-sync.ts`:

- **30 s poll** against `GET /api/model/info` (same cadence as the existing `CRON_POLL_INTERVAL_MS` pattern in `desktop-controller.tsx:147`).
- Takes a baseline on the first tick after gateway open.
- On subsequent ticks, **re-seeds the composer only when**:
  - no live session is active (existing in-flight footer guard), AND
  - the server's value changed since the last tick, AND
  - the composer is still showing the previous baseline (i.e. the user never made an explicit divergent pick)
- Wired into `desktop-controller.tsx` next to the existing gateway-open `refreshCurrentModel()` call (line 857) so the lifecycle matches the rest of the model-sync plumbing.

## Why the "divergent pick" check uses the server's last-seen value, not the composer's value

The test contract pinned in `use-model-controls.test.tsx` is "a user pick is sacred — never clobber a pick". A naive "compare to `$currentModel`" check would lose that invariant: if the user picks X (different from server default Y) and then Y changes to Z externally, you'd want X to win. By comparing the server's value to the server's *last-seen* value, we only act when the *server* changed — and we only act on the composer when the composer was still showing the old server default, which by construction means the user hasn't picked.

The first-run empty-composer seed remains `refreshCurrentModel`'s job (called on boot and gateway open). This hook owns drift after that seed.

## Tests

8 new tests in `use-model-profile-sync.test.tsx`:

- first tick takes baseline, does not write to composer
- re-seeds when server drifts and composer followed baseline
- never overwrites an explicit user pick, even after server drifts
- no-op while a live session is active (footer owns the model label)
- baseline preserved when backend call fails (transient)
- no write when server value unchanged
- empty server value recorded as new baseline without clobbering composer
- hook mounts + unmounts without crashing (real `render(<Harness/>)` smoke)

All 5 existing `use-model-controls` tests still pass. The exported `syncProfileDefaultTick` helper is what the tests drive directly — avoids fighting fake timers around the polling machinery.

Full suite: 6 pre-existing failures on `origin/main` (Windows path separators, Electron boot backoff), unchanged by this PR. `npx tsc -p . --noEmit` clean.

## Scope

This is the smallest piece of #50013's two-part proposal:

1. **This PR.** Re-seed the Desktop composer when the profile default changes (polling fallback — ships without backend protocol work).
2. **Tracked separately** by the umbrella issue #13547 and the existing PR #13823: bind the Dashboard to the user's active profile (currently dashboard is profile-bound at startup with no UI selector — needs the supervisor/per-profile-worker pattern or similar).

The polling approach here is the smallest viable patch and the same pattern as the existing cron-jobs poll. The WebSocket push variant called out in #50013 is left for a follow-up — it needs a new gateway method, a renderer subscription path, and event-bus work in `web_server.py`. Polling covers the user-visible symptom today.

## Reproducing the bug pre-fix

```
$ grep -A2 '^model:' ~/.hermes/profiles/coder/config.yaml
  default: minimax/minimax-m3
  provider: kilocode

$ grep -A2 '^model:' ~/.hermes/config.yaml
  default: xiaomi/mimo-v2.5-pro
  provider: kilocode

# Desktop composer (Electron LevelDB): hermes.desktop.composer.model = "minimax/minimax-m3"
# Dashboard (running against default profile): main model shows mimo-v2.5-pro

# Now: hermes model --profile coder anthropic/claude-sonnet-4.7
# - Dashboard (default profile): unchanged (it doesn't watch coder)
# - Desktop composer: STAYS minimax/minimax-m3 (the bug)
```

Post-fix:

```
# Same edit; within one polling interval the Desktop composer
# reflects anthropic/claude-sonnet-4.7.
```
