### PR TITLE
fix(bedrock): non-Claude models ignore --model flag and route through Anthropic SDK

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -42,6 +42,7 @@ class CLIAgentSetupMixin:
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                target_model=self.model or None,
             )
         except Exception as exc:
             _primary_exc = exc

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1756,7 +1756,10 @@ def resolve_runtime_provider(
         # Dual-path routing: Claude models use AnthropicBedrock SDK for full
         # feature parity (prompt caching, thinking budgets, adaptive thinking).
         # Non-Claude models use the Converse API for multi-model support.
-        _current_model = str(model_cfg.get("default") or "").strip()
+        # Prefer target_model (runtime override) over the config default so
+        # that --model deepseek.v3.2 routes to bedrock_converse even when the
+        # persisted config.yaml default is a Claude model.
+        _current_model = str(target_model or model_cfg.get("default") or "").strip()
         if is_anthropic_bedrock_model(_current_model):
             # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path
             runtime = {


### PR DESCRIPTION
## Problem

When `config.yaml` has a Claude model as the default (e.g. `global.anthropic.claude-sonnet-4-6`) and you run:

```
hermes chat --provider bedrock --model deepseek.v3.2
```

The agent crashes with HTTP 400. DeepSeek gets routed through the AnthropicBedrock SDK, which injects Claude-specific params (`anthropic_version`, `thinking` budget) that Bedrock rejects.

## Root Cause

`resolve_runtime_provider` decides between `anthropic_messages` (AnthropicBedrock SDK) and `bedrock_converse` (Converse API) by checking `model_cfg.get('default')` — the **config file default**, not the runtime model. The `--model` CLI flag is invisible to the routing decision.

`target_model` already exists on `resolve_runtime_provider` for exactly this purpose (used by OpenCode Zen/Go) but was never wired up for the CLI chat path.

## Fix

Two-line change:
1. `runtime_provider.py`: prefer `target_model` over `model_cfg` default when deciding `api_mode` for Bedrock
2. `cli_agent_setup_mixin.py`: pass `self.model` as `target_model` so the runtime `--model` flag reaches the resolver

## Impact

Any user with Claude as their config default cannot use non-Claude Bedrock models (DeepSeek, Nova, Llama, Mistral, etc.) from the CLI without permanently changing their config. Unrelated to the `max_tokens` cap in #37298/#37309.

## Verified

```
hermes chat -q "find Bitcoin price" --provider bedrock --model deepseek.v3.2 -t web
```

Before: HTTP 400 crash. After: routes to `bedrock_converse`, tool calls work, returns correct result.
