### PR TITLE
feat(desktop): add skill source filters

### DIFF
--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -40,10 +40,10 @@ function toolset(overrides: Record<string, unknown> = {}) {
   }
 }
 
-function renderSkills() {
+function renderSkills(initialEntry = '/skills?tab=toolsets') {
   return import('./index').then(({ SkillsView }) =>
     render(
-      <MemoryRouter initialEntries={['/skills?tab=toolsets']}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <SkillsView />
       </MemoryRouter>
     )
@@ -99,5 +99,27 @@ describe('SkillsView toolset management', () => {
     fireEvent.click(configureBtn)
 
     await waitFor(() => expect(getToolsetConfig).toHaveBeenCalledWith('web'))
+  })
+})
+
+
+describe('SkillsView skill provenance filters', () => {
+  it('filters to custom skills and shows provenance badges', async () => {
+    getSkills.mockResolvedValue([
+      { name: 'ours', description: 'custom', category: 'custom-agent-systems', enabled: true, source: 'custom' },
+      { name: 'builtin', description: 'bundled', category: 'software-development', enabled: true, source: 'bundled' }
+    ])
+
+    await renderSkills('/skills?tab=skills')
+
+    expect(await screen.findByText('ours')).toBeTruthy()
+    expect(screen.getByText('builtin')).toBeTruthy()
+    expect(screen.getAllByText('Custom').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Bundled').length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Custom/i })[0]!)
+
+    await waitFor(() => expect(screen.getByText('ours')).toBeTruthy())
+    expect(screen.queryByText('builtin')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -24,15 +24,52 @@ import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 const SKILLS_MODES = ['skills', 'toolsets'] as const
 type SkillsMode = (typeof SKILLS_MODES)[number]
 
+const SKILL_SOURCE_FILTERS = ['all', 'custom', 'bundled'] as const
+type SkillSourceFilter = (typeof SKILL_SOURCE_FILTERS)[number]
+
+function skillSourceFor(skill: SkillInfo): Exclude<SkillInfo['source'], 'hub' | undefined> | 'hub' {
+  if (skill.source === 'bundled' || skill.source === 'hub') {
+    return skill.source
+  }
+  return 'custom'
+}
+
+function matchesSkillSource(skill: SkillInfo, sourceFilter: SkillSourceFilter): boolean {
+  if (sourceFilter === 'all') {
+    return true
+  }
+  return skillSourceFor(skill) === sourceFilter
+}
+
+function skillSourceLabel(skill: SkillInfo): string {
+  const source = skillSourceFor(skill)
+  if (source === 'bundled') {
+    return 'Bundled'
+  }
+  if (source === 'hub') {
+    return 'Hub'
+  }
+  return 'Custom'
+}
+
 function categoryFor(skill: SkillInfo): string {
   return asText(skill.category) || 'general'
 }
 
-function filteredSkills(skills: SkillInfo[], query: string, category: string | null): SkillInfo[] {
+function filteredSkills(
+  skills: SkillInfo[],
+  query: string,
+  category: string | null,
+  sourceFilter: SkillSourceFilter
+): SkillInfo[] {
   const q = query.trim().toLowerCase()
 
   return skills
     .filter(skill => {
+      if (!matchesSkillSource(skill, sourceFilter)) {
+        return false
+      }
+
       if (category && categoryFor(skill) !== category) {
         return false
       }
@@ -80,10 +117,16 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
   const [skills, setSkills] = useState<SkillInfo[] | null>(null)
   const [toolsets, setToolsets] = useState<ToolsetInfo[] | null>(null)
   const [activeCategory, setActiveCategory] = useState<string | null>(null)
+  const [sourceFilter, setSourceFilter] = useState<SkillSourceFilter>('all')
   const [refreshing, setRefreshing] = useState(false)
   const [savingSkill, setSavingSkill] = useState<string | null>(null)
   const [savingToolset, setSavingToolset] = useState<string | null>(null)
   const [expandedToolset, setExpandedToolset] = useState<string | null>(null)
+
+  const skillsForSource = useMemo(
+    () => (skills ? skills.filter(skill => matchesSkillSource(skill, sourceFilter)) : []),
+    [skills, sourceFilter]
+  )
 
   const refreshCapabilities = useCallback(async () => {
     setRefreshing(true)
@@ -112,13 +155,13 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
   }, [refreshCapabilities])
 
   const categories = useMemo(() => {
-    if (!skills) {
+    if (!skillsForSource) {
       return []
     }
 
     const counts = new Map<string, number>()
 
-    for (const skill of skills) {
+    for (const skill of skillsForSource) {
       const key = categoryFor(skill)
       counts.set(key, (counts.get(key) || 0) + 1)
     }
@@ -126,11 +169,11 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
     return Array.from(counts.entries())
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([key, count]) => ({ key, count }))
-  }, [skills])
+  }, [skillsForSource])
 
   const visibleSkills = useMemo(
-    () => (skills ? filteredSkills(skills, query, mode === 'skills' ? activeCategory : null) : []),
-    [activeCategory, mode, query, skills]
+    () => (skills ? filteredSkills(skills, query, mode === 'skills' ? activeCategory : null, sourceFilter) : []),
+    [activeCategory, mode, query, skills, sourceFilter]
   )
 
   const visibleToolsets = useMemo(() => (toolsets ? filteredToolsets(toolsets, query) : []), [query, toolsets])
@@ -147,6 +190,8 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
   }, [visibleSkills])
 
   const totalSkills = skills?.length || 0
+  const customSkills = skills?.filter(skill => skillSourceFor(skill) === 'custom').length || 0
+  const bundledSkills = skills?.filter(skill => skillSourceFor(skill) === 'bundled').length || 0
   const enabledToolsets = toolsets?.filter(toolset => toolset.enabled).length || 0
 
   async function handleToggleSkill(skill: SkillInfo, enabled: boolean) {
@@ -194,8 +239,32 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
       filters={
         mode === 'skills' && categories.length > 0 ? (
           <>
-            <TextTab active={activeCategory === null} onClick={() => setActiveCategory(null)}>
+            <TextTab
+              active={sourceFilter === 'all' && activeCategory === null}
+              onClick={() => {
+                setSourceFilter('all')
+                setActiveCategory(null)
+              }}
+            >
               {t.skills.all} <TextTabMeta>{totalSkills}</TextTabMeta>
+            </TextTab>
+            <TextTab
+              active={sourceFilter === 'custom'}
+              onClick={() => {
+                setSourceFilter('custom')
+                setActiveCategory(null)
+              }}
+            >
+              Custom <TextTabMeta>{customSkills}</TextTabMeta>
+            </TextTab>
+            <TextTab
+              active={sourceFilter === 'bundled'}
+              onClick={() => {
+                setSourceFilter('bundled')
+                setActiveCategory(null)
+              }}
+            >
+              Bundled <TextTabMeta>{bundledSkills}</TextTabMeta>
             </TextTab>
             {categories.map(category => (
               <TextTab
@@ -260,7 +329,19 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
                         key={skill.name}
                       >
                         <div className="min-w-0">
-                          <div className="truncate text-sm font-medium">{skill.name}</div>
+                          <div className="flex items-center gap-2">
+                            <div className="truncate text-sm font-medium">{skill.name}</div>
+                            <Badge
+                              className={cn(
+                                'shrink-0',
+                                skillSourceFor(skill) === 'custom'
+                                  ? 'bg-(--ui-accent-subtle) text-(--ui-accent-strong)'
+                                  : 'bg-(--ui-bg-quinary) text-(--ui-text-tertiary)'
+                              )}
+                            >
+                              {skillSourceLabel(skill)}
+                            </Badge>
+                          </div>
                           <p className="mt-0.5 text-xs text-muted-foreground">
                             {asText(skill.description) || t.skills.noDescription}
                           </p>

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -540,6 +540,7 @@ export interface SkillInfo {
   description: string
   enabled: boolean
   name: string
+  source?: 'bundled' | 'custom' | 'hub'
 }
 
 export interface ToolsetInfo {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10264,11 +10264,19 @@ class SkillToggle(BaseModel):
 async def get_skills(profile: Optional[str] = None):
     from tools.skills_tool import _find_all_skills
     from hermes_cli.skills_config import get_disabled_skills
+    from tools.skill_usage import is_bundled, is_hub_installed
     with _profile_scope(profile):
         config = load_config()
         disabled = get_disabled_skills(config)
         skills = _find_all_skills(skip_disabled=True)
     for s in skills:
+        name = str(s.get("name") or "")
+        if is_hub_installed(name):
+            s["source"] = "hub"
+        elif is_bundled(name):
+            s["source"] = "bundled"
+        else:
+            s["source"] = "custom"
         s["enabled"] = s["name"] not in disabled
     return skills
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3397,11 +3397,13 @@ class TestNewEndpoints:
         if skills:
             assert "name" in skills[0]
             assert "enabled" in skills[0]
+            assert "source" in skills[0]
 
     def test_skills_list_includes_disabled_skills(self, monkeypatch):
         import tools.skills_tool as skills_tool
         import hermes_cli.skills_config as skills_config
         import hermes_cli.web_server as web_server
+        import tools.skill_usage as skill_usage
 
         def _fake_find_all_skills(*, skip_disabled=False):
             if skip_disabled:
@@ -3416,6 +3418,8 @@ class TestNewEndpoints:
         monkeypatch.setattr(skills_tool, "_find_all_skills", _fake_find_all_skills)
         monkeypatch.setattr(skills_config, "get_disabled_skills", lambda config: {"disabled-skill"})
         monkeypatch.setattr(web_server, "load_config", lambda: {"skills": {"disabled": ["disabled-skill"]}})
+        monkeypatch.setattr(skill_usage, "is_bundled", lambda name: name == "disabled-skill")
+        monkeypatch.setattr(skill_usage, "is_hub_installed", lambda name: False)
 
         resp = self.client.get("/api/skills")
 
@@ -3426,12 +3430,14 @@ class TestNewEndpoints:
                 "description": "active",
                 "category": "demo",
                 "enabled": True,
+                "source": "custom",
             },
             {
                 "name": "disabled-skill",
                 "description": "disabled",
                 "category": "demo",
                 "enabled": False,
+                "source": "bundled",
             },
         ]
 


### PR DESCRIPTION
## Summary
- expose skill provenance from `/api/skills` as `source` (`custom`, `bundled`, `hub`)
- add `Custom` / `Bundled` filter tabs in Hermes Desktop Skills view
- add per-skill provenance badges in the Desktop UI
- extend backend and UI tests for source-aware skill rendering

## Why
Desktop currently groups skills by category only, which makes Fritz's own skills hard to distinguish from Hermes-shipped bundled skills. This change surfaces provenance directly in the API and UI.

## Test Plan
- [x] `cd apps/desktop && npm run test:ui -- src/app/skills/index.test.tsx`
- [x] `cd apps/desktop && npm run typecheck`
- [x] `cd apps/desktop && npm run build`
- [x] verified backend function output locally via `hermes_cli.web_server.get_skills(profile='fritz')` showing expected `category` and `source`
- [x] relaunched packaged Hermes Desktop locally after rebuild; app stayed up and the previous packaged icon-path crash did not recur

## Notes
- pushed from fork because the authenticated account has read-only access to the upstream repository
