### PR TITLE
fix(docker): bake feishu (lark-oapi) into the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,10 +177,18 @@ RUN npm install --prefer-offline --no-audit && \
 # avoids the cross-platform failures that kept [matrix] out of [all]
 # while still making Matrix work in the published container. Fixes #30399.
 #
+# The Feishu gateway's deps ([feishu] extra: lark-oapi) are baked in for the
+# same reason: the [messaging] extra installed below carries telegram/discord/
+# slack but not lark-oapi, and [all] left feishu to lazy-install only. With
+# HERMES_DISABLE_LAZY_INSTALLS=1 and the read-only venv (chmod -R a-w
+# /opt/hermes), the runtime lazy-install can never run, so Feishu silently
+# fails to connect ("No adapter available for feishu"). Baking [feishu] in
+# mirrors the matrix/hindsight handling above. Fixes #50205.
+#
 # The editable link is created after the source copy below.
 COPY pyproject.toml uv.lock ./
 RUN touch ./README.md
-RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra anthropic --extra bedrock --extra azure-identity --extra hindsight --extra matrix
+RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra anthropic --extra bedrock --extra azure-identity --extra hindsight --extra matrix --extra feishu
 
 # ---------- Frontend build (cached independently from Python source) ----------
 # Copy only the frontend source trees first so that Python-only changes don't

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -265,3 +265,33 @@ def test_locale_catalogs_ship_in_both_wheel_and_sdist():
     on_disk = list((REPO_ROOT / "locales").glob("*.yaml"))
     assert on_disk, "expected locales/*.yaml catalogs on disk"
 
+
+def test_dockerfile_bakes_feishu_extra():
+    """Regression test for #50205.
+
+    The published Docker image disables lazy installs
+    (HERMES_DISABLE_LAZY_INSTALLS=1) and makes the venv read-only, so every
+    messaging adapter must be installed at build time. The [messaging] extra
+    carries telegram/discord/slack but NOT lark-oapi, and [all] left feishu
+    to lazy-install only — so the Dockerfile's `uv sync` must pass
+    `--extra feishu` explicitly or Feishu silently fails to connect in Docker.
+    """
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    # Anchor on the `RUN` directive: an abbreviated `# uv sync ...` doc-comment
+    # higher up would otherwise match first and mask the real build line.
+    m = re.search(
+        r"^RUN uv sync [^\n]*--no-install-project[^\n]*", dockerfile, re.MULTILINE
+    )
+    assert m, "Dockerfile must contain the production `RUN uv sync` line"
+    sync_line = m.group(0)
+    assert "--extra feishu" in sync_line, (
+        "Dockerfile `uv sync` must include `--extra feishu` so lark-oapi is "
+        "baked into the image — lazy installs are disabled and the venv is "
+        "read-only, so Feishu cannot self-install at runtime (#50205)"
+    )
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    feishu = data["project"]["optional-dependencies"].get("feishu", [])
+    assert any(dep.startswith("lark-oapi") for dep in feishu), (
+        "[feishu] extra must pin lark-oapi for the Docker bake to pull it"
+    )
+

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -277,10 +277,16 @@ def test_dockerfile_bakes_feishu_extra():
     `--extra feishu` explicitly or Feishu silently fails to connect in Docker.
     """
     dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
-    # Anchor on the `RUN` directive: an abbreviated `# uv sync ...` doc-comment
-    # higher up would otherwise match first and mask the real build line.
+    # Fold `\`-continued lines so a future reformat of the build command
+    # (line wraps, or an env-var prefix like `RUN FOO=bar uv sync ...`) still
+    # presents as one logical line. Then anchor on a `RUN` directive that runs
+    # `uv sync --no-install-project`, so an abbreviated `# uv sync ...`
+    # doc-comment higher up can't match first and mask the real build line.
+    logical = re.sub(r"\\\n\s*", " ", dockerfile)
     m = re.search(
-        r"^RUN uv sync [^\n]*--no-install-project[^\n]*", dockerfile, re.MULTILINE
+        r"^RUN .*?\buv sync\b[^\n]*--no-install-project[^\n]*",
+        logical,
+        re.MULTILINE,
     )
     assert m, "Dockerfile must contain the production `RUN uv sync` line"
     sync_line = m.group(0)


### PR DESCRIPTION
## What does this PR do?

Bakes the Feishu gateway's dependency (`lark-oapi`, via the `[feishu]` extra) into the published Docker image so the Feishu channel actually connects in containers.

The image disables runtime lazy-installs (`HERMES_DISABLE_LAZY_INSTALLS=1`) and makes the install venv read-only (`chmod -R a-w /opt/hermes`), so every messaging adapter must be installed at build time. The Feishu adapter imports `lark_oapi` (`plugins/platforms/feishu/adapter.py`), which only ships in the `[feishu]` extra — but the Dockerfile's `uv sync` doesn't request it: `[messaging]` carries telegram/discord/slack (no `lark-oapi`) and `[all]` leaves `feishu` to lazy-install only. So Feishu silently fails to connect in Docker (`No adapter available for feishu` / `lark-oapi not installed`), unlike telegram/discord/slack.

The fix appends `--extra feishu` to the build-time `uv sync`, mirroring the existing matrix (#30399) and hindsight (#38128) bakes that exist for the same disabled-lazy-install reason.

Sibling code paths that may need the same fix: none. `[feishu]` is the only messaging extra missing from the Docker `uv sync` line — telegram/discord/slack ship via `[messaging]`; matrix, hindsight, anthropic/bedrock/azure are already explicit `--extra` flags. DingTalk/WeCom/WhatsApp/Signal remain intentionally lazy-install (documented in `pyproject.toml`) and are out of scope here.

## Related Issue

Fixes #50205

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `Dockerfile`: append `--extra feishu` to the build-time `RUN uv sync ...` line so `lark-oapi` is installed into the baked venv; add a comment block (matching the existing matrix/hindsight convention) explaining why the bake is required.
- `tests/test_packaging_metadata.py`: add `test_dockerfile_bakes_feishu_extra`, a static regression test that parses the Dockerfile's `RUN uv sync` line and asserts `--extra feishu` is present, and that the `[feishu]` extra pins `lark-oapi`.

## How to Test

1. `uv run --with pytest --with setuptools python3 -m pytest tests/test_packaging_metadata.py -q` — all pass.
2. Fail-before / pass-after: with `--extra feishu` removed from the `uv sync` line the new test fails on `assert "--extra feishu" in sync_line`; restoring it passes.
3. Real-world: build the image and confirm `lark_oapi` imports inside it (e.g. `docker run --rm <image> python -c "import lark_oapi"`) — previously `ModuleNotFoundError`, now resolves, so the Feishu adapter no longer reports `No adapter available for feishu`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (static packaging test; Docker image is Linux-only)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (Dockerfile comment added inline; no user-facing doc change needed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (Docker image is Linux-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A