### PR TITLE
fix(auth): heal poisoned stored Nous inference URL on the no-refresh read path

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5608,8 +5608,25 @@ def resolve_nous_runtime_credentials(
             or os.getenv("NOUS_PORTAL_BASE_URL")
             or DEFAULT_NOUS_PORTAL_URL
         ).rstrip("/")
+        # The stored inference_base_url is network-provenance (persisted from a
+        # Portal refresh response), so validate it here too. The refresh sites
+        # already heal a poisoned value, but on the no-refresh read path — the
+        # common steady state, when the access token is still valid and no
+        # refresh fires — the stored value was previously served unvalidated.
+        # A poisoned auth.json (e.g. a staging host persisted before the host
+        # allowlist existed) then 401s forever against a dead endpoint (a 401
+        # from the inference host does not trigger an OAuth refresh, so the
+        # poisoned value never heals). Reject -> fall back to the default,
+        # mirroring the refresh-site heal. The NOUS_INFERENCE_BASE_URL env
+        # override stays unvalidated: it is user-provided (the documented
+        # dev/staging escape hatch), not network-provenance.
+        stored_inference_base_url = _optional_base_url(state.get("inference_base_url"))
+        if stored_inference_base_url is not None:
+            stored_inference_base_url = _validate_nous_inference_url_from_network(
+                stored_inference_base_url
+            )
         inference_base_url = (
-            _optional_base_url(state.get("inference_base_url"))
+            stored_inference_base_url
             or os.getenv("NOUS_INFERENCE_BASE_URL")
             or DEFAULT_NOUS_INFERENCE_URL
         ).rstrip("/")

--- a/tests/hermes_cli/test_nous_inference_url_validation.py
+++ b/tests/hermes_cli/test_nous_inference_url_validation.py
@@ -291,3 +291,96 @@ class TestHealsPoisonedStoredValue:
 
         result = auth.refresh_nous_oauth_from_state(state, force_refresh=True)
         assert result["inference_base_url"] == good
+
+
+class TestNoRefreshReadPathHeals:
+    """A poisoned stored inference_base_url must also heal on the
+    *no-refresh* read path of ``resolve_nous_runtime_credentials``.
+
+    The refresh sites (#49735) heal a poisoned value only when a refresh
+    fires. But when the access token is still a usable invoke JWT — the
+    common steady state — no refresh fires, and a poisoned ``auth.json``
+    value (e.g. a staging host persisted before the allowlist existed) was
+    previously read via the unrestricted ``_optional_base_url`` and served
+    verbatim: every nous call + the aux compression call 401s forever
+    against the dead endpoint (a 401 from the inference host does not
+    trigger an OAuth refresh, so it never self-heals). The stored value is
+    network-provenance, so it is now validated on read too; the
+    user-provided ``NOUS_INFERENCE_BASE_URL`` env override stays exempt.
+    """
+
+    def _patch_no_refresh(self, monkeypatch, auth, state):
+        import contextlib
+
+        # No refresh fires: the stored access token is a usable invoke JWT.
+        monkeypatch.setattr(auth, "_nous_invoke_jwt_status", lambda *a, **k: None)
+        monkeypatch.setattr(
+            auth, "_auth_store_lock", lambda *a, **k: contextlib.nullcontext()
+        )
+        monkeypatch.setattr(auth, "_load_auth_store", lambda *a, **k: {})
+        monkeypatch.setattr(auth, "_load_provider_state", lambda store, pid: state)
+        monkeypatch.setattr(auth, "_save_provider_state", lambda *a, **k: None)
+        monkeypatch.setattr(auth, "_save_auth_store", lambda *a, **k: None)
+        monkeypatch.setattr(auth, "_write_shared_nous_state", lambda *a, **k: None)
+        monkeypatch.setattr(auth, "_sync_nous_pool_from_auth_store", lambda *a, **k: None)
+        monkeypatch.setattr(auth, "_resolve_verify", lambda *a, **k: True)
+        monkeypatch.setattr(auth, "_assert_nous_inference_jwt_usable", lambda *a, **k: None)
+        monkeypatch.setattr(auth, "_select_nous_invoke_jwt", lambda *a, **k: None)
+        monkeypatch.delenv("NOUS_INFERENCE_BASE_URL", raising=False)
+
+    def test_no_refresh_heals_poisoned_stored_url(self, monkeypatch):
+        import hermes_cli.auth as auth
+
+        state = {
+            "access_token": "tok",
+            "refresh_token": "rtok",
+            "client_id": "hermes-cli",
+            "portal_base_url": auth.DEFAULT_NOUS_PORTAL_URL,
+            "inference_base_url": "https://stg-inference-api.nousresearch.com/v1",
+            "agent_key": "ak-123",
+        }
+        self._patch_no_refresh(monkeypatch, auth, state)
+
+        result = auth.resolve_nous_runtime_credentials()
+
+        assert result["base_url"] == auth.DEFAULT_NOUS_INFERENCE_URL, (
+            "poisoned stored URL must heal to the production default on the "
+            f"no-refresh read path, got {result['base_url']!r}"
+        )
+
+    def test_no_refresh_keeps_valid_stored_url(self, monkeypatch):
+        import hermes_cli.auth as auth
+
+        good = "https://inference-api.nousresearch.com/v1"
+        state = {
+            "access_token": "tok",
+            "refresh_token": "rtok",
+            "client_id": "hermes-cli",
+            "portal_base_url": auth.DEFAULT_NOUS_PORTAL_URL,
+            "inference_base_url": good,
+            "agent_key": "ak-123",
+        }
+        self._patch_no_refresh(monkeypatch, auth, state)
+
+        result = auth.resolve_nous_runtime_credentials()
+        assert result["base_url"] == good
+
+    def test_no_refresh_env_override_bypasses_validation(self, monkeypatch):
+        """The documented dev/staging env override is user-provided, not
+        network-provenance, so it must still win and stay unvalidated even
+        when the stored value is rejected."""
+        import hermes_cli.auth as auth
+
+        state = {
+            "access_token": "tok",
+            "refresh_token": "rtok",
+            "client_id": "hermes-cli",
+            "portal_base_url": auth.DEFAULT_NOUS_PORTAL_URL,
+            "inference_base_url": "https://stg-inference-api.nousresearch.com/v1",
+            "agent_key": "ak-123",
+        }
+        self._patch_no_refresh(monkeypatch, auth, state)
+        monkeypatch.setenv("NOUS_INFERENCE_BASE_URL", "https://dev-box.local/v1")
+
+        result = auth.resolve_nous_runtime_credentials()
+        assert result["base_url"] == "https://dev-box.local/v1"


### PR DESCRIPTION
Follow-up to merged #49735 (heal a poisoned Nous `inference_base_url`).

## Problem
#49735 healed a poisoned stored URL **only on the OAuth-refresh path** (both refresh sites reset to the default when `_validate_nous_inference_url_from_network()` rejects the Portal-returned URL). But `resolve_nous_runtime_credentials` reads the **stored** `inference_base_url` via the unrestricted `_optional_base_url` (`auth.py:5612`), and the heal lives inside `if force_refresh or invoke_jwt_status is not None:`.

When the access token is still a usable invoke JWT — the **common steady state** — no refresh fires, the heal block is skipped, and the stored value flows straight to `state["inference_base_url"]` (persist) and the returned `base_url`. So a poisoned `auth.json` (e.g. a `stg-inference-api...` host persisted *before* the allowlist existed — the exact incident #49735 cites) keeps 401ing forever: a 401 from the dead inference endpoint does **not** trigger an OAuth refresh, so the refresh-path heal is never reached.

## Fix
Validate the stored `inference_base_url` on read, before the `or`-chain, mirroring the refresh-site heal: reject → fall back to the default (which then persists, repairing `auth.json` on first read).

The stored value is **network-provenance** (it was persisted from a Portal refresh response), so validating it is consistent with the existing trust model. The user-provided `NOUS_INFERENCE_BASE_URL` env override stays **unvalidated** — it's the documented dev/staging escape hatch — by validating only the stored branch and leaving the `os.getenv` line untouched.

All three existing guard tests still hold:
- `test_no_unvalidated_inference_base_url_assignments_remain` — only `state.get(...)` is read via `_optional_base_url`; the guarded `refreshed.get`/`mint_payload.get` patterns are untouched.
- `test_validator_wired_at_all_known_call_sites` — the 2 refresh-site validator calls are unchanged (the new call uses `stored_inference_base_url`).
- `test_env_override_path_does_not_call_validator` — the `os.getenv("NOUS_INFERENCE_BASE_URL")` line never gains the validator.

## Tests
New `TestNoRefreshReadPathHeals` (3 cases, valid token so no refresh fires): poisoned stored URL → heals to default (fails on pre-fix code); allowlisted stored URL → preserved; poisoned stored + `NOUS_INFERENCE_BASE_URL` env set → env value used unvalidated (escape hatch intact).

## Note / scope
`refresh_nous_oauth_pure` accepts `inference_base_url` as a caller-resolved parameter and likewise doesn't re-validate it on its own no-refresh path. I scoped this PR to the documented runtime resolver (`resolve_nous_runtime_credentials`, matching the #49735 incident); happy to fold a symmetric guard into `refresh_nous_oauth_pure` if you'd prefer.

Every symbol re-read against current `main`. If this has already been addressed via a separate patch, feel free to close.
