### PR TITLE
feat(cli): improve interactive MCP add flow

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -12,6 +12,8 @@ import asyncio
 import logging
 import os
 import re
+import shlex
+import sys
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -71,6 +73,88 @@ def _confirm(question: str, default: bool = True) -> bool:
 def _prompt(question: str, *, password: bool = False, default: str = "") -> str:
     from hermes_cli.cli_output import prompt as _shared_prompt
     return _shared_prompt(question, default=default, password=password)
+
+
+def _is_interactive_stdin() -> bool:
+    return bool(getattr(sys.stdin, "isatty", lambda: False)())
+
+
+def _prompt_required(question: str, *, default: str = "") -> str:
+    """Prompt until a non-empty value is provided or input is cancelled."""
+    suffix = f" [{default}]" if default else ""
+    while True:
+        try:
+            value = input(color(f"  {question}{suffix}: ", Colors.YELLOW)).strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return ""
+        if value:
+            return value
+        if default:
+            return default
+        _warning("A value is required.")
+
+
+def _pick_mcp_option(
+    title: str,
+    options: List[Tuple[str, str]],
+    *,
+    default_index: int = 0,
+) -> Optional[str]:
+    """Show a picker for a short MCP CLI choice and return the option key."""
+    labels = [label for _, label in options]
+    try:
+        from hermes_cli.curses_ui import curses_single_select
+
+        idx = curses_single_select(title, labels, default_index=default_index)
+    except Exception:
+        logger.debug("MCP picker failed; falling back to numbered prompt", exc_info=True)
+        print(color(f"\n  {title}", Colors.YELLOW))
+        for i, label in enumerate(labels, 1):
+            marker = "→" if i - 1 == default_index else " "
+            print(f"  {marker} {i}. {label}")
+        print()
+        try:
+            val = input(
+                color(f"  Choice [1-{len(labels)}] ({default_index + 1}): ", Colors.DIM)
+            ).strip()
+            idx = default_index if not val else int(val) - 1
+        except (ValueError, KeyboardInterrupt, EOFError):
+            return None
+
+    if idx is None:
+        return None
+    if 0 <= idx < len(options):
+        print()
+        return options[idx][0]
+    return None
+
+
+def _choose_http_auth_method(auth_type: Optional[str]) -> Optional[str]:
+    """Resolve HTTP auth mode for `hermes mcp add`.
+
+    Explicit CLI flags continue to win. In interactive mode, ask directly
+    instead of assuming API-key auth after a yes/no prompt.
+    """
+    if auth_type == "oauth":
+        return "oauth"
+    if auth_type == "header":
+        return "api_key"
+    if auth_type:
+        return auth_type
+    if not _is_interactive_stdin():
+        # Preserve non-interactive safety: do not prompt or assume credentials.
+        return "none"
+
+    return _pick_mcp_option(
+        "Authentication method for this HTTP MCP server",
+        [
+            ("oauth", "OAuth — browser-based OAuth / PKCE (recommended for hosted MCPs)"),
+            ("api_key", "API key — Authorization: Bearer <token> from .env"),
+            ("none", "None — no authentication"),
+        ],
+        default_index=0,
+    )
 
 
 # ─── Config Helpers ───────────────────────────────────────────────────────────
@@ -298,7 +382,7 @@ def _unwrap_exception_group(exc: BaseException) -> Exception:
 
 def cmd_mcp_add(args):
     """Add a new MCP server with discovery-first tool selection."""
-    name = args.name
+    name = getattr(args, "name", None)
     url = getattr(args, "url", None)
     # Read from `mcp_command` (set by --command via explicit dest) — see
     # mcp_add_p.add_argument("--command", dest="mcp_command", ...) in
@@ -310,6 +394,62 @@ def cmd_mcp_add(args):
     auth_type = getattr(args, "auth", None)
     preset_name = getattr(args, "preset", None)
     raw_env = getattr(args, "env", None)
+
+    interactive = _is_interactive_stdin()
+
+    if not name:
+        if not interactive:
+            _error("Must specify a server name.")
+            _info('Example: hermes mcp add work --url "https://mcp.example.com/mcp"')
+            return
+        print()
+        _info("Add a new MCP server")
+        name = _prompt_required("Server name")
+        if not name:
+            _info("Cancelled.")
+            return
+
+    if interactive and not url and not command and not preset_name:
+        transport_options = [
+            ("url", "Hosted URL — HTTP/SSE endpoint, best for managed MCPs"),
+            ("command", "Local command — stdio server launched by Hermes"),
+        ]
+        if _MCP_PRESETS:
+            transport_options.append(
+                ("preset", f"Preset — known template ({', '.join(sorted(_MCP_PRESETS))})")
+            )
+        transport = _pick_mcp_option(
+            "How should Hermes connect to this MCP server?",
+            transport_options,
+            default_index=0,
+        )
+        if transport is None:
+            _info("Cancelled.")
+            return
+        if transport == "url":
+            url = _prompt_required("MCP endpoint URL")
+            if not url:
+                _info("Cancelled.")
+                return
+        elif transport == "command":
+            command = _prompt_required("Stdio command")
+            if not command:
+                _info("Cancelled.")
+                return
+            raw_args = _prompt("Command arguments", default="").strip()
+            if raw_args:
+                try:
+                    cmd_args = shlex.split(raw_args)
+                except ValueError as exc:
+                    _error(f"Invalid command arguments: {exc}")
+                    return
+        elif transport == "preset":
+            if _MCP_PRESETS:
+                _info(f"Available presets: {', '.join(sorted(_MCP_PRESETS))}")
+            preset_name = _prompt_required("Preset name")
+            if not preset_name:
+                _info("Cancelled.")
+                return
 
     server_config: Dict[str, Any] = {}
     try:
@@ -336,7 +476,7 @@ def cmd_mcp_add(args):
         _info("Examples:")
         _info('  hermes mcp add ink --url "https://mcp.ml.ink/mcp"')
         _info('  hermes mcp add github --command npx --args @modelcontextprotocol/server-github')
-        _info('  hermes mcp add myserver --preset mypreset')
+        _info('  hermes mcp add myserver --preset codex')
         return
 
     # Check if server already exists
@@ -365,55 +505,56 @@ def cmd_mcp_add(args):
 
     # ── Authentication ────────────────────────────────────────────────
 
-    if url and auth_type == "oauth":
-        print()
-        _info(f"Starting OAuth flow for '{name}'...")
-        oauth_ok = False
-        try:
-            from tools.mcp_oauth_manager import get_manager
-            oauth_auth = get_manager().get_or_build_provider(name, url, None)
-            if oauth_auth:
-                server_config["auth"] = "oauth"
-                _success("OAuth configured (tokens will be acquired on first connection)")
-                oauth_ok=True
-            else:
-                _warning("OAuth setup failed — MCP SDK auth module not available")
-        except Exception as exc:
-            _warning(f"OAuth error: {exc}")
-
-        if not oauth_ok:
-            _info("This server may not support OAuth.")
-            if _confirm("Continue without authentication?", default=True):
-                # Don't store auth: oauth — server doesn't support it
-                pass
-            else:
-                _info("Cancelled.")
-                return
-
-    elif url:
-        # Prompt for API key / Bearer token for HTTP servers
+    if url:
         print()
         _info(f"Connecting to {url}")
-        needs_auth = _confirm("Does this server require authentication?", default=True)
-        if needs_auth:
-            if auth_type == "header" or not auth_type:
-                env_key = _env_key_for_server(name)
-                existing_key = get_env_value(env_key)
-                if existing_key:
-                    _success(f"{env_key}: already configured")
-                    api_key = existing_key
-                else:
-                    api_key = _prompt("API key / Bearer token", password=True)
-                    if api_key:
-                        api_key = _strip_bearer_prefix(api_key)
-                        save_env_value(env_key, api_key)
-                        _success(f"Saved to {display_hermes_home()}/.env as {env_key}")
+        auth_method = _choose_http_auth_method(auth_type)
+        if auth_method is None:
+            _info("Cancelled.")
+            return
 
-                # Set header with env var interpolation
-                if api_key or existing_key:
-                    server_config["headers"] = {
-                        "Authorization": f"Bearer ${{{env_key}}}"
-                    }
+        if auth_method == "oauth":
+            _info(f"Starting OAuth setup for '{name}'...")
+            oauth_ok = False
+            try:
+                from tools.mcp_oauth_manager import get_manager
+                oauth_auth = get_manager().get_or_build_provider(name, url, None)
+                if oauth_auth:
+                    server_config["auth"] = "oauth"
+                    _success("OAuth configured (tokens will be acquired on first connection)")
+                    oauth_ok = True
+                else:
+                    _warning("OAuth setup failed — MCP SDK auth module not available")
+            except Exception as exc:
+                _warning(f"OAuth error: {exc}")
+
+            if not oauth_ok:
+                _info("This server may not support OAuth.")
+                if _confirm("Continue without authentication?", default=True):
+                    # Don't store auth: oauth — server doesn't support it
+                    pass
+                else:
+                    _info("Cancelled.")
+                    return
+
+        elif auth_method == "api_key":
+            env_key = _env_key_for_server(name)
+            existing_key = get_env_value(env_key)
+            if existing_key:
+                _success(f"{env_key}: already configured")
+                api_key = existing_key
+            else:
+                api_key = _prompt("API key / Bearer token", password=True)
+                if api_key:
+                    api_key = _strip_bearer_prefix(api_key)
+                    save_env_value(env_key, api_key)
+                    _success(f"Saved to {display_hermes_home()}/.env as {env_key}")
+
+            # Set header with env var interpolation
+            if api_key or existing_key:
+                server_config["headers"] = {
+                    "Authorization": f"Bearer ${{{env_key}}}"
+                }
 
     # ── Discovery: connect and list tools ─────────────────────────────
 

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -41,7 +41,11 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     mcp_add_p = mcp_sub.add_parser(
         "add", help="Add an MCP server (discovery-first install)"
     )
-    mcp_add_p.add_argument("name", help="Server name (used as config key)")
+    mcp_add_p.add_argument(
+        "name",
+        nargs="?",
+        help="Server name (used as config key); prompted when omitted in a TTY",
+    )
     mcp_add_p.add_argument("--url", help="HTTP/SSE endpoint URL")
     # dest="mcp_command" so this flag does not clobber the top-level
     # subparser's args.command attribute, which the dispatcher reads to

--- a/tests/hermes_cli/test_mcp_add_command_dest.py
+++ b/tests/hermes_cli/test_mcp_add_command_dest.py
@@ -38,7 +38,7 @@ def _build_parser():
     mcp_sub = mcp_p.add_subparsers(dest="mcp_action")
 
     mcp_add = mcp_sub.add_parser("add")
-    mcp_add.add_argument("name")
+    mcp_add.add_argument("name", nargs="?")
     mcp_add.add_argument("--url")
     mcp_add.add_argument("--command", dest="mcp_command")
     mcp_add.add_argument("--args", nargs=argparse.REMAINDER, default=[])
@@ -84,8 +84,18 @@ class TestMcpAddCommandDest:
         args = parser.parse_args(["mcp", "add", "foo"])
 
         assert args.command == "mcp"
+        assert args.name == "foo"
         assert args.mcp_command is None
         assert args.url is None
+
+    def test_bare_mcp_add_can_prompt_for_name_later(self):
+        """`hermes mcp add` parses so the handler can run an interactive flow."""
+        parser = _build_parser()
+        args = parser.parse_args(["mcp", "add"])
+
+        assert args.command == "mcp"
+        assert args.mcp_action == "add"
+        assert args.name is None
 
     def test_args_passthrough_keeps_nested_option_flags(self):
         """`--args` must keep command flags like Docker MCP's --profile."""

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -201,8 +201,8 @@ class TestMcpAdd:
         monkeypatch.setattr(
             "hermes_cli.mcp_config._probe_single_server", mock_probe
         )
-        # No auth, accept all tools
-        inputs = iter(["n", ""])  # no auth needed, enable all
+        # Non-interactive path skips auth prompt; accept all tools.
+        inputs = iter([""])
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
         from hermes_cli.mcp_config import cmd_mcp_add
@@ -218,6 +218,162 @@ class TestMcpAdd:
         config = load_config()
         assert "ink" in config.get("mcp_servers", {})
         assert config["mcp_servers"]["ink"]["url"] == "https://mcp.ml.ink/mcp"
+
+    def test_add_http_server_interactive_oauth_choice(self, tmp_path, capsys, monkeypatch):
+        """Interactive HTTP add offers OAuth as an explicit auth method."""
+        from unittest.mock import MagicMock
+
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        monkeypatch.setattr("hermes_cli.mcp_config.sys.stdin", fake_stdin)
+
+        class FakeManager:
+            def get_or_build_provider(self, name, url, config):
+                assert name == "hosted"
+                assert url == "https://mcp.example.com/mcp"
+                return object()
+
+        def mock_probe(name, config, **kw):
+            assert config["auth"] == "oauth"
+            return [("search", "Search")]
+
+        monkeypatch.setattr("tools.mcp_oauth_manager.get_manager", lambda: FakeManager())
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", mock_probe)
+        monkeypatch.setattr("hermes_cli.curses_ui.curses_single_select", lambda *a, **kw: 0)
+        inputs = iter([""])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        from hermes_cli.config import load_config
+
+        cmd_mcp_add(_make_args(name="hosted", url="https://mcp.example.com/mcp"))
+        out = capsys.readouterr().out
+        assert "OAuth configured" in out
+        assert "Saved" in out
+        assert load_config()["mcp_servers"]["hosted"]["auth"] == "oauth"
+
+    def test_add_http_server_interactive_prompts_for_missing_name_and_url(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """`hermes mcp add` can collect name, transport, and auth interactively."""
+        from unittest.mock import MagicMock
+
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        monkeypatch.setattr("hermes_cli.mcp_config.sys.stdin", fake_stdin)
+
+        def mock_probe(name, config, **kw):
+            assert name == "work"
+            assert config["url"] == "https://mcp.example.com/mcp"
+            assert "auth" not in config
+            assert "headers" not in config
+            return [("search", "Search")]
+
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", mock_probe)
+        picker_choices = iter([0, 2])  # transport: url, auth: none
+        monkeypatch.setattr(
+            "hermes_cli.curses_ui.curses_single_select",
+            lambda *a, **kw: next(picker_choices),
+        )
+        inputs = iter([
+            "work",                         # server name
+            "https://mcp.example.com/mcp",  # endpoint URL
+            "",                             # enable all tools
+        ])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        from hermes_cli.config import load_config
+
+        cmd_mcp_add(_make_args(name=None))
+        out = capsys.readouterr().out
+        assert "Saved" in out
+        assert load_config()["mcp_servers"]["work"]["url"] == "https://mcp.example.com/mcp"
+
+    def test_add_http_server_interactive_api_key_choice(self, tmp_path, capsys, monkeypatch):
+        """Auth picker can choose API-key mode and persist an Authorization header."""
+        from unittest.mock import MagicMock
+
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        monkeypatch.setattr("hermes_cli.mcp_config.sys.stdin", fake_stdin)
+
+        def mock_probe(name, config, **kw):
+            assert config["headers"] == {"Authorization": "Bearer ${MCP_HOSTED_API_KEY}"}
+            return [("search", "Search")]
+
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", mock_probe)
+        monkeypatch.setattr("hermes_cli.curses_ui.curses_single_select", lambda *a, **kw: 1)
+        monkeypatch.setattr("hermes_cli.mcp_config.get_env_value", lambda key: "secret-token")
+        inputs = iter([""])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        from hermes_cli.config import load_config
+
+        cmd_mcp_add(_make_args(name="hosted", url="https://mcp.example.com/mcp"))
+        out = capsys.readouterr().out
+        assert "Saved" in out
+        assert "headers" in load_config()["mcp_servers"]["hosted"]
+
+    def test_add_interactive_transport_picker_cancel_does_not_save(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Cancelling the transport picker exits before writing config."""
+        from unittest.mock import MagicMock
+
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        monkeypatch.setattr("hermes_cli.mcp_config.sys.stdin", fake_stdin)
+        monkeypatch.setattr("hermes_cli.curses_ui.curses_single_select", lambda *a, **kw: None)
+        monkeypatch.setattr("builtins.input", lambda _: "work")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        from hermes_cli.config import load_config
+
+        cmd_mcp_add(_make_args(name=None))
+        out = capsys.readouterr().out
+        assert "Cancelled" in out
+        assert "mcp_servers" not in load_config()
+
+    def test_add_interactive_auth_picker_cancel_does_not_save(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Cancelling the auth picker exits before probing or writing config."""
+        from unittest.mock import MagicMock
+
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        monkeypatch.setattr("hermes_cli.mcp_config.sys.stdin", fake_stdin)
+        monkeypatch.setattr("hermes_cli.curses_ui.curses_single_select", lambda *a, **kw: None)
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        from hermes_cli.config import load_config
+
+        cmd_mcp_add(_make_args(name="hosted", url="https://mcp.example.com/mcp"))
+        out = capsys.readouterr().out
+        assert "Cancelled" in out
+        assert "mcp_servers" not in load_config()
+
+    def test_add_interactive_preset_name_ctrl_c_cancels(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Ctrl-C at the preset-name prompt cancels instead of looping forever."""
+        from unittest.mock import MagicMock
+
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        monkeypatch.setattr("hermes_cli.mcp_config.sys.stdin", fake_stdin)
+        monkeypatch.setattr("hermes_cli.curses_ui.curses_single_select", lambda *a, **kw: 2)
+        monkeypatch.setattr("builtins.input", lambda _: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        from hermes_cli.config import load_config
+
+        cmd_mcp_add(_make_args(name="work"))
+        out = capsys.readouterr().out
+        assert "Cancelled" in out
+        assert "mcp_servers" not in load_config()
 
     def test_add_stdio_server(self, tmp_path, capsys, monkeypatch):
         """Add a stdio server."""
@@ -260,7 +416,7 @@ class TestMcpAdd:
         monkeypatch.setattr(
             "hermes_cli.mcp_config._probe_single_server", mock_probe_fail
         )
-        inputs = iter(["n", "y"])  # no auth, yes save disabled
+        inputs = iter(["y"])  # yes save disabled
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
         from hermes_cli.mcp_config import cmd_mcp_add


### PR DESCRIPTION
## What does this PR do?

This PR improves the `hermes mcp add` experience for modern hosted MCP servers.

Previously, adding an HTTP MCP server was clunky: users had to know the exact flag shape up front, and the interactive auth flow implicitly chose API-key auth. That does not match many hosted/enterprise MCP deployments where OAuth is the expected path.

This change adds a TTY-friendly interactive flow that can prompt for the server name and connection transport, then uses Hermes' existing picker UI for:

- hosted URL / HTTP-SSE endpoint
- local stdio command
- known preset

For HTTP MCP servers, authentication is now explicit via picker options:

- OAuth / PKCE
- API key / bearer token
- no auth

Existing explicit CLI usage is preserved, including `--auth oauth`, `--auth header`, `--url`, `--command`, and `--preset`. Non-interactive/scripted behavior remains safe and does not unexpectedly prompt for credentials.

## Related Issue

No issue filed.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/subcommands/mcp.py`
  - Made the `hermes mcp add` server name optional so interactive TTY sessions can prompt for it.
- `hermes_cli/mcp_config.py`
  - Added an interactive required-value prompt helper with graceful Ctrl-C/EOF cancellation.
  - Added a short-choice MCP picker helper using the existing `curses_single_select` UI, with numbered fallback.
  - Added picker-based transport selection for hosted URL, stdio command, and preset.
  - Added picker-based HTTP auth selection for OAuth, API key, and no auth.
  - Preserved explicit flag behavior for `--auth oauth` and `--auth header`.
  - Preserved non-interactive safety by avoiding surprise credential prompts in scripted paths.
  - Fixed cancellation behavior at required prompts such as preset name.
- `tests/hermes_cli/test_mcp_add_command_dest.py`
  - Updated parser coverage for optional `mcp add` name while preserving the `--command` dest regression guard.
- `tests/hermes_cli/test_mcp_config.py`
  - Added coverage for OAuth picker selection, API-key picker selection, bare interactive `hermes mcp add`, picker cancellation, and Ctrl-C at the preset-name prompt.

## How to Test

1. Run the focused automated tests:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_add_command_dest.py
   ```

2. Optional manual smoke test with an isolated Hermes home:

   ```bash
   TMP_HOME="$(mktemp -d)"
   HERMES_HOME="$TMP_HOME" python -m hermes_cli.main mcp add
   cat "$TMP_HOME/config.yaml"
   ```

3. Suggested manual paths to exercise:

   - `hermes mcp add` → enter server name → choose Hosted URL → choose OAuth.
   - `hermes mcp add` → enter server name → choose Hosted URL → choose None.
   - `hermes mcp add` → enter server name → choose Preset → press Ctrl-C at the preset-name prompt.
   - Existing explicit OAuth form:

     ```bash
     HERMES_HOME="$(mktemp -d)" python -m hermes_cli.main mcp add myserver --url "https://example.com/mcp" --auth oauth
     ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run relevant tests and all tests pass: `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_add_command_dest.py`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- Omarchy 3.8.2 (kernel 7.0.9-arch2-1), ubuntu 24.04, and macOS 15.5.1 -->

### Documentation & Housekeeping

- [x] N/A — I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] N/A — I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] N/A — I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses existing CLI picker/fallback patterns and does not add platform-specific process/path behavior.
- [x] N/A — I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test run:

```text
scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_add_command_dest.py

53 tests passed
```


