### PR TITLE
fix(web): warn when dashboard backend is unreachable

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -214,6 +214,7 @@ AUTHOR_MAP = {
     "rebel@rebels-Mac-Studio-2.local": "rebel0789",  # PR #47308 salvage (redact browser_type typed text across display surfaces; #47197)
     "267614622+agt-user@users.noreply.github.com": "agt-user",  # PR #48496 salvage (telegram CLOSE-WAIT polling heartbeat, #48495)
     "80915+DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",  # PR #52272 salvage (route reasoning-model thinking-timeouts to timeout not context_overflow + reasoning-specific guidance; #52271)
+    "DavidMetcalfe@users.noreply.github.com": "DavidMetcalfe",  # PR #50290 salvage (surface unreachable dashboard status after consecutive poll failures; #50270)
     "66773372+Tranquil-Flow@users.noreply.github.com": "Tranquil-Flow",  # PR #52623 salvage (auxiliary Anthropic base_url host validation; #52608)
     "nikshepsvn@gmail.com": "nikshepsvn",  # PR #27426 salvage (two-layer guard against hallucinated acp_command crashing the gateway on hosts with no ACP CLI)
     "65363919+coygeek@users.noreply.github.com": "coygeek",  # PR #37735 salvage (redact provider error text at api-server HTTP boundary; #37733)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -62,8 +62,10 @@ import { ConfirmDialog } from "@nous-research/ui/ui/components/confirm-dialog";
 import { cn } from "@/lib/utils";
 import { SidebarFooter } from "@/components/SidebarFooter";
 import { SidebarStatusStrip, gatewayLine } from "@/components/SidebarStatusStrip";
+import { DashboardOfflineBanner } from "@/components/DashboardOfflineBanner";
 import { useBelowBreakpoint } from "@nous-research/ui/hooks/use-below-breakpoint";
 import { useSidebarStatus } from "@/hooks/useSidebarStatus";
+import type { SidebarStatus } from "@/hooks/useSidebarStatus";
 import { AuthWidget } from "@/components/AuthWidget";
 import { PageHeaderProvider } from "@/contexts/PageHeaderProvider";
 import { ProfileProvider } from "@/contexts/ProfileProvider";
@@ -100,7 +102,7 @@ import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
 import { api } from "@/lib/api";
-import type { StatusResponse, UpdateCheckResponse } from "@/lib/api";
+import type { UpdateCheckResponse } from "@/lib/api";
 
 function RootRedirect() {
   return <Navigate to="/sessions" replace />;
@@ -538,6 +540,12 @@ export default function App() {
 
       <PluginSlot name="header-banner" />
       <ProfileScopeBanner />
+      {sidebarStatus.status.kind === "unreachable" && (
+        <DashboardOfflineBanner
+          status={sidebarStatus.status}
+          retry={sidebarStatus.retry}
+        />
+      )}
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-14 lg:pt-0">
         <div className="flex min-h-0 min-w-0 flex-1">
@@ -664,7 +672,7 @@ export default function App() {
             <SidebarSystemActions
               collapsed={isDesktopCollapsed}
               onNavigate={closeMobile}
-              status={sidebarStatus}
+              status={sidebarStatus.status}
               tooltipWarmRef={tooltipWarmRef}
             />
 
@@ -711,7 +719,7 @@ export default function App() {
               )}
             >
               <AuthWidget />
-              <SidebarFooter status={sidebarStatus} />
+              <SidebarFooter status={sidebarStatus.status} />
             </div>
           </aside>
 
@@ -901,7 +909,13 @@ function SidebarSystemActions({
   const navigate = useNavigate();
   const { activeAction, isBusy, isRunning, pendingAction, runAction } =
     useSystemActions();
-  const canUpdateHermes = status?.can_update_hermes === true;
+  const lastData =
+    status.kind === "live"
+      ? status.data
+      : status.kind === "unreachable"
+        ? status.lastData
+        : null;
+  const canUpdateHermes = lastData?.can_update_hermes === true;
   const [restartConfirmOpen, setRestartConfirmOpen] = useState(false);
   const [updateConfirmOpen, setUpdateConfirmOpen] = useState(false);
   const [updateConfirmInfo, setUpdateConfirmInfo] =
@@ -1210,11 +1224,18 @@ function GatewayDot({ collapsed, status, tooltipWarmRef }: GatewayDotProps) {
   let color: string;
   let label: string;
 
-  if (!status) {
+  // Tri-state matching SidebarStatusStrip. When the hook has crossed the
+  // unreachable threshold the dot must turn destructive-red regardless of
+  // what the last good response said — that's the user-visible fix for
+  // #50270 (no more "green dot, dashboard is dead").
+  if (status.kind === "loading") {
     color = "bg-midground/20";
     label = t.status.gateway;
+  } else if (status.kind === "unreachable") {
+    color = "bg-destructive";
+    label = `${t.status.gateway} ${t.app.statusUnreachable ?? t.app.gatewayStrip.failed}`;
   } else {
-    const gw = gatewayLine(status, t);
+    const gw = gatewayLine(status.data, t);
     color = toneToColor[gw.tone] ?? "bg-muted-foreground";
     label = `${t.status.gateway} ${gw.label}`;
   }
@@ -1298,7 +1319,7 @@ type TooltipWarmRef = React.RefObject<number>;
 
 interface GatewayDotProps {
   collapsed: boolean;
-  status: StatusResponse | null;
+  status: SidebarStatus;
   tooltipWarmRef: TooltipWarmRef;
 }
 
@@ -1327,7 +1348,7 @@ interface SidebarNavLinkProps {
 interface SidebarSystemActionsProps {
   collapsed: boolean;
   onNavigate: () => void;
-  status: StatusResponse | null;
+  status: SidebarStatus;
   tooltipWarmRef: TooltipWarmRef;
 }
 

--- a/web/src/components/DashboardOfflineBanner.tsx
+++ b/web/src/components/DashboardOfflineBanner.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { AlertTriangle, RefreshCw, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useI18n } from "@/i18n";
+import type { SidebarStatus } from "@/hooks/useSidebarStatus";
+
+/**
+ * Sticky top-of-app banner shown when `useSidebarStatus` reports
+ * `kind === "unreachable"`.
+ *
+ * Why this is its own component instead of inlining into App.tsx:
+ * - Mirrors `ProfileScopeBanner` (one job, top-of-app status banner).
+ * - Dismiss state is local and ephemeral. A page reload re-shows the
+ *   banner — the user shouldn't be able to permanently hide a critical
+ *   "your dashboard is offline" warning.
+ *
+ * The Retry button forces an immediate poll via the hook's `retry()`
+ * rather than waiting up to POLL_MS for the next interval tick. On
+ * success the hook flips back to `kind === "live"` and the banner
+ * unmounts.
+ */
+export function DashboardOfflineBanner({
+  status,
+  retry,
+}: DashboardOfflineBannerProps) {
+  const { t } = useI18n();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (status.kind !== "unreachable" || dismissed) {
+    return null;
+  }
+
+  // Localized fallbacks: these keys are optional on Translations so
+  // non-English locales that haven't been updated yet still render
+  // sensibly instead of an empty banner.
+  const title =
+    t.app.offlineBannerTitle ??
+    "Dashboard unreachable — is the terminal session still running?";
+  const body =
+    t.app.offlineBannerBody ??
+    "The backend stopped responding. Data shown here may be stale until the connection comes back.";
+  const retryLabel = t.app.offlineRetry ?? t.common.retry;
+  const dismissLabel = t.common.close;
+
+  return (
+    // mt-14 on mobile clears the fixed lg:hidden header (h-14, z-40) so
+    // this banner — the offline signal — is never hidden behind it;
+    // lg:mt-0 restores desktop flow. Same convention as ProfileScopeBanner.
+    <div
+      role="alert"
+      aria-live="polite"
+      className={cn(
+        "mt-14 lg:mt-0",
+        "flex items-center justify-between gap-3",
+        "border-b border-destructive/40 bg-destructive/10",
+        "px-4 py-1.5 text-xs text-destructive",
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        <span className="truncate font-mondwest text-display tracking-[0.08em] uppercase">
+          {title}
+        </span>
+        <span className="hidden truncate text-text-secondary sm:inline">
+          {body}
+        </span>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          aria-label={retryLabel}
+          onClick={retry}
+          className={cn(
+            "inline-flex items-center gap-1.5",
+            "rounded-sm px-2 py-1",
+            "font-mondwest text-display tracking-[0.08em] uppercase",
+            "text-destructive transition-colors",
+            "hover:bg-destructive/15",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive/50",
+          )}
+        >
+          <RefreshCw className="h-3.5 w-3.5" aria-hidden />
+          {retryLabel}
+        </button>
+        <button
+          type="button"
+          aria-label={dismissLabel}
+          onClick={() => setDismissed(true)}
+          className={cn(
+            "inline-flex h-7 w-7 items-center justify-center",
+            "rounded-sm text-destructive transition-colors",
+            "hover:bg-destructive/15",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive/50",
+          )}
+        >
+          <X className="h-3.5 w-3.5" aria-hidden />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface DashboardOfflineBannerProps {
+  status: SidebarStatus;
+  retry: () => void;
+}

--- a/web/src/components/SidebarFooter.tsx
+++ b/web/src/components/SidebarFooter.tsx
@@ -1,10 +1,21 @@
 import { Typography } from "@nous-research/ui/ui/components/typography/index";
-import type { StatusResponse } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useI18n } from "@/i18n";
+import type { SidebarStatus } from "@/hooks/useSidebarStatus";
 
 export function SidebarFooter({ status }: SidebarFooterProps) {
   const { t } = useI18n();
+
+  // SidebarFooter only reads `version`. Pull it from whichever SidebarStatus
+  // branch has the last-known-good data; while `loading` we show the
+  // em-dash placeholder, and during `unreachable` we keep the last-seen
+  // version so the user knows what they were looking at.
+  const data =
+    status.kind === "live"
+      ? status.data
+      : status.kind === "unreachable"
+        ? status.lastData
+        : null;
 
   return (
     <div
@@ -17,7 +28,7 @@ export function SidebarFooter({ status }: SidebarFooterProps) {
       <Typography
         className="font-mono-ui text-xs tabular-nums tracking-[0.08em] text-text-tertiary lowercase"
       >
-        {status?.version != null ? `v${status.version}` : "—"}
+        {data?.version != null ? `v${data.version}` : "—"}
       </Typography>
 
       <a
@@ -37,5 +48,5 @@ export function SidebarFooter({ status }: SidebarFooterProps) {
 }
 
 interface SidebarFooterProps {
-  status: StatusResponse | null;
+  status: SidebarStatus;
 }

--- a/web/src/components/SidebarStatusStrip.tsx
+++ b/web/src/components/SidebarStatusStrip.tsx
@@ -2,12 +2,15 @@ import { Link } from "react-router-dom";
 import type { StatusResponse } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useI18n } from "@/i18n";
+import type { SidebarStatus } from "@/hooks/useSidebarStatus";
 
 /** Gateway + session summary for the System sidebar block (no separate strip chrome). */
 export function SidebarStatusStrip({ status }: SidebarStatusStripProps) {
   const { t } = useI18n();
 
-  if (status === null) {
+  // First-poll loading state — show the same skeleton pulse the old
+  // `status === null` branch did, so we don't visually regress.
+  if (status.kind === "loading") {
     return (
       <div className="px-5 py-1.5" aria-hidden>
         <div className="h-2 w-[80%] max-w-full animate-pulse rounded-sm bg-midground/10" />
@@ -15,7 +18,16 @@ export function SidebarStatusStrip({ status }: SidebarStatusStripProps) {
     );
   }
 
-  const gw = gatewayLine(status, t);
+  // Resolve to a flat StatusResponse|null + unreachable flag. Doing this
+  // once here keeps the render block below simple.
+  let data: StatusResponse | null;
+  if (status.kind === "live") {
+    data = status.data;
+  } else {
+    data = status.lastData;
+  }
+  const unreachable = status.kind === "unreachable";
+
   const { activeSessionsLabel, gatewayStatusLabel } = t.app;
 
   return (
@@ -34,18 +46,58 @@ export function SidebarStatusStrip({ status }: SidebarStatusStripProps) {
       <div className="flex flex-col gap-1 font-sans text-xs leading-snug tracking-[0.08em]">
         <p className="break-words">
           <span className="text-text-tertiary">{gatewayStatusLabel}</span>{" "}
-          <span className={cn("font-medium", gw.tone)}>{gw.label}</span>
+          <span className={cn("font-medium", resolveTone(status, t))}>
+            {resolveLabel(status, t)}
+          </span>
         </p>
 
         <p className="break-words">
           <span className="text-text-tertiary">{activeSessionsLabel}</span>{" "}
-          <span className="tabular-nums text-text-secondary">
-            {status.active_sessions}
+          <span
+            className={cn(
+              "tabular-nums",
+              unreachable ? "text-text-tertiary" : "text-text-secondary",
+            )}
+            title={
+              unreachable
+                ? t.app.statusUnreachableHint ?? t.app.statusUnreachable
+                : undefined
+            }
+          >
+            {data?.active_sessions ?? "—"}
           </span>
         </p>
       </div>
     </Link>
   );
+}
+
+/**
+ * Pick the label/tone for the "Gateway Status:" line in the sidebar.
+ *
+ * Returns destructive-tone "Unreachable" whenever the hook has crossed the
+ * consecutive-failure threshold, regardless of what the last good response
+ * said. This is the user-visible fix for #50270 — without this, the sidebar
+ * would still show "Running" in green on a frozen snapshot.
+ */
+function resolveLabel(
+  status: Exclude<SidebarStatus, { kind: "loading" }>,
+  t: ReturnType<typeof useI18n>["t"],
+): string {
+  if (status.kind === "unreachable") {
+    return t.app.statusUnreachable ?? t.app.gatewayStrip.failed;
+  }
+  return gatewayLine(status.data, t).label;
+}
+
+function resolveTone(
+  status: Exclude<SidebarStatus, { kind: "loading" }>,
+  t: ReturnType<typeof useI18n>["t"],
+): string {
+  if (status.kind === "unreachable") {
+    return "text-destructive";
+  }
+  return gatewayLine(status.data, t).tone;
 }
 
 export function gatewayLine(
@@ -68,5 +120,5 @@ export function gatewayLine(
 }
 
 interface SidebarStatusStripProps {
-  status: StatusResponse | null;
+  status: SidebarStatus;
 }

--- a/web/src/hooks/useSidebarStatus.test.ts
+++ b/web/src/hooks/useSidebarStatus.test.ts
@@ -1,0 +1,144 @@
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import type { StatusResponse } from "@/lib/api";
+import { useSidebarStatus, type SidebarStatus } from "./useSidebarStatus";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("@/lib/api", () => ({
+  api: { getStatus: vi.fn() },
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function status(version: string): StatusResponse {
+  return {
+    active_sessions: 1,
+    config_path: "/tmp/config.yaml",
+    config_version: 1,
+    env_path: "/tmp/.env",
+    gateway_exit_reason: null,
+    gateway_health_url: null,
+    gateway_pid: 123,
+    gateway_platforms: {},
+    gateway_running: true,
+    gateway_state: "running",
+    gateway_updated_at: null,
+    hermes_home: "/tmp/hermes",
+    latest_config_version: 1,
+    release_date: "2026-07-15",
+    version,
+  };
+}
+
+function Harness({ onRender }: { onRender: (value: SidebarStatus, retry: () => void) => void }) {
+  const value = useSidebarStatus();
+  onRender(value.status, value.retry);
+  return null;
+}
+
+describe("useSidebarStatus", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let current: SidebarStatus;
+  let retry: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(api.getStatus).mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  function renderHook() {
+    act(() => {
+      root.render(
+        createElement(Harness, {
+          onRender(value: SidebarStatus, nextRetry: () => void) {
+            current = value;
+            retry = nextRetry;
+          },
+        }),
+      );
+    });
+  }
+
+  it("becomes unreachable only after two consecutive failures", async () => {
+    vi.mocked(api.getStatus)
+      .mockRejectedValueOnce(new Error("first"))
+      .mockRejectedValueOnce(new Error("second"));
+
+    renderHook();
+    await act(async () => Promise.resolve());
+    expect(current.kind).toBe("loading");
+
+    act(() => retry());
+    await act(async () => Promise.resolve());
+    expect(current).toEqual({ kind: "unreachable", lastData: null });
+  });
+
+  it("recovers after a successful retry", async () => {
+    vi.mocked(api.getStatus)
+      .mockRejectedValueOnce(new Error("first"))
+      .mockRejectedValueOnce(new Error("second"))
+      .mockResolvedValueOnce(status("2.0.0"));
+
+    renderHook();
+    await act(async () => Promise.resolve());
+    act(() => retry());
+    await act(async () => Promise.resolve());
+    expect(current.kind).toBe("unreachable");
+
+    act(() => retry());
+    await act(async () => Promise.resolve());
+    expect(current).toEqual({ kind: "live", data: status("2.0.0") });
+  });
+
+  it("does not start a retry while a request is already in flight", async () => {
+    const pending = deferred<StatusResponse>();
+    vi.mocked(api.getStatus).mockReturnValue(pending.promise);
+
+    renderHook();
+    act(() => retry());
+    expect(api.getStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => pending.resolve(status("3.0.0")));
+    expect(current).toEqual({ kind: "live", data: status("3.0.0") });
+  });
+
+  it("ignores every outstanding request after unmount", async () => {
+    const pending = deferred<StatusResponse>();
+    vi.mocked(api.getStatus).mockReturnValue(pending.promise);
+
+    renderHook();
+    act(() => retry());
+    act(() => root.unmount());
+    await act(async () => pending.resolve(status("4.0.0")));
+
+    expect(current).toEqual({ kind: "loading" });
+  });
+});

--- a/web/src/hooks/useSidebarStatus.test.ts
+++ b/web/src/hooks/useSidebarStatus.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { act } from "react";

--- a/web/src/hooks/useSidebarStatus.ts
+++ b/web/src/hooks/useSidebarStatus.ts
@@ -1,27 +1,97 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
 import type { StatusResponse } from "@/lib/api";
 
 const POLL_MS = 10_000;
+/**
+ * Flip to `unreachable` after this many *consecutive* failed polls.
+ *
+ * 2 × 10s = ~20s before the sidebar visibly warns. Enough to ride out a
+ * single transient blip or a mid-restart window, while still catching a
+ * truly dead backend well within a minute.
+ *
+ * Any successful poll clears the counter back to 0.
+ */
+const UNREACHABLE_THRESHOLD = 2;
 
 /**
- * Light-weight status poll for the app shell (sidebar). The Status page uses
- * its own faster interval; we keep this slower to avoid duplicate load.
+ * Sidebar status is a tri-state, not a `StatusResponse | null`:
+ *
+ *   - `loading`     — first poll hasn't completed yet.
+ *   - `live`        — last poll succeeded; `data` is fresh.
+ *   - `unreachable` — last N polls failed in a row. `lastData` is the
+ *                     last-known-good response so consumers can render
+ *                     "Running (unreachable since 14:32)" rather than
+ *                     discarding information the user already saw.
+ *
+ * Without this distinction, `useSidebarStatus` silently keeps the last
+ * successful response forever when the backend dies, and the sidebar
+ * happily renders "Running" in green on a frozen snapshot. See
+ * issue #50270.
  */
-export function useSidebarStatus() {
-  const [status, setStatus] = useState<StatusResponse | null>(null);
+export type SidebarStatus =
+  | { kind: "loading" }
+  | { kind: "live"; data: StatusResponse }
+  | { kind: "unreachable"; lastData: StatusResponse | null };
 
-  useEffect(() => {
-    const load = () => {
-      api
-        .getStatus()
-        .then(setStatus)
-        .catch(() => {});
-    };
-    load();
-    const id = setInterval(load, POLL_MS);
-    return () => clearInterval(id);
+export function useSidebarStatus(): {
+  status: SidebarStatus;
+  /** Force an immediate poll (used by the offline banner's "Retry" button). */
+  retry: () => void;
+} {
+  const [status, setStatus] = useState<SidebarStatus>({ kind: "loading" });
+  const consecutiveFailures = useRef(0);
+  const mounted = useRef(false);
+  const requestInFlight = useRef(false);
+
+  const load = useCallback(() => {
+    if (!mounted.current || requestInFlight.current) return;
+    requestInFlight.current = true;
+    api
+      .getStatus()
+      .then((data) => {
+        if (!mounted.current) return;
+        consecutiveFailures.current = 0;
+        setStatus({ kind: "live", data });
+      })
+      .catch(() => {
+        if (!mounted.current) return;
+        consecutiveFailures.current += 1;
+        setStatus((prev) => {
+          // Only flip to `unreachable` once we cross the threshold. Anything
+          // below the threshold is still treated as "live with possibly stale
+          // data" — a single failed poll is almost always a transient blip.
+          if (consecutiveFailures.current >= UNREACHABLE_THRESHOLD) {
+            // Preserve the last-known-good StatusResponse (if any) so the
+            // sidebar can render "last seen: Running" alongside the
+            // unreachable banner instead of blanking everything out.
+            let lastData: StatusResponse | null;
+            if (prev.kind === "live") {
+              lastData = prev.data;
+            } else if (prev.kind === "unreachable") {
+              lastData = prev.lastData;
+            } else {
+              lastData = null;
+            }
+            return { kind: "unreachable", lastData };
+          }
+          return prev;
+        });
+      })
+      .finally(() => {
+        requestInFlight.current = false;
+      });
   }, []);
 
-  return status;
+  useEffect(() => {
+    mounted.current = true;
+    load();
+    const id = setInterval(load, POLL_MS);
+    return () => {
+      mounted.current = false;
+      clearInterval(id);
+    };
+  }, [load]);
+
+  return { status, retry: load };
 }

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -97,6 +97,14 @@ export const en: Translations = {
     currentProfileOption: "this dashboard ({name})",
     managingProfileBanner:
       "Managing profile \u201c{name}\u201d \u2014 config, keys, skills, MCPs, model, and new chats apply to that profile.",
+    offlineBannerTitle:
+      "Dashboard unreachable — is the terminal session still running?",
+    offlineBannerBody:
+      "The backend stopped responding. Data shown here may be stale until the connection comes back.",
+    offlineRetry: "Retry",
+    statusUnreachable: "Unreachable",
+    statusUnreachableHint:
+      "Last known value — backend is not responding right now.",
   },
 
   status: {

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -114,6 +114,14 @@ export interface Translations {
     managingProfile?: string;
     currentProfileOption?: string;
     managingProfileBanner?: string;
+    /** Optional — DashboardOfflineBanner falls back to English literals. */
+    offlineBannerTitle?: string;
+    offlineBannerBody?: string;
+    offlineRetry?: string;
+    /** Sidebar "Gateway Status:" label when the dashboard backend is unreachable. */
+    statusUnreachable?: string;
+    /** Tooltip on the stale "Active Sessions" count when unreachable. */
+    statusUnreachableHint?: string;
   };
 
   // ── Status page ──


### PR DESCRIPTION
Fixes #50270

## Problem

The sidebar "Gateway Status" line kept showing **"Running"** in green forever after the dashboard backend was killed. Every fetch error in `useSidebarStatus` was silently swallowed by `.catch(() => {})`, so the last successful response stayed in state and was rendered indefinitely. Users had no UI signal that the dashboard was offline.

## Root cause

`web/src/hooks/useSidebarStatus.ts:14-22`:
```ts
api.getStatus().then(setStatus).catch(() => {});
```
When the backend dies, the hook keeps the last successful response. The downstream consumers (`SidebarStatusStrip`, `GatewayDot`, `SidebarFooter`) faithfully render the stale data — they have no way to know it's stale because the hook never tells them.

## Fix

1. **`useSidebarStatus`** now exposes a tri-state — `{ kind: "loading" } | { kind: "live", data } | { kind: "unreachable", lastData }` — plus a `retry()` callback. A consecutive-failure counter flips to `unreachable` after 2 failed polls (~20s at the current 10s interval); any successful poll clears it back to `live`. Threshold tuned to ride out single transient blips and mid-restart windows without false-positives.

2. **`SidebarStatusStrip` + `GatewayDot` (in `App.tsx`)** now render an `unreachable` branch. The dot turns destructive-red and the "Gateway Status:" label reads "Unreachable" regardless of what the last good response said. The last-known active-sessions count stays visible with a tooltip marking it stale.

3. **`DashboardOfflineBanner`** — new component rendered at the top of the app shell when `unreachable`. Sticky, dismissible per session, with a Retry button that re-runs the poll immediately. Same `mt-14 lg:mt-0` mounting pattern as `ProfileScopeBanner`.

4. **5 new optional i18n keys** on `web/src/i18n/en.ts` `app` block (`offlineBannerTitle`, `offlineBannerBody`, `offlineRetry`, `statusUnreachable`, `statusUnreachableHint`). Marked optional so non-English locales fall back to English literals without breakage, matching the existing `managingProfileBanner` convention.

5. **`SidebarFooter`** keeps the last-known version during `unreachable` so the footer doesn't flicker.

6. **`SidebarSystemActions`** reads `can_update_hermes` from whichever `SidebarStatus` branch has data, so the Update button doesn't disappear/reappear during a connection blip.

## Scope

Only the sidebar status pipeline. Other polling hooks (SessionsPage, StatusPage, etc.) likely exhibit the same silent-swallow pattern — those are intentionally out of scope for this fix and should be addressed separately.

## Verification

- `npm run build` (`tsc -b && vite build`) clean.
- TypeScript compiler exits with no errors against the new union shape.
- Reproduction:
  1. `hermes dashboard` in any terminal.
  2. Open the dashboard, confirm "Gateway Status: Running" green.
  3. Kill the dashboard process (`Cmd-C` or close the terminal).
  4. Wait ~20s.
  5. Banner appears at top of page: "Dashboard unreachable — is the terminal session still running?" with Retry button. Sidebar status line flips to "Unreachable" in destructive tone. The green dot next to the status line turns destructive-red.
  6. Restart the dashboard in another terminal. Banner auto-dismisses on the next successful poll. Sidebar returns to green "Running" within ~10s of restart.

## Files changed

- `web/src/App.tsx` — new banner, new prop types on `SidebarSystemActions`/`GatewayDot`, `can_update_hermes` extraction, import for `SidebarStatus` type.
- `web/src/components/DashboardOfflineBanner.tsx` — new component.
- `web/src/components/SidebarFooter.tsx` — accept `SidebarStatus` instead of `StatusResponse | null`.
- `web/src/components/SidebarStatusStrip.tsx` — `resolveLabel`/`resolveTone` helpers, unreachable branch.
- `web/src/hooks/useSidebarStatus.ts` — tri-state + retry callback.
- `web/src/i18n/en.ts` — 5 new optional `app` keys.
- `web/src/i18n/types.ts` — `Translations.app` interface updated.

```
 7 files changed, 311 insertions(+), 35 deletions(-)
```