### PR TITLE
fix(agent): reset summary-failure cooldown on model switch

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -689,6 +689,13 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.awaiting_real_usage_after_compression = False
         self._ineffective_compression_count = 0
+        # Clear the summary-generation failure cooldown.  The cooldown was set
+        # because the OLD model/provider couldn't produce a summary (no provider
+        # configured, timeout, model-not-found, etc.).  The new model has
+        # different capabilities and credentials — let it attempt summarization
+        # immediately rather than inheriting a stale block that can suppress
+        # compression for up to 10 minutes after the switch.
+        self._summary_failure_cooldown_until = 0.0
 
     def __init__(
         self,

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2324,6 +2324,20 @@ class TestUpdateModelResetsCalibration:
         assert comp.should_defer_preflight_to_real_usage(comp.threshold_tokens + 5_000) is False
 
 
+    def test_summary_failure_cooldown_cleared(self):
+        """Stale summary-failure cooldown from the old model must not block
+        the new model from generating summaries after a switch."""
+        import time
+        comp = self._comp()
+        # Simulate a 600-second cooldown set because the old model had no
+        # provider configured for summarization.
+        comp._summary_failure_cooldown_until = time.monotonic() + 600
+
+        comp.update_model("new-model", context_length=128_000)
+
+        assert comp._summary_failure_cooldown_until == 0.0
+
+
 class TestTruncateToolCallArgsJson:
     """Regression tests for #11762.
 


### PR DESCRIPTION
## Summary

- `update_model()` now clears `_summary_failure_cooldown_until` so a stale summary-generation cooldown from the previous model does not suppress context compression on the new model.

## Problem

When summary generation fails (e.g. "no provider configured" on a local model, or a transient timeout), the compressor enters a cooldown of 30–600 seconds during which `_generate_summary()` short-circuits and returns `None`. If the user switches models via `/model` during this window, the cooldown persists even though the new model has different capabilities and credentials. This leaves context compression suppressed for up to 10 minutes after the switch — the exact class of stale-state-after-switch bug that #50137 addressed for the calibration fields in the same function.

## Fix

Add `self._summary_failure_cooldown_until = 0.0` to `update_model()`, directly after the calibration resets added by #50137. The new model's first summary attempt will either succeed (repopulating the success state) or fail on its own terms (setting a fresh cooldown appropriate to ITS failure mode).

## Test plan

- [x] New test `test_summary_failure_cooldown_cleared` in `TestUpdateModelResetsCalibration` — sets a 600s cooldown, calls `update_model()`, asserts cooldown is 0.
- [x] Full `test_context_compressor.py` suite passes (107 tests).