### PR TITLE
fix(photon): classify Envoy overflow errors as retryable; add typing cooldown

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -85,6 +85,20 @@ _DEDUP_WINDOW_SECONDS = 48 * 3600
 
 _SIDECAR_DIR = Path(__file__).parent / "sidecar"
 
+# Photon / Envoy / spectrum-ts error substrings that indicate a transient
+# upstream overload rather than a permanent failure.  These are not in the
+# core _RETRYABLE_ERROR_PATTERNS because they are specific to this adapter.
+_PHOTON_RETRYABLE_PATTERNS = (
+    "internal sidecar error",
+    "upstream connect error",
+    "reset reason: overflow",
+)
+
+# Minimum seconds between typing-indicator calls for the same chat.
+# iMessage is a personal channel — suppressing rapid repeats reduces
+# upstream gRPC pressure during Photon overflow events.
+_TYPING_COOLDOWN_SECONDS = 5.0
+
 # Group-chat mention wake words. When ``require_mention`` is enabled, group
 # messages are ignored unless they match one of these patterns — same
 # behavior and defaults as the BlueBubbles iMessage channel so the two
@@ -234,6 +248,8 @@ class PhotonAdapter(BasePlatformAdapter):
         # react action default to "the message that triggered me" without
         # requiring the model to thread message ids through tool calls.
         self._last_inbound_by_chat: Dict[str, str] = {}
+        # Last time we sent a typing indicator per chat, for cooldown gating.
+        self._typing_last_sent: Dict[str, float] = {}
 
         # Group-chat mention gating (parity with BlueBubbles). When enabled,
         # group messages are ignored unless they match a wake word; DMs are
@@ -988,6 +1004,10 @@ class PhotonAdapter(BasePlatformAdapter):
         )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
+        now = time.time()
+        if now - self._typing_last_sent.get(chat_id, 0.0) < _TYPING_COOLDOWN_SECONDS:
+            return
+        self._typing_last_sent[chat_id] = now
         try:
             await self._sidecar_call(
                 "/typing", {"spaceId": chat_id, "state": "start"}
@@ -996,6 +1016,7 @@ class PhotonAdapter(BasePlatformAdapter):
             logger.debug("[photon] send_typing failed: %s", e)
 
     async def stop_typing(self, chat_id: str) -> None:
+        self._typing_last_sent.pop(chat_id, None)
         try:
             await self._sidecar_call(
                 "/typing", {"spaceId": chat_id, "state": "stop"}
@@ -1189,13 +1210,22 @@ class PhotonAdapter(BasePlatformAdapter):
             return content
         return strip_markdown(content)
 
+    @staticmethod
+    def _is_retryable_error(error: Optional[str]) -> bool:
+        if BasePlatformAdapter._is_retryable_error(error):
+            return True
+        if not error:
+            return False
+        lowered = error.lower()
+        return any(pat in lowered for pat in _PHOTON_RETRYABLE_PATTERNS)
+
     async def _send_with_retry(
         self,
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
         metadata: Any = None,
-        max_retries: int = 2,
+        max_retries: int = 1,
         base_delay: float = 2.0,
     ) -> SendResult:
         """Retry sends without the generic Markdown banner.

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -855,6 +855,21 @@ class PhotonAdapter(BasePlatformAdapter):
                 logger.info("[photon-sidecar] %s", line.decode("utf-8", "replace").rstrip())
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("[photon-sidecar] supervisor exited: %s", e)
+        if self._inbound_running:
+            exit_code = proc.poll()
+            logger.error(
+                "[photon] sidecar exited unexpectedly (code %s) — triggering reconnect",
+                exit_code,
+            )
+            self._set_fatal_error(
+                "SIDECAR_CRASHED",
+                f"Photon sidecar exited unexpectedly (code {exit_code})",
+                retryable=True,
+            )
+            try:
+                await self._notify_fatal_error()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("[photon] fatal-error notification failed: %s", exc)
 
     async def _stop_sidecar(self) -> None:
         proc = self._sidecar_proc


### PR DESCRIPTION
Closes #50185

## Root cause

Three independent gaps in `PhotonAdapter` let a transient Photon/Spectrum upstream overflow degrade delivery, amplify gRPC pressure, and — when the sidecar crashed outright — leave the adapter silently dead with no path to self-recovery.

---

### Gap 1 — retryable error classification

`BasePlatformAdapter._is_retryable_error` matches generic network strings but not the Photon/Envoy-specific strings produced during an upstream overflow:

- `internal sidecar error` — the sidecar propagates the gRPC failure as `500 {"ok":false,"error":"..."}`.
- `upstream connect error` — Envoy circuit-breaker message.
- `reset reason: overflow` — Envoy explicit overflow reason.

Because `is_network = False`, `_send_with_retry` skipped the retry loop and fell through to the plain-text fallback, which also failed immediately.

### Gap 2 — typing indicator burst

`send_typing` had no rate gate. During an overflow event, repeated typing calls kept hitting the sidecar → gRPC upstream, widening the failure window instead of letting it recover.

### Gap 3 — sidecar death not detected (silent, no self-recovery)

When the sidecar process exited mid-session, `_supervise_sidecar` returned silently — `readline` hit EOF, the log-pump loop broke, nothing notified the gateway. `_inbound_loop` entered an infinite retry loop against a dead port, `_running` stayed `True`, and the adapter remained in `self.adapters` with no path to recovery short of a manual gateway restart.

---

## Changes (`plugins/platforms/photon/adapter.py` only)

| | Before | After |
|---|---|---|
| Overflow errors retried? | No — fell through immediately | Yes — 1 retry after 2 s backoff |
| Typing burst under overflow | Fires every call | Suppressed to 1 call per chat per 5 s |
| Typing after turn completes | May be delayed up to 5 s | Fires immediately (`stop_typing` resets cooldown) |
| Sidecar crash mid-session | Silent death, infinite retry loop, no recovery | Detected → reconnect watcher retries within 30 s |
| `base.py` touched? | — | No |
| Other adapters affected? | — | No |

### `_PHOTON_RETRYABLE_PATTERNS` + `_is_retryable_error` override

Added a module-level tuple of three high-specificity Envoy/sidecar substrings and a `@staticmethod` override of `_is_retryable_error` on `PhotonAdapter` that delegates to `BasePlatformAdapter._is_retryable_error` first, then checks the Photon-specific patterns. Core `_RETRYABLE_ERROR_PATTERNS` and all other adapters are untouched.

`"unavailable"` was considered but excluded — redundant (the other two Envoy patterns cover the reported string) and broader than necessary.

### `send_typing` cooldown + `stop_typing` reset

`_typing_last_sent: Dict[str, float]` tracks the last firing timestamp per chat. `send_typing` skips the sidecar call if fewer than 5 s have elapsed. `stop_typing` pops the entry so the next `send_typing` at the start of a new turn always fires — only rapid consecutive starts without a stop in between are suppressed.

### `max_retries=1` in `PhotonAdapter._send_with_retry`

Reduced from 2 to 1. A single 2 s back-off is enough to check whether the Envoy circuit-breaker has opened; a second retry at 4 s adds latency without meaningfully improving recovery odds for overflow events (which resolve on the order of hundreds of milliseconds).

### Sidecar death detection in `_supervise_sidecar`

Added a detection tail: after the log-pump loop exits (EOF or exception), the method checks `_inbound_running`. If still `True`, the exit was unexpected — calls `_set_fatal_error("SIDECAR_CRASHED", retryable=True)` + `_notify_fatal_error()`. The reconnect watcher picks up the platform within 30 s and retries with exponential backoff (30 s → 300 s cap).

The `_inbound_running` guard is safe against races: `disconnect()` sets `_inbound_running = False` *before* `_stop_sidecar()` cancels the supervisor task. `CancelledError` is `BaseException` (not `Exception`), so it bypasses the `except` clause and propagates normally — the detection block never runs during a clean shutdown.

---

## Verification

- All `_send_with_retry` callers in `base.py` and `run.py` use keyword args with no explicit `max_retries` — the default change applies only to `PhotonAdapter` via MRO.
- `stop_typing` is called with only `chat_id` at all five call sites; the added `pop` is idempotent.
- `_PHOTON_RETRYABLE_PATTERNS` is referenced only within `photon/adapter.py`.
- `_notify_fatal_error` returns early if no handler is set — safe in standalone/test use.