### PR TITLE
fix(agent): Copilot Claude chat-completions — plain httpx transport + preserve routed headers (#12066)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -809,6 +809,8 @@ def init_agent(
                 # _default_headers instead.
                 _routed_headers = getattr(_routed_client, "_custom_headers", None)
                 if not _routed_headers:
+                    _routed_headers = getattr(_routed_client, "default_headers", None)
+                if not _routed_headers:
                     _routed_headers = getattr(_routed_client, "_default_headers", None)
                 if _routed_headers:
                     client_kwargs["default_headers"] = dict(_routed_headers)
@@ -861,6 +863,8 @@ def init_agent(
                             if _provider_timeout is not None:
                                 client_kwargs["timeout"] = _provider_timeout
                             _fb_headers = getattr(_fb_client, "_custom_headers", None)
+                            if not _fb_headers:
+                                _fb_headers = getattr(_fb_client, "default_headers", None)
                             if not _fb_headers:
                                 _fb_headers = getattr(_fb_client, "_default_headers", None)
                             if _fb_headers:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3557,6 +3557,9 @@ class AIAgent:
             import httpx as _httpx
             import socket as _socket
 
+            if "api.githubcopilot.com" in str(base_url or "").lower():
+                return _httpx.Client()
+
             _sock_opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
             if hasattr(_socket, "TCP_KEEPIDLE"):
                 _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPIDLE, 30))

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -145,6 +145,27 @@ def test_create_openai_client_no_proxy_when_env_unset(mock_openai, monkeypatch):
     http_client.close()
 
 
+@patch("run_agent.OpenAI")
+def test_create_openai_client_uses_plain_httpx_client_for_copilot(mock_openai, monkeypatch):
+    """Copilot Claude chat-completions rejects the custom socket-options transport."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+
+    agent = _make_agent()
+    kwargs = {
+        "api_key": "test-key",
+        "base_url": "https://api.githubcopilot.com",
+    }
+    agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    forwarded = mock_openai.call_args.kwargs
+    http_client = _extract_http_client(forwarded)
+    assert isinstance(http_client, httpx.Client)
+    assert getattr(http_client._transport._pool, "_socket_options", None) is None
+    http_client.close()
+
+
 def test_get_proxy_for_base_url_returns_none_when_host_bypassed(monkeypatch):
     """NO_PROXY must suppress the proxy for matching base_urls.
 

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -110,6 +110,31 @@ def test_routed_client_preserves_openai_sdk_custom_headers(mock_openai):
 
 
 @patch("run_agent.OpenAI")
+def test_routed_client_preserves_openai_sdk_default_headers(mock_openai):
+    mock_openai.return_value = MagicMock()
+    routed_client = SimpleNamespace(
+        api_key="test-key",
+        base_url="https://api.githubcopilot.com",
+        default_headers={"copilot-integration-id": "vscode-chat"},
+    )
+
+    with patch("agent.auxiliary_client.resolve_provider_client", return_value=(
+        routed_client,
+        "claude-opus-4.7",
+    )):
+        agent = AIAgent(
+            provider="copilot",
+            model="claude-opus-4.7",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["copilot-integration-id"] == "vscode-chat"
+
+
+@patch("run_agent.OpenAI")
 def test_gmi_base_url_picks_up_profile_user_agent(mock_openai):
     """GMI declares User-Agent on its ProviderProfile.default_headers.
 


### PR DESCRIPTION
## Summary
Copilot Claude `chat_completions` calls now succeed in Hermes instead of failing with `400 model_not_supported` while the same token/model/payload works via raw `requests`.

Two compounding bugs, both confirmed on current `main`:

1. **Transport** — every OpenAI-wire client (incl. `api.githubcopilot.com`) was wrapped in Hermes' custom `httpx.HTTPTransport(socket_options=...)` keepalive transport. Copilot's Claude chat-completions path rejects that transport and returns a misleading `model_not_supported`. Plain `httpx` and raw `requests` succeed.
2. **Header handoff** — when rebuilding a routed OpenAI client, Hermes copied headers from `_custom_headers` → `_default_headers`, but real SDK v2 clients expose the merged headers on the **public** `default_headers` property; that middle fallback was missing.

## Changes
- `run_agent.py`: `_build_keepalive_http_client()` returns a plain `httpx.Client()` for `api.githubcopilot.com` (still reads env proxies via `trust_env`), keeping the custom keepalive socket-options transport for every other host (#10324 dead-connection detection preserved).
- `agent/agent_init.py`: add public `default_headers` as the middle fallback in the routed-client header copy, at both the primary and fallback client-rebuild sites.
- Two regression tests: Copilot gets a plain httpx client (no socket options); routed SDK-v2 `default_headers` are preserved.

## Validation
| | Before | After |
|---|---|---|
| Copilot keepalive transport | custom socket_options | plain `httpx.Client()` (E2E: `socket_options is None`) |
| Non-copilot keepalive transport | custom socket_options | unchanged (E2E confirmed present) |
| Routed SDK-v2 `default_headers` | dropped | preserved |
| `tests/run_agent/{test_provider_attribution_headers,test_create_openai_client_proxy_env}.py` | — | 24/24 pass |

Salvages #39159 (@konsisumer) onto current `main` with authorship preserved. Fixes #12066. Supersedes the heavier closed dup #15185 (@briandevans).

## Infographic

![copilot-claude-400-fix](https://v3b.fal.media/files/b/0a9f377b/N5J7k-PKAArOKGa-IecAx_ywyYb22O.png)
