### PR TITLE
fix: _host_derived_api_key misidentifies vendor on ccTLD domains

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -150,18 +150,30 @@ def _host_derived_api_key(base_url: str) -> str:
         labels.pop(0)
     if len(labels) < 2:
         return ""
-    # Take the *registrable* label (second-to-last). For typical provider
-    # hosts this is what users intuitively call "the vendor":
-    #   deepseek.com               → labels[-2] = "deepseek"  ✓
-    #   api.groq.com → groq.com    → labels[-2] = "groq"      ✓
-    #   api.mistral.ai             → labels[-2] = "mistral"   ✓
-    # Crucially, lookalike hosts pick the ATTACKER's label, not the spoofed
-    # vendor:
-    #   api.deepseek.com.attacker.test → labels[-2] = "attacker"
-    # so DEEPSEEK_API_KEY stays put and the chain falls through to
-    # no-key-required. This mirrors how `base_url_host_matches` resists the
-    # same lookalike attack for explicit hosts.
-    vendor = labels[-2]
+    # Known second-level domains that form part of a two-part public suffix
+    # (e.g. ``.co.uk``, ``.com.au``, ``.co.jp``).  When the TLD is exactly
+    # two characters AND the next label inward belongs to this set, the
+    # registrable domain sits at labels[-3] rather than labels[-2].
+    # Without this correction, ``api.myhost.co.uk`` extracts ``CO_API_KEY``
+    # instead of ``MYHOST_API_KEY`` — see GHSA / PR for details.
+    #
+    # The label-based heuristics from #28660 still protect lookalike hosts:
+    #   api.deepseek.com.attacker.test → labels[-2] = "attacker"  ✓
+    _TWO_PART_TLD_SECOND = frozenset({
+        "co", "com", "org", "net", "gov", "edu", "ac", "sch", "nom",
+    })
+    # Take the *registrable* label. For typical provider hosts
+    # (``deepseek.com``, ``groq.com``, ``mistral.ai``) this is labels[-2].
+    # For two-part ccTLDs (``myhost.co.uk``, ``myhost.com.au``) jump one
+    # label deeper so the registrable portion is not a TLD sub-component.
+    if (
+        len(labels) >= 3
+        and labels[-2] in _TWO_PART_TLD_SECOND
+        and len(labels[-1]) == 2
+    ):
+        vendor = labels[-3]
+    else:
+        vendor = labels[-2]
     # Sanitize to env var charset: A-Z, 0-9, underscore.
     sanitized = "".join(ch if ch.isalnum() else "_" for ch in vendor).upper()
     if not sanitized or not sanitized[0].isalpha():


### PR DESCRIPTION
Summary
_host_derived_api_key() in hermes_cli/runtime_provider.py derives <VENDOR>_API_KEY from the hostname by taking labels[-2] as the vendor label. Correct for .com/.ai/.io, but wrong for two-segment ccTLDs (.co.uk, .com.au, .co.jp).

On those domains labels[-2] extracts the TLD sub-component ("co", "com") instead of the actual vendor, so CO_API_KEY is looked up instead of MYPROVIDER_API_KEY. Since this is the last-resort fallback (after explicit_api_key → key_env → host-gated keys), it silently returns empty → chain falls to "no-key-required". Degraded, safe, no credential leak — but silently broken.

Failure cases

Hostname                  | Current labels[-2] | Env var                        | Should be
api.myprovider.co.uk | "co"                      | CO_API_KEY ❌           | MYPROVIDER_API_KEY
api.somehost.com.au | "com"                  | COM_API_KEY ❌        | SOMEHOST_API_KEY
api.deepseek.com      | "deepseek"          | DEEPSEEK_API_KEY ✅|(unchanged)

Fix
Conservative heuristic — when TLD is exactly 2 chars AND the penultimate label is a known ccTLD second-level component, use labels[-3]:
_TWO_PART_TLD_SECOND = frozenset({
    "co", "com", "org", "net", "gov", "edu", "ac", "sch", "nom",
})
if len(labels) >= 3 and labels[-2] in _TWO_PART_TLD_SECOND and len(labels[-1]) == 2:
    vendor = labels[-3]
else:
    vendor = labels[-2]

Three guards prevent false positives: len(labels)>=3 catches api.x.ai, labels[-2] in frozenset catches .com/..dev, len(labels[-1])==2 catches non-ccTLD domains. Lookalike-attack defence from #28660 preserved — api.deepseek.com.attacker.test still resolves to "attacker".

How this differs from prior PRs
This file has two prior security fixes. This PR is a different class of problem:

PR         | Class                                | Stage
#28660 | Security (credential leak) | Which env vars to try (host-gating: only send OpenAI key to openai.com)
#14676 | Security (URL hijack)        | Which base URL is trusted to enter the chain (upstream gate)
This PR | Correctness bug               | How vendor is extracted from the hostname (downstream step, inside the chain)

Same function, different defect type. I introduced _host_derived_api_key() in #28660 to solve credential leaking; this PR fixes a parsing error in that function on ccTLD domains.

Impact
This is a functional correctness defect, not a cosmetic issue. The function's own contract — "extract the registrable label" — is violated on every ccTLD domain. The bug is deterministic and unconditional: any custom provider on a two-segment ccTLD will always derive the wrong env-var name. The fact that it works on .com is coincidental — a single-segment TLD just happens to produce the right answer from the wrong algorithm.

Three compounding factors make this worse than it first appears:

Silent failure with no diagnostic. When the derived env var doesn't exist (which it almost never will — nobody sets CO_API_KEY or COM_API_KEY), the chain silently falls through. The user gets "no-key-required" as the bearer token with zero indication that auto-detection was attempted and failed. There is no log line, no warning, no hint that a key_env setting would fix it.

Self-hosted and enterprise deployments are the primary victims. These are exactly the environments most likely to use organisational ccTLD domains — .ac.uk (UK universities), .gov.uk (UK government), .co.jp (Japanese companies), .com.au (Australian businesses) — where custom inference endpoints are common and explicit key_env configuration is easily overlooked.

The fix is trivial relative to the correctness gap. The function already walks the hostname label-by-label with explicit ccTLD-awareness in its lookalike-defence logic (#28660). It simply doesn't apply the same awareness when extracting the vendor — an inconsistency in the same function, not a missing capability.

Severity justification: A function that claims to extract the vendor label but demonstrably returns "co" instead of "myprovider" on valid real-world domains is not performing its stated task. The outcome is degraded functionality (no auto-detected API key) with no user-visible signal that degradation occurred — a class of bug that wastes debugging time and erodes trust in auto-configuration.

