### PR TITLE
feat(teams): render slash-command confirmation (/new, /reset, /undo) as Adaptive Card buttons

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1005,6 +1005,33 @@ class TeamsAdapter(BasePlatformAdapter):
                 body=AdaptiveCardActionMessageResponse(value="Unknown action."),
             )
 
+        # Slash-command confirmation buttons (/new, /reset, /undo, /reload-mcp)
+        # route through tools.slash_confirm, NOT the exec-approval path. They
+        # govern the clicker's own session lifecycle, and the base-class text
+        # fallback (reply /approve|/always|/cancel) is itself ungated — so this
+        # branch runs before the TEAMS_ALLOWED_USERS gate that protects the
+        # dangerous-command approval buttons below.
+        slash_choice = {
+            "slash_confirm_once": "once",
+            "slash_confirm_always": "always",
+            "slash_confirm_cancel": "cancel",
+        }.get(hermes_action)
+        if slash_choice is not None:
+            from tools import slash_confirm as _slash_confirm
+
+            confirm_id = data.get("confirm_id", "")
+            result_text = await _slash_confirm.resolve(session_key, confirm_id, slash_choice)
+            if result_text is None:
+                result_text = "⚠️ Confirmation already resolved or expired."
+            return InvokeResponse(
+                status=200,
+                body=AdaptiveCardActionCardResponse(
+                    value=AdaptiveCard()
+                    .with_version("1.4")
+                    .with_body([TextBlock(text=result_text, wrap=True)])
+                ),
+            )
+
         # Only authorized users may click approval buttons.
         # Default-deny: require either TEAMS_ALLOWED_USERS or an explicit
         # TEAMS_ALLOW_ALL_USERS=true opt-in. Without one of these set, the
@@ -1143,6 +1170,67 @@ class TeamsAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             logger.error("[teams] send_exec_approval failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e), retryable=True)
+
+    async def send_slash_confirm(
+        self,
+        chat_id: str,
+        title: str,
+        message: str,
+        session_key: str,
+        confirm_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a three-button slash-command confirmation as an Adaptive Card.
+
+        Overrides the base text fallback so /new, /reset, /undo and /reload-mcp
+        get native Approve Once / Always Approve / Cancel buttons on Teams, on
+        par with Telegram/Discord/Slack. Button clicks are routed back through
+        ``_on_card_action`` to ``tools.slash_confirm.resolve()``.
+
+        ``session_key`` and ``confirm_id`` ride directly in the button data;
+        Action.Execute payloads have no tight size limit (unlike Telegram's
+        64-byte callback_data), so no server-side state map is needed.
+        """
+        if not self._app:
+            return SendResult(success=False, error="Teams app not initialized")
+
+        btn_data_base = {"session_key": session_key, "confirm_id": confirm_id}
+
+        card = (
+            AdaptiveCard()
+            .with_version("1.4")
+            .with_body([
+                TextBlock(text=title, wrap=True, weight="Bolder"),
+                TextBlock(text=message, wrap=True),
+            ])
+            .with_actions([
+                ExecuteAction(
+                    title="Approve Once",
+                    verb="hermes_slash_confirm",
+                    data={**btn_data_base, "hermes_action": "slash_confirm_once"},
+                    style="positive",
+                ),
+                ExecuteAction(
+                    title="Always Approve",
+                    verb="hermes_slash_confirm",
+                    data={**btn_data_base, "hermes_action": "slash_confirm_always"},
+                ),
+                ExecuteAction(
+                    title="Cancel",
+                    verb="hermes_slash_confirm",
+                    data={**btn_data_base, "hermes_action": "slash_confirm_cancel"},
+                    style="destructive",
+                ),
+            ])
+        )
+
+        try:
+            result = await self._send_card(chat_id, card)
+            message_id = getattr(result, "id", None) if result else None
+            return SendResult(success=True, message_id=message_id)
+        except Exception as e:
+            logger.error("[teams] send_slash_confirm failed: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e), retryable=True)
 
     async def send(

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1022,13 +1022,36 @@ class TeamsAdapter(BasePlatformAdapter):
             confirm_id = data.get("confirm_id", "")
             result_text = await _slash_confirm.resolve(session_key, confirm_id, slash_choice)
             if result_text is None:
-                result_text = "⚠️ Confirmation already resolved or expired."
+                return InvokeResponse(
+                    status=200,
+                    body=AdaptiveCardActionCardResponse(
+                        value=AdaptiveCard()
+                        .with_version("1.4")
+                        .with_body([
+                            TextBlock(text="⚠️ Confirmation already resolved or expired.", wrap=True)
+                        ])
+                    ),
+                )
+            # Action.Execute card-refresh responses are unreliable on some Teams
+            # desktop clients (the in-place card update silently no-ops, so the
+            # clicker sees nothing), so deliver the outcome as a real
+            # conversation message too — that renders on every client. The
+            # refreshed card just collapses the buttons.
+            try:
+                await ctx.send(result_text)
+            except Exception as e:
+                logger.warning("[teams] slash-confirm follow-up message failed: %s", e)
+            status = {
+                "once": "✅ Approved (once)",
+                "always": "🔒 Always approved",
+                "cancel": "❌ Cancelled",
+            }.get(slash_choice, "Done")
             return InvokeResponse(
                 status=200,
                 body=AdaptiveCardActionCardResponse(
                     value=AdaptiveCard()
                     .with_version("1.4")
-                    .with_body([TextBlock(text=result_text, wrap=True)])
+                    .with_body([TextBlock(text=status, wrap=True, weight="Bolder")])
                 ),
             )
 

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -508,6 +508,7 @@ class TestTeamsSlashConfirm:
         action = SimpleNamespace(data=data)
         ctx = MagicMock()
         ctx.activity.value.action = action
+        ctx.send = AsyncMock()
         return ctx
 
     @pytest.mark.anyio
@@ -563,6 +564,9 @@ class TestTeamsSlashConfirm:
 
         await adapter._on_card_action(ctx)
         resolve_mock.assert_awaited_once_with("sess-1", "c1", "once")
+        # Outcome must also be posted as a real conversation message so it
+        # renders on Teams desktop clients that drop the card-refresh response.
+        ctx.send.assert_awaited_once_with("🔄 Started a new session.")
 
 
 def _make_summary_payload():

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -499,6 +499,72 @@ class TestTeamsSend:
         assert call_args[0][0] == "conv-id"
 
 
+# ---------------------------------------------------------------------------
+# Tests: Slash-command confirmation buttons (/new, /reset, /undo, /reload-mcp)
+# ---------------------------------------------------------------------------
+
+class TestTeamsSlashConfirm:
+    def _make_card_ctx(self, data):
+        action = SimpleNamespace(data=data)
+        ctx = MagicMock()
+        ctx.activity.value.action = action
+        return ctx
+
+    @pytest.mark.anyio
+    async def test_send_slash_confirm_returns_error_without_app(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = None
+        result = await adapter.send_slash_confirm(
+            "conv-id", "/new", "Confirm /new", "sess-1", "c1",
+        )
+        assert result.success is False
+        assert "not initialized" in result.error
+
+    @pytest.mark.anyio
+    async def test_send_slash_confirm_sends_card(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_result = MagicMock()
+        mock_result.id = "msg-9"
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(return_value=mock_result)
+        adapter._app = mock_app
+
+        result = await adapter.send_slash_confirm(
+            "conv-id", "/new", "Confirm /new", "sess-1", "c1",
+        )
+        assert result.success is True
+        assert result.message_id == "msg-9"
+        mock_app.send.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_card_action_routes_slash_confirm_to_resolve(self, monkeypatch):
+        import tools.slash_confirm as _slash_confirm
+
+        resolve_mock = AsyncMock(return_value="🔄 Started a new session.")
+        monkeypatch.setattr(_slash_confirm, "resolve", resolve_mock)
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        ctx = self._make_card_ctx({
+            "hermes_action": "slash_confirm_once",
+            "session_key": "sess-1",
+            "confirm_id": "c1",
+        })
+
+        # No TEAMS_ALLOWED_USERS set: slash-confirm must NOT be blocked by the
+        # exec-approval auth gate (it runs before that gate).
+        monkeypatch.delenv("TEAMS_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("TEAMS_ALLOW_ALL_USERS", raising=False)
+
+        await adapter._on_card_action(ctx)
+        resolve_mock.assert_awaited_once_with("sess-1", "c1", "once")
+
+
 def _make_summary_payload():
     return TeamsMeetingSummaryPayload(
         meeting_ref=TeamsMeetingRef(meeting_id="meeting-123"),


### PR DESCRIPTION
## What does this PR do?

The Teams adapter never overrode `send_slash_confirm`, so the gateway's three-option confirmation prompt for `/new`, `/reset`, `/undo` and `/reload-mcp` fell back to **plain text on Teams** — users saw the "⚠️ Confirm /new … Approve Once / Always Approve / Cancel" prompt but **no buttons**, and had to know to reply `/approve` / `/always` / `/cancel`.

This adds `TeamsAdapter.send_slash_confirm`, modeled on the adapter's existing `send_exec_approval`, so Teams renders native Adaptive Card buttons on par with Telegram/Discord/Slack. The base-class docstring (`gateway/platforms/base.py:2497`) already anticipates per-platform overrides; Teams was just never wired (it had cards for *tool* approvals but not slash-confirm).

## Related Issue

Fixes #50269

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/teams/adapter.py`
  - **`send_slash_confirm`** — builds an Adaptive Card with the gateway-supplied `title` + `message` and three `ExecuteAction` buttons (`hermes_slash_confirm` verb; `slash_confirm_once|always|cancel`). `session_key` + `confirm_id` ride directly in the button `data` (Action.Execute has no tight payload size limit, unlike Telegram's 64-byte callback_data — so no server-side state map is needed). A successful `SendResult` suppresses the gateway's text fallback.
  - **`_on_card_action`** — detects the `slash_confirm_*` action namespace and resolves via `tools.slash_confirm.resolve(session_key, confirm_id, choice)`, returning the handler's result text in the response card. This branch runs **before** the `TEAMS_ALLOWED_USERS` gate that protects dangerous-command approvals: slash-confirm governs the clicker's own session lifecycle, and the base-class text fallback is itself ungated, so gating it would regress UX.
- `tests/gateway/test_teams.py` — `TestTeamsSlashConfirm`: card send (with/without app) + `_on_card_action` routing to `resolve()`.

## How to Test

1. `pytest tests/gateway/test_teams.py -q` → 60 passed (3 new).
2. Live: run a gateway with the Teams adapter + default config (`approvals.destructive_slash_confirm: true`), send `/new` in a Teams DM → three buttons render; clicking "Approve Once" starts a fresh session, "Cancel" leaves the conversation unchanged.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(teams):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the adapter tests (`pytest tests/gateway/test_teams.py -q`) and they pass; ruff clean
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (DGX Spark, aarch64), hermes-agent v2026.6.5

### Documentation & Housekeeping

- [x] N/A — no new config keys; behavior follows the existing `approvals.destructive_slash_confirm` gate
- [x] N/A — no architecture/workflow change
- [x] Cross-platform: pure adapter logic, no platform-specific syscalls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cfa6nXahmpfFDVrUCN2qj
