### PR TITLE
fix(agent): surface fallback switch notice on recovery (#50229)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1322,7 +1322,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         agent._buffer_status(
             f"🔄 Primary model failed — switching to fallback: "
-            f"{fb_model} via {fb_provider}"
+            f"{fb_model} via {fb_provider}",
+            emit_on_success=True,
         )
         logger.info(
             "Fallback activated: %s → %s (%s)",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2812,10 +2812,14 @@ def run_conversation(
                     if not pool_may_recover:
                         if classified.reason == FailoverReason.billing:
                             agent._buffer_status(
-                                "⚠️ Billing or credits exhausted — switching to fallback provider..."
+                                "⚠️ Billing or credits exhausted — switching to fallback provider...",
+                                emit_on_success=True,
                             )
                         else:
-                            agent._buffer_status("⚠️ Rate limited — switching to fallback provider...")
+                            agent._buffer_status(
+                                "⚠️ Rate limited — switching to fallback provider...",
+                                emit_on_success=True,
+                            )
                         if agent._try_activate_fallback(reason=classified.reason):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
@@ -4416,9 +4420,10 @@ def run_conversation(
                 # Reset retry counter/signature on successful content
                 agent._empty_content_retries = 0
                 agent._thinking_prefill_retries = 0
-                # Successful content reached — drop any buffered retry
-                # status from earlier failed attempts in this turn.
-                agent._clear_status_buffer()
+                # Successful content reached — surface fallback notices that
+                # change the user's active backend, but still drop ordinary
+                # retry noise from earlier failed attempts in this turn.
+                agent._flush_recovery_status_buffer()
 
                 if (
                     agent.api_mode == "codex_responses"

--- a/run_agent.py
+++ b/run_agent.py
@@ -851,13 +851,14 @@ class AIAgent:
     # (agent.log) are unaffected — every individual emission site still
     # writes to ``logger.warning`` / ``logger.info`` for diagnosis.
 
-    def _buffer_status(self, message: str) -> None:
+    def _buffer_status(self, message: str, *, emit_on_success: bool = False) -> None:
         """Buffer a retry/fallback status message.
 
         Stored as a (kind, text) tuple where ``kind`` is one of:
-        - ``"status"``  -> replays via ``_emit_status``
-        - ``"vprint"``  -> replays via ``_vprint(force=True)``
-        - ``"warn"``    -> replays via ``_emit_warning``
+        - ``"status"``             -> replays via ``_emit_status`` on terminal failure
+        - ``"status_on_success"``  -> replays via ``_emit_status`` on recovery or failure
+        - ``"vprint"``             -> replays via ``_vprint(force=True)``
+        - ``"warn"``               -> replays via ``_emit_warning``
         Used to defer noisy retry chatter until we know whether the
         turn ultimately recovered or failed.
         """
@@ -866,7 +867,8 @@ class AIAgent:
             if buf is None:
                 buf = []
                 self._retry_status_buffer = buf
-            buf.append(("status", message))
+            kind = "status_on_success" if emit_on_success else "status"
+            buf.append((kind, message))
         except Exception:
             # Never break the retry loop on a buffer hiccup.
             pass
@@ -891,6 +893,30 @@ class AIAgent:
         except Exception:
             pass
 
+    def _flush_recovery_status_buffer(self) -> None:
+        """Emit success-visible fallback notices and drop retry noise.
+
+        Most retry chatter is intentionally buffered and discarded when a turn
+        recovers.  A provider/model fallback is different: after success the
+        user is now on a different backend, so notices marked
+        ``status_on_success`` must survive the recovery path.
+        """
+        try:
+            buf = getattr(self, "_retry_status_buffer", None)
+            if not buf:
+                return
+            messages = list(buf)
+            buf.clear()
+            for kind, msg in messages:
+                if kind != "status_on_success":
+                    continue
+                try:
+                    self._emit_status(msg)
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
     def _flush_status_buffer(self) -> None:
         """Emit buffered retry messages — call on terminal failure.
 
@@ -906,7 +932,7 @@ class AIAgent:
             buf.clear()
             for kind, msg in messages:
                 try:
-                    if kind == "status":
+                    if kind in {"status", "status_on_success"}:
                         self._emit_status(msg)
                     elif kind == "warn":
                         self._emit_warning(msg)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -85,6 +85,47 @@ def test_persist_user_message_override_rewrites_text_turns(agent):
     assert messages == [{"role": "user", "content": "hello"}]
 
 
+def test_success_recovery_flushes_only_fallback_status_not_retry_noise(agent):
+    emitted = []
+    agent.status_callback = lambda kind, message: emitted.append((kind, message))
+
+    agent._buffer_status("retrying primary in 5s")
+    agent._buffer_status("switching to fallback: glm via zai", emit_on_success=True)
+
+    agent._flush_recovery_status_buffer()
+
+    assert emitted == [("lifecycle", "switching to fallback: glm via zai")]
+    assert agent._retry_status_buffer == []
+
+
+def test_terminal_failure_flushes_retry_and_fallback_status(agent):
+    emitted = []
+    agent.status_callback = lambda kind, message: emitted.append((kind, message))
+
+    agent._buffer_status("retrying primary in 5s")
+    agent._buffer_status("switching to fallback: glm via zai", emit_on_success=True)
+
+    agent._flush_status_buffer()
+
+    assert emitted == [
+        ("lifecycle", "retrying primary in 5s"),
+        ("lifecycle", "switching to fallback: glm via zai"),
+    ]
+    assert agent._retry_status_buffer == []
+
+
+def test_recovery_status_flush_is_fail_open(agent):
+    def broken_status_callback(_message):
+        raise RuntimeError("display failed")
+
+    agent.status_callback = broken_status_callback
+    agent._buffer_status("switching to fallback", emit_on_success=True)
+
+    agent._flush_recovery_status_buffer()
+
+    assert agent._retry_status_buffer == []
+
+
 def test_persist_user_message_override_preserves_multimodal_turns(agent):
     multimodal_content = [
         {"type": "text", "text": "What color is this?"},
@@ -3784,18 +3825,30 @@ class TestRunConversation:
             agent._fallback_activated = True
             agent.model = "anthropic/claude-sonnet-4"
             agent.provider = "openrouter"
+            agent._buffer_status(
+                "🔄 Primary model failed — switching to fallback: "
+                "anthropic/claude-sonnet-4 via openrouter",
+                emit_on_success=True,
+            )
             return True
+
+        status_messages = []
 
         with (
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
             patch.object(agent, "_try_activate_fallback", side_effect=_mock_fallback),
+            patch.object(agent, "_emit_status", side_effect=status_messages.append),
         ):
             result = agent.run_conversation("answer me")
         assert fallback_called["called"], "Fallback should have been triggered"
         assert result["completed"] is True
         assert result["final_response"] == "Fallback answer."
+        assert status_messages == [
+            "🔄 Primary model failed — switching to fallback: "
+            "anthropic/claude-sonnet-4 via openrouter",
+        ]
 
     def test_empty_response_fallback_also_empty_returns_empty(self, agent):
         """If fallback also returns empty, final response is (empty)."""


### PR DESCRIPTION
## Summary
- preserve fallback-switch status messages through successful recovery while still dropping ordinary retry noise
- mark eager rate-limit/billing failover and concrete fallback activation notices as success-visible
- keep terminal-failure flushing behavior for both ordinary retry and fallback notices

## Verification
- RED on upstream/main: `test_success_recovery_flushes_only_fallback_status_not_retry_noise`, `test_terminal_failure_flushes_retry_and_fallback_status`, and `test_recovery_status_flush_is_fail_open` failed with `TypeError: AIAgent._buffer_status() got an unexpected keyword argument 'emit_on_success'`\n- GREEN focused: 4 passed (`test_success_recovery_flushes_only_fallback_status_not_retry_noise`, `test_terminal_failure_flushes_retry_and_fallback_status`, `test_recovery_status_flush_is_fail_open`, `TestRunConversation::test_empty_response_triggers_fallback_provider`)\n- GREEN containing file: `tests/run_agent/test_run_agent.py` — 387 passed, 3 warnings\n- Publication re-check after rebase: focused 4 passed, 3 warnings\n\n## Competitor / duplicate check\n- Same-author issue search for #50229: none\n- Same-author branch search `fix/50229*`: none\n- Open PR search for #50229: none\n- Keyword search for fallback provider/status notification: none\n\nAuto-published by Moonsong via Path B automated pipeline.