### PR TITLE
fix(gateway): revive gateway on /restart under Restart=on-failure units

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4149,34 +4149,51 @@ class GatewayRunner:
                 service_name = "hermes-gateway"
 
             current_pid = os.getpid()
-            show = subprocess.run(
-                [
-                    systemctl,
-                    "--user",
-                    "show",
-                    service_name,
-                    "--property=MainPID",
-                    "--value",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=2,
-            )
-            if (show.stdout or "").strip() != str(current_pid):
+
+            # Detect whether the gateway unit is registered as a system or
+            # user service.  Daemon-style deployments are typically system
+            # units (e.g. /etc/systemd/system/hermes-gateway.service), while
+            # `hermes setup` under a non-root account may register a user
+            # unit.  Hard-coding ``--user`` broke system-unit deployments:
+            # systemctl returned an empty MainPID, the PID-equality check
+            # below failed, and the planned-restart helper was never
+            # launched — leaving the gateway dead until a manual reboot.
+            def _query_pid(scope_flags):
+                try:
+                    out = subprocess.run(
+                        [systemctl, *scope_flags, "show", service_name,
+                         "--property=MainPID", "--value"],
+                        capture_output=True, text=True, timeout=2,
+                    )
+                    return (out.stdout or "").strip()
+                except Exception:
+                    return ""
+
+            system_pid = _query_pid([])
+            user_pid = _query_pid(["--user"])
+            if str(current_pid) == system_pid:
+                scope_flags = []
+                systemctl_scope = "systemctl"
+            elif str(current_pid) == user_pid:
+                scope_flags = ["--user"]
+                systemctl_scope = "systemctl --user"
+            else:
+                # MainPID does not match in either scope — likely invoked
+                # outside of systemd or the unit was renamed.  Bail out
+                # rather than restart the wrong unit.
                 return
 
-            systemctl_user = "systemctl --user"
             service_arg = shlex.quote(service_name)
             shell_cmd = (
                 f"while kill -0 {current_pid} 2>/dev/null; do sleep 0.2; done; "
-                f"{systemctl_user} reset-failed {service_arg}; "
-                f"{systemctl_user} restart {service_arg}"
+                f"{systemctl_scope} reset-failed {service_arg}; "
+                f"{systemctl_scope} restart {service_arg}"
             )
             unit_name = f"{service_name}-planned-restart-{current_pid}".replace(".", "-")
             subprocess.Popen(
                 [
                     systemd_run,
-                    "--user",
+                    *scope_flags,
                     "--collect",
                     "--unit",
                     unit_name,
@@ -4189,9 +4206,10 @@ class GatewayRunner:
                 start_new_session=True,
             )
             logger.info(
-                "Launched systemd planned-restart helper for %s (pid=%s)",
+                "Launched systemd planned-restart helper for %s (pid=%s, scope=%s)",
                 service_name,
                 current_pid,
+                "user" if scope_flags else "system",
             )
         except Exception as e:
             logger.debug("Failed to launch systemd planned-restart helper: %s", e)
@@ -6795,17 +6813,21 @@ class GatewayRunner:
 
             if self._restart_requested and self._restart_via_service:
                 self._launch_systemd_restart_shortcut()
-                # systemd units use Restart=always, so a planned restart should
-                # exit cleanly and still be relaunched.  Using TEMPFAIL here
-                # makes systemd treat the operator-requested restart as a
-                # failure and can trip stepped restart backoff.  launchd's
-                # KeepAlive.SuccessfulExit=false needs a non-zero exit to
-                # relaunch, so keep the old code on macOS.
-                self._exit_code = (
-                    GATEWAY_SERVICE_RESTART_EXIT_CODE
-                    if sys.platform == "darwin" or not os.environ.get("INVOCATION_ID")
-                    else 0
-                )
+                # Always exit with TEMPFAIL (75) on service-managed
+                # restarts.  The shortcut helper above is best-effort and
+                # commonly fails on real deployments: non-root gateway
+                # units hit Polkit denials when invoking ``systemd-run
+                # --system``, headless boxes have no user bus for
+                # ``--user``, and operator-managed unit files may use
+                # ``Restart=on-failure`` rather than ``Restart=always``.
+                # Exit 75 paired with ``RestartForceExitStatus=75`` makes
+                # systemd treat the planned restart as a controlled
+                # failure and revive the unit via ``Restart=on-failure``,
+                # regardless of whether the helper survived.  Without
+                # this, a clean exit (0) on Linux left the gateway dead
+                # until someone rebooted the host.  ``StartLimitBurst``
+                # in the unit file still bounds accidental loops.
+                self._exit_code = GATEWAY_SERVICE_RESTART_EXIT_CODE
                 self._exit_reason = self._exit_reason or "Gateway restart requested"
 
             self._draining = False

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -134,7 +134,7 @@ async def test_gateway_stop_interrupts_after_drain_timeout():
 
 
 @pytest.mark.asyncio
-async def test_gateway_stop_systemd_service_restart_exits_cleanly(tmp_path, monkeypatch):
+async def test_gateway_stop_systemd_service_restart_uses_tempfail(tmp_path, monkeypatch):
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     runner, adapter = make_restart_runner()
     adapter.disconnect = AsyncMock()
@@ -145,7 +145,12 @@ async def test_gateway_stop_systemd_service_restart_exits_cleanly(tmp_path, monk
         await runner.stop(restart=True, service_restart=True)
 
     runner._launch_systemd_restart_shortcut.assert_called_once_with()
-    assert runner._exit_code == 0
+    # Exit 75 (EX_TEMPFAIL) so RestartForceExitStatus=75 in the unit
+    # file revives the gateway via Restart=on-failure, even when the
+    # planned-restart helper fails (Polkit denial, missing user bus,
+    # headless box, or operator-managed unit using on-failure instead
+    # of always).  StartLimitBurst still bounds accidental loops.
+    assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
     assert (tmp_path / ".restart_pending.json").exists()
 
 


### PR DESCRIPTION
## Problem

The in-chat `/restart` command leaves the gateway dead on systemd deployments whose unit file uses `Restart=on-failure` (the most common setup recommended in deployment guides and used by `hermes setup` on Ubuntu). The gateway drains, exits cleanly, and never comes back — the only recovery is a host reboot.

Confirmed reproduction: operator-managed unit file at \`/etc/systemd/system/hermes-gateway.service\` with \`User=ubunutu\`, \`Restart=on-failure\`, \`RestartForceExitStatus=75\`. After \`/restart\` from Feishu the gateway stays down indefinitely until someone runs \`sudo systemctl restart hermes-gateway\` or reboots the host.

## Root cause

Three independent bugs in series, any one of which breaks \`/restart\` on affected deployments:

1. **Wrong exit-code assumption** (\`gateway/run.py\` \`_stop_impl\`): the Linux/systemd branch returned exit code \`0\` under the assumption that all systemd units use \`Restart=always\` and would relaunch on a clean exit. Units with \`Restart=on-failure\` never see \`0\` as a trigger, so systemd does nothing.

2. **Hardcoded \`--user\` scope** (\`gateway/run.py\` \`_launch_systemd_restart_shortcut\`): the planned-restart helper assumed the unit was registered as a user service. On system-level deployments (the common case) \`systemctl --user show hermes-gateway\` returns an empty \`MainPID\`, the PID-equality check fails, and the helper silently returns without launching anything.

3. **Polkit denial on \`systemd-run --system\`** (deployment reality): non-root gateway units (e.g. \`User=ubunutu\`) invoke \`systemd-run --system\` to create the transient restart helper, but Polkit rejects it with \`Interactive authentication required\`. The \`--user\` fallback requires a D-Bus user session that is absent on headless servers. So even after the scope bug above is fixed, the helper still cannot start in real deployments.

## Fix

**Always exit \`75\` (EX_TEMPFAIL) on service-managed restarts.** Combined with the existing \`RestartForceExitStatus=75\` directive in the unit file, systemd treats the planned restart as a controlled failure and revives the gateway via \`Restart=on-failure\`, with \`RestartSec\` as the only delay.

\`\`\`diff
- self._exit_code = (
-     GATEWAY_SERVICE_RESTART_EXIT_CODE
-     if sys.platform == "darwin" or not os.environ.get("INVOCATION_ID")
-     else 0
- )
+ self._exit_code = GATEWAY_SERVICE_RESTART_EXIT_CODE
\`\`\`

The planned-restart helper is still attempted (for setups that want sub-\`RestartSec\` restarts), but it is no longer load-bearing. If \`systemd-run\` is denied by Polkit or the user bus is missing, the helper silently fails and systemd's own \`Restart=\` machinery takes over.

A second commit also fixes the scope detection in \`_launch_systemd_restart_shortcut\` so the helper (when it does work) targets the correct scope:

\`\`\`python
system_pid = _query_pid([])      # systemctl show ...
user_pid   = _query_pid(["--user"])

if current_pid == system_pid:    scope = []             # /etc/systemd/system
elif current_pid == user_pid:    scope = ["--user"]     # systemctl --user
else:                            return                 # not systemd
\`\`\`

## Behavior matrix after fix

| Unit file                                   | Helper outcome  | Gateway revived by            |
|---------------------------------------------|-----------------|-------------------------------|
| \`Restart=always\`, root gateway             | ✓ sub-second    | helper or systemd             |
| \`Restart=on-failure\`, root gateway         | ✓ sub-second    | helper or systemd (exit 75)   |
| \`Restart=on-failure\`, non-root gateway     | ✗ Polkit denied | systemd (exit 75)             |
| Headless without D-Bus user session          | ✗ no user bus   | systemd (exit 75)             |
| Not under systemd                           | n/a             | existing non-systemd paths    |

## Safety

- \`StartLimitBurst\` / \`StartLimitIntervalSec\` in the unit file still bound accidental restart loops.
- macOS launchd path is unchanged (\`KeepAlive.SuccessfulExit=false\`).
- No impact on crash recovery: crashes still produce the same exit codes they always did.

## Verification

End-to-end on Ubuntu 24.04 with hermes-gateway as a \`/etc/systemd/system/\` service under \`User=ubunutu\`, using \`Restart=on-failure\`, \`RestartSec=30\`, \`RestartForceExitStatus=75\`, \`StartLimitIntervalSec=600\`, \`StartLimitBurst=5\`.

- \`/restart\` from Feishu: gateway drains in <1s, exits 75, systemd revives it ~30s later. No manual intervention.
- Repeated 5× in quick succession: works correctly, then \`start-limit-hit\` kicks in as expected.
- After \`systemctl reset-failed\`: \`/restart\` works again.

## Tests

\`tests/gateway/test_gateway_shutdown.py\`:

- Renamed \`test_gateway_stop_systemd_service_restart_exits_cleanly\` → \`test_gateway_stop_systemd_service_restart_uses_tempfail\`.
- Asserts \`_exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE\` (75) instead of \`0\`.

\`\`\`
$ pytest tests/gateway/test_gateway_shutdown.py
14 passed in 16.58s
\`\`\`