### PR TITLE
fix(photon): avoid retrying ambiguous delivery failures

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -98,6 +98,34 @@ _DEFAULT_MENTION_PATTERNS = [
 # ---------------------------------------------------------------------------
 # Module-level helpers — also used by check_fn / standalone send
 
+# Substring patterns that indicate the sidecar/upstream call FAILED but the
+# message MAY have already been delivered to iMessage. Retrying these double-
+# or triple-posts. Matched case-insensitively against the error string.
+_AMBIGUOUS_DELIVERY_PATTERNS = (
+    "remote refused stream reset",
+    "stream reset",
+    "internal sidecar error",
+    "sidecar /send returned 500",
+    "sidecar /send-attachment returned 500",
+    "upstream connect error",
+    "upstream connect failure",
+    "disconnect/reset before headers",
+)
+
+
+def _is_ambiguous_delivery_error(error: Any) -> bool:
+    """True when an error MAY have still resulted in delivery to iMessage.
+
+    Used by ``_send_with_retry`` to skip the retry + plain-text fallback that
+    would otherwise double-post the same message. See spam root-cause note in
+    that method.
+    """
+    if not error:
+        return False
+    lowered = str(error).lower()
+    return any(pat in lowered for pat in _AMBIGUOUS_DELIVERY_PATTERNS)
+
+
 def _coerce_port(value: Any, default: int) -> int:
     try:
         return int(value)
@@ -1217,6 +1245,22 @@ class PhotonAdapter(BasePlatformAdapter):
         error_str = result.error or ""
         is_network = result.retryable or self._is_retryable_error(error_str)
         if not is_network and self._is_timeout_error(error_str):
+            return result
+
+        # Ambiguous-delivery guard: sidecar may return 500 after the message
+        # already reached iMessage when the upstream gRPC stream is reset
+        # mid-flight (envoy "remote refused stream reset" / spectrum-ts
+        # "internal sidecar error" with a successful underlying send). Retrying
+        # in that case double- or triple-posts the same content to the user
+        # (root cause of the photon spam, 2026-06-21). Bail without retry; the
+        # caller will see a failed SendResult but the user only sees the one
+        # actually-delivered copy.
+        if _is_ambiguous_delivery_error(error_str):
+            logger.warning(
+                "[photon] Send returned %s — treating as ambiguous delivery "
+                "(message may have reached iMessage); skipping retry to avoid spam",
+                error_str[:200],
+            )
             return result
 
         if is_network:

--- a/tests/gateway/test_photon_ambiguous_delivery.py
+++ b/tests/gateway/test_photon_ambiguous_delivery.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+@pytest.mark.asyncio
+async def test_photon_ambiguous_delivery_error_skips_retry(monkeypatch):
+    monkeypatch.setenv("PHOTON_MARKDOWN", "false")
+    adapter = PhotonAdapter(PlatformConfig(enabled=True, token="test-token"))
+    calls: list[str] = []
+
+    async def send_once(
+        chat_id: str,
+        content: str,
+        reply_to: str | None = None,
+        metadata: object | None = None,
+    ) -> SendResult:
+        calls.append(content)
+        return SendResult(
+            success=False,
+            error="sidecar /send returned 500: remote refused stream reset",
+            retryable=True,
+        )
+
+    adapter.send = send_once
+
+    result = await adapter._send_with_retry(
+        chat_id="chat-1",
+        content="hello",
+        max_retries=2,
+        base_delay=0,
+    )
+
+    assert result.success is False
+    assert len(calls) == 1


### PR DESCRIPTION
Fixes #50249.

## Summary

- Treat Photon sidecar stream-reset / `internal sidecar error` 500s as **ambiguous-delivery** failures in `PhotonAdapter._send_with_retry`.
- Skip the existing retry + plain-text fallback for that class of error — the underlying iMessage send has likely already succeeded, so retrying double- / triple-posts the same message to the user.
- Real network timeouts and other retryable errors keep the existing retry behavior.

Root cause is documented inline alongside the new guard so the next person debugging Photon spam can find it without re-deriving the gRPC stream-reset race.

## Diff

- `plugins/platforms/photon/adapter.py` — add `_AMBIGUOUS_DELIVERY_PATTERNS`, `_is_ambiguous_delivery_error()`, and an early-return guard at the top of `_send_with_retry`'s retry block.
- `tests/gateway/test_photon_ambiguous_delivery.py` — new regression test asserting `send` is called exactly once when the adapter sees `sidecar /send returned 500: remote refused stream reset`.

Total: **+83 / -0** across 2 files.

## Validation

- `uv run pytest tests/gateway/test_photon_ambiguous_delivery.py -q` → 1 passed
- `uv run ruff check plugins/platforms/photon/adapter.py tests/gateway/test_photon_ambiguous_delivery.py` → All checks passed

## Notes

- Cache- and alternation-safe: no system-prompt, message-history, or tool-schema changes.
- Branch is rebased on current `NousResearch/hermes-agent@main` (was `65a477f12`), so the diff is exactly the 83 lines above — no fork-drift noise.
- Supersedes my fork-only attempt at trac3r00/hermes-agent#1, which I'll close once this lands.
