### PR TITLE
fix(telegram): avoid rich messages for CJK text (#47653)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1048,6 +1048,16 @@ class TelegramAdapter(BasePlatformAdapter):
         r"int|prod|sqrt|lim|infty|begin\{(?:equation|align|matrix|cases)\}))",
         re.IGNORECASE | re.DOTALL,
     )
+    _RICH_CJK_RE = re.compile(
+        "["
+        "\u3040-\u30ff"  # Hiragana, Katakana
+        "\u3400-\u4dbf"  # CJK Extension A
+        "\u4e00-\u9fff"  # CJK Unified Ideographs
+        "\uac00-\ud7af"  # Hangul syllables
+        "\uf900-\ufaff"  # CJK Compatibility Ideographs
+        "\U00020000-\U000323af"  # CJK extensions and compatibility supplement
+        "]"
+    )
 
     def _has_telegram_desktop_details_math_crash_shape(self, content: str) -> bool:
         """Return True for rich-message details+math content that crashes TDesktop.
@@ -1064,6 +1074,16 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._RICH_MATH_IN_DETAILS_RE.search(details_block):
                 return True
         return False
+
+    def _has_telegram_desktop_cjk_rich_garble_shape(self, content: str) -> bool:
+        """Return True for CJK content that current TDesktop rich drafts garble.
+
+        Telegram Mac/Desktop Bot API 10.1 rich-message rendering currently
+        leaves overlapping draft/overlay glyph artifacts for CJK text (#47653).
+        The legacy MarkdownV2 path renders the same text cleanly, so skip rich
+        delivery up front until affected clients age out.
+        """
+        return bool(content and self._RICH_CJK_RE.search(content))
 
     def _needs_rich_rendering(self, content: str) -> bool:
         """Return True for markdown constructs that the legacy path degrades.
@@ -1103,6 +1123,7 @@ class TelegramAdapter(BasePlatformAdapter):
             and content.strip()
             and self._needs_rich_rendering(content)
             and not self._has_telegram_desktop_details_math_crash_shape(content)
+            and not self._has_telegram_desktop_cjk_rich_garble_shape(content)
             and self._content_fits_rich_limits(content)
             and self._bot_supports_rich()
         )
@@ -1424,6 +1445,7 @@ class TelegramAdapter(BasePlatformAdapter):
             and content
             and content.strip()
             and not self._has_telegram_desktop_details_math_crash_shape(content)
+            and not self._has_telegram_desktop_cjk_rich_garble_shape(content)
             and self._content_fits_rich_limits(content)
             and self._bot_supports_rich()
         )

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -24,6 +24,8 @@ from telegram.error import BadRequest, NetworkError, TimedOut
 # Content exercising rich-only constructs: a heading, a real Markdown table,
 # and a task list. Pipes / brackets must survive untouched into the payload.
 RICH_CONTENT = "## Results\n\n| Case | Status |\n|---|---|\n| rich | ✅ |\n\n- [x] table renders"
+CJK_RICH_CONTENT = "## 持仓\n\n| 项目 | 状态 |\n|---|---|\n| 早盘 | 正常 |"
+ASTRAL_CJK_RICH_CONTENT = "## Rare Han\n\n| glyph | status |\n|---|---|\n| \U00030000 | ok |"
 DANGEROUS_DETAILS_MATH = (
     "<details><summary>Complex proof</summary>\n\n"
     "$$\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}$$\n\n"
@@ -160,6 +162,28 @@ async def test_math_outside_details_still_uses_rich_send():
 
 
 @pytest.mark.asyncio
+async def test_cjk_rich_content_skips_rich_send_to_avoid_tdesktop_garble():
+    adapter = _make_adapter()
+
+    result = await adapter.send("12345", CJK_RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_astral_cjk_rich_content_skips_rich_send_to_avoid_tdesktop_garble():
+    adapter = _make_adapter()
+
+    result = await adapter.send("12345", ASTRAL_CJK_RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_rich_messages_opt_out_uses_legacy_send_path():
     adapter = _make_adapter(extra={"rich_messages": False})
 
@@ -281,13 +305,15 @@ async def test_oversized_content_skips_rich_and_chunks():
 async def test_rich_limit_is_characters_not_bytes():
     """Telegram's rich limit is UTF-8 characters, not encoded bytes."""
     adapter = _make_adapter()
-    # Rich-eligible (table) so the content takes the rich path; the CJK body
-    # is 20k chars / 60k UTF-8 bytes — over the byte count, under the char cap.
-    cjk = "| a | b |\n|---|---|\n" + "测" * 20000  # 20k chars, ~60k UTF-8 bytes
-    assert len(cjk.encode("utf-8")) > TelegramAdapter.RICH_MESSAGE_MAX_BYTES
-    assert len(cjk) <= TelegramAdapter.RICH_MESSAGE_MAX_CHARS
+    # Rich-eligible (table) so the content takes the rich path; the accented
+    # body is 20k chars / 40k UTF-8 bytes — over the byte count, under the
+    # character cap. CJK is intentionally avoided here because affected
+    # Telegram Desktop clients render CJK rich drafts incorrectly.
+    accented = "| a | b |\n|---|---|\n" + "é" * 20000
+    assert len(accented.encode("utf-8")) > TelegramAdapter.RICH_MESSAGE_MAX_BYTES
+    assert len(accented) <= TelegramAdapter.RICH_MESSAGE_MAX_CHARS
 
-    result = await adapter.send("12345", cjk)
+    result = await adapter.send("12345", accented)
 
     assert result.success is True
     bot = adapter._bot
@@ -529,6 +555,18 @@ async def test_rich_draft_happy_path_sends_raw_markdown():
 
 
 @pytest.mark.asyncio
+async def test_cjk_rich_content_skips_rich_draft_to_avoid_tdesktop_garble():
+    adapter = _make_adapter()
+    adapter._bot.do_api_request = AsyncMock(return_value=True)
+
+    result = await adapter.send_draft("12345", draft_id=7, content=CJK_RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.send_message_draft.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_rich_draft_capability_failure_falls_back_and_latches_off():
     adapter = _make_adapter()
     adapter._bot.do_api_request = AsyncMock(side_effect=BadRequest("Method not found"))
@@ -671,6 +709,19 @@ async def test_finalize_edit_plain_content_stays_legacy():
     assert result.success is True
     adapter._bot.do_api_request.assert_not_called()
     adapter._bot.edit_message_text.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_finalize_edit_cjk_rich_content_stays_legacy_to_avoid_tdesktop_garble():
+    adapter = _make_adapter()
+
+    result = await adapter.edit_message(
+        "12345", "555", CJK_RICH_CONTENT, finalize=True,
+    )
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.edit_message_text.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
CJK responses (Chinese/Japanese/Korean) sent via Bot API 10.1 rich messages no longer show garbled overlapping glyph artifacts on the Telegram Mac/Desktop client. The rich renderer mangles CJK draft/overlay glyphs (#47653, confirmed by the reporter to affect every message containing CJK), while the legacy MarkdownV2 path renders the same text cleanly — so we skip the rich send / draft / final-edit paths up front when content contains CJK.

Salvages #47681 by @tt-a1i (fixes #47653), reconstructed onto current `main` (the Telegram adapter moved from `gateway/platforms/telegram.py` to `plugins/platforms/telegram/adapter.py`). Authorship preserved.

Closes #47653.

## Changes
- `plugins/platforms/telegram/adapter.py`:
  - `_RICH_CJK_RE` — covers Hiragana/Katakana, CJK Unified + Ext A, Hangul, CJK Compatibility, and astral-plane CJK extensions.
  - `_has_telegram_desktop_cjk_rich_garble_shape()` — mirrors the existing `_has_telegram_desktop_details_math_crash_shape` guard pattern.
  - Applied to both rich-eligibility gates: `_rich_eligible` (send + final edit) and `_should_attempt_rich_draft`.
- `tests/gateway/test_telegram_rich_messages.py`: CJK skips rich on send / draft / finalize-edit; astral-plane CJK covered; the byte-vs-char-limit test switched from CJK to accented Latin (CJK now takes the legacy path).

## Validation
| Content | Path |
|---|---|
| CJK table (zh/ja/ko) | legacy MarkdownV2 (renders cleanly) |
| Astral-plane CJK | legacy MarkdownV2 |
| ASCII / accented-Latin table | rich (unchanged) |

- 63 targeted tests pass (was 59, +4 CJK cases).
- E2E: guard trips on zh/ja/ko/astral CJK, leaves ASCII and accented Latin (`café résumé`) on the rich path — targeted, not a blanket disable.

## Premise check
Independently corroborated: issue #47653 (@alextxj) reports the same Mac-client CJK garble and confirms disabling rich fixes it. This routes around a *broken* client renderer (legacy is strictly better for CJK), rather than disabling a working feature.

## Infographic

![cjk-rich-guard](https://v3b.fal.media/files/b/0a9f3396/vUBKAEEaIiLzk_gnhSLBk_05f2vA9k.png)
