### PR TITLE
fix(config): redact model api_key in config show output

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -249,6 +249,36 @@ def _mask_token(token: str) -> str:
     return mask_secret(token, head=6, tail=4, floor=18)
 
 
+# Match credential field names the same way the env scanner does, so config
+# display and log redaction stay consistent.
+_SECRET_NAME_RE = re.compile(_SECRET_ENV_NAMES, re.IGNORECASE)
+
+
+def _is_secret_key(name: object) -> bool:
+    """True if a config field name holds a credential (api_key, token, ...)."""
+    return isinstance(name, str) and (
+        name.lower() in _SENSITIVE_BODY_KEYS or bool(_SECRET_NAME_RE.search(name))
+    )
+
+
+def redact_mapping(mapping, *, force: bool = False):
+    """Return a copy of mapping with credential values masked for display.
+
+    The text redactor only catches double-quoted JSON, but a dict repr uses
+    single quotes, so config blocks like the model dict need masking by field.
+    Shallow on purpose, since model and provider blocks are flat. Non-dict
+    input and non-string values pass through, and the input is never changed.
+    Respects security.redact_secrets unless force is set.
+    """
+    assert isinstance(force, bool), "force must be a bool"
+    if not isinstance(mapping, dict) or not (force or _REDACT_ENABLED):
+        return mapping
+    return {
+        key: mask_secret(val, empty=val) if isinstance(val, str) and _is_secret_key(key) else val
+        for key, val in mapping.items()
+    }
+
+
 def _redact_query_string(query: str) -> str:
     """Redact sensitive parameter values in a URL query string.
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6468,7 +6468,10 @@ def show_config():
     # Model settings
     print()
     print(color("◆ Model", Colors.CYAN, Colors.BOLD))
-    print(f"  Model:        {config.get('model', 'not set')}")
+    # A custom provider keeps the api_key inside the model dict, so mask its
+    # credential fields before printing instead of dumping the raw dict.
+    from agent.redact import redact_mapping
+    print(f"  Model:        {redact_mapping(config.get('model', 'not set'))}")
     _cfg_max_turns = config.get('agent', {}).get('max_turns', DEFAULT_CONFIG['agent']['max_turns'])
     print(f"  Max turns:    {_cfg_max_turns}")
     # Warn on stale HERMES_MAX_ITERATIONS ghost in .env that disagrees with

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -486,3 +486,66 @@ class TestXaiToken:
     def test_prefix_visible_in_masked_output(self):
         result = redact_sensitive_text(self.KEY, force=True)
         assert result.startswith("xai-AB")
+
+
+class TestRedactMapping:
+    """redact_mapping masks credential fields in config dicts like the model
+    block, which the text redactor misses because a dict repr uses single
+    quotes."""
+
+    KEY = "cfut_FAKE1234567890ABCDEFsecret"
+
+    def _model(self):
+        return {
+            "default": "@cf/moonshotai/kimi-k2.7-code",
+            "provider": "custom",
+            "base_url": "https://example.invalid/v1",
+            "api_key": self.KEY,
+            "reasoning_effort": "medium",
+        }
+
+    def test_api_key_masked(self):
+        from agent.redact import redact_mapping
+
+        result = redact_mapping(self._model())
+        assert result["api_key"] != self.KEY
+        assert self.KEY not in str(result)
+
+    def test_non_secret_fields_untouched(self):
+        from agent.redact import redact_mapping
+
+        result = redact_mapping(self._model())
+        assert result["provider"] == "custom"
+        assert result["base_url"] == "https://example.invalid/v1"
+        assert result["reasoning_effort"] == "medium"
+
+    def test_input_not_mutated(self):
+        from agent.redact import redact_mapping
+
+        original = self._model()
+        redact_mapping(original)
+        assert original["api_key"] == self.KEY
+
+    def test_non_dict_passthrough(self):
+        from agent.redact import redact_mapping
+
+        assert redact_mapping("not set") == "not set"
+        assert redact_mapping(None) is None
+
+    def test_force_overrides_disabled(self, monkeypatch):
+        from agent.redact import redact_mapping
+
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        # Disabled and no force, so the key passes through (the opt-out).
+        assert redact_mapping(self._model())["api_key"] == self.KEY
+        # force still masks even when redaction is off.
+        assert redact_mapping(self._model(), force=True)["api_key"] != self.KEY
+
+    def test_other_credential_field_names(self):
+        from agent.redact import redact_mapping
+
+        block = {"auth_token": "x" * 24, "client_secret": "y" * 24, "name": "ok"}
+        result = redact_mapping(block)
+        assert result["auth_token"] != "x" * 24
+        assert result["client_secret"] != "y" * 24
+        assert result["name"] == "ok"


### PR DESCRIPTION
Issue

  hermes config show prints the model block as a raw dict, leaking api_key in
  plaintext even with security.redact_secrets enabled (#50245). The report files it
  under config set, but set only prints the scalar value it just wrote. The dict that
  exposes the key is the Model line from config show.

  Repro:
  1. set security.redact_secrets: true in ~/.hermes/config.yaml
  2. run hermes model and set up a custom compatible provider with an api_key
     (this writes model as a dict with api_key into config.yaml)
  3. run hermes config show and read the Model line

  Solution

  show_config printed config['model'] directly, and for a custom provider that value
  is a dict with an inline api_key. The existing text redactor only matches
  double-quoted JSON, but a Python dict repr uses single quotes, so the key slipped
  through. Added redact_mapping to mask credential fields in structured config and
  used it when printing the model block. Non-dict input and non-secret fields pass
  through unchanged, and the redact_secrets opt-out still works.

  Result

  The model api_key now renders masked as cfut...cret instead of in full. Added unit
  tests in test_redact.py: the key is masked, non-secret fields are untouched, the
  input dict is not mutated, force masks even when redaction is off, and the opt-out
  preserves the raw value.

  fix #50245
