### PR TITLE
feat(cli): add AXI Tools section to welcome banner

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -602,6 +602,21 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
                     f"[red]— failed[/]"
                 )
 
+    # AXI Tools section (only if installed)
+    try:
+        from tools.mcp_tool import get_axi_status
+        axi_status = get_axi_status()
+    except Exception:
+        axi_status = []
+
+    if axi_status:
+        right_lines.append("")
+        right_lines.append(f"[bold {accent}]AXI Tools[/]")
+        for axi in axi_status:
+            right_lines.append(
+                f"[dim {dim}]{axi['name']}[/] [{text}]({axi['type']})[/]"
+            )
+
     right_lines.append("")
     right_lines.append(f"[bold {accent}]Available Skills[/]")
     skills_by_category = get_available_skills()
@@ -626,6 +641,8 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     summary_parts = [f"{len(tools)} tools", f"{total_skills} skills"]
     if mcp_connected:
         summary_parts.append(f"{mcp_connected} MCP servers")
+    if axi_status:
+        summary_parts.append(f"{len(axi_status)} AXI tools")
     summary_parts.append("/help for commands")
     # Indicate when the codex_app_server runtime is active so users
     # understand why tool counts may not match what's actually reachable


### PR DESCRIPTION
## What does this PR do?

Adds an "AXI Tools" section to the CLI welcome banner, displaying installed AXI tools alongside MCP Servers and Skills. This provides visibility into which AXI binaries are available in the environment, matching the information already shown in the TUI branding panel.

## Related Issue

Fixes # (no issue linked — this is a feature enhancement)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/banner.py`:
  - Add AXI Tools section below MCP Servers in the banner
  - Call `tools.mcp_tool.get_axi_status()` to discover installed AXI binaries
  - Display each AXI tool with its name and type
  - Add AXI tool count to the footer summary line (e.g., "42 tools · 12 skills · 3 MCP servers · 2 AXI tools /help for commands")
  - Gracefully handle missing `get_axi_status()` function with empty fallback

## How to Test

1. Install an AXI binary (e.g., `cluster-ops-axi`) to `~/.local/bin/cluster-ops-axi`
2. Start the Hermes CLI: `hermes`
3. Verify the welcome banner shows "AXI Tools" section with the installed binary
4. Verify the footer summary includes the AXI tool count
5. Test without AXI tools installed — banner should render normally without AXI section

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A for UI-only change
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses standard `~/.local/bin` path and graceful exception handling
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A

## Screenshots / Logs

Example banner output with AXI tools installed:

```
┌─ Hermes Agent v0.17.0 — model: glm-4.7 (zai) ────────────────────────────────┐
│  Model: glm-4.7 (zai) │ Provider: zai                                      │
└─────────────────────────────────────────────────────────────────────────────┘

42 tools · 12 skills

MCP Servers
  filesystem (stdio) — 4 tool(s)
  github (stdio) — 8 tool(s)

AXI Tools
  cluster-ops-axi (axi)
  npm-axi (axi)

Available Skills
  ...

42 tools · 12 skills · 2 MCP servers · 2 AXI tools /help for commands
```