### PR TITLE
fix(batch_runner): close the per-prompt agent to release sandboxes/clients (#50197)

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -313,6 +313,7 @@ def _process_single_prompt(
         if config.get("verbose"):
             print(f"   Prompt {prompt_index}: Using container image {container_image}")
     
+    agent = None
     try:
         # Sample toolsets from distribution for this prompt
         selected_toolsets = sample_toolsets_from_distribution(config["distribution"])
@@ -395,6 +396,17 @@ def _process_single_prompt(
                 "timestamp": datetime.now().isoformat()
             }
         }
+    finally:
+        # Release the ephemeral batch agent's resources (terminal sandboxes,
+        # browser daemons, cached httpx clients) instead of leaking them across
+        # prompts in long batch runs. Best-effort: a cleanup failure must not
+        # mask the result or crash the batch. Addresses the batch_runner.py
+        # leak reported in #50197.
+        if agent is not None:
+            try:
+                agent.close()
+            except Exception:
+                pass
 
 
 def _process_batch_worker(args: Tuple) -> Dict[str, Any]:


### PR DESCRIPTION
Addresses the `batch_runner.py` location from #50197.

## Bug

`batch_runner.py` creates a fresh `AIAgent` per prompt:

```python
try:
    ...
    agent = AIAgent(... skip_memory=True ...)
    result = agent.run_conversation(prompt, task_id=task_id)
    ...
    return { ... }
except Exception as e:
    ...
    return { ... }
# no finally - agent is never closed
```

The `try` has an `except` but **no `finally`**, so the agent is never
`close()`d. Every prompt in a batch leaks the resources the agent holds -
terminal sandboxes, browser daemons, and cached httpx clients. Over a large
batch run these accumulate for the lifetime of the process.

This is the `batch_runner.py:325` entry in the #50197 audit ("agent created at
325, run_conversation at 349, has try/except but no finally block at all").

## Fix

Add a `finally` that closes the agent, with an `agent = None` guard so it''s
safe even if `AIAgent(...)` construction itself raises:

```python
agent = None
try:
    ...
    agent = AIAgent(...)
    ...
finally:
    if agent is not None:
        try:
            agent.close()
        except Exception:
            pass
```

Scope notes:
- `close()` is the correct cleanup here: this is an **ephemeral batch worker**
  that owns its own sandboxes/clients (not a user-facing background process), so
  there''s no `release_clients`-vs-`close` concern from #38958.
- The agent is built with `skip_memory=True`, so there''s no memory provider to
  shut down - `close()` alone covers the leaked resources.
- Cleanup is best-effort (`try/except`): a teardown error must not mask the
  prompt result or abort the batch.
- The `finally` runs after both the success and error `return`s, and after all
  uses of `agent` (trajectory conversion at line ~358), so nothing is closed
  prematurely.

## Scope

This PR fixes only the `batch_runner.py` site. The other locations in #50197
(`tui_gateway`, `feishu_comment`, `cli_commands_mixin`, `acp/session.py`,
`curator`) involve background/long-lived agents where the correct teardown
(`close()` vs `release_clients()` per #38958) needs per-call judgement, so they
are better handled separately rather than with a blanket `close()`.

## Verification

- Confirmed on current `main`: the function has `try`/`except` and no `finally`;
  the agent created at line ~325 is used through ~358 and never closed.
- Confirmed `skip_memory=True` is set, so no memory-provider teardown is needed.
- No open PR touches `batch_runner.py` agent cleanup (checked before opening).