### PR TITLE
fix: trigger model fallback on transport errors (connection/timeout/overloaded)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2791,15 +2791,25 @@ def run_conversation(
                     # Fall through to normal error handling if compression
                     # is exhausted or didn't help.
 
-                # Eager fallback for rate-limit errors (429 or quota exhaustion).
-                # When a fallback model is configured, switch immediately instead
-                # of burning through retries with exponential backoff -- the
-                # primary provider won't recover within the retry window.
+                # Eager fallback for rate-limit errors (429 or quota exhaustion)
+                # and transport errors (connection failure / timeout / provider
+                # overloaded).  Rate limits and billing: switch immediately —
+                # the primary provider won't recover within the retry window.
+                # Transport errors: allow 1 retry first (transient hiccups
+                # recover), then fall back if the provider is truly unreachable.
                 is_rate_limited = classified.reason in {
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
                 }
-                if is_rate_limited and agent._fallback_index < len(agent._fallback_chain):
+                _is_transport_failure = classified.reason in {
+                    FailoverReason.timeout,
+                    FailoverReason.overloaded,
+                }
+                _should_fallback = (
+                    is_rate_limited
+                    or (_is_transport_failure and retry_count >= 2)
+                )
+                if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
@@ -2813,6 +2823,10 @@ def run_conversation(
                         if classified.reason == FailoverReason.billing:
                             agent._buffer_status(
                                 "⚠️ Billing or credits exhausted — switching to fallback provider..."
+                            )
+                        elif _is_transport_failure:
+                            agent._buffer_status(
+                                "⚠️ Provider unreachable — switching to fallback provider..."
                             )
                         else:
                             agent._buffer_status("⚠️ Rate limited — switching to fallback provider...")

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -734,7 +734,7 @@ def classify_api_error(
     # ── 7. Transport / timeout heuristics ───────────────────────────
 
     if error_type in _TRANSPORT_ERROR_TYPES or isinstance(error, (TimeoutError, ConnectionError, OSError)):
-        return _result(FailoverReason.timeout, retryable=True)
+        return _result(FailoverReason.timeout, retryable=True, should_fallback=True)
 
     # ── 8. Fallback: unknown ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Previously, the fallback chain only activated for rate-limit (429) and billing (402) errors. When the primary model's API was unreachable (connection error, timeout, provider overloaded), the agent retried the same failing provider until max_iterations was exhausted, with no attempt to switch to a configured fallback provider.

This was observed in production: a cron job using mimo-v2.5 failed repeatedly with `RuntimeError: Connection error.` even though `fallback_providers: [deepseek]` was configured. The fallback never triggered because connection errors weren't in the fallback activation set.

## Changes

### `agent/error_classifier.py`
Mark transport errors (`ConnectionError`, `ConnectError`, `APIConnectionError`, timeout, overloaded) with `should_fallback=True` so the conversation loop can use this signal.

### `agent/conversation_loop.py`
Expand the fallback trigger condition to include `FailoverReason.timeout` and `FailoverReason.overloaded`:

- **Rate-limit/billing**: Keep existing eager fallback behavior (immediate switch)
- **Transport errors**: Allow 1 retry first (transient hiccups can recover), then fall back if the provider is truly unreachable

## Testing

- `test_error_classifier.py`: 161/161 ✅
- `test_stream_drop_logging.py`: 10/10 ✅
- `test_auxiliary_client.py`: 222/222 ✅
- `test_scheduler.py`: 135/136 (1 pre-existing failure unrelated to this change)

## Impact

This fix benefits both cron jobs and interactive sessions. When the primary model provider is temporarily unreachable, the agent automatically recovers by switching to the configured fallback instead of failing after exhausting retries.