### PR TITLE
fix(gateway): harden HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS parsing via _float_env (#50120)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7765,8 +7765,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
 
-            _telegram_followup_grace = float(
-                os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
+            _telegram_followup_grace = _float_env(
+                "HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", 3.0
             )
             _started_at = self._running_agents_ts.get(_quick_key, 0)
             if (

--- a/tests/gateway/test_followup_grace_env.py
+++ b/tests/gateway/test_followup_grace_env.py
@@ -1,0 +1,43 @@
+"""Regression test for #50120.
+
+A malformed HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS must not crash the Telegram
+message handler. The grace read must go through the hardened ``_float_env``
+helper, like every other timeout env read in ``gateway/run.py``.
+"""
+
+import importlib
+import pathlib
+import re
+
+from gateway.run import _float_env
+
+VAR = "HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS"
+
+
+def test_float_env_handles_malformed_value(monkeypatch):
+    monkeypatch.setenv(VAR, "abc")
+    assert _float_env(VAR, 3.0) == 3.0
+
+
+def test_float_env_handles_blank_value(monkeypatch):
+    monkeypatch.setenv(VAR, "   ")
+    assert _float_env(VAR, 3.0) == 3.0
+
+
+def test_float_env_parses_valid_value(monkeypatch):
+    monkeypatch.setenv(VAR, "5.5")
+    assert _float_env(VAR, 3.0) == 5.5
+
+
+def test_grace_read_routes_through_float_env():
+    """Pin the call site: the grace read must use _float_env, not bare float()."""
+    src = pathlib.Path(importlib.import_module("gateway.run").__file__).read_text()
+
+    assert re.search(
+        r"_float_env\(\s*[\"']HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS[\"']", src
+    ), "grace read should route through _float_env"
+
+    assert not re.search(
+        r"float\(\s*os\.getenv\(\s*[\"']HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS[\"']",
+        src,
+    ), "bare float(os.getenv(...)) for grace must be removed"


### PR DESCRIPTION
## What & Why

Fixes #50120. A malformed `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` (typo,
whitespace, stray string) crashed `_handle_message` in `gateway/run.py`,
dropping the inbound Telegram message on the rapid-follow-up hot path.

## Root cause

The grace window was read with a bare
`float(os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0"))`. A
non-numeric value raises `ValueError`. Every sibling timeout env read in the
file already routes through the hardened `_float_env` helper; this read (added
later) was the lone bare-`float` env read left.

## Fix

Route the grace read through the existing `_float_env(name, default)` helper, so
a misconfigured value falls back to the 3.0 default instead of crashing —
consistent with `HERMES_AGENT_TIMEOUT`, `HERMES_AGENT_NOTIFY_INTERVAL`, etc.

## Tests

Adds `tests/gateway/test_followup_grace_env.py` (stdlib + pytest, no network):

malformed/blank values fall back to the default, valid values parse, and a
source-level check pins the call site to `_float_env` (guards against
regression to a bare `float(os.getenv(...))`).

## How to test

```
scripts/run_tests.sh tests/gateway/test_followup_grace_env.py -q   # 4 passed
```

## Platforms tested

Linux/Windows — pure env-parsing change, platform-agnostic.