### PR TITLE
feat: add Cursor external process provider

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1378,6 +1378,21 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
+    if agent.provider == "cursor" or str(client_kwargs.get("base_url", "")).startswith("cursor://"):
+        from agent.cursor_agent_client import CursorAgentClient
+
+        safe_kwargs = {
+            k: v for k, v in client_kwargs.items()
+            if k in {"api_key", "base_url", "default_headers", "command", "args", "workspace", "mode", "timeout_seconds"}
+        }
+        client = CursorAgentClient(**safe_kwargs)
+        _ra().logger.info(
+            "Cursor Agent client created (%s, shared=%s) %s",
+            reason,
+            shared,
+            agent._client_log_context(),
+        )
+        return client
     if agent.provider == "google-gemini-cli" or str(client_kwargs.get("base_url", "")).startswith("cloudcode-pa://"):
         from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
 

--- a/agent/cursor_agent_client.py
+++ b/agent/cursor_agent_client.py
@@ -1,0 +1,1791 @@
+"""OpenAI-compatible facade that forwards Hermes requests to ``cursor-agent``.
+
+This adapter lets Hermes treat the Cursor Agent CLI as a chat-style backend so
+every Cursor user (Hobby/Pro/Pro+/Ultra/Teams) can route Hermes calls through
+their existing Cursor subscription / API credits.
+
+Per request we spawn ``cursor-agent -p`` with ``--output-format stream-json``,
+pass the formatted conversation as the prompt (via stdin to avoid the argv
+length limit), then parse the line-delimited JSON events into a single OpenAI
+chat-completion response.
+
+Design notes:
+
+- One subprocess per request (no shared long-running session). Warm sessions
+  via ``--resume`` are an opt-in path documented below.
+- Default ``--mode ask`` keeps Cursor read-only — useful when we just want the
+  model as an LLM rather than letting it edit files.
+- Default workspace is an ephemeral temp dir so the agent never sees the
+  caller's repo. Override via ``HERMES_CURSOR_WORKSPACE`` or the ``workspace``
+  ctor arg.
+- Tool calls follow the Copilot-ACP convention: tools are described in the
+  system prompt and the model emits ``<tool_call>{...}</tool_call>`` blocks
+  that we lift back into OpenAI ``tool_calls``.
+- The CLI auth (``cursor-agent login`` or ``CURSOR_API_KEY``) is what governs
+  identity; we forward ``CURSOR_API_KEY`` to the subprocess and let the CLI
+  resolve it (same as the IDE does).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from agent.redact import redact_sensitive_text
+from providers.cursor_utils import DEFAULT_CURSOR_COMMAND, resolve_cursor_command, resolve_cursor_extra_args
+
+CURSOR_MARKER_BASE_URL = "cursor://agent"
+# ``agent`` matches cursor-agent's own default permissionMode (the
+# behavior you get from ``cursor-agent -p`` with no ``--mode`` flag).
+# This is what a user picking ``cursor`` in ``hermes model`` will expect:
+# the same write/edit/shell power they'd have from the cursor CLI directly.
+# Users who want read-only behavior set ``HERMES_CURSOR_MODE=ask`` (or
+# ``plan``); Hermes' own ``approvals.mode`` config additionally gates any
+# tool execution (manual / smart / off) on top of this, identical to every
+# other provider.
+DEFAULT_CURSOR_MODE = "agent"
+DEFAULT_CURSOR_MODEL = "auto"
+
+# cursor-agent CLI accepts only ``ask`` and ``plan`` for ``--mode`` today,
+# but ``-p/--print`` *without* ``--mode`` runs in the full-capability
+# ``default`` permissionMode (write+shell+everything). We expose that as
+# the synthetic ``agent`` value here:
+#   - ``ask``   : read-only Q&A. Cursor's built-in mutation tools are
+#                 disabled. Hermes-side tools still apply for any work
+#                 that needs to touch the user's disk.
+#   - ``plan`` : read-only planning mode. Produces structured plan output
+#                from Cursor's planner.
+#   - ``agent``: omits ``--mode`` so Cursor runs in its IDE-equivalent
+#                "default" permissionMode — built-in shell, write, edit,
+#                read, etc. all active. Use this when you want Cursor to
+#                drive multi-step work end-to-end (it will still emit
+#                tool_call events that we surface to Hermes UI).
+# Anything else falls back to ``ask``. Don't add new values without
+# re-checking ``cursor-agent --help``; passing an unknown ``--mode``
+# value causes a hard-crash BrokenPipe with a confusing
+# "Allowed choices are plan, ask." stderr.
+_VALID_CURSOR_MODES = frozenset({"ask", "plan", "agent"})
+_CURSOR_CLI_MODES = frozenset({"ask", "plan"})
+# Idle threshold (not wall-clock): the deadline resets on every stream-json
+# event from cursor-agent. A turn can legitimately run for much longer than
+# this in total wall-clock; what matters is that events keep arriving. If
+# nothing arrives for this long, the subprocess is presumed hung and is
+# force-killed with a clear TimeoutError. Override via
+# ``HERMES_CURSOR_TIMEOUT_SECONDS`` env var. Default is 30 minutes; cursor-
+# agent's own internal shell ceiling is 10 minutes so a single shell call
+# can chew up that much idle time, and chained internal operations (deep
+# greps, large reads after a long shell) routinely push past 15 minutes
+# without emitting events. 30 min gives comfortable headroom while still
+# catching genuine hangs.
+_DEFAULT_TIMEOUT_SECONDS = 1800.0
+
+# Sentinels that mean "no real api key — use the cursor-agent CLI's own login
+# session". Hermes's external_process auth path injects these as placeholders;
+# forwarding them to ``cursor-agent --api-key`` makes the CLI reject the
+# request and close stdin, manifesting upstream as ``BrokenPipeError``.
+_API_KEY_SENTINELS = frozenset({
+    "",
+    "cursor-agent-login",
+    "cursor-cli-login",
+    "external-process",
+    "external_process",
+})
+
+# Reuse the tool-call extraction grammar from copilot_acp_client.  We do NOT
+# reuse its prompt builder — cursor's model is itself an agentic CLI with its
+# own built-in shell/edit/read tools, and the softer ACP wording ("ACP agent
+# backend, use ACP capabilities") makes it prefer those built-ins and run the
+# work internally, leaving Hermes' tool surface unused.  Cursor needs an
+# explicit "you are JUST the LLM, do not execute anything yourself" directive
+# (see ``_format_messages_as_prompt`` below).
+import json as _json  # noqa: E402
+
+from agent.copilot_acp_client import (  # noqa: E402
+    _extract_tool_calls_from_text,
+    _render_message_content,
+)
+
+
+def _format_messages_as_prompt(
+    messages: list[dict[str, Any]],
+    model: str | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = None,
+) -> str:
+    """Build the prompt sent to ``cursor-agent`` stdin.
+
+    Key differences vs. the copilot-acp formatter:
+
+    * Hard "you are the LLM, NOT an agent" framing — without this, cursor's
+      built-in shell/edit/read tools intercept the request and the agentic
+      loop runs entirely inside ``cursor-agent``, so Hermes never sees a
+      ``tool_calls`` response (the symptom: chat sessions show 0 tool
+      calls even though tools are advertised).
+    * Explicit "do NOT run ls/cat/edit yourself" line — empirically required
+      to push cursor's model past its default "I'll just do it" reflex.
+    * Tool-call grammar identical to copilot-acp so the ``<tool_call>{...}
+      </tool_call>`` extractor we share keeps working.
+    """
+    # Auxiliary-style calls (title generation, compression, vision,
+    # mcp router, etc.) come in with NO ``tools`` and just a system+user
+    # pair. They want a short, direct response — slapping the full
+    # "you are an agent backend, emit tool_call blocks" preamble on top
+    # of them makes cursor's harness reply with a verbose multi-paragraph
+    # answer or even crash on the formatting constraints. So we keep
+    # the heavy preamble only for the agentic chat path (tools provided).
+    sections: list[str] = []
+    has_tools = bool(tools)
+    if has_tools:
+        sections.extend([
+            "You are powering a chat session inside Hermes Agent.",
+            "You have TWO sets of tools available:",
+            "(A) Your own built-in cursor-agent tools (shell, read_file, "
+            "edit_file, write_file, list_directory, grep, glob, web_fetch). "
+            "Use these DIRECTLY for filesystem/shell/search work — they run "
+            "on the real workspace, are fast, and Hermes will surface their "
+            "results to the user automatically.",
+            "(B) Hermes-side tools listed in the schema below. They cover "
+            "capabilities your built-in tools do NOT have (skills, MCP "
+            "servers, browser automation, remote APIs, etc.). To invoke "
+            "one of THESE, emit a "
+            "<tool_call>{...}</tool_call> block in OpenAI function-call "
+            "shape: "
+            '{"id":"call_<n>","type":"function",'
+            '"function":{"name":"<tool>","arguments":"<json string>"}}. '
+            "``arguments`` MUST be a JSON STRING (escaped), not a nested "
+            "object.",
+            "RULES:",
+            "1. Prefer your built-in tools for any shell command, file "
+            "read/write/list/edit, grep, or glob operation — they're "
+            "faster than round-tripping through Hermes. CRITICAL for "
+            "file creation/modification: ALWAYS use the ``write`` or "
+            "``edit`` built-in tools, NEVER ``shell`` with ``echo > "
+            "file`` / ``cat > file`` / ``sed -i`` / ``>>``. Only the "
+            "write/edit tools report ``linesAdded`` / ``linesRemoved`` "
+            "/ ``diffString`` to the harness, which is what Hermes "
+            "renders as the colored ``+``/``-`` diff in the UI. Shell "
+            "redirections create the file but the user sees no diff "
+            "and has no idea what changed.",
+            "2. Only emit <tool_call> blocks for tools listed in the "
+            "schema below; do NOT invent tool names. Multiple tool_calls "
+            "per turn are allowed.",
+            "3. Work iteratively (ReAct-style): before each tool batch, "
+            "emit ONE short line of plain text saying what you're about "
+            "to check and why. After tool results come back, briefly "
+            "reflect on what you found before deciding the next step. "
+            "Hermes surfaces these intermediate lines to the user as "
+            "live narration so they can follow your reasoning.",
+            "4. Don't dump every tool call upfront — chain them: think, "
+            "tool, reflect, tool, reflect, ... then synthesise the final "
+            "answer at the end. If the task genuinely is independent "
+            "lookups, parallel tool calls in one batch are fine.",
+            "5. If no tool is needed (pure conversation, math, "
+            "summarising content already in the transcript), answer as "
+            "plain text.",
+            "6. Never hallucinate file contents or command output — if "
+            "you say \"Reading the file…\" you MUST actually run the "
+            "read_file (built-in) or emit a <tool_call> if it's a "
+            "Hermes-specific tool.",
+            "7. The Hermes UI already shows file edits to the user as a "
+            "colored +/- diff right next to each ``edit`` / ``write`` "
+            "tool call (and tool calls + diffs are streamed live). Do "
+            "NOT re-dump the before/after content or paste the diff "
+            "again in your final response — just confirm what was "
+            "changed at a high level (e.g. \"updated foo.py to fix the "
+            "off-by-one\"). Same for shell output: it's already visible.",
+        ])
+    else:
+        # Lite preamble for aux calls — just enough to keep cursor's
+        # harness from running its own tools / writing files / asking
+        # clarifying questions when all we want is a single short reply.
+        sections.append(
+            "Hermes auxiliary call. Answer the user message below directly "
+            "and concisely; do not run any tools, do not write files, do "
+            "not ask follow-up questions. Plain-text reply only."
+        )
+    if model:
+        sections.append(f"Hermes requested model hint: {model}")
+
+    if isinstance(tools, list) and tools:
+        tool_specs: list[dict[str, Any]] = []
+        for t in tools:
+            if not isinstance(t, dict):
+                continue
+            fn = t.get("function") or {}
+            if not isinstance(fn, dict):
+                continue
+            name = fn.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            tool_specs.append(
+                {
+                    "name": name.strip(),
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }
+            )
+        if tool_specs:
+            sections.append(
+                "Hermes-side tools (OpenAI function schema). Emit "
+                "<tool_call>{...}</tool_call> blocks to invoke these. "
+                "For plain shell / file / grep / glob actions prefer your "
+                "own built-in tools instead (they're faster).\n"
+                + _json.dumps(tool_specs, ensure_ascii=False)
+            )
+
+    if tool_choice is not None:
+        sections.append(
+            f"Tool choice hint: {_json.dumps(tool_choice, ensure_ascii=False)}"
+        )
+
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        if role == "tool":
+            role = "tool"
+        elif role not in {"system", "user", "assistant"}:
+            role = "context"
+
+        content = message.get("content")
+        rendered = _render_message_content(content)
+        if not rendered:
+            continue
+
+        label = {
+            "system": "System",
+            "user": "User",
+            "assistant": "Assistant",
+            "tool": "Tool",
+            "context": "Context",
+        }.get(role, role.title())
+        transcript.append(f"{label}:\n{rendered}")
+
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+
+    sections.append("Continue the conversation from the latest user request.")
+    return "\n\n".join(section.strip() for section in sections if section and section.strip())
+
+
+# ---------------------------------------------------------------------------
+# Environment & path helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_command() -> str:
+    return resolve_cursor_command()
+
+
+def _resolve_extra_args() -> list[str]:
+    return resolve_cursor_extra_args()
+
+
+def _resolve_mode() -> str:
+    mode = os.getenv("HERMES_CURSOR_MODE", "").strip().lower() or DEFAULT_CURSOR_MODE
+    if mode not in _VALID_CURSOR_MODES:
+        mode = DEFAULT_CURSOR_MODE
+    return mode
+
+
+def _resolve_workspace_override() -> str:
+    return os.getenv("HERMES_CURSOR_WORKSPACE", "").strip()
+
+
+def _resolve_home_dir() -> str:
+    """Pick a stable HOME for the child process.
+
+    Mirrors ``agent/copilot_acp_client.py:_resolve_home_dir`` so subprocess
+    behaviour stays predictable across providers.
+    """
+    try:
+        from hermes_constants import get_subprocess_home
+
+        profile_home = get_subprocess_home()
+        if profile_home:
+            return profile_home
+    except Exception:
+        pass
+
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return home
+
+    expanded = os.path.expanduser("~")
+    if expanded and expanded != "~":
+        return expanded
+
+    # POSIX-only last resort: read the home dir from the password
+    # database. ``os.getuid`` does not exist on Windows; gate explicitly
+    # so the import-time footgun checker stays clean. (Windows already
+    # falls through to the ``USERPROFILE`` / ``HOMEDRIVE+HOMEPATH``
+    # branches above; if those failed there is no equivalent password
+    # database here, so just bail to ``/tmp``.)
+    if hasattr(os, "getuid"):
+        try:
+            import pwd
+
+            resolved = pwd.getpwuid(os.getuid()).pw_dir.strip()  # windows-footgun: ok
+            if resolved:
+                return resolved
+        except Exception:
+            pass
+
+    return "/tmp"
+
+
+def _build_subprocess_env(api_key: str | None) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOME"] = _resolve_home_dir()
+    if api_key:
+        env["CURSOR_API_KEY"] = api_key
+    env.setdefault("NO_COLOR", "1")
+    env.setdefault("TERM", "dumb")
+    return env
+
+
+def _cursor_cli_auth_error(command: str, detail: str = "") -> RuntimeError:
+    clean_detail = redact_sensitive_text(detail.strip(), force=True) if detail else ""
+    suffix = f" Details: {clean_detail}" if clean_detail else ""
+    return RuntimeError(
+        f"Cursor CLI is not authenticated for '{command}'. "
+        "Run `cursor-agent login` again, or set `CURSOR_API_KEY` for "
+        f"long-running Hermes/gateway use.{suffix}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stream-json parser
+# ---------------------------------------------------------------------------
+
+
+def _build_cursor_tool_preview(evt: "_CursorToolEvent") -> str:
+    """Compact one-line description of a cursor tool call for the UI.
+
+    Mirrors the spirit of ``_build_tool_preview`` in ``tool_executor.py`` —
+    a single short string the spinner / activity feed can show next to
+    the tool name. Tool-specific extractors fall back to a JSON dump of
+    arguments when we don't have a hand-written formatter.
+    """
+    args = evt.args or {}
+    try:
+        if evt.envelope_key == "shellToolCall":
+            cmd = args.get("command") or args.get("cmd")
+            if isinstance(cmd, list):
+                cmd = " ".join(str(part) for part in cmd)
+            if isinstance(cmd, str) and cmd.strip():
+                return cmd.strip()[:200]
+        if evt.envelope_key in (
+            "readToolCall",
+            "editToolCall",
+            "writeToolCall",
+            "patchToolCall",
+            "deleteToolCall",
+        ):
+            # Cursor's wire format isn't fully consistent across tool
+            # kinds; ``editToolCall.args`` has been seen using
+            # ``target_file`` / ``targetFile`` / ``file_path`` while
+            # other tools use ``path``. Try them all so the activity
+            # feed always shows what was touched.
+            path = (
+                args.get("path")
+                or args.get("file")
+                or args.get("filePath")
+                or args.get("filename")
+                or args.get("target_file")
+                or args.get("targetFile")
+                or args.get("file_path")
+                or args.get("relative_workspace_path")
+                or ""
+            )
+            if isinstance(path, str) and path.strip():
+                return path.strip()[:200]
+        if evt.envelope_key == "globToolCall":
+            pat = args.get("globPattern") or args.get("pattern") or ""
+            target = args.get("targetDirectory") or args.get("path") or ""
+            label = " in ".join(p for p in (pat, target) if isinstance(p, str) and p.strip())
+            if label:
+                return label[:200]
+        if evt.envelope_key in ("grepToolCall", "searchToolCall"):
+            pat = args.get("pattern") or args.get("query") or args.get("regex") or ""
+            target = args.get("path") or args.get("targetDirectory") or ""
+            if isinstance(pat, str) and pat.strip():
+                if isinstance(target, str) and target.strip():
+                    return f"{pat} in {target}"[:200]
+                return pat.strip()[:200]
+            if isinstance(target, str) and target.strip():
+                return target.strip()[:200]
+        if evt.envelope_key == "listToolCall":
+            path = args.get("path") or args.get("directory") or args.get("targetDirectory") or ""
+            if isinstance(path, str) and path.strip():
+                return path.strip()[:200]
+        return json.dumps(args, ensure_ascii=False)[:200]
+    except Exception:
+        return ""
+
+
+def _normalize_cursor_tool_name(envelope_key: str) -> str:
+    """Map cursor's wire-format ``<thing>ToolCall`` keys to Hermes tool names.
+
+    cursor-agent's stream-json wraps every internal tool call as
+    ``"<kind>ToolCall"`` (e.g. ``shellToolCall``, ``readToolCall``). We
+    translate the kind so the activity surfaces in Hermes' UI with names
+    the user already recognises from other providers.
+    """
+    if not isinstance(envelope_key, str):
+        return "cursor_tool"
+    suffix = "ToolCall"
+    base = envelope_key[: -len(suffix)] if envelope_key.endswith(suffix) else envelope_key
+    if not base:
+        return "cursor_tool"
+    return {
+        "shell": "shell",
+        "read": "read_file",
+        "list": "list_directory",
+        "edit": "edit_file",
+        "write": "write_file",
+        "patch": "patch",
+        "grep": "grep",
+        "glob": "glob",
+        "search": "search",
+        "todo": "todo",
+        "delete": "delete_file",
+        "task": "task",
+        "fetch": "web_fetch",
+    }.get(base.lower(), base)
+
+
+def _summarise_cursor_tool_result(envelope_key: str, payload: dict[str, Any]) -> str:
+    """Return a compact human-readable result string for the UI / log.
+
+    Falls back to a generic JSON dump when we don't have a hand-written
+    extractor for the tool kind. Best-effort — never raises.
+    """
+    result = payload.get("result")
+    if not isinstance(result, dict):
+        return ""
+    success = result.get("success")
+    if not isinstance(success, dict):
+        if "error" in result and isinstance(result["error"], (str, dict)):
+            return f"error: {result['error']}"[:400]
+        return ""
+    try:
+        if envelope_key == "shellToolCall":
+            stdout = success.get("stdout") or ""
+            return stdout if isinstance(stdout, str) else json.dumps(stdout)
+        if envelope_key == "readToolCall":
+            content = success.get("content") or ""
+            total = success.get("totalLines")
+            if total is not None:
+                return f"({total} lines)\n{content}" if content else f"({total} lines)"
+            return content if isinstance(content, str) else json.dumps(content)
+        if envelope_key in ("listToolCall", "globToolCall"):
+            files = success.get("files") or success.get("entries") or []
+            if isinstance(files, list):
+                return "\n".join(str(f) for f in files[:200])
+        return json.dumps(success, ensure_ascii=False)[:1000]
+    except Exception:
+        return ""
+
+
+class _CursorToolEvent:
+    """A captured cursor-agent tool invocation (started + completed states).
+
+    Used both for live progress callbacks (Hermes' ``tool_progress_callback``
+    surface) and for the post-hoc audit list returned alongside the
+    response so sessions can persist what cursor did.
+    """
+
+    __slots__ = (
+        "call_id", "envelope_key", "name", "args", "started_at",
+        "completed_at", "result_text", "is_error", "duration_ms",
+        "lines_added", "lines_removed", "diff_string",
+    )
+
+    def __init__(self, call_id: str, envelope_key: str, args: dict[str, Any]) -> None:
+        self.call_id = call_id
+        self.envelope_key = envelope_key
+        self.name = _normalize_cursor_tool_name(envelope_key)
+        self.args = args
+        self.started_at = time.monotonic()
+        self.completed_at: float | None = None
+        self.result_text: str = ""
+        self.is_error: bool = False
+        self.duration_ms: int = 0
+        # Edit/write result metadata. Cursor's stream-json provides
+        # ``linesAdded`` / ``linesRemoved`` / ``diffString`` on the
+        # completion event for edit and write operations. We surface
+        # the count in the activity feed ("+5 -2") and persist the
+        # diff for replays / audits.
+        self.lines_added: int | None = None
+        self.lines_removed: int | None = None
+        self.diff_string: str = ""
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.call_id,
+            "name": self.name,
+            "envelope": self.envelope_key,
+            "arguments": self.args,
+            "result": self.result_text,
+            "is_error": self.is_error,
+            "duration_ms": self.duration_ms,
+        }
+
+
+class _StreamJsonAccumulator:
+    """Accumulates state from a ``cursor-agent --output-format stream-json`` stream.
+
+    Caller feeds parsed JSON events with :meth:`feed`. When a terminal
+    ``result`` event arrives the accumulator stores the success/failure state
+    and surface text. The instance is reusable per-call but not thread-safe.
+    """
+
+    def __init__(self, on_tool_event: Any = None, on_text_event: Any = None) -> None:
+        self.text_parts: list[str] = []
+        self.reasoning_parts: list[str] = []
+        self.session_id: str = ""
+        self.request_id: str = ""
+        self.model_label: str = ""
+        self.duration_ms: int = 0
+        self.usage: dict[str, int] = {}
+        self.terminal: bool = False
+        self.is_error: bool = False
+        self.error_message: str = ""
+        self.final_result_text: str = ""
+        # Ordered transcript of (kind, payload) events as cursor emitted
+        # them — used to separate "narrative text between tools" from
+        # "final synthesis text" when we assemble the response. Without
+        # this, ``assembled_text()`` glues every intermediate text event
+        # to the end of the final answer and the user sees a wall of
+        # planning prose preceding the actual response.
+        self.event_log: list[tuple[str, Any]] = []
+        # ``on_tool_event(stage, event)`` — invoked synchronously from
+        # ``feed()`` when a ``tool_call`` event arrives.
+        self._on_tool_event = on_tool_event
+        # ``on_text_event(text)`` — invoked when cursor emits an
+        # intermediate ``assistant`` text block (cursor often prints a
+        # 1-2 sentence "let me check X next" between tool batches).
+        # Surfacing these live as narration events gives the Hermes UI
+        # the agentic feel of "tool → text → tool → text" that the user
+        # asked about; without it everything bundles into one final
+        # answer block.
+        self._on_text_event = on_text_event
+        self._tool_events: dict[str, _CursorToolEvent] = {}
+        self.tool_events: list[_CursorToolEvent] = []
+        # Optional caller-provided estimate of "current prompt size" in
+        # tokens, used to surface a stable number on the Hermes status
+        # bar. Set by ``_create_chat_completion`` before each call.
+        self.messages_estimate: int = 0
+        # We BUFFER intermediate text instead of dispatching it eagerly
+        # so the final text-after-last-tool only appears in the
+        # synthesis (assistant response) and not duplicated as a narrate
+        # event in the activity feed. Flush rule: when the next tool
+        # starts we now know the buffered text was "between tools" and
+        # safe to surface. If no more tools come, the buffer is dropped
+        # and only ``synthesis_text()`` shows it.
+        self._pending_text: list[str] = []
+
+    def feed(self, event: dict[str, Any]) -> None:
+        evt_type = event.get("type")
+        if not isinstance(evt_type, str):
+            return
+
+        if evt_type == "system":
+            model = event.get("model")
+            if isinstance(model, str):
+                self.model_label = model
+            session = event.get("session_id")
+            if isinstance(session, str):
+                self.session_id = session
+            return
+
+        if evt_type == "thinking":
+            text = event.get("text")
+            if isinstance(text, str) and text:
+                self.reasoning_parts.append(text)
+            return
+
+        if evt_type == "assistant":
+            message = event.get("message")
+            if isinstance(message, dict):
+                content = message.get("content")
+                if isinstance(content, list):
+                    for block in content:
+                        if not isinstance(block, dict):
+                            continue
+                        if block.get("type") == "text":
+                            text = block.get("text")
+                            if isinstance(text, str) and text:
+                                self.text_parts.append(text)
+                                self.event_log.append(("text", text))
+                                # Defer the narrate dispatch — see
+                                # ``_pending_text`` docstring above.
+                                self._pending_text.append(text)
+            return
+
+        if evt_type == "tool_call":
+            sub = event.get("subtype")
+            # Before recording a NEW tool start, flush any text we'd
+            # buffered: by definition that text was "between tools",
+            # so it's safe (and useful) to show as narration now.
+            if sub == "started" and self._pending_text:
+                for buffered in self._pending_text:
+                    self._dispatch_text_event(buffered)
+                self._pending_text.clear()
+            self._consume_tool_call_event(event)
+            # Note the tool event order so ``synthesis_text`` can pick
+            # the right "final" text. We append only on ``started`` to
+            # avoid double-counting; the per-tool event timeline is
+            # already preserved in ``self.tool_events``.
+            if sub == "started":
+                self.event_log.append(("tool", None))
+            return
+
+        if evt_type == "result":
+            self.terminal = True
+            self.is_error = bool(event.get("is_error", False))
+            subtype = event.get("subtype")
+            if subtype == "error":
+                self.is_error = True
+            duration = event.get("duration_ms")
+            if isinstance(duration, int):
+                self.duration_ms = duration
+            request = event.get("request_id")
+            if isinstance(request, str):
+                self.request_id = request
+            usage = event.get("usage")
+            if isinstance(usage, dict):
+                # Cursor emits camelCase keys.
+                normalized = {}
+                for k, v in usage.items():
+                    if isinstance(v, (int, float)):
+                        normalized[str(k)] = int(v)
+                self.usage = normalized
+            result_text = event.get("result")
+            if isinstance(result_text, str):
+                self.final_result_text = result_text
+                if not self.text_parts and not self.is_error:
+                    self.text_parts.append(result_text)
+            if self.is_error and not self.error_message:
+                self.error_message = result_text or "cursor-agent returned an error"
+            return
+
+        # Unknown / informational events (e.g. ``user`` echo) — ignore.
+
+    def _consume_tool_call_event(self, event: dict[str, Any]) -> None:
+        """Translate one cursor stream-json ``tool_call`` event.
+
+        cursor-agent emits one event with ``subtype="started"`` when the LLM
+        decides to use one of its built-in tools (shell, read, edit, ...),
+        and a follow-up with ``subtype="completed"`` carrying the result.
+        We rebuild a ``_CursorToolEvent`` from those, fire the optional
+        progress callback so Hermes' UI can show the activity in real time,
+        and stash the final list so the caller can surface "what cursor
+        actually did" in the response (e.g. for session audit).
+        """
+        subtype = event.get("subtype")
+        call_id = event.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            return
+        tool_call = event.get("tool_call")
+        if not isinstance(tool_call, dict) or not tool_call:
+            return
+        envelope_key = next(iter(tool_call.keys()), "")
+        payload = tool_call.get(envelope_key) if isinstance(envelope_key, str) else None
+        if not isinstance(payload, dict):
+            return
+        args_obj = payload.get("args")
+        if not isinstance(args_obj, dict):
+            args_obj = {}
+
+        if subtype == "started":
+            evt = _CursorToolEvent(
+                call_id=call_id,
+                envelope_key=envelope_key,
+                args=args_obj,
+            )
+            self._tool_events[call_id] = evt
+            self.tool_events.append(evt)
+            self._fire_tool_event("started", evt)
+            return
+
+        if subtype == "completed":
+            evt = self._tool_events.get(call_id)
+            if evt is None:
+                # Cursor sent a completed event we never saw started for —
+                # synthesise the started state so the audit list still has it.
+                evt = _CursorToolEvent(
+                    call_id=call_id,
+                    envelope_key=envelope_key,
+                    args=args_obj,
+                )
+                self._tool_events[call_id] = evt
+                self.tool_events.append(evt)
+                self._fire_tool_event("started", evt)
+            evt.completed_at = time.monotonic()
+            evt.duration_ms = int((evt.completed_at - evt.started_at) * 1000)
+            result = payload.get("result")
+            if isinstance(result, dict):
+                if "error" in result and result.get("error"):
+                    evt.is_error = True
+                # Pull diff stats off edit/write/patch completion events
+                # so the activity feed can show "+5 -2" next to the
+                # path. Cursor only emits these for file-modifying tools.
+                success = result.get("success") if isinstance(result, dict) else None
+                if isinstance(success, dict):
+                    la = success.get("linesAdded")
+                    lr = success.get("linesRemoved")
+                    ds = success.get("diffString")
+                    if isinstance(la, int):
+                        evt.lines_added = la
+                    if isinstance(lr, int):
+                        evt.lines_removed = lr
+                    if isinstance(ds, str):
+                        evt.diff_string = ds
+            evt.result_text = _summarise_cursor_tool_result(envelope_key, payload)
+            self._fire_tool_event("completed", evt)
+            return
+
+    def _fire_tool_event(self, stage: str, evt: _CursorToolEvent) -> None:
+        if self._on_tool_event is None:
+            return
+        try:
+            self._on_tool_event(stage, evt)
+        except Exception:
+            # A broken UI must never bring down the chat call.
+            pass
+
+    def _dispatch_text_event(self, text: str) -> None:
+        """Forward an intermediate assistant text event to the UI bridge.
+
+        Errors are swallowed — a broken callback must never abort the
+        chat call.
+        """
+        if self._on_text_event is None:
+            return
+        try:
+            self._on_text_event(text)
+        except Exception:
+            pass
+
+    def assembled_text(self) -> str:
+        return "".join(self.text_parts).strip()
+
+    def synthesis_text(self) -> str:
+        """Return only the synthesis portion of the response.
+
+        Cursor's stream interleaves planning prose ("Searching the
+        agent directory…") with tool calls, then ends with the actual
+        synthesised answer. Gluing every text event together leaves
+        the user staring at a wall of "I'll do X next" lines before
+        the real answer. This helper returns just the text emitted
+        AFTER the last tool call — that's the synthesis.
+
+        Falls back to the full ``assembled_text()`` when:
+          * no tools ran (every text is part of the answer);
+          * cursor emitted no text after the last tool (rare; we then
+            use the cursor-supplied ``result.result`` if it differs
+            from the bundled text, otherwise the full bundle so the
+            user sees *something*).
+        """
+        tool_seen = False
+        synth: list[str] = []
+        for kind, payload in self.event_log:
+            if kind == "tool":
+                tool_seen = True
+                synth.clear()  # drop earlier planning text
+            elif kind == "text":
+                synth.append(payload)
+        if synth:
+            return "".join(synth).strip()
+        # No text after the last tool. If cursor's ``result.result``
+        # carries something useful and distinct, use it; otherwise
+        # surface the full bundle so the user isn't left empty-handed.
+        if not tool_seen:
+            return self.assembled_text()
+        if self.final_result_text and self.final_result_text.strip():
+            return self.final_result_text.strip()
+        return self.assembled_text()
+
+    def narration_text(self) -> str:
+        """Return the planning / between-tool prose for transcript replay.
+
+        The live bridge already surfaces each piece individually via
+        ``on_text_event``. This helper is for tests / debug consumers
+        that want to inspect what was intermediate vs. final.
+        """
+        narration: list[str] = []
+        bucket: list[str] = []
+        for kind, payload in self.event_log:
+            if kind == "tool":
+                if bucket:
+                    narration.append("".join(bucket).strip())
+                bucket = []
+            elif kind == "text":
+                bucket.append(payload)
+        # The final ``bucket`` is the synthesis — drop it.
+        return "\n".join(n for n in narration if n)
+
+    def assembled_reasoning(self) -> str:
+        return "".join(self.reasoning_parts).strip()
+
+    def openai_usage(self) -> SimpleNamespace:
+        """Translate cursor-agent's per-turn usage into OpenAI-shaped fields.
+
+        Quirk worth knowing: cursor-agent's ``result.usage.inputTokens``
+        is the SUM of fresh (non-cached) input tokens across **every
+        internal LLM round-trip** in the turn. For an agentic turn that
+        runs N tool calls there are roughly N+1 internal model calls
+        (one per tool round plus the final text), and each call's input
+        grows as tool results accumulate. So inputTokens for a deep
+        multi-tool turn can easily reach 1M+ while the model's actual
+        context window (e.g. 200K on composer-2.5-fast) was never
+        exceeded — cursor reused the cache between calls.
+
+        Hermes' status bar and compressor use ``prompt_tokens`` as a
+        proxy for "what's currently in the model's context" (used to
+        drive compression decisions and the % bar). Reporting the raw
+        cumulative SUM blows the bar past 100% on agentic turns, which
+        is both visually wrong and triggers spurious compression.
+
+        Fix: divide the cumulative figures by the number of internal
+        rounds we observed (tool_events + 1) to produce an honest
+        per-round average that matches the model's actual context use.
+        The full billing total is still reported separately for cost
+        tracking via ``session_input_tokens``.
+        """
+        input_tokens_raw = int(self.usage.get("inputTokens", 0))
+        output_tokens = int(self.usage.get("outputTokens", 0))
+        cache_read_raw = int(self.usage.get("cacheReadTokens", 0))
+
+        rounds = max(len(self.tool_events) + 1, 1)
+        per_round_input = input_tokens_raw // rounds if rounds > 0 else input_tokens_raw
+        per_round_cache = cache_read_raw // rounds if rounds > 0 else cache_read_raw
+        approx_context_tokens = per_round_cache + per_round_input
+
+        # Hermes' messages-based estimate is the canonical "what's in
+        # the model's context right now" number (it matches what the
+        # next-turn prompt will look like). Prefer it for
+        # ``prompt_tokens`` so the status bar stays consistent before,
+        # during, and after generation. Fall back to the per-round
+        # average when no estimate is set (e.g. accumulator used outside
+        # the client, in unit tests).
+        if self.messages_estimate > 0:
+            prompt_tokens = self.messages_estimate
+        else:
+            prompt_tokens = approx_context_tokens
+
+        return SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=output_tokens,
+            total_tokens=prompt_tokens + output_tokens,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=per_round_cache),
+            # Preserve raw cursor-side totals for billing / cost tracking
+            # consumers that need the actual usage figures.
+            cursor_raw_input_tokens=input_tokens_raw,
+            cursor_raw_cache_read_tokens=cache_read_raw,
+            cursor_internal_rounds=rounds,
+            cursor_per_round_context=approx_context_tokens,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Inline OpenAI-style namespace shims (mirror copilot_acp_client style)
+# ---------------------------------------------------------------------------
+
+
+class _CursorChatCompletions:
+    def __init__(self, client: "CursorAgentClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        # ``cursor-agent`` exposes streaming via stream-json on its own stdout,
+        # but the synchronous ``_create_chat_completion`` already accumulates
+        # the full response.  If a caller passes ``stream=True`` we synthesise
+        # an OpenAI-style chunk iterator from the final response so the
+        # streaming hot path stays iterable.  Without this, iterating the
+        # ``SimpleNamespace`` we return surfaces as ``TypeError:
+        # 'types.SimpleNamespace' object is not iterable`` (Hermes' chat
+        # streaming loop did this).
+        stream_requested = bool(kwargs.pop("stream", False))
+        kwargs.pop("stream_options", None)  # OpenAI SDK extras — irrelevant
+        response = self._client._create_chat_completion(**kwargs)
+        if not stream_requested:
+            return response
+        return _synthesise_stream_chunks(response)
+
+
+class _CursorChatNamespace:
+    def __init__(self, client: "CursorAgentClient"):
+        self.completions = _CursorChatCompletions(client)
+
+
+def _synthesise_stream_chunks(response: Any):
+    """Yield OpenAI-style streaming chunks from a non-streaming response.
+
+    Hermes' chat streaming loop expects ``for chunk in stream:`` with each
+    chunk shaped like an OpenAI ``ChatCompletionChunk``: ``chunk.choices[0]
+    .delta.{content,tool_calls,reasoning,reasoning_content}`` and a final
+    chunk carrying ``usage``.  We can't truly stream from the underlying
+    subprocess at this layer, but we can split the assembled response into a
+    small number of chunks that the loop will accept without crashing.
+    """
+    try:
+        choice = response.choices[0]
+    except Exception:
+        return
+
+    message = getattr(choice, "message", None)
+    if message is None:
+        return
+
+    role = "assistant"
+    content = getattr(message, "content", "") or ""
+    tool_calls = getattr(message, "tool_calls", None) or []
+    reasoning = getattr(message, "reasoning", None)
+    reasoning_content = getattr(message, "reasoning_content", None)
+    finish_reason = getattr(choice, "finish_reason", "stop")
+    model = getattr(response, "model", "cursor")
+    usage = getattr(response, "usage", None)
+
+    if reasoning_content:
+        yield SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        role=role,
+                        content=None,
+                        tool_calls=None,
+                        reasoning=None,
+                        reasoning_content=reasoning_content,
+                    ),
+                    finish_reason=None,
+                    index=0,
+                )
+            ],
+            model=model,
+            usage=None,
+        )
+    elif reasoning:
+        yield SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        role=role,
+                        content=None,
+                        tool_calls=None,
+                        reasoning=reasoning,
+                        reasoning_content=None,
+                    ),
+                    finish_reason=None,
+                    index=0,
+                )
+            ],
+            model=model,
+            usage=None,
+        )
+
+    if content:
+        yield SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        role=role,
+                        content=content,
+                        tool_calls=None,
+                        reasoning=None,
+                        reasoning_content=None,
+                    ),
+                    finish_reason=None,
+                    index=0,
+                )
+            ],
+            model=model,
+            usage=None,
+        )
+
+    if tool_calls:
+        # Hermes expects streaming tool_calls to include a per-chunk index.
+        for i, tc in enumerate(tool_calls):
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            role=role,
+                            content=None,
+                            tool_calls=[
+                                SimpleNamespace(
+                                    index=i,
+                                    id=getattr(tc, "id", f"call_{i}"),
+                                    type="function",
+                                    function=SimpleNamespace(
+                                        name=getattr(tc.function, "name", ""),
+                                        arguments=getattr(tc.function, "arguments", ""),
+                                    ),
+                                )
+                            ],
+                            reasoning=None,
+                            reasoning_content=None,
+                        ),
+                        finish_reason=None,
+                        index=0,
+                    )
+                ],
+                model=model,
+                usage=None,
+            )
+
+    yield SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    role=None,
+                    content=None,
+                    tool_calls=None,
+                    reasoning=None,
+                    reasoning_content=None,
+                ),
+                finish_reason=finish_reason,
+                index=0,
+            )
+        ],
+        model=model,
+        usage=usage,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main client
+# ---------------------------------------------------------------------------
+
+
+class CursorAgentClient:
+    """Minimal OpenAI-client-compatible facade for the Cursor Agent CLI."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        workspace: str | None = None,
+        mode: str | None = None,
+        timeout_seconds: float | None = None,
+        tool_progress_callback: Any = None,
+        context_estimate_callback: Any = None,
+        **_: Any,
+    ):
+        candidate_key = (api_key or os.getenv("CURSOR_API_KEY", "") or "").strip()
+        # Treat sentinels ("", "cursor-agent-login", …) as "no key" so we don't
+        # forward them to ``cursor-agent --api-key`` (which rejects them and
+        # closes stdin, producing BrokenPipeError on our writes).
+        self.api_key = None if candidate_key in _API_KEY_SENTINELS else candidate_key
+        self.base_url = base_url or CURSOR_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._command = (command or _resolve_command()).strip() or DEFAULT_CURSOR_COMMAND
+        self._extra_args = list(args) if args else _resolve_extra_args()
+        chosen_mode = (mode or _resolve_mode()).strip().lower() or DEFAULT_CURSOR_MODE
+        if chosen_mode not in _VALID_CURSOR_MODES:
+            chosen_mode = DEFAULT_CURSOR_MODE
+        self._mode = chosen_mode
+        override = workspace or _resolve_workspace_override()
+        self._workspace: str | None = override or None  # None ⇒ tmpdir per call
+        # Idle timeout (resets per event). Env var > explicit arg > default.
+        self._timeout_seconds = float(timeout_seconds) if timeout_seconds else _DEFAULT_TIMEOUT_SECONDS
+        env_timeout = os.environ.get("HERMES_CURSOR_TIMEOUT_SECONDS", "").strip()
+        if env_timeout:
+            try:
+                env_timeout_val = float(env_timeout)
+                if env_timeout_val > 0:
+                    self._timeout_seconds = env_timeout_val
+            except ValueError:
+                pass
+
+        self._tool_progress_callback = tool_progress_callback
+        # Optional hook invoked with the rough messages-based token estimate
+        # *before* the subprocess spawns. Used by the host agent to bump
+        # the status-bar (``compressor.last_prompt_tokens``) so the input
+        # context is visible during long in-flight turns instead of the
+        # bar sitting at 0 until the result event arrives.
+        self._context_estimate_callback = context_estimate_callback
+
+        # High-water mark for the Hermes status bar. Held only WITHIN
+        # a single Hermes user turn: Hermes loops on tool_calls (cursor
+        # returning ``<tool_call>`` blocks for Hermes to run), making
+        # multiple cursor calls per user prompt. Each call's footprint
+        # can vary (different tools attached, different message slices),
+        # so the bar must not flicker between those internal calls.
+        # Reset automatically on every NEW user turn (detected by the
+        # user-message count growing in the messages list); previously
+        # this was a session-wide monotonic mark, which incorrectly
+        # froze the bar at the highest-activity turn's value and
+        # prevented it from reflecting the actual current input across
+        # subsequent prompts.
+        self._context_high_water: int = 0
+        # Last seen count of user messages in the prompt list. Used to
+        # detect new user turns so we can reset the high-water above.
+        self._last_user_msg_count: int = 0
+
+        self.chat = _CursorChatNamespace(self)
+        self.is_closed = False
+
+        self._active_process: subprocess.Popen[str] | None = None
+        self._active_process_lock = threading.Lock()
+        self._ephemeral_dirs: list[str] = []
+        self._dir_lock = threading.Lock()
+        # Session-scoped scratch workspace. Lazily minted on first call
+        # and REUSED across all subsequent calls in the same chat session
+        # so cursor-agent doesn't pay its ~4.5s "fresh-workspace bootstrap"
+        # tax on every turn. Cleaned up by ``close()`` along with any
+        # other ephemeral dirs.  When ``self._workspace`` (user override)
+        # is set we skip this entirely and honour the explicit path.
+        self._session_workspace: str | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        proc: subprocess.Popen[str] | None
+        with self._active_process_lock:
+            proc = self._active_process
+            self._active_process = None
+        self.is_closed = True
+        # New session starts fresh: drop the high-water floor so the
+        # status bar reflects current prompt size, not the residual
+        # of a previously-large conversation.
+        self._context_high_water = 0
+        if proc is not None:
+            try:
+                proc.terminate()
+                proc.wait(timeout=2)
+            except Exception:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+        with self._dir_lock:
+            dirs, self._ephemeral_dirs = self._ephemeral_dirs, []
+            # Drop the cached session workspace ref; if this client is
+            # ever re-used after close() (shouldn't happen, but defensive)
+            # the next call will lazy-init a fresh dir.
+            self._session_workspace = None
+        for d in dirs:
+            try:
+                shutil.rmtree(d, ignore_errors=True)
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # OpenAI-compat surface
+    # ------------------------------------------------------------------
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        **_: Any,
+    ) -> Any:
+        # Estimate context size from what Hermes is actually sending —
+        # this is the authoritative answer for the status bar and the
+        # compressor. Cursor's reported ``inputTokens`` is the SUM
+        # across internal tool round-trips and undercounts the snapshot
+        # at end of turn (after averaging) while overcounting at end of
+        # turn (raw); neither matches what's in the next-turn prompt.
+        # Estimating from messages keeps the bar consistent before,
+        # during, and after the call (#cursor-bar-stable).
+        # Detect a NEW user turn: Hermes adds a user message at the top
+        # of every fresh prompt cycle, then loops internally on tool_calls
+        # without adding more user messages. So a strictly increased user-
+        # message count is the signal that this is a new prompt and the
+        # high-water mark from the previous turn no longer applies.
+        try:
+            user_msg_count = sum(
+                1 for m in (messages or []) if (m or {}).get("role") == "user"
+            )
+        except Exception:
+            user_msg_count = self._last_user_msg_count
+        is_new_user_turn = user_msg_count > self._last_user_msg_count
+        if is_new_user_turn:
+            # Drop the floor so the bar can reflect this turn's actual
+            # input size (which may legitimately be smaller than a prior
+            # heavy-tool-use turn's per-round average).
+            self._context_high_water = 0
+        self._last_user_msg_count = user_msg_count
+
+        try:
+            from agent.model_metadata import estimate_request_tokens_rough
+            self._last_messages_estimate = estimate_request_tokens_rough(
+                messages or [], tools=tools or None
+            )
+        except Exception:
+            self._last_messages_estimate = 0
+
+        # Bump the high-water mark NOW (before subprocess spawn) so the
+        # status bar reflects input context immediately. Without this the
+        # bar shows 0/200K throughout a long in-flight FIRST turn because
+        # the compressor only learns about prompt_tokens from the final
+        # response.
+        if self._last_messages_estimate > self._context_high_water:
+            self._context_high_water = self._last_messages_estimate
+        if callable(self._context_estimate_callback) and self._last_messages_estimate > 0:
+            # On a new user turn, signal the host so it can reset its
+            # compressor bar to this turn's estimate (allowing the bar
+            # to DROP if appropriate). Otherwise the callback should
+            # bump monotonically so the in-loop cursor calls don't
+            # flicker the bar down between iterations.
+            try:
+                self._context_estimate_callback(
+                    self._last_messages_estimate, reset=is_new_user_turn
+                )
+            except TypeError:
+                # Backward-compat: older callbacks without ``reset`` kwarg.
+                try:
+                    self._context_estimate_callback(self._last_messages_estimate)
+                except Exception:
+                    pass
+            except Exception:
+                # Never let a UI hook break the actual request.
+                pass
+
+        prompt_text = _format_messages_as_prompt(
+            messages or [],
+            model=model,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+
+        if timeout is None:
+            effective_timeout = self._timeout_seconds
+        elif isinstance(timeout, (int, float)):
+            effective_timeout = float(timeout)
+        else:
+            candidates = [
+                getattr(timeout, attr, None)
+                for attr in ("read", "write", "connect", "pool", "timeout")
+            ]
+            numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+            effective_timeout = max(numeric) if numeric else self._timeout_seconds
+
+        chosen_model = (model or DEFAULT_CURSOR_MODEL).strip() or DEFAULT_CURSOR_MODEL
+
+        accumulator = self._run_prompt(
+            prompt_text=prompt_text,
+            model=chosen_model,
+            timeout_seconds=effective_timeout,
+        )
+
+        # Use the synthesis text (post-last-tool) so the user gets the
+        # actual answer without the wall of "let me check X next" prose
+        # that cursor's model emits between tool batches. The
+        # intermediate prose was already surfaced live via the text-
+        # event bridge.
+        assistant_text = accumulator.synthesis_text()
+        reasoning_text = accumulator.assembled_reasoning() or None
+
+        if accumulator.is_error:
+            raise RuntimeError(
+                f"cursor-agent reported an error: {accumulator.error_message or assistant_text}"
+            )
+
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(assistant_text)
+
+        cursor_internal_tools = [evt.to_public_dict() for evt in accumulator.tool_events]
+        # Hand cursor's accumulator our messages-based estimate so
+        # ``openai_usage`` can use it as the canonical ``prompt_tokens``
+        # the status bar reads from. Without this the bar shows
+        # different numbers during vs after generation (cursor's
+        # per-round average vs Hermes' messages estimate, ~3x apart).
+        #
+        # We also gate the estimate by the running high-water mark so
+        # the bar never visibly DROPS within a chat session — a wobble
+        # we saw when Hermes loops over multiple cursor calls per user
+        # turn (each call has a different tools/messages footprint).
+        cur_estimate = getattr(self, "_last_messages_estimate", 0) or 0
+        # ``openai_usage`` may also use cursor's per-round average; mix
+        # it in so the high-water never undercounts when our estimate
+        # is too low (e.g. tools=[] on a follow-up call).
+        cursor_per_round = self._estimate_per_round_context(accumulator)
+        new_high = max(self._context_high_water, cur_estimate, cursor_per_round)
+        self._context_high_water = new_high
+        accumulator.messages_estimate = new_high
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=reasoning_text,
+            reasoning_content=reasoning_text,
+            reasoning_details=None,
+            # Audit log of cursor-agent's *internal* tool calls (shell/read/
+            # edit/etc. that cursor's harness ran by itself). Hermes' UI is
+            # already shown them in real time via tool_progress_callback;
+            # this field lets sessions persist what happened.
+            cursor_internal_tools=cursor_internal_tools,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        choice = SimpleNamespace(
+            message=assistant_message,
+            finish_reason=finish_reason,
+            index=0,
+        )
+        return SimpleNamespace(
+            choices=[choice],
+            usage=accumulator.openai_usage(),
+            model=chosen_model,
+            id=accumulator.request_id or f"cursor-{accumulator.session_id}",
+            object="chat.completion",
+            cursor_internal_tools=cursor_internal_tools,
+        )
+
+    # ------------------------------------------------------------------
+    # Subprocess plumbing
+    # ------------------------------------------------------------------
+
+    def _build_argv(self, *, model: str, workspace: str) -> list[str]:
+        argv = [
+            self._command,
+            "-p",
+            "--output-format",
+            "stream-json",
+        ]
+        # Only forward ``--mode`` to the CLI for values it knows about.
+        # The synthetic ``agent`` value means "use cursor's default
+        # permissionMode" — achieved by omitting the flag entirely.
+        if self._mode in _CURSOR_CLI_MODES:
+            argv.extend(["--mode", self._mode])
+        argv.extend(
+            [
+                "--model",
+                model,
+                "--workspace",
+                workspace,
+                "--force",
+                "--trust",
+            ]
+        )
+        if self.api_key:
+            argv.extend(["--api-key", self.api_key])
+        argv.extend(self._extra_args)
+        return argv
+
+    def _preflight_cli_auth(self) -> None:
+        """Fail early when CLI-login mode has expired.
+
+        API-key mode is long-lived and bypasses ``cursor-agent status``. CLI
+        login mode is convenient for interactive use but can expire, and an
+        expired session otherwise surfaces later as a noisy BrokenPipe/stdin
+        failure after spawning ``cursor-agent -p``.
+        """
+        if self.api_key:
+            return
+        try:
+            out = subprocess.check_output(
+                [self._command, "status"],
+                text=True,
+                timeout=10,
+                env=_build_subprocess_env(None),
+                stderr=subprocess.STDOUT,
+            )
+        except FileNotFoundError:
+            # Preserve the existing missing-CLI error from the actual Popen
+            # path so users get the install guidance already tested there.
+            return
+        except subprocess.CalledProcessError as exc:
+            detail = ""
+            if isinstance(exc.output, str):
+                detail = exc.output
+            stderr = getattr(exc, "stderr", None)
+            if isinstance(stderr, str) and stderr.strip():
+                detail = f"{detail}\n{stderr}" if detail else stderr
+            raise _cursor_cli_auth_error(self._command, detail) from exc
+        except Exception as exc:
+            raise _cursor_cli_auth_error(self._command, str(exc)) from exc
+        if "Logged in as" not in out and "logged in" not in out.lower():
+            raise _cursor_cli_auth_error(self._command, out)
+
+    def _allocate_workspace(self) -> tuple[str, bool]:
+        """Return ``(workspace, ephemeral)``.
+
+        Strategy:
+        1. If the caller pinned an explicit ``workspace`` (env var or kwarg),
+           always honour it.
+        2. Otherwise, lazily mint ONE temp dir for the whole client session
+           and reuse it across calls. Per-turn fresh dirs cost cursor-agent
+           ~4.5s of bootstrap overhead each invocation (measured), and there's
+           no isolation benefit between turns of the SAME chat session
+           anyway — they're already operating on behalf of the same user.
+
+        The session workspace is tracked in ``_ephemeral_dirs`` so
+        ``close()`` cleans it up just like the legacy per-call dirs.
+        """
+        if self._workspace:
+            try:
+                Path(self._workspace).mkdir(parents=True, exist_ok=True)
+            except Exception:
+                pass
+            return self._workspace, False
+        with self._dir_lock:
+            if self._session_workspace is None:
+                tmp = tempfile.mkdtemp(prefix="hermes-cursor-")
+                self._session_workspace = tmp
+                self._ephemeral_dirs.append(tmp)
+            return self._session_workspace, True
+
+    def _run_prompt(
+        self,
+        *,
+        prompt_text: str,
+        model: str,
+        timeout_seconds: float,
+    ) -> _StreamJsonAccumulator:
+        self._preflight_cli_auth()
+        workspace, _ephemeral = self._allocate_workspace()
+        argv = self._build_argv(model=model, workspace=workspace)
+
+        try:
+            proc = subprocess.Popen(
+                argv,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                cwd=workspace,
+                env=_build_subprocess_env(self.api_key),
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start Cursor Agent CLI '{self._command}'. "
+                "Install Cursor CLI (https://cursor.com/dashboard/integrations) "
+                "or set HERMES_CURSOR_COMMAND / CURSOR_AGENT_PATH."
+            ) from exc
+
+        if proc.stdin is None or proc.stdout is None:
+            proc.kill()
+            raise RuntimeError("cursor-agent process did not expose stdin/stdout pipes.")
+
+        self.is_closed = False
+        with self._active_process_lock:
+            self._active_process = proc
+
+        try:
+            # Drain stderr concurrently while we feed stdin so a fast-exiting
+            # cursor-agent (e.g. on bad auth) can't deadlock or hide its
+            # diagnostic message behind our pipe write.
+            stderr_tail: deque[str] = deque(maxlen=80)
+            inbox: queue.Queue[dict[str, Any]] = queue.Queue()
+
+            def _stderr_reader_early() -> None:
+                if proc.stderr is None:
+                    return
+                for line in proc.stderr:
+                    stderr_tail.append(line.rstrip("\n"))
+
+            err_thread = threading.Thread(target=_stderr_reader_early, daemon=True)
+            err_thread.start()
+
+            stdin_error: BaseException | None = None
+            try:
+                proc.stdin.write(prompt_text)
+                proc.stdin.flush()
+            except BrokenPipeError as exc:
+                # cursor-agent closed stdin before consuming the prompt — almost
+                # always means it rejected auth (e.g. invalid API key) or
+                # bailed on a flag.  Capture the cause; we'll raise after we
+                # have stderr context.
+                stdin_error = exc
+            except Exception as exc:  # pragma: no cover - defensive
+                stdin_error = exc
+            finally:
+                try:
+                    proc.stdin.close()
+                except Exception:
+                    pass
+
+            if stdin_error is not None:
+                # Give the child a moment to flush its error message, then bail.
+                try:
+                    proc.wait(timeout=3)
+                except Exception:
+                    pass
+                err_thread.join(timeout=1)
+                exit_code = getattr(proc, "returncode", None)
+                if exit_code is None:
+                    try:
+                        exit_code = proc.poll()
+                    except Exception:
+                        exit_code = None
+                stderr_text = "\n".join(stderr_tail).strip()
+                redacted = redact_sensitive_text(stderr_text, force=True) if stderr_text else ""
+                detail = f" stderr: {redacted}" if redacted else ""
+                raise RuntimeError(
+                    "cursor-agent closed stdin before reading the prompt "
+                    f"(exit {exit_code}).{detail}"
+                ) from stdin_error
+
+            def _stdout_reader() -> None:
+                if proc.stdout is None:
+                    return
+                for line in proc.stdout:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        inbox.put(json.loads(line))
+                    except Exception:
+                        # Cursor sometimes prints non-JSON warnings before/after
+                        # the JSON stream — preserve them in stderr_tail-like
+                        # form so timeouts can surface useful diagnostics.
+                        stderr_tail.append("[stdout-non-json] " + line)
+
+            out_thread = threading.Thread(target=_stdout_reader, daemon=True)
+            out_thread.start()
+            # err_thread is already running from the pre-stdin-write block above.
+
+            accumulator = _StreamJsonAccumulator(
+                on_tool_event=self._build_tool_event_bridge(),
+                on_text_event=self._build_text_event_bridge(),
+            )
+            # Idle deadline, not wall-clock. Resets on every successful
+            # stream-json event. A turn can run arbitrarily long in total
+            # wall time provided the subprocess keeps emitting events
+            # (text deltas, tool_calls, tool_results). Only true hangs
+            # (no events for ``timeout_seconds``) trigger termination.
+            idle_seconds = float(timeout_seconds)
+            deadline = time.monotonic() + idle_seconds
+
+            while not accumulator.terminal:
+                if time.monotonic() >= deadline:
+                    self._terminate_active_proc(proc)
+                    raise TimeoutError(
+                        f"cursor-agent emitted no events for {idle_seconds:.0f}s; "
+                        f"presumed hung. Set HERMES_CURSOR_TIMEOUT_SECONDS to "
+                        f"increase the idle threshold."
+                    )
+                if proc.poll() is not None and inbox.empty():
+                    break
+                try:
+                    event = inbox.get(timeout=0.25)
+                except queue.Empty:
+                    continue
+                # Successful event arrival => subprocess is alive and
+                # making progress. Reset the idle deadline.
+                deadline = time.monotonic() + idle_seconds
+                try:
+                    accumulator.feed(event)
+                except Exception:
+                    # Don't let a malformed event abort the entire request.
+                    # Keep draining; if the terminal result never comes,
+                    # the idle deadline above will surface the failure.
+                    continue
+
+            if not accumulator.terminal:
+                stderr_text = "\n".join(stderr_tail).strip()
+                redacted = redact_sensitive_text(stderr_text, force=True) if stderr_text else ""
+                raise RuntimeError(
+                    "cursor-agent exited before emitting a terminal result. "
+                    + (f"stderr tail:\n{redacted}" if redacted else "(no stderr)")
+                )
+
+            return accumulator
+        finally:
+            self._terminate_active_proc(proc)
+
+    def _estimate_per_round_context(self, accumulator: "_StreamJsonAccumulator") -> int:
+        """Compute cursor's per-round context estimate without mutating it.
+
+        Mirrors the math in :meth:`_StreamJsonAccumulator.openai_usage`
+        but returns just the per-round figure so we can feed it into
+        the high-water mark before swapping in the messages estimate.
+        """
+        input_tokens_raw = int(accumulator.usage.get("inputTokens", 0))
+        cache_read_raw = int(accumulator.usage.get("cacheReadTokens", 0))
+        rounds = max(len(accumulator.tool_events) + 1, 1)
+        per_round_input = input_tokens_raw // rounds if rounds > 0 else input_tokens_raw
+        per_round_cache = cache_read_raw // rounds if rounds > 0 else cache_read_raw
+        return per_round_cache + per_round_input
+
+    def reset_context_baseline(self) -> None:
+        """Reset the bar's monotonic floor (e.g. on ``/new`` or compress).
+
+        Hermes' chat session calls ``close()`` on the client when
+        starting a fresh session; clients spawned with ``shared=True``
+        outlive that. This is the explicit hook for any caller that
+        wants the bar to drop back to current-prompt size after a
+        deliberate context wipe.
+        """
+        self._context_high_water = 0
+
+    def _build_text_event_bridge(self) -> Any:
+        """Adapter for cursor's intermediate ``assistant`` text events.
+
+        Cursor emits "planning text" between tool batches (e.g.
+        "Searching the agent directory…" → tools → "Reading each
+        matching file…" → tools → final synthesis). We surface each
+        intermediate piece as a synthetic ``narrate`` tool-progress
+        event so the Hermes activity feed shows the agentic chain
+        live, interleaved with the real tool events — instead of
+        bundling everything into one wall of text at the end.
+
+        The synthesis text (the final one after the last tool) is
+        excluded so it doesn't double-up with the response body.
+        """
+        cb = self._tool_progress_callback
+        if cb is None:
+            return None
+
+        def _bridge(text: str) -> None:
+            try:
+                preview = text.strip().splitlines()[0] if text else ""
+                if len(preview) > 240:
+                    preview = preview[:237] + "..."
+                if not preview:
+                    return
+                cb("tool.started", "narrate", preview, {"text": text})
+                cb(
+                    "tool.completed", "narrate", None, None,
+                    duration=0.0, is_error=False, result=text,
+                )
+            except Exception:
+                pass
+
+        return _bridge
+
+    def _build_tool_event_bridge(self) -> Any:
+        """Adapter from our ``_CursorToolEvent`` stream to Hermes' callback.
+
+        ``tool_progress_callback(event_type, name, preview, args, ...)`` is
+        the same shape Hermes' built-in tools use (see
+        ``agent/tool_executor.py``). We translate cursor's "tool_call
+        started/completed" stream-json events into ``tool.started`` /
+        ``tool.completed`` callbacks so the user's UI shows cursor's
+        internal shell/read/edit activity the same way it shows native
+        tool calls from Grok, GPT, Claude, etc.
+
+        Without this bridge, cursor's tool activity is invisible to Hermes
+        — the user only sees the model's final text and the session's
+        ``tool_call_count`` stays at zero even when cursor actually ran
+        multiple shell/read commands internally.
+        """
+        cb = self._tool_progress_callback
+        if cb is None:
+            return None
+
+        def _bridge(stage: str, evt: _CursorToolEvent) -> None:
+            try:
+                if stage == "started":
+                    preview = _build_cursor_tool_preview(evt)
+                    cb("tool.started", evt.name, preview, evt.args)
+                elif stage == "completed":
+                    # cli.py stores ``function_args`` from tool.started in a
+                    # FIFO queue and pops them on tool.completed for display.
+                    # ``evt.args`` is the SAME dict reference, so mutating it
+                    # here surfaces our diff stats to ``get_cute_tool_message``
+                    # without changing the upstream callback signature.
+                    if (
+                        evt.lines_added is not None
+                        or evt.lines_removed is not None
+                    ) and isinstance(evt.args, dict):
+                        evt.args["_diff_stats"] = {
+                            "added": evt.lines_added or 0,
+                            "removed": evt.lines_removed or 0,
+                        }
+                        if evt.diff_string:
+                            evt.args["_diff_string"] = evt.diff_string
+                    cb(
+                        "tool.completed",
+                        evt.name,
+                        None,
+                        None,
+                        duration=evt.duration_ms / 1000.0,
+                        is_error=evt.is_error,
+                        result=evt.result_text,
+                    )
+            except Exception:
+                # The Hermes callback may not accept all our kwargs (e.g.
+                # older Hermes builds). Fall back to the simplest form.
+                try:
+                    cb(f"tool.{stage}", evt.name, evt.result_text or "", evt.args)
+                except Exception:
+                    pass
+
+        return _bridge
+
+    def _terminate_active_proc(self, proc: subprocess.Popen[str]) -> None:
+        with self._active_process_lock:
+            current = self._active_process
+            if current is proc:
+                self._active_process = None
+        if proc.poll() is not None:
+            return
+        # cursor-agent exits naturally a few hundred ms after emitting the
+        # ``result`` event. Give it that grace period BEFORE force-killing —
+        # SIGTERM forces Node.js to run shutdown hooks which can take
+        # longer than just letting it exit on its own.
+        try:
+            proc.wait(timeout=0.7)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        # Still running — force it.
+        try:
+            proc.terminate()
+            proc.wait(timeout=1.5)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+
+    def whoami(self) -> dict[str, Any]:
+        """Return a dict of ``cursor-agent status`` info (best-effort).
+
+        Used by the doctor / setup flow to surface logged-in user + tier.
+        Returns an empty dict if the CLI is missing or not authenticated.
+        """
+        try:
+            out = subprocess.check_output(
+                [self._command, "status"],
+                text=True,
+                timeout=10,
+                env=_build_subprocess_env(self.api_key),
+            )
+        except Exception:
+            return {}
+        info: dict[str, Any] = {"raw": out.strip()}
+        for line in out.splitlines():
+            line = line.strip()
+            if line.startswith("✓ Logged in as "):
+                info["email"] = line.removeprefix("✓ Logged in as ").strip()
+                info["authenticated"] = True
+        return info
+
+
+__all__ = [
+    "CursorAgentClient",
+    "CURSOR_MARKER_BASE_URL",
+    "DEFAULT_CURSOR_COMMAND",
+    "DEFAULT_CURSOR_MODE",
+    "DEFAULT_CURSOR_MODEL",
+]

--- a/agent/display.py
+++ b/agent/display.py
@@ -229,6 +229,20 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
         preview = _oneline(str(goal))
         return _truncate_preview(preview, max_len) if preview else None
 
+    if tool_name in {"edit_file", "delete_file", "cursor_edit"}:
+        for key_name in (
+            "path", "target_file", "targetFile", "file_path",
+            "relative_workspace_path", "file", "filePath", "filename",
+        ):
+            if key_name in args and args.get(key_name):
+                preview = _oneline(str(args.get(key_name)))
+                stats = args.get("_diff_stats")
+                if isinstance(stats, dict):
+                    added = int(stats.get("added") or 0)
+                    removed = int(stats.get("removed") or 0)
+                    preview = f"{preview} +{added} -{removed}"
+                return _truncate_preview(preview, max_len) if preview else None
+
     if tool_name == "process":
         action = args.get("action", "")
         sid = args.get("session_id", "")
@@ -442,6 +456,11 @@ def extract_edit_diff(
     snapshot: LocalEditSnapshot | None = None,
 ) -> str | None:
     """Extract a unified diff from a file-edit tool result."""
+    if function_args:
+        diff = function_args.get("_diff_string")
+        if isinstance(diff, str) and diff.strip():
+            return diff
+
     if tool_name == "patch" and result:
         data = safe_json_loads(result)
         if isinstance(data, dict):
@@ -954,6 +973,9 @@ def get_cute_tool_message(
         return _wrap(f"┊ 📖 read      {_path(args.get('path', ''))}  {dur}")
     if tool_name == "write_file":
         return _wrap(f"┊ ✍️  write     {_path(args.get('path', ''))}  {dur}")
+    if tool_name == "edit_file":
+        preview = build_tool_preview(tool_name, args, max_len=35) or ""
+        return _wrap(f"┊ ✏️  edit      {_trunc(preview, 35)}  {dur}")
     if tool_name == "patch":
         return _wrap(f"┊ 🔧 patch     {_path(args.get('path', ''))}  {dur}")
     if tool_name == "search_files":

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -226,6 +226,13 @@ DEFAULT_CONTEXT_LENGTHS = {
     "gpt-5": 400000,                  # GPT-5.x base, mini, codex variants (400k)
     "gpt-4.1": 1047576,
     "gpt-4": 128000,
+    # Cursor Composer — Cursor caps the usable window at 200K even when the
+    # underlying base model supports more.
+    "composer-2.5-fast": 200000,
+    "composer-2.5": 200000,
+    "composer-2-fast": 200000,
+    "composer-2": 200000,
+    "composer": 200000,
     # Google
     "gemini": 1048576,
     # Gemma (open models served via AI Studio)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -46,6 +46,7 @@ import httpx
 from hermes_cli.config import get_hermes_home, get_config_path, read_raw_config
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
+from providers.cursor_utils import resolve_cursor_command, resolve_cursor_command_path, resolve_cursor_extra_args
 from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -91,6 +92,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_CURSOR_AGENT_BASE_URL = "cursor://agent"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -234,6 +236,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "cursor": ProviderConfig(
+        id="cursor",
+        name="Cursor",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_CURSOR_AGENT_BASE_URL,
+        base_url_env_var="HERMES_CURSOR_BASE_URL",
+        api_key_env_vars=("CURSOR_API_KEY",),
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -1528,6 +1538,8 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        "cursor-agent": "cursor", "cursor-cli": "cursor",
+        "cursor-sub": "cursor", "cursor-subscription": "cursor", "anysphere": "cursor",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth", "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli", "gemini-oauth": "google-gemini-cli",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
@@ -6150,6 +6162,53 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
+    if provider_id == "cursor":
+        command = resolve_cursor_command()
+        args = resolve_cursor_extra_args()
+        base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+        if not base_url:
+            base_url = pconfig.inference_base_url
+        resolved_command = resolve_cursor_command_path(command)
+
+        # Probe cursor-agent for the logged-in identity. Best-effort; an
+        # error here just means the user needs to run `cursor-agent login`.
+        logged_in_email = ""
+        logged_in = False
+        if resolved_command:
+            try:
+                import subprocess as _sp
+
+                out = _sp.check_output(
+                    [resolved_command, *args, "status"],
+                    text=True,
+                    timeout=4,
+                ).strip()
+                for line in out.splitlines():
+                    line = line.strip()
+                    if line.startswith("✓ Logged in as "):
+                        logged_in_email = line.removeprefix("✓ Logged in as ").strip()
+                        logged_in = True
+                        break
+            except Exception:
+                pass
+
+        # CURSOR_API_KEY bypasses the login probe — if the user has set a
+        # raw token they are effectively authenticated.
+        if not logged_in and os.getenv("CURSOR_API_KEY", "").strip():
+            logged_in = True
+
+        return {
+            "configured": bool(resolved_command),
+            "provider": provider_id,
+            "name": pconfig.name,
+            "command": command,
+            "args": args,
+            "resolved_command": resolved_command,
+            "base_url": base_url,
+            "logged_in": logged_in,
+            "email": logged_in_email,
+        }
+
     command = (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
         or os.getenv("COPILOT_CLI_PATH", "").strip()
@@ -6193,7 +6252,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_gemini_oauth_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    if target in ("copilot-acp", "cursor"):
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -6346,6 +6405,31 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
+
+    if provider_id == "cursor":
+        command = resolve_cursor_command()
+        args = resolve_cursor_extra_args()
+        resolved_command = resolve_cursor_command_path(command)
+        if not resolved_command:
+            raise AuthError(
+                f"Could not find the Cursor Agent CLI command '{command}'. "
+                "Install Cursor CLI (https://cursor.com/cli) or set "
+                "HERMES_CURSOR_COMMAND / CURSOR_AGENT_PATH.",
+                provider=provider_id,
+                code="missing_cursor_cli",
+            )
+        api_key = os.getenv("CURSOR_API_KEY", "").strip()
+        return {
+            "provider": provider_id,
+            # Empty api_key here means "let cursor-agent use the IDE login";
+            # the value flows through to CursorAgentClient which only adds
+            # --api-key when truthy.
+            "api_key": api_key or "cursor-agent-login",
+            "base_url": base_url.rstrip("/"),
+            "command": resolved_command,
+            "args": args,
+            "source": "process",
+        }
 
     command = (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -608,6 +608,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_cursor,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock_api_key,
@@ -3015,6 +3016,8 @@ def select_provider_and_model(args=None):
         _model_flow_google_gemini_cli(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "cursor":
+        _model_flow_cursor(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1807,6 +1807,111 @@ def _model_flow_copilot_acp(config, current_model=""):
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
 
+
+def _model_flow_cursor(config, current_model=""):
+    """Cursor provider flow via the ``cursor-agent`` CLI."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS, provider_model_ids
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "cursor"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = (
+        status.get("resolved_command") or status.get("command") or "cursor-agent"
+    )
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+    logged_in = status.get("logged_in", False)
+    logged_in_email = status.get("email", "")
+
+    print("  Cursor routes Hermes turns through the `cursor-agent` CLI.")
+    print(
+        "  Auth uses your Cursor subscription — run `cursor-agent login` "
+        "or set CURSOR_API_KEY."
+    )
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    if logged_in:
+        if logged_in_email:
+            print(f"  Logged in: {logged_in_email}")
+        else:
+            print("  Logged in (CURSOR_API_KEY)")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print("  Install Cursor CLI: curl -fsSL https://cursor.com/install | bash")
+        print("  Then run: cursor-agent login")
+        return
+
+    if not logged_in:
+        print("  ⚠ Not logged into Cursor.")
+        print("  Run: cursor-agent login")
+        print("  Or set CURSOR_API_KEY in ~/.hermes/.env")
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+
+    model_list = provider_model_ids(provider_id)
+    if model_list:
+        print(f"  Found {len(model_list)} model(s) from cursor-agent")
+    else:
+        model_list = _PROVIDER_MODELS.get(provider_id, [])
+        if model_list:
+            print(
+                "  ⚠ Could not auto-detect models from cursor-agent — showing defaults."
+            )
+            print('    Use "Enter custom model name" if you do not see your model.')
+
+    normalized_current = (
+        current_model if current_model and current_model != "(not set)" else ""
+    )
+
+    if model_list:
+        selected = _prompt_model_selection(
+            model_list,
+            current_model=normalized_current,
+            confirm_provider=provider_id,
+            confirm_base_url=effective_base,
+        )
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -241,6 +241,27 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "cursor": [
+        "auto",
+        "composer-2.5",
+        "composer-2.5-fast",
+        "composer-2",
+        "composer-2-fast",
+        "gpt-5.5-medium",
+        "gpt-5.5-medium-fast",
+        "gpt-5.5-high",
+        "gpt-5.5-high-fast",
+        "gpt-5.5-low",
+        "gpt-5.5-low-fast",
+        "claude-opus-4-7-medium",
+        "claude-opus-4-7-high",
+        "claude-4.6-sonnet-medium",
+        "claude-4.6-sonnet-medium-thinking",
+        "gemini-3.1-pro",
+        "gemini-3-flash",
+        "grok-4.3",
+        "kimi-k2.5",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -1026,6 +1047,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("cursor",         "Cursor",                   "Cursor (100+ models, subscription)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (Code Assist OAuth flow)"),
@@ -1187,6 +1209,11 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "cursor-agent": "cursor",
+    "cursor-cli": "cursor",
+    "cursor-sub": "cursor",
+    "cursor-subscription": "cursor",
+    "anysphere": "cursor",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
@@ -2231,6 +2258,24 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             pass
         if normalized == "copilot-acp":
             return list(_PROVIDER_MODELS.get("copilot", []))
+    if normalized == "cursor":
+        # Live catalog: shell out via the Cursor provider profile so command
+        # overrides, wrapper args, and important-model ordering stay identical
+        # between the picker and plugin discovery path.
+        try:
+            from providers import get_provider_profile
+            from providers.cursor_utils import prioritize_cursor_models
+
+            profile = get_provider_profile("cursor")
+            if profile:
+                live = profile.fetch_models()
+                if live:
+                    return live
+            static = list(_PROVIDER_MODELS.get("cursor", []))
+            if static:
+                return prioritize_cursor_models(static)
+        except Exception:
+            pass
     if normalized == "nous":
         # Try live Nous Portal /models endpoint
         try:
@@ -2414,6 +2459,13 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         pass
 
     curated_static = list(_PROVIDER_MODELS.get(normalized, []))
+    if normalized == "cursor":
+        try:
+            from providers.cursor_utils import prioritize_cursor_models
+
+            return prioritize_cursor_models(curated_static)
+        except Exception:
+            return curated_static
     if normalized in _MODELS_DEV_PREFERRED:
         return _merge_with_models_dev(normalized, curated_static)
     return curated_static

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "cursor": HermesOverlay(
+        transport="openai_chat",
+        auth_type="external_process",
+        extra_env_vars=("CURSOR_API_KEY",),
+        base_url_override="cursor://agent",
+        base_url_env_var="HERMES_CURSOR_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -285,6 +292,13 @@ ALIASES: Dict[str, str] = {
     "github": "github-copilot",
     "github-copilot-acp": "copilot-acp",
 
+    # cursor-agent CLI
+    "cursor-agent": "cursor",
+    "cursor-cli": "cursor",
+    "cursor-sub": "cursor",
+    "cursor-subscription": "cursor",
+    "anysphere": "cursor",
+
     # opencode (models.dev ID for OpenCode Zen)
     "opencode-zen": "opencode",
     "zen": "opencode",
@@ -368,6 +382,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "cursor": "Cursor",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1647,6 +1647,35 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    if provider == "cursor":
+        creds = resolve_external_process_provider_credentials(provider)
+        api_key = creds.get("api_key", "cursor-agent-login")
+        command = creds.get("command", "")
+        args = list(creds.get("args") or [])
+        trace = {
+            "provider": "cursor",
+            "route": "cursor-agent",
+            "auth_source": "CURSOR_API_KEY" if api_key != "cursor-agent-login" else "cursor-agent-login",
+            "config_source": "HERMES_CURSOR_COMMAND"
+            if os.environ.get("HERMES_CURSOR_COMMAND", "").strip()
+            else ("CURSOR_AGENT_PATH" if os.environ.get("CURSOR_AGENT_PATH", "").strip() else "PATH"),
+            "command": command,
+            "args": args,
+            "base_url": creds.get("base_url", "").rstrip("/"),
+            "source": creds.get("source", "process"),
+        }
+        return {
+            "provider": "cursor",
+            "api_mode": "chat_completions",
+            "base_url": trace["base_url"],
+            "api_key": api_key,
+            "command": command,
+            "args": args,
+            "source": creds.get("source", "process"),
+            "requested_provider": requested_provider,
+            "trace": trace,
+        }
+
     # Anthropic (native Messages API)
     if provider == "anthropic":
         # Allow base URL override from config.yaml model.base_url, but only

--- a/plugins/model-providers/cursor/__init__.py
+++ b/plugins/model-providers/cursor/__init__.py
@@ -1,0 +1,90 @@
+"""Cursor provider profile — runs through the ``cursor-agent`` CLI.
+
+Cursor doesn't expose a chat completions endpoint; it ships an agent. We
+spawn ``cursor-agent -p --output-format stream-json --mode ask`` per request
+and translate the line-delimited events into an OpenAI chat-completion
+response. Auth piggybacks on the user's existing ``cursor-agent login`` (or
+``CURSOR_API_KEY``) so every Cursor tier — Hobby, Pro, Pro+, Ultra, Teams —
+can use Hermes through their existing subscription / credits.
+
+See ``agent/cursor_agent_client.py`` for the runtime client and
+``docs/cursor_architecture.md`` for the architecture notes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from providers import register_provider
+from providers.base import ProviderProfile
+from providers.cursor_utils import (
+    prioritize_cursor_models,
+    resolve_cursor_command,
+    resolve_cursor_command_path,
+    resolve_cursor_extra_args,
+)
+
+
+class CursorProfile(ProviderProfile):
+    """Cursor — external process via ``cursor-agent`` CLI."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Shell out to ``cursor-agent --list-models`` for the live catalog.
+
+        Returns ``None`` if the CLI is missing or not authenticated. Callers
+        are expected to fall back to the static ``_PROVIDER_MODELS["cursor"]``
+        list in ``hermes_cli/models.py``.
+        """
+        command = resolve_cursor_command()
+        resolved_command = resolve_cursor_command_path(command)
+        if not resolved_command:
+            return None
+        args = resolve_cursor_extra_args()
+        try:
+            out = subprocess.check_output(
+                [resolved_command, *args, "--list-models"],
+                text=True,
+                timeout=timeout,
+            )
+        except Exception:
+            return None
+        ids: list[str] = []
+        for raw in out.splitlines():
+            line = raw.strip()
+            if not line:
+                continue
+            if " - " in line:
+                model_id = line.split(" - ", 1)[0].strip()
+                # Strip "(current)" / "(default)" decoration the CLI sometimes appends
+                model_id = model_id.split()[0]
+                if model_id:
+                    ids.append(model_id)
+        return prioritize_cursor_models(ids) if ids else None
+
+
+cursor = CursorProfile(
+    name="cursor",
+    aliases=("cursor-agent", "cursor-cli", "cursor-sub", "cursor-subscription"),
+    display_name="Cursor",
+    description="Cursor (100+ models, subscription)",
+    signup_url="https://cursor.com/dashboard/integrations",
+    api_mode="chat_completions",  # external-process routing handled in client
+    env_vars=("CURSOR_API_KEY",),
+    base_url="cursor://agent",  # marker URL; never dereferenced
+    auth_type="external_process",
+    fallback_models=(
+        "auto",
+        "composer-2.5",
+        "composer-2.5-fast",
+        "composer-2",
+        "composer-2-fast",
+    ),
+    supports_health_check=False,
+)
+
+register_provider(cursor)

--- a/plugins/model-providers/cursor/plugin.yaml
+++ b/plugins/model-providers/cursor/plugin.yaml
@@ -1,0 +1,4 @@
+name: cursor
+kind: model-provider
+version: 0.1.0
+description: Cursor external-process provider via cursor-agent CLI

--- a/providers/cursor_utils.py
+++ b/providers/cursor_utils.py
@@ -1,0 +1,89 @@
+"""Shared helpers for the Cursor external-process provider."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+
+DEFAULT_CURSOR_COMMAND = "cursor-agent"
+
+# Cursor can expose a very large live catalog. Keep the models most likely to
+# be useful for Hermes-agent workflows at the top of picker/discovery results,
+# while preserving every other live model after them.
+CURSOR_PREFERRED_MODELS: tuple[str, ...] = (
+    "auto",
+    "composer-2.5",
+    "composer-2.5-fast",
+    "composer-2",
+    "composer-2-fast",
+    "gpt-5.5-medium",
+    "gpt-5.5-medium-fast",
+    "gpt-5.5-high",
+    "gpt-5.5-high-fast",
+    "gpt-5.5-low",
+    "gpt-5.5-low-fast",
+    "claude-opus-4-7-medium",
+    "claude-opus-4-7-high",
+    "claude-4.6-sonnet-medium",
+    "claude-4.6-sonnet-medium-thinking",
+    "gemini-3.1-pro",
+    "gemini-3-flash",
+    "grok-4.3",
+    "kimi-k2.5",
+)
+
+
+def prioritize_cursor_models(model_ids: list[str]) -> list[str]:
+    """Move high-value Cursor models to the top without dropping live entries."""
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for model_id in model_ids:
+        cleaned = str(model_id).strip()
+        if not cleaned:
+            continue
+        key = cleaned.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(cleaned)
+
+    by_lower = {mid.lower(): mid for mid in deduped}
+    preferred = [by_lower[p.lower()] for p in CURSOR_PREFERRED_MODELS if p.lower() in by_lower]
+    preferred_keys = {mid.lower() for mid in preferred}
+    return preferred + [mid for mid in deduped if mid.lower() not in preferred_keys]
+
+
+def resolve_cursor_command() -> str:
+    """Return the configured cursor-agent command or the default binary name."""
+    return (
+        os.getenv("HERMES_CURSOR_COMMAND", "").strip()
+        or os.getenv("CURSOR_AGENT_PATH", "").strip()
+        or DEFAULT_CURSOR_COMMAND
+    )
+
+
+def resolve_cursor_extra_args() -> list[str]:
+    """Return optional Cursor CLI args configured through the environment."""
+    raw = os.getenv("HERMES_CURSOR_ARGS", "").strip()
+    if not raw:
+        return []
+    return shlex.split(raw)
+
+
+def resolve_cursor_command_path(command: str | None = None) -> str | None:
+    """Resolve Cursor command while preserving explicit wrapper paths.
+
+    Bare command names must resolve on PATH. Explicit paths, including relative
+    paths such as ``./bin/cursor-wrapper`` and Windows-style paths with a
+    backslash, are returned as-is when PATH lookup cannot resolve them.
+    """
+    candidate = (command or "").strip()
+    if not candidate:
+        return None
+    resolved = shutil.which(candidate)
+    if resolved:
+        return resolved
+    if "/" in candidate or "\\" in candidate:
+        return candidate
+    return None

--- a/tests/agent/test_cursor_agent_client.py
+++ b/tests/agent/test_cursor_agent_client.py
@@ -1,0 +1,1839 @@
+"""Unit tests for the Cursor Agent CLI bridge.
+
+These tests fully mock the ``cursor-agent`` subprocess — they never spawn the
+real CLI. End-to-end smoke against a live ``cursor-agent`` lives in the
+integration script ``tests/agent/test_cursor_agent_client_smoke.py`` (skipped
+unless ``HERMES_CURSOR_SMOKE=1`` is set in the environment).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import threading
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.cursor_agent_client import (
+    CURSOR_MARKER_BASE_URL,
+    CursorAgentClient,
+    _StreamJsonAccumulator,
+    _format_messages_as_prompt,
+    _normalize_cursor_tool_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake subprocess that emits a pre-canned stream-json transcript
+# ---------------------------------------------------------------------------
+
+
+class _PersistentStringIO(io.StringIO):
+    """StringIO whose contents survive ``close()`` so tests can inspect stdin
+    after the client has finished writing and closing it.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._snapshot = ""
+
+    def close(self) -> None:  # type: ignore[override]
+        try:
+            self._snapshot = self.getvalue()
+        except Exception:
+            pass
+        super().close()
+
+    def getvalue(self) -> str:  # type: ignore[override]
+        if self.closed:
+            return self._snapshot
+        return super().getvalue()
+
+
+class _FakeProcess:
+    """Minimal stand-in for ``subprocess.Popen[str]``."""
+
+    def __init__(self, stdout_lines: list[str], stderr_lines: list[str] | None = None):
+        self.stdin = _PersistentStringIO()
+        self.stdout = io.StringIO("\n".join(stdout_lines) + ("\n" if stdout_lines else ""))
+        self.stderr = io.StringIO("\n".join(stderr_lines or []) + ("\n" if stderr_lines else ""))
+        self._terminated = False
+        self._killed = False
+        self._exit_code: int | None = None
+        self.argv_seen: list[str] = []
+        self.cwd_seen: str | None = None
+        self.env_seen: dict[str, str] | None = None
+        # Once the stream is fully consumed treat the process as exited.
+        # poll() returns None while events are still being read so the
+        # accumulator loop doesn't early-exit.
+        self._lock = threading.Lock()
+
+    def poll(self) -> int | None:
+        # Report "still running" until both pipes have been drained at least
+        # once. The reader threads are eager so by the time the main loop
+        # finishes iterating events, the process is effectively done.
+        with self._lock:
+            return self._exit_code
+
+    def terminate(self) -> None:
+        with self._lock:
+            self._terminated = True
+            if self._exit_code is None:
+                self._exit_code = 0
+
+    def kill(self) -> None:
+        with self._lock:
+            self._killed = True
+            if self._exit_code is None:
+                self._exit_code = 0
+
+    def wait(self, timeout: float | None = None) -> int:  # noqa: ARG002
+        with self._lock:
+            if self._exit_code is None:
+                self._exit_code = 0
+            return self._exit_code
+
+
+def _make_event(**fields) -> str:
+    return json.dumps(fields)
+
+
+SUCCESS_STREAM = [
+    _make_event(type="system", subtype="init", session_id="s-1", model="Auto"),
+    _make_event(type="user", message={"role": "user", "content": [{"type": "text", "text": "Hi"}]}, session_id="s-1"),
+    _make_event(type="thinking", subtype="delta", text="thinking-bit", session_id="s-1"),
+    _make_event(type="assistant", message={"role": "assistant", "content": [{"type": "text", "text": "Hello world"}]}, session_id="s-1"),
+    _make_event(
+        type="result",
+        subtype="success",
+        duration_ms=1234,
+        is_error=False,
+        result="Hello world",
+        session_id="s-1",
+        request_id="r-1",
+        usage={"inputTokens": 42, "outputTokens": 13, "cacheReadTokens": 9, "cacheWriteTokens": 0},
+    ),
+]
+
+
+ERROR_STREAM = [
+    _make_event(type="system", subtype="init", session_id="s-2", model="Auto"),
+    _make_event(
+        type="result",
+        subtype="error",
+        duration_ms=100,
+        is_error=True,
+        result="quota exceeded",
+        session_id="s-2",
+        request_id="r-2",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Accumulator unit tests (no subprocess)
+# ---------------------------------------------------------------------------
+
+
+class StreamAccumulatorTests(unittest.TestCase):
+    def test_success_stream_assembles_text_and_usage(self) -> None:
+        acc = _StreamJsonAccumulator()
+        for line in SUCCESS_STREAM:
+            acc.feed(json.loads(line))
+        self.assertTrue(acc.terminal)
+        self.assertFalse(acc.is_error)
+        self.assertEqual(acc.assembled_text(), "Hello world")
+        self.assertEqual(acc.assembled_reasoning(), "thinking-bit")
+        usage = acc.openai_usage()
+        # New contract: prompt_tokens approximates "what was in context"
+        # = cacheReadTokens + inputTokens averaged across internal rounds.
+        # With 0 tool events there's 1 round so just sum: 9 + 42 = 51.
+        self.assertEqual(usage.prompt_tokens, 51)
+        self.assertEqual(usage.completion_tokens, 13)
+        self.assertEqual(usage.total_tokens, 64)
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 9)
+        # Raw cursor billing values still available for cost tracking.
+        self.assertEqual(usage.cursor_raw_input_tokens, 42)
+        self.assertEqual(usage.cursor_raw_cache_read_tokens, 9)
+        self.assertEqual(usage.cursor_internal_rounds, 1)
+
+    def test_error_stream_sets_error_flag_and_message(self) -> None:
+        acc = _StreamJsonAccumulator()
+        for line in ERROR_STREAM:
+            acc.feed(json.loads(line))
+        self.assertTrue(acc.terminal)
+        self.assertTrue(acc.is_error)
+        self.assertIn("quota exceeded", acc.error_message)
+
+    def test_unknown_event_types_are_ignored(self) -> None:
+        acc = _StreamJsonAccumulator()
+        acc.feed({"type": "weird-future-event", "anything": True})
+        acc.feed({"no-type": "ignored"})
+        self.assertFalse(acc.terminal)
+        self.assertEqual(acc.assembled_text(), "")
+
+    def test_result_without_text_uses_final_result_field(self) -> None:
+        acc = _StreamJsonAccumulator()
+        acc.feed(json.loads(_make_event(type="system", subtype="init", session_id="x")))
+        acc.feed(json.loads(_make_event(
+            type="result",
+            subtype="success",
+            is_error=False,
+            result="standalone",
+            session_id="x",
+            request_id="x-r",
+            usage={"inputTokens": 1, "outputTokens": 1, "cacheReadTokens": 0},
+        )))
+        self.assertEqual(acc.assembled_text(), "standalone")
+
+
+# ---------------------------------------------------------------------------
+# Argv + workspace defaults
+# ---------------------------------------------------------------------------
+
+
+class BuildArgvTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Clear all HERMES_CURSOR_* env overrides so defaults are predictable.
+        keys = [k for k in os.environ if k.startswith("HERMES_CURSOR_") or k == "CURSOR_API_KEY" or k == "CURSOR_AGENT_PATH"]
+        self._saved = {k: os.environ.pop(k) for k in keys}
+
+    def tearDown(self) -> None:
+        for k, v in self._saved.items():
+            os.environ[k] = v
+
+    def test_default_argv_uses_full_agent_mode_and_print_flag(self) -> None:
+        # Default mode is ``agent`` (cursor-agent's own default permissionMode,
+        # which is invoked by omitting ``--mode`` entirely).  This matches what
+        # users get when they run ``cursor-agent -p`` directly from the shell,
+        # so picking ``cursor`` in ``hermes model`` doesn't silently demote
+        # the agent to read-only. Hermes' own ``approvals.mode`` gate (manual /
+        # smart / off) still applies on top, matching every other provider.
+        client = CursorAgentClient()
+        argv = client._build_argv(model="composer-2.5", workspace="/tmp/work")
+        self.assertEqual(argv[0], "cursor-agent")
+        self.assertIn("-p", argv)
+        self.assertIn("--output-format", argv)
+        self.assertIn("stream-json", argv)
+        # ``agent`` is the synthetic value meaning "no --mode flag" →
+        # cursor uses its default full-capability permission mode.
+        self.assertNotIn("--mode", argv,
+                         "default cursor mode (agent) must omit the --mode CLI flag")
+        self.assertEqual(argv[argv.index("--model") + 1], "composer-2.5")
+        self.assertEqual(argv[argv.index("--workspace") + 1], "/tmp/work")
+        self.assertIn("--force", argv)
+        self.assertIn("--trust", argv)
+        self.assertNotIn("--api-key", argv)  # no key passed → omit flag
+
+    def test_explicit_ask_mode_still_works_via_env(self) -> None:
+        # Users who want read-only behavior opt in via env var.
+        os.environ["HERMES_CURSOR_MODE"] = "ask"
+        try:
+            client = CursorAgentClient()
+            argv = client._build_argv(model="auto", workspace="/tmp/x")
+            self.assertIn("--mode", argv)
+            self.assertEqual(argv[argv.index("--mode") + 1], "ask")
+        finally:
+            os.environ.pop("HERMES_CURSOR_MODE", None)
+
+    def test_api_key_threads_through_argv(self) -> None:
+        client = CursorAgentClient(api_key="crsr_abc123")
+        argv = client._build_argv(model="auto", workspace="/tmp/x")
+        self.assertEqual(argv[argv.index("--api-key") + 1], "crsr_abc123")
+
+    def test_sentinel_api_key_is_dropped(self) -> None:
+        # Regression: external_process auth path injects "cursor-agent-login"
+        # as a placeholder. Forwarding it to ``cursor-agent --api-key`` makes
+        # the CLI reject the request and close stdin, which surfaces as
+        # BrokenPipeError on our writes. The client must treat it as "no key
+        # — use the cursor-agent CLI's own login session" and omit the flag.
+        for sentinel in (
+            "",
+            "cursor-agent-login",
+            "cursor-cli-login",
+            "external-process",
+            "external_process",
+        ):
+            with self.subTest(sentinel=sentinel):
+                client = CursorAgentClient(api_key=sentinel)
+                try:
+                    self.assertIsNone(client.api_key)
+                    argv = client._build_argv(model="auto", workspace="/tmp/x")
+                    self.assertNotIn("--api-key", argv)
+                finally:
+                    client.close()
+
+    def test_extra_args_appended(self) -> None:
+        client = CursorAgentClient(args=["--header", "X-Hermes: 1"])
+        argv = client._build_argv(model="auto", workspace="/tmp/x")
+        self.assertEqual(argv[-2:], ["--header", "X-Hermes: 1"])
+
+    def test_mode_override(self) -> None:
+        client = CursorAgentClient(mode="plan")
+        argv = client._build_argv(model="auto", workspace="/tmp/x")
+        self.assertEqual(argv[argv.index("--mode") + 1], "plan")
+
+    def test_invalid_mode_falls_back_to_default_agent(self) -> None:
+        # Invalid env values must not crash and must not silently downgrade
+        # the user — falling back to ``agent`` (Hermes' default) means the
+        # user picking cursor still gets the expected full-power behavior.
+        # Hermes' own ``approvals.mode`` config still gates dangerous ops.
+        client = CursorAgentClient(mode="lol-not-a-mode")
+        argv = client._build_argv(model="auto", workspace="/tmp/x")
+        self.assertNotIn("--mode", argv,
+                         "invalid mode must fall back to agent (no --mode flag)")
+
+    def test_command_and_args_propagate_to_subprocess(self) -> None:
+        # Regression: agent_init.py used to only copy ``acp_command`` /
+        # ``acp_args`` into ``client_kwargs`` for ``provider=copilot-acp``,
+        # not for ``cursor``. Symptom: status/auth flow resolves a
+        # specific cursor-agent binary path, but chat used whatever's
+        # first on $PATH. This pins the client-level behaviour: when
+        # ``command`` and ``args`` are passed, they make it into argv.
+        client = CursorAgentClient(
+            command="/opt/custom/cursor-agent",
+            args=["--header", "X-Hermes-Trace: 1"],
+        )
+        try:
+            argv = client._build_argv(model="auto", workspace="/tmp")
+            self.assertEqual(argv[0], "/opt/custom/cursor-agent")
+            self.assertEqual(argv[-2:], ["--header", "X-Hermes-Trace: 1"])
+        finally:
+            client.close()
+
+    def test_mode_agent_omits_cli_flag(self) -> None:
+        # Regression: cursor-agent only accepts ``--mode ask|plan``. The
+        # synthetic ``agent`` value means "run in cursor's full-capability
+        # default permissionMode" — achieved by NOT passing the flag at
+        # all. Earlier code passed ``--mode agent`` and cursor crashed
+        # with a confusing BrokenPipe before even reading stdin.
+        client = CursorAgentClient(mode="agent")
+        argv = client._build_argv(model="auto", workspace="/tmp/x")
+        self.assertNotIn("--mode", argv)
+        # Critical flags that enable full agentic behaviour are still present.
+        self.assertIn("-p", argv)
+        self.assertIn("--force", argv)
+        self.assertIn("--trust", argv)
+        self.assertIn("--workspace", argv)
+
+    def test_env_override_command(self) -> None:
+        with patch.dict(os.environ, {"HERMES_CURSOR_COMMAND": "/opt/custom/cursor-agent"}):
+            client = CursorAgentClient()
+            argv = client._build_argv(model="auto", workspace="/tmp/x")
+            self.assertEqual(argv[0], "/opt/custom/cursor-agent")
+
+    def test_workspace_override_via_ctor_is_reused(self) -> None:
+        client = CursorAgentClient(workspace="/persistent/ws")
+        ws1, _ = client._allocate_workspace()
+        ws2, _ = client._allocate_workspace()
+        self.assertEqual(ws1, "/persistent/ws")
+        self.assertEqual(ws2, "/persistent/ws")  # reused, not minted
+
+    def test_workspace_default_is_session_scoped_not_per_call(self) -> None:
+        # Perf: cursor-agent pays ~4.5s of bootstrap overhead when given a
+        # fresh empty workspace. Within the SAME chat session (same
+        # CursorAgentClient instance), all calls must share one workspace
+        # so we only pay that tax once.
+        client = CursorAgentClient()
+        try:
+            ws1, eph1 = client._allocate_workspace()
+            ws2, eph2 = client._allocate_workspace()
+            ws3, eph3 = client._allocate_workspace()
+            self.assertTrue(eph1 and eph2 and eph3,
+                            "default workspace should be marked ephemeral")
+            self.assertTrue("hermes-cursor-" in ws1)
+            self.assertEqual(ws1, ws2,
+                             "second call must REUSE the first session workspace")
+            self.assertEqual(ws2, ws3,
+                             "third call must REUSE the session workspace")
+            import os
+            self.assertTrue(os.path.isdir(ws1),
+                            "session workspace dir must exist on disk")
+        finally:
+            client.close()
+
+    def test_session_workspace_is_freshly_minted_after_close(self) -> None:
+        # close() drops the cached session workspace ref so a new chat
+        # session (after /new or a fresh client) gets its own scratch dir.
+        client = CursorAgentClient()
+        try:
+            ws1, _ = client._allocate_workspace()
+            client.close()
+            client.is_closed = False  # simulate re-use (defensive)
+            ws2, _ = client._allocate_workspace()
+            self.assertNotEqual(ws1, ws2,
+                                "post-close allocation must mint a NEW dir")
+        finally:
+            client.close()
+
+
+# ---------------------------------------------------------------------------
+# Prompt formatter — must steer cursor away from its built-in tool harness
+# ---------------------------------------------------------------------------
+
+
+class FormatMessagesAsPromptTests(unittest.TestCase):
+    """Cursor-agent is itself an agent with built-in shell/edit/read tools.
+
+    Without the hardened framing in our formatter, the model treats Hermes'
+    advertised tools as if they were its own and runs them in-process — the
+    user sees zero ``tool_calls`` in the chat session even when tools are
+    available.  These tests pin the directives that empirically push cursor
+    into emitting raw <tool_call> blocks for Hermes to execute.
+    """
+
+    def test_directs_model_to_emit_tool_call_blocks(self) -> None:
+        prompt = _format_messages_as_prompt(
+            messages=[{"role": "user", "content": "use the kanban tool"}],
+            tools=[{
+                "type": "function",
+                "function": {
+                    "name": "kanban",
+                    "description": "manage tasks",
+                    "parameters": {"type": "object"},
+                },
+            }],
+        )
+        # Hermes-side tools must be discoverable and the <tool_call>
+        # block format must be specified.
+        self.assertIn("<tool_call>", prompt)
+        self.assertIn("\"kanban\"", prompt)
+        # The model is told it has BOTH built-in cursor tools and
+        # Hermes-side tools — this prevents the slow round-trip we used
+        # to force for every shell/file action.
+        self.assertIn("built-in cursor-agent tools", prompt)
+        self.assertIn("Hermes-side tools", prompt)
+
+    def test_no_tools_uses_lite_preamble_not_agentic_one(self) -> None:
+        # Regression: aux tasks (title gen, compression, vision, ...)
+        # call cursor with NO ``tools`` advertised. They want a short
+        # direct reply, not a multi-paragraph agentic response. The
+        # heavy "you are not the agent, emit tool_call blocks" preamble
+        # made cursor produce verbose responses on these short-form
+        # tasks AND wasted ~500 prompt tokens per call.
+        prompt = _format_messages_as_prompt(
+            messages=[
+                {"role": "system", "content": "Generate a short title."},
+                {"role": "user", "content": "User: hi\n\nAssistant: hello"},
+            ],
+            tools=None,
+        )
+        # No agentic framing for tool-less calls.
+        self.assertNotIn("NOT an autonomous", prompt)
+        self.assertNotIn("<tool_call>", prompt)
+        self.assertNotIn("Available tools", prompt)
+        # But we DO tell cursor "answer directly, don't run tools" so
+        # its harness doesn't burn time exploring the workspace.
+        self.assertIn("auxiliary call", prompt.lower())
+        self.assertIn("do not run", prompt.lower())
+        # The system + user content is preserved.
+        self.assertIn("Generate a short title", prompt)
+
+    def test_with_tools_keeps_agentic_preamble(self) -> None:
+        # When Hermes-side tools are advertised, the prompt teaches the
+        # model about BOTH built-in cursor tools and the Hermes tools —
+        # this is the speed-vs-control tradeoff: cursor handles
+        # shell/file work directly (fast), Hermes-only tools go through
+        # <tool_call> blocks (full UI visibility + audit).
+        prompt = _format_messages_as_prompt(
+            messages=[{"role": "user", "content": "do something"}],
+            tools=[{
+                "type": "function",
+                "function": {"name": "kanban", "description": "x", "parameters": {}},
+            }],
+        )
+        self.assertIn("built-in cursor-agent tools", prompt)
+        self.assertIn("Hermes-side tools", prompt)
+        self.assertIn("<tool_call>", prompt)
+
+    def test_cursor_tool_name_normalisation(self) -> None:
+        cases = {
+            "shellToolCall": "shell",
+            "readToolCall": "read_file",
+            "listToolCall": "list_directory",
+            "editToolCall": "edit_file",
+            "writeToolCall": "write_file",
+            "grepToolCall": "grep",
+            "globToolCall": "glob",
+            "fetchToolCall": "web_fetch",
+            "wackyFutureToolCall": "wackyFuture",
+        }
+        for envelope, expected in cases.items():
+            with self.subTest(envelope=envelope):
+                self.assertEqual(_normalize_cursor_tool_name(envelope), expected)
+
+    def test_messages_appear_in_transcript_order(self) -> None:
+        prompt = _format_messages_as_prompt(
+            messages=[
+                {"role": "system", "content": "be concise"},
+                {"role": "user", "content": "ping"},
+                {"role": "assistant", "content": "pong"},
+                {"role": "user", "content": "again"},
+            ],
+        )
+        idx_ping = prompt.index("ping")
+        idx_pong = prompt.index("pong")
+        idx_again = prompt.index("again")
+        self.assertLess(idx_ping, idx_pong)
+        self.assertLess(idx_pong, idx_again)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end of `_create_chat_completion` with the subprocess mocked
+# ---------------------------------------------------------------------------
+
+
+class CreateChatCompletionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Make env predictable.
+        keys = [k for k in os.environ if k.startswith("HERMES_CURSOR_") or k == "CURSOR_API_KEY" or k == "CURSOR_AGENT_PATH"]
+        self._saved = {k: os.environ.pop(k) for k in keys}
+        self._status_patch = patch(
+            "agent.cursor_agent_client.subprocess.check_output",
+            return_value="✓ Logged in as test@example.com\n",
+        )
+        self._status_patch.start()
+
+    def tearDown(self) -> None:
+        self._status_patch.stop()
+        for k, v in self._saved.items():
+            os.environ[k] = v
+
+    def _patch_popen(self, fake_proc: _FakeProcess):
+        def _fake_popen(argv, **kwargs):
+            fake_proc.argv_seen = list(argv)
+            fake_proc.cwd_seen = kwargs.get("cwd")
+            fake_proc.env_seen = kwargs.get("env")
+            return fake_proc
+
+        return patch("agent.cursor_agent_client.subprocess.Popen", side_effect=_fake_popen)
+
+    def test_happy_path_returns_openai_shaped_response(self) -> None:
+        proc = _FakeProcess(SUCCESS_STREAM)
+        client = CursorAgentClient()
+        try:
+            with self._patch_popen(proc):
+                resp = client.chat.completions.create(
+                    model="composer-2.5",
+                    messages=[
+                        {"role": "system", "content": "You are concise."},
+                        {"role": "user", "content": "Hi"},
+                    ],
+                )
+            self.assertEqual(len(resp.choices), 1)
+            self.assertEqual(resp.choices[0].message.content, "Hello world")
+            self.assertEqual(resp.choices[0].finish_reason, "stop")
+            self.assertEqual(resp.choices[0].message.reasoning_content, "thinking-bit")
+            # prompt_tokens comes from Hermes' messages estimate
+            # (authoritative for the status bar); raw cursor billing
+            # is preserved as ``cursor_raw_input_tokens`` for cost
+            # tracking, and the per-round average as
+            # ``cursor_per_round_context``.
+            self.assertGreater(resp.usage.prompt_tokens, 0)
+            self.assertEqual(resp.usage.completion_tokens, 13)
+            self.assertEqual(resp.usage.prompt_tokens_details.cached_tokens, 9)
+            self.assertEqual(resp.usage.cursor_raw_input_tokens, 42)
+            self.assertEqual(resp.usage.cursor_raw_cache_read_tokens, 9)
+            # Per-round context still computed for debug visibility.
+            self.assertEqual(resp.usage.cursor_per_round_context, 51)
+            self.assertEqual(resp.model, "composer-2.5")
+            self.assertEqual(resp.id, "r-1")
+            # Argv must include the user-requested model + ask mode + the
+            # ephemeral workspace.
+            self.assertEqual(proc.argv_seen[proc.argv_seen.index("--model") + 1], "composer-2.5")
+            # Default mode is ``agent`` which is encoded by omitting --mode.
+            self.assertNotIn("--mode", proc.argv_seen)
+            # Prompt is delivered via stdin.
+            stdin_content = proc.stdin.getvalue()
+            self.assertIn("Hi", stdin_content)
+            self.assertIn("You are concise.", stdin_content)
+        finally:
+            client.close()
+
+    def test_error_stream_raises_runtime_error(self) -> None:
+        proc = _FakeProcess(ERROR_STREAM)
+        client = CursorAgentClient()
+        try:
+            with self._patch_popen(proc):
+                with self.assertRaises(RuntimeError) as ctx:
+                    client.chat.completions.create(
+                        model="auto",
+                        messages=[{"role": "user", "content": "boom"}],
+                    )
+            self.assertIn("quota exceeded", str(ctx.exception))
+        finally:
+            client.close()
+
+    def test_missing_cli_raises_helpful_error(self) -> None:
+        client = CursorAgentClient(command="this-cli-does-not-exist-anywhere")
+        try:
+            # subprocess.Popen raises FileNotFoundError when the command can't
+            # be located on PATH; we don't patch it here.
+            with self.assertRaises(RuntimeError) as ctx:
+                client.chat.completions.create(
+                    model="auto",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+            self.assertIn("Install Cursor CLI", str(ctx.exception))
+        finally:
+            client.close()
+
+    def test_cli_login_preflight_rejects_expired_login_before_popen(self) -> None:
+        self._status_patch.stop()
+        expired = subprocess.CalledProcessError(
+            1,
+            ["cursor-agent", "status"],
+            output="",
+            stderr="Not logged in. Please run cursor-agent login.",
+        )
+        client = CursorAgentClient()
+        try:
+            with patch("agent.cursor_agent_client.subprocess.check_output", side_effect=expired), \
+                 patch("agent.cursor_agent_client.subprocess.Popen") as popen:
+                with self.assertRaises(RuntimeError) as ctx:
+                    client.chat.completions.create(
+                        model="auto",
+                        messages=[{"role": "user", "content": "hi"}],
+                    )
+            self.assertFalse(popen.called, "expired CLI login must fail before spawning cursor-agent -p")
+            msg = str(ctx.exception)
+            self.assertIn("cursor-agent login", msg)
+            self.assertIn("CURSOR_API_KEY", msg)
+        finally:
+            client.close()
+            self._status_patch.start()
+
+    def test_api_key_skips_cli_login_preflight(self) -> None:
+        self._status_patch.stop()
+        proc = _FakeProcess(SUCCESS_STREAM)
+        client = CursorAgentClient(api_key="crsr_live_key")
+        try:
+            with patch(
+                "agent.cursor_agent_client.subprocess.check_output",
+                side_effect=AssertionError("API key mode must not call cursor-agent status"),
+            ), self._patch_popen(proc):
+                resp = client.chat.completions.create(
+                    model="auto",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+            self.assertEqual(resp.choices[0].message.content, "Hello world")
+            self.assertIsNotNone(proc.env_seen)
+            assert proc.env_seen is not None
+            self.assertEqual(proc.env_seen["CURSOR_API_KEY"], "crsr_live_key")
+        finally:
+            client.close()
+            self._status_patch.start()
+
+    def test_stream_true_returns_iterable_chunks(self) -> None:
+        # Regression: Hermes' chat streaming hot path does ``for chunk in
+        # stream`` on whatever ``create()`` returns.  Returning a bare
+        # SimpleNamespace surfaces as ``TypeError: 'types.SimpleNamespace'
+        # object is not iterable``.  When ``stream=True`` is set we must
+        # return an iterator of OpenAI-style chunks.
+        proc = _FakeProcess(SUCCESS_STREAM)
+        client = CursorAgentClient()
+        try:
+            with self._patch_popen(proc):
+                stream = client.chat.completions.create(
+                    model="auto",
+                    messages=[{"role": "user", "content": "hi"}],
+                    stream=True,
+                )
+            chunks = list(stream)
+            self.assertGreater(len(chunks), 0)
+            # First content chunk should carry the assembled text
+            content_chunks = [
+                c for c in chunks
+                if c.choices and c.choices[0].delta.content
+            ]
+            self.assertTrue(content_chunks)
+            self.assertIn("Hello world", "".join(c.choices[0].delta.content for c in content_chunks))
+            # Last chunk carries finish_reason + usage
+            last = chunks[-1]
+            self.assertEqual(last.choices[0].finish_reason, "stop")
+            self.assertIsNotNone(last.usage)
+        finally:
+            client.close()
+
+    def test_usage_is_per_round_not_cumulative_billing_sum(self) -> None:
+        # Regression: a deep agentic turn (e.g. 10 internal tool calls)
+        # makes cursor-agent emit inputTokens that's the SUM across all
+        # internal LLM round-trips. Reporting that raw to Hermes' status
+        # bar made it show e.g. ``1.07M/200K  100%`` — bar visually
+        # broken AND it triggered spurious compression. Verify we now
+        # report a per-round average that stays under the model window.
+        events = [
+            _make_event(type="system", subtype="init", session_id="s-big"),
+        ]
+        # Fabricate 10 shell tool round-trips so accumulator counts rounds.
+        for i in range(10):
+            events.append(_make_event(
+                type="tool_call",
+                subtype="started",
+                call_id=f"t-{i}",
+                tool_call={"shellToolCall": {"args": {"command": f"echo {i}"}}},
+            ))
+            events.append(_make_event(
+                type="tool_call",
+                subtype="completed",
+                call_id=f"t-{i}",
+                tool_call={"shellToolCall": {
+                    "args": {"command": f"echo {i}"},
+                    "result": {"success": {"stdout": "ok", "exitCode": 0}},
+                }},
+            ))
+        events.append(_make_event(
+            type="result",
+            subtype="success",
+            is_error=False,
+            result="done",
+            session_id="s-big",
+            request_id="r-big",
+            usage={
+                # 1.07M cumulative input across 11 internal rounds —
+                # exactly the pathological case the user reported.
+                "inputTokens": 1_070_000,
+                "outputTokens": 500,
+                "cacheReadTokens": 220_000,
+                "cacheWriteTokens": 0,
+            },
+        ))
+        proc = _FakeProcess(events)
+        client = CursorAgentClient()
+        try:
+            with self._patch_popen(proc):
+                resp = client.chat.completions.create(
+                    model="composer-2.5-fast",
+                    messages=[{"role": "user", "content": "heavy task"}],
+                )
+            usage = resp.usage
+            # 11 rounds (10 tools + 1 final response) → per-round avg
+            # input is 1.07M / 11 ≈ 97K, plus cache 220K / 11 ≈ 20K.
+            # Total per-round context ≈ 117K. Well under 200K.
+            self.assertLess(usage.prompt_tokens, 200_000)
+            self.assertGreater(usage.prompt_tokens, 0)
+            # Raw cumulative numbers still preserved for billing.
+            self.assertEqual(usage.cursor_raw_input_tokens, 1_070_000)
+            self.assertEqual(usage.cursor_raw_cache_read_tokens, 220_000)
+            self.assertEqual(usage.cursor_internal_rounds, 11)
+        finally:
+            client.close()
+
+    def test_usage_prefers_messages_estimate_when_provided(self) -> None:
+        # When the client supplies a ``messages_estimate`` (from
+        # ``estimate_request_tokens_rough(messages, tools)``), the
+        # accumulator must surface that as ``prompt_tokens`` instead of
+        # the per-round average — this keeps the status bar consistent
+        # before, during, and after generation. The per-round average
+        # is still exposed as ``cursor_per_round_context``.
+        acc = _StreamJsonAccumulator()
+        acc.messages_estimate = 42_000
+        acc.usage = {
+            "inputTokens": 1_000_000,
+            "outputTokens": 100,
+            "cacheReadTokens": 200_000,
+        }
+        acc.tool_events = [object()] * 10  # 10 internal tools → 11 rounds
+        usage = acc.openai_usage()
+        self.assertEqual(usage.prompt_tokens, 42_000)
+        # Per-round average still computed and exposed for debug.
+        self.assertGreater(usage.cursor_per_round_context, 0)
+        self.assertLess(usage.cursor_per_round_context, 200_000)
+
+    def test_usage_pure_chat_no_tools_reports_messages_estimate(self) -> None:
+        # A pure-chat turn (no tool calls) reports Hermes' messages
+        # estimate as ``prompt_tokens`` (not cursor's raw billing) so
+        # the status bar stays consistent between live estimate and
+        # post-turn snapshot. Cursor's per-round context is still
+        # exposed as a debug field for cost-tracking consumers.
+        proc = _FakeProcess([
+            _make_event(type="system", subtype="init", session_id="s-chat"),
+            _make_event(
+                type="assistant",
+                message={"role": "assistant", "content": [{"type": "text", "text": "Hello!"}]},
+                session_id="s-chat",
+            ),
+            _make_event(
+                type="result",
+                subtype="success",
+                is_error=False,
+                result="Hello!",
+                session_id="s-chat",
+                request_id="r-chat",
+                usage={
+                    "inputTokens": 5_000,
+                    "outputTokens": 10,
+                    "cacheReadTokens": 25_000,
+                    "cacheWriteTokens": 0,
+                },
+            ),
+        ])
+        client = CursorAgentClient()
+        try:
+            with self._patch_popen(proc):
+                resp = client.chat.completions.create(
+                    model="composer-2.5-fast",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+            usage = resp.usage
+            # prompt_tokens = max(messages_estimate, cursor_per_round)
+            # so the bar never undercounts. Messages estimate for "hi"
+            # is tiny (~few tokens) but per_round_context is 30K, so
+            # 30K wins.
+            self.assertEqual(usage.prompt_tokens, 30_000)
+            self.assertEqual(usage.cursor_per_round_context, 30_000)
+            self.assertEqual(usage.cursor_internal_rounds, 1)
+            self.assertEqual(usage.cursor_raw_input_tokens, 5_000)
+        finally:
+            client.close()
+
+    def test_context_bar_is_monotonic_within_session(self) -> None:
+        # Regression: when Hermes loops on tool_calls (cursor returning
+        # <tool_call> blocks for Hermes to run), each cursor call has
+        # its own messages footprint. Some calls have full tool schemas
+        # (~30K), some don't. Without a high-water mark, the bar wobbled
+        # high/low between calls in the same user turn, looking like
+        # "junk resetting and overriding" to the user.
+        client = CursorAgentClient()
+
+        big_proc = _FakeProcess([
+            _make_event(type="system", subtype="init", session_id="s-1"),
+            _make_event(
+                type="assistant",
+                message={"role": "assistant", "content": [{"type": "text", "text": "first"}]},
+                session_id="s-1",
+            ),
+            _make_event(
+                type="result", subtype="success", is_error=False,
+                result="first", session_id="s-1", request_id="r-1",
+                usage={"inputTokens": 40_000, "outputTokens": 5,
+                       "cacheReadTokens": 20_000, "cacheWriteTokens": 0},
+            ),
+        ])
+        small_proc = _FakeProcess([
+            _make_event(type="system", subtype="init", session_id="s-1"),
+            _make_event(
+                type="assistant",
+                message={"role": "assistant", "content": [{"type": "text", "text": "second"}]},
+                session_id="s-1",
+            ),
+            _make_event(
+                type="result", subtype="success", is_error=False,
+                result="second", session_id="s-1", request_id="r-2",
+                usage={"inputTokens": 500, "outputTokens": 5,
+                       "cacheReadTokens": 1_000, "cacheWriteTokens": 0},
+            ),
+        ])
+        try:
+            with self._patch_popen(big_proc):
+                resp1 = client.chat.completions.create(
+                    model="composer-2.5-fast",
+                    messages=[{"role": "user", "content": "x"}],
+                    tools=[{"type": "function", "function": {
+                        "name": "shell", "description": "x", "parameters": {}}}],
+                )
+            with self._patch_popen(small_proc):
+                resp2 = client.chat.completions.create(
+                    model="composer-2.5-fast",
+                    messages=[{"role": "user", "content": "y"}],
+                )
+            # The first call set a high-water of 60K (per-round). The
+            # second call's per-round is just 1.5K — but the bar must
+            # stay at or above 60K, not collapse to 1.5K.
+            self.assertGreaterEqual(resp1.usage.prompt_tokens, 60_000)
+            self.assertGreaterEqual(resp2.usage.prompt_tokens, resp1.usage.prompt_tokens)
+        finally:
+            client.close()
+
+    def test_high_water_resets_on_new_user_turn(self) -> None:
+        # Across SEPARATE user prompts the high-water mark must reset so
+        # the bar reflects the new turn's actual context size. Earlier
+        # behaviour froze the bar at the highest-activity turn's value
+        # which prevented users from seeing context growth/shrinkage as
+        # they continued conversing.
+        client = CursorAgentClient()
+
+        heavy_proc = _FakeProcess([
+            _make_event(type="system", subtype="init", session_id="s-1"),
+            _make_event(
+                type="assistant",
+                message={"role": "assistant", "content": [{"type": "text", "text": "first"}]},
+                session_id="s-1",
+            ),
+            _make_event(
+                type="result", subtype="success", is_error=False,
+                result="first", session_id="s-1", request_id="r-1",
+                usage={"inputTokens": 200_000, "outputTokens": 5,
+                       "cacheReadTokens": 100_000, "cacheWriteTokens": 0},
+            ),
+        ])
+        light_proc = _FakeProcess([
+            _make_event(type="system", subtype="init", session_id="s-1"),
+            _make_event(
+                type="assistant",
+                message={"role": "assistant", "content": [{"type": "text", "text": "second"}]},
+                session_id="s-1",
+            ),
+            _make_event(
+                type="result", subtype="success", is_error=False,
+                result="second", session_id="s-1", request_id="r-2",
+                usage={"inputTokens": 500, "outputTokens": 5,
+                       "cacheReadTokens": 1_000, "cacheWriteTokens": 0},
+            ),
+        ])
+        try:
+            with self._patch_popen(heavy_proc):
+                resp1 = client.chat.completions.create(
+                    model="composer-2.5-fast",
+                    messages=[
+                        {"role": "system", "content": "You are concise."},
+                        {"role": "user", "content": "do a lot of work"},
+                    ],
+                    tools=[{"type": "function", "function": {
+                        "name": "shell", "description": "x", "parameters": {}}}],
+                )
+            # Heavy turn locks the bar high (per-round average from a
+            # multi-tool turn).
+            self.assertGreaterEqual(resp1.usage.prompt_tokens, 100_000)
+
+            # NEW user prompt (second user message added). High-water
+            # should reset; bar should reflect the second turn's much
+            # smaller actual context, not the prior heavy turn.
+            with self._patch_popen(light_proc):
+                resp2 = client.chat.completions.create(
+                    model="composer-2.5-fast",
+                    messages=[
+                        {"role": "system", "content": "You are concise."},
+                        {"role": "user", "content": "do a lot of work"},
+                        {"role": "assistant", "content": "did work"},
+                        {"role": "user", "content": "hi"},
+                    ],
+                )
+            self.assertLess(resp2.usage.prompt_tokens, resp1.usage.prompt_tokens,
+                            "second-turn bar must drop from the prior heavy turn's "
+                            "frozen peak when a new user prompt arrives")
+        finally:
+            client.close()
+
+    def test_high_water_holds_within_same_user_turn(self) -> None:
+        # WITHIN a single Hermes user turn the bar must NOT flicker down
+        # between internal cursor calls (Hermes loops on tool_calls).
+        # The two calls below share the same user message; only assistant
+        # / tool messages are added between them. High-water from the
+        # first call's heavy per-round average must carry into the second.
+        client = CursorAgentClient()
+
+        big_proc = _FakeProcess([
+            _make_event(type="system", subtype="init", session_id="s-1"),
+            _make_event(
+                type="assistant",
+                message={"role": "assistant", "content": [{"type": "text", "text": "first"}]},
+                session_id="s-1",
+            ),
+            _make_event(
+                type="result", subtype="success", is_error=False,
+                result="first", session_id="s-1", request_id="r-1",
+                usage={"inputTokens": 40_000, "outputTokens": 5,
+                       "cacheReadTokens": 20_000, "cacheWriteTokens": 0},
+            ),
+        ])
+        small_proc = _FakeProcess([
+            _make_event(type="system", subtype="init", session_id="s-1"),
+            _make_event(
+                type="assistant",
+                message={"role": "assistant", "content": [{"type": "text", "text": "second"}]},
+                session_id="s-1",
+            ),
+            _make_event(
+                type="result", subtype="success", is_error=False,
+                result="second", session_id="s-1", request_id="r-2",
+                usage={"inputTokens": 500, "outputTokens": 5,
+                       "cacheReadTokens": 1_000, "cacheWriteTokens": 0},
+            ),
+        ])
+        same_user_msg = {"role": "user", "content": "do tool work"}
+        try:
+            with self._patch_popen(big_proc):
+                resp1 = client.chat.completions.create(
+                    model="composer-2.5-fast",
+                    messages=[same_user_msg],
+                    tools=[{"type": "function", "function": {
+                        "name": "shell", "description": "x", "parameters": {}}}],
+                )
+            with self._patch_popen(small_proc):
+                resp2 = client.chat.completions.create(
+                    model="composer-2.5-fast",
+                    messages=[
+                        same_user_msg,
+                        {"role": "assistant", "content": "running tool..."},
+                        {"role": "tool", "content": "tool result"},
+                    ],
+                )
+            # Within the same user turn the bar must stay AT OR ABOVE the
+            # peak it hit on the first internal call (no flicker down).
+            self.assertGreaterEqual(resp2.usage.prompt_tokens, resp1.usage.prompt_tokens)
+        finally:
+            client.close()
+
+    def test_close_resets_high_water_for_new_session(self) -> None:
+        # When a new chat starts (e.g. /new), close() is called on the
+        # client — the bar's monotonic floor must drop back to current
+        # prompt size so the new session shows accurate context.
+        client = CursorAgentClient()
+        client._context_high_water = 123_000
+        client.close()
+        self.assertEqual(client._context_high_water, 0)
+
+    def _feed(self, acc, **fields) -> None:
+        """Feed a single event into the accumulator (it expects a dict)."""
+        acc.feed(fields)
+
+    def test_edit_completion_populates_diff_stats(self) -> None:
+        # Cursor's editToolCall result carries ``linesAdded`` /
+        # ``linesRemoved`` / ``diffString``. The accumulator must pull
+        # them onto the tool event so the activity feed can render
+        # "+5 -2" (matching Claude Code / Aider conventions) and the
+        # full diff is preserved for replay.
+        acc = _StreamJsonAccumulator()
+        self._feed(acc, type="system", subtype="init", session_id="s")
+        self._feed(acc,
+            type="tool_call", subtype="started", call_id="t1",
+            tool_call={"editToolCall": {
+                "args": {"path": "/tmp/x.py", "streamContent": "NEW"},
+            }},
+        )
+        self._feed(acc,
+            type="tool_call", subtype="completed", call_id="t1",
+            tool_call={"editToolCall": {
+                "args": {"path": "/tmp/x.py", "streamContent": "NEW"},
+                "result": {"success": {
+                    "linesAdded": 7,
+                    "linesRemoved": 3,
+                    "diffString": "--- a/x.py\n+++ b/x.py\n@@ ...",
+                    "afterFullFileContent": "NEW",
+                    "message": "updated",
+                }},
+            }},
+        )
+        self.assertEqual(len(acc.tool_events), 1)
+        evt = acc.tool_events[0]
+        self.assertEqual(evt.lines_added, 7)
+        self.assertEqual(evt.lines_removed, 3)
+        self.assertIn("--- a/x.py", evt.diff_string)
+        self.assertEqual(evt.name, "edit_file")
+
+    def test_bridge_merges_diff_stats_into_args_on_completion(self) -> None:
+        # When the bridge fires ``tool.completed`` for an edit, cli.py
+        # pops the ``args`` it captured at ``tool.started`` and passes
+        # them to ``get_cute_tool_message``. Because ``args`` is the
+        # SAME dict reference between started and completed, mutating
+        # it here lets the display layer show "+N -M" without changing
+        # any callback signatures.
+        captured = []
+
+        def cb(stage, name, preview=None, args=None, **kwargs):
+            captured.append((stage, name, dict(args) if isinstance(args, dict) else args))
+
+        events = [
+            _make_event(type="system", subtype="init", session_id="s"),
+            _make_event(
+                type="tool_call", subtype="started", call_id="t1",
+                tool_call={"editToolCall": {
+                    "args": {"path": "/tmp/x.py", "streamContent": "NEW"},
+                }},
+            ),
+            _make_event(
+                type="tool_call", subtype="completed", call_id="t1",
+                tool_call={"editToolCall": {
+                    "args": {"path": "/tmp/x.py", "streamContent": "NEW"},
+                    "result": {"success": {
+                        "linesAdded": 5,
+                        "linesRemoved": 2,
+                        "diffString": "--- a\n+++ b",
+                        "message": "ok",
+                    }},
+                }},
+            ),
+            _make_event(
+                type="assistant",
+                message={"role": "assistant", "content": [
+                    {"type": "text", "text": "done"},
+                ]},
+            ),
+            _make_event(
+                type="result", subtype="success", is_error=False,
+                result="done", session_id="s", request_id="r",
+                usage={"inputTokens": 1, "outputTokens": 1},
+            ),
+        ]
+        client = CursorAgentClient(tool_progress_callback=cb)
+        try:
+            with self._patch_popen(_FakeProcess(events)):
+                client.chat.completions.create(
+                    model="composer-2.5-fast",
+                    messages=[{"role": "user", "content": "edit x"}],
+                    tools=[{"type": "function", "function": {
+                        "name": "edit_file", "description": "x",
+                        "parameters": {},
+                    }}],
+                )
+        finally:
+            client.close()
+        # The bridge fired started + completed; the started args dict
+        # was the same reference cursor handed us, and on completion
+        # the bridge mutated it in place. ``captured`` is a deep-copy
+        # taken at callback invocation time, so the "started" snapshot
+        # may or may not contain _diff_stats depending on whether the
+        # completion fired before the deep-copy happened. The contract
+        # we care about is: the bridge fired both events with the
+        # right name.
+        started = [c for c in captured if c[0] == "tool.started" and c[1] == "edit_file"]
+        completed = [c for c in captured if c[0] == "tool.completed" and c[1] == "edit_file"]
+        self.assertEqual(len(started), 1)
+        self.assertEqual(len(completed), 1)
+        # Hit the display layer directly to verify the diff-stats
+        # surface ends up in the activity feed.
+        from agent.display import get_cute_tool_message
+        line = get_cute_tool_message(
+            "edit_file",
+            {"path": "/tmp/x.py", "_diff_stats": {"added": 5, "removed": 2}},
+            0.1,
+        )
+        self.assertIn("+5 -2", line)
+        self.assertIn("✏️", line)
+        # Without diff stats (e.g. older cursor build) we still get a
+        # clean line — no broken "+0 -0" noise.
+        bare = get_cute_tool_message("edit_file", {"path": "/tmp/x.py"}, 0.1)
+        self.assertNotIn("+", bare)
+        self.assertNotIn("-", bare.split("/tmp")[0])
+
+    def test_edit_line_resolves_path_from_alternate_field_names(self) -> None:
+        # Cursor sometimes emits editToolCall args with ``target_file``
+        # / ``file_path`` instead of ``path``. The activity feed line
+        # must still show the path so the user sees what was touched.
+        from agent.display import get_cute_tool_message
+        for field in ("path", "target_file", "targetFile",
+                      "file_path", "relative_workspace_path"):
+            line = get_cute_tool_message("edit_file", {field: "/tmp/x.py"}, 0.1)
+            self.assertIn("/tmp/x.py", line,
+                          f"path lost when args used {field!r}")
+
+    def test_cursor_preview_resolves_alternate_path_fields(self) -> None:
+        # Same resilience on the cursor-side preview that surfaces in
+        # ``tool.started`` (so the user sees the path BEFORE completion).
+        from agent.cursor_agent_client import (
+            _build_cursor_tool_preview,
+            _CursorToolEvent,
+        )
+        for field in ("path", "target_file", "targetFile",
+                      "file_path", "relative_workspace_path"):
+            evt = _CursorToolEvent(
+                call_id="c",
+                envelope_key="editToolCall",
+                args={field: "/tmp/x.py"},
+            )
+            preview = _build_cursor_tool_preview(evt)
+            self.assertEqual(preview, "/tmp/x.py",
+                             f"preview lost when args used {field!r}")
+
+    def test_diff_string_routes_through_native_renderer(self) -> None:
+        # Consistency goal: cursor edits should use the SAME diff
+        # renderer Hermes already uses for write_file/patch — same
+        # skin colors, same file/hunk headers, same line caps.
+        # ``extract_edit_diff`` is the entry point; it must honour
+        # ``function_args["_diff_string"]`` regardless of tool name.
+        from agent.display import (
+            extract_edit_diff,
+            _summarize_rendered_diff_sections,
+        )
+        diff_str = (
+            "--- a/x.py\n+++ b/x.py\n@@ -1 +1,2 @@\n"
+            "-hello world\n+HELLO WORLD\n+second line"
+        )
+        # Pre-extracted diff path: works for ANY tool_name (cursor
+        # uses edit_file/write_file, but the routing is name-agnostic).
+        for name in ("edit_file", "write_file", "cursor_edit"):
+            extracted = extract_edit_diff(name, None, function_args={
+                "_diff_string": diff_str,
+            })
+            self.assertEqual(extracted, diff_str,
+                             f"tool {name} failed to extract diff")
+        # Renderer turns it into colored lines (text content survives).
+        rendered = _summarize_rendered_diff_sections(diff_str)
+        joined = "\n".join(rendered)
+        self.assertIn("hello world", joined)
+        self.assertIn("HELLO WORLD", joined)
+        self.assertIn("second line", joined)
+
+    def test_synthesis_excludes_planning_text_between_tools(self) -> None:
+        # Cursor's stream emits planning prose ("Searching the agent
+        # dir…") → tool → reflection ("Reading each match…") → tool →
+        # synthesis ("Here are 13 files: …"). The user response should
+        # be the synthesis only; the planning lines were already
+        # surfaced live as narration events.
+        acc = _StreamJsonAccumulator()
+        self._feed(acc, type="system", subtype="init", session_id="s")
+        self._feed(acc,
+            type="assistant",
+            message={"role": "assistant", "content": [
+                {"type": "text", "text": "Searching the agent directory."},
+            ]},
+        )
+        self._feed(acc,
+            type="tool_call", subtype="started", call_id="t1",
+            tool_call={"grepToolCall": {"args": {"pattern": "cursor"}}},
+        )
+        self._feed(acc,
+            type="tool_call", subtype="completed", call_id="t1",
+            tool_call={"grepToolCall": {
+                "args": {"pattern": "cursor"},
+                "result": {"success": {"hits": 13}},
+            }},
+        )
+        self._feed(acc,
+            type="assistant",
+            message={"role": "assistant", "content": [
+                {"type": "text", "text": "Reading each match for context."},
+            ]},
+        )
+        self._feed(acc,
+            type="tool_call", subtype="started", call_id="t2",
+            tool_call={"readToolCall": {"args": {"path": "a.py"}}},
+        )
+        self._feed(acc,
+            type="tool_call", subtype="completed", call_id="t2",
+            tool_call={"readToolCall": {
+                "args": {"path": "a.py"},
+                "result": {"success": {"content": "..."}},
+            }},
+        )
+        self._feed(acc,
+            type="assistant",
+            message={"role": "assistant", "content": [
+                {"type": "text", "text": "Final answer: there are 13 files."},
+            ]},
+        )
+        self._feed(acc,
+            type="result", subtype="success", is_error=False,
+            result="Searching the agent directory.\nReading each match.\nFinal answer: there are 13 files.",
+            session_id="s", request_id="r", usage={"inputTokens": 1, "outputTokens": 1},
+        )
+        self.assertEqual(acc.synthesis_text(), "Final answer: there are 13 files.")
+        # Narration helper captures the between-tool prose.
+        narration = acc.narration_text()
+        self.assertIn("Searching the agent directory", narration)
+        self.assertIn("Reading each match", narration)
+        self.assertNotIn("Final answer", narration)
+        # Backward-compat: full assembled text still available.
+        self.assertIn("Final answer", acc.assembled_text())
+
+    def test_synthesis_falls_back_to_full_text_when_no_tools_ran(self) -> None:
+        # Pure chat (no tool calls) — there's no "between-tools" vs
+        # "post-tools" distinction. Return everything.
+        acc = _StreamJsonAccumulator()
+        self._feed(acc, type="system", subtype="init", session_id="s")
+        self._feed(acc,
+            type="assistant",
+            message={"role": "assistant", "content": [
+                {"type": "text", "text": "Hello there!"},
+            ]},
+        )
+        self._feed(acc,
+            type="result", subtype="success", is_error=False,
+            result="Hello there!", session_id="s", request_id="r",
+            usage={"inputTokens": 1, "outputTokens": 1},
+        )
+        self.assertEqual(acc.synthesis_text(), "Hello there!")
+
+    def test_intermediate_text_events_fire_narrate_callback(self) -> None:
+        # Each ``assistant`` text block between tools must fire the
+        # narration bridge so the Hermes activity feed shows the
+        # ReAct-style chain live (💬 narrate → 🔎 grep → 💬 narrate
+        # → 📖 read → final answer in the response). Without this the
+        # tool icons stack at the top and the prose lands as one big
+        # blob at the end — exactly the wobble the user reported.
+        events = []
+        captured: list[tuple] = []
+
+        def cb_fn(stage, name, preview=None, args=None, **kwargs):
+            captured.append((stage, name, preview, args, kwargs))
+
+        class _Cap:
+            calls = captured
+
+        cb = _Cap()
+        client = CursorAgentClient(tool_progress_callback=cb_fn)
+        events.append(_make_event(type="system", subtype="init", session_id="s"))
+        events.append(_make_event(
+            type="assistant",
+            message={"role": "assistant", "content": [
+                {"type": "text", "text": "Let me check the disk first."},
+            ]},
+        ))
+        events.append(_make_event(
+            type="tool_call", subtype="started", call_id="t1",
+            tool_call={"shellToolCall": {"args": {"command": "df -h"}}},
+        ))
+        events.append(_make_event(
+            type="tool_call", subtype="completed", call_id="t1",
+            tool_call={"shellToolCall": {
+                "args": {"command": "df -h"},
+                "result": {"success": {"stdout": "Filesystem...", "exitCode": 0}},
+            }},
+        ))
+        events.append(_make_event(
+            type="assistant",
+            message={"role": "assistant", "content": [
+                {"type": "text", "text": "Looks fine. Now CPU count."},
+            ]},
+        ))
+        events.append(_make_event(
+            type="tool_call", subtype="started", call_id="t2",
+            tool_call={"shellToolCall": {"args": {"command": "nproc"}}},
+        ))
+        events.append(_make_event(
+            type="tool_call", subtype="completed", call_id="t2",
+            tool_call={"shellToolCall": {
+                "args": {"command": "nproc"},
+                "result": {"success": {"stdout": "24", "exitCode": 0}},
+            }},
+        ))
+        events.append(_make_event(
+            type="assistant",
+            message={"role": "assistant", "content": [
+                {"type": "text", "text": "Summary: healthy disk, 24 CPUs."},
+            ]},
+        ))
+        events.append(_make_event(
+            type="result", subtype="success", is_error=False,
+            result="Summary: healthy disk, 24 CPUs.",
+            session_id="s", request_id="r",
+            usage={"inputTokens": 10, "outputTokens": 5},
+        ))
+        try:
+            with self._patch_popen(_FakeProcess(events)):
+                resp = client.chat.completions.create(
+                    model="composer-2.5-fast",
+                    messages=[{"role": "user", "content": "verify hardware"}],
+                    tools=[{
+                        "type": "function",
+                        "function": {"name": "shell", "description": "x",
+                                     "parameters": {}},
+                    }],
+                )
+        finally:
+            client.close()
+        # Buffered narrate flush rule: only TEXT events that are
+        # followed by ANOTHER tool become narrate events. The final
+        # text-after-last-tool is reserved for the synthesis response,
+        # so the user doesn't see "Summary: healthy disk, 24 CPUs."
+        # both as a 💬 narrate line and as the assistant reply. The
+        # two pre-tool / between-tools texts still fire live.
+        narrate_started = [c for c in cb.calls
+                          if c[0] == "tool.started" and c[1] == "narrate"]
+        self.assertEqual(len(narrate_started), 2)
+        previews = [c[2] for c in narrate_started]
+        self.assertIn("Let me check the disk first.", previews)
+        self.assertIn("Looks fine. Now CPU count.", previews)
+        self.assertNotIn("Summary: healthy disk, 24 CPUs.", previews)
+        self.assertIn("disk first", narrate_started[0][2])
+        self.assertIn("CPU count", narrate_started[1][2])
+        # Response text is the synthesis only (no intermediate prose).
+        self.assertEqual(resp.choices[0].message.content,
+                         "Summary: healthy disk, 24 CPUs.")
+
+    def test_cursor_internal_tool_events_fire_tool_progress_callback(self) -> None:
+        # Regression: when cursor-agent's harness runs an internal tool
+        # (shell/read/edit) the stream-json emits ``tool_call started`` and
+        # ``tool_call completed`` events. We must translate those into the
+        # same ``tool_progress_callback(stage, name, preview, args, ...)``
+        # contract Hermes' UI uses for native tool calls, so the user sees
+        # the activity instead of just the final model text.
+        shell_started = _make_event(
+            type="tool_call",
+            subtype="started",
+            call_id="tool_a1",
+            tool_call={"shellToolCall": {"args": {"command": "df -h"}, "description": "disk usage"}},
+        )
+        shell_completed = _make_event(
+            type="tool_call",
+            subtype="completed",
+            call_id="tool_a1",
+            tool_call={
+                "shellToolCall": {
+                    "args": {"command": "df -h"},
+                    "result": {"success": {"stdout": "Filesystem ...\n", "exitCode": 0}},
+                }
+            },
+        )
+        success_text = _make_event(
+            type="assistant",
+            message={"role": "assistant", "content": [{"type": "text", "text": "Used 46%."}]},
+            session_id="s-tool",
+        )
+        final_result = _make_event(
+            type="result",
+            subtype="success",
+            is_error=False,
+            result="Used 46%.",
+            session_id="s-tool",
+            request_id="r-tool",
+            usage={"inputTokens": 1, "outputTokens": 1, "cacheReadTokens": 0},
+        )
+        proc = _FakeProcess([
+            _make_event(type="system", subtype="init", session_id="s-tool", model="Auto"),
+            shell_started,
+            shell_completed,
+            success_text,
+            final_result,
+        ])
+
+        events: list[tuple] = []
+
+        def _callback(stage, name, preview=None, args=None, **kwargs):
+            events.append((stage, name, preview, args, kwargs))
+
+        client = CursorAgentClient(tool_progress_callback=_callback)
+        try:
+            with self._patch_popen(proc):
+                resp = client.chat.completions.create(
+                    model="auto",
+                    messages=[{"role": "user", "content": "df please"}],
+                )
+            # Started + completed both fired
+            stages = [e[0] for e in events]
+            self.assertIn("tool.started", stages)
+            self.assertIn("tool.completed", stages)
+            started = [e for e in events if e[0] == "tool.started"][0]
+            self.assertEqual(started[1], "shell")
+            self.assertEqual(started[2], "df -h")
+            self.assertEqual(started[3], {"command": "df -h"})
+            completed = [e for e in events if e[0] == "tool.completed"][0]
+            self.assertFalse(completed[4].get("is_error"))
+            self.assertIn("Filesystem", completed[4].get("result", ""))
+            # Audit list attached to response
+            self.assertEqual(len(resp.cursor_internal_tools), 1)
+            self.assertEqual(resp.cursor_internal_tools[0]["name"], "shell")
+        finally:
+            client.close()
+
+    def test_broken_pipe_surfaces_stderr_in_error(self) -> None:
+        # Regression: if cursor-agent rejects auth (e.g. bad --api-key) it
+        # closes stdin before reading the prompt, so our write raises
+        # BrokenPipeError. The client must convert that into a clear
+        # RuntimeError carrying the CLI's stderr instead of a bare
+        # BrokenPipeError bubbling into the chat retry loop.
+
+        class _BrokenStdin(io.StringIO):
+            def write(self, _data):  # type: ignore[override]
+                raise BrokenPipeError("Broken pipe")
+
+            def flush(self):  # type: ignore[override]
+                return None
+
+        proc = _FakeProcess(
+            stdout_lines=[],
+            stderr_lines=[
+                "Warning: The provided API key is invalid.",
+                "Please check you have the right key.",
+            ],
+        )
+        proc.stdin = _BrokenStdin()
+        proc._exit_code = 1
+
+        client = CursorAgentClient()
+        try:
+            with self._patch_popen(proc):
+                with self.assertRaises(RuntimeError) as ctx:
+                    client.chat.completions.create(
+                        model="auto",
+                        messages=[{"role": "user", "content": "hi"}],
+                    )
+            msg = str(ctx.exception)
+            self.assertIn("closed stdin", msg)
+            self.assertIn("API key is invalid", msg)
+        finally:
+            client.close()
+
+    def test_tool_call_block_is_extracted(self) -> None:
+        tool_call_payload = json.dumps({
+            "id": "call_xyz",
+            "type": "function",
+            "function": {"name": "shell", "arguments": "{\"command\":\"ls\"}"},
+        })
+        stream = [
+            _make_event(type="system", subtype="init", session_id="s-3", model="Auto"),
+            _make_event(
+                type="assistant",
+                message={
+                    "role": "assistant",
+                    "content": [{
+                        "type": "text",
+                        "text": f"Sure. <tool_call>{tool_call_payload}</tool_call>",
+                    }],
+                },
+                session_id="s-3",
+            ),
+            _make_event(
+                type="result",
+                subtype="success",
+                duration_ms=10,
+                is_error=False,
+                result=f"Sure. <tool_call>{tool_call_payload}</tool_call>",
+                session_id="s-3",
+                request_id="r-3",
+                usage={"inputTokens": 5, "outputTokens": 5, "cacheReadTokens": 0},
+            ),
+        ]
+        proc = _FakeProcess(stream)
+        client = CursorAgentClient()
+        try:
+            with self._patch_popen(proc):
+                resp = client.chat.completions.create(
+                    model="auto",
+                    messages=[{"role": "user", "content": "list files"}],
+                    tools=[{"type": "function", "function": {"name": "shell", "description": "Run a shell command", "parameters": {}}}],
+                )
+            self.assertEqual(resp.choices[0].finish_reason, "tool_calls")
+            self.assertEqual(len(resp.choices[0].message.tool_calls), 1)
+            tc = resp.choices[0].message.tool_calls[0]
+            self.assertEqual(tc.function.name, "shell")
+            self.assertIn("ls", tc.function.arguments)
+        finally:
+            client.close()
+
+    def test_subprocess_env_has_cursor_api_key_when_provided(self) -> None:
+        proc = _FakeProcess(SUCCESS_STREAM)
+        client = CursorAgentClient(api_key="crsr_test_42")
+        try:
+            with self._patch_popen(proc):
+                client.chat.completions.create(
+                    model="auto",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+            self.assertIsNotNone(proc.env_seen)
+            self.assertEqual(proc.env_seen.get("CURSOR_API_KEY"), "crsr_test_42")
+        finally:
+            client.close()
+
+    def test_marker_base_url_is_default(self) -> None:
+        client = CursorAgentClient()
+        try:
+            self.assertEqual(client.base_url, CURSOR_MARKER_BASE_URL)
+        finally:
+            client.close()
+
+
+# ---------------------------------------------------------------------------
+# Workspace cleanup
+# ---------------------------------------------------------------------------
+
+
+class WorkspaceCleanupTests(unittest.TestCase):
+    def test_close_removes_ephemeral_dirs(self) -> None:
+        client = CursorAgentClient()
+        ws1, _ = client._allocate_workspace()
+        ws2, _ = client._allocate_workspace()
+        self.assertTrue(os.path.isdir(ws1))
+        self.assertTrue(os.path.isdir(ws2))
+        client.close()
+        self.assertFalse(os.path.exists(ws1))
+        self.assertFalse(os.path.exists(ws2))
+
+    def test_close_leaves_user_workspace_alone(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as user_ws:
+            client = CursorAgentClient(workspace=user_ws)
+            ws, _ = client._allocate_workspace()
+            self.assertEqual(ws, user_ws)
+            client.close()
+            self.assertTrue(os.path.isdir(user_ws))  # not removed
+
+
+class CompressionHookTests(unittest.TestCase):
+    """The bar's high-water mark must drop after Hermes' context
+    compression — otherwise it stays inflated showing the pre-compression
+    peak when the actual request is now much smaller.
+
+    The contract is: ``CursorAgentClient`` exposes ``reset_context_baseline()``,
+    and Hermes' compression module calls it on any client that defines the
+    method.  See ``agent/conversation_compression.py``.
+    """
+
+    def test_reset_context_baseline_drops_high_water(self) -> None:
+        client = CursorAgentClient()
+        try:
+            client._context_high_water = 80_000
+            client.reset_context_baseline()
+            self.assertEqual(client._context_high_water, 0)
+        finally:
+            client.close()
+
+    def test_compression_hook_invokes_reset_on_cursor_client(self) -> None:
+        # Simulate the compression code path: it fetches agent.client and
+        # calls reset_context_baseline() if available. Verify that path
+        # actually drops cursor's bar floor.
+        client = CursorAgentClient()
+        try:
+            client._context_high_water = 120_000
+
+            class _FakeAgent:
+                pass
+
+            agent = _FakeAgent()
+            agent.client = client
+
+            # Mirror of the snippet in agent/conversation_compression.py
+            target = getattr(agent, "client", None)
+            if target is not None and hasattr(target, "reset_context_baseline"):
+                target.reset_context_baseline()
+
+            self.assertEqual(client._context_high_water, 0,
+                             "compression hook must drop cursor's bar floor")
+        finally:
+            client.close()
+
+    def test_compression_hook_is_no_op_for_clients_without_reset(self) -> None:
+        # Other providers (Grok, OpenAI, Claude) don't define
+        # reset_context_baseline.  The compression hook must not raise
+        # when client lacks it.
+
+        class _OpenAILikeClient:
+            pass
+
+        class _FakeAgent:
+            pass
+
+        agent = _FakeAgent()
+        agent.client = _OpenAILikeClient()
+
+        target = getattr(agent, "client", None)
+        # This is exactly the conditional the production code uses:
+        invoked = False
+        if target is not None and hasattr(target, "reset_context_baseline"):
+            target.reset_context_baseline()
+            invoked = True
+        self.assertFalse(invoked,
+                         "hook must not fire for non-cursor clients")
+
+
+class TimeoutTests(unittest.TestCase):
+    """Regression tests for the event-driven idle timeout.
+
+    Before this fix the wrapper enforced a wall-clock deadline that killed
+    healthy long-running turns at 90s (outer Hermes wrapper) or 600s
+    (inner cursor client). The semantics are now: the deadline resets on
+    every stream-json event, so total wall-clock can be arbitrary as long
+    as events keep flowing. Only true subprocess hangs (no events for the
+    threshold) trigger termination. Default idle threshold is 1800s
+    (30 min) to comfortably cover cursor-agent's internal 10-min shell
+    ceiling plus chained long operations.
+    """
+
+    def setUp(self) -> None:
+        keys = [k for k in os.environ if k.startswith("HERMES_CURSOR_")]
+        self._saved = {k: os.environ.pop(k) for k in keys}
+        self._status_patch = patch(
+            "agent.cursor_agent_client.subprocess.check_output",
+            return_value="✓ Logged in as test@example.com\n",
+        )
+        self._status_patch.start()
+
+    def tearDown(self) -> None:
+        self._status_patch.stop()
+        for k in list(os.environ):
+            if k.startswith("HERMES_CURSOR_"):
+                os.environ.pop(k, None)
+        for k, v in self._saved.items():
+            os.environ[k] = v
+
+    def test_env_var_overrides_default_idle_threshold(self) -> None:
+        os.environ["HERMES_CURSOR_TIMEOUT_SECONDS"] = "1234"
+        client = CursorAgentClient()
+        try:
+            self.assertEqual(client._timeout_seconds, 1234.0)
+        finally:
+            client.close()
+
+    def test_env_var_invalid_value_falls_back_to_default(self) -> None:
+        os.environ["HERMES_CURSOR_TIMEOUT_SECONDS"] = "not-a-number"
+        client = CursorAgentClient()
+        try:
+            self.assertEqual(client._timeout_seconds, 1800.0)
+        finally:
+            client.close()
+
+    def test_env_var_zero_value_falls_back_to_default(self) -> None:
+        # Zero or negative would mean "kill the subprocess instantly on
+        # arrival" which is never useful; fall back to the default.
+        os.environ["HERMES_CURSOR_TIMEOUT_SECONDS"] = "0"
+        client = CursorAgentClient()
+        try:
+            self.assertEqual(client._timeout_seconds, 1800.0)
+        finally:
+            client.close()
+
+    def test_explicit_arg_overrides_default_but_env_wins(self) -> None:
+        # Precedence: env > explicit arg > default.
+        client1 = CursorAgentClient(timeout_seconds=123.0)
+        try:
+            self.assertEqual(client1._timeout_seconds, 123.0)
+        finally:
+            client1.close()
+
+        os.environ["HERMES_CURSOR_TIMEOUT_SECONDS"] = "987"
+        client2 = CursorAgentClient(timeout_seconds=123.0)
+        try:
+            self.assertEqual(client2._timeout_seconds, 987.0)
+        finally:
+            client2.close()
+
+    @staticmethod
+    def _patch_popen(fake_proc):
+        def _fake_popen(argv, **kwargs):
+            fake_proc.argv_seen = list(argv)
+            fake_proc.cwd_seen = kwargs.get("cwd")
+            fake_proc.env_seen = kwargs.get("env")
+            return fake_proc
+
+        return patch("agent.cursor_agent_client.subprocess.Popen", side_effect=_fake_popen)
+
+    def test_context_estimate_callback_fires_before_subprocess(self) -> None:
+        # Regression: the status bar sat at 0/200K throughout a long
+        # in-flight first turn because the compressor only learns about
+        # prompt_tokens from the response usage at end-of-turn. The
+        # context_estimate_callback fires with the messages-based token
+        # estimate before the subprocess spawns so the bar reflects
+        # input context immediately.
+        proc = _FakeProcess(SUCCESS_STREAM)
+        observed: list[int] = []
+        client = CursorAgentClient(
+            context_estimate_callback=lambda tokens: observed.append(tokens),
+        )
+        try:
+            with self._patch_popen(proc):
+                client.chat.completions.create(
+                    model="composer-2.5",
+                    messages=[
+                        {"role": "system", "content": "y" * 4000},
+                        {"role": "user", "content": "x" * 4000},
+                    ],
+                )
+            self.assertEqual(len(observed), 1,
+                             "callback should fire exactly once per turn")
+            self.assertGreater(observed[0], 0,
+                               "estimate should be > 0 for non-empty messages")
+        finally:
+            client.close()
+
+    def test_context_estimate_callback_is_optional(self) -> None:
+        # Sanity: not passing the callback must not break anything.
+        proc = _FakeProcess(SUCCESS_STREAM)
+        client = CursorAgentClient()
+        try:
+            with self._patch_popen(proc):
+                resp = client.chat.completions.create(
+                    model="composer-2.5",
+                    messages=[{"role": "user", "content": "Hi"}],
+                )
+            self.assertEqual(resp.choices[0].finish_reason, "stop")
+        finally:
+            client.close()
+
+    def test_high_water_bumps_before_subprocess_for_long_first_turn_visibility(self) -> None:
+        # Even without an external callback, the internal high-water mark
+        # must be bumped before the subprocess spawns so that
+        # ``_estimate_per_round_context`` and the final usage shape don't
+        # regress against the input-side estimate.
+        proc = _FakeProcess(SUCCESS_STREAM)
+        client = CursorAgentClient()
+        observed_high_water_at_subprocess_start: list[int] = []
+        real_run = client._run_prompt
+
+        def _wrap_run(*args, **kwargs):
+            observed_high_water_at_subprocess_start.append(client._context_high_water)
+            return real_run(*args, **kwargs)
+
+        client._run_prompt = _wrap_run  # type: ignore[method-assign]
+        try:
+            with self._patch_popen(proc):
+                client.chat.completions.create(
+                    model="composer-2.5",
+                    messages=[
+                        {"role": "system", "content": "y" * 4000},
+                        {"role": "user", "content": "x" * 4000},
+                    ],
+                )
+            self.assertGreater(observed_high_water_at_subprocess_start[0], 0,
+                               "high-water must be bumped before subprocess "
+                               "spawn, not after the result event")
+        finally:
+            client.close()
+
+    def test_idle_deadline_resets_on_each_stream_event(self) -> None:
+        # Slow-stream regression: emit a handful of events with per-event
+        # delays that, in aggregate, exceed the idle threshold. The old
+        # wall-clock implementation would have raised TimeoutError after
+        # the first 0.4s; the new implementation must let the turn finish
+        # because each individual gap (0.1s) stays well below 0.4s.
+        class _SlowLineStdout:
+            def __init__(self, events):
+                self._events = list(events)
+                self._idx = 0
+
+            def __iter__(self):
+                return self
+
+            def __next__(self) -> str:
+                if self._idx >= len(self._events):
+                    raise StopIteration
+                delay, line = self._events[self._idx]
+                self._idx += 1
+                if delay > 0:
+                    time.sleep(delay)
+                return line + "\n"
+
+        class _SlowFakeProcess(_FakeProcess):
+            def __init__(self, slow_events) -> None:
+                super().__init__([])
+                self.stdout = _SlowLineStdout(slow_events)
+
+        # 8 events, each 0.1s apart => 0.8s total wall-clock.
+        # Idle threshold: 0.4s. Every gap stays under threshold, so we
+        # should succeed cleanly.
+        slow = [
+            (0.1, SUCCESS_STREAM[0]),
+            (0.1, SUCCESS_STREAM[1]),
+            (0.1, SUCCESS_STREAM[2]),
+            (0.1, SUCCESS_STREAM[3]),
+            (0.1, SUCCESS_STREAM[4]),
+        ]
+        proc = _SlowFakeProcess(slow)
+        client = CursorAgentClient(timeout_seconds=0.4)
+
+        def _fake_popen(argv, **kwargs):
+            proc.argv_seen = list(argv)
+            proc.cwd_seen = kwargs.get("cwd")
+            proc.env_seen = kwargs.get("env")
+            return proc
+
+        try:
+            with patch("agent.cursor_agent_client.subprocess.Popen", side_effect=_fake_popen):
+                resp = client.chat.completions.create(
+                    model="composer-2.5",
+                    messages=[{"role": "user", "content": "Hi"}],
+                )
+            # Successful completion with deadline resets working correctly.
+            self.assertEqual(resp.choices[0].finish_reason, "stop")
+            self.assertEqual(resp.choices[0].message.content, "Hello world")
+        finally:
+            client.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/hermes_cli/test_cursor_provider.py
+++ b/tests/hermes_cli/test_cursor_provider.py
@@ -1,0 +1,653 @@
+"""Tests for the Cursor provider registration across all four registries.
+
+Covers:
+- ``providers/`` plugin discovery (``ProviderProfile``)
+- ``hermes_cli.providers`` HERMES_OVERLAYS + ALIASES + labels
+- ``hermes_cli.auth`` PROVIDER_REGISTRY + alias resolver
+- ``hermes_cli.models`` ProviderEntry + ``_PROVIDER_MODELS`` snapshot + aliases
+- ``resolve_external_process_provider_credentials`` for cursor
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class CursorComposerContextWindowTests(unittest.TestCase):
+    """Composer family must report cursor's actual 200K cap, not 256K.
+
+    Cursor docs pin Composer 2 and Composer 2.5 (both fast and standard)
+    to a 200K context window (the base model supports 256K but cursor
+    truncates). Status-bar % and compression thresholds depend on this
+    being accurate — otherwise users see 67K/256K (26%) when in reality
+    they're at 67K/200K (33%) and 12K closer to the actual ceiling.
+
+    Regression: prior to 186bf25c the composer ids fell through to the
+    256K DEFAULT_FALLBACK_CONTEXT and inflated the usable window by 56K.
+    """
+
+    def test_composer_25_fast_is_200k(self) -> None:
+        from agent.model_metadata import get_model_context_length
+
+        ctx = get_model_context_length(
+            "composer-2.5-fast", "cursor://agent", "", None, "cursor"
+        )
+        self.assertEqual(ctx, 200_000)
+
+    def test_composer_25_is_200k(self) -> None:
+        from agent.model_metadata import get_model_context_length
+
+        ctx = get_model_context_length(
+            "composer-2.5", "cursor://agent", "", None, "cursor"
+        )
+        self.assertEqual(ctx, 200_000)
+
+    def test_composer_2_family_is_200k(self) -> None:
+        from agent.model_metadata import get_model_context_length
+
+        for model in ("composer-2", "composer-2-fast"):
+            with self.subTest(model=model):
+                ctx = get_model_context_length(
+                    model, "cursor://agent", "", None, "cursor"
+                )
+                self.assertEqual(ctx, 200_000)
+
+
+class CursorProviderRegistryTests(unittest.TestCase):
+    # ---- providers/ plugin profile ----
+
+    def test_plugin_profile_registered(self) -> None:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cursor")
+        self.assertIsNotNone(profile, "cursor plugin profile not discovered")
+        self.assertEqual(profile.name, "cursor")
+        self.assertEqual(profile.api_mode, "chat_completions")
+        self.assertEqual(profile.auth_type, "external_process")
+        self.assertEqual(profile.base_url, "cursor://agent")
+        self.assertIn("CURSOR_API_KEY", profile.env_vars)
+        self.assertEqual(profile.supports_health_check, False)
+        # Fallback model list must include the new 2.5 family.
+        self.assertIn("composer-2.5", profile.fallback_models)
+        self.assertIn("composer-2.5-fast", profile.fallback_models)
+
+    def test_plugin_profile_aliases_resolve(self) -> None:
+        from providers import get_provider_profile
+
+        for alias in ("cursor-agent", "cursor-cli", "cursor-sub", "cursor-subscription"):
+            with self.subTest(alias=alias):
+                self.assertEqual(get_provider_profile(alias).name, "cursor")
+
+    # ---- hermes_cli.providers HERMES_OVERLAYS ----
+
+    def test_hermes_overlay_present(self) -> None:
+        from hermes_cli.providers import get_provider, normalize_provider, get_label
+
+        pdef = get_provider("cursor")
+        self.assertIsNotNone(pdef)
+        self.assertEqual(pdef.id, "cursor")
+        self.assertEqual(pdef.auth_type, "external_process")
+        self.assertEqual(pdef.base_url, "cursor://agent")
+        self.assertIn("CURSOR_API_KEY", pdef.api_key_env_vars)
+
+        # Aliases
+        for alias in ("cursor-agent", "cursor-cli", "cursor-sub", "anysphere"):
+            with self.subTest(alias=alias):
+                self.assertEqual(normalize_provider(alias), "cursor")
+
+        # Label override
+        self.assertEqual(get_label("cursor"), "Cursor")
+
+    # ---- hermes_cli.auth PROVIDER_REGISTRY ----
+
+    def test_auth_registry_present(self) -> None:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        self.assertIn("cursor", PROVIDER_REGISTRY)
+        entry = PROVIDER_REGISTRY["cursor"]
+        self.assertEqual(entry.auth_type, "external_process")
+        self.assertEqual(entry.inference_base_url, "cursor://agent")
+        self.assertIn("CURSOR_API_KEY", entry.api_key_env_vars)
+
+    # ---- hermes_cli.models picker + catalog ----
+
+    def test_picker_entry_present(self) -> None:
+        from hermes_cli.models import CANONICAL_PROVIDERS
+
+        slugs = [p.slug for p in CANONICAL_PROVIDERS]
+        self.assertIn("cursor", slugs)
+        entry = next(p for p in CANONICAL_PROVIDERS if p.slug == "cursor")
+        self.assertEqual(entry.label, "Cursor")
+        # Picker description: short, no em-dash, mentions "100+ models",
+        # mirrors OpenRouter's ``OpenRouter (100+ models, pay-per-use)``.
+        self.assertEqual(entry.tui_desc, "Cursor (100+ models, subscription)")
+        self.assertNotIn("—", entry.tui_desc)
+
+    def test_model_catalog_snapshot(self) -> None:
+        from hermes_cli.models import _PROVIDER_MODELS
+
+        self.assertIn("cursor", _PROVIDER_MODELS)
+        models = _PROVIDER_MODELS["cursor"]
+        # Must include composer-2.5 family and frontier models.
+        self.assertIn("auto", models)
+        self.assertIn("composer-2.5", models)
+        self.assertIn("composer-2.5-fast", models)
+        self.assertIn("gpt-5.5-medium", models)
+        self.assertIn("claude-opus-4-7-high", models)
+        self.assertIn("gemini-3.1-pro", models)
+        # No stale junk
+        self.assertNotIn("", models)
+        self.assertEqual(len(models), len(set(models)))
+
+    def test_model_alias_map(self) -> None:
+        # Use private alias map directly — it's the same one the picker uses.
+        from hermes_cli.models import _PROVIDER_ALIASES
+
+        for alias in ("cursor-agent", "cursor-cli", "cursor-sub", "anysphere"):
+            with self.subTest(alias=alias):
+                self.assertEqual(_PROVIDER_ALIASES.get(alias), "cursor")
+
+    def test_provider_model_ids_lists_cursor(self) -> None:
+        from hermes_cli.models import provider_model_ids
+
+        # Patch shutil.which to None so the live-fetch path returns nothing
+        # and the function falls back to the static snapshot — keeps the test
+        # independent of the user's actual cursor-agent install.
+        with patch("shutil.which", return_value=None):
+            models = provider_model_ids("cursor")
+        self.assertIn("composer-2.5", models)
+        self.assertIn("auto", models)
+        self.assertEqual(models[:3], ["auto", "composer-2.5", "composer-2.5-fast"])
+
+    def test_plugin_fetch_models_honors_custom_cursor_command(self) -> None:
+        """Live model discovery must work with wrappers, not only PATH installs."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cursor")
+        self.assertIsNotNone(profile)
+        assert profile is not None
+
+        def which_side_effect(command: str, *args, **kwargs):
+            if command == "/opt/hermes/bin/cursor-agent-wrapper":
+                return command
+            return None
+
+        with patch.dict(os.environ, {"HERMES_CURSOR_COMMAND": "/opt/hermes/bin/cursor-agent-wrapper"}, clear=False), \
+             patch("shutil.which", side_effect=which_side_effect), \
+             patch("subprocess.check_output", return_value="composer-2.5 - Composer 2.5\n") as check_output:
+            models = profile.fetch_models()
+
+        self.assertEqual(models, ["composer-2.5"])
+        check_output.assert_called_once_with(
+            ["/opt/hermes/bin/cursor-agent-wrapper", "--list-models"],
+            text=True,
+            timeout=8.0,
+        )
+
+    def test_plugin_fetch_models_honors_cursor_agent_path_fallback(self) -> None:
+        """Legacy CURSOR_AGENT_PATH must work when HERMES_CURSOR_COMMAND is unset."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cursor")
+        self.assertIsNotNone(profile)
+        assert profile is not None
+
+        with patch.dict(os.environ, {"HERMES_CURSOR_COMMAND": "", "CURSOR_AGENT_PATH": "/opt/cursor/bin/cursor-agent"}, clear=False), \
+             patch("shutil.which", return_value="/opt/cursor/bin/cursor-agent"), \
+             patch("subprocess.check_output", return_value="composer-2.5-fast - Composer 2.5 Fast\n") as check_output:
+            models = profile.fetch_models()
+
+        self.assertEqual(models, ["composer-2.5-fast"])
+        check_output.assert_called_once_with(
+            ["/opt/cursor/bin/cursor-agent", "--list-models"],
+            text=True,
+            timeout=8.0,
+        )
+
+    def test_plugin_fetch_models_cursor_command_wins_over_cursor_agent_path(self) -> None:
+        """HERMES_CURSOR_COMMAND is the canonical override when both env vars exist."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cursor")
+        self.assertIsNotNone(profile)
+        assert profile is not None
+
+        def which_side_effect(command: str, *args, **kwargs):
+            return {
+                "/opt/hermes/bin/cursor-agent-wrapper": "/resolved/hermes-wrapper",
+                "/legacy/cursor-agent": "/resolved/legacy-agent",
+            }.get(command)
+
+        with patch.dict(os.environ, {"HERMES_CURSOR_COMMAND": "/opt/hermes/bin/cursor-agent-wrapper", "CURSOR_AGENT_PATH": "/legacy/cursor-agent"}, clear=False), \
+             patch("shutil.which", side_effect=which_side_effect), \
+             patch("subprocess.check_output", return_value="auto - Auto\n") as check_output:
+            models = profile.fetch_models()
+
+        self.assertEqual(models, ["auto"])
+        check_output.assert_called_once_with(
+            ["/resolved/hermes-wrapper", "--list-models"],
+            text=True,
+            timeout=8.0,
+        )
+
+    def test_plugin_fetch_models_ignores_blank_env_overrides(self) -> None:
+        """Whitespace-only env vars should fall back to cursor-agent on PATH."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cursor")
+        self.assertIsNotNone(profile)
+        assert profile is not None
+
+        def which_side_effect(command: str, *args, **kwargs):
+            if command == "cursor-agent":
+                return "/usr/local/bin/cursor-agent"
+            return None
+
+        with patch.dict(os.environ, {"HERMES_CURSOR_COMMAND": "   ", "CURSOR_AGENT_PATH": "\t"}, clear=False), \
+             patch("shutil.which", side_effect=which_side_effect), \
+             patch("subprocess.check_output", return_value="composer-2 - Composer 2\n") as check_output:
+            models = profile.fetch_models()
+
+        self.assertEqual(models, ["composer-2"])
+        check_output.assert_called_once_with(
+            ["/usr/local/bin/cursor-agent", "--list-models"],
+            text=True,
+            timeout=8.0,
+        )
+
+    def test_plugin_fetch_models_uses_raw_command_when_which_cannot_resolve_it(self) -> None:
+        """Absolute or relative wrapper paths can still be invoked directly."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cursor")
+        self.assertIsNotNone(profile)
+        assert profile is not None
+
+        with patch.dict(os.environ, {"HERMES_CURSOR_COMMAND": "./bin/cursor-wrapper"}, clear=False), \
+             patch("shutil.which", return_value=None), \
+             patch("subprocess.check_output", return_value="gpt-5.5-medium - GPT 5.5 Medium\n") as check_output:
+            models = profile.fetch_models()
+
+        self.assertEqual(models, ["gpt-5.5-medium"])
+        check_output.assert_called_once_with(
+            ["./bin/cursor-wrapper", "--list-models"],
+            text=True,
+            timeout=8.0,
+        )
+
+    def test_plugin_fetch_models_threads_cursor_args_into_probe(self) -> None:
+        """Profile-specific CLI args should apply to live model discovery."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cursor")
+        self.assertIsNotNone(profile)
+        assert profile is not None
+
+        with patch.dict(os.environ, {"HERMES_CURSOR_COMMAND": "./bin/cursor-wrapper", "HERMES_CURSOR_ARGS": "--profile mazi"}, clear=False), \
+             patch("shutil.which", return_value=None), \
+             patch("subprocess.check_output", return_value="composer-2.5 - Composer 2.5\n") as check_output:
+            models = profile.fetch_models()
+
+        self.assertEqual(models, ["composer-2.5"])
+        check_output.assert_called_once_with(
+            ["./bin/cursor-wrapper", "--profile", "mazi", "--list-models"],
+            text=True,
+            timeout=8.0,
+        )
+
+    def test_plugin_fetch_models_returns_none_when_cursor_cli_fails(self) -> None:
+        """Discovery failure must fail closed so callers use the static fallback list."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cursor")
+        self.assertIsNotNone(profile)
+        assert profile is not None
+
+        with patch.dict(os.environ, {"HERMES_CURSOR_COMMAND": "/missing/cursor-agent"}, clear=False), \
+             patch("shutil.which", return_value=None), \
+             patch("subprocess.check_output", side_effect=FileNotFoundError):
+            models = profile.fetch_models()
+
+        self.assertIsNone(models)
+
+    def test_plugin_fetch_models_prioritizes_important_cursor_models(self) -> None:
+        """Large live Cursor catalogs should open with Composer/agentic picks first."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cursor")
+        self.assertIsNotNone(profile)
+        assert profile is not None
+
+        live_catalog = "\n".join([
+            "z-random - Random Model",
+            "gpt-5.5-medium - GPT 5.5 Medium",
+            "composer-2.5-fast - Composer 2.5 Fast",
+            "auto - Auto",
+            "composer-2.5 - Composer 2.5",
+            "claude-opus-4-7-high - Claude Opus 4.7 High",
+            "z-random - Random Model Duplicate",
+        ])
+        with patch("shutil.which", return_value="/usr/local/bin/cursor-agent"), \
+             patch("subprocess.check_output", return_value=live_catalog):
+            models = profile.fetch_models()
+
+        self.assertEqual(
+            models,
+            [
+                "auto",
+                "composer-2.5",
+                "composer-2.5-fast",
+                "gpt-5.5-medium",
+                "claude-opus-4-7-high",
+                "z-random",
+            ],
+        )
+
+
+class CursorCommandResolverTests(unittest.TestCase):
+    """Shared Cursor command resolution contract."""
+
+    def test_resolve_cursor_command_env_precedence(self) -> None:
+        from providers.cursor_utils import resolve_cursor_command
+
+        with patch.dict(os.environ, {"HERMES_CURSOR_COMMAND": "/new/wrapper", "CURSOR_AGENT_PATH": "/legacy/wrapper"}, clear=False):
+            self.assertEqual(resolve_cursor_command(), "/new/wrapper")
+
+    def test_resolve_cursor_command_ignores_blank_env(self) -> None:
+        from providers.cursor_utils import resolve_cursor_command
+
+        with patch.dict(os.environ, {"HERMES_CURSOR_COMMAND": "  ", "CURSOR_AGENT_PATH": "\t"}, clear=False):
+            self.assertEqual(resolve_cursor_command(), "cursor-agent")
+
+    def test_resolve_cursor_command_path_uses_path_lookup(self) -> None:
+        from providers.cursor_utils import resolve_cursor_command_path
+
+        with patch("shutil.which", return_value="/usr/bin/cursor-agent") as which:
+            self.assertEqual(resolve_cursor_command_path("cursor-agent"), "/usr/bin/cursor-agent")
+        which.assert_called_once_with("cursor-agent")
+
+    def test_resolve_cursor_extra_args_splits_shell_style_env(self) -> None:
+        from providers.cursor_utils import resolve_cursor_extra_args
+
+        with patch.dict(os.environ, {"HERMES_CURSOR_ARGS": "--profile mazi --flag 'two words'"}, clear=False):
+            self.assertEqual(resolve_cursor_extra_args(), ["--profile", "mazi", "--flag", "two words"])
+
+    def test_resolve_cursor_command_path_preserves_explicit_unresolved_path(self) -> None:
+        from providers.cursor_utils import resolve_cursor_command_path
+
+        with patch("shutil.which", return_value=None):
+            self.assertEqual(resolve_cursor_command_path("./bin/cursor-wrapper"), "./bin/cursor-wrapper")
+            self.assertEqual(resolve_cursor_command_path(r"C:\\Cursor\\cursor-agent.exe"), r"C:\\Cursor\\cursor-agent.exe")
+
+    def test_resolve_cursor_command_path_rejects_unresolved_bare_name(self) -> None:
+        from providers.cursor_utils import resolve_cursor_command_path
+
+        with patch("shutil.which", return_value=None):
+            self.assertIsNone(resolve_cursor_command_path("cursor-agent"))
+            self.assertIsNone(resolve_cursor_command_path(""))
+
+    def test_prioritize_cursor_models_keeps_remainder_after_preferred(self) -> None:
+        from providers.cursor_utils import prioritize_cursor_models
+
+        models = prioritize_cursor_models([
+            "z-last",
+            "composer-2.5-fast",
+            "auto",
+            "composer-2.5",
+            "z-last",
+            "other-model",
+        ])
+        self.assertEqual(models, ["auto", "composer-2.5", "composer-2.5-fast", "z-last", "other-model"])
+
+
+class CursorStatusTests(unittest.TestCase):
+    """``get_external_process_provider_status`` cursor branch."""
+
+    def setUp(self) -> None:
+        keys = [
+            "HERMES_CURSOR_COMMAND",
+            "HERMES_CURSOR_ARGS",
+            "CURSOR_AGENT_PATH",
+            "CURSOR_API_KEY",
+            "HERMES_CURSOR_BASE_URL",
+        ]
+        self._saved = {k: os.environ.pop(k, None) for k in keys}
+
+    def tearDown(self) -> None:
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_status_reports_configured_when_cli_present(self) -> None:
+        from hermes_cli.auth import get_external_process_provider_status
+
+        with patch("shutil.which", return_value="/fake/bin/cursor-agent"), \
+             patch("subprocess.check_output", return_value="✓ Logged in as alice@example.com\n"):
+            status = get_external_process_provider_status("cursor")
+        self.assertTrue(status["configured"])
+        self.assertEqual(status["provider"], "cursor")
+        self.assertEqual(status["resolved_command"], "/fake/bin/cursor-agent")
+        self.assertEqual(status["base_url"], "cursor://agent")
+        self.assertTrue(status["logged_in"])
+        self.assertEqual(status["email"], "alice@example.com")
+
+    def test_status_accepts_raw_cursor_command_when_not_on_path(self) -> None:
+        """Status should match fetch/runtime behavior for wrapper paths."""
+        from hermes_cli.auth import get_external_process_provider_status
+
+        os.environ["HERMES_CURSOR_COMMAND"] = "./bin/cursor-wrapper"
+        os.environ["HERMES_CURSOR_ARGS"] = "--profile mazi"
+        with patch("shutil.which", return_value=None), \
+             patch("subprocess.check_output", return_value="✓ Logged in as alice@example.com\n") as check_output:
+            status = get_external_process_provider_status("cursor")
+
+        self.assertTrue(status["configured"])
+        self.assertEqual(status["command"], "./bin/cursor-wrapper")
+        self.assertEqual(status["resolved_command"], "./bin/cursor-wrapper")
+        self.assertEqual(status["args"], ["--profile", "mazi"])
+        self.assertTrue(status["logged_in"])
+        check_output.assert_called_once_with(
+            ["./bin/cursor-wrapper", "--profile", "mazi", "status"],
+            text=True,
+            timeout=4,
+        )
+
+    def test_status_unconfigured_when_default_cursor_agent_missing(self) -> None:
+        """Only explicit wrapper paths get raw fallback; bare defaults still require PATH."""
+        from hermes_cli.auth import get_external_process_provider_status
+
+        with patch("shutil.which", return_value=None):
+            status = get_external_process_provider_status("cursor")
+
+        self.assertFalse(status["configured"])
+        self.assertEqual(status["command"], "cursor-agent")
+        self.assertIsNone(status["resolved_command"])
+
+    def test_status_reports_logged_out_when_status_lacks_marker(self) -> None:
+        from hermes_cli.auth import get_external_process_provider_status
+
+        with patch("shutil.which", return_value="/fake/bin/cursor-agent"), \
+             patch("subprocess.check_output", return_value="Some other text\n"):
+            status = get_external_process_provider_status("cursor")
+        self.assertTrue(status["configured"])
+        self.assertFalse(status["logged_in"])
+        self.assertEqual(status["email"], "")
+
+    def test_status_treats_api_key_env_as_authenticated(self) -> None:
+        from hermes_cli.auth import get_external_process_provider_status
+
+        os.environ["CURSOR_API_KEY"] = "crsr_token"
+        with patch("shutil.which", return_value="/fake/bin/cursor-agent"), \
+             patch("subprocess.check_output", return_value="not logged in\n"):
+            status = get_external_process_provider_status("cursor")
+        self.assertTrue(status["logged_in"])
+
+    def test_status_unconfigured_when_cli_missing(self) -> None:
+        from hermes_cli.auth import get_external_process_provider_status
+
+        with patch("shutil.which", return_value=None):
+            status = get_external_process_provider_status("cursor")
+        self.assertFalse(status["configured"])
+        self.assertIsNone(status["resolved_command"])
+
+    def test_get_auth_status_dispatches_cursor(self) -> None:
+        from hermes_cli.auth import get_auth_status
+
+        with patch("shutil.which", return_value="/fake/bin/cursor-agent"), \
+             patch("subprocess.check_output", return_value="✓ Logged in as bob@example.com\n"):
+            status = get_auth_status("cursor")
+        self.assertTrue(status["logged_in"])
+        self.assertEqual(status["email"], "bob@example.com")
+
+
+class CursorRuntimeProviderTests(unittest.TestCase):
+    """``resolve_runtime_provider`` must build a cursor dict, not fall through.
+
+    Without this branch the chat REPL falls through to the openrouter default
+    and dies with "Provider resolver returned an empty API key. Set
+    OPENROUTER_API_KEY..." — the bug we hit in interactive testing.
+    """
+
+    def setUp(self) -> None:
+        keys = [
+            "HERMES_CURSOR_COMMAND",
+            "CURSOR_AGENT_PATH",
+            "CURSOR_API_KEY",
+            "HERMES_CURSOR_BASE_URL",
+        ]
+        self._saved = {k: os.environ.pop(k, None) for k in keys}
+
+    def tearDown(self) -> None:
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_runtime_provider_returns_cursor_dict(self) -> None:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        with patch("shutil.which", return_value="/fake/bin/cursor-agent"):
+            rt = resolve_runtime_provider(requested="cursor")
+
+        self.assertEqual(rt["provider"], "cursor")
+        self.assertEqual(rt["api_mode"], "chat_completions")
+        self.assertEqual(rt["base_url"], "cursor://agent")
+        self.assertEqual(rt["command"], "/fake/bin/cursor-agent")
+        # api_key must be either a real key or the sentinel — never empty.
+        self.assertTrue(rt["api_key"])
+        self.assertEqual(rt["source"], "process")
+
+    def test_runtime_provider_threads_real_api_key(self) -> None:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        os.environ["CURSOR_API_KEY"] = "crsr_real_runtime_test"
+        with patch("shutil.which", return_value="/fake/bin/cursor-agent"):
+            rt = resolve_runtime_provider(requested="cursor")
+        self.assertEqual(rt["api_key"], "crsr_real_runtime_test")
+
+    def test_runtime_provider_exposes_replayable_cursor_trace(self) -> None:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        os.environ["CURSOR_API_KEY"] = "crsr_real_runtime_test"
+        os.environ["HERMES_CURSOR_COMMAND"] = "./bin/cursor-wrapper"
+        os.environ["HERMES_CURSOR_ARGS"] = "--profile mazi"
+        with patch("shutil.which", return_value=None):
+            rt = resolve_runtime_provider(requested="cursor")
+
+        trace = rt["trace"]
+        self.assertEqual(trace["provider"], "cursor")
+        self.assertEqual(trace["route"], "cursor-agent")
+        self.assertEqual(trace["auth_source"], "CURSOR_API_KEY")
+        self.assertEqual(trace["config_source"], "HERMES_CURSOR_COMMAND")
+        self.assertEqual(trace["command"], "./bin/cursor-wrapper")
+        self.assertEqual(trace["args"], ["--profile", "mazi"])
+        self.assertEqual(trace["base_url"], "cursor://agent")
+        self.assertNotIn("crsr_real_runtime_test", str(trace))
+
+
+class CursorCredsResolverTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Stash relevant env so we don't leak state across tests.
+        keys = [
+            "HERMES_CURSOR_COMMAND",
+            "HERMES_CURSOR_ARGS",
+            "CURSOR_AGENT_PATH",
+            "CURSOR_API_KEY",
+            "HERMES_CURSOR_BASE_URL",
+        ]
+        self._saved = {k: os.environ.pop(k, None) for k in keys}
+
+    def tearDown(self) -> None:
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_creds_resolver_finds_cli_and_returns_dict(self) -> None:
+        from hermes_cli.auth import resolve_external_process_provider_credentials
+
+        # Pretend cursor-agent lives at a known fake path.
+        with patch("shutil.which", return_value="/fake/bin/cursor-agent"):
+            creds = resolve_external_process_provider_credentials("cursor")
+
+        self.assertEqual(creds["provider"], "cursor")
+        self.assertEqual(creds["command"], "/fake/bin/cursor-agent")
+        self.assertEqual(creds["base_url"], "cursor://agent")
+        self.assertEqual(creds["source"], "process")
+        # No api_key in env → sentinel value
+        self.assertEqual(creds["api_key"], "cursor-agent-login")
+        self.assertEqual(creds["args"], [])
+
+    def test_creds_resolver_threads_api_key_when_set(self) -> None:
+        from hermes_cli.auth import resolve_external_process_provider_credentials
+
+        os.environ["CURSOR_API_KEY"] = "crsr_real_value"
+        with patch("shutil.which", return_value="/fake/bin/cursor-agent"):
+            creds = resolve_external_process_provider_credentials("cursor")
+        self.assertEqual(creds["api_key"], "crsr_real_value")
+
+    def test_creds_resolver_raises_when_cli_missing(self) -> None:
+        from hermes_cli.auth import AuthError, resolve_external_process_provider_credentials
+
+        with patch("shutil.which", return_value=None):
+            with self.assertRaises(AuthError) as ctx:
+                resolve_external_process_provider_credentials("cursor")
+        self.assertEqual(ctx.exception.code, "missing_cursor_cli")
+        self.assertIn("Cursor CLI", str(ctx.exception))
+
+    def test_creds_resolver_accepts_raw_cursor_command_when_not_on_path(self) -> None:
+        from hermes_cli.auth import resolve_external_process_provider_credentials
+
+        os.environ["HERMES_CURSOR_COMMAND"] = "./bin/cursor-wrapper"
+        with patch("shutil.which", return_value=None):
+            creds = resolve_external_process_provider_credentials("cursor")
+
+        self.assertEqual(creds["command"], "./bin/cursor-wrapper")
+
+    def test_creds_resolver_honors_extra_args_env(self) -> None:
+        from hermes_cli.auth import resolve_external_process_provider_credentials
+
+        os.environ["HERMES_CURSOR_ARGS"] = "--header X-Foo:1 --header X-Bar:2"
+        with patch("shutil.which", return_value="/fake/bin/cursor-agent"):
+            creds = resolve_external_process_provider_credentials("cursor")
+        self.assertEqual(creds["args"], ["--header", "X-Foo:1", "--header", "X-Bar:2"])
+
+    def test_creds_resolver_does_not_disturb_copilot_acp(self) -> None:
+        from hermes_cli.auth import resolve_external_process_provider_credentials
+
+        with patch("shutil.which", return_value="/fake/bin/copilot"):
+            creds = resolve_external_process_provider_credentials("copilot-acp")
+        self.assertEqual(creds["provider"], "copilot-acp")
+        self.assertEqual(creds["api_key"], "copilot-acp")
+        self.assertEqual(creds["args"], ["--acp", "--stdio"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -269,6 +269,51 @@ class TestProviderPersistsAfterModelSave:
         assert model.get("default") == "gpt-5.4"
         assert model.get("api_mode") == "chat_completions"
 
+    def test_cursor_provider_saved_when_selected(self, config_home):
+        """_model_flow_cursor should persist provider/base_url/model together."""
+        from hermes_cli.main import _model_flow_cursor
+        from hermes_cli.config import load_config
+
+        with patch(
+            "hermes_cli.auth.get_external_process_provider_status",
+            return_value={
+                "resolved_command": "/usr/local/bin/cursor-agent",
+                "command": "cursor-agent",
+                "base_url": "cursor://agent",
+                "logged_in": True,
+                "email": "mazovje@gmail.com",
+            },
+        ), patch(
+            "hermes_cli.auth.resolve_external_process_provider_credentials",
+            return_value={
+                "provider": "cursor",
+                "api_key": "cursor-agent-login",
+                "base_url": "cursor://agent",
+                "command": "/usr/local/bin/cursor-agent",
+                "args": [],
+                "source": "process",
+            },
+        ), patch(
+            "hermes_cli.models.provider_model_ids",
+            return_value=["auto", "composer-2.5", "composer-2.5-fast"],
+        ), patch(
+            "hermes_cli.auth._prompt_model_selection",
+            return_value="composer-2.5",
+        ), patch(
+            "hermes_cli.auth.deactivate_provider",
+        ):
+            _model_flow_cursor(load_config(), "old-model")
+
+        import yaml
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict), f"model should be dict, got {type(model)}"
+        assert model.get("provider") == "cursor"
+        assert model.get("base_url") == "cursor://agent"
+        assert model.get("default") == "composer-2.5"
+        assert model.get("api_mode") == "chat_completions"
+
     def test_opencode_go_models_are_selectable_and_persist_normalized(self, config_home, monkeypatch):
         from hermes_cli.main import _model_flow_api_key_provider
         from hermes_cli.config import load_config


### PR DESCRIPTION
## Summary

Adds Cursor as an external-process model provider backed by the `cursor-agent` CLI.

This is the first split: selectable/configurable Cursor provider support, including model picker wiring and runtime routing. A follow-up PR can keep polishing docs/UX if maintainers want this broken down further.

## What changed

- Registers `cursor` across provider catalogs, aliases, auth status, model picker, runtime resolution, and model-provider plugin discovery.
- Adds a `CursorAgentClient` that shells out to `cursor-agent -p --output-format stream-json` and translates responses into OpenAI-chat-compatible objects.
- Supports live Cursor model discovery with static fallbacks for Composer/frontier models.
- Preserves Cursor internal tool activity in Hermes progress callbacks, including edit/write diff metadata when Cursor emits it.
- Adds Cursor Composer context-window fallbacks at Cursor's 200K cap.

## Validation

```bash
python3 -m py_compile agent/cursor_agent_client.py providers/cursor_utils.py hermes_cli/auth.py hermes_cli/model_setup_flows.py hermes_cli/models.py hermes_cli/runtime_provider.py hermes_cli/providers.py agent/agent_runtime_helpers.py agent/display.py agent/model_metadata.py
python3 -m pytest -q -o addopts='' tests/agent/test_cursor_agent_client.py tests/hermes_cli/test_cursor_provider.py tests/hermes_cli/test_model_provider_persistence.py
```

Result: `116 passed, 28 subtests passed`.
