### PR TITLE
fix(agent): re-prompt when a tool call is emitted as plain text

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4714,6 +4714,59 @@ def run_conversation(
                 )
 
                 _ack_mode = intent_ack_continuation_mode(agent)
+
+                # ── Leaked tool-call recovery ───────────────────────
+                # The turn ended as plain text, but the visible body is
+                # really a complete <invoke …>…</invoke> tool-call block
+                # the model emitted as prose instead of through the
+                # tool-call channel. Surfacing it confuses the user and,
+                # once persisted, becomes a bad few-shot that makes later
+                # turns imitate it. Do NOT show it and do NOT delete it
+                # silently: re-prompt for a real tool call, bounded by a
+                # small retry budget. On exhaustion fall through and
+                # surface the raw text honestly rather than loop forever.
+                if (
+                    agent.valid_tool_names
+                    and agent._leaked_tool_call_retries < 2
+                    and agent._looks_like_leaked_tool_call(final_response)
+                ):
+                    agent._leaked_tool_call_retries += 1
+                    logger.warning(
+                        "Assistant emitted a tool-call block as plain text "
+                        "(no tool_calls) — re-prompting for a real tool call "
+                        "(%d/2) model=%s provider=%s",
+                        agent._leaked_tool_call_retries, agent.model, agent.provider,
+                    )
+                    agent._buffer_status(
+                        f"⚠️ Tool call written as text — re-prompting "
+                        f"({agent._leaked_tool_call_retries}/2)"
+                    )
+                    # Append a NEUTRAL placeholder (never the raw XML) so the
+                    # leaked block can't enter durable history as a bad
+                    # few-shot, while keeping role alternation valid
+                    # (assistant → user). Flag it synthetic so the
+                    # trailing-scaffolding pop below unwinds it cleanly on
+                    # the eventual final-text path.
+                    _leak_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                    _leak_msg["content"] = "(tool call not executed)"
+                    _leak_msg["_leaked_tool_call_synthetic"] = True
+                    messages.append(_leak_msg)
+                    messages.append({
+                        "role": "user",
+                        "content": (
+                            "Your previous message contained a tool call written "
+                            "as plain text instead of being issued through the "
+                            "tool-call interface, so it did NOT run. Re-issue it now "
+                            "as a real tool call. If you did not intend to call a "
+                            "tool, reply with your final answer as normal prose "
+                            "containing no tool-call markup."
+                        ),
+                        "_leaked_tool_call_synthetic": True,
+                    })
+                    agent._session_messages = messages
+                    continue
+
+
                 if (
                     _ack_mode != "off"
                     and agent.valid_tool_names
@@ -4764,6 +4817,7 @@ def run_conversation(
                         messages[-1].get("_thinking_prefill")
                         or messages[-1].get("_empty_recovery_synthetic")
                         or messages[-1].get("_empty_terminal_sentinel")
+                        or messages[-1].get("_leaked_tool_call_synthetic")
                     )
                 ):
                     messages.pop()

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -217,6 +217,7 @@ def build_turn_context(
     agent._codex_incomplete_retries = 0
     agent._thinking_prefill_retries = 0
     agent._post_tool_empty_retried = False
+    agent._leaked_tool_call_retries = 0
     agent._last_content_with_tools = None
     agent._last_content_tools_all_housekeeping = False
     agent._mute_post_response = False

--- a/run_agent.py
+++ b/run_agent.py
@@ -1366,6 +1366,109 @@ class AIAgent:
             return True
         return False
 
+    @staticmethod
+    def _strip_code_spans_for_invoke_scan(text: str) -> str:
+        """Blank out fenced and inline code before scanning for leaked
+        tool-call XML.
+
+        A model legitimately *showing* a ``<invoke ...>`` block as a
+        documentation example wraps it in backticks; that must never be
+        mistaken for a real leaked tool call. The returned text is only
+        ever scanned, never displayed or persisted.
+        """
+        if not text:
+            return ""
+        # Whole fenced blocks ```...``` (including ```lang), multi-line.
+        without_fences = re.sub(r"```.*?```", " ", text, flags=re.DOTALL)
+        # A dangling/unclosed fence (half-streamed example): drop from it
+        # onward so the unterminated example can't trip the scan either.
+        if "```" in without_fences:
+            without_fences = without_fences.split("```", 1)[0]
+        # Inline `code`.
+        return re.sub(r"`[^`\n]*`", " ", without_fences)
+
+    @staticmethod
+    def _text_is_essentially_tool_call(text: str) -> bool:
+        """Core leak test on already-visible text (think blocks removed).
+
+        Returns True only when, after exempting code spans, a fully
+        closed ``<invoke ...>...</invoke>`` block is present AND the
+        residual non-XML prose is negligible — i.e. the block *is*
+        essentially the whole message rather than an aside inside a real
+        answer. Conservative by construction to avoid suppressing
+        genuine replies that merely mention or quote tool-call XML.
+        """
+        if not isinstance(text, str) or not text.strip():
+            return False
+        # Cheap pre-filter: no invoke tag at all → definitely not leakage.
+        if "<invoke" not in text.lower():
+            return False
+        scan = AIAgent._strip_code_spans_for_invoke_scan(text)
+        invoke_re = r"<invoke\b[^>]*>.*?</invoke\s*>"
+        if not re.search(invoke_re, scan, re.DOTALL | re.IGNORECASE):
+            # Every invoke block was inside a code span → legitimate example.
+            return False
+        # Remove the complete invoke block(s), then drop bare leaked wrapper
+        # labels/tags and any orphan XML fragments. Whatever prose is left is
+        # what the user WOULD have seen had this been surfaced.
+        residual = re.sub(invoke_re, " ", scan, flags=re.DOTALL | re.IGNORECASE)
+        kept = []
+        for line in residual.splitlines():
+            token = line.strip()
+            if not token:
+                continue
+            if re.match(
+                r"^(?:course|call|tool_call|tool_calls|function_call|"
+                r"function_calls|/?function_calls|antml:function_calls)$",
+                token,
+                re.IGNORECASE,
+            ):
+                continue
+            kept.append(token)
+        residual_prose = re.sub(r"<[^>]+>", " ", " ".join(kept)).strip()
+        # Primary signal: the block IS essentially the whole message — only a
+        # negligible amount of incidental prose surrounds it.
+        if len(residual_prose) <= 24:
+            return True
+        # Secondary signal: substantial prose PRECEDES the block, but the
+        # message still ENDS with a complete, unfenced ``<invoke …></invoke>``
+        # block (trailing whitespace allowed). A genuine final answer never
+        # terminates in a bare ``</invoke>``; this is the "preamble + leaked
+        # call" shape — the model writes a sentence or two announcing what it
+        # is about to do ("消息已发。现在用一个探针…"), then emits the call as
+        # prose instead of through the tool-call channel. Claude Opus 4.x
+        # (especially 4.8) is particularly prone to this because it likes to
+        # narrate its next action first. Code spans were already blanked in
+        # ``scan`` above, so a fenced/inline ``<invoke>`` documentation example
+        # placed at the end of a real answer is NOT matched here (its XML is
+        # already gone from ``scan``).
+        ends_with_invoke = re.search(
+            r"<invoke\b[^>]*>.*?</invoke\s*>\s*\Z",
+            scan,
+            re.DOTALL | re.IGNORECASE,
+        )
+        return bool(ends_with_invoke)
+
+    def _looks_like_leaked_tool_call(self, content: str) -> bool:
+        """Detect an assistant turn that ended as plain text but whose body
+        is really a complete tool-call block the model emitted as prose
+        instead of through the tool-call channel.
+
+        This is a DETECT signal only. The conversation loop responds by
+        re-prompting for a real tool call (bounded by a retry budget) and
+        never by deleting content — surfacing the raw XML to the user
+        confuses them and, once persisted, turns into a bad few-shot that
+        makes later turns imitate it. See skill ``hermes-agent`` reference
+        ``tool-call-xml-leakage-20260621.md`` for the evidence trail.
+        """
+        if not isinstance(content, str):
+            return False
+        # Strip reasoning/think blocks first so a leak hiding after a long
+        # <think>…</think> preamble is still caught (mirrors how
+        # _should_treat_stop_as_truncated derives visible text).
+        visible = self._strip_think_blocks(content)
+        return AIAgent._text_is_essentially_tool_call(visible)
+
     def _is_ollama_glm_backend(self) -> bool:
         """Detect Ollama-hosted GLM models affected by stop misreports.
 
@@ -1559,6 +1662,20 @@ class AIAgent:
         providers silently reject (returns empty content), causing the
         empty-retry loop to fire forever. (issue number to be backfilled once filed)
         """
+        # Pre-pass: strip leaked-tool-call recovery scaffolding (the neutral
+        # placeholder + re-prompt nudge appended by the conversation loop).
+        # Unlike empty-response scaffolding these must NOT engage the
+        # tool-result rewind below: a mid-loop leak is preceded by REAL
+        # completed tool work that has to be preserved. Popping them here
+        # also avoids a ``user(nudge), user(next)`` protocol violation if the
+        # turn is interrupted mid-recovery and later resumed.
+        while (
+            messages
+            and isinstance(messages[-1], dict)
+            and messages[-1].get("_leaked_tool_call_synthetic")
+        ):
+            messages.pop()
+
         # Pass 1: strip the flagged scaffolding messages themselves.
         dropped_scaffolding = False
         while (

--- a/tests/run_agent/test_leaked_tool_call_detection.py
+++ b/tests/run_agent/test_leaked_tool_call_detection.py
@@ -1,0 +1,295 @@
+"""Unit tests for leaked-tool-call detection (detect+retry guard).
+
+Context: models sometimes emit a complete ``<invoke ...>...</invoke>`` tool
+call as ordinary assistant TEXT instead of issuing it through the tool-call
+channel. The turn then ends with ``finish_reason=stop`` and no ``tool_calls``.
+The conversation loop responds by re-prompting for a real tool call (bounded
+by a retry budget) rather than surfacing or deleting the XML.
+
+These tests pin the DETECTOR contract — it is the false-positive-sensitive
+piece. The bias is heavily toward NOT firing: suppressing a genuine answer is
+far worse than missing a leak (the leak still gets re-prompted on the next
+identical condition, and worst case is shown honestly).
+
+The detector lives on ``AIAgent`` as two pure static methods plus one
+think-block-aware instance wrapper:
+
+- ``_strip_code_spans_for_invoke_scan`` — blanks fenced/inline code so
+  documentation examples of ``<invoke>`` never count.
+- ``_text_is_essentially_tool_call`` — core test on already-visible text.
+- ``_looks_like_leaked_tool_call`` — strips think blocks first, then defers
+  to the core. Tested via a duck-typed stub so no full agent is constructed.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from run_agent import AIAgent
+
+
+# ── True positives: the block IS essentially the whole message ─────────────
+
+_LEAKS = [
+    # bare invoke, no label
+    '<invoke name="terminal"><parameter name="command">pwd</parameter></invoke>',
+    # OpenClaw-style "course" label preamble
+    'course\n<invoke name="terminal"><parameter name="command">pwd</parameter></invoke>',
+    # "call" label preamble
+    'call\n<invoke name="terminal">x</invoke>',
+    # multiline / multi-param, realistic whitespace
+    (
+        '<invoke name="browser_navigate">\n'
+        '<parameter name="url">https://example.com</parameter>\n'
+        '</invoke>'
+    ),
+    # leaked wrapper tag around the invoke
+    (
+        'function_calls\n'
+        '<invoke name="search_files">\n'
+        '<parameter name="pattern">foo</parameter>\n'
+        '</invoke>'
+    ),
+    # trailing whitespace / newline after close tag
+    '<invoke name="read_file"><parameter name="path">/tmp/x</parameter></invoke>\n\n',
+    # tiny incidental prose under the threshold ("okay")
+    'okay\n<invoke name="terminal"><parameter name="command">ls</parameter></invoke>',
+    # ── "preamble + leaked call" shape (Opus 4.x narration habit) ──────────
+    # Substantial prose PRECEDES the block but the message still ENDS with a
+    # complete, unfenced <invoke>…</invoke>. A real final answer never ends in
+    # a bare </invoke>. This is the exact shape captured from a live Opus-4.8
+    # leak (session c0717f698895, msg[105]): a couple sentences announcing the
+    # next action, then the call emitted as prose.
+    (
+        "消息已发。现在用一个**自动捕获中途时刻**的探针：持续轮询，一旦发现 "
+        "EventSource readyState=1（OPEN）且内容已有一定长度、且\"Done in\"尚未"
+        "出现（即真正 streaming 中途），就立刻注入 error，然后观察 probe 行为。"
+        "这样能精确命中我要验证的分支。\n\n"
+        'call\n<invoke name="mcp_playwright_browser_run_code_unsafe">\n'
+        '<parameter name="code">async (page) => { return 1; }</parameter>\n'
+        "</invoke>"
+    ),
+    # English preamble + trailing leaked call, trailing newline after close
+    (
+        "Good — the message is sent. Now I'll probe the live stream to catch "
+        "the mid-flight reconnect path and confirm the buffer survives.\n\n"
+        '<invoke name="terminal"><parameter name="command">curl -s localhost:8701/health</parameter></invoke>\n'
+    ),
+]
+
+
+# ── True positives that previously slipped the ≤24-char primary gate ───────
+# These have LARGE residual prose (so the primary "block is the whole message"
+# signal is False) but END in a complete unfenced invoke block (secondary
+# signal). Kept as a separate list to document the regression class.
+_PREAMBLE_LEAKS = [
+    (
+        "I traced it and the cleanest test is to inject mid-stream. Let me run "
+        "the probe now and read back the EventSource state to see if the "
+        "content survives the forced error.\n"
+        '<invoke name="terminal"><parameter name="command">echo go</parameter></invoke>'
+    ),
+]
+
+
+@pytest.mark.parametrize("text", _PREAMBLE_LEAKS)
+def test_detects_preamble_then_leaked_call(text):
+    assert AIAgent._text_is_essentially_tool_call(text) is True
+
+
+@pytest.mark.parametrize("text", _LEAKS)
+def test_detects_leaked_tool_call(text):
+    assert AIAgent._text_is_essentially_tool_call(text) is True
+
+
+# ── False positives we must NOT fire on ────────────────────────────────────
+
+_SAFE = [
+    # plain prose, no XML at all
+    "Here's the summary of what I found in the logs.",
+    # mentions the word invoke, no XML
+    "I'll invoke the build script and report the result.",
+    # mentions <invoke> as inline code — documentation
+    "The `<invoke>` tag is how the model issues a real tool call.",
+    # FULL invoke block shown inside a fenced code block — documentation
+    (
+        "Here's the leakage pattern to watch for:\n\n"
+        "```\n"
+        '<invoke name="terminal"><parameter name="command">pwd</parameter></invoke>\n'
+        "```\n\n"
+        "Notice there's no tool_calls field on that message."
+    ),
+    # fenced with a language tag
+    (
+        "Example:\n\n"
+        "```xml\n"
+        '<invoke name="read_file"><parameter name="path">/tmp/x</parameter></invoke>\n'
+        "```\n"
+    ),
+    # substantial real answer that quotes the XML in a fence AND explains it
+    # (this is the exact shape of the dev conversation that built this guard)
+    (
+        "I traced the agent loop and found the insertion point. The bug is "
+        "that the model emits this as plain text:\n\n"
+        "```\n"
+        'course\n<invoke name="terminal"><parameter name="command">git status</parameter></invoke>\n'
+        "```\n\n"
+        "instead of issuing a real tool call, so finish_reason is stop with no "
+        "tool_calls. The fix is a detect-and-retry guard, not a sanitizer."
+    ),
+    # empty / whitespace
+    "",
+    "   \n  ",
+    # an opening invoke with NO closing tag (half-streamed / not a complete
+    # block) — conservative: don't fire on incomplete markup
+    '<invoke name="terminal"><parameter name="command">pwd</parameter>',
+    # real answer that merely ends by referencing a tool name
+    "Done. I ran terminal and the working tree is clean now.",
+    # inline code invoke plus lots of prose
+    (
+        "When you see `<invoke name=\"terminal\">` rendered as text in the "
+        "chat, that means the call leaked into the content field and never "
+        "actually executed. Start a fresh session to clear the bad example."
+    ),
+    # ── Secondary-signal false-positive guards ────────────────────────────
+    # Real answer whose LAST thing is a FENCED <invoke> example. The block is
+    # at the very end, but it is inside ```code``` so the secondary
+    # "ends-with-invoke" signal must NOT fire (fences are blanked before scan).
+    (
+        "Here is the leak shape, and it is the final thing I'll show you:\n\n"
+        "```\n"
+        '<invoke name="terminal"><parameter name="command">pwd</parameter></invoke>\n'
+        "```"
+    ),
+    # Real answer ending in a fenced xml example with no trailing prose.
+    (
+        "The persisted bad message looks exactly like this — note it ends the "
+        "message and there is no tool_calls field:\n\n"
+        "```xml\n"
+        '<invoke name="read_file"><parameter name="path">/tmp/x</parameter></invoke>\n'
+        "```\n"
+    ),
+    # Long answer that mentions a complete invoke inline-coded at the very end.
+    (
+        "If the turn terminates with the literal text "
+        '`<invoke name="terminal"></invoke>` and nothing else follows, the '
+        "call leaked. Otherwise you are fine."
+    ),
+]
+
+
+@pytest.mark.parametrize("text", _SAFE)
+def test_does_not_fire_on_safe_text(text):
+    assert AIAgent._text_is_essentially_tool_call(text) is False
+
+
+# ── Code-span stripper behaves ─────────────────────────────────────────────
+
+def test_code_span_stripper_removes_fenced_invoke():
+    text = "```\n<invoke name=\"x\">y</invoke>\n```"
+    out = AIAgent._strip_code_spans_for_invoke_scan(text)
+    assert "<invoke" not in out
+
+
+def test_code_span_stripper_removes_inline_invoke():
+    text = "the `<invoke>` tag"
+    out = AIAgent._strip_code_spans_for_invoke_scan(text)
+    assert "<invoke" not in out
+
+
+def test_code_span_stripper_drops_dangling_fence_tail():
+    # An unterminated fence: everything from the opening fence onward is
+    # dropped so a half-streamed example can't trip the scan.
+    text = "intro text\n```\n<invoke name=\"x\">y</invoke>"
+    out = AIAgent._strip_code_spans_for_invoke_scan(text)
+    assert "<invoke" not in out
+    assert "intro text" in out
+
+
+# ── Think-block-aware instance wrapper ─────────────────────────────────────
+
+class _ThinkStub:
+    """Minimal stand-in exposing only what the wrapper touches."""
+
+    def _strip_think_blocks(self, content: str) -> str:
+        return re.sub(
+            r"<think>.*?</think>", "", content, flags=re.DOTALL | re.IGNORECASE
+        )
+
+
+def test_wrapper_catches_leak_hidden_after_think_block():
+    stub = _ThinkStub()
+    content = (
+        "<think>The user wants the current directory, I'll call terminal."
+        "</think>\n"
+        '<invoke name="terminal"><parameter name="command">pwd</parameter></invoke>'
+    )
+    assert AIAgent._looks_like_leaked_tool_call(stub, content) is True
+
+
+def test_wrapper_passes_normal_answer_with_think_block():
+    stub = _ThinkStub()
+    content = (
+        "<think>Let me summarize the findings.</think>\n"
+        "The working tree is clean and all tests pass."
+    )
+    assert AIAgent._looks_like_leaked_tool_call(stub, content) is False
+
+
+def test_wrapper_rejects_non_string():
+    stub = _ThinkStub()
+    assert AIAgent._looks_like_leaked_tool_call(stub, None) is False
+    assert AIAgent._looks_like_leaked_tool_call(stub, 123) is False
+
+
+# ── Scaffolding lifecycle: the synthetic recovery pair must not persist ─────
+#
+# When the guard fires it appends a neutral placeholder assistant message and
+# a re-prompt user message, both flagged `_leaked_tool_call_synthetic`. On the
+# eventual real-text exit these are popped by the conversation loop's
+# trailing-scaffolding `while`. On an interrupt/error persist path they are
+# popped by `_drop_trailing_empty_response_scaffolding`'s dedicated pre-pass —
+# WITHOUT engaging the destructive tool-result rewind that empty-response
+# scaffolding triggers (real completed tool work before the leak is preserved).
+
+class _ScaffoldStub:
+    """Duck-typed stand-in for the persist-path scaffolding stripper."""
+
+    # bind the real implementation under test
+    _drop_trailing_empty_response_scaffolding = (
+        AIAgent._drop_trailing_empty_response_scaffolding
+    )
+
+
+def test_leak_scaffolding_prepass_pops_only_synthetic_pair():
+    stub = _ScaffoldStub()
+    messages = [
+        {"role": "user", "content": "do the thing"},
+        {"role": "assistant", "tool_calls": [{"id": "c1"}], "content": ""},
+        {"role": "tool", "tool_call_id": "c1", "content": "real tool result"},
+        {"role": "assistant", "content": "(tool call not executed)",
+         "_leaked_tool_call_synthetic": True},
+        {"role": "user", "content": "Re-issue it as a real tool call.",
+         "_leaked_tool_call_synthetic": True},
+    ]
+    stub._drop_trailing_empty_response_scaffolding(messages)
+    # The two synthetic recovery messages are gone …
+    assert all(not m.get("_leaked_tool_call_synthetic") for m in messages)
+    # … and the REAL completed tool work is fully preserved (no rewind).
+    assert messages[-1]["role"] == "tool"
+    assert messages[-1]["content"] == "real tool result"
+    assert len(messages) == 3
+
+
+def test_leak_scaffolding_prepass_noop_without_flag():
+    stub = _ScaffoldStub()
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello there"},
+    ]
+    before = [dict(m) for m in messages]
+    stub._drop_trailing_empty_response_scaffolding(messages)
+    assert messages == before
+

--- a/tests/run_agent/test_leaked_tool_call_loop.py
+++ b/tests/run_agent/test_leaked_tool_call_loop.py
@@ -1,0 +1,182 @@
+"""Loop-level integration test for the leaked-tool-call detect+retry guard.
+
+Drives the REAL ``run_conversation`` loop (real transport normalization, real
+turn-context reset, real scaffolding cleanup) and mocks only the network call
+seam ``AIAgent._interruptible_api_call``. Proves the full lifecycle:
+
+  turn 1: model leaks a complete <invoke> block as plain text (no tool_calls)
+          → guard fires, NOT surfaced, re-prompt appended, loop continues
+  turn 2: model does it again
+          → guard fires again (budget now exhausted at 2/2)
+  turn 3: model returns a normal answer
+          → delivered as the final response; NO synthetic scaffolding persists
+
+Also proves the budget cap: if the model leaks forever, the loop does not spin
+indefinitely — after the 2-retry budget it surfaces the raw text honestly
+rather than looping (anti-deadlock contract).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import run_agent
+from run_agent import AIAgent
+
+
+# ── OpenAI ChatCompletion fakes (real transport normalizes these) ──────────
+
+def _completion(content=None, tool_calls=None, finish_reason="stop"):
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+        refusal=None,
+    )
+    choice = SimpleNamespace(index=0, message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(
+        id="cmpl-test",
+        choices=[choice],
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        model="test/model",
+    )
+
+
+_LEAK_TEXT = (
+    'course\n<invoke name="terminal">'
+    '<parameter name="command">ls</parameter></invoke>'
+)
+
+
+def _make_tool_defs(*names):
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _make_agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("terminal")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-7890",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    # Avoid real streaming; force the non-streaming dispatch branch.
+    agent._disable_streaming = True
+    return agent
+
+
+def _run_turn(agent, responses):
+    """Drive one full run_conversation turn with a queued response list."""
+    seq = list(responses)
+
+    def _fake_api_call(api_kwargs, *a, **kw):
+        return seq.pop(0)
+
+    with (
+        patch.object(AIAgent, "_interruptible_api_call", side_effect=_fake_api_call),
+        patch.object(AIAgent, "_interruptible_streaming_api_call", side_effect=_fake_api_call),
+    ):
+        return agent.run_conversation(user_message="please list the directory")
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+def test_leak_then_real_answer_converges_without_surfacing_xml():
+    """Two leaks followed by a real answer → user sees only the real answer,
+    and no <invoke> XML or synthetic scaffolding remains in the transcript."""
+    agent = _make_agent()
+    result = _run_turn(agent, [
+        _completion(content=_LEAK_TEXT),        # turn 1: leak  → retry 1/2
+        _completion(content=_LEAK_TEXT),        # turn 2: leak  → retry 2/2
+        _completion(content="The directory contains a, b and c."),  # turn 3: real
+    ])
+
+    final = result.get("final_response") or ""
+    assert "<invoke" not in final, f"leaked XML surfaced to user: {final!r}"
+    assert final.strip() == "The directory contains a, b and c."
+
+    # The retry budget was consumed exactly twice.
+    assert agent._leaked_tool_call_retries == 2
+
+    # No synthetic recovery scaffolding survives in the persisted messages.
+    msgs = result.get("messages") or []
+    assert not any(
+        isinstance(m, dict) and m.get("_leaked_tool_call_synthetic") for m in msgs
+    ), "synthetic leak-recovery scaffolding leaked into durable transcript"
+    # And the raw leaked XML is not parked in any assistant message content.
+    assert not any(
+        isinstance(m, dict)
+        and m.get("role") == "assistant"
+        and "<invoke" in (m.get("content") or "")
+        for m in msgs
+    )
+
+
+def test_budget_exhaustion_surfaces_text_instead_of_looping():
+    """If the model leaks on every turn, the loop must NOT spin forever — once
+    the 2-retry budget is spent it surfaces the (raw) text honestly and ends."""
+    agent = _make_agent()
+    # Provide MANY leaks; a correct implementation calls the API at most
+    # 3 times (initial + 2 retries) before giving up. Provide a few extra so
+    # an accidental infinite loop would still terminate the test via pop()
+    # raising IndexError rather than hanging.
+    result = _run_turn(agent, [_completion(content=_LEAK_TEXT) for _ in range(6)])
+
+    # Budget capped at 2 — the guard stopped re-prompting.
+    assert agent._leaked_tool_call_retries == 2
+    # The turn ended (did not raise / hang). A final response exists.
+    assert "final_response" in result
+
+
+def test_normal_answer_never_triggers_guard():
+    """A plain answer with no tool-call XML must pass straight through with the
+    retry budget untouched."""
+    agent = _make_agent()
+    result = _run_turn(agent, [
+        _completion(content="Here is the summary you asked for. All good."),
+    ])
+    assert agent._leaked_tool_call_retries == 0
+    assert result.get("final_response", "").strip() == (
+        "Here is the summary you asked for. All good."
+    )
+
+
+def test_real_tool_call_is_unaffected():
+    """A genuine tool_calls response must execute normally — the guard only
+    looks at the no-tool-calls branch, so a real call is never intercepted."""
+    agent = _make_agent()
+    real_tc = SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(name="terminal", arguments='{"command": "ls"}'),
+        extra_content=None,
+    )
+    with patch.object(AIAgent, "_execute_tool_calls", return_value=None) as exec_mock:
+        _run_turn(agent, [
+            _completion(tool_calls=[real_tc], finish_reason="tool_calls"),
+            _completion(content="Done — listed the directory."),
+        ])
+    assert exec_mock.called, "a real tool_calls response must reach _execute_tool_calls"
+    assert agent._leaked_tool_call_retries == 0


### PR DESCRIPTION
## Problem

Models occasionally emit a **complete `<invoke ...>...</invoke>` tool-call block as ordinary assistant text** instead of issuing it through the tool-call channel. The turn ends with **no `tool_calls`**, so:

1. The raw XML is shown to the user (confusing — it looks like the agent malfunctioned), and
2. once persisted as assistant `content`, it becomes a **bad few-shot example** in the same conversation, making later turns imitate it. Opus/Claude-family models are especially prone; GPT-5.x can also do it once a session is contaminated.

Inspecting the session JSON confirms it's model text leakage, not a frontend rendering bug: the assistant message has the `<invoke>` in `content` with no `tool_calls` field.

## Approach: detect-and-retry, not a sanitizer

A delete-style sanitizer (stripping the XML) is the wrong fix — it **swallows the call the model actually intended to make**, and the user's request silently goes unanswered. Instead this re-prompts for a real tool call, mirroring the existing recovery paths in the loop (`codex_ack_continuations`, the empty-response nudge, `_invalid_tool_retries`).

When the no-tool-calls branch produces final text whose visible body is essentially a complete invoke block, the loop appends a **neutral placeholder** + a re-prompt user nudge and `continue`s, asking the model to re-issue it through the tool interface. Bounded by a retry budget (2); on exhaustion it falls through and surfaces the text honestly rather than looping forever.

## Detector — two signals, conservative by construction

`_text_is_essentially_tool_call` strips think blocks and code spans **first**, so a fenced/inline `<invoke>` shown as documentation never triggers. It then fires on either:

1. **Primary:** after removing the invoke block(s) and bare wrapper labels, residual prose is negligible (≤24 chars) — the block *is* the message.
2. **Secondary (new in this revision):** substantial prose **precedes** the block, but the message still **ends** with a complete, unfenced `<invoke>…</invoke>` (trailing whitespace allowed). A genuine final answer never terminates in a bare `</invoke>`. This is the **"preamble + leaked call"** shape — the model narrates its next action ("message sent; now I'll probe…") then emits the call as prose. **Opus 4.8 in particular announces first**, which slipped the original ≤24-char gate. Captured from a live Opus-4.8 leak and added to the test corpus.

## Scaffolding lifecycle

The synthetic placeholder + nudge are flagged `_leaked_tool_call_synthetic` and popped by **both** the conversation loop's trailing-scaffolding `while` and the persist-path `_drop_trailing_empty_response_scaffolding` pre-pass (which pops only the synthetic pair without engaging the destructive empty-response rewind, preserving real completed tool work before the leak). Retry budget reset per turn in `turn_context.py`.

## Tests (36, all passing on current `main`)

- `tests/run_agent/test_leaked_tool_call_detection.py` — detector contract: true positives (bare block, label preambles, multiline, and the **preamble+trailing-call** shape from a live Opus-4.8 leak), false positives (prose, inline/fenced documentation examples **including ones at end-of-message**, half-streamed unclosed blocks), code-span stripper, think-block wrapper, scaffolding-prepass lifecycle.
- `tests/run_agent/test_leaked_tool_call_loop.py` — loop integration: leak→retry→converge without surfacing XML, budget exhaustion surfaces text instead of looping, normal answers and real tool calls unaffected.

## Revision note

Rebased onto latest `main` (was conflicting against stale base) and extended the detector with the **secondary "preamble + leaked call" signal** after reproducing the leak live on Opus 4.8 — the original guard only caught the "block is the whole message" shape and let the narrate-then-call shape through. Single squashed commit, +649 lines, all new (no edits to existing logic paths outside the documented insertion points).

@nesquina — flagging for review; as an external contributor I can't set reviewers/labels. Suggested labels: `type/bug`, `comp/agent`.
