### PR TITLE
fix(research): keep trajectory uncompressed when summarization fails

### DIFF
--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -628,3 +628,75 @@ class TestCompressionToolPairIntegrity:
             {"from": "tool", "value": "<tool_response>a</tool_response>"},
         ]
         assert tc._snap_boundary(trajectory, 1, 0, 1) == 0
+
+
+# ---------------------------------------------------------------------------
+# TrajectoryCompressor — a failed summary must not corrupt the trajectory
+# ---------------------------------------------------------------------------
+
+
+class TestFailedSummaryKeepsTrajectory:
+    """When summarization fails after all retries the real turns must survive."""
+
+    def _config(self):
+        config = CompressionConfig()
+        config.protect_last_n_turns = 2
+        config.summary_target_tokens = 4
+        return config
+
+    def test_generate_summary_returns_none_when_all_retries_fail(self):
+        config = CompressionConfig(max_retries=2)
+        tc = _make_compressor(config)
+        tc._use_call_llm = False
+        tc.client = MagicMock()
+        tc.client.chat.completions.create.side_effect = RuntimeError("api down")
+        metrics = TrajectoryMetrics()
+
+        assert tc._generate_summary("turns", metrics) is None
+        assert metrics.summarization_errors == 2
+
+    @pytest.mark.asyncio
+    async def test_generate_summary_async_returns_none_when_all_retries_fail(self):
+        config = CompressionConfig(max_retries=2)
+        tc = _make_compressor(config)
+        tc._use_call_llm = False
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=RuntimeError("api down")
+        )
+        tc._get_async_client = MagicMock(return_value=mock_client)
+        metrics = TrajectoryMetrics()
+
+        assert await tc._generate_summary_async("turns", metrics) is None
+        assert metrics.summarization_errors == 2
+
+    def test_sync_failed_summary_leaves_trajectory_uncompressed(self):
+        tc = _make_compressor(self._config())
+        tc._generate_summary = MagicMock(return_value=None)
+        trajectory = _paired_trajectory()
+        tc.config.target_max_tokens = _target_that_splits_after_index_4(tc, trajectory)
+
+        compressed, metrics = tc.compress_trajectory(trajectory)
+
+        # Original turns are preserved verbatim — no placeholder substitution.
+        assert compressed == trajectory
+        assert not metrics.was_compressed
+        assert metrics.still_over_limit
+        assert _count_marker(compressed, "<tool_call>") == _count_marker(
+            compressed, "<tool_response>"
+        )
+        assert "[CONTEXT SUMMARY]" not in "".join(t["value"] for t in compressed)
+
+    @pytest.mark.asyncio
+    async def test_async_failed_summary_leaves_trajectory_uncompressed(self):
+        tc = _make_compressor(self._config())
+        tc._generate_summary_async = AsyncMock(return_value=None)
+        trajectory = _paired_trajectory()
+        tc.config.target_max_tokens = _target_that_splits_after_index_4(tc, trajectory)
+
+        compressed, metrics = await tc.compress_trajectory_async(trajectory)
+
+        assert compressed == trajectory
+        assert not metrics.was_compressed
+        assert metrics.still_over_limit
+        assert "[CONTEXT SUMMARY]" not in "".join(t["value"] for t in compressed)

--- a/tests/test_trajectory_compressor_async.py
+++ b/tests/test_trajectory_compressor_async.py
@@ -11,7 +11,7 @@ each asyncio.run() gets a client bound to the current loop.
 """
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -131,7 +131,7 @@ async def test_generate_summary_async_kimi_omits_temperature():
     compressor.logger = MagicMock()
     compressor._use_call_llm = False
     async_client = MagicMock()
-    async_client.chat.completions.create = MagicMock(return_value=SimpleNamespace(
+    async_client.chat.completions.create = AsyncMock(return_value=SimpleNamespace(
         choices=[SimpleNamespace(message=SimpleNamespace(content="[CONTEXT SUMMARY]: summary"))]
     ))
     compressor._get_async_client = MagicMock(return_value=async_client)
@@ -160,7 +160,7 @@ async def test_generate_summary_async_public_moonshot_kimi_k2_5_omits_temperatur
     compressor.logger = MagicMock()
     compressor._use_call_llm = False
     async_client = MagicMock()
-    async_client.chat.completions.create = MagicMock(return_value=SimpleNamespace(
+    async_client.chat.completions.create = AsyncMock(return_value=SimpleNamespace(
         choices=[SimpleNamespace(message=SimpleNamespace(content="[CONTEXT SUMMARY]: summary"))]
     ))
     compressor._get_async_client = MagicMock(return_value=async_client)
@@ -189,7 +189,7 @@ async def test_generate_summary_async_public_moonshot_cn_kimi_k2_5_omits_tempera
     compressor.logger = MagicMock()
     compressor._use_call_llm = False
     async_client = MagicMock()
-    async_client.chat.completions.create = MagicMock(return_value=SimpleNamespace(
+    async_client.chat.completions.create = AsyncMock(return_value=SimpleNamespace(
         choices=[SimpleNamespace(message=SimpleNamespace(content="[CONTEXT SUMMARY]: summary"))]
     ))
     compressor._get_async_client = MagicMock(return_value=async_client)

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -607,16 +607,18 @@ class TrajectoryCompressor:
             return text
         return "[CONTEXT SUMMARY]:" if not text else f"[CONTEXT SUMMARY]: {text}"
     
-    def _generate_summary(self, content: str, metrics: TrajectoryMetrics) -> str:
+    def _generate_summary(self, content: str, metrics: TrajectoryMetrics) -> Optional[str]:
         """
         Generate a summary of the compressed turns using OpenRouter.
-        
+
         Args:
             content: The content to summarize
             metrics: Metrics object to update
-            
+
         Returns:
-            Summary string
+            Summary string, or ``None`` if summarization failed after all
+            retries (the caller must then leave the trajectory uncompressed
+            rather than discard the real turns).
         """
         prompt = f"""Summarize the following agent conversation turns concisely. This summary will replace these turns in the conversation history.
 
@@ -673,19 +675,23 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 if attempt < self.config.max_retries - 1:
                     time.sleep(jittered_backoff(attempt + 1, base_delay=self.config.retry_delay, max_delay=30.0))
                 else:
-                    # Fallback: create a basic summary
-                    return "[CONTEXT SUMMARY]: [Summary generation failed - previous turns contained tool calls and responses that have been compressed to save context space.]"
+                    # All retries exhausted. Signal failure so the caller keeps
+                    # the trajectory verbatim — replacing real tool turns with a
+                    # generic placeholder would corrupt the training signal.
+                    return None
     
-    async def _generate_summary_async(self, content: str, metrics: TrajectoryMetrics) -> str:
+    async def _generate_summary_async(self, content: str, metrics: TrajectoryMetrics) -> Optional[str]:
         """
         Generate a summary of the compressed turns using OpenRouter (async version).
-        
+
         Args:
             content: The content to summarize
             metrics: Metrics object to update
-            
+
         Returns:
-            Summary string
+            Summary string, or ``None`` if summarization failed after all
+            retries (the caller must then leave the trajectory uncompressed
+            rather than discard the real turns).
         """
         prompt = f"""Summarize the following agent conversation turns concisely. This summary will replace these turns in the conversation history.
 
@@ -742,8 +748,10 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 if attempt < self.config.max_retries - 1:
                     await asyncio.sleep(jittered_backoff(attempt + 1, base_delay=self.config.retry_delay, max_delay=30.0))
                 else:
-                    # Fallback: create a basic summary
-                    return "[CONTEXT SUMMARY]: [Summary generation failed - previous turns contained tool calls and responses that have been compressed to save context space.]"
+                    # All retries exhausted. Signal failure so the caller keeps
+                    # the trajectory verbatim — replacing real tool turns with a
+                    # generic placeholder would corrupt the training signal.
+                    return None
     
     def compress_trajectory(
         self,
@@ -848,7 +856,19 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
 
         # Generate summary
         summary = self._generate_summary(content_to_summarize, metrics)
-        
+        if summary is None:
+            # Summarization failed after all retries. Keep the trajectory
+            # verbatim instead of overwriting real turns with a placeholder,
+            # which would silently corrupt the training data.
+            self.logger.warning(
+                "Skipping compression: summarization failed after all retries; "
+                "keeping trajectory uncompressed"
+            )
+            metrics.compressed_tokens = total_tokens
+            metrics.compressed_turns = len(trajectory)
+            metrics.still_over_limit = total_tokens > self.config.target_max_tokens
+            return trajectory, metrics
+
         # Build compressed trajectory
         compressed = []
         
@@ -963,7 +983,19 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
 
         # Generate summary (ASYNC)
         summary = await self._generate_summary_async(content_to_summarize, metrics)
-        
+        if summary is None:
+            # Summarization failed after all retries. Keep the trajectory
+            # verbatim instead of overwriting real turns with a placeholder,
+            # which would silently corrupt the training data.
+            self.logger.warning(
+                "Skipping compression: summarization failed after all retries; "
+                "keeping trajectory uncompressed"
+            )
+            metrics.compressed_tokens = total_tokens
+            metrics.compressed_turns = len(trajectory)
+            metrics.still_over_limit = total_tokens > self.config.target_max_tokens
+            return trajectory, metrics
+
         # Build compressed trajectory
         compressed = []
         


### PR DESCRIPTION
## What does this PR do?

When summarization exhausted all retries, the compressor replaced the real
middle turns with a generic "[CONTEXT SUMMARY]: ... failed" placeholder and
still marked the trajectory as compressed. That silently corrupted the
training signal and discarded the original turns. Now a failed summary leaves
the trajectory verbatim and flags it still-over-limit.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `trajectory_compressor.py`: `_generate_summary` / `_generate_summary_async`
  return `None` on total failure instead of a placeholder string.
- `trajectory_compressor.py`: `compress_trajectory` /
  `compress_trajectory_async` skip compression and return the original turns
  (marked `still_over_limit`) when the summary is `None`.
- `tests/test_trajectory_compressor.py`: added sync/async tests for the
  failed-summary path.
- `tests/test_trajectory_compressor_async.py`: made the Kimi temperature mocks
  awaitable (`AsyncMock`) so they exercise the success path.

## How to Test

1. `pytest tests/test_trajectory_compressor.py tests/test_trajectory_compressor_async.py -q`
2. All 47 tests pass.
3. New tests confirm a failed summary leaves turns intact and uncompressed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A