### PR TITLE
fix(skills): dedup skill slash commands on the normalized slug

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -402,7 +402,24 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
                         continue
-                    _skill_commands[f"/{cmd_name}"] = {
+                    # The seen_names check above dedups on the raw frontmatter
+                    # name, but the command map is keyed by the normalized slug.
+                    # Two distinct names that collapse to the same slug (e.g.
+                    # "git_helper" vs "git-helper") would otherwise both pass
+                    # that check and the second write would silently clobber the
+                    # first. Dedup on the resolved slug too, first-wins: since
+                    # the local SKILLS_DIR is scanned before external dirs, a
+                    # local/built-in skill keeps its slash command rather than
+                    # being shadowed by a later colliding skill.
+                    cmd_key = f"/{cmd_name}"
+                    if cmd_key in _skill_commands:
+                        logger.debug(
+                            "Skill %r maps to slash command %s already claimed by "
+                            "%r; keeping the first and skipping this one.",
+                            name, cmd_key, _skill_commands[cmd_key]["name"],
+                        )
+                        continue
+                    _skill_commands[cmd_key] = {
                         "name": name,
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -377,6 +377,32 @@ class TestScanSkillCommands:
         assert "/sonarr-v3v4-api" in result
         assert any("/" in k[1:] for k in result) is False  # no unescaped /
 
+    def test_slug_collision_keeps_first_skill(self, tmp_path):
+        """Two skills whose names normalize to the same slug do not clobber.
+
+        ``git_helper`` and ``git-helper`` are distinct frontmatter names but
+        both reduce to the ``/git-helper`` command. The first one scanned must
+        keep the command rather than being silently overwritten by the second.
+        """
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            # ``a-first`` sorts before ``z-second`` so the index walk visits the
+            # underscore-named skill first; that one must win the slash command.
+            first = tmp_path / "a-first"
+            first.mkdir()
+            (first / "SKILL.md").write_text(
+                "---\nname: git_helper\ndescription: First skill.\n---\n\nBody.\n"
+            )
+            second = tmp_path / "z-second"
+            second.mkdir()
+            (second / "SKILL.md").write_text(
+                "---\nname: git-helper\ndescription: Second skill.\n---\n\nBody.\n"
+            )
+            result = scan_skill_commands()
+        assert "/git-helper" in result
+        # First-wins: the entry resolves to the first skill, not the shadowing one.
+        assert result["/git-helper"]["name"] == "git_helper"
+        assert result["/git-helper"]["skill_dir"] == str(first)
+
 
 class TestResolveSkillCommandKey:
     """Telegram bot-command names disallow hyphens, so the menu registers


### PR DESCRIPTION
scan_skill_commands() rejected duplicates with `if name in seen_names`,
which compares the raw frontmatter `name`, yet it keyed the command map by
the normalized slug `cmd_name` (lowercased, spaces/underscores collapsed to
hyphens, invalid characters stripped). Two skills whose names differ only
after normalization — for example `git_helper` and `git-helper` — therefore
passed the seen-names check as distinct entries while resolving to the same
`/git-helper` command, and the second write silently overwrote the first.

The consequence was that one skill became unreachable via its slash command
and invoking `/<slug>` loaded the wrong skill body, pointing at the wrong
skill_dir and skill_md_path. Because the local SKILLS_DIR is scanned before
external directories with last-write-wins semantics, an externally added
skill could even shadow the command of a bundled or local skill.

The scan now dedups on the resolved slug as well, keeping the first skill
scanned (first-wins). This preserves the local-before-external precedence so
a local or built-in skill retains its slash command rather than being
shadowed, and the dropped collision is logged at debug level for diagnosis.

## What does this PR do?

It fixes a slash-command collision in the skills scanner so that two skills
whose names normalize to the same slug no longer silently overwrite one
another, which previously made one skill unreachable and could route a
`/command` to the wrong skill body.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/skill_commands.py`: `scan_skill_commands()` now guards the command
  map against slug collisions, keeping the first-scanned skill and logging the
  dropped collision at debug level.
- `tests/agent/test_skill_commands.py`: added
  `test_slug_collision_keeps_first_skill`, which registers `git_helper` and
  `git-helper` and asserts the first-scanned skill retains the `/git-helper`
  command.

## How to Test

1. Create two skills whose `name` values normalize to the same slug, such as
   `git_helper` and `git-helper`.
2. Before this change, `scan_skill_commands()` returned a single `/git-helper`
   entry pointing at whichever skill was scanned last.
3. After this change, the first-scanned skill keeps the command. Run
   `.venv/bin/python -m pytest tests/agent/test_skill_commands.py -q` and
   confirm all tests pass, including `test_slug_collision_keeps_first_skill`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A