### PR TITLE
fix(desktop): show statusbar item tooltips on hover

### DIFF
--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -2,6 +2,7 @@ import type { ComponentProps, ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { Tip } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
 // Shared chrome styling for interactive statusbar items (button / link / menu
@@ -97,93 +98,101 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
   if (item.variant === 'menu' && (item.menuContent || (item.menuItems && item.menuItems.length > 0))) {
     return (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} type="button">
-            {content}
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align={item.menuAlign ?? 'start'}
-          className={cn('w-56', item.menuContent && 'p-0', item.menuClassName)}
-          side="top"
-          sideOffset={8}
-        >
-          {item.menuContent
-            ? item.menuContent
-            : (item.menuItems ?? [])
-                .filter(menuItem => !menuItem.hidden)
-                .map(menuItem => (
-                  <DropdownMenuItem
-                    className={cn('gap-2 text-foreground focus:bg-accent [&_svg]:size-4', menuItem.className)}
-                    disabled={menuItem.disabled}
-                    key={menuItem.id}
-                    onSelect={() => {
-                      if (menuItem.to) {
-                        navigate(menuItem.to)
-                      }
+      <Tip label={item.title}>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} type="button">
+              {content}
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align={item.menuAlign ?? 'start'}
+            className={cn('w-56', item.menuContent && 'p-0', item.menuClassName)}
+            side="top"
+            sideOffset={8}
+          >
+            {item.menuContent
+              ? item.menuContent
+              : (item.menuItems ?? [])
+                  .filter(menuItem => !menuItem.hidden)
+                  .map(menuItem => (
+                    <DropdownMenuItem
+                      className={cn('gap-2 text-foreground focus:bg-accent [&_svg]:size-4', menuItem.className)}
+                      disabled={menuItem.disabled}
+                      key={menuItem.id}
+                      onSelect={() => {
+                        if (menuItem.to) {
+                          navigate(menuItem.to)
+                        }
 
-                      menuItem.onSelect?.()
-                    }}
-                  >
-                    {menuItem.href ? (
-                      <a
-                        className="inline-flex w-full items-center gap-2"
-                        href={menuItem.href}
-                        rel="noreferrer"
-                        target="_blank"
-                      >
-                        {menuItem.icon}
-                        <span className="truncate">{menuItem.label}</span>
-                      </a>
-                    ) : (
-                      <>
-                        {menuItem.icon}
-                        <span className="truncate">{menuItem.label}</span>
-                      </>
-                    )}
-                  </DropdownMenuItem>
-                ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
+                        menuItem.onSelect?.()
+                      }}
+                    >
+                      {menuItem.href ? (
+                        <a
+                          className="inline-flex w-full items-center gap-2"
+                          href={menuItem.href}
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          {menuItem.icon}
+                          <span className="truncate">{menuItem.label}</span>
+                        </a>
+                      ) : (
+                        <>
+                          {menuItem.icon}
+                          <span className="truncate">{menuItem.label}</span>
+                        </>
+                      )}
+                    </DropdownMenuItem>
+                  ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </Tip>
     )
   }
 
   if (item.variant === 'text' && !item.onSelect && !item.to && !item.href) {
     return (
-      <div
-        className={cn(
-          'inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
-          item.className
-        )}
-      >
-        {content}
-      </div>
+      <Tip label={item.title}>
+        <div
+          className={cn(
+            'inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
+            item.className
+          )}
+        >
+          {content}
+        </div>
+      </Tip>
     )
   }
 
   if (item.href || item.variant === 'link') {
     return (
-      <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
-        {content}
-      </a>
+      <Tip label={item.title}>
+        <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
+          {content}
+        </a>
+      </Tip>
     )
   }
 
   return (
-    <button
-      className={cn(STATUSBAR_ACTION_CLASS, item.className)}
-      disabled={item.disabled}
-      onClick={event => {
-        if (item.to) {
-          navigate(item.to)
-        }
+    <Tip label={item.title}>
+      <button
+        className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+        disabled={item.disabled}
+        onClick={event => {
+          if (item.to) {
+            navigate(item.to)
+          }
 
-        item.onSelect?.({ shiftKey: event.shiftKey })
-      }}
-      type="button"
-    >
-      {content}
-    </button>
+          item.onSelect?.({ shiftKey: event.shiftKey })
+        }}
+        type="button"
+      >
+        {content}
+      </button>
+    </Tip>
   )
 }


### PR DESCRIPTION
## What does this PR do?

Every statusbar button/menu/text/link in Hermes Desktop had a hover tooltip defined in code that never reached the DOM. Specifically, `use-statusbar-items.tsx` populates `title: ...` on every StatusbarItem (YOLO, gateway health, agents, cron, version, context usage, session timer, turn timer), but `StatusbarControls` (`apps/desktop/src/app/shell/statusbar-controls.tsx`) never forwarded that field to the rendered element. The status bar was the only major chrome in the desktop shell without hover hints.

This wraps each of the four `StatusbarItemView` render branches (menu trigger, text, link, action) in the existing `Tip` wrapper from `components/ui/tooltip.tsx`, which:

- Carries its own `TooltipProvider`, so it works anywhere without an ancestor provider.
- Defaults to `delayDuration={0}` (instant on hover).
- Auto-themes (`bg-foreground` / `text-background`, inverts per theme).
- Is the established pattern elsewhere in the shell (`profile-switcher.tsx`, `sidebar.tsx`).
- Renders the child untouched when `label` is falsy, so items without a title stay zero-cost.

Net effect: hovering the lightning bolt in the bottom-right now explains exactly what `copy.yoloOn` / `copy.yoloOff` already describe — "YOLO off — click to auto-approve dangerous commands. Shift+click toggles it globally."

## Related Issue

Fixes the underlying gap, no upstream issue filed. The intent strings were already authored (e.g. `i18n/en.ts:1615-1616`); only the rendering was missing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/shell/statusbar-controls.tsx`
  - Import `Tip` from `@/components/ui/tooltip`.
  - Wrap each of the 4 `StatusbarItemView` render branches (lines ~98–188) in `<Tip label={item.title}>`. Tip is a no-op when `title` is undefined, so behavior for un-titled items is unchanged.

No data-layer changes; every existing `title:` value flows through unchanged.

## How to Test

1. `cd apps/desktop && npm run typecheck` — passes (tsc -p . --noEmit, no diagnostics).
2. `cd apps/desktop && npx eslint src/app/shell/statusbar-controls.tsx` — passes (no warnings).
3. `npm run dev` and hover each statusbar item:
   - **Lightning bolt (YOLO)** → "YOLO off — click to auto-approve dangerous commands. Shift+click toggles it globally." (or the "on" variant when YOLO is active).
   - **Command-center / gateway-health / agents / cron / version** → their existing `title` strings.
   - **Context usage / session timer / turn timer** → their `title` strings (text variant was previously the most obviously broken — `<div>`s had no fallback at all).
4. Verify click behavior is unchanged: YOLO click still toggles per-session, Shift+click still toggles globally; menu/links still navigate; nothing regressed.
5. Confirm the Tip wrapper is a no-op when `title` is absent (e.g. an `extraLeftItems`/`extraRightItems` item without a title renders identically to before).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant checks and they pass (`npm run typecheck`, `npx eslint` on the touched file)
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — *N/A: there are no existing UI tests for `StatusbarControls` or the statusbar items hook. Adding a Vitest + jsdom test for a tooltip wrapper on a small render-only component would be net-negative noise; the change is verified by typecheck + lint + manual hover.*
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing docs describe this behavior)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (renderer-only React change, no platform-specific code touched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ cd apps/desktop && npm run typecheck
$ npx eslint src/app/shell/statusbar-controls.tsx
$ # both exit 0, no output
```

Manual verification (macOS 26.5.1): hovering the zap and other statusbar items now shows the intended tooltip on hover; clicks remain unchanged.