### PR TITLE
fix(acp): preserve compaction-archived transcript on per-turn persist

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -423,8 +423,9 @@ class SessionManager:
     def _persist(self, state: SessionState) -> None:
         """Write session state to the database.
 
-        Creates the session record if it doesn't exist, then replaces all
-        stored messages with the current in-memory history.
+        Creates the session record if it doesn't exist, then replaces the live
+        (active) stored messages with the current in-memory history while
+        leaving any soft-archived rows (e.g. compaction-archived turns) intact.
         """
         db = self._get_db()
         if db is None:
@@ -464,7 +465,18 @@ class SessionManager:
             # Replace stored messages with current history atomically so a
             # mid-rewrite failure rolls back and the previously persisted
             # conversation is preserved (salvaged from #13675).
-            db.replace_messages(state.session_id, state.history)
+            #
+            # active_only=True: the AIAgent shares this session id and its
+            # DB (see _make_agent), so when its context grows past the
+            # compression threshold it runs in-place compaction via
+            # archive_and_compact, which soft-archives the pre-compaction
+            # turns (active=0, compacted=1) to keep them on disk and
+            # discoverable by session_search (#38763). A full-history replace
+            # here would DELETE those archived rows the moment the turn ends,
+            # silently wiping the transcript of every long-running ACP
+            # session. Replacing only the live (active=1) rows keeps the
+            # archived history intact while still refreshing the active set.
+            db.replace_messages(state.session_id, state.history, active_only=True)
         except Exception:
             logger.warning("Failed to persist ACP session %s", state.session_id, exc_info=True)
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2667,21 +2667,39 @@ class SessionDB:
             now_ts = max(now_ts + 1e-6, message_timestamp + 1e-6)
         return inserted, tool_calls_total
 
-    def replace_messages(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
-        """Atomically replace every message for a session.
+    def replace_messages(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        active_only: bool = False,
+    ) -> None:
+        """Atomically replace the stored messages for a session.
 
         Used by transcript-rewrite flows such as /retry, /undo, and /compress.
         The delete + reinsert sequence must commit as one transaction so a
         mid-rewrite failure does not leave SQLite with a partial transcript.
 
-        DESTRUCTIVE: the prior rows are DELETEd (and drop out of the FTS index).
-        For compaction that must preserve the pre-compaction transcript under
-        the same id, use :meth:`archive_and_compact` instead.
+        DESTRUCTIVE by default: every row for the session is DELETEd (and drops
+        out of the FTS index). For compaction that must preserve the
+        pre-compaction transcript under the same id, use
+        :meth:`archive_and_compact` instead.
+
+        Pass ``active_only=True`` to replace ONLY the live (``active = 1``) rows,
+        leaving soft-archived rows (``active = 0`` — e.g. the compacted=1 turns
+        that :meth:`archive_and_compact` keeps on disk for #38763 durability, or
+        rewind/undo rows) untouched. This is what callers that share a session
+        id with an agent already running in-place compaction must use, so a
+        full-history rewrite doesn't wipe the rows the agent deliberately
+        archived. ``message_count``/``tool_call_count`` then track the live set,
+        matching :meth:`archive_and_compact`.
         """
+
+        active_clause = " AND active = 1" if active_only else ""
 
         def _do(conn):
             conn.execute(
-                "DELETE FROM messages WHERE session_id = ?", (session_id,)
+                f"DELETE FROM messages WHERE session_id = ?{active_clause}",
+                (session_id,),
             )
             conn.execute(
                 "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -216,6 +216,52 @@ class TestListAndCleanup:
         assert messages[0]["content"] == "original"
         assert isinstance(messages[0].get("timestamp"), (int, float))
 
+    def test_save_session_preserves_compaction_archived_history(self, manager):
+        """A per-turn persist must not wipe the agent's archived transcript.
+
+        The ACP AIAgent shares its session id and DB with the SessionManager,
+        so when it compacts in-place it calls archive_and_compact(), which
+        soft-archives the pre-compaction turns (active=0, compacted=1) to keep
+        them on disk and discoverable. The very next save_session() used to run
+        a full-history replace_messages() whose unconditional DELETE wiped those
+        archived rows. _persist now replaces only the active rows, so the
+        archived pre-compaction transcript survives.
+        """
+        state = manager.create_session()
+        state.history = [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+        ]
+        manager.save_session(state.session_id)
+
+        db = manager._get_db()
+        # Simulate the agent compacting in place: the live turns become
+        # archived (active=0, compacted=1) and a summary becomes the new live
+        # head — exactly what conversation_compression.archive_and_compact does
+        # against the shared session id.
+        compacted = [{"role": "user", "content": "[summary of earlier turns]"}]
+        db.archive_and_compact(state.session_id, compacted)
+
+        # The next ACP turn ends and persists the (now compacted) history plus a
+        # fresh exchange.
+        state.history = compacted + [
+            {"role": "user", "content": "second question"},
+            {"role": "assistant", "content": "second answer"},
+        ]
+        manager.save_session(state.session_id)
+
+        # Live load: only the compacted/active set, no archived rows.
+        active = db.get_messages_as_conversation(state.session_id)
+        active_contents = [m["content"] for m in active]
+        assert "first question" not in active_contents
+        assert "second answer" in active_contents
+
+        # Full load: the pre-compaction transcript is still on disk.
+        all_rows = db.get_messages(state.session_id, include_inactive=True)
+        all_contents = [r["content"] for r in all_rows]
+        assert "first question" in all_contents
+        assert "first answer" in all_contents
+
     def test_cleanup_clears_all(self, manager):
         s1 = manager.create_session()
         s2 = manager.create_session()


### PR DESCRIPTION
## What does this PR do?

Stops every long-running ACP session from silently losing its entire
pre-compaction transcript. The ACP `AIAgent` is created with the same
`session_id` and `SessionDB` as the adapter (`_make_agent`), so once its
context grows past the compression threshold it compacts *in place* via
`SessionDB.archive_and_compact()`, which deliberately soft-archives the
pre-compaction turns (`active=0, compacted=1`) to keep them on disk and
discoverable by `session_search` (the #38763 durability guarantee). The
problem: as soon as that turn ends, `SessionManager._persist()` called
`replace_messages()`, whose unconditional `DELETE FROM messages WHERE
session_id = ?` wiped *all* rows for the id — including the ones the agent
had just archived. Net effect: auto-compaction fires, the turn returns, and
the archived history is gone.

Why this approach: the per-turn persist only ever needs to refresh the live
(active) set — the agent already owns archival. So `_persist` now replaces
only `active=1` rows and leaves soft-archived rows untouched, rather than
trying to teach the adapter about compaction state. This keeps the existing
atomic delete+reinsert contract (the #13675 rollback-on-failure guarantee)
fully intact for the live set.

Why not change `replace_messages` outright: it's also used by destructive
rewrite flows (/retry, /undo, /compress, forks) that genuinely want every
row gone, so the new behavior is opt-in via an `active_only` flag and all
other callers are unchanged.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: add an `active_only: bool = False` parameter to
  `SessionDB.replace_messages()`. When set, the `DELETE` is scoped with
  `AND active = 1` so soft-archived rows survive; `message_count`/
  `tool_call_count` then track the live set, matching `archive_and_compact()`.
  Default is unchanged, so existing callers keep their destructive semantics.
- `acp_adapter/session.py`: `SessionManager._persist()` now calls
  `replace_messages(..., active_only=True)`, and the method docstrings are
  updated to reflect that only the live rows are replaced.
- `tests/acp/test_session.py`: add
  `test_save_session_preserves_compaction_archived_history`, a regression
  test that compacts a session in place and asserts the archived turns remain
  retrievable via `get_messages(include_inactive=True)` after a subsequent
  `save_session()`.

## How to Test

1. Reproduce: with the fix reverted, run the new test — it fails because the
   per-turn persist deletes the archived rows.
2. Verify the fix: `scripts/run_tests.sh tests/acp/test_session.py` — the new
   `test_save_session_preserves_compaction_archived_history` passes, and the
   existing #13675 rollback test still passes.
3. Regression-check the shared method: the `replace_messages` /
   `archive_and_compact` SessionDB tests in `tests/hermes_state/` and
   `tests/test_hermes_state.py` all pass, confirming default callers are
   unaffected.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A