### PR TITLE
fix(gateway): bridge MSGRAPH_WEBHOOK_HOST env into webhook config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1563,6 +1563,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         "1",
         "yes",
     }
+    msgraph_webhook_host = os.getenv("MSGRAPH_WEBHOOK_HOST")
     msgraph_webhook_port = os.getenv("MSGRAPH_WEBHOOK_PORT")
     msgraph_webhook_client_state = os.getenv("MSGRAPH_WEBHOOK_CLIENT_STATE", "")
     msgraph_webhook_resources = os.getenv("MSGRAPH_WEBHOOK_ACCEPTED_RESOURCES", "")
@@ -1572,6 +1573,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if (
         msgraph_webhook_enabled
         or Platform.MSGRAPH_WEBHOOK in config.platforms
+        or msgraph_webhook_host
         or msgraph_webhook_port
         or msgraph_webhook_client_state
         or msgraph_webhook_resources
@@ -1581,6 +1583,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.MSGRAPH_WEBHOOK] = PlatformConfig()
         if msgraph_webhook_enabled:
             config.platforms[Platform.MSGRAPH_WEBHOOK].enabled = True
+        if msgraph_webhook_host:
+            config.platforms[Platform.MSGRAPH_WEBHOOK].extra["host"] = (
+                msgraph_webhook_host
+            )
         if msgraph_webhook_port:
             try:
                 config.platforms[Platform.MSGRAPH_WEBHOOK].extra["port"] = int(

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -51,6 +51,7 @@ class TestMSGraphWebhookConfig:
             platforms={Platform.MSGRAPH_WEBHOOK: PlatformConfig(enabled=True, extra={})}
         )
 
+        monkeypatch.setenv("MSGRAPH_WEBHOOK_HOST", "127.0.0.1")
         monkeypatch.setenv("MSGRAPH_WEBHOOK_PORT", "8650")
         monkeypatch.setenv("MSGRAPH_WEBHOOK_CLIENT_STATE", "env-state")
         monkeypatch.setenv(
@@ -61,12 +62,39 @@ class TestMSGraphWebhookConfig:
         _apply_env_overrides(config)
 
         extra = config.platforms[Platform.MSGRAPH_WEBHOOK].extra
+        assert extra["host"] == "127.0.0.1"
         assert extra["port"] == 8650
         assert extra["client_state"] == "env-state"
         assert extra["accepted_resources"] == [
             "communications/onlineMeetings",
             "chats/getAllMessages",
         ]
+
+    def test_env_host_enables_documented_loopback_quickstart(self, monkeypatch):
+        """The env-only quickstart sets MSGRAPH_WEBHOOK_HOST=127.0.0.1.
+
+        That value must reach the adapter so the loopback bind is accepted
+        without a source CIDR allowlist. Regression: the host env var was
+        previously not bridged into config, so the adapter stayed on its
+        ``0.0.0.0`` default and ``connect()`` failed closed at startup,
+        demanding ``allowed_source_cidrs`` the docs never mentioned.
+        """
+        config = GatewayConfig()
+
+        monkeypatch.setenv("MSGRAPH_WEBHOOK_ENABLED", "true")
+        monkeypatch.setenv("MSGRAPH_WEBHOOK_HOST", "127.0.0.1")
+        monkeypatch.setenv("MSGRAPH_WEBHOOK_CLIENT_STATE", "env-state")
+
+        _apply_env_overrides(config)
+
+        assert Platform.MSGRAPH_WEBHOOK in config.platforms
+        platform_config = config.platforms[Platform.MSGRAPH_WEBHOOK]
+        assert platform_config.extra["host"] == "127.0.0.1"
+
+        adapter = MSGraphWebhookAdapter(platform_config)
+        assert adapter._host == "127.0.0.1"
+        # Loopback bind must not require a source CIDR allowlist.
+        assert adapter._source_allowlist_required_but_missing() is False
 
 
 class TestMSGraphValidationHandshake:

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -499,6 +499,7 @@ Inbound change-notification listener for Graph events (Teams meetings, calendar,
 | Variable | Description |
 |----------|-------------|
 | `MSGRAPH_WEBHOOK_ENABLED` | Enable the `msgraph_webhook` gateway platform (`true`/`1`/`yes`). |
+| `MSGRAPH_WEBHOOK_HOST` | Address the listener binds to (default: `0.0.0.0`). Use `127.0.0.1` for loopback-only dev tunnels / local reverse proxies; non-loopback binds also require `MSGRAPH_WEBHOOK_ALLOWED_SOURCE_CIDRS`. |
 | `MSGRAPH_WEBHOOK_PORT` | Port the listener binds to (default: `8646`). |
 | `MSGRAPH_WEBHOOK_CLIENT_STATE` | Shared secret Graph echoes in every notification; compared with `hmac.compare_digest`. Generate with `openssl rand -hex 32`. |
 | `MSGRAPH_WEBHOOK_ACCEPTED_RESOURCES` | Comma-separated allowlist of Graph resource paths/patterns (e.g. `communications/onlineMeetings,chats/*/messages`). Trailing `*` is prefix-matching. Empty = accept all. |

--- a/website/docs/user-guide/messaging/msgraph-webhook.md
+++ b/website/docs/user-guide/messaging/msgraph-webhook.md
@@ -36,12 +36,13 @@ Or via env vars in `~/.hermes/.env` (auto-merged on startup):
 
 ```bash
 MSGRAPH_WEBHOOK_ENABLED=true
+MSGRAPH_WEBHOOK_HOST=127.0.0.1
 MSGRAPH_WEBHOOK_PORT=8646
 MSGRAPH_WEBHOOK_CLIENT_STATE=<generate-with-openssl-rand-hex-32>
 MSGRAPH_WEBHOOK_ACCEPTED_RESOURCES=communications/onlineMeetings
 ```
 
-Note: the bind host is read from `extra.host` in `config.yaml` (see the example above); there is no `MSGRAPH_WEBHOOK_HOST` env-var override.
+Note: env vars merge into the config at gateway startup and take priority over `config.yaml` when a setting is defined in both places.
 
 Start the gateway: `hermes gateway run`. The listener exposes:
 
@@ -70,7 +71,7 @@ All settings go under `platforms.msgraph_webhook.extra`:
 | `max_seen_receipts` | `5000` | Dedupe cache size for notification IDs. Oldest entries evicted when the cap is hit. |
 | `allowed_source_cidrs` | `[]` | Required for non-loopback binds. Leave empty only when the listener is bound to loopback and fronted by a local tunnel / reverse proxy. |
 
-Most settings also have an equivalent env var (`MSGRAPH_WEBHOOK_*`) that merges into the config at gateway startup (the exception is `host`, which is config-only — see the note above) — see the [environment variables reference](/reference/environment-variables#microsoft-graph-teams-meetings).
+Most settings also have an equivalent env var (`MSGRAPH_WEBHOOK_*`) that merges into the config at gateway startup — see the [environment variables reference](/reference/environment-variables#microsoft-graph-teams-meetings).
 
 ## Security Hardening
 


### PR DESCRIPTION
## What does this PR do?

The Microsoft Graph webhook listener's documented **env-only quickstart** tells
users to set `MSGRAPH_WEBHOOK_HOST=127.0.0.1`, but the gateway never read that
variable. `_apply_env_overrides()` in `gateway/config.py` bridged
`MSGRAPH_WEBHOOK_ENABLED/PORT/CLIENT_STATE/ACCEPTED_RESOURCES/ALLOWED_SOURCE_CIDRS`
into config — but **not** `_HOST`.

As a result, a user following the documented loopback quickstart got a listener
that ignored their host setting, fell back to the adapter's `0.0.0.0` default,
and then **refused to start** — because a non-loopback bind fails closed without
`allowed_source_cidrs`. The documented quickstart was broken at startup.

This PR reads `MSGRAPH_WEBHOOK_HOST` and writes it to
`platforms.msgraph_webhook.extra["host"]`, mirroring the existing
`API_SERVER_HOST` and `WHATSAPP_CLOUD_WEBHOOK_HOST` env bridges (msgraph was the
only webhook-style platform whose host couldn't be set via env). It also
reconciles the docs, which had drifted into contradicting each other:
`msgraph-webhook.md` explicitly claimed host was "config-only" while
`teams-meetings.md` instructed users to set the env var.

## Related Issue

No existing issue — this is a docs↔code drift found during review. The
hardening that added the CIDR fail-closed guard updated the quickstart docs to
show `MSGRAPH_WEBHOOK_HOST` but never added the config bridge.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update

## Changes Made

- `gateway/config.py` — `_apply_env_overrides()` now reads `MSGRAPH_WEBHOOK_HOST`,
  adds it to the platform-materialization trigger, and writes `extra["host"]`.
- `tests/gateway/test_msgraph_webhook.py` — extended the existing env-override
  test and added a regression test for the documented loopback quickstart.
- `website/docs/user-guide/messaging/msgraph-webhook.md` — added the host line to
  the env quickstart and removed the two now-incorrect "host is config-only" notes.
- `website/docs/reference/environment-variables.md` — added the missing
  `MSGRAPH_WEBHOOK_HOST` reference row.

## How to Test

Reproduction (before the fix):
1. In `~/.hermes/.env`, set `MSGRAPH_WEBHOOK_ENABLED=true`,
   `MSGRAPH_WEBHOOK_HOST=127.0.0.1`, and `MSGRAPH_WEBHOOK_CLIENT_STATE=<secret>`
   (the documented quickstart).
2. Start the gateway → the listener binds `0.0.0.0` and refuses to start,
   logging "Refusing to start: binding to 0.0.0.0 requires extra.allowed_source_cidrs".

After the fix: the same env config binds `127.0.0.1` and starts cleanly with no
CIDR allowlist required.

Automated tests:

    python -m pytest tests/gateway/test_msgraph_webhook.py -q
    # 28 passed

New/updated coverage in `tests/gateway/test_msgraph_webhook.py`:
- `test_env_overrides_apply_to_existing_msgraph_webhook_platform` — now also asserts
  `MSGRAPH_WEBHOOK_HOST` lands in `extra["host"]`.
- `test_env_host_enables_documented_loopback_quickstart` (new) — env-only config with
  `MSGRAPH_WEBHOOK_HOST=127.0.0.1` materializes the platform, sets `extra["host"]`,
  and the adapter accepts the loopback bind without a source-CIDR allowlist
  (`_source_allowlist_required_but_missing()` is `False`).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the affected test suite (`pytest tests/gateway/test_msgraph_webhook.py -q`) — 28 passed
- [x] I've added tests for my changes
- [ ] I've tested on my platform: tested locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation (msgraph-webhook.md, environment-variables.md)
- [x] N/A — no new config keys for `cli-config.yaml.example` (env-var bridge only;
      `extra.host` already documented)
- [x] N/A — no architecture/workflow changes for CONTRIBUTING.md / AGENTS.md
- [x] N/A — change is a plain env-var read with no OS-specific behavior
- [x] N/A — no tool descriptions/schemas changed