### PR TITLE
fix(desktop): avoid titlebar overlap with macOS traffic lights

### DIFF
--- a/apps/desktop/src/app/shell/app-shell.tsx
+++ b/apps/desktop/src/app/shell/app-shell.tsx
@@ -22,7 +22,7 @@ import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '../layout-constants'
 
 import { KeybindPanel } from './keybind-panel'
 import { StatusbarControls, type StatusbarItem } from './statusbar-controls'
-import { TITLEBAR_HEIGHT, titlebarControlsPosition } from './titlebar'
+import { TITLEBAR_HEIGHT, resolveTitlebarFullscreen, titlebarControlsPosition } from './titlebar'
 import { TitlebarControls, type TitlebarTool } from './titlebar-controls'
 
 interface AppShellProps {
@@ -79,7 +79,7 @@ export function AppShell({
   const fileBrowserWidthOverride = useStore($paneWidthOverride(FILE_BROWSER_PANE_ID))
   const connection = useStore($connection)
   const viewportFullscreen = useSyncExternalStore(subscribeWindowSize, viewportIsFullscreen, () => false)
-  const isFullscreen = Boolean(connection?.isFullscreen) || viewportFullscreen
+  const isFullscreen = resolveTitlebarFullscreen(connection?.isFullscreen, viewportFullscreen, connection?.windowButtonPosition)
   // Every secondary window (new-session scratch, subagent watch, cmd-click
   // pop-out) is a compact side panel — none of them carry the full titlebar
   // tool cluster. Gate on isSecondaryWindow, never the narrower new-session flag.

--- a/apps/desktop/src/app/shell/titlebar.test.ts
+++ b/apps/desktop/src/app/shell/titlebar.test.ts
@@ -4,6 +4,7 @@ import {
   TITLEBAR_CONTROL_OFFSET_X,
   TITLEBAR_EDGE_INSET,
   TITLEBAR_FALLBACK_WINDOW_BUTTON_X,
+  resolveTitlebarFullscreen,
   titlebarControlsPosition
 } from './titlebar'
 
@@ -22,5 +23,19 @@ describe('titlebarControlsPosition', () => {
 
   it('uses the macOS fallback while the initial window state is unknown', () => {
     expect(titlebarControlsPosition(undefined).left).toBe(TITLEBAR_FALLBACK_WINDOW_BUTTON_X + TITLEBAR_CONTROL_OFFSET_X)
+  })
+})
+
+describe('resolveTitlebarFullscreen', () => {
+  it('trusts the backend fullscreen state when it is true', () => {
+    expect(resolveTitlebarFullscreen(true, false, { x: 24, y: 10 })).toBe(true)
+  })
+
+  it('does not treat macOS maximize as fullscreen when traffic lights are visible', () => {
+    expect(resolveTitlebarFullscreen(false, true, { x: 24, y: 10 })).toBe(false)
+  })
+
+  it('uses the viewport fallback only when there are no left-side native controls', () => {
+    expect(resolveTitlebarFullscreen(false, true, null)).toBe(true)
   })
 })

--- a/apps/desktop/src/app/shell/titlebar.ts
+++ b/apps/desktop/src/app/shell/titlebar.ts
@@ -27,6 +27,23 @@ export const titlebarHeaderTitleClass = 'min-w-0 flex-1 overflow-hidden'
 export const titlebarHeaderShadowClass =
   "after:pointer-events-none after:absolute after:left-0 after:right-0 after:top-full after:h-4 after:bg-linear-to-b after:from-(--ui-chat-surface-background) after:to-transparent after:content-['']"
 
+export function resolveTitlebarFullscreen(
+  backendFullscreen: boolean | undefined,
+  viewportFullscreen: boolean,
+  windowButtonPosition: HermesConnection['windowButtonPosition'] | undefined
+) {
+  if (backendFullscreen) {
+    return true
+  }
+
+  // The viewport-size fallback is useful before the main-process fullscreen
+  // event reaches the renderer, but macOS maximize/zoom can also make the
+  // viewport fill the screen while the traffic lights remain visible. When
+  // Electron reports a left-side window button position, trust that signal and
+  // keep titlebar tools clear of the traffic lights.
+  return viewportFullscreen && windowButtonPosition === null
+}
+
 export function titlebarControlsPosition(
   windowButtonPosition: HermesConnection['windowButtonPosition'] | undefined,
   isFullscreen = false


### PR DESCRIPTION
## Summary
- Fix macOS desktop titlebar spacing when a window is maximized/zoomed but not in true fullscreen
- Keep left titlebar tools clear of visible traffic-light controls by trusting Electron's reported `windowButtonPosition`
- Add regression coverage for the fullscreen resolver behavior

## Test plan
- `npm run typecheck`
- `npm run test:ui -- src/app/shell/titlebar.test.ts`

## Notes
Observed on macOS: when Hermes Desktop is maximized, the viewport-size fallback can classify the window as fullscreen even though the red/yellow/green traffic lights remain visible. That pins the sidebar/swap titlebar tools to the left edge and overlaps the native controls. This change only applies the viewport fallback when there are no left-side native controls to dodge.