### PR TITLE
fix(desktop): run gateway import in executor thread to unblock /api/status and port announcement

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -144,6 +144,22 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     provider.start(stop_event, interval=interval)
 
 
+def _warm_gateway_module() -> None:
+    try:
+        import hermes_cli.gateway  # noqa: F401
+    except Exception:
+        pass
+
+
+def _resolve_restart_drain_timeout() -> float:
+    try:
+        from hermes_cli.gateway import _get_restart_drain_timeout
+        return _get_restart_drain_timeout()
+    except ImportError:
+        from gateway.restart import DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+        return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+
+
 @asynccontextmanager
 async def _lifespan(app: "FastAPI"):
     app.state.event_channels = {}  # dict[str, set]
@@ -153,6 +169,14 @@ async def _lifespan(app: "FastAPI"):
     # On app.state (not a module global) so the Lock binds to the running
     # event loop during lifespan startup — see _get_event_state's docstring.
     app.state.chat_argv_lock = asyncio.Lock()
+
+    # Fire hermes_cli.gateway import into a background thread so the event
+    # loop is not blocked and HERMES_DASHBOARD_READY fires without delay.
+    # On a cold Windows install the module chain triggers .pyc compilation
+    # and Defender real-time scans that can stall the event loop for 15-30s.
+    # Running in an executor means the cost is paid in a worker thread while
+    # the server socket is already open and accepting probes.
+    asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)
 
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes
@@ -1855,19 +1879,15 @@ async def get_status(profile: Optional[str] = None):
             gateway_state=gateway_state,
         )
         # Resolved drain timeout (seconds) so NAS can size its poll deadline
-        # without out-of-band knowledge.  Reuse the single resolver
-        # (HERMES_RESTART_DRAIN_TIMEOUT env → config agent.restart_drain_timeout
-        # → default) rather than re-deriving the precedence chain here.
-        try:
-            from hermes_cli.gateway import _get_restart_drain_timeout
-
-            restart_drain_timeout = _get_restart_drain_timeout()
-        except ImportError:
-            # Resolver moved/renamed — fall back to the real default so the
-            # field stays a numeric poll-deadline hint, never None.
-            from gateway.restart import DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
-
-            restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+        # without out-of-band knowledge.  Offload to a thread: on a cold
+        # Windows install the first import of hermes_cli.gateway blocks the
+        # asyncio event loop for 15-30s (.pyc compilation + Defender scans),
+        # exceeding the desktop handshake's 15s socket timeout.  After the
+        # first call the module is in sys.modules and run_in_executor returns
+        # in microseconds.
+        restart_drain_timeout = await asyncio.get_running_loop().run_in_executor(
+            None, _resolve_restart_drain_timeout
+        )
 
         # Dashboard auth gate (Phase 7): surface whether the gate is engaged
         # and which providers are registered so ``hermes status`` and the

--- a/tests/hermes_cli/test_web_server_boot_handshake.py
+++ b/tests/hermes_cli/test_web_server_boot_handshake.py
@@ -1,0 +1,188 @@
+"""
+Integration tests for the desktop boot handshake fix (PR #50231 / issue #50209).
+
+Simulates a slow hermes_cli.gateway import (15-30 s on a fresh Windows install
+with Defender scanning every new .pyc) by patching the two helpers that touch
+the blocking import and measuring event-loop freedom + response latency.
+
+Three scenarios are covered:
+
+1. _lifespan fire-and-forget: patched _warm_gateway_module sleeps N seconds in
+   a thread; TestClient startup must complete in << N seconds (event loop not
+   blocked, HERMES_DASHBOARD_READY would fire immediately).
+
+2. get_status run_in_executor: patched _resolve_restart_drain_timeout sleeps N
+   seconds in a thread; a concurrent fast endpoint (/api/version) must respond
+   during the wait, proving the event loop stayed free.
+
+3. No orphan accumulation: three concurrent /api/status requests all receive a
+   200 response — no socket timeouts, no connection resets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import threading
+from unittest.mock import patch
+
+import pytest
+
+import hermes_cli.web_server as web_server_mod
+
+SLOW_SECONDS = 3  # represents the Defender worst-case (scaled down for CI speed)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_slow_warm(seconds: float):
+    """Return a _warm_gateway_module replacement that sleeps in the caller thread."""
+    def _slow():
+        time.sleep(seconds)
+    return _slow
+
+
+def _make_slow_drain(seconds: float):
+    """Return a _resolve_restart_drain_timeout replacement that sleeps in thread."""
+    def _slow():
+        time.sleep(seconds)
+        return 180.0
+    return _slow
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — _lifespan fire-and-forget does not block the event loop
+# ---------------------------------------------------------------------------
+
+def test_lifespan_warmup_is_nonblocking():
+    """
+    _warm_gateway_module runs in an executor (fire-and-forget).
+    Even if it sleeps for SLOW_SECONDS, TestClient startup must complete
+    in well under that time — proving the event loop was never blocked and
+    HERMES_DASHBOARD_READY would have fired without delay.
+    """
+    from fastapi.testclient import TestClient
+
+    with patch.object(web_server_mod, "_warm_gateway_module", _make_slow_warm(SLOW_SECONDS)):
+        t0 = time.perf_counter()
+        with TestClient(web_server_mod.app, raise_server_exceptions=False) as _client:
+            startup_ms = (time.perf_counter() - t0) * 1000
+
+    # Startup must complete in under half of SLOW_SECONDS (generous margin).
+    # If the import were synchronous, startup would block for >= SLOW_SECONDS.
+    threshold_ms = (SLOW_SECONDS * 1000) / 2
+    assert startup_ms < threshold_ms, (
+        f"_lifespan blocked the event loop: startup took {startup_ms:.0f} ms "
+        f"but slow import is {SLOW_SECONDS * 1000:.0f} ms — "
+        f"fire-and-forget is not working."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — get_status run_in_executor keeps event loop free for other requests
+# ---------------------------------------------------------------------------
+
+def test_get_status_does_not_block_event_loop():
+    """
+    /api/status calls _resolve_restart_drain_timeout via run_in_executor.
+    While that slow call is running in a thread, a concurrent fast request
+    (/api/version) must still get a response — proving the event loop stayed
+    free during the import.
+    """
+    import httpx
+    from anyio import from_thread, to_thread
+
+    results: dict[str, float] = {}
+    errors: list[str] = []
+
+    async def _run():
+        transport = httpx.ASGITransport(app=web_server_mod.app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            # Fire both requests concurrently
+            async with asyncio.TaskGroup() as tg:
+                async def _status():
+                    t = time.perf_counter()
+                    r = await client.get("/api/status", timeout=SLOW_SECONDS + 5)
+                    results["status_ms"] = (time.perf_counter() - t) * 1000
+                    results["status_code"] = r.status_code
+
+                async def _version():
+                    # Small delay so /api/status starts first
+                    await asyncio.sleep(0.1)
+                    t = time.perf_counter()
+                    r = await client.get("/api/version", timeout=5)
+                    results["version_ms"] = (time.perf_counter() - t) * 1000
+                    results["version_code"] = r.status_code
+
+                tg.create_task(_status())
+                tg.create_task(_version())
+
+    with patch.object(
+        web_server_mod, "_resolve_restart_drain_timeout", _make_slow_drain(SLOW_SECONDS)
+    ):
+        asyncio.run(_run())
+
+    # /api/version must have responded well before /api/status finished
+    assert "version_ms" in results, "Fast endpoint never responded"
+    assert "status_ms" in results, "/api/status never responded"
+
+    version_ms = results["version_ms"]
+    status_ms = results["status_ms"]
+
+    # /api/version should respond in < SLOW_SECONDS (event loop free)
+    assert version_ms < SLOW_SECONDS * 1000, (
+        f"/api/version took {version_ms:.0f} ms — event loop was blocked by "
+        f"/api/status (which waited {status_ms:.0f} ms for the slow import)."
+    )
+
+    # /api/status itself eventually returns 200
+    assert results.get("status_code") == 200, (
+        f"/api/status returned {results.get('status_code')} instead of 200"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — no orphan accumulation: concurrent probes all receive 200
+# ---------------------------------------------------------------------------
+
+def test_concurrent_status_probes_all_respond():
+    """
+    Three concurrent /api/status requests must all receive HTTP 200.
+    If the event loop were blocked, later requests would pile up and
+    the desktop shell would eventually reset the connection (WinError 10054).
+    """
+    import httpx
+
+    PROBES = 3
+    responses: list[int] = []
+
+    async def _run():
+        transport = httpx.ASGITransport(app=web_server_mod.app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            tasks = [
+                client.get("/api/status", timeout=SLOW_SECONDS + 5)
+                for _ in range(PROBES)
+            ]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for r in results:
+                if isinstance(r, Exception):
+                    responses.append(-1)
+                else:
+                    responses.append(r.status_code)
+
+    with patch.object(
+        web_server_mod, "_resolve_restart_drain_timeout", _make_slow_drain(SLOW_SECONDS)
+    ):
+        asyncio.run(_run())
+
+    failed = [c for c in responses if c != 200]
+    assert not failed, (
+        f"{len(failed)}/{PROBES} probes failed (codes: {responses}). "
+        f"This would cause WinError 10054 and orphan accumulation on desktop."
+    )


### PR DESCRIPTION
Closes #50209

## Problem

On a fresh Windows 11 install (no `.pyc` cache, Windows Defender real-time protection enabled), the Hermes desktop shell hangs at ~94% and fails with:

```
Hermes backend did not become ready: Timed out connecting to Hermes backend after 15000ms
```

The backend was provably healthy — `HERMES_DASHBOARD_READY` was printed and `curl /` returned HTTP 200. The boot entered a silent respawn loop, each iteration flooding `errors.log` with:

```
ConnectionResetError: [WinError 10054] An existing connection was forcibly closed by the remote host
```

Reproduced on both native Windows 11 and Ubuntu 24.04 under WSL2.

## Root Cause

Commit `0ee75469d` introduced a lazy import inside the `async def get_status` handler to resolve `restart_drain_timeout`:

```python
# hermes_cli/web_server.py — inside async def get_status()
try:
    from hermes_cli.gateway import _get_restart_drain_timeout   # ← the problem
    restart_drain_timeout = _get_restart_drain_timeout()
except ImportError:
    ...
```

`hermes_cli.gateway` is a ~3 700-line module whose import chain pulls in `hermes_cli.setup`, `hermes_cli.nous_subscription`, `tools.tool_backend_helpers`, and several others. On a cold disk with no `.pyc` bytecode cache, Python must compile every file and Windows Defender performs real-time scanning of each new `.pyc` as it is written. This stalls the asyncio event loop for **15–30 seconds**.

### Failure sequence

```
1. uvicorn binds port → prints HERMES_DASHBOARD_READY
2. Electron starts polling GET /api/status (15 s socket timeout per probe)
3. get_status: from hermes_cli.gateway import … blocks event loop for >15 s
4. Node.js req.destroy() fires → WinError 10054 on Python side
5. Electron exhausts 45 s deadline → "did not become ready"
6. Desktop kills backend → orphaned Python process holds SQLite lock
7. Next spawn finds SQLite busy → fails faster → spawns another orphan
8. Multiple HERMES_DASHBOARD_READY from different ports appear in logs
```

### Why `curl /` was misleading

`curl /` hits the StaticFiles mount (SPA HTML), served by Starlette entirely outside the asyncio application handler. It never reaches `get_status` and therefore never triggers the import.

## First Attempt and Regression

The first fix moved the import into `_lifespan` as a synchronous pre-warm. This introduced a **second failure mode**:

```
Timed out waiting for Hermes backend port announcement (45000ms)
```

`_lifespan` runs *before* uvicorn binds its port. A synchronous import there blocked the event loop before `HERMES_DASHBOARD_READY` was ever printed — trading the 15 s socket timeout for a 45 s port-announcement timeout, while the orphan accumulation continued unchanged.

### Regression failure sequence

```
1. _lifespan: import hermes_cli.gateway (synchronous — blocks event loop)
2. Defender scans every .pyc → event loop stalled before port can bind
3. HERMES_DASHBOARD_READY never printed within 45 s
4. Electron times out waiting for port announcement
5. Desktop kills backend → orphan accumulates → loop repeats
```

## Fix

`run_in_executor` in two places — the blocking import is offloaded to a worker thread so the asyncio event loop stays free throughout the entire boot sequence.

### 1. `_lifespan` — fire-and-forget background warm-up

```python
asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)
```

No `await`. The call returns in ~3 ms, uvicorn binds the port, `HERMES_DASHBOARD_READY` fires immediately. The import runs in a worker thread in parallel with the server already accepting connections.

### 2. `get_status` — drain-timeout resolver in executor

```python
restart_drain_timeout = await asyncio.get_running_loop().run_in_executor(
    None, _resolve_restart_drain_timeout
)
```

If the first `/api/status` probe arrives before the background warm-up finishes, the executor handles the blocking import in a thread — the event loop stays free for all other concurrent requests. After the first call, `hermes_cli.gateway` is in `sys.modules` and subsequent calls return in microseconds.

Both helpers are extracted as module-level sync functions (`_warm_gateway_module`, `_resolve_restart_drain_timeout`) so they can be unit-tested independently of FastAPI or uvicorn.

### Option comparison

| Option | Trade-off |
|---|---|
| `run_in_executor` in both `_lifespan` + `get_status` **(chosen)** | Zero event loop blocking; port announces immediately; defense-in-depth |
| Synchronous import in `_lifespan` (first attempt) | Regresses to 45 s port-announcement timeout |
| `run_in_executor` only in `get_status` | Correct, but no background warm-up before first probe |
| Move import to module level of `web_server.py` | Circular-import risk; changes module load contract |
| Increase Node.js socket timeout | Treats symptom, not cause |

## Test plan

- [x] 297 existing `web_server` tests pass — confirmed locally (`134 s`)
- [x] `_lifespan` fire-and-forget: TestClient startup completes in < 1.5 s with `_warm_gateway_module` patched to sleep 3 s — proves port announces without delay (`test_lifespan_warmup_is_nonblocking`)
- [x] Event loop stays free during slow drain-timeout import: `/api/version` responds during a 3 s patched `/api/status` call (`test_get_status_does_not_block_event_loop`)
- [x] Three concurrent `/api/status` probes with slow import all return HTTP 200 — no connection resets, no orphan accumulation (`test_concurrent_status_probes_all_respond`)
- [ ] Fresh Windows 11 install (no `.pyc` cache, Defender enabled): boot completes without 15 s or 45 s timeout — **requires validation on a cold machine**
- [ ] No `WinError 10054` flood in `errors.log` on first launch — **requires validation on a cold machine**