### PR TITLE
fix: parse voice beep_enabled with truthy helper

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -175,7 +175,7 @@ from hermes_cli.browser_connect import (
     try_launch_chrome_debug,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
-from utils import base_url_host_matches, fast_safe_load
+from utils import base_url_host_matches, fast_safe_load, is_truthy_value
 
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
@@ -11469,7 +11469,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             from hermes_cli.config import load_config
             voice_cfg = load_config().get("voice", {})
             if isinstance(voice_cfg, dict):
-                return bool(voice_cfg.get("beep_enabled", True))
+                return is_truthy_value(voice_cfg.get("beep_enabled"), default=True)
         except Exception:
             pass
         return True

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -26,6 +26,7 @@ import os
 import sys
 import threading
 from typing import Any, Callable, Optional
+from utils import is_truthy_value
 
 # Modifier aliases mirrored from the TUI parser (``ui-tui/src/lib/platform.ts``)
 # ``_MOD_ALIASES`` table — the contract that removes the cross-runtime
@@ -251,7 +252,7 @@ def _beeps_enabled() -> bool:
 
         voice_cfg = load_config().get("voice", {})
         if isinstance(voice_cfg, dict):
-            return bool(voice_cfg.get("beep_enabled", True))
+            return is_truthy_value(voice_cfg.get("beep_enabled"), default=True)
     except Exception:
         pass
     return True

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -707,3 +707,32 @@ class TestContinuousLoopSimulation:
         # The in-flight transcript was suppressed because we stopped mid-flight
         assert transcripts == []
         assert voice.is_continuous_active() is False
+
+
+class TestBeepsEnabled:
+    """Tests hermes_cli.voice._beeps_enabled() config parsing."""
+
+    def test_beeps_enabled_by_default(self, monkeypatch):
+        from hermes_cli.voice import _beeps_enabled
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"voice": {}})
+        assert _beeps_enabled() is True
+
+    @pytest.mark.parametrize("raw_value,expected", [
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+        ("true", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+    ])
+    def test_quoted_values_parsed_correctly(self, monkeypatch, raw_value, expected):
+        from hermes_cli.voice import _beeps_enabled
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"voice": {"beep_enabled": raw_value}},
+        )
+        assert _beeps_enabled() is expected

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -947,6 +947,52 @@ class TestVoiceBeepConfigReal:
     def test_beeps_can_be_disabled(self, _cfg):
         cli = _make_voice_cli()
         assert cli._voice_beeps_enabled() is False
+    @patch("hermes_cli.config.load_config", return_value={"voice": {"beep_enabled": "false"}})
+    def test_quoted_false_string_disables_beeps(self, _cfg):
+        cli = _make_voice_cli()
+        assert cli._voice_beeps_enabled() is False
+
+    @patch("hermes_cli.config.load_config", return_value={"voice": {"beep_enabled": "0"}})
+    def test_quoted_zero_string_disables_beeps(self, _cfg):
+        cli = _make_voice_cli()
+        assert cli._voice_beeps_enabled() is False
+
+    @patch("hermes_cli.config.load_config", return_value={"voice": {"beep_enabled": "no"}})
+    def test_quoted_no_string_disables_beeps(self, _cfg):
+        cli = _make_voice_cli()
+        assert cli._voice_beeps_enabled() is False
+
+    @patch("hermes_cli.config.load_config", return_value={"voice": {"beep_enabled": "off"}})
+    def test_quoted_off_string_disables_beeps(self, _cfg):
+        cli = _make_voice_cli()
+        assert cli._voice_beeps_enabled() is False
+
+    @patch("hermes_cli.config.load_config", return_value={"voice": {"beep_enabled": "true"}})
+    def test_quoted_true_string_enables_beeps(self, _cfg):
+        cli = _make_voice_cli()
+        assert cli._voice_beeps_enabled() is True
+
+    @patch("hermes_cli.config.load_config", return_value={"voice": {"beep_enabled": "1"}})
+    def test_quoted_one_string_enables_beeps(self, _cfg):
+        cli = _make_voice_cli()
+        assert cli._voice_beeps_enabled() is True
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off"])
+    def test_standalone_voice_false_like_strings_disable_beeps(self, value):
+        from hermes_cli.voice import _beeps_enabled
+
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": {"beep_enabled": value}}):
+            assert _beeps_enabled() is False
+
+    @pytest.mark.parametrize("value", ["true", "1"])
+    def test_standalone_voice_true_like_strings_enable_beeps(self, value):
+        from hermes_cli.voice import _beeps_enabled
+
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": {"beep_enabled": value}}):
+            assert _beeps_enabled() is True
+
 
     @patch("cli._cprint")
     @patch("cli.threading.Thread")


### PR DESCRIPTION
## Summary

Fixes `voice.beep_enabled` config parsing so that quoted false-like strings such as `"false"`, `"0"`, `"no"`, and `"off"` correctly disable beeps.

## Why

Setting this in `config.yaml` still enabled beeps:

```yaml
voice:
  beep_enabled: "false"
```

The bug happened because both `hermes_cli/voice.py` and `cli.py` used raw Python `bool(...)` coercion. In Python, `bool("false")` returns `True` because any non-empty string is truthy.

This replaces raw `bool(...)` parsing with the repo's existing `is_truthy_value()` helper.

Fixes #49883.

## What changed

* `hermes_cli/voice.py`

  * Imported `is_truthy_value`
  * Replaced raw `bool(...)` parsing in `_beeps_enabled()`

* `cli.py`

  * Added `is_truthy_value` to the existing utils import
  * Replaced raw `bool(...)` parsing in `_voice_beeps_enabled()`

* `tests/tools/test_voice_cli_integration.py`

  * Added regression coverage for quoted false-like and true-like values

## Behavior

| Config value      |   Before |    After |
| ----------------- | -------: | -------: |
| `true` / `True`   |  enabled |  enabled |
| `false` / `False` | disabled | disabled |
| `"true"`          |  enabled |  enabled |
| `"false"`         |  enabled | disabled |
| `"0"`             |  enabled | disabled |
| `"no"`            |  enabled | disabled |
| `"off"`           |  enabled | disabled |
| `"1"`             |  enabled |  enabled |
| missing           |  enabled |  enabled |

## Validation

* Both `beep_enabled` parsing locations now use `is_truthy_value(..., default=True)`
* `TestVoiceBeepConfigReal`: 9/9 passed
* Voice-related tests: 134 passed
* ACP approval isolation tests: 7 passed
* 5 unrelated failures were reproduced identically on `upstream/main`, so they are pre-existing and not caused by this change

## Risk

Low. This uses the repo's existing truthy parsing helper and preserves the previous default behavior: missing `voice.beep_enabled` still defaults to enabled.
