### PR TITLE
fix(api-server): free /v1/runs concurrency slot on run completion, not only on SSE-consume

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3636,13 +3636,18 @@ class APIServerAdapter(BasePlatformAdapter):
         The cap bounds total in-flight agent activity across every
         agent-serving endpoint: the non-streaming chat/responses paths
         (tracked by ``_inflight_agent_runs``) plus the ``/v1/runs`` streaming
-        path (tracked by ``_run_streams``). A configured value of 0 disables
-        the cap entirely.
+        path (tracked by ``_active_run_tasks`` — the set of still-running
+        ``_run_and_close`` background tasks). A run that has finished frees
+        its slot immediately via that task's ``finally`` block, even when its
+        event stream is still pending SSE consumption or orphan-TTL sweep
+        (``_run_streams`` outlives the run by design); counting active tasks
+        keeps the cap bounding live work rather than buffered, already-completed
+        streams. A configured value of 0 disables the cap entirely.
         """
         limit = self._max_concurrent_runs
         if limit <= 0:
             return None
-        inflight = self._inflight_agent_runs + len(self._run_streams)
+        inflight = self._inflight_agent_runs + len(self._active_run_tasks)
         if inflight >= limit:
             return web.json_response(
                 _openai_error(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -461,14 +461,33 @@ class TestConcurrencyCap:
         assert resp.headers.get("Retry-After")
 
     def test_cap_counts_both_buckets(self):
-        # /v1/runs (tracked by _run_streams) + chat/responses (inflight)
+        # /v1/runs (active background tasks, tracked by _active_run_tasks)
+        # + chat/responses (inflight)
         adapter = _make_adapter()
         adapter._max_concurrent_runs = 4
         adapter._inflight_agent_runs = 2
-        adapter._run_streams = {"r1": object(), "r2": object()}
+        adapter._active_run_tasks = {"r1": object(), "r2": object()}
         resp = adapter._concurrency_limited_response()
         assert resp is not None
         assert resp.status == 429
+
+    def test_completed_runs_release_cap_slot(self):
+        # Regression (#7483 follow-up): a /v1/runs whose agent has finished
+        # but whose SSE was never consumed leaves a record in _run_streams
+        # (cleared only on SSE-consume or the 300s orphan-TTL sweep). That
+        # buffered, already-completed stream must NOT keep counting against
+        # the concurrency cap, or 10 cheap unconsumed POSTs lock out every
+        # agent endpoint for 5 minutes — inverting the cap into a DoS lever.
+        # The cap counts active background tasks (_active_run_tasks), which
+        # the run's finally block pops on completion.
+        adapter = _make_adapter()
+        adapter._max_concurrent_runs = 3
+        adapter._inflight_agent_runs = 0
+        # 5 completed-but-unconsumed runs linger in _run_streams ...
+        adapter._run_streams = {f"r{i}": object() for i in range(5)}
+        # ... but none are still running.
+        adapter._active_run_tasks = {}
+        assert adapter._concurrency_limited_response() is None
 
     def test_zero_disables_cap(self):
         adapter = _make_adapter()


### PR DESCRIPTION
Follow-up to merged #50007 (the `gateway.api_server.max_concurrent_runs` cap, #7483).

## Problem
The cap counts `len(self._run_streams)`, but a `/v1/runs` request never pops its `_run_streams` entry when the run **completes** — only when the SSE stream is consumed (`_handle_run_events` finally, `api_server.py:4154-4155`) or after the 300s orphan sweep (`_RUN_STREAM_TTL`, `4295-4309`). `_run_and_close()`'s finally (`4070-4075`) pops `_active_run_agents` / `_active_run_tasks` / `_run_approval_sessions` and pushes the close sentinel, but leaves `_run_streams` / `_run_streams_created` in place.

So a client that POSTs `/v1/runs` and never connects to `/v1/runs/{run_id}/events` holds a cap slot for up to **5 minutes after the run is already done**. Ten such cheap, unconsumed POSTs reach the default cap of 10 and return `429` from **every** agent endpoint (`/v1/chat/completions`, `/v1/responses`, `/v1/runs`) for 5 minutes — the DoS-prevention cap becomes a DoS lever, within the same accounting the PR added.

## Fix
Count `len(self._active_run_tasks)` instead of `len(self._run_streams)` for the `/v1/runs` bucket. `_active_run_tasks[run_id]` is set synchronously right after the run task is created and popped unconditionally in `_run_and_close()`'s finally, so a finished run releases its slot immediately — mirroring how `_inflight_agent_runs` bounds the chat/responses path.

`_run_streams` is intentionally **left untouched**: it outlives the run (300s TTL) so a client can still subscribe to `/events` and replay a fast run's buffered events. Popping it on completion (the other obvious fix) would regress that deferred-replay path to a 404. The cap should bound *live work*, not already-completed streams pending consumption.

## Tests
- `test_cap_counts_both_buckets` updated to track the `/v1/runs` bucket via `_active_run_tasks` (active runs) rather than `_run_streams`.
- New `test_completed_runs_release_cap_slot`: 5 completed-but-unconsumed runs lingering in `_run_streams` with an empty `_active_run_tasks` no longer trip the cap (fails on the pre-fix accounting, passes after).

Every symbol re-read against current `main`. If this has already been addressed via a separate patch, feel free to close and mark accordingly.
