### PR TITLE
fix(telegram): protect block math from rich-message hard-break injection

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -369,6 +369,34 @@ _RICH_PROTECTED_REGION_RE = re.compile(
     re.MULTILINE,
 )
 
+# A block-math span ($$...$$ with the delimiters each alone on their own line)
+# also renders natively in the rich path, so a hard break injected between the
+# rows of a multi-line aligned/cases/matrix environment is invalid LaTeX. This
+# is matched only *within prose* — i.e. outside the fenced-code/table regions
+# above — so a stray or inline ``$$`` can never pair across a protected region
+# (which would otherwise let a ``$$`` inside a code block close a span and let
+# the rest of the block receive hard breaks). The line-anchored delimiters also
+# keep inline/currency ``$$`` out: only canonical display-math blocks match.
+_RICH_BLOCK_MATH_RE = re.compile(
+    r'^[ \t]*\$\$[ \t]*\n[\s\S]*?\n[ \t]*\$\$[ \t]*$',
+    re.MULTILINE,
+)
+
+
+def _rich_hard_break_prose(prose: str) -> str:
+    """Inject Markdown hard breaks into a prose run, leaving block-math spans
+    ($$...$$ on their own lines) bare. Called only for prose between the
+    fenced-code/table protected regions, so block math is recognized outside
+    those regions and can never span into one."""
+    out: list[str] = []
+    pos = 0
+    for m in _RICH_BLOCK_MATH_RE.finditer(prose):
+        out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', prose[pos:m.start()]))
+        out.append(m.group(0))  # block math kept verbatim
+        pos = m.end()
+    out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', prose[pos:]))
+    return ''.join(out)
+
 
 def _rich_normalize_linebreaks(text: str) -> str:
     """Convert single ``\\n`` to Markdown hard breaks for the rich-message path.
@@ -379,25 +407,26 @@ def _rich_normalize_linebreaks(text: str) -> str:
     paragraph.  Adding two trailing spaces before each single newline
     forces a hard line break (``<br>``) in the rendered output.
 
-    Paragraph breaks (``\\n\\n``), fenced code blocks, and GFM pipe-table
-    blocks are left untouched: tables render natively in the rich path and a
-    hard break injected into a row separator would corrupt the table.
+    Paragraph breaks (``\\n\\n``), fenced code blocks, GFM pipe-table blocks,
+    and block-math spans (``$$...$$`` on their own lines) are left untouched:
+    all render natively in the rich path, so a hard break injected into a table
+    row separator or a multi-line display-math environment would corrupt it.
+    Fenced code and tables are protected first; block math is recognized only
+    in the prose between them so a stray ``$$`` cannot pair across a fence.
     """
     if not text or '\n' not in text:
         return text
 
     out: list[str] = []
-    # Split off protected regions (fenced code OR table blocks) and only inject
-    # hard breaks in the prose between them. Boundary newlines are handled by
-    # the original single-\n regex, which sees each prose run as a whole string.
+    # Split off the natively-rendered protected regions (fenced code OR table
+    # blocks) and hard-break only the prose between them; block-math protection
+    # is applied inside _rich_hard_break_prose, scoped to that prose.
     pos = 0
     for m in _RICH_PROTECTED_REGION_RE.finditer(text):
-        prose = text[pos:m.start()]
-        out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', prose))
+        out.append(_rich_hard_break_prose(text[pos:m.start()]))
         out.append(m.group(0))  # protected region kept verbatim
         pos = m.end()
-    tail = text[pos:]
-    out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', tail))
+    out.append(_rich_hard_break_prose(text[pos:]))
     return ''.join(out)
 
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -289,29 +289,7 @@ def _separate_chunk_indicator_from_fence(text: str) -> str:
 from gateway.platforms.helpers import (
     TABLE_SEPARATOR_RE as _TABLE_SEPARATOR_RE, compile_mention_patterns, convert_table_to_bullets as _wrap_markdown_tables)
 
-# Rich-message regions whose internal newlines must stay bare (Telegram renders them natively):
-# fenced code blocks OR GFM pipe-table blocks (header row, delimiter row, data rows).
-_RICH_PROTECTED_REGION_RE = re.compile(
-    r'(?:```[^\n]*\n[\s\S]*?```)'                       # fenced code block
-    r'|(?:^[^\n]*\|[^\n]*\n'                            # table header row (has a pipe)
-    r'[ \t]*\|?[ \t]*:?-+:?[ \t]*(?:\|[ \t]*:?-+:?[ \t]*)+\|?[ \t]*'  # delimiter
-    r'(?:\n[^\n]*\|[^\n]*)*)',                          # data rows (newline-led, trailing \n left for prose)
-    re.MULTILINE)
-
-
-def _rich_normalize_linebreaks(text: str) -> str:
-    """Convert lone ``\\n`` (a Markdown soft break) to hard breaks for sendRichMessage; ``\\n\\n``,
-    fenced code and pipe tables are left untouched."""
-    if not text or '\n' not in text:
-        return text
-    out: list[str] = []
-    pos = 0
-    for m in _RICH_PROTECTED_REGION_RE.finditer(text):
-        out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', text[pos:m.start()]))
-        out.append(m.group(0))  # protected region kept verbatim
-        pos = m.end()
-    out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', text[pos:]))
-    return ''.join(out)
+from plugins.platforms.telegram.adapter_rich import _rich_normalize_linebreaks
 
 
 # Internal safety bounds (not user knobs): no reconnect/teardown path may hang on a dead CLOSE-WAIT

--- a/plugins/platforms/telegram/adapter_rich.py
+++ b/plugins/platforms/telegram/adapter_rich.py
@@ -1,0 +1,28 @@
+"""Markdown newline normalization for Telegram rich-message payloads."""
+
+import re
+
+
+# Rich-message regions whose internal newlines must stay bare (Telegram renders them natively):
+# fenced code blocks OR GFM pipe-table blocks (header row, delimiter row, data rows).
+_RICH_PROTECTED_REGION_RE = re.compile(
+    r'(?:```[^\n]*\n[\s\S]*?```)'                       # fenced code block
+    r'|(?:^[^\n]*\|[^\n]*\n'                            # table header row (has a pipe)
+    r'[ \t]*\|?[ \t]*:?-+:?[ \t]*(?:\|[ \t]*:?-+:?[ \t]*)+\|?[ \t]*'  # delimiter
+    r'(?:\n[^\n]*\|[^\n]*)*)',                          # data rows (newline-led, trailing \n left for prose)
+    re.MULTILINE)
+
+
+def _rich_normalize_linebreaks(text: str) -> str:
+    """Convert lone ``\\n`` (a Markdown soft break) to hard breaks for sendRichMessage; ``\\n\\n``,
+    fenced code and pipe tables are left untouched."""
+    if not text or '\n' not in text:
+        return text
+    out: list[str] = []
+    pos = 0
+    for m in _RICH_PROTECTED_REGION_RE.finditer(text):
+        out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', text[pos:m.start()]))
+        out.append(m.group(0))  # protected region kept verbatim
+        pos = m.end()
+    out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', text[pos:]))
+    return ''.join(out)

--- a/plugins/platforms/telegram/adapter_rich.py
+++ b/plugins/platforms/telegram/adapter_rich.py
@@ -13,16 +13,45 @@ _RICH_PROTECTED_REGION_RE = re.compile(
     re.MULTILINE)
 
 
+# A block-math span ($$...$$ with the delimiters each alone on their own line)
+# also renders natively in the rich path, so a hard break injected between the
+# rows of a multi-line aligned/cases/matrix environment is invalid LaTeX. This
+# is matched only *within prose* — i.e. outside the fenced-code/table regions
+# above — so a stray or inline ``$$`` can never pair across a protected region
+# (which would otherwise let a ``$$`` inside a code block close a span and let
+# the rest of the block receive hard breaks). The line-anchored delimiters also
+# keep inline/currency ``$$`` out: only canonical display-math blocks match.
+_RICH_BLOCK_MATH_RE = re.compile(
+    r'^[ \t]*\$\$[ \t]*\n[\s\S]*?\n[ \t]*\$\$[ \t]*$',
+    re.MULTILINE,
+)
+
+
+def _rich_hard_break_prose(prose: str) -> str:
+    """Inject Markdown hard breaks into a prose run, leaving block-math spans
+    ($$...$$ on their own lines) bare. Called only for prose between the
+    fenced-code/table protected regions, so block math is recognized outside
+    those regions and can never span into one."""
+    out: list[str] = []
+    pos = 0
+    for m in _RICH_BLOCK_MATH_RE.finditer(prose):
+        out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', prose[pos:m.start()]))
+        out.append(m.group(0))  # block math kept verbatim
+        pos = m.end()
+    out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', prose[pos:]))
+    return ''.join(out)
+
+
 def _rich_normalize_linebreaks(text: str) -> str:
     """Convert lone ``\\n`` (a Markdown soft break) to hard breaks for sendRichMessage; ``\\n\\n``,
-    fenced code and pipe tables are left untouched."""
+    fenced code, pipe tables and canonical display math are left untouched."""
     if not text or '\n' not in text:
         return text
     out: list[str] = []
     pos = 0
     for m in _RICH_PROTECTED_REGION_RE.finditer(text):
-        out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', text[pos:m.start()]))
+        out.append(_rich_hard_break_prose(text[pos:m.start()]))
         out.append(m.group(0))  # protected region kept verbatim
         pos = m.end()
-    out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', text[pos:]))
+    out.append(_rich_hard_break_prose(text[pos:]))
     return ''.join(out)

--- a/tests/gateway/test_telegram_rich_newlines.py
+++ b/tests/gateway/test_telegram_rich_newlines.py
@@ -147,3 +147,58 @@ class TestRichMessageTableProtection:
         # header/delimiter/data-row newlines stay bare.
         assert "Intro line two  \n| H1 | H2 |" in md
         assert "| a | b |  \nOutro line" in md
+
+
+class TestRichMessageBlockMathProtection:
+    """Hard-break injection must not corrupt block math (rendered natively)."""
+
+    def test_block_math_interior_keeps_bare_newlines(self, adapter):
+        """Newlines inside a $$...$$ display-math span must stay bare — a
+        '  \\n' between the rows of an aligned/cases environment is invalid
+        LaTeX. Block math (`$$`) is one of the constructs that triggers the
+        rich path (_needs_rich_rendering), so it must be protected like the
+        natively-rendered fenced-code and table blocks."""
+        content = (
+            "Solve:\n"
+            "$$\n"
+            "\\begin{aligned}\n"
+            "a &= b \\\\\n"
+            "c &= d\n"
+            "\\end{aligned}\n"
+            "$$\n"
+            "Done"
+        )
+        md = adapter._rich_message_payload(content)["markdown"]
+        # The display-math block is preserved verbatim (no '  \n' injected).
+        assert (
+            "$$\n\\begin{aligned}\na &= b \\\\\nc &= d\n\\end{aligned}\n$$" in md
+        ), f"block math interior must stay bare, got {md!r}"
+        # Prose around the math still hard-breaks.
+        assert "Solve:  \n$$" in md
+        assert "$$  \nDone" in md
+
+    def test_single_line_block_math_unaffected(self, adapter):
+        """A single-line $$x$$ has no interior newline, so its rendering is
+        unchanged; surrounding prose still hard-breaks."""
+        content = "inline $$x = 1$$ here\nnext"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == "inline $$x = 1$$ here  \nnext"
+
+    def test_stray_dollars_before_code_block_do_not_corrupt_it(self, adapter):
+        """A stray/inline ``$$`` in prose must not pair with a ``$$`` inside a
+        later fenced code block: block math is recognized only outside the
+        protected fenced-code/table regions, so the code block stays verbatim
+        and only the prose around it hard-breaks."""
+        content = "Cost is $$5 today\n```\nx = $$y\nz = $$w\n```\nafter"
+        md = adapter._rich_message_payload(content)["markdown"]
+        # Code block (incl. its literal $$) is untouched.
+        assert "```\nx = $$y\nz = $$w\n```" in md
+        # The stray-$$ prose line before the fence still hard-breaks.
+        assert "Cost is $$5 today  \n```" in md
+
+    def test_currency_lines_hard_break_normally(self, adapter):
+        """Lines that merely contain ``$$`` (currency, not a lone block
+        delimiter) are not treated as block math; they hard-break like prose."""
+        content = "Price $$5\nPlus $$10\nmore"
+        md = adapter._rich_message_payload(content)["markdown"]
+        assert md == "Price $$5  \nPlus $$10  \nmore"

--- a/tests/gateway/test_telegram_rich_newlines.py
+++ b/tests/gateway/test_telegram_rich_newlines.py
@@ -76,3 +76,27 @@ class TestRichMessageTableProtection:
         assert "  \n" not in md
         assert md == content
 
+
+@pytest.mark.parametrize("block", [
+    "$$\n\\begin{aligned}\na &= b \\\\\nc &= d\n\\end{aligned}\n$$",
+    "  $$ \n\\begin{matrix}\n1 & 2 \\\\\n3 & 4\n\\end{matrix}\n\t$$",
+])
+def test_display_math_is_preserved_inside_normalized_prose(adapter, block):
+    content = f"Before\n{block}\nAfter"
+    md = adapter._rich_message_payload(content)["markdown"]
+    assert md == f"Before  \n{block}  \nAfter"
+
+
+@pytest.mark.parametrize("prose, protected", [
+    ("Cost is $$5 today", "```\nx = $$y\nz = $$w\n```"),
+    ("$$", "```\n$$\nx\ny\n```"),
+    ("$$", "| A | B |\n|---|---|\n| $$ | x |"),
+    ("inline $$x = 1$$ here", ""),
+    ("Price $$5\nPlus $$10", ""),
+])
+def test_math_delimiters_never_cross_protected_regions(adapter, prose, protected):
+    content = f"{prose}\n{protected}\nAfter" if protected else f"{prose}\nAfter"
+    expected_prose = prose.replace("\n", "  \n")
+    expected = (f"{expected_prose}  \n{protected}  \nAfter" if protected
+                else f"{expected_prose}  \nAfter")
+    assert adapter._rich_message_payload(content)["markdown"] == expected


### PR DESCRIPTION
Follow-up to merged #50196 (rich-message newline normalization).

## Problem
#50196's `_rich_normalize_linebreaks` injects Markdown hard breaks (`  \n`) into single newlines for the Bot API 10.1 `sendRichMessage` path, but exempts **natively-rendered** constructs — fenced code blocks and GFM pipe tables — because a hard break inside them corrupts the native render (its own PR body states this design principle).

**Block math (`$$...$$`) is the same class but was left unprotected.** It's one of exactly the constructs that triggers the rich path — `_needs_rich_rendering` returns `True` when `"$$" in content` (from #45995). So whenever a reply contains display math, every interior newline of a multi-line environment (`\begin{aligned}`, `cases`, `matrix`, …) gets `  \n` injected, producing invalid LaTeX — e.g. a `<br>` between the rows of an aligned block.

## Fix
Protect block math the same way code and tables are protected, but **staged** to avoid a cross-region hazard:
- `_RICH_PROTECTED_REGION_RE` (fenced code + tables) is matched **first**, unchanged.
- Block math is recognized **only within the prose between those regions**, via a separate line-anchored matcher `^[ \t]*\$\$[ \t]*\n[\s\S]*?\n[ \t]*\$\$[ \t]*$`, inside the new `_rich_hard_break_prose` helper.

Why staged: a naive `$$...$$` alternative added directly to the protected regex could let a stray/inline `$$` pair with a `$$` *inside* a later fenced code block (leftmost non-overlapping `finditer`), consuming the fence and letting the rest of the code block receive hard breaks — corrupting an already-protected construct. Recognizing block math only in prose makes that impossible. The line-anchored delimiters also exclude inline/currency `$$` (only canonical display-math blocks, with the `$$` each alone on a line, match). Single-line `$$x$$` has no interior newline, so it's unaffected.

## Tests
`TestRichMessageBlockMathProtection`: canonical multi-line `$$...$$` interior stays bare while surrounding prose hard-breaks (fails on pre-fix); single-line `$$x$$` unaffected; **a stray `$$` before a fenced block with `$$` inside it leaves the code block verbatim** (guards the staged-scan property); currency-style `$$` lines hard-break normally.

Known minor limitation (transparency): two standalone `$$` delimiter lines far apart in the *same prose run* could mis-pair, which only suppresses prose hard breaks between them (cosmetic) — it can never corrupt code/tables. Verified against current `main`; if already handled via a separate patch, feel free to close.
