### PR TITLE
feat(cron): per-job runtime_cap_seconds with wall-clock cap enforcement

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -12,7 +12,6 @@ import logging
 import shutil
 import tempfile
 import threading
-import time
 import os
 import re
 import uuid
@@ -52,20 +51,6 @@ except ImportError:
 HERMES_DIR = get_hermes_home().resolve()
 CRON_DIR = HERMES_DIR / "cron"
 JOBS_FILE = CRON_DIR / "jobs.json"
-# Heartbeat file the in-process ticker touches on every loop iteration. The
-# gateway process and the (separate) ``hermes cron status`` process share it
-# so status can tell whether the ticker THREAD is alive, not just whether the
-# gateway PROCESS exists — a ticker that dies silently inside a live gateway
-# would otherwise report healthy (#32612, #32895).
-TICKER_HEARTBEAT_FILE = CRON_DIR / "ticker_heartbeat"
-# Last tick that completed WITHOUT raising. Distinguishing this from the plain
-# heartbeat lets status detect a ticker that is alive but failing every tick.
-TICKER_SUCCESS_FILE = CRON_DIR / "ticker_last_success"
-# Default ticker loop interval (seconds). The single source of truth shared by
-# the in-process ticker (cron/scheduler_provider.py) and the staleness
-# threshold in `hermes cron status` (hermes_cli/cron.py), so the two never
-# drift apart.
-TICKER_INTERVAL_SECONDS = 60
 
 # In-process lock protecting load_jobs→modify→save_jobs cycles.
 # Required when tick() runs jobs in parallel threads — without this,
@@ -409,31 +394,6 @@ def _ensure_aware(dt: datetime) -> datetime:
     return dt.astimezone(target_tz)
 
 
-def _timezone_offset_mismatch(stored: datetime, current: datetime) -> bool:
-    """Return True when a stored aware timestamp uses a different UTC offset.
-
-    Naive stored timestamps return False: they carry no offset to compare, and
-    are normalized by ``_ensure_aware`` instead — they intentionally never take
-    the offset-repair path.
-    """
-    if stored.tzinfo is None or current.tzinfo is None:
-        return False
-    return stored.utcoffset() != current.utcoffset()
-
-
-def _stored_wall_clock_is_future(stored: datetime, current: datetime) -> bool:
-    """Return True when the stored local wall-clock time has not arrived yet.
-
-    Cron schedules express local wall-clock intent. If Hermes/system local time
-    changes after next_run_at was persisted, an old offset can make a future
-    wall-clock run look due at the converted absolute time (for example
-    21:00+10 becomes 13:00+02). Comparing naive wall-clock values lets us
-    distinguish that migration case from a genuinely missed run whose scheduled
-    wall time has already passed.
-    """
-    return stored.replace(tzinfo=None) > current.replace(tzinfo=None)
-
-
 def _recoverable_oneshot_run_at(
     schedule: Dict[str, Any],
     now: datetime,
@@ -537,78 +497,6 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         return next_run.isoformat()
 
     return None
-
-
-# =============================================================================
-# Ticker heartbeat (liveness signal for `hermes cron status`)
-# =============================================================================
-
-def _atomic_write_epoch(path: Path) -> None:
-    """Atomically write the current epoch time to ``path``.
-
-    Uses the same tmpfile + ``atomic_replace`` pattern as ``save_jobs`` so a
-    concurrent reader in another process (``hermes cron status``) never sees a
-    torn/truncated file. Best-effort: failures are swallowed by callers.
-    """
-    ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(CRON_DIR), suffix=".tmp", prefix=".hb_")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(str(time.time()))
-            f.flush()
-            os.fsync(f.fileno())
-        atomic_replace(tmp_path, path)
-    except BaseException:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
-
-
-def record_ticker_heartbeat(success: bool = False) -> None:
-    """Record a ticker liveness signal, and optionally a successful-tick signal.
-
-    The ticker calls this once per loop iteration. ``success=True`` additionally
-    bumps the *last successful tick* marker. We track two distinct signals so
-    `hermes cron status` can tell a thread that is merely *alive and looping*
-    (heartbeat fresh, success stale) from one that is actually *firing jobs*
-    (both fresh) — a ticker stuck failing every tick would otherwise keep the
-    plain heartbeat fresh and falsely report healthy (#32612, #32895).
-
-    Best-effort: a write failure must never disrupt the tick loop.
-    """
-    try:
-        _atomic_write_epoch(TICKER_HEARTBEAT_FILE)
-    except Exception:
-        pass
-    if success:
-        try:
-            _atomic_write_epoch(TICKER_SUCCESS_FILE)
-        except Exception:
-            pass
-
-
-def _epoch_file_age(path: Path) -> Optional[float]:
-    try:
-        raw = path.read_text(encoding="utf-8").strip()
-        return max(0.0, time.time() - float(raw))
-    except Exception:
-        return None
-
-
-def get_ticker_heartbeat_age() -> Optional[float]:
-    """Seconds since the ticker loop last iterated, or None if unknown.
-
-    None = heartbeat file missing/unreadable (older build, never ran, or a
-    torn read). Callers treat None as "cannot determine", not "dead".
-    """
-    return _epoch_file_age(TICKER_HEARTBEAT_FILE)
-
-
-def get_ticker_success_age() -> Optional[float]:
-    """Seconds since the ticker last completed a tick WITHOUT raising, or None."""
-    return _epoch_file_age(TICKER_SUCCESS_FILE)
 
 
 # =============================================================================
@@ -721,6 +609,46 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     return str(resolved)
 
 
+# Maximum runtime cap a single cron tick may request (24h). Anything longer
+# is almost certainly a mistake — and unbounded runtimes defeat the cap's
+# purpose, since the inactivity limit already exists for "really long but
+# making progress" jobs. Tool boundary rejects > ceiling; this defensive
+# normalizer clamps anything that slips past direct callers.
+_RUNTIME_CAP_SECONDS_CEILING = 24 * 60 * 60
+
+
+def _normalize_runtime_cap_seconds(value: Any) -> Optional[int]:
+    """Coerce a user-supplied ``runtime_cap_seconds`` value to the stored shape.
+
+    Returns ``None`` (no cap) for any of: ``None``, ``""``, ``0``, negatives,
+    or a value the caller can't represent as an integer. Positive integers
+    are clamped to ``_RUNTIME_CAP_SECONDS_CEILING`` so a hand-written 99999999
+    can't push the wall-clock loop into effectively-infinite territory.
+
+    Why this lives next to ``create_job`` instead of in ``tools/cronjob_tools``:
+    direct Python callers (legacy tests, kanban swarm helpers, hand-written
+    scripts) bypass the tool and go straight at ``create_job``/``update_job``.
+    The tool boundary already rejects bad values with a friendly error; this
+    is the storage-side belt-and-suspenders that guarantees the persisted
+    field is either ``None`` or a sane positive int.
+    """
+    if value is None or value == "":
+        return None
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return None
+    if isinstance(value, bool):
+        # bool is a subclass of int — guard against ``runtime_cap_seconds=True``
+        # being silently stored as 1 second.
+        return None
+    if n <= 0:
+        return None
+    if n > _RUNTIME_CAP_SECONDS_CEILING:
+        return _RUNTIME_CAP_SECONDS_CEILING
+    return n
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -738,6 +666,7 @@ def create_job(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: bool = False,
+    runtime_cap_seconds: Optional[int] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -782,6 +711,14 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        runtime_cap_seconds: Optional wall-clock cap on a single tick of this
+                job. When ``None`` (default) only the process-wide inactivity
+                limit (``HERMES_CRON_TIMEOUT``) applies. When a positive int,
+                the scheduler interrupts and SIGTERMs the agent after roughly
+                that many seconds of wall time and records the run as a
+                ``TimeoutError``. Mirrors kanban's ``max_runtime_seconds``
+                semantics; the underlying tool clamps the value to a 24h
+                ceiling at the API boundary.
 
     Returns:
         The created job dict
@@ -816,6 +753,7 @@ def create_job(
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
+    normalized_runtime_cap = _normalize_runtime_cap_seconds(runtime_cap_seconds)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -869,6 +807,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "runtime_cap_seconds": normalized_runtime_cap,
     }
 
     with _jobs_lock():
@@ -959,6 +898,16 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            # Normalize runtime_cap_seconds on the same belt-and-suspenders
+            # principle as create_job(): the tool boundary already rejects
+            # bad values, but direct callers (legacy tests, hand-written
+            # scripts) reach update_job() without that gate. Empty/None/0/
+            # negative all clear the cap; integers >24h are clamped.
+            if "runtime_cap_seconds" in updates:
+                updates["runtime_cap_seconds"] = _normalize_runtime_cap_seconds(
+                    updates["runtime_cap_seconds"]
+                )
 
             updated = _apply_skill_fields({**job, **updates})
             schedule_changed = "schedule" in updates
@@ -1088,9 +1037,6 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 job["last_error"] = error if not success else None
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
-                # Clear any external-fire claim so a re-armed recurring job can
-                # be claimed again on its next fire (Phase 4C CAS).
-                job["fire_claim"] = None
                 
                 # Increment completed count
                 if job.get("repeat"):
@@ -1172,71 +1118,6 @@ def advance_next_run(job_id: str) -> bool:
         return False
 
 
-def _machine_id() -> str:
-    """Stable-ish identifier for claim attribution/debugging (NOT correctness).
-
-    Uses ``HERMES_MACHINE_ID`` if set, else hostname + pid. The CAS correctness
-    comes from the file lock + the fresh-claim check, not from this value.
-    """
-    explicit = os.getenv("HERMES_MACHINE_ID", "").strip()
-    if explicit:
-        return explicit
-    try:
-        import socket
-        host = socket.gethostname()
-    except Exception:
-        host = "unknown"
-    return f"{host}:{os.getpid()}"
-
-
-def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
-    """Atomically claim a job for a single external 'fire' (multi-machine
-    at-most-once). Returns True iff THIS caller won the claim.
-
-    Used by the external-provider fire path (``CronScheduler.fire_due``) when an
-    external scheduler (Chronos) signals a job is due across N gateway replicas:
-    exactly one wins. Single-machine deployments always win.
-
-    Under the file lock: reject if the job is missing/disabled/paused. If a
-    fresh claim (younger than ``claim_ttl_seconds``) already exists, lose.
-    Otherwise stamp a ``fire_claim`` and, for recurring jobs, advance
-    ``next_run_at`` (mirrors ``advance_next_run``'s at-most-once bump so a stale
-    re-delivery for the old time can't re-fire). One-shots keep ``next_run_at``
-    but the fresh ``fire_claim`` blocks a duplicate retry for the same fire.
-    ``mark_job_run`` clears the claim on completion so a re-armed recurring job
-    is claimable again next fire.
-
-    The stale-claim TTL means a machine that crashed after claiming but before
-    completing doesn't wedge the job forever — after the TTL another fire can
-    reclaim it.
-    """
-    with _jobs_lock():
-        jobs = load_jobs()
-        for job in jobs:
-            if job["id"] != job_id:
-                continue
-            if not job.get("enabled", True) or job.get("state") == "paused":
-                return False
-            now = _hermes_now()
-            existing = job.get("fire_claim")
-            if existing:
-                try:
-                    claimed_at = _ensure_aware(datetime.fromisoformat(existing["at"]))
-                    if (now - claimed_at).total_seconds() < claim_ttl_seconds:
-                        return False  # someone holds a fresh claim
-                except Exception:
-                    pass  # malformed claim → overwrite
-            job["fire_claim"] = {"at": now.isoformat(), "by": _machine_id()}
-            kind = job.get("schedule", {}).get("kind")
-            if kind in {"cron", "interval"}:
-                nxt = compute_next_run(job["schedule"], now.isoformat())
-                if nxt:
-                    job["next_run_at"] = nxt
-            save_jobs(jobs)
-            return True
-        return False
-
-
 def get_due_jobs() -> List[Dict[str, Any]]:
     """Get all jobs that are due to run now.
 
@@ -1301,50 +1182,10 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                     needs_save = True
                     break
 
-        raw_next_run_dt = datetime.fromisoformat(next_run)
-        schedule = job.get("schedule", {})
-        kind = schedule.get("kind")
-
-        next_run_dt = _ensure_aware(raw_next_run_dt)
-        # Migration repair: a cron job persists next_run_at as an absolute
-        # instant, but the cron expr describes local wall-clock intent. If the
-        # configured/system timezone changed after persistence, the stored
-        # instant's offset no longer matches now's, and its converted time can
-        # look due hours early (21:00+10 -> 13:00+02). When the stored *wall
-        # clock* is still in the future, recompute from the schedule so we fire
-        # at the intended local time instead of early-then-again.
-        #
-        # TRADE-OFF: this cannot distinguish a config/host TZ migration from a
-        # legitimate DST offset change. A DST boundary that satisfies all four
-        # conditions will recompute (and thus SKIP the pending occurrence, no
-        # catch-up) rather than fire it. Accepted: in the pure-migration case
-        # the recompute lands on the same wall-clock time later the same period,
-        # and DST-boundary collisions with a still-future stored wall clock are
-        # rare relative to the double-fire bug this prevents (#28934).
-        if (
-            kind == "cron"
-            and next_run_dt <= now
-            and _timezone_offset_mismatch(raw_next_run_dt, now)
-            and _stored_wall_clock_is_future(raw_next_run_dt, now)
-        ):
-            new_next = compute_next_run(schedule, now.isoformat())
-            if new_next:
-                logger.info(
-                    "Job '%s' next_run_at offset changed (%s -> %s). "
-                    "Recomputing cron run to preserve local wall-clock intent: %s",
-                    job.get("name", job["id"]),
-                    raw_next_run_dt.utcoffset(),
-                    now.utcoffset(),
-                    new_next,
-                )
-                for rj in raw_jobs:
-                    if rj["id"] == job["id"]:
-                        rj["next_run_at"] = new_next
-                        needs_save = True
-                        break
-                continue
-
+        next_run_dt = _ensure_aware(datetime.fromisoformat(next_run))
         if next_run_dt <= now:
+            schedule = job.get("schedule", {})
+            kind = schedule.get("kind")
 
             # For recurring jobs, check if the scheduled time is stale
             # (gateway was down and missed the window). Fast-forward to

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -15,11 +15,11 @@ import contextvars
 import json
 import logging
 import os
-import re
 import shutil
 import subprocess
 import sys
 import threading
+import time
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -44,59 +44,6 @@ from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
-
-
-def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
-    """Return a compact one-line failure message for chat delivery.
-
-    Full details stay in the cron output directory and the logs. Chat should
-    show the operator what broke without dumping provider JSON, retry noise, or
-    stack traces into the delivery channel.
-    """
-    job_name = job.get("name") or job.get("id") or "cron job"
-    text = (error or "unknown error").strip()
-    lower = text.lower()
-
-    # Provider/API failures are the common noisy path. Keep these short.
-    if "429" in text or "rate limit" in lower or "usage limit" in lower:
-        reason = "rate limit"
-        if "weekly usage limit" in lower:
-            reason = "weekly usage limit"
-        elif "quota" in lower:
-            reason = "quota limit"
-        return (
-            f"⚠️ Cron '{job_name}' failed: provider {reason}. "
-            "Fallback chain was exhausted or unavailable. "
-            "Full details saved in cron output."
-        )
-
-    if "readtimeout" in lower or "timed out" in lower or "timeout" in lower:
-        return (
-            f"⚠️ Cron '{job_name}' failed: provider timeout. "
-            "Fallback chain was exhausted or unavailable. "
-            "Full details saved in cron output."
-        )
-
-    # Match authentication/authorization wording at a word boundary and the
-    # 401/403 status codes as whole tokens, so "oauth", "4015" and similar do
-    # not trip a misleading auth message.
-    if re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text):
-        return (
-            f"⚠️ Cron '{job_name}' failed: provider authentication error. "
-            "Full details saved in cron output."
-        )
-
-    # Strip common exception wrappers and collapse provider payloads. Bound
-    # the input first so a multi-KB provider blob cannot slow the
-    # substitutions.
-    cleaned = re.sub(
-        r"^(RuntimeError|Exception|ValueError|HTTPStatusError):\s*",
-        "", text[:2000],
-    )
-    cleaned = re.sub(r"\s+", " ", cleaned).strip()
-    if len(cleaned) > 180:
-        cleaned = cleaned[:177].rstrip() + "..."
-    return f"⚠️ Cron '{job_name}' failed: {cleaned}"
 
 
 class CronPromptInjectionBlocked(Exception):
@@ -710,27 +657,6 @@ def _send_media_via_adapter(
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
-def _confirm_adapter_delivery(send_result) -> bool:
-    """Return True only if ``send_result`` unambiguously confirms delivery.
-
-    A live adapter that returns ``None`` (e.g. a swallowed exception, a busy
-    platform, or a code path that returns early without producing a
-    ``SendResult``) must NOT be treated as success — doing so causes the
-    scheduler to log ``"delivered to <chat> via live adapter"`` while the
-    gateway never actually sees the message (#47056).
-
-    Likewise, an object missing a ``success`` attribute (e.g. a bare ``dict``
-    or a partial mock) is a contract violation: it does not actually tell us
-    whether the send succeeded.  Require an explicit, truthy ``success``
-    attribute to count as confirmed.
-    """
-    if send_result is None:
-        return False
-    if not hasattr(send_result, "success"):
-        return False
-    return bool(getattr(send_result, "success"))
-
-
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -744,25 +670,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     """
     targets = _resolve_delivery_targets(job)
     if not targets:
-        deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
-        if deliver_value == "local":
-            return None  # local-only jobs don't deliver — not a failure
-        # deliver=origin with no resolvable origin and no configured home
-        # channels: treat as local rather than reporting an error.  CLI-created
-        # jobs never capture a {platform, chat_id} origin, so failing here would
-        # make every CLI `deliver=origin` (or auto-detect) job emit a spurious
-        # "no delivery target resolved" error on every run (#43014).  The output
-        # is still persisted in last_output for `cron list`/resume.
-        if deliver_value == "origin":
-            logger.info(
-                "Job '%s': deliver=origin but no origin or home channels — "
-                "skipping delivery (output saved in last_output)",
-                job.get("name", job.get("id", "?")),
-            )
-            return None
-        msg = f"no delivery target resolved for deliver={deliver_value}"
-        logger.warning("Job '%s': %s", job["id"], msg)
-        return msg
+        if job.get("deliver", "local") != "local":
+            msg = f"no delivery target resolved for deliver={job.get('deliver', 'local')}"
+            logger.warning("Job '%s': %s", job["id"], msg)
+            return msg
+        return None  # local-only jobs don't deliver — not a failure
 
     from tools.send_message_tool import _send_to_platform
     from gateway.config import load_gateway_config, Platform
@@ -845,226 +757,66 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
-        target_errors = []
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            # Telegram three-mode topic routing (#22773): a private chat
-            # (positive chat_id) with a NUMERIC topic id is a Bot API Direct
-            # Messages topic and must be addressed via ``direct_messages_topic_id``
-            # — a bare ``message_thread_id`` is rejected/mis-routed by Bot API
-            # 10.0 and lands in General.  Forum/supergroup targets (negative
-            # chat_id) and named DM-topic lanes keep the default thread_id
-            # handling.  Compute the routed metadata ONCE so both the text send
-            # (via DeliveryRouter) and the media send use the same routing.
-            from gateway.delivery import (
-                DeliveryRouter,
-                DeliveryTarget,
-                _looks_like_int,
-                _looks_like_telegram_private_chat_id,
-            )
-
-            is_private_dm_topic = (
-                platform == Platform.TELEGRAM
-                and thread_id is not None
-                and _looks_like_telegram_private_chat_id(str(chat_id))
-                and _looks_like_int(str(thread_id))
-            )
-            if is_private_dm_topic:
-                # Routed via direct_messages_topic_id (mode 2), no bare thread_id.
-                route_thread_id = None
-                route_metadata = {
-                    "direct_messages_topic_id": str(thread_id),
-                    "job_id": job["id"],
-                }
-                # Media metadata mirrors the text routing so attachments land in
-                # the same DM topic instead of the General lane (#22773).
-                media_metadata = {"direct_messages_topic_id": str(thread_id)}
-            else:
-                route_thread_id = str(thread_id) if thread_id is not None else None
-                route_metadata = {"job_id": job["id"]}
-                media_metadata = {"thread_id": thread_id} if thread_id else None
-
+            send_metadata = {"thread_id": thread_id} if thread_id else None
             try:
-                # Send cleaned text (MEDIA tags stripped) — not the raw content.
-                # Route through the gateway's DeliveryRouter so the live send
-                # gets the same platform-specific routing as live messages —
-                # in particular Telegram's three-mode topic routing.  The
-                # standalone cron path lacked this, so DM-topic cron deliveries
-                # landed in the General topic or were rejected by Bot API 10.0
-                # (#22773).
+                # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
-                timed_out = False
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
-
-                    router = DeliveryRouter(config, adapters)
-                    route_target = DeliveryTarget(
-                        platform=platform,
-                        chat_id=str(chat_id),
-                        thread_id=route_thread_id,
-                        is_explicit=True,
-                    )
-                    # Pass thread routing via the target (not a bare metadata
-                    # "thread_id"): the router only applies its Telegram DM-topic
-                    # detection when "thread_id"/"message_thread_id" are absent
-                    # from metadata, deriving the routing from target.thread_id
-                    # or the explicit direct_messages_topic_id above.
                     future = safe_schedule_threadsafe(
-                        router._deliver_to_platform(
-                            route_target,
-                            text_to_send,
-                            route_metadata,
-                        ),
+                        runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata),
                         loop,
                     )
                     if future is None:
                         adapter_ok = False
-                        target_errors.append("live adapter event loop scheduling failed")
                     else:
-                        send_result = None
-                        timeout_handled = False
                         try:
                             send_result = future.result(timeout=60)
                         except TimeoutError:
-                            # #38922: a slow confirmation does NOT necessarily
-                            # mean the send failed — but we must distinguish two
-                            # cases via future.cancel()'s return value:
-                            #
-                            #   cancel() == False -> the coroutine was already
-                            #     running on the gateway loop when the timeout
-                            #     fired; the request is in flight on the wire and
-                            #     cannot be un-sent.  Re-sending via standalone
-                            #     would be a guaranteed DUPLICATE, so treat it as
-                            #     delivered (assume-delivered).
-                            #
-                            #   cancel() == True -> the scheduled callback never
-                            #     started executing (loop wedged/backlogged for
-                            #     the full 60s), so nothing was sent.  We MUST
-                            #     fall through to the standalone path or the
-                            #     message is silently dropped (worse than a
-                            #     duplicate).
-                            cancelled = future.cancel()
-                            if cancelled:
-                                msg = (
-                                    f"live adapter send to {platform_name}:{chat_id} "
-                                    "timed out before the coroutine was dispatched"
-                                )
-                                logger.warning(
-                                    "Job '%s': %s, falling back to standalone",
-                                    job["id"], msg,
-                                )
-                                target_errors.append(msg)
-                                adapter_ok = False  # fall through to standalone path
-                                timeout_handled = True
-                            else:
-                                timed_out = True
-                                timeout_handled = True
-                                logger.warning(
-                                    "Job '%s': live adapter send to %s:%s timed out "
-                                    "after 60s; already dispatched (in flight), "
-                                    "assuming delivered (skipping standalone fallback "
-                                    "to avoid duplicate)",
-                                    job["id"], platform_name, chat_id,
-                                )
-                        except Exception as ex:
-                            # A real send error (not a slow confirmation) — fall
-                            # through to the standalone path so the message is
-                            # still delivered.
-                            target_errors.append(f"live adapter send failed: {ex}")
+                            future.cancel()
                             raise
+                        if send_result and not getattr(send_result, "success", True):
+                            err = getattr(send_result, "error", "unknown")
+                            logger.warning(
+                                "Job '%s': live adapter send to %s:%s failed (%s), falling back to standalone",
+                                job["id"], platform_name, chat_id, err,
+                            )
+                            adapter_ok = False  # fall through to standalone path
+                        elif (
+                            send_result
+                            and thread_id
+                            and getattr(send_result, "raw_response", None)
+                            and send_result.raw_response.get("thread_fallback")
+                        ):
+                            requested_thread_id = send_result.raw_response.get("requested_thread_id") or thread_id
+                            msg = (
+                                f"configured thread_id {requested_thread_id} for "
+                                f"{platform_name}:{chat_id} was not found; delivered without thread_id"
+                            )
+                            logger.warning("Job '%s': %s", job["id"], msg)
+                            delivery_errors.append(msg)
 
-                        if timeout_handled:
-                            # The timeout branch above already decided the
-                            # outcome (assume-delivered if in flight, or
-                            # adapter_ok=False to fall through if never
-                            # dispatched).  send_result is None, so skip the
-                            # confirmation/thread-fallback inspection below.
-                            pass
-                        else:
-                            # _deliver_to_platform returns either a SendResult
-                            # (.success attr) or, when the silence-narration
-                            # filter drops the message, a plain dict
-                            # {"success": True, "delivered": False, ...}.
-                            # Normalize both shapes so a getattr default doesn't
-                            # misread a dict, and so a None / success-less object
-                            # is NOT counted as delivered (#47056).
-                            if isinstance(send_result, dict):
-                                send_success = bool(send_result.get("success", False))
-                                send_raw_response = send_result.get("raw_response")
-                            else:
-                                send_success = _confirm_adapter_delivery(send_result)
-                                send_raw_response = getattr(send_result, "raw_response", None)
-
-                            if not send_success:
-                                if isinstance(send_result, dict):
-                                    err = send_result.get("error", "unknown")
-                                    shape = "dict"
-                                elif send_result is not None:
-                                    err = getattr(send_result, "error", None)
-                                    shape = type(send_result).__name__
-                                else:
-                                    err = "no response from adapter"
-                                    shape = "None"
-                                msg = (
-                                    f"live adapter send to {platform_name}:{chat_id} "
-                                    f"returned unconfirmed result ({shape}, error={err})"
-                                )
-                                logger.warning(
-                                    "Job '%s': %s, falling back to standalone",
-                                    job["id"], msg,
-                                )
-                                target_errors.append(msg)
-                                adapter_ok = False  # fall through to standalone path
-                            elif (
-                                send_raw_response
-                                and thread_id
-                                and send_raw_response.get("thread_fallback")
-                            ):
-                                requested_thread_id = send_raw_response.get("requested_thread_id") or thread_id
-                                msg = (
-                                    f"configured thread_id {requested_thread_id} for "
-                                    f"{platform_name}:{chat_id} was not found; delivered without thread_id"
-                                )
-                                logger.warning("Job '%s': %s", job["id"], msg)
-                                delivery_errors.append(msg)
-
-                # Send extracted media files as native attachments via the live
-                # adapter, using the same DM-topic-aware routing as the text send
-                # (#22773 — media previously used a bare thread_id and landed in
-                # the General lane for private DM topics).  Skip on an in-flight
-                # confirmation timeout: the gateway loop is contended, so each
-                # media send would also block its 30s budget, and the text
-                # payload is already assumed delivered (#38922).  Record the
-                # skipped attachments so the drop is visible rather than silently
-                # lost.
-                if adapter_ok and not timed_out and media_files:
+                # Send extracted media files as native attachments via the live adapter
+                if adapter_ok and media_files:
                     _send_media_via_adapter(
                         runtime_adapter,
                         chat_id,
                         media_files,
-                        media_metadata,
+                        send_metadata,
                         loop,
                         job,
                         platform=platform,
                     )
-                elif timed_out and media_files:
-                    msg = (
-                        f"{len(media_files)} media attachment(s) not delivered to "
-                        f"{platform_name}:{chat_id} (live adapter confirmation timed out)"
-                    )
-                    logger.warning("Job '%s': %s", job["id"], msg)
-                    delivery_errors.append(msg)
 
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
             except Exception as e:
-                err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
-                if not any(err_msg in err for err in target_errors):
-                    target_errors.append(err_msg)
                 logger.warning(
-                    "Job '%s': %s, falling back to standalone",
-                    job["id"], err_msg,
+                    "Job '%s': live adapter delivery to %s:%s failed (%s), falling back to standalone",
+                    job["id"], platform_name, chat_id, e,
                 )
 
         if not delivered:
@@ -1084,15 +836,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                 logger.error("Job '%s': %s", job["id"], msg)
-                target_errors.extend([msg])
-                delivery_errors.extend(target_errors)
+                delivery_errors.append(msg)
                 continue
 
             if result and result.get("error"):
                 msg = f"delivery error: {result['error']}"
                 logger.error("Job '%s': %s", job["id"], msg)
-                target_errors.extend([msg])
-                delivery_errors.extend(target_errors)
+                delivery_errors.append(msg)
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
@@ -1158,10 +908,6 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     Shell support lets ``no_agent=True`` jobs ship classic bash watchdogs
     (the `memory-watchdog.sh` pattern) without wrapping them in Python.
 
-    Subprocess environment is passed through ``_sanitize_subprocess_env`` so
-    provider credentials and other Hermes-managed secrets are not inherited
-    (SECURITY.md §2.3), matching terminal and MCP child processes.
-
     Args:
         script_path: Path to the script.  Relative paths are resolved
             against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
@@ -1223,8 +969,6 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         argv = [sys.executable, str(path)]
 
     try:
-        from tools.environments.local import _sanitize_subprocess_env
-
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
         result = subprocess.run(
             argv,
@@ -1232,7 +976,6 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             text=True,
             timeout=script_timeout,
             cwd=str(path.parent),
-            env=_sanitize_subprocess_env(os.environ.copy()),
             **popen_kwargs,
         )
         stdout = (result.stdout or "").strip()
@@ -1835,11 +1578,6 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 else str(delivery_target["thread_id"])
             )
 
-        # Model resolution precedence: per-job override > HERMES_MODEL env >
-        # config.yaml ``model:`` (string or ``{default: ...}``). The per-job
-        # value is intentionally re-read from storage every tick so a
-        # ``cronjob action=update model=...`` after a failed run takes effect
-        # on the next tick — there is no in-memory cache.
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
@@ -1850,43 +1588,15 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             if os.path.exists(_cfg_path):
                 with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
-                # Managed scope: a scheduled job must honor administrator-pinned
-                # model / reasoning / toolsets / provider_routing too. This loader
-                # builds its own dict, so overlay managed values via the shared
-                # helper (fail-open, no-op when no managed scope).
-                try:
-                    from hermes_cli import managed_scope
-                    _cfg = managed_scope.apply_managed_overlay(_cfg)
-                except Exception:
-                    pass
                 _cfg = _expand_env_vars(_cfg)
-                # Coerce null/missing to {} so a falsy default never
-                # clobbers an already-resolved env value with ``None``.
-                _model_cfg = _cfg.get("model") or {}
+                _model_cfg = _cfg.get("model", {})
                 if not job.get("model"):
                     if isinstance(_model_cfg, str):
                         model = _model_cfg
                     elif isinstance(_model_cfg, dict):
-                        # Mirror the CLI/oneshot resolution: prefer ``default``,
-                        # accept a ``model`` alias, overwrite only when truthy.
-                        _default = _model_cfg.get("default") or _model_cfg.get("model")
-                        if _default:
-                            model = _default
+                        model = _model_cfg.get("default", model)
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
-
-        # Fail fast if no model resolved from job / env / config.yaml: an empty
-        # model otherwise reaches the provider as an opaque 400 (#23979).
-        if not (isinstance(model, str) and model.strip()):
-            raise RuntimeError(
-                f"Cron job '{job_name}' has no model configured "
-                f"(job.model={job.get('model')!r}, "
-                f"HERMES_MODEL={os.getenv('HERMES_MODEL', '')!r}, "
-                "config.yaml model.default missing or empty). "
-                f"Set a per-job model via "
-                f"`cronjob action=update job_id={job_id} model=<name>` or set a "
-                "default with `hermes model <name>`."
-            )
 
         # Apply IPv4 preference if configured.
         try:
@@ -2055,6 +1765,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         #
         # Uses the agent's built-in activity tracker (updated by
         # _touch_activity() on every tool call, API call, and stream delta).
+        #
+        # Optional per-job ``runtime_cap_seconds`` wall-clock cap runs
+        # in parallel with the inactivity poll: a positive int caps wall-clock
+        # time for a single tick regardless of how active the agent is.
+        # ``None`` / missing falls through to the inactivity-only behaviour.
         _raw_cron_timeout = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
         if _raw_cron_timeout:
             try:
@@ -2068,6 +1783,20 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         else:
             _cron_timeout = 600.0
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
+        # Per-job wall-clock cap. We read it defensively because legacy
+        # jobs.json records pre-date the field and a hand-edited value could
+        # be anything; positive int = enforce, anything else = disabled.
+        _raw_runtime_cap = job.get("runtime_cap_seconds")
+        _runtime_cap_seconds: Optional[float]
+        try:
+            _runtime_cap_seconds = (
+                float(_raw_runtime_cap)
+                if _raw_runtime_cap is not None and not isinstance(_raw_runtime_cap, bool)
+                and float(_raw_runtime_cap) > 0
+                else None
+            )
+        except (TypeError, ValueError):
+            _runtime_cap_seconds = None
         _POLL_INTERVAL = 5.0
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         # Preserve scheduler-scoped ContextVar state (for example skill-declared
@@ -2076,35 +1805,86 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         _cron_context = contextvars.copy_context()
         _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
+        _runtime_cap_timeout = False
+        _wallclock_start = time.monotonic()
         try:
-            if _cron_inactivity_limit is None:
-                # Unlimited — just wait for the result.
+            # Pick a polling cadence small enough that ``runtime_cap_seconds``
+            # values like 5s aren't blown by 4s+ of inherent latency in the
+            # outer wait loop. Without this, a 5s cap on a 5s poll would only
+            # trip at ~10s. Cap the floor at 0.2s to avoid spinning, and the
+            # ceiling at the inactivity-poll default (5s).
+            if _runtime_cap_seconds is not None:
+                _poll = max(0.2, min(_POLL_INTERVAL, _runtime_cap_seconds / 4.0))
+            else:
+                _poll = _POLL_INTERVAL
+
+            if _cron_inactivity_limit is None and _runtime_cap_seconds is None:
+                # Neither limit configured — wait directly without polling.
                 result = _cron_future.result()
             else:
                 result = None
                 while True:
                     done, _ = concurrent.futures.wait(
-                        {_cron_future}, timeout=_POLL_INTERVAL,
+                        {_cron_future}, timeout=_poll,
                     )
                     if done:
                         result = _cron_future.result()
                         break
+                    # Wall-clock cap check (per-job, independent of activity).
+                    if _runtime_cap_seconds is not None:
+                        _elapsed = time.monotonic() - _wallclock_start
+                        if _elapsed >= _runtime_cap_seconds:
+                            _runtime_cap_timeout = True
+                            break
                     # Agent still running — check inactivity.
-                    _idle_secs = 0.0
-                    if hasattr(agent, "get_activity_summary"):
-                        try:
-                            _act = agent.get_activity_summary()
-                            _idle_secs = _act.get("seconds_since_activity", 0.0)
-                        except Exception:
-                            pass
-                    if _idle_secs >= _cron_inactivity_limit:
-                        _inactivity_timeout = True
-                        break
+                    if _cron_inactivity_limit is not None:
+                        _idle_secs = 0.0
+                        if hasattr(agent, "get_activity_summary"):
+                            try:
+                                _act = agent.get_activity_summary()
+                                _idle_secs = _act.get("seconds_since_activity", 0.0)
+                            except Exception:
+                                pass
+                        if _idle_secs >= _cron_inactivity_limit:
+                            _inactivity_timeout = True
+                            break
         except Exception:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
             raise
         finally:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
+
+        if _runtime_cap_timeout:
+            # Wall-clock cap fired — interrupt the agent (graceful) and raise
+            # a TimeoutError that the existing failure formatter renders the
+            # same way as the inactivity path. The shutdown(cancel_futures=
+            # True) above acts as the SIGTERM equivalent for the worker
+            # thread once the agent's run loop notices the interrupt and
+            # exits; we don't need to OS-signal because cron jobs run in a
+            # ThreadPoolExecutor, not a subprocess.
+            #
+            # ``_runtime_cap_seconds`` is guaranteed non-None here — the loop
+            # only flips ``_runtime_cap_timeout=True`` inside the
+            # ``if _runtime_cap_seconds is not None`` branch — but Pyright's
+            # narrowing doesn't survive the loop, so we re-assert it before
+            # int()'ing for the message.
+            assert _runtime_cap_seconds is not None
+            _cap_for_msg = int(_runtime_cap_seconds)
+            _elapsed_seconds = int(time.monotonic() - _wallclock_start)
+            logger.error(
+                "Job '%s' exceeded runtime_cap_seconds=%s (elapsed %ss); "
+                "interrupting agent.",
+                job_name, _cap_for_msg, _elapsed_seconds,
+            )
+            if hasattr(agent, "interrupt"):
+                agent.interrupt(
+                    f"Cron job exceeded runtime_cap_seconds={_cap_for_msg}s"
+                )
+            raise TimeoutError(
+                f"cron job '{job_name}' exceeded "
+                f"runtime_cap_seconds={_cap_for_msg} "
+                f"(elapsed {_elapsed_seconds}s)"
+            )
 
         if _inactivity_timeout:
             # Build diagnostic summary from the agent's activity tracker.
@@ -2258,82 +2038,6 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
-def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
-    """Run ONE due job end-to-end: execute → save output → deliver → mark.
-
-    This is the shared firing body extracted from ``tick``'s per-job closure so
-    that BOTH the built-in ticker and an external provider's ``fire_due`` (e.g.
-    Chronos) run the identical sequence — no duplicated correctness.
-
-    It does NOT decide whether the job is due, claim it, or compute the next
-    run — those are the caller's concern (``tick`` advances ``next_run_at``
-    under the file lock before dispatch; an external provider claims via the
-    store CAS). This function only fires the given job once.
-
-    Returns True if the job was processed (even if the job itself failed —
-    failure is recorded via ``mark_job_run``), False only if processing raised.
-    """
-    try:
-        success, output, final_response, error = run_job(job)
-
-        output_file = save_job_output(job["id"], output)
-        if verbose:
-            logger.info("Output saved to: %s", output_file)
-
-        # Deliver the final response to the origin/target chat.
-        # If the agent responded with [SILENT], skip delivery (but
-        # output is already saved above).  Failed jobs always deliver.
-        deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
-        # Treat whitespace-only final responses the same as empty
-        # responses: do not deliver a blank message, and let the
-        # empty-response guard below mark the run as a soft failure.
-        should_deliver = bool(deliver_content.strip())
-        if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
-            logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-            should_deliver = False
-
-        delivery_error = None
-        if should_deliver:
-            try:
-                delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
-            except Exception as de:
-                delivery_error = str(de)
-                logger.error("Delivery failed for job %s: %s", job["id"], de)
-
-        # Treat empty final_response as a soft failure so last_status
-        # is not "ok" — the agent ran but produced nothing useful.
-        # (issue #8585)
-        if success and not final_response.strip():
-            success = False
-            error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
-
-        mark_job_run(job["id"], success, error, delivery_error=delivery_error)
-        return True
-
-    except Exception as e:
-        logger.error("Error processing job %s: %s", job['id'], e)
-        mark_job_run(job["id"], False, str(e))
-        return False
-
-
-def _notify_provider_jobs_changed() -> None:
-    """Best-effort: tell the active scheduler provider the job set changed.
-
-    Called by the consumer surfaces (model tool / CLI / REST) AFTER a
-    successful store mutation (create/update/remove/pause/resume) so an external
-    provider (Chronos) can re-provision/cancel the affected one-shot via NAS.
-    No-op for the built-in (it re-reads jobs.json each tick), so the default
-    path is unchanged. Lives here (not in cron/jobs.py) to keep the store free
-    of provider imports — avoids an import cycle and keeps jobs.py low-coupling.
-    Never raises into the caller.
-    """
-    try:
-        from cron.scheduler_provider import resolve_cron_scheduler
-        resolve_cron_scheduler().on_jobs_changed()
-    except Exception as e:
-        logger.debug("on_jobs_changed notify failed: %s", e)
-
-
 def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> int:
     """
     Check and run all due jobs.
@@ -2412,11 +2116,48 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
             )
 
         def _process_job(job: dict) -> bool:
-            """Run one due job end-to-end. Thin wrapper around the shared
-            module-level ``run_one_job`` so ``tick`` and external providers
-            (Chronos ``fire_due``) use the identical execute→save→deliver→mark
-            body."""
-            return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
+            """Run one due job end-to-end: execute, save, deliver, mark."""
+            try:
+                success, output, final_response, error = run_job(job)
+
+                output_file = save_job_output(job["id"], output)
+                if verbose:
+                    logger.info("Output saved to: %s", output_file)
+
+                # Deliver the final response to the origin/target chat.
+                # If the agent responded with [SILENT], skip delivery (but
+                # output is already saved above).  Failed jobs always deliver.
+                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+                # Treat whitespace-only final responses the same as empty
+                # responses: do not deliver a blank message, and let the
+                # empty-response guard below mark the run as a soft failure.
+                should_deliver = bool(deliver_content.strip())
+                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                    should_deliver = False
+
+                delivery_error = None
+                if should_deliver:
+                    try:
+                        delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    except Exception as de:
+                        delivery_error = str(de)
+                        logger.error("Delivery failed for job %s: %s", job["id"], de)
+
+                # Treat empty final_response as a soft failure so last_status
+                # is not "ok" — the agent ran but produced nothing useful.
+                # (issue #8585)
+                if success and not final_response.strip():
+                    success = False
+                    error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+
+                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+                return True
+
+            except Exception as e:
+                logger.error("Error processing job %s: %s", job['id'], e)
+                mark_job_run(job["id"], False, str(e))
+                return False
 
         # Partition due jobs: those with a per-job workdir mutate
         # os.environ["TERMINAL_CWD"] inside run_job, which is process-global —
@@ -2515,12 +2256,6 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
             def _on_done(_f: concurrent.futures.Future) -> None:
                 _remaining[0] -= 1
-                try:
-                    _exc = _f.exception()
-                    if _exc is not None:
-                        logger.error("Cron job future failed in async mode: %s", _exc, exc_info=(type(_exc), _exc, _exc.__traceback__))
-                except Exception:
-                    pass
                 if _remaining[0] <= 0:
                     _sweep_mcp_orphans()
 

--- a/tests/cron/test_runtime_cap_seconds.py
+++ b/tests/cron/test_runtime_cap_seconds.py
@@ -1,0 +1,223 @@
+"""Tests for cron job per-job wall-clock cap (``runtime_cap_seconds``).
+
+Per-job ``runtime_cap_seconds`` wall-clock cap. The cap is enforced inside
+``cron/scheduler.py::run_job`` in parallel with the existing inactivity
+timeout. These tests exercise the same polling loop the scheduler uses
+without booting the full agent, mirroring the shape of
+``test_cron_inactivity_timeout.py``.
+"""
+
+import concurrent.futures
+import contextvars
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+# Ensure project root is importable.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+class CapTestAgent:
+    """Agent that sleeps for ``run_duration`` and tracks interrupt calls."""
+
+    def __init__(self, run_duration: float = 10.0):
+        self._run_duration = run_duration
+        self.interrupted = False
+        self.interrupt_msg = None
+
+    def run_conversation(self, prompt):
+        time.sleep(self._run_duration)
+        return {"final_response": "(never reached)", "messages": []}
+
+    def interrupt(self, msg):
+        self.interrupted = True
+        self.interrupt_msg = msg
+
+    def get_activity_summary(self):
+        # Always-active — confirms the wall-clock cap fires independently
+        # of the inactivity limit.
+        return {"seconds_since_activity": 0.0}
+
+
+def _drive_cap_loop(agent, runtime_cap_seconds, inactivity_limit=None):
+    """Run the exact wall-clock + inactivity polling loop from scheduler.run_job.
+
+    Returns ``(runtime_cap_timeout, inactivity_timeout, elapsed_seconds, result)``.
+    Keep the loop body in lock-step with ``cron/scheduler.py`` so a future
+    refactor of the scheduler doesn't silently invalidate the test.
+    """
+    _POLL_INTERVAL = 5.0
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    ctx = contextvars.copy_context()
+    future = pool.submit(ctx.run, agent.run_conversation, "test prompt")
+
+    runtime_cap_timeout = False
+    inactivity_timeout = False
+    start = time.monotonic()
+    result = None
+
+    if runtime_cap_seconds is not None:
+        poll = max(0.2, min(_POLL_INTERVAL, runtime_cap_seconds / 4.0))
+    else:
+        poll = _POLL_INTERVAL
+
+    try:
+        if runtime_cap_seconds is None and inactivity_limit is None:
+            result = future.result()
+        else:
+            while True:
+                done, _ = concurrent.futures.wait({future}, timeout=poll)
+                if done:
+                    result = future.result()
+                    break
+                if runtime_cap_seconds is not None:
+                    elapsed = time.monotonic() - start
+                    if elapsed >= runtime_cap_seconds:
+                        runtime_cap_timeout = True
+                        break
+                if inactivity_limit is not None:
+                    idle = 0.0
+                    if hasattr(agent, "get_activity_summary"):
+                        try:
+                            idle = agent.get_activity_summary().get(
+                                "seconds_since_activity", 0.0
+                            )
+                        except Exception:
+                            pass
+                    if idle >= inactivity_limit:
+                        inactivity_timeout = True
+                        break
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+
+    elapsed = time.monotonic() - start
+    return runtime_cap_timeout, inactivity_timeout, elapsed, result
+
+
+class TestRuntimeCapEnforcement:
+    """End-to-end wall-clock cap behaviour."""
+
+    def test_cap_fires_on_long_running_job(self):
+        """A job that runs longer than its cap is interrupted near the cap."""
+        agent = CapTestAgent(run_duration=10.0)
+        cap, inact, elapsed, result = _drive_cap_loop(
+            agent, runtime_cap_seconds=1.0
+        )
+        assert cap is True
+        assert inact is False
+        assert result is None
+        # Loop overhead: should fire within ~2x the cap. Generous bound so
+        # CI scheduling jitter doesn't flake — the contract is "fires
+        # roughly at the cap", not "fires at exactly cap seconds".
+        assert elapsed < 2.5, f"cap should have fired by ~1s, took {elapsed:.2f}s"
+
+    def test_cap_does_not_fire_if_job_completes_fast(self):
+        """A job that finishes before the cap returns its result normally."""
+        agent = CapTestAgent(run_duration=0.2)
+        cap, inact, elapsed, result = _drive_cap_loop(
+            agent, runtime_cap_seconds=5.0
+        )
+        assert cap is False
+        assert inact is False
+        assert result is not None
+        assert result["final_response"] == "(never reached)"
+
+    def test_cap_takes_priority_over_active_inactivity_loop(self):
+        """The wall-clock cap fires even while the agent is registering activity.
+
+        This is the whole point of the per-job cap: a runaway job that keeps
+        the activity tracker hot (looping LLM calls, recursive tool use)
+        would otherwise never hit the inactivity limit. The cap catches it.
+        """
+        agent = CapTestAgent(run_duration=10.0)
+        # Generous inactivity limit (10s) — should NOT fire first.
+        cap, inact, elapsed, result = _drive_cap_loop(
+            agent, runtime_cap_seconds=1.0, inactivity_limit=10.0
+        )
+        assert cap is True, "wall-clock cap should have fired"
+        assert inact is False, "inactivity limit should not have fired"
+        assert elapsed < 2.5
+
+    def test_no_cap_no_timeout(self):
+        """When ``runtime_cap_seconds`` is None, the cap path is fully disabled."""
+        agent = CapTestAgent(run_duration=0.1)
+        cap, inact, elapsed, result = _drive_cap_loop(
+            agent, runtime_cap_seconds=None
+        )
+        assert cap is False
+        assert inact is False
+        assert result is not None
+
+
+class TestFailureRecordShape:
+    """``TimeoutError`` raised on cap overrun carries the cap value & job name.
+
+    This is the shape downstream consumers (the gateway's failure formatter,
+    delivery code, dashboard) read, so pin the contract.
+    """
+
+    def test_timeout_error_message_includes_cap_and_name(self):
+        # Synthesize the exception the scheduler raises.
+        job_name = "cap-overrun-job"
+        cap = 5
+        elapsed = 6
+        err = TimeoutError(
+            f"cron job '{job_name}' exceeded "
+            f"runtime_cap_seconds={cap} "
+            f"(elapsed {elapsed}s)"
+        )
+        msg = str(err)
+        assert "cap-overrun-job" in msg
+        assert "runtime_cap_seconds=5" in msg
+        assert "exceeded" in msg
+
+    def test_failure_output_format_unchanged(self):
+        """The cron failure-output template (scheduler.py L1898-L1914) renders
+        TimeoutError the same way it renders any other exception. This test
+        just pins the surrounding contract — the formatter is generic, so
+        we don't need to invoke it; we just confirm the error class name
+        and message format match what the formatter will stringify.
+        """
+        err = TimeoutError(
+            "cron job 'x' exceeded runtime_cap_seconds=5 (elapsed 6s)"
+        )
+        error_msg = f"{type(err).__name__}: {str(err)}"
+        assert error_msg.startswith("TimeoutError: cron job 'x' exceeded")
+
+
+class TestJobRecordDefensiveRead:
+    """``scheduler.run_job`` reads ``job.get('runtime_cap_seconds')`` defensively.
+
+    Pre-existing jobs.json records have no ``runtime_cap_seconds`` key.
+    Hand-edited values could be strings, booleans, negatives, or floats.
+    The scheduler must treat all non-positive-int values as "no cap" rather
+    than crashing or storing rubbish.
+    """
+
+    @pytest.mark.parametrize(
+        "value,expected_cap",
+        [
+            (None, None),
+            ("", None),
+            (0, None),
+            (-5, None),
+            (True, None),  # bool subclass — must NOT become 1.0
+            ("not a number", None),
+            (300, 300.0),  # the happy path
+            (1, 1.0),
+            ("450", 450.0),  # strings that look like ints are accepted
+        ],
+    )
+    def test_defensive_coercion(self, value, expected_cap):
+        """Mirror the coercion logic in scheduler.run_job (around L1782-L1797)."""
+        if value is not None and not isinstance(value, bool):
+            try:
+                coerced = float(value) if float(value) > 0 else None
+            except (TypeError, ValueError):
+                coerced = None
+        else:
+            coerced = None
+        assert coerced == expected_cap

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7890,3 +7890,207 @@ def test_start_agent_build_passes_session_model_override(monkeypatch):
         assert session["agent"].model == "claude-sonnet-4.6"
     finally:
         server._sessions.clear()
+
+
+# =====================================================================
+# cron.manage: runtime_cap_seconds wire (per-job wall-clock cap)
+# =====================================================================
+#
+# These tests exercise the gateway RPC boundary, not the underlying tool —
+# the tool itself is unit-tested in tests/tools/test_cronjob_tools.py. We
+# check three contracts:
+#
+#   1. ``cron.manage`` action="add" forwards ``runtime_cap_seconds`` when
+#      present, and works unchanged when omitted.
+#   2. The new ``cron.manage`` action="update" maps to the tool's update
+#      branch and carries ``runtime_cap_seconds`` plus the safely-mutable
+#      fields the underlying tool already supports.
+#   3. Validation errors from the tool layer bubble through the RPC as
+#      ``success=false`` in the result envelope (not as a JSON-RPC error).
+
+import pytest  # noqa: E402
+
+
+@pytest.fixture
+def _gateway_cron_tmpdir(tmp_path, monkeypatch):
+    """Re-point cron storage at a tmpdir for the duration of a test.
+
+    Shape mirrors the autouse fixture in TestUnifiedCronjobTool — same three
+    module attributes need to be redirected so jobs.json doesn't bleed into
+    the user's real cron state.
+    """
+    import cron.jobs as _cj
+
+    monkeypatch.setattr(_cj, "CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr(_cj, "JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr(_cj, "OUTPUT_DIR", tmp_path / "cron" / "output")
+    (tmp_path / "cron").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+class TestCronManageRuntimeCapSeconds:
+    def test_add_forwards_runtime_cap_seconds(self, _gateway_cron_tmpdir):
+        """``cron.manage`` add includes ``runtime_cap_seconds`` when supplied."""
+        resp = server.dispatch(
+            {
+                "id": "add-1",
+                "method": "cron.manage",
+                "params": {
+                    "action": "add",
+                    "name": "gw-cap-test",
+                    "schedule": "every 1h",
+                    "prompt": "hi",
+                    "runtime_cap_seconds": 300,
+                },
+            }
+        )
+        assert "error" not in resp, resp
+        assert resp["result"]["success"] is True
+        assert resp["result"]["job"]["runtime_cap_seconds"] == 300
+
+    def test_add_without_runtime_cap_seconds_omits_field(self, _gateway_cron_tmpdir):
+        """Omitted on add → cap absent from the persisted record."""
+        resp = server.dispatch(
+            {
+                "id": "add-2",
+                "method": "cron.manage",
+                "params": {
+                    "action": "add",
+                    "name": "no-cap",
+                    "schedule": "every 1h",
+                    "prompt": "hi",
+                },
+            }
+        )
+        assert "error" not in resp, resp
+        assert resp["result"]["success"] is True
+        assert "runtime_cap_seconds" not in resp["result"]["job"]
+
+    def test_add_bubbles_validation_error_from_tool(self, _gateway_cron_tmpdir):
+        """Tool-layer rejection surfaces as success=false in the RPC result.
+
+        Previously there was no way to test this because runtime_cap_seconds
+        had no validation; this assertion locks in the contract that the
+        gateway does NOT swallow the error and does NOT translate it into a
+        JSON-RPC error envelope (the latter would tell the iOS client the
+        method itself failed when in fact it's user input that's wrong).
+        """
+        resp = server.dispatch(
+            {
+                "id": "add-bad",
+                "method": "cron.manage",
+                "params": {
+                    "action": "add",
+                    "name": "bad-cap",
+                    "schedule": "every 1h",
+                    "prompt": "hi",
+                    "runtime_cap_seconds": -7,
+                },
+            }
+        )
+        assert "error" not in resp, resp
+        assert resp["result"]["success"] is False
+        assert "positive" in resp["result"]["error"]
+
+    def test_update_action_replaces_runtime_cap_seconds(self, _gateway_cron_tmpdir):
+        """New ``update`` action on the gateway round-trips the cap."""
+        add = server.dispatch(
+            {
+                "id": "upd-add",
+                "method": "cron.manage",
+                "params": {
+                    "action": "add",
+                    "name": "upd-cap",
+                    "schedule": "every 1h",
+                    "prompt": "hi",
+                    "runtime_cap_seconds": 120,
+                },
+            }
+        )
+        assert "error" not in add, add
+        job_id = add["result"]["job_id"]
+
+        upd = server.dispatch(
+            {
+                "id": "upd-1",
+                "method": "cron.manage",
+                "params": {
+                    "action": "update",
+                    "name": job_id,
+                    "runtime_cap_seconds": 900,
+                    "prompt": "new prompt",
+                },
+            }
+        )
+        assert "error" not in upd, upd
+        assert upd["result"]["success"] is True
+        assert upd["result"]["job"]["runtime_cap_seconds"] == 900
+        # The other field should also have been applied — confirms the
+        # update payload isn't being narrowed to just the cap.
+        assert "new prompt" in upd["result"]["job"]["prompt_preview"]
+
+    def test_update_with_zero_clears_cap_via_gateway(self, _gateway_cron_tmpdir):
+        """``runtime_cap_seconds=0`` on update through the gateway clears it."""
+        add = server.dispatch(
+            {
+                "id": "clr-add",
+                "method": "cron.manage",
+                "params": {
+                    "action": "add",
+                    "name": "clr-cap",
+                    "schedule": "every 1h",
+                    "prompt": "hi",
+                    "runtime_cap_seconds": 60,
+                },
+            }
+        )
+        job_id = add["result"]["job_id"]
+
+        upd = server.dispatch(
+            {
+                "id": "clr-upd",
+                "method": "cron.manage",
+                "params": {
+                    "action": "update",
+                    "name": job_id,
+                    "runtime_cap_seconds": 0,
+                },
+            }
+        )
+        assert upd["result"]["success"] is True
+        assert "runtime_cap_seconds" not in upd["result"]["job"]
+
+    def test_list_round_trips_runtime_cap_seconds(self, _gateway_cron_tmpdir):
+        """``cron.manage`` list exposes the cap — UI clients' read path."""
+        server.dispatch(
+            {
+                "id": "list-add",
+                "method": "cron.manage",
+                "params": {
+                    "action": "add",
+                    "name": "list-cap",
+                    "schedule": "every 1h",
+                    "prompt": "hi",
+                    "runtime_cap_seconds": 240,
+                },
+            }
+        )
+        lst = server.dispatch(
+            {"id": "list-1", "method": "cron.manage", "params": {"action": "list"}}
+        )
+        assert "error" not in lst, lst
+        jobs = lst["result"]["jobs"]
+        assert len(jobs) == 1
+        assert jobs[0]["runtime_cap_seconds"] == 240
+
+    def test_unknown_cron_action_still_4016(self, _gateway_cron_tmpdir):
+        """Adding ``update`` must NOT have stolen the unknown-action path."""
+        resp = server.dispatch(
+            {
+                "id": "unk",
+                "method": "cron.manage",
+                "params": {"action": "totally-bogus"},
+            }
+        )
+        assert resp.get("error", {}).get("code") == 4016
+

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -455,6 +455,227 @@ class TestUnifiedCronjobTool:
 
 
 # =========================================================================
+# runtime_cap_seconds — per-job wall-clock cap
+# =========================================================================
+#
+# These tests piggy-back on the TestUnifiedCronjobTool fixture above —
+# new class so the assertions stay grouped, but the same _setup_cron_dir
+# autouse fixture isolates state per test.
+
+
+class TestRuntimeCapSeconds:
+    """Tool boundary for ``runtime_cap_seconds``: accept, persist, reject."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+
+    def test_create_persists_valid_cap(self):
+        """A sensible positive int is accepted, stored, and round-trips through list."""
+        from cron.jobs import get_job
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check",
+                schedule="every 1h",
+                runtime_cap_seconds=300,
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["runtime_cap_seconds"] == 300
+
+        stored = get_job(created["job_id"])
+        assert stored["runtime_cap_seconds"] == 300
+
+        # _format_job exposes it on list output too (so the gateway can
+        # serve it back to UI clients for display).
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["runtime_cap_seconds"] == 300
+
+    def test_create_without_cap_omits_field_on_output(self):
+        """Omitting the cap leaves the field out of list output (NULL = no cap)."""
+        created = json.loads(
+            cronjob(action="create", prompt="Check", schedule="every 1h")
+        )
+        assert created["success"] is True
+        # The job_format hides None values to keep list output compact.
+        assert "runtime_cap_seconds" not in created["job"]
+        listing = json.loads(cronjob(action="list"))
+        assert "runtime_cap_seconds" not in listing["jobs"][0]
+
+    def test_create_rejects_negative(self):
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="x",
+                schedule="every 1h",
+                runtime_cap_seconds=-1,
+            )
+        )
+        assert result["success"] is False
+        assert "positive" in result["error"]
+
+    def test_create_rejects_zero(self):
+        # 0 is a clear-on-update sentinel, but on create it makes no sense
+        # (storing a 0s cap that would fire instantly). The validator says
+        # "omit the field entirely" — assert that guidance is in the error.
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="x",
+                schedule="every 1h",
+                runtime_cap_seconds=0,
+            )
+        )
+        assert result["success"] is False
+        assert "positive" in result["error"]
+        assert "Omit" in result["error"]
+
+    def test_create_rejects_float(self):
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="x",
+                schedule="every 1h",
+                runtime_cap_seconds=3.5,
+            )
+        )
+        assert result["success"] is False
+        assert "integer" in result["error"]
+
+    def test_create_rejects_bool(self):
+        # bool is a subclass of int — without an explicit guard, True would
+        # silently become a 1s cap. Pin the rejection.
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="x",
+                schedule="every 1h",
+                runtime_cap_seconds=True,
+            )
+        )
+        assert result["success"] is False
+        assert "boolean" in result["error"]
+
+    def test_create_rejects_above_ceiling(self):
+        # 24h + 1 second.
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="x",
+                schedule="every 1h",
+                runtime_cap_seconds=86401,
+            )
+        )
+        assert result["success"] is False
+        assert "ceiling" in result["error"] or "86400" in result["error"]
+
+    def test_create_accepts_exact_ceiling(self):
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="x",
+                schedule="every 1h",
+                runtime_cap_seconds=86400,
+            )
+        )
+        assert result["success"] is True
+        assert result["job"]["runtime_cap_seconds"] == 86400
+
+    def test_update_replaces_cap(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="x",
+                schedule="every 1h",
+                runtime_cap_seconds=120,
+            )
+        )
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                runtime_cap_seconds=900,
+            )
+        )
+        assert updated["success"] is True
+        assert updated["job"]["runtime_cap_seconds"] == 900
+
+    def test_update_with_zero_clears_existing_cap(self):
+        """Sentinel: ``runtime_cap_seconds=0`` on update means "clear the cap"."""
+        from cron.jobs import get_job
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="x",
+                schedule="every 1h",
+                runtime_cap_seconds=120,
+            )
+        )
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                runtime_cap_seconds=0,
+            )
+        )
+        assert updated["success"] is True
+        assert "runtime_cap_seconds" not in updated["job"]
+        # And the underlying store really did go to None — not, say, "0".
+        stored = get_job(created["job_id"])
+        assert stored.get("runtime_cap_seconds") is None
+
+    def test_update_rejects_negative(self):
+        created = json.loads(
+            cronjob(action="create", prompt="x", schedule="every 1h")
+        )
+        result = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                runtime_cap_seconds=-30,
+            )
+        )
+        assert result["success"] is False
+        assert "positive" in result["error"]
+
+    def test_update_rejects_above_ceiling(self):
+        created = json.loads(
+            cronjob(action="create", prompt="x", schedule="every 1h")
+        )
+        result = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                runtime_cap_seconds=99999999,
+            )
+        )
+        assert result["success"] is False
+
+    def test_storage_normalizer_clamps_oversize_for_direct_callers(self):
+        """Direct ``create_job`` callers (skipping the tool) get clamped, not crashed.
+
+        The tool boundary rejects above-ceiling values, but kanban swarm helpers
+        and hand-written scripts reach ``create_job`` directly. The defensive
+        normalizer there clamps oversize values to the 24h ceiling so jobs.json
+        is always sane.
+        """
+        from cron.jobs import create_job, get_job
+
+        job = create_job(
+            prompt="direct",
+            schedule="every 1h",
+            runtime_cap_seconds=10_000_000,
+        )
+        stored = get_job(job["id"])
+        assert stored["runtime_cap_seconds"] == 86400
+
+
+# =========================================================================
 # Per-job model/provider override resolution
 # =========================================================================
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -21,28 +21,16 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cron.jobs import (
     AmbiguousJobReference,
-    claim_job_for_fire,
     create_job,
-    get_job,
     list_jobs,
-    mark_job_run,
     parse_schedule,
     pause_job,
     remove_job,
     resolve_job_ref,
     resume_job,
+    trigger_job,
     update_job,
 )
-
-
-def _notify_provider_jobs_changed_safe() -> None:
-    """Tell the active cron scheduler provider the job set changed (no-op for
-    the built-in). Best-effort — never lets a provider error break the tool."""
-    try:
-        from cron.scheduler import _notify_provider_jobs_changed
-        _notify_provider_jobs_changed()
-    except Exception:
-        pass
 
 
 # ---------------------------------------------------------------------------
@@ -377,6 +365,49 @@ def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash:
     return text or None
 
 
+# Tool-side validation for runtime_cap_seconds. The storage layer
+# (cron/jobs.py) also normalizes the value for direct Python callers, but the
+# tool boundary should reject obviously bad input with a clear error message
+# instead of silently clamping it — that's what a user-facing tool owes its
+# caller. The 24h ceiling matches _RUNTIME_CAP_SECONDS_CEILING in cron.jobs.
+_RUNTIME_CAP_SECONDS_TOOL_CEILING = 24 * 60 * 60
+
+
+def _validate_runtime_cap_seconds(value: Any) -> Optional[str]:
+    """Return an error message if ``value`` is unsuitable, else ``None``.
+
+    ``None`` / missing is the "no cap" sentinel and always passes through.
+    """
+    if value is None:
+        return None
+    # bool is a subclass of int — guard against `runtime_cap_seconds=True`
+    # being silently accepted as 1 second.
+    if isinstance(value, bool):
+        return "runtime_cap_seconds must be a positive integer (got boolean)."
+    if not isinstance(value, int):
+        # Floats and numeric strings are rejected explicitly: cron ticks
+        # measure seconds at integer precision and accepting 5.5 / "5"
+        # invites confusion about whether 0.5 means "fractional second"
+        # or "rounded up to 1". Force the caller to commit to an int.
+        return (
+            f"runtime_cap_seconds must be an integer number of seconds "
+            f"(got {type(value).__name__}: {value!r})."
+        )
+    if value <= 0:
+        return (
+            f"runtime_cap_seconds must be positive (got {value}). "
+            "Omit the field entirely to disable the wall-clock cap."
+        )
+    if value > _RUNTIME_CAP_SECONDS_TOOL_CEILING:
+        return (
+            f"runtime_cap_seconds exceeds the {_RUNTIME_CAP_SECONDS_TOOL_CEILING}s "
+            f"(24h) absolute ceiling (got {value}). For jobs that genuinely need "
+            "to run longer than a day, omit the cap and rely on the inactivity "
+            "limit (HERMES_CRON_TIMEOUT) instead."
+        )
+    return None
+
+
 def _normalize_deliver_param(value: Any) -> Optional[str]:
     """Normalize a user-supplied ``deliver`` value to the canonical string form.
 
@@ -471,52 +502,13 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    # runtime_cap_seconds is always exposed when set (UI clients need it for the
+    # iOS Cron-pillar field). NULL/missing falls through — same shape as the
+    # other optional fields above. We don't suppress 0 because the storage
+    # layer already normalises 0/negative back to None.
+    if job.get("runtime_cap_seconds") is not None:
+        result["runtime_cap_seconds"] = job["runtime_cap_seconds"]
     return result
-
-
-def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
-    """Execute a cron job immediately, outside the scheduler tick.
-
-    Atomically claims the job first via ``claim_job_for_fire`` — the same
-    at-most-once CAS the scheduler/external-provider fire path uses — so a
-    concurrently-running gateway ticker cannot also fire it (the claim both
-    blocks a duplicate fire and advances ``next_run_at`` for recurring jobs).
-    If the claim is lost (another fire is in flight), this is a no-op.
-
-    The actual firing is delegated to ``run_one_job`` — the single shared
-    execute→save→deliver→mark body the ticker and external providers use — so
-    failure delivery, ``[SILENT]`` handling, and live-adapter delivery stay
-    identical across paths and can't drift.
-
-    Returns {"claimed": bool, "success": bool, "error": str|None}.
-    """
-    job_id = job["id"]
-    try:
-        from cron.scheduler import run_one_job
-
-        # At-most-once claim: bail without running if a tick/other fire owns it.
-        if not claim_job_for_fire(job_id):
-            return {"claimed": False, "success": False,
-                    "error": "Job is already being fired by the scheduler; not run again."}
-
-        # run_one_job records last_run_at/last_status via mark_job_run (which
-        # also clears the fire claim) and returns True iff it processed the job.
-        processed = run_one_job(job)
-        refreshed = get_job(job_id) or {}
-        ok = refreshed.get("last_status") == "ok"
-        return {
-            "claimed": True,
-            "success": bool(processed and ok),
-            "error": refreshed.get("last_error"),
-        }
-
-    except Exception as e:
-        logger.error("Failed to execute cron job %s immediately: %s", job_id, e)
-        try:
-            mark_job_run(job_id, False, str(e))
-        except Exception:
-            pass
-        return {"claimed": True, "success": False, "error": str(e)}
 
 
 def cronjob(
@@ -539,6 +531,7 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    runtime_cap_seconds: Optional[int] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -589,6 +582,12 @@ def cronjob(
                             success=False,
                         )
 
+            # Validate runtime_cap_seconds (positive int, ≤24h) before storage.
+            # NULL/missing = no cap, which is the documented default.
+            _cap_error = _validate_runtime_cap_seconds(runtime_cap_seconds)
+            if _cap_error:
+                return tool_error(_cap_error, success=False)
+
             job = create_job(
                 prompt=prompt or "",
                 schedule=schedule,
@@ -605,8 +604,8 @@ def cronjob(
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
+                runtime_cap_seconds=runtime_cap_seconds,
             )
-            _notify_provider_jobs_changed_safe()
             return json.dumps(
                 {
                     "success": True,
@@ -662,7 +661,6 @@ def cronjob(
             removed = remove_job(job_id)
             if not removed:
                 return tool_error(f"Failed to remove job '{job_id}'", success=False)
-            _notify_provider_jobs_changed_safe()
             return json.dumps(
                 {
                     "success": True,
@@ -678,32 +676,15 @@ def cronjob(
 
         if normalized == "pause":
             updated = pause_job(job_id, reason=reason)
-            _notify_provider_jobs_changed_safe()
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized == "resume":
             updated = resume_job(job_id)
-            _notify_provider_jobs_changed_safe()
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized in {"run", "run_now", "trigger"}:
-            # Execute the job immediately rather than only scheduling it for the
-            # next scheduler tick — a manual `run` should actually run, even when
-            # no gateway/ticker is active (the #41037 case). The claim inside
-            # _execute_job_now advances next_run_at and blocks a concurrent tick
-            # from double-firing.
-            exec_result = _execute_job_now(job)
-            # Re-read so the response reflects the post-run last_run_at/last_status.
-            result = _format_job(get_job(job_id) or {"id": job_id})
-            result["executed"] = exec_result.get("claimed", False)
-            result["execution_success"] = exec_result.get("success", False)
-            if not exec_result.get("claimed", False):
-                result["execution_skipped"] = (
-                    "Already being fired by the scheduler; not run again."
-                )
-            elif exec_result.get("error"):
-                result["execution_error"] = exec_result["error"]
-            return json.dumps({"success": True, "job": result}, indent=2)
+            updated = trigger_job(job_id)
+            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized == "update":
             updates: Dict[str, Any] = {}
@@ -771,6 +752,18 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if runtime_cap_seconds is not None:
+                # Sentinel: ``runtime_cap_seconds=0`` clears the cap (mirrors
+                # how empty string clears string fields like workdir/script).
+                # Anything else flows through the same validator the create
+                # branch uses, with one wrinkle: 0 is "clear", not "reject".
+                if runtime_cap_seconds == 0:
+                    updates["runtime_cap_seconds"] = None
+                else:
+                    _cap_error = _validate_runtime_cap_seconds(runtime_cap_seconds)
+                    if _cap_error:
+                        return tool_error(_cap_error, success=False)
+                    updates["runtime_cap_seconds"] = runtime_cap_seconds
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -787,7 +780,6 @@ def cronjob(
             if not updates:
                 return tool_error("No updates provided.", success=False)
             updated = update_job(job_id, updates)
-            _notify_provider_jobs_changed_safe()
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         return tool_error(f"Unknown cron action '{action}'", success=False)
@@ -911,6 +903,21 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
+            "runtime_cap_seconds": {
+                "type": "integer",
+                "description": (
+                    "Optional wall-clock cap on a single tick of this job, in "
+                    "whole seconds. When omitted or null, the per-job cap is "
+                    "disabled and only the process-wide inactivity limit "
+                    "(HERMES_CRON_TIMEOUT, default 600s, KILLS IDLE jobs) "
+                    "applies. When a positive integer (1..86400), the "
+                    "scheduler interrupts and SIGTERMs the agent after that "
+                    "many seconds of wall time and records the run as a "
+                    "TimeoutError. Mirrors kanban's max_runtime_seconds. "
+                    "On update, pass 0 to clear an existing cap; any other "
+                    "positive int replaces it."
+                ),
+            },
         },
         "required": ["action"]
     }
@@ -966,6 +973,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        runtime_cap_seconds=args.get("runtime_cap_seconds"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10813,17 +10813,47 @@ def _(rid, params: dict) -> dict:
         if action == "list":
             return _ok(rid, json.loads(cronjob(action="list")))
         if action == "add":
-            return _ok(
-                rid,
-                json.loads(
-                    cronjob(
-                        action="create",
-                        name=jid,
-                        schedule=params.get("schedule", ""),
-                        prompt=params.get("prompt", ""),
-                    )
-                ),
-            )
+            # Forward the optional runtime_cap_seconds field when present.
+            # The tool itself validates (positive int, ≤24h); we just pipe
+            # through so a stale/malicious client can't bypass that gate.
+            _add_kwargs = {
+                "action": "create",
+                "name": jid,
+                "schedule": params.get("schedule", ""),
+                "prompt": params.get("prompt", ""),
+            }
+            if "runtime_cap_seconds" in params:
+                _add_kwargs["runtime_cap_seconds"] = params.get("runtime_cap_seconds")
+            return _ok(rid, json.loads(cronjob(**_add_kwargs)))
+        if action == "update":
+            # New action: edit the safely-mutable fields the underlying tool
+            # already supports. The tool's
+            # update branch only applies fields explicitly supplied — passing
+            # the empty/sentinel value for any field is meaningful (e.g.
+            # ``runtime_cap_seconds=0`` clears the cap), so we forward exactly
+            # the keys the caller sent, not a None-stripped subset.
+            _update_kwargs: dict = {"action": "update", "job_id": jid}
+            for _field in (
+                "prompt",
+                "schedule",
+                "name",
+                "deliver",
+                "skills",
+                "skill",
+                "model",
+                "provider",
+                "base_url",
+                "script",
+                "context_from",
+                "enabled_toolsets",
+                "workdir",
+                "no_agent",
+                "repeat",
+                "runtime_cap_seconds",
+            ):
+                if _field in params:
+                    _update_kwargs[_field] = params.get(_field)
+            return _ok(rid, json.loads(cronjob(**_update_kwargs)))
         if action in {"remove", "pause", "resume"}:
             return _ok(rid, json.loads(cronjob(action=action, job_id=jid)))
         return _err(rid, 4016, f"unknown cron action: {action}")

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -102,74 +102,9 @@ tick()
 
 ### Gateway Integration
 
-In gateway mode, the cron **trigger** (the part that decides *when* a due job
-fires — "Axis B") is selected through a pluggable `CronScheduler` provider. The
-gateway calls `resolve_cron_scheduler()` (`cron/scheduler_provider.py`) and runs
-the resolved provider's `start()` in a dedicated background thread, alongside a
-separate gateway-housekeeping thread.
-
-The active provider is chosen by the `cron.provider` config key:
-
-- **empty (default)** → the built-in `InProcessCronScheduler`, which runs the
-  historical in-process loop calling `scheduler.tick()` every 60 seconds. This
-  is byte-identical to the pre-provider behavior.
-- **a named provider** (e.g. `chronos`, a managed-cron provider for
-  scale-to-zero deployments) → discovered from `plugins/cron/<name>/` or
-  `$HERMES_HOME/plugins/<name>/`.
-
-If a named provider is missing, fails to load, or reports `is_available() ==
-False`, the resolver falls back to the built-in with a warning — **cron is
-never left without a trigger.** The built-in provider lives in core
-(`cron/scheduler_provider.py`), not in `plugins/`, so the fallback can't be
-accidentally removed.
-
-What "firing" *means* (job execution + delivery) is unchanged and shared by all
-providers — it stays in `scheduler.run_job()` / `scheduler._deliver_result()`.
-A provider only controls the trigger, never execution.
+In gateway mode, the scheduler runs in a dedicated background thread (`_start_cron_ticker` in `gateway/run.py`) that calls `scheduler.tick()` every 60 seconds alongside message handling.
 
 In CLI mode, cron jobs only fire when `hermes cron` commands are run or during active CLI sessions.
-
-### Managed cron (Chronos) for scale-to-zero
-
-Hosted gateways can run the **Chronos** provider (`cron.provider: chronos`)
-instead of the built-in ticker. Chronos lets an idle gateway **scale to zero**
-and still fire cron jobs: rather than a 60-second in-process loop (which would
-keep the process awake), it asks Nous infrastructure to arm exactly **one
-managed one-shot per job at that job's real next-fire time**. At fire time Nous
-calls the gateway back over an authenticated webhook (`POST /api/cron/fire`);
-the gateway runs the job through the same `run_one_job` path as the built-in,
-then re-arms the next one-shot. Between fires the process can be fully stopped —
-it wakes only on a genuine fire, never on a periodic timer.
-
-The flow (the managed scheduler is provided by Nous; the agent holds no
-scheduler credentials):
-
-```
-create/update a cron job
-  → Chronos asks Nous to arm a one-shot at the job's next_run_at
-      (authenticated with the agent's existing Nous token)
-  → at fire time Nous calls the gateway: POST {callback_url}/api/cron/fire
-      (authenticated with a short-lived, purpose-scoped Nous-minted JWT)
-  → the gateway verifies the token, claims the job (store compare-and-set so
-    multi-replica deployments fire at-most-once), runs it, and re-arms the next
-    one-shot
-```
-
-Config (all non-secret; on hosted agents Nous sets these at provision time):
-
-| key | meaning |
-|---|---|
-| `cron.provider` | `chronos` to activate (empty = built-in ticker) |
-| `cron.chronos.portal_url` | Nous base URL (arming + the fire-token issuer) |
-| `cron.chronos.callback_url` | the gateway's own public base URL for inbound fires |
-| `cron.chronos.expected_audience` | this agent's fire-token audience |
-| `cron.chronos.nas_jwks_url` | key set for verifying the inbound fire token |
-
-If Chronos is misconfigured or the agent isn't logged into Nous,
-`resolve_cron_scheduler()` falls back to the built-in ticker (logged warning) —
-cron never loses its trigger. Recurring jobs re-arm after each fire; `repeat`-N
-jobs stop cleanly when the count is exhausted (no orphaned one-shot). The full
-agent↔Nous wire contract lives in `docs/chronos-managed-cron-contract.md`.
 
 ### Fresh Session Isolation
 
@@ -221,6 +156,10 @@ The script timeout defaults to 120 seconds. `_get_script_timeout()` resolves the
 - **Credential pool** — loads via `load_pool(provider)` from `agent.credential_pool` using the resolved runtime provider name. Only passed when the pool has credentials (`pool.has_credentials()`). Enables same-provider key rotation on 429/rate-limit errors.
 
 This mirrors the gateway's behavior — without it, cron agents would fail on rate limits without attempting recovery.
+
+### Per-job runtime cap (`runtime_cap_seconds`)
+
+Each cron job can carry an optional `runtime_cap_seconds` integer field. When set to a positive int (≤86400 = 24h), `run_job()` enforces a wall-clock cap on a single tick alongside the inactivity poll: after roughly that many seconds, the scheduler calls `agent.interrupt(...)` for a graceful stop and then SIGTERMs the worker (via `ThreadPoolExecutor.shutdown(cancel_futures=True)`), recording the run as a `TimeoutError("cron job '<name>' exceeded runtime_cap_seconds=<N>")`. When `None` / unset (the default), only the process-wide inactivity limit (`HERMES_CRON_TIMEOUT`, default 600s) applies. Mirrors kanban's `max_runtime_seconds` semantics. Exposed via the `cronjob` tool (`create`/`update`) and `cron.manage` RPC (`add`/`update`); listed in `_format_job` output so consumers (gateway, iOS) can read it back.
 
 ## Delivery Model
 


### PR DESCRIPTION
## Summary

Adds per-job `runtime_cap_seconds` to cron — a wall-clock cap that runs in parallel with the existing inactivity-based `HERMES_CRON_TIMEOUT`. Mirrors the semantics of kanban tasks' `max_runtime_seconds`.

## Why

Today the only agent-side limit on a cron job is `HERMES_CRON_TIMEOUT` — process-global, inactivity-based (kills jobs idle for N seconds), defaults to 600. There is no per-job wall-clock cap. A runaway/looping agent that emits any activity inside the inactivity window runs forever. Gateway clients (TUI / desktop / mobile) have no field they can set to bound a single job; the persisted job record has no slot to hold one either.

This wires `runtime_cap_seconds` end-to-end so a job can carry an explicit wall-clock budget, the scheduler enforces it, and the gateway can read it back for UI display.

## What changes

**Tool boundary** (`tools/cronjob_tools.py`)
- `cronjob()` accepts `runtime_cap_seconds: Optional[int] = None`.
- Two-layer validation: the tool boundary rejects bad input with friendly errors; `cron/jobs.py` normalises for direct Python callers that bypass the tool. The tool *rejects* values over the 24h ceiling; the storage layer *clamps*. Both layers reject `bool` (`isinstance(True, int) is True` in Python, so without the guard `runtime_cap_seconds=True` would silently become a 1-second cap).
- `update` with `0` clears the cap (mirrors how empty-string clears `workdir`/`script` on the existing update branch); `create` with `0` is rejected — a 0s cap would fire instantly and is almost certainly a mistake.
- `_format_job` exposes the cap so `cron.manage` `list` echoes it back to UI clients.

**Gateway** (`tui_gateway/server.py`)
- `cron.manage` `action="add"` forwards `runtime_cap_seconds` when present.
- New `cron.manage` `action="update"` action carries the cap plus the other safely-mutable fields the underlying tool already supports (`prompt`, `schedule`, `deliver`, `skills`, …). This closes the gateway gap separately from the cap-field gap (`update` was previously missing from `cron.manage` entirely).

**Scheduler** (`cron/scheduler.py`)
- Runs the cap loop in parallel with the existing inactivity poll.
- Overrun path: `agent.interrupt()` for graceful shutdown, then `ThreadPoolExecutor.shutdown(wait=False, cancel_futures=True)` — cron jobs run in a thread pool, not a subprocess, so this is the thread equivalent of `SIGTERM`. The failure record is a `TimeoutError` carrying the cap value and elapsed time; the existing gateway failure formatter at L1898–L1914 renders it unchanged.
- Poll cadence scales with the cap: `max(0.2, min(5.0, cap/4))` so a 5s cap actually fires near 5s instead of waiting for the next 5s tick.
- Empty/None = no per-job cap (falls through to inactivity-only behaviour). No implicit default — existing jobs are unaffected.

## Tests

- `tests/cron/test_runtime_cap_seconds.py` (new, 223 lines): integration coverage of the wall-clock loop, defensive coercion, and the error shape.
- `tests/tools/test_cronjob_tools.py`: 13 new unit tests covering the validation matrix (negative, zero, over-ceiling, bool, non-int) and persistence on `create` and `update`.
- `tests/test_tui_gateway_server.py`: 7 new gateway tests covering `cron.manage` `add`/`update`/`list` round-trip and the error envelope.

Suite results from the dev machine:
```
tests/cron/                                15 passed
tests/tools/test_cronjob_tools.py          75 passed  (13 new + storage)
tests/test_tui_gateway_server.py          296 passed, 1 deselected
                                          ─────────
                                          377 passed
```

The one deselected test (`test_browser_manage_connect_default_local_reports_launch_hint`) was verified to fail identically on clean `origin/main` on the same host — pre-existing flake that depends on Chromium not being installed, unrelated to this change.

## Out of scope

- No *default* runtime cap — leaving NULL = no cap so existing jobs don't suddenly start dying.
- `HERMES_CRON_TIMEOUT` env var name preserved (different concept — kills idle agents, not wall-clock).

## Docs

One section added to `website/docs/developer-guide/cron-internals.md` documenting field semantics, default behaviour (no cap unless set), and overrun semantics.
