### PR TITLE
feat(skills): enforce before-final verification gates

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -570,7 +570,7 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
             code_preview += "..."
         return f"[execute_code] `{code_preview}` ({line_count} lines output)"
 
-    if tool_name in {"skill_view", "skills_list", "skill_manage"}:
+    if tool_name in {"skill_activate", "skill_view", "skills_list", "skill_manage"}:
         name = args.get("name", "?")
         return f"[{tool_name}] name={name} ({content_len:,} chars)"
 

--- a/agent/display.py
+++ b/agent/display.py
@@ -426,8 +426,8 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
         "search_files": "pattern", "browser_navigate": "url",
         "browser_click": "ref", "browser_type": "text",
         "image_generate": "prompt", "text_to_speech": "text",
-        "vision_analyze": "question",
-        "skill_view": "name", "skills_list": "category",
+        "vision_analyze": "question", "mixture_of_agents": "user_prompt",
+        "skill_activate": "name", "skill_view": "name", "skills_list": "category",
         "cronjob": "action",
         "execute_code": "code", "delegate_task": "goal",
         "clarify": "question", "skill_manage": "name",
@@ -1269,6 +1269,8 @@ def get_cute_tool_message(
         return _wrap(f"┊ 📚 skills    list {args.get('category', 'all')}  {dur}")
     if tool_name == "skill_view":
         return _wrap(f"┊ 📚 skill     {_trunc(args.get('name', ''), 30)}  {dur}")
+    if tool_name == "skill_activate":
+        return _wrap(f"┊ 📚 skill     activate {_trunc(args.get('name', ''), 22)}  {dur}")
     if tool_name == "image_generate":
         return _wrap(f"┊ 🎨 create    {_trunc(args.get('prompt', ''), 35)}  {dur}")
     if tool_name == "text_to_speech":
@@ -1306,5 +1308,4 @@ def get_cute_tool_message(
 # =========================================================================
 # Honcho session line (one-liner with clickable OSC 8 hyperlink)
 # =========================================================================
-
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1584,6 +1584,8 @@ def build_skills_system_prompt(
             "## Skills (mandatory)\n"
             "Before replying, scan the skills below. If a skill matches or is even partially relevant "
             "to your task, you MUST load it with skill_view(name) and follow its instructions. "
+            "Loading is only inspection; once you decide to actually use a loaded skill, call "
+            "skill_activate(name) before continuing with the skill's workflow. "
             "Err on the side of loading — it is always better to have context you don't need "
             "than to miss critical steps, pitfalls, or established workflows. "
             "Skills contain specialized knowledge — API endpoints, tool-specific commands, "

--- a/agent/skill_verification.py
+++ b/agent/skill_verification.py
@@ -1,0 +1,302 @@
+"""Runtime verification gates for loaded skills.
+
+Skills can declare a deterministic before-final verifier in SKILL.md
+frontmatter.  When the agent loads such a skill via skill_view, this module
+records the verifier for the current session.  turn_finalizer drains and runs
+those verifiers before returning the final response.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from agent.skill_utils import parse_frontmatter
+
+_MAX_OUTPUT_PREVIEW_CHARS = 1200
+_DEFAULT_TIMEOUT_SECONDS = 120
+_MAX_TIMEOUT_SECONDS = 3600
+_PENDING_BY_SESSION: dict[str, dict[str, "SkillVerificationSpec"]] = {}
+_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class SkillVerificationSpec:
+    name: str
+    command: str
+    skill_dir: str | None = None
+    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS
+    success_exit_codes: tuple[int, ...] = (0,)
+    on_failure: str = "block_final"
+
+
+@dataclass(frozen=True)
+class SkillVerificationCheck:
+    spec: SkillVerificationSpec
+    passed: bool
+    exit_code: int | None = None
+    timed_out: bool = False
+    error: str = ""
+    stdout: str = ""
+    stderr: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "skill": self.spec.name,
+            "command": self.spec.command,
+            "passed": self.passed,
+            "exit_code": self.exit_code,
+            "timed_out": self.timed_out,
+            "error": self.error,
+            "on_failure": self.spec.on_failure,
+        }
+
+
+@dataclass(frozen=True)
+class SkillVerificationResult:
+    checks: tuple[SkillVerificationCheck, ...]
+    blocked: bool
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "blocked": self.blocked,
+            "checks": [check.to_dict() for check in self.checks],
+        }
+
+
+def record_skill_view_payload(session_id: str | None, payload: dict[str, Any]) -> bool:
+    """Record a loaded skill's before-final verifier for this session."""
+    key = _session_key(session_id)
+    if not key or not isinstance(payload, dict) or not payload.get("success"):
+        return False
+
+    spec = extract_before_final_spec(payload)
+    if spec is None:
+        return False
+
+    with _LOCK:
+        _PENDING_BY_SESSION.setdefault(key, {})[spec.name] = spec
+    return True
+
+
+def pending_verification_specs(session_id: str | None) -> list[SkillVerificationSpec]:
+    """Return pending specs for tests and observability."""
+    key = _session_key(session_id)
+    if not key:
+        return []
+    with _LOCK:
+        return list(_PENDING_BY_SESSION.get(key, {}).values())
+
+
+def clear_session_verifications(session_id: str | None) -> None:
+    key = _session_key(session_id)
+    if not key:
+        return
+    with _LOCK:
+        _PENDING_BY_SESSION.pop(key, None)
+
+
+def run_before_final_verifications(session_id: str | None) -> SkillVerificationResult | None:
+    """Run and drain pending before-final verifiers for a session."""
+    specs = _drain_session_specs(session_id)
+    if not specs:
+        return None
+
+    checks = tuple(_run_check(spec) for spec in specs)
+    blocking_failures = [
+        check
+        for check in checks
+        if not check.passed and check.spec.on_failure == "block_final"
+    ]
+    blocked = bool(blocking_failures)
+    message = _format_blocked_message(blocking_failures) if blocked else ""
+    return SkillVerificationResult(checks=checks, blocked=blocked, message=message)
+
+
+def extract_before_final_spec(payload: dict[str, Any]) -> SkillVerificationSpec | None:
+    """Extract a required before-final verifier from a skill_view payload."""
+    content = str(payload.get("content") or "")
+    frontmatter, _body = parse_frontmatter(content)
+    verification = _extract_verification_block(frontmatter)
+    if not verification:
+        return None
+
+    before_final = verification.get("before_final")
+    if not isinstance(before_final, dict):
+        return None
+    if not bool(before_final.get("required")):
+        return None
+
+    command = before_final.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return None
+
+    return SkillVerificationSpec(
+        name=str(payload.get("name") or frontmatter.get("name") or "unknown-skill"),
+        command=command.strip(),
+        skill_dir=_normalize_optional_string(payload.get("skill_dir")),
+        timeout_seconds=_normalize_timeout(before_final.get("timeout_seconds")),
+        success_exit_codes=_normalize_success_exit_codes(
+            before_final.get("success_exit_codes")
+        ),
+        on_failure=_normalize_on_failure(before_final.get("on_failure")),
+    )
+
+
+def _extract_verification_block(frontmatter: dict[str, Any]) -> dict[str, Any] | None:
+    metadata = frontmatter.get("metadata")
+    if isinstance(metadata, dict):
+        hermes_meta = metadata.get("hermes")
+        if isinstance(hermes_meta, dict):
+            verification = hermes_meta.get("verification")
+            if isinstance(verification, dict):
+                return verification
+
+    verification = frontmatter.get("verification")
+    if isinstance(verification, dict):
+        return verification
+    return None
+
+
+def _drain_session_specs(session_id: str | None) -> list[SkillVerificationSpec]:
+    key = _session_key(session_id)
+    if not key:
+        return []
+    with _LOCK:
+        specs_by_name = _PENDING_BY_SESSION.pop(key, {})
+    return list(specs_by_name.values())
+
+
+def _run_check(spec: SkillVerificationSpec) -> SkillVerificationCheck:
+    cwd = _existing_skill_dir(spec.skill_dir)
+    try:
+        completed = subprocess.run(
+            spec.command,
+            cwd=str(cwd) if cwd else None,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=spec.timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return SkillVerificationCheck(
+            spec=spec,
+            passed=False,
+            timed_out=True,
+            stdout=_coerce_output(exc.stdout),
+            stderr=_coerce_output(exc.stderr),
+            error=f"timed out after {spec.timeout_seconds}s",
+        )
+    except Exception as exc:
+        return SkillVerificationCheck(
+            spec=spec,
+            passed=False,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    return SkillVerificationCheck(
+        spec=spec,
+        passed=completed.returncode in spec.success_exit_codes,
+        exit_code=completed.returncode,
+        stdout=completed.stdout or "",
+        stderr=completed.stderr or "",
+    )
+
+
+def _format_blocked_message(failures: list[SkillVerificationCheck]) -> str:
+    lines = [
+        "Skill verification failed before the final response.",
+        "",
+        "The assistant's unverified final answer was blocked because one or more required skill verifiers failed:",
+    ]
+    for check in failures:
+        lines.extend(
+            [
+                "",
+                f"- skill: {check.spec.name}",
+                f"  command: {check.spec.command}",
+            ]
+        )
+        if check.timed_out:
+            lines.append(f"  result: timed out after {check.spec.timeout_seconds}s")
+        elif check.exit_code is not None:
+            lines.append(f"  exit_code: {check.exit_code}")
+        if check.error:
+            lines.append(f"  error: {check.error}")
+        output = _preview_output(check.stdout, check.stderr)
+        if output:
+            lines.append("  output:")
+            lines.extend(f"    {line}" for line in output.splitlines())
+    return "\n".join(lines)
+
+
+def _preview_output(stdout: str, stderr: str) -> str:
+    chunks = []
+    if stdout.strip():
+        chunks.append("stdout:\n" + stdout.strip())
+    if stderr.strip():
+        chunks.append("stderr:\n" + stderr.strip())
+    out = "\n\n".join(chunks)
+    if len(out) <= _MAX_OUTPUT_PREVIEW_CHARS:
+        return out
+    return out[: _MAX_OUTPUT_PREVIEW_CHARS - 3].rstrip() + "..."
+
+
+def _normalize_timeout(raw: Any) -> int:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = _DEFAULT_TIMEOUT_SECONDS
+    return max(1, min(value, _MAX_TIMEOUT_SECONDS))
+
+
+def _normalize_success_exit_codes(raw: Any) -> tuple[int, ...]:
+    if raw is None:
+        return (0,)
+    if not isinstance(raw, list):
+        raw = [raw]
+    values: list[int] = []
+    for item in raw:
+        try:
+            values.append(int(item))
+        except (TypeError, ValueError):
+            continue
+    return tuple(values) or (0,)
+
+
+def _normalize_on_failure(raw: Any) -> str:
+    value = str(raw or "block_final").strip().lower()
+    return value if value else "block_final"
+
+
+def _normalize_optional_string(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    value = str(raw).strip()
+    return value or None
+
+
+def _existing_skill_dir(raw: str | None) -> Path | None:
+    if not raw:
+        return None
+    path = Path(raw)
+    try:
+        return path if path.is_dir() else None
+    except OSError:
+        return None
+
+
+def _session_key(session_id: str | None) -> str:
+    return str(session_id or "").strip()
+
+
+def _coerce_output(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)

--- a/agent/skill_verification.py
+++ b/agent/skill_verification.py
@@ -1,13 +1,15 @@
-"""Runtime verification gates for loaded skills.
+"""Runtime verification gates for activated skills.
 
 Skills can declare a deterministic before-final verifier in SKILL.md
-frontmatter.  When the agent loads such a skill via skill_view, this module
-records the verifier for the current session.  turn_finalizer drains and runs
-those verifiers before returning the final response.
+frontmatter.  Loading a skill records its verifier as an inert candidate for the
+current session.  A separate activation step arms that verifier, and
+turn_finalizer drains and runs only activated verifiers before returning the
+final response.
 """
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 import threading
 from dataclasses import dataclass
@@ -19,6 +21,8 @@ from agent.skill_utils import parse_frontmatter
 _MAX_OUTPUT_PREVIEW_CHARS = 1200
 _DEFAULT_TIMEOUT_SECONDS = 120
 _MAX_TIMEOUT_SECONDS = 3600
+_ALLOW_COMMANDS_CONFIG_KEY = "skills.verification.allow_commands"
+_LOADED_BY_SESSION: dict[str, dict[str, "SkillVerificationSpec"]] = {}
 _PENDING_BY_SESSION: dict[str, dict[str, "SkillVerificationSpec"]] = {}
 _LOCK = threading.Lock()
 
@@ -69,7 +73,7 @@ class SkillVerificationResult:
 
 
 def record_skill_view_payload(session_id: str | None, payload: dict[str, Any]) -> bool:
-    """Record a loaded skill's before-final verifier for this session."""
+    """Record a loaded skill's before-final verifier candidate for this session."""
     key = _session_key(session_id)
     if not key or not isinstance(payload, dict) or not payload.get("success"):
         return False
@@ -79,12 +83,38 @@ def record_skill_view_payload(session_id: str | None, payload: dict[str, Any]) -
         return False
 
     with _LOCK:
-        _PENDING_BY_SESSION.setdefault(key, {})[spec.name] = spec
+        loaded = _LOADED_BY_SESSION.setdefault(key, {})
+        for alias in _spec_aliases(payload, spec):
+            loaded[alias] = spec
     return True
 
 
+def activate_skill_verification(session_id: str | None, skill_name: str | None) -> bool:
+    """Arm a previously loaded skill verifier for this session."""
+    key = _session_key(session_id)
+    name_key = _skill_key(skill_name)
+    if not key or not name_key:
+        return False
+
+    with _LOCK:
+        spec = _LOADED_BY_SESSION.get(key, {}).get(name_key)
+        if spec is None:
+            return False
+        _PENDING_BY_SESSION.setdefault(key, {})[name_key] = spec
+    return True
+
+
+def loaded_verification_specs(session_id: str | None) -> list[SkillVerificationSpec]:
+    """Return loaded but inert specs for tests and observability."""
+    key = _session_key(session_id)
+    if not key:
+        return []
+    with _LOCK:
+        return list(_LOADED_BY_SESSION.get(key, {}).values())
+
+
 def pending_verification_specs(session_id: str | None) -> list[SkillVerificationSpec]:
-    """Return pending specs for tests and observability."""
+    """Return activated pending specs for tests and observability."""
     key = _session_key(session_id)
     if not key:
         return []
@@ -97,6 +127,7 @@ def clear_session_verifications(session_id: str | None) -> None:
     if not key:
         return
     with _LOCK:
+        _LOADED_BY_SESSION.pop(key, None)
         _PENDING_BY_SESSION.pop(key, None)
 
 
@@ -173,11 +204,34 @@ def _drain_session_specs(session_id: str | None) -> list[SkillVerificationSpec]:
 
 def _run_check(spec: SkillVerificationSpec) -> SkillVerificationCheck:
     cwd = _existing_skill_dir(spec.skill_dir)
+    if not _command_verifiers_enabled():
+        return SkillVerificationCheck(
+            spec=spec,
+            passed=False,
+            error=(
+                "command verifiers are disabled; set "
+                f"{_ALLOW_COMMANDS_CONFIG_KEY}=true in config.yaml to allow "
+                "activated skill commands"
+            ),
+        )
+    try:
+        argv = shlex.split(spec.command)
+    except ValueError as exc:
+        return SkillVerificationCheck(
+            spec=spec,
+            passed=False,
+            error=f"invalid command syntax: {exc}",
+        )
+    if not argv:
+        return SkillVerificationCheck(
+            spec=spec,
+            passed=False,
+            error="empty verifier command",
+        )
     try:
         completed = subprocess.run(
-            spec.command,
+            argv,
             cwd=str(cwd) if cwd else None,
-            shell=True,
             capture_output=True,
             text=True,
             timeout=spec.timeout_seconds,
@@ -292,6 +346,33 @@ def _existing_skill_dir(raw: str | None) -> Path | None:
 
 def _session_key(session_id: str | None) -> str:
     return str(session_id or "").strip()
+
+
+def _skill_key(name: str | None) -> str:
+    return str(name or "").strip().lower()
+
+
+def _spec_aliases(
+    payload: dict[str, Any],
+    spec: SkillVerificationSpec,
+) -> set[str]:
+    raw_aliases = {
+        spec.name,
+        payload.get("name"),
+        payload.get("requested_name"),
+        payload.get("_requested_name"),
+    }
+    aliases = {_skill_key(alias) for alias in raw_aliases}
+    return {alias for alias in aliases if alias}
+
+
+def _command_verifiers_enabled() -> bool:
+    try:
+        from hermes_cli.config import cfg_get
+
+        return bool(cfg_get(_ALLOW_COMMANDS_CONFIG_KEY, False))
+    except Exception:
+        return False
 
 
 def _coerce_output(value: Any) -> str:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -257,7 +257,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
                 stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
 
-    has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
+    has_skills_tools = any(
+        name in agent.valid_tool_names
+        for name in ["skills_list", "skill_view", "skill_activate", "skill_manage"]
+    )
     if has_skills_tools:
         avail_toolsets = {
             toolset

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -46,6 +46,7 @@ MUTATING_TOOL_NAMES = frozenset(
         "patch",
         "todo",
         "memory",
+        "skill_activate",
         "skill_manage",
         "browser_click",
         "browser_type",

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -80,6 +80,7 @@ EXPOSED_TOOLS: tuple[str, ...] = (
     "browser_vision",
     "vision_analyze",
     "image_generate",
+    "skill_activate",
     "skill_view",
     "skills_list",
     "text_to_speech",

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -332,6 +332,21 @@ def finalize_turn(
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
 
+    _skill_verification_result = None
+    if final_response and not interrupted:
+        try:
+            from agent.skill_verification import run_before_final_verifications
+
+            _skill_verification_result = run_before_final_verifications(
+                agent.session_id or ""
+            )
+            if _skill_verification_result and _skill_verification_result.blocked:
+                final_response = _skill_verification_result.message
+                failed = True
+                completed = False
+        except Exception as exc:
+            logger.warning("skill before-final verification failed: %s", exc)
+
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.
     # Plugins can use this to persist conversation data (e.g. sync
@@ -407,6 +422,8 @@ def finalize_turn(
     # (the response is still returned either way — #8049).
     if _cleanup_errors:
         result["cleanup_errors"] = _cleanup_errors
+    if _skill_verification_result is not None:
+        result["skill_verification"] = _skill_verification_result.to_dict()
     # If a /steer landed after the final assistant turn (no more tool
     # batches to drain into), hand it back to the caller so it can be
     # delivered as the next user turn instead of being silently lost.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -333,6 +333,7 @@ def finalize_turn(
             logger.warning("transform_llm_output hook failed: %s", exc)
 
     _skill_verification_result = None
+    _skill_verification_error = None
     if final_response and not interrupted:
         try:
             from agent.skill_verification import run_before_final_verifications
@@ -346,6 +347,14 @@ def finalize_turn(
                 completed = False
         except Exception as exc:
             logger.warning("skill before-final verification failed: %s", exc)
+            _skill_verification_error = f"{type(exc).__name__}: {exc}"
+            final_response = (
+                "Skill verification could not run before the final response.\n\n"
+                "The assistant's unverified final answer was blocked because "
+                f"the verification infrastructure raised {_skill_verification_error}"
+            )
+            failed = True
+            completed = False
 
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.
@@ -424,6 +433,8 @@ def finalize_turn(
         result["cleanup_errors"] = _cleanup_errors
     if _skill_verification_result is not None:
         result["skill_verification"] = _skill_verification_result.to_dict()
+    if _skill_verification_error is not None:
+        result["skill_verification_error"] = _skill_verification_error
     # If a /steer landed after the final assistant turn (no more tool
     # batches to drain into), hand it back to the caller so it can be
     # delivered as the next user turn instead of being silently lost.

--- a/model_tools.py
+++ b/model_tools.py
@@ -226,7 +226,7 @@ _LEGACY_TOOLSET_MAP = {
     "terminal_tools": ["terminal"],
     "vision_tools": ["vision_analyze"],
     "image_tools": ["image_generate"],
-    "skills_tools": ["skills_list", "skill_view", "skill_manage"],
+    "skills_tools": ["skills_list", "skill_view", "skill_activate", "skill_manage"],
     "browser_tools": [
         "browser_navigate", "browser_snapshot", "browser_click",
         "browser_type", "browser_scroll", "browser_back",

--- a/tests/agent/test_skill_verification.py
+++ b/tests/agent/test_skill_verification.py
@@ -44,15 +44,20 @@ def test_extract_before_final_spec_from_metadata_hermes():
     assert spec.on_failure == "block_final"
 
 
-def test_skill_view_records_required_before_final_verifier(tmp_path, monkeypatch):
+def test_skill_view_loads_candidate_activation_arms_verifier(tmp_path, monkeypatch):
     from agent.skill_verification import (
+        activate_skill_verification,
         clear_session_verifications,
+        loaded_verification_specs,
         pending_verification_specs,
         run_before_final_verifications,
     )
     from tools import skills_tool
     from tools.skills_tool import _skill_view_with_bump
 
+    monkeypatch.setattr(
+        "agent.skill_verification._command_verifiers_enabled", lambda: True
+    )
     skill_dir = tmp_path / "verified-skill"
     skill_dir.mkdir()
     (skill_dir / "SKILL.md").write_text(_skill_md("true"), encoding="utf-8")
@@ -65,6 +70,13 @@ def test_skill_view_records_required_before_final_verifier(tmp_path, monkeypatch
     )
 
     assert result["success"] is True
+    loaded = loaded_verification_specs("session-1")
+    assert len(loaded) == 1
+    assert loaded[0].name == "verified-skill"
+    assert pending_verification_specs("session-1") == []
+    assert run_before_final_verifications("session-1") is None
+
+    assert activate_skill_verification("session-1", "verified-skill") is True
     specs = pending_verification_specs("session-1")
     assert len(specs) == 1
     assert specs[0].name == "verified-skill"
@@ -80,6 +92,7 @@ def test_skill_view_records_required_before_final_verifier(tmp_path, monkeypatch
 def test_skill_view_support_file_does_not_record_verifier(tmp_path, monkeypatch):
     from agent.skill_verification import (
         clear_session_verifications,
+        loaded_verification_specs,
         pending_verification_specs,
     )
     from tools import skills_tool
@@ -102,16 +115,21 @@ def test_skill_view_support_file_does_not_record_verifier(tmp_path, monkeypatch)
     )
 
     assert result["success"] is True
+    assert loaded_verification_specs("session-2") == []
     assert pending_verification_specs("session-2") == []
 
 
-def test_failed_before_final_verifier_blocks_response():
+def test_failed_before_final_verifier_blocks_response(monkeypatch):
     from agent.skill_verification import (
+        activate_skill_verification,
         clear_session_verifications,
         record_skill_view_payload,
         run_before_final_verifications,
     )
 
+    monkeypatch.setattr(
+        "agent.skill_verification._command_verifiers_enabled", lambda: True
+    )
     session_id = "session-fail"
     command = f"{shlex.quote(sys.executable)} -c 'import sys; sys.exit(7)'"
     clear_session_verifications(session_id)
@@ -124,11 +142,98 @@ def test_failed_before_final_verifier_blocks_response():
             "content": _skill_md(command, name="failing-skill"),
         },
     )
+    activated = activate_skill_verification(session_id, "failing-skill")
     verification = run_before_final_verifications(session_id)
 
     assert recorded is True
+    assert activated is True
     assert verification is not None
     assert verification.blocked is True
     assert verification.checks[0].exit_code == 7
     assert "Skill verification failed before the final response." in verification.message
     assert "failing-skill" in verification.message
+
+
+def test_activation_accepts_requested_skill_alias(monkeypatch):
+    from agent.skill_verification import (
+        activate_skill_verification,
+        clear_session_verifications,
+        record_skill_view_payload,
+    )
+
+    monkeypatch.setattr(
+        "agent.skill_verification._command_verifiers_enabled", lambda: True
+    )
+    session_id = "session-alias"
+    clear_session_verifications(session_id)
+
+    recorded = record_skill_view_payload(
+        session_id,
+        {
+            "success": True,
+            "name": "verified-skill",
+            "_requested_name": "category/verified-skill",
+            "content": _skill_md("true", name="verified-skill"),
+        },
+    )
+
+    assert recorded is True
+    assert activate_skill_verification(session_id, "category/verified-skill") is True
+
+
+def test_command_verifier_disabled_by_default_blocks_response(monkeypatch):
+    from agent.skill_verification import (
+        activate_skill_verification,
+        clear_session_verifications,
+        record_skill_view_payload,
+        run_before_final_verifications,
+    )
+
+    session_id = "session-disabled"
+    clear_session_verifications(session_id)
+
+    recorded = record_skill_view_payload(
+        session_id,
+        {
+            "success": True,
+            "name": "disabled-command-skill",
+            "content": _skill_md("true", name="disabled-command-skill"),
+        },
+    )
+    activated = activate_skill_verification(session_id, "disabled-command-skill")
+    verification = run_before_final_verifications(session_id)
+
+    assert recorded is True
+    assert activated is True
+    assert verification is not None
+    assert verification.blocked is True
+    assert verification.checks[0].passed is False
+    assert "command verifiers are disabled" in verification.checks[0].error
+
+
+def test_skill_activate_tool_arms_loaded_verifier(tmp_path, monkeypatch):
+    from agent.skill_verification import (
+        clear_session_verifications,
+        pending_verification_specs,
+    )
+    from tools import skills_tool
+    from tools.skills_tool import _skill_activate, _skill_view_with_bump
+
+    skill_dir = tmp_path / "verified-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(_skill_md("true"), encoding="utf-8")
+
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", tmp_path)
+    clear_session_verifications("session-tool")
+
+    viewed = json.loads(
+        _skill_view_with_bump({"name": "verified-skill"}, session_id="session-tool")
+    )
+    activated = json.loads(
+        _skill_activate({"name": "verified-skill"}, session_id="session-tool")
+    )
+
+    assert viewed["success"] is True
+    assert activated["success"] is True
+    assert activated["verification_armed"] is True
+    assert len(pending_verification_specs("session-tool")) == 1

--- a/tests/agent/test_skill_verification.py
+++ b/tests/agent/test_skill_verification.py
@@ -1,0 +1,134 @@
+import json
+import shlex
+import sys
+
+
+def _skill_md(command: str, *, name: str = "verified-skill") -> str:
+    return f"""---
+name: {name}
+description: test skill with runtime verification
+metadata:
+  hermes:
+    verification:
+      before_final:
+        required: true
+        command: "{command}"
+        timeout_seconds: 5
+        success_exit_codes: [0]
+        on_failure: block_final
+---
+
+# Verified Skill
+
+Do the workflow, then rely on runtime verification before final.
+"""
+
+
+def test_extract_before_final_spec_from_metadata_hermes():
+    from agent.skill_verification import extract_before_final_spec
+
+    spec = extract_before_final_spec(
+        {
+            "success": True,
+            "name": "verified-skill",
+            "skill_dir": "/tmp/skill",
+            "content": _skill_md("true"),
+        }
+    )
+
+    assert spec is not None
+    assert spec.name == "verified-skill"
+    assert spec.command == "true"
+    assert spec.timeout_seconds == 5
+    assert spec.success_exit_codes == (0,)
+    assert spec.on_failure == "block_final"
+
+
+def test_skill_view_records_required_before_final_verifier(tmp_path, monkeypatch):
+    from agent.skill_verification import (
+        clear_session_verifications,
+        pending_verification_specs,
+        run_before_final_verifications,
+    )
+    from tools import skills_tool
+    from tools.skills_tool import _skill_view_with_bump
+
+    skill_dir = tmp_path / "verified-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(_skill_md("true"), encoding="utf-8")
+
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", tmp_path)
+    clear_session_verifications("session-1")
+
+    result = json.loads(
+        _skill_view_with_bump({"name": "verified-skill"}, session_id="session-1")
+    )
+
+    assert result["success"] is True
+    specs = pending_verification_specs("session-1")
+    assert len(specs) == 1
+    assert specs[0].name == "verified-skill"
+
+    verification = run_before_final_verifications("session-1")
+
+    assert verification is not None
+    assert verification.blocked is False
+    assert verification.checks[0].passed is True
+    assert pending_verification_specs("session-1") == []
+
+
+def test_skill_view_support_file_does_not_record_verifier(tmp_path, monkeypatch):
+    from agent.skill_verification import (
+        clear_session_verifications,
+        pending_verification_specs,
+    )
+    from tools import skills_tool
+    from tools.skills_tool import _skill_view_with_bump
+
+    skill_dir = tmp_path / "verified-skill"
+    refs_dir = skill_dir / "references"
+    refs_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(_skill_md("true"), encoding="utf-8")
+    (refs_dir / "notes.md").write_text("notes", encoding="utf-8")
+
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", tmp_path)
+    clear_session_verifications("session-2")
+
+    result = json.loads(
+        _skill_view_with_bump(
+            {"name": "verified-skill", "file_path": "references/notes.md"},
+            session_id="session-2",
+        )
+    )
+
+    assert result["success"] is True
+    assert pending_verification_specs("session-2") == []
+
+
+def test_failed_before_final_verifier_blocks_response():
+    from agent.skill_verification import (
+        clear_session_verifications,
+        record_skill_view_payload,
+        run_before_final_verifications,
+    )
+
+    session_id = "session-fail"
+    command = f"{shlex.quote(sys.executable)} -c 'import sys; sys.exit(7)'"
+    clear_session_verifications(session_id)
+
+    recorded = record_skill_view_payload(
+        session_id,
+        {
+            "success": True,
+            "name": "failing-skill",
+            "content": _skill_md(command, name="failing-skill"),
+        },
+    )
+    verification = run_before_final_verifications(session_id)
+
+    assert recorded is True
+    assert verification is not None
+    assert verification.blocked is True
+    assert verification.checks[0].exit_code == 7
+    assert "Skill verification failed before the final response." in verification.message
+    assert "failing-skill" in verification.message

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -164,6 +164,41 @@ def test_single_cleanup_step_raises_does_not_skip_others(step):
     assert len(result["cleanup_errors"]) == 1
 
 
+def test_skill_verification_infrastructure_error_blocks_response(monkeypatch):
+    import agent.skill_verification as skill_verification
+
+    def _raise_verification_error(_session_id):
+        raise RuntimeError("verifier registry unavailable")
+
+    monkeypatch.setattr(
+        skill_verification,
+        "run_before_final_verifications",
+        _raise_verification_error,
+    )
+    agent = _StubAgent(raise_in=())
+
+    result = finalize_turn(
+        agent,
+        final_response="ready to send",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=[{"role": "user", "content": "do a thing"}],
+        conversation_history=None,
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="do a thing",
+        original_user_message="do a thing",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response",
+    )
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert "Skill verification could not run" in result["final_response"]
+    assert result["skill_verification_error"] == "RuntimeError: verifier registry unavailable"
+
+
 def test_clean_turn_has_no_cleanup_errors_key():
     agent = _StubAgent(raise_in=())
     result = _run(agent)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1144,11 +1144,18 @@ class TestBuildSystemPrompt:
         assert "NOUS SUBSCRIPTION BLOCK" in prompt
 
     def test_skills_prompt_derives_available_toolsets_from_loaded_tools(self):
-        tools = _make_tool_defs("web_search", "skills_list", "skill_view", "skill_manage")
+        tools = _make_tool_defs(
+            "web_search",
+            "skills_list",
+            "skill_view",
+            "skill_activate",
+            "skill_manage",
+        )
         toolset_map = {
             "web_search": "web",
             "skills_list": "skills",
             "skill_view": "skills",
+            "skill_activate": "skills",
             "skill_manage": "skills",
         }
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1613,6 +1613,13 @@ def _skill_view_with_bump(args, **kw):
     try:
         parsed = json.loads(result)
         if isinstance(parsed, dict) and parsed.get("success"):
+            if not args.get("file_path"):
+                try:
+                    from agent.skill_verification import record_skill_view_payload
+
+                    record_skill_view_payload(kw.get("session_id"), parsed)
+                except Exception:
+                    pass
             # Use the resolved skill name from the payload when present —
             # qualified forms ("plugin:skill") return with the canonical name.
             resolved = parsed.get("name") or name

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1576,7 +1576,7 @@ SKILLS_LIST_SCHEMA = {
 
 SKILL_VIEW_SCHEMA = {
     "name": "skill_view",
-    "description": "Skills allow for loading information about specific tasks and workflows, as well as scripts and templates. Load a skill's full content or access its linked files (references, templates, scripts). First call returns SKILL.md content plus a 'linked_files' dict showing available references/templates/scripts. To access those, call again with file_path parameter.",
+    "description": "Skills allow for loading information about specific tasks and workflows, as well as scripts and templates. Load a skill's full content or access its linked files (references, templates, scripts). First call returns SKILL.md content plus a 'linked_files' dict showing available references/templates/scripts. To access those, call again with file_path parameter. Loading is not activation; call skill_activate after you decide to follow the skill.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1588,6 +1588,21 @@ SKILL_VIEW_SCHEMA = {
                 "type": "string",
                 "description": "OPTIONAL: Path to a linked file within the skill (e.g., 'references/api.md', 'templates/config.yaml', 'scripts/validate.py'). Omit to get the main SKILL.md content.",
             },
+        },
+        "required": ["name"],
+    },
+}
+
+SKILL_ACTIVATE_SCHEMA = {
+    "name": "skill_activate",
+    "description": "Mark a previously loaded skill as actually used for this turn. If the skill declares a runtime before-final verifier, this arms it so the final response is checked. Call only after deciding to follow the skill, not while merely inspecting candidates.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "The skill name to activate.",
+            }
         },
         "required": ["name"],
     },
@@ -1617,6 +1632,7 @@ def _skill_view_with_bump(args, **kw):
                 try:
                     from agent.skill_verification import record_skill_view_payload
 
+                    parsed["_requested_name"] = name
                     record_skill_view_payload(kw.get("session_id"), parsed)
                 except Exception:
                     pass
@@ -1635,11 +1651,52 @@ def _skill_view_with_bump(args, **kw):
     return result
 
 
+def _skill_activate(args, **kw):
+    """Activate a loaded skill for this turn and arm any before-final verifier."""
+    name = str(args.get("name") or "").strip()
+    if not name:
+        return tool_error("Skill name is required.")
+
+    verification_armed = False
+    try:
+        from agent.skill_verification import activate_skill_verification
+
+        verification_armed = activate_skill_verification(kw.get("session_id"), name)
+    except Exception:
+        verification_armed = False
+
+    try:
+        from tools.skill_usage import bump_use
+
+        bump_use(name)
+    except Exception:
+        pass
+
+    return json.dumps(
+        {
+            "success": True,
+            "name": name,
+            "activated": True,
+            "verification_armed": verification_armed,
+        },
+        ensure_ascii=False,
+    )
+
+
 registry.register(
     name="skill_view",
     toolset="skills",
     schema=SKILL_VIEW_SCHEMA,
     handler=_skill_view_with_bump,
+    check_fn=check_skills_requirements,
+    emoji="📚",
+)
+
+registry.register(
+    name="skill_activate",
+    toolset="skills",
+    schema=SKILL_ACTIVATE_SCHEMA,
+    handler=_skill_activate,
     check_fn=check_skills_requirements,
     emoji="📚",
 )


### PR DESCRIPTION
## Summary
- add runtime session tracking for skills that declare `metadata.hermes.verification.before_final`
- record verifier specs when `skill_view` loads the main `SKILL.md`
- run required verifiers in `finalize_turn` before the final response and block failed `block_final` responses

Draft for #44637. This MVP treats a successful main `skill_view` call as activation; explicit activation and streaming suppression are intentionally left for maintainer direction.

## Tests
- `scripts/run_tests.sh tests/agent/test_skill_verification.py -- -q`
- `scripts/run_tests.sh tests/agent/test_skill_commands.py tests/agent/test_external_skills.py -- -q`
- `.venv/bin/ruff check agent/skill_verification.py agent/turn_finalizer.py tools/skills_tool.py tests/agent/test_skill_verification.py`