### PR TITLE
fix(gateway): tolerate malformed SMS_WEBHOOK_PORT via env_int

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -35,6 +35,7 @@ from gateway.platforms.base import (
     SendResult,
 )
 from gateway.platforms.helpers import redact_phone, strip_markdown
+from utils import env_int
 
 logger = logging.getLogger(__name__)
 
@@ -68,9 +69,7 @@ class SmsAdapter(BasePlatformAdapter):
         self._account_sid: str = os.environ["TWILIO_ACCOUNT_SID"]
         self._auth_token: str = os.environ["TWILIO_AUTH_TOKEN"]
         self._from_number: str = os.getenv("TWILIO_PHONE_NUMBER", "")
-        self._webhook_port: int = int(
-            os.getenv("SMS_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))
-        )
+        self._webhook_port: int = env_int("SMS_WEBHOOK_PORT", DEFAULT_WEBHOOK_PORT)
         self._webhook_host: str = os.getenv("SMS_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST)
         self._webhook_url: str = os.getenv("SMS_WEBHOOK_URL", "").strip()
         self._runner = None

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -215,6 +215,40 @@ class TestWebhookHostConfig:
             adapter = SmsAdapter(pc)
             assert adapter._webhook_url == "https://example.com/webhooks/twilio"
 
+    def test_default_port_is_8080(self):
+        from plugins.platforms.sms.adapter import DEFAULT_WEBHOOK_PORT
+        assert DEFAULT_WEBHOOK_PORT == 8080
+
+    def test_port_from_env(self):
+        from plugins.platforms.sms.adapter import SmsAdapter
+
+        env = {
+            "TWILIO_ACCOUNT_SID": "ACtest",
+            "TWILIO_AUTH_TOKEN": "tok",
+            "TWILIO_PHONE_NUMBER": "+15550001111",
+            "SMS_WEBHOOK_PORT": "3000",
+        }
+        with patch.dict(os.environ, env):
+            pc = PlatformConfig(enabled=True, api_key="tok")
+            adapter = SmsAdapter(pc)
+            assert adapter._webhook_port == 3000
+
+    def test_malformed_port_falls_back_to_default(self):
+        """A typo'd SMS_WEBHOOK_PORT must fall back to the default, not crash
+        adapter init (env_int parity with other platforms)."""
+        from plugins.platforms.sms.adapter import SmsAdapter, DEFAULT_WEBHOOK_PORT
+
+        env = {
+            "TWILIO_ACCOUNT_SID": "ACtest",
+            "TWILIO_AUTH_TOKEN": "tok",
+            "TWILIO_PHONE_NUMBER": "+15550001111",
+            "SMS_WEBHOOK_PORT": "not-a-port",
+        }
+        with patch.dict(os.environ, env):
+            pc = PlatformConfig(enabled=True, api_key="tok")
+            adapter = SmsAdapter(pc)
+            assert adapter._webhook_port == DEFAULT_WEBHOOK_PORT
+
 
 # ── Startup guard (fail-closed) ────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

The SMS (Twilio) adapter parsed `SMS_WEBHOOK_PORT` with a raw `int()`:

```python
self._webhook_port: int = int(os.getenv("SMS_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT)))
```

A malformed or typo'd value (e.g. `SMS_WEBHOOK_PORT=not-a-port`, or a stray
non-digit character) raises `ValueError` during adapter construction. The
platform registry wraps `adapter_factory(config)` in a try/except
(`gateway/platform_registry.py`), so the whole gateway doesn't crash — but the
**SMS platform silently fails to initialize**, logging an opaque
`invalid literal for int()` traceback instead of falling back to the documented
default of `8080`.

This is also an inconsistency: SMS is the only platform that reads a port from
the environment with a raw `int()`. Every other one already uses the
`env_int()` helper, which strips whitespace and falls back to the default on
malformed input:

- `plugins/platforms/email/adapter.py` → `EMAIL_IMAP_PORT`, `EMAIL_SMTP_PORT`
- `plugins/platforms/telegram/adapter.py` → `TELEGRAM_WEBHOOK_PORT`
- `gateway/config.py` → `WECOM_CALLBACK_PORT`, `BLUEBUBBLES_WEBHOOK_PORT`

The fix switches SMS to `env_int()`, restoring graceful degradation and making
the behavior consistent across platforms. Valid ports behave exactly as before.

## Related Issue

No existing issue — small robustness fix. Happy to open one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/sms/adapter.py`: import `env_int` from `utils`; replace the
  raw `int(os.getenv("SMS_WEBHOOK_PORT", ...))` with
  `env_int("SMS_WEBHOOK_PORT", DEFAULT_WEBHOOK_PORT)`.
- `tests/gateway/test_sms.py`: add three regression tests under
  `TestWebhookHostConfig` — default port constant, a valid env value, and a
  malformed value falling back to the default.

## How to Test

1. **Reproduce (before the fix):** set Twilio creds + `SMS_WEBHOOK_PORT=not-a-port`
   and construct `SmsAdapter(pc)` → raises `ValueError: invalid literal for int()`,
   and the SMS platform fails to load.
2. **After the fix:** the same construction succeeds and
   `adapter._webhook_port == 8080` (default); a valid value like
   `SMS_WEBHOOK_PORT=3000` still yields `3000`.
3. **Run the tests:**

   ```
   python -m pytest tests/gateway/test_sms.py -q
   ```
   →
   ```
   42 passed
   ```
   (39 existing + 3 new)

   Adapter-construction / registry paths that exercise this code:
   ```
   python -m pytest tests/gateway/test_plugin_platform_interface.py tests/gateway/test_platform_registry.py -q
   ```
   →
   ```
   50 passed, 7 skipped
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): ...`)
- [ ] I searched for existing PRs to make sure this isn't a duplicate <!-- verify with: gh search prs --repo NousResearch/hermes-agent "SMS_WEBHOOK_PORT" -->
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant tests and they pass (`tests/gateway/test_sms.py`, `test_plugin_platform_interface.py`, `test_platform_registry.py` — see results above)
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] N/A — docs already document `SMS_WEBHOOK_PORT` default `8080`; behavior now matches the docs
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] N/A — pure-Python env parsing, no OS-specific code paths
- [x] N/A — no tool description/schema changes