### PR TITLE
feat(sessions): add client-safe custom metadata

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1260,6 +1260,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "skills": {"method": "GET", "path": "/v1/skills"},
                 "toolsets": {"method": "GET", "path": "/v1/toolsets"},
                 "sessions": {"method": "GET", "path": "/api/sessions"},
+                "sessions_search": {"method": "GET", "path": "/api/sessions/search"},
                 "session_create": {"method": "POST", "path": "/api/sessions"},
                 "session": {"method": "GET", "path": "/api/sessions/{session_id}"},
                 "session_update": {"method": "PATCH", "path": "/api/sessions/{session_id}"},
@@ -1380,7 +1381,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "end_reason", "message_count", "tool_call_count", "input_tokens",
             "output_tokens", "cache_read_tokens", "cache_write_tokens",
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
-            "api_call_count", "parent_session_id", "last_active", "preview",
+            "api_call_count", "custom_metadata", "parent_session_id", "last_active", "preview",
             "_lineage_root_id",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
@@ -1456,6 +1457,48 @@ class APIServerAdapter(BasePlatformAdapter):
             "has_more": len(sessions) == limit,
         })
 
+    async def _handle_search_sessions(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/search — search session custom metadata."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        db = self._ensure_session_db()
+        if db is None:
+            return web.json_response(_openai_error("Session database unavailable", code="session_db_unavailable"), status=503)
+
+        limit = self._parse_nonnegative_int(request.query.get("limit"), default=50, maximum=200)
+        offset = self._parse_nonnegative_int(request.query.get("offset"), default=0, maximum=1_000_000)
+        source = request.query.get("source") or None
+        key = request.query.get("metadata_key") or request.query.get("key") or None
+        value = request.query.get("metadata_value") or request.query.get("value")
+        q = request.query.get("q") or None
+        if not key and not q:
+            return web.json_response(
+                _openai_error("session metadata search requires q or metadata_key", code="invalid_session_search"),
+                status=400,
+            )
+        if not key and value is not None:
+            return web.json_response(
+                _openai_error("metadata_value requires metadata_key", code="invalid_session_search"),
+                status=400,
+            )
+        sessions = db.search_sessions_by_custom_metadata(
+            key=key,
+            value=value,
+            query=q,
+            source=source,
+            limit=limit,
+            offset=offset,
+        )
+        return web.json_response({
+            "object": "list",
+            "data": [self._session_response(s) for s in sessions],
+            "limit": limit,
+            "offset": offset,
+            "has_more": len(sessions) == limit,
+        })
+
     async def _handle_create_session(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions — create an empty Hermes session row."""
         auth_err = self._check_auth(request)
@@ -1482,7 +1525,17 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = body.get("system_prompt")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_prompt must be a string", code="invalid_system_prompt"), status=400)
-        db.create_session(session_id, "api_server", model=str(model) if model else None, system_prompt=system_prompt)
+        custom_metadata = body.get("custom_metadata")
+        try:
+            db.create_session(
+                session_id,
+                "api_server",
+                model=str(model) if model else None,
+                system_prompt=system_prompt,
+                custom_metadata=custom_metadata,
+            )
+        except ValueError as exc:
+            return web.json_response(_openai_error(str(exc), code="invalid_custom_metadata"), status=400)
         title = body.get("title")
         if title is not None:
             try:
@@ -1515,7 +1568,7 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
-        allowed = {"title", "end_reason"}
+        allowed = {"title", "end_reason", "custom_metadata", "custom_metadata_update", "custom_metadata_remove"}
         unknown = sorted(set(body) - allowed)
         if unknown:
             return web.json_response(_openai_error(f"Unsupported session fields: {', '.join(unknown)}", code="unsupported_session_field"), status=400)
@@ -1526,6 +1579,26 @@ class APIServerAdapter(BasePlatformAdapter):
                 db.set_session_title(session_id, "" if body["title"] is None else str(body["title"]))
             except ValueError as exc:
                 return web.json_response(_openai_error(str(exc), code="invalid_title"), status=400)
+        try:
+            if "custom_metadata" in body:
+                metadata = body["custom_metadata"]
+                if metadata is None:
+                    metadata = {}
+                db.set_session_custom_metadata(session_id, metadata)
+            if "custom_metadata_update" in body or "custom_metadata_remove" in body:
+                updates = body.get("custom_metadata_update")
+                if updates is None:
+                    updates = {}
+                remove = body.get("custom_metadata_remove") or []
+                if not isinstance(remove, list):
+                    return web.json_response(_openai_error("custom_metadata_remove must be a list", code="invalid_custom_metadata"), status=400)
+                db.update_session_custom_metadata(
+                    session_id,
+                    updates,
+                    remove=remove,
+                )
+        except ValueError as exc:
+            return web.json_response(_openai_error(str(exc), code="invalid_custom_metadata"), status=400)
         if body.get("end_reason"):
             db.end_session(session_id, str(body["end_reason"]))
         session = db.get_session(session_id) or session
@@ -4343,6 +4416,9 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/toolsets", self._handle_toolsets)
             # Session/client control surface (thin wrappers over SessionDB + _run_agent)
             self._app.router.add_get("/api/sessions", self._handle_list_sessions)
+            # Literal route must be registered before /api/sessions/{session_id}
+            # or aiohttp will treat "search" as a session id.
+            self._app.router.add_get("/api/sessions/search", self._handle_search_sessions)
             self._app.router.add_post("/api/sessions", self._handle_create_session)
             self._app.router.add_get("/api/sessions/{session_id}", self._handle_get_session)
             self._app.router.add_patch("/api/sessions/{session_id}", self._handle_patch_session)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12174,6 +12174,19 @@ def main():
     sessions_rename.add_argument("session_id", help="Session ID to rename")
     sessions_rename.add_argument("title", nargs="+", help="New title for the session")
 
+    sessions_metadata = sessions_subparsers.add_parser(
+        "metadata", help="Inspect or update a session's custom metadata"
+    )
+    sessions_metadata.add_argument(
+        "session_id",
+        nargs="?",
+        help="Session ID to update (omit with --current to use HERMES_SESSION_ID)",
+    )
+    sessions_metadata.add_argument("--current", action="store_true", help="Use the active HERMES_SESSION_ID")
+    sessions_metadata.add_argument("--json", dest="metadata_json", help="Replace metadata with a JSON object")
+    sessions_metadata.add_argument("--set", action="append", default=[], metavar="KEY=VALUE", help="Set one metadata key (repeatable)")
+    sessions_metadata.add_argument("--remove", action="append", default=[], metavar="KEY", help="Remove one metadata key (repeatable)")
+
     sessions_browse = sessions_subparsers.add_parser(
         "browse",
         help="Interactive session picker — browse, search, and resume sessions",
@@ -12358,6 +12371,51 @@ def main():
                     print(f"Session '{args.session_id}' not found.")
             except ValueError as e:
                 print(f"Error: {e}")
+
+        elif action == "metadata":
+            target = os.environ.get("HERMES_SESSION_ID", "") if getattr(args, "current", False) else (args.session_id or "")
+            if not target:
+                print("Error: provide a session_id or pass --current inside an active Hermes session.")
+                return
+            resolved_session_id = db.resolve_session_id(target)
+            if not resolved_session_id:
+                print(f"Session '{target}' not found.")
+                return
+
+            changed = False
+            try:
+                if args.metadata_json is not None:
+                    replacement = _json.loads(args.metadata_json)
+                    db.set_session_custom_metadata(resolved_session_id, replacement)
+                    changed = True
+                updates = {}
+                for item in args.set:
+                    if "=" not in item:
+                        print(f"Error: --set expects KEY=VALUE, got {item!r}")
+                        return
+                    key, value = item.split("=", 1)
+                    key = key.strip()
+                    if not key:
+                        print("Error: --set key must not be empty")
+                        return
+                    try:
+                        updates[key] = _json.loads(value)
+                    except Exception:
+                        updates[key] = value
+                if updates or args.remove:
+                    db.update_session_custom_metadata(resolved_session_id, updates, remove=args.remove)
+                    changed = True
+            except _json.JSONDecodeError as e:
+                print(f"Error: invalid JSON metadata: {e}")
+                return
+            except ValueError as e:
+                print(f"Error: {e}")
+                return
+
+            metadata = db.get_session_custom_metadata(resolved_session_id)
+            if changed:
+                print(f"Updated metadata for session '{resolved_session_id}'.")
+            print(_json.dumps(metadata, ensure_ascii=False, indent=2, sort_keys=True))
 
         elif action == "browse":
             limit = getattr(args, "limit", 500) or 500

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -539,6 +539,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     cost_source TEXT,
     pricing_version TEXT,
     title TEXT,
+    custom_metadata TEXT,
     api_call_count INTEGER DEFAULT 0,
     handoff_state TEXT,
     handoff_platform TEXT,
@@ -677,6 +678,8 @@ class SessionDB:
     _WRITE_RETRY_MAX_S = 0.150   # 150ms
     # Attempt a PASSIVE WAL checkpoint every N successful writes.
     _CHECKPOINT_EVERY_N_WRITES = 50
+    MAX_CUSTOM_METADATA_BYTES = 16 * 1024
+    MAX_CUSTOM_METADATA_DEPTH = 8
 
     def __init__(self, db_path: Path = None, read_only: bool = False):
         self.db_path = db_path or DEFAULT_DB_PATH
@@ -1346,13 +1349,16 @@ class SessionDB:
         user_id: str = None,
         parent_session_id: str = None,
         cwd: str = None,
+        custom_metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
+        custom_metadata_json = self.encode_custom_metadata(custom_metadata)
+
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, cwd, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, parent_session_id, cwd, custom_metadata, started_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
@@ -1362,6 +1368,7 @@ class SessionDB:
                     system_prompt,
                     parent_session_id,
                     cwd,
+                    custom_metadata_json,
                     time.time(),
                 ),
             )
@@ -1371,6 +1378,114 @@ class SessionDB:
         """Create a new session record. Returns the session_id."""
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
+
+    @classmethod
+    def _validate_custom_metadata_value(cls, value: Any, *, depth: int = 0) -> Any:
+        """Return a JSON-safe custom metadata value or raise ``ValueError``."""
+        if depth > cls.MAX_CUSTOM_METADATA_DEPTH:
+            raise ValueError(
+                f"custom_metadata is too deeply nested (max depth {cls.MAX_CUSTOM_METADATA_DEPTH})"
+            )
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+        if isinstance(value, list):
+            return [cls._validate_custom_metadata_value(v, depth=depth + 1) for v in value]
+        if isinstance(value, dict):
+            clean: Dict[str, Any] = {}
+            for key, item in value.items():
+                if not isinstance(key, str) or not key.strip():
+                    raise ValueError("custom_metadata keys must be non-empty strings")
+                if any(ch in key for ch in "\r\n\x00"):
+                    raise ValueError("custom_metadata keys must not contain control characters")
+                clean[key.strip()] = cls._validate_custom_metadata_value(item, depth=depth + 1)
+            return clean
+        raise ValueError(f"custom_metadata values must be JSON-compatible, got {type(value).__name__}")
+
+    @classmethod
+    def encode_custom_metadata(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Validate and encode a session custom metadata object for storage."""
+        if metadata is None:
+            return None
+        if not isinstance(metadata, dict):
+            raise ValueError("custom_metadata must be a JSON object")
+        clean = cls._validate_custom_metadata_value(metadata)
+        encoded = json.dumps(clean, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        if len(encoded.encode("utf-8")) > cls.MAX_CUSTOM_METADATA_BYTES:
+            raise ValueError(
+                f"custom_metadata is too large (max {cls.MAX_CUSTOM_METADATA_BYTES} bytes)"
+            )
+        return encoded
+
+    @staticmethod
+    def decode_custom_metadata(raw: Any) -> Dict[str, Any]:
+        """Decode stored custom metadata, degrading malformed legacy text to {}."""
+        if not raw:
+            return {}
+        if isinstance(raw, dict):
+            return raw
+        try:
+            parsed = json.loads(str(raw))
+        except (TypeError, ValueError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+
+    def _session_row_to_dict(self, row) -> Dict[str, Any]:
+        session = dict(row)
+        session["custom_metadata"] = self.decode_custom_metadata(session.get("custom_metadata"))
+        return session
+
+    def get_session_custom_metadata(self, session_id: str) -> Dict[str, Any]:
+        """Return the client-safe custom metadata object for ``session_id``."""
+        session = self.get_session(session_id)
+        if not session:
+            return {}
+        return dict(session.get("custom_metadata") or {})
+
+    def set_session_custom_metadata(self, session_id: str, metadata: Dict[str, Any]) -> bool:
+        """Replace a session's custom metadata object."""
+        encoded = self.encode_custom_metadata(metadata)
+
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE sessions SET custom_metadata = ? WHERE id = ?",
+                (encoded, session_id),
+            )
+            return cursor.rowcount > 0
+
+        return bool(self._execute_write(_do))
+
+    def update_session_custom_metadata(
+        self,
+        session_id: str,
+        updates: Dict[str, Any],
+        *,
+        remove: Optional[List[str]] = None,
+    ) -> bool:
+        """Merge custom metadata keys, optionally removing keys first."""
+        if not isinstance(updates, dict):
+            raise ValueError("custom_metadata updates must be a JSON object")
+        remove = [str(k).strip() for k in (remove or []) if str(k).strip()]
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT custom_metadata FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if row is None:
+                return False
+            current = self.decode_custom_metadata(row["custom_metadata"])
+            for key in remove:
+                current.pop(key, None)
+            current.update(updates)
+            encoded = self.encode_custom_metadata(current)
+            conn.execute(
+                "UPDATE sessions SET custom_metadata = ? WHERE id = ?",
+                (encoded, session_id),
+            )
+            return True
+
+        return bool(self._execute_write(_do))
+
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session as ended.
 
@@ -1761,7 +1876,7 @@ class SessionDB:
                 "SELECT * FROM sessions WHERE id = ?", (session_id,)
             )
             row = cursor.fetchone()
-        return dict(row) if row else None
+        return self._session_row_to_dict(row) if row else None
 
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.
@@ -1991,7 +2106,7 @@ class SessionDB:
                 "SELECT * FROM sessions WHERE title = ?", (title,)
             )
             row = cursor.fetchone()
-        return dict(row) if row else None
+        return self._session_row_to_dict(row) if row else None
 
     def resolve_session_by_title(self, title: str) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
@@ -2283,7 +2398,7 @@ class SessionDB:
             rows = cursor.fetchall()
         sessions = []
         for row in rows:
-            s = dict(row)
+            s = self._session_row_to_dict(row)
             # Build the preview from the raw substring
             raw = s.pop("_preview_raw", "").strip()
             if raw:
@@ -2387,7 +2502,7 @@ class SessionDB:
 
         runs: List[Dict[str, Any]] = []
         for row in rows:
-            s = dict(row)
+            s = self._session_row_to_dict(row)
             raw = s.pop("_preview_raw", "").strip()
             if raw:
                 text = raw[:60]
@@ -2423,7 +2538,7 @@ class SessionDB:
             row = cursor.fetchone()
         if not row:
             return None
-        s = dict(row)
+        s = self._session_row_to_dict(row)
         raw = s.pop("_preview_raw", "").strip()
         if raw:
             text = raw[:60]
@@ -3856,7 +3971,57 @@ class SessionDB:
                     "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
                     (limit, offset),
                 )
-            return [dict(row) for row in cursor.fetchall()]
+            return [self._session_row_to_dict(row) for row in cursor.fetchall()]
+
+    def search_sessions_by_custom_metadata(
+        self,
+        *,
+        key: Optional[str] = None,
+        value: Any = None,
+        query: Optional[str] = None,
+        source: Optional[str] = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """Search sessions by client-safe custom metadata.
+
+        ``key`` + ``value`` performs exact key/value matching. ``query`` performs
+        a case-insensitive substring search across metadata keys and scalar
+        values, useful for API/webhook lookups such as finding an issue id.
+        """
+        try:
+            limit = max(1, min(int(limit), 200))
+        except (TypeError, ValueError):
+            limit = 20
+        try:
+            offset = max(0, int(offset))
+        except (TypeError, ValueError):
+            offset = 0
+        key = str(key).strip() if key is not None else None
+        needle = str(query or "").strip().lower()
+        exact_value = None if value is None else str(value).lower()
+        rows = self.list_sessions_rich(
+            source=source,
+            limit=100000,
+            offset=0,
+            include_archived=True,
+            order_by_last_active=True,
+        )
+        matches: List[Dict[str, Any]] = []
+        for row in rows:
+            metadata = row.get("custom_metadata") or {}
+            if key:
+                if key not in metadata:
+                    continue
+                candidate = metadata.get(key)
+                if value is not None and str(candidate).lower() != exact_value:
+                    continue
+            if needle:
+                haystack = json.dumps(metadata, ensure_ascii=False, sort_keys=True).lower()
+                if needle not in haystack:
+                    continue
+            matches.append(row)
+        return matches[offset:offset + limit]
 
     # =========================================================================
     # Utility

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -40,6 +40,7 @@ def _create_session_app(adapter: APIServerAdapter) -> web.Application:
     app = web.Application()
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
     app.router.add_get("/api/sessions", adapter._handle_list_sessions)
+    app.router.add_get("/api/sessions/search", adapter._handle_search_sessions)
     app.router.add_post("/api/sessions", adapter._handle_create_session)
     app.router.add_get("/api/sessions/{session_id}", adapter._handle_get_session)
     app.router.add_patch("/api/sessions/{session_id}", adapter._handle_patch_session)
@@ -69,6 +70,7 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["skills_api"] is True
     assert features["realtime_voice"] is False
     assert data["endpoints"]["sessions"] == {"method": "GET", "path": "/api/sessions"}
+    assert data["endpoints"]["sessions_search"] == {"method": "GET", "path": "/api/sessions/search"}
     assert data["endpoints"]["session_chat_stream"] == {
         "method": "POST",
         "path": "/api/sessions/{session_id}/chat/stream",
@@ -127,12 +129,20 @@ async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeyp
 async def test_session_crud_and_message_history(adapter, session_db):
     app = _create_session_app(adapter)
     async with TestClient(TestServer(app)) as cli:
-        create_resp = await cli.post("/api/sessions", json={"title": "Mobile chat", "model": "test-model"})
+        create_resp = await cli.post(
+            "/api/sessions",
+            json={
+                "title": "Mobile chat",
+                "model": "test-model",
+                "custom_metadata": {"issue_id": "HERMES-123", "summary": "Mobile import"},
+            },
+        )
         assert create_resp.status == 201
         created = await create_resp.json()
         session_id = created["session"]["id"]
         assert created["object"] == "hermes.session"
         assert created["session"]["title"] == "Mobile chat"
+        assert created["session"]["custom_metadata"] == {"issue_id": "HERMES-123", "summary": "Mobile import"}
 
         session_db.append_message(session_id, "user", "hello from phone")
         session_db.append_message(session_id, "assistant", "hello from hermes")
@@ -157,10 +167,37 @@ async def test_session_crud_and_message_history(adapter, session_db):
         assert [m["role"] for m in messages["data"]] == ["user", "assistant"]
         assert messages["data"][0]["content"] == "hello from phone"
 
-        patch_resp = await cli.patch(f"/api/sessions/{session_id}", json={"title": "Renamed"})
+        patch_resp = await cli.patch(
+            f"/api/sessions/{session_id}",
+            json={
+                "title": "Renamed",
+                "custom_metadata_update": {"status": "triaged"},
+                "custom_metadata_remove": ["summary"],
+            },
+        )
         assert patch_resp.status == 200
         patched = await patch_resp.json()
         assert patched["session"]["title"] == "Renamed"
+        assert patched["session"]["custom_metadata"] == {"issue_id": "HERMES-123", "status": "triaged"}
+
+        search_resp = await cli.get("/api/sessions/search?metadata_key=issue_id&metadata_value=HERMES-123")
+        assert search_resp.status == 200
+        searched = await search_resp.json()
+        assert [s["id"] for s in searched["data"]] == [session_id]
+
+        text_search_resp = await cli.get("/api/sessions/search?q=triaged")
+        assert text_search_resp.status == 200
+        text_searched = await text_search_resp.json()
+        assert [s["id"] for s in text_searched["data"]] == [session_id]
+
+        empty_search_resp = await cli.get("/api/sessions/search")
+        assert empty_search_resp.status == 400
+
+        invalid_resp = await cli.patch(f"/api/sessions/{session_id}", json={"custom_metadata": []})
+        assert invalid_resp.status == 400
+
+        invalid_update_resp = await cli.patch(f"/api/sessions/{session_id}", json={"custom_metadata_update": []})
+        assert invalid_update_resp.status == 400
 
         delete_resp = await cli.delete(f"/api/sessions/{session_id}")
         assert delete_resp.status == 200

--- a/tests/hermes_cli/test_argparse_flag_propagation.py
+++ b/tests/hermes_cli/test_argparse_flag_propagation.py
@@ -182,3 +182,75 @@ class TestAcceptHooksOnAgentSubparsers:
             f"stderr: {result.stderr[:300]}"
         )
         assert "unrecognized arguments" not in result.stderr
+
+
+def test_sessions_metadata_updates_current_session(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {}
+
+    class FakeDB:
+        def resolve_session_id(self, session_id):
+            captured["resolved_from"] = session_id
+            return "current-session"
+
+        def update_session_custom_metadata(self, session_id, updates, *, remove=None):
+            captured["updated"] = (session_id, updates, remove)
+            return True
+
+        def get_session_custom_metadata(self, session_id):
+            captured["read"] = session_id
+            return {"issue_id": "HERMES-123", "priority": 2}
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setenv("HERMES_SESSION_ID", "current-session")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "metadata", "--current", "--set", "issue_id=HERMES-123", "--set", "priority=2"],
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert captured == {
+        "resolved_from": "current-session",
+        "updated": ("current-session", {"issue_id": "HERMES-123", "priority": 2}, []),
+        "read": "current-session",
+        "closed": True,
+    }
+    assert "Updated metadata for session 'current-session'." in output
+    assert '"issue_id": "HERMES-123"' in output
+
+
+def test_sessions_metadata_replaces_with_json(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {}
+
+    class FakeDB:
+        def resolve_session_id(self, session_id):
+            return "s1"
+
+        def set_session_custom_metadata(self, session_id, metadata):
+            captured["set"] = (session_id, metadata)
+            return True
+
+        def get_session_custom_metadata(self, session_id):
+            return captured["set"][1]
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", "metadata", "s1", "--json", '{"summary":"done"}'])
+
+    main_mod.main()
+
+    assert captured["set"] == ("s1", {"summary": "done"})
+    assert '"summary": "done"' in capsys.readouterr().out

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -217,6 +217,37 @@ class TestSessionLifecycle:
         child = db.get_session("child")
         assert child["parent_session_id"] == "parent"
 
+    def test_custom_metadata_round_trips_and_searches(self, db):
+        db.create_session(
+            session_id="s1",
+            source="cli",
+            custom_metadata={"issue_id": "HERMES-123", "summary": "first-class metadata"},
+        )
+        assert db.get_session("s1")["custom_metadata"] == {
+            "issue_id": "HERMES-123",
+            "summary": "first-class metadata",
+        }
+
+        assert db.update_session_custom_metadata(
+            "s1",
+            {"status": "triaged"},
+            remove=["summary"],
+        ) is True
+        assert db.get_session_custom_metadata("s1") == {
+            "issue_id": "HERMES-123",
+            "status": "triaged",
+        }
+
+        assert [s["id"] for s in db.search_sessions_by_custom_metadata(key="issue_id", value="HERMES-123")] == ["s1"]
+        assert [s["id"] for s in db.search_sessions_by_custom_metadata(query="triaged")] == ["s1"]
+
+    def test_custom_metadata_rejects_invalid_shapes(self, db):
+        db.create_session(session_id="s1", source="cli")
+        with pytest.raises(ValueError, match="JSON object"):
+            db.set_session_custom_metadata("s1", ["not", "an", "object"])
+        with pytest.raises(ValueError, match="too large"):
+            db.set_session_custom_metadata("s1", {"blob": "x" * (SessionDB.MAX_CUSTOM_METADATA_BYTES + 1)})
+
     def test_db_initializes_without_fts5_module(self, tmp_path, monkeypatch):
         real_connect = sqlite3.connect
 
@@ -2261,6 +2292,78 @@ class TestSchemaInit:
         cursor = db._conn.execute("PRAGMA table_info(sessions)")
         columns = {row[1] for row in cursor.fetchall()}
         assert "title" in columns
+
+    def test_custom_metadata_column_reconciles_on_legacy_db(self, tmp_path):
+        """Existing state.db files gain custom_metadata through column reconciliation."""
+        old_db = tmp_path / "old.db"
+        import sqlite3
+
+        conn = sqlite3.connect(old_db)
+        conn.executescript(
+            """
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version VALUES (11);
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                user_id TEXT,
+                model TEXT,
+                model_config TEXT,
+                system_prompt TEXT,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL,
+                end_reason TEXT,
+                message_count INTEGER DEFAULT 0,
+                tool_call_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                cache_read_tokens INTEGER DEFAULT 0,
+                cache_write_tokens INTEGER DEFAULT 0,
+                reasoning_tokens INTEGER DEFAULT 0,
+                billing_provider TEXT,
+                billing_base_url TEXT,
+                billing_mode TEXT,
+                estimated_cost_usd REAL,
+                actual_cost_usd REAL,
+                cost_status TEXT,
+                cost_source TEXT,
+                pricing_version TEXT,
+                title TEXT,
+                api_call_count INTEGER DEFAULT 0,
+                FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL REFERENCES sessions(id),
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_count INTEGER,
+                finish_reason TEXT,
+                reasoning TEXT,
+                reasoning_content TEXT,
+                reasoning_details TEXT,
+                codex_reasoning_items TEXT,
+                codex_message_items TEXT
+            );
+            """
+        )
+        conn.close()
+
+        db = SessionDB(db_path=old_db)
+        try:
+            cursor = db._conn.execute("PRAGMA table_info(sessions)")
+            columns = {row[1] for row in cursor.fetchall()}
+            assert "custom_metadata" in columns
+
+            db.create_session("s1", source="cli", custom_metadata={"issue_id": "HERMES-123"})
+            assert db.get_session("s1")["custom_metadata"] == {"issue_id": "HERMES-123"}
+        finally:
+            db.close()
 
     def test_topic_mode_schema_is_not_auto_migrated_on_open(self, tmp_path):
         """Opening an old DB should not add topic-mode columns until /topic opts in.

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -49,7 +49,7 @@ def _seed_modpack_sessions(db):
     db.append_message("s_middle", role="assistant", content="Modpack version bumped 0.4 → 0.8.5; quest coverage page added.")
 
     # Newest session — modpack mob spawn fix
-    db.create_session("s_newest", source="cli")
+    db.create_session("s_newest", source="cli", custom_metadata={"issue_id": "HERMES-456", "summary": "Mob spawn fix"})
     db._conn.execute("UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
                      (now - 1000, "Modpack Mob Spawn Fix", "s_newest"))
     db.append_message("s_newest", role="user", content="Fix the modpack mob spawning")
@@ -148,6 +148,12 @@ class TestBrowseShape:
         result = json.loads(session_search(db=db))
         titles = [r.get("title") for r in result["results"]]
         assert any("Modpack" in (t or "") for t in titles)
+
+    def test_browse_returns_custom_metadata(self, db):
+        _seed_modpack_sessions(db)
+        result = json.loads(session_search(db=db))
+        newest = next(r for r in result["results"] if r["session_id"] == "s_newest")
+        assert newest["custom_metadata"]["issue_id"] == "HERMES-456"
 
 
 # =========================================================================

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -211,6 +211,7 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
             "source": meta.get("source"),
             "model": meta.get("model"),
             "title": meta.get("title"),
+            "custom_metadata": meta.get("custom_metadata") or {},
         },
         "message_count": total,
         "truncated": truncated,
@@ -251,6 +252,7 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
                 "last_active": s.get("last_active", ""),
                 "message_count": s.get("message_count", 0),
                 "preview": s.get("preview", ""),
+                "custom_metadata": s.get("custom_metadata") or {},
             })
             if len(results) >= limit:
                 break
@@ -380,6 +382,7 @@ def _scroll(
             "source": session_meta.get("source"),
             "model": session_meta.get("model"),
             "title": session_meta.get("title"),
+            "custom_metadata": session_meta.get("custom_metadata") or {},
         },
         "window": window,
         "messages": [_shape_message(m, anchor_id=around_message_id) for m in messages],
@@ -469,6 +472,7 @@ def _discover(
             "source": session_meta.get("source") or match_info.get("source", "unknown"),
             "model": session_meta.get("model") or match_info.get("model") or "unknown",
             "title": session_meta.get("title") or None,
+            "custom_metadata": session_meta.get("custom_metadata") or {},
             "matched_role": match_info.get("role"),
             "match_message_id": msg_id,
             "snippet": match_info.get("snippet") or "",

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -11,7 +11,7 @@ Source file: `hermes_state.py`
 
 ```
 ~/.hermes/state.db (SQLite, WAL mode)
-├── sessions              — Session metadata, token counts, billing
+├── sessions              — Session metadata, token counts, billing, custom metadata
 ├── messages              — Full message history per session
 ├── messages_fts          — FTS5 virtual table (content + tool_name + tool_calls)
 ├── messages_fts_trigram  — FTS5 virtual table with trigram tokenizer (CJK / substring search)
@@ -59,6 +59,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     cost_source TEXT,
     pricing_version TEXT,
     title TEXT,
+    custom_metadata TEXT,
     api_call_count INTEGER DEFAULT 0,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
@@ -203,6 +204,22 @@ db.end_session("sess_abc123", end_reason="user_exit")
 
 # Reopen a session (clear ended_at/end_reason)
 db.reopen_session("sess_abc123")
+```
+
+### Custom Session Metadata
+
+`custom_metadata` stores a bounded JSON object for client-safe labels attached to a session, such as issue IDs, workflow status, or generated summaries. It is separate from `model_config`, `system_prompt`, and `messages`, so updating it does not alter prompt context, message history, or prompt-cache stability. The API server and CLI expose this as session metadata; callers should not store secrets there.
+
+```python
+db.create_session(
+    session_id="sess_abc123",
+    source="api_server",
+    custom_metadata={"issue_id": "HERMES-123"},
+)
+db.update_session_custom_metadata(
+    "sess_abc123",
+    {"summary": "Investigated API session state"},
+)
 ```
 
 ### Store Messages

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1303,6 +1303,7 @@ Subcommands:
 | `prune` | Delete old sessions. |
 | `stats` | Show session-store statistics. |
 | `rename <session-id> <title>` | Set or change a session title. |
+| `metadata [session-id] [--current] [--json JSON] [--set KEY=VALUE] [--remove KEY]` | Inspect or update client-safe custom metadata on a session. |
 
 ## `hermes insights`
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -319,16 +319,36 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/api/sessions` | List sessions (paginated — `limit`, `offset`, `source`, `include_children`) |
-| `POST` | `/api/sessions` | Create an empty session |
-| `GET` | `/api/sessions/{id}` | Read session metadata |
-| `PATCH` | `/api/sessions/{id}` | Update title or `end_reason` |
+| `GET` | `/api/sessions/search` | Search sessions by `custom_metadata` (`q`, `metadata_key`, `metadata_value`) |
+| `POST` | `/api/sessions` | Create an empty session, optionally with `custom_metadata` |
+| `GET` | `/api/sessions/{id}` | Read session metadata, including `custom_metadata` |
+| `PATCH` | `/api/sessions/{id}` | Update title, `end_reason`, or custom metadata (`custom_metadata`, `custom_metadata_update`, `custom_metadata_remove`) |
 | `DELETE` | `/api/sessions/{id}` | Delete a session |
 | `GET` | `/api/sessions/{id}/messages` | Message history for a session |
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
 | `POST` | `/api/sessions/{id}/chat` | Run one synchronous agent turn |
 | `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |
 
+`custom_metadata` is a bounded JSON object for client-safe labels such as issue IDs, workflow states, or generated summaries. It is stored separately from prompts and messages, so it does not change conversation context or prompt caching. Do not store secrets in custom metadata. Search requires either `q` or `metadata_key`; `metadata_value` is an exact-match refinement for `metadata_key`.
+
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
+
+To attach metadata, send `PATCH /api/sessions/{id}` with a JSON body. If `custom_metadata` and `custom_metadata_update` are sent together, Hermes replaces the object first, then applies the merge/remove operation:
+
+```json
+{
+  "custom_metadata_update": {
+    "issue_id": "HERMES-123",
+    "summary": "Investigated API session state"
+  }
+}
+```
+
+Search the attached metadata later with:
+
+```text
+GET /api/sessions/search?metadata_key=issue_id&metadata_value=HERMES-123
+```
 
 ```bash
 # fork a session and run one turn


### PR DESCRIPTION
## Summary

Adds client-safe custom metadata for Hermes sessions so external clients, humans, and active agents can attach labels such as issue IDs, workflow states, or generated summaries without mutating prompts, messages, or model configuration.

## What changed

- Add bounded JSON `custom_metadata` storage on session rows, with validation and legacy DB reconciliation coverage.
- Expose metadata through existing session APIs, including create, patch replace/merge/remove, and `/api/sessions/search` lookup.
- Add `hermes sessions metadata` for CLI/human updates, including `--current` using the existing `HERMES_SESSION_ID` path for active agents.
- Include custom metadata in `session_search` results so agents can understand attached labels during recall.
- Document API, CLI, and session-storage behavior.

## Testing

- `scripts/run_tests.sh tests/test_hermes_state.py tests/gateway/test_session_api.py tests/tools/test_session_search.py tests/hermes_cli/test_argparse_flag_propagation.py`
- `python -m py_compile hermes_state.py gateway/platforms/api_server.py tools/session_search_tool.py hermes_cli/main.py tests/hermes_cli/test_argparse_flag_propagation.py`
- `git diff --check`
- `python scripts/check-windows-footguns.py --all`
