### PR TITLE
fix(tools): measure multimodal tool results against per-turn budget

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -492,6 +492,54 @@ class TestEnforceTurnBudget:
         result = enforce_turn_budget([], env=None, config=BudgetConfig(turn_budget=200_000))
         assert result == []
 
+    def test_multimodal_list_content_counts_real_size(self):
+        """A multimodal content list (image_url) must be measured by its real
+        character size, not by its block count. A large base64 image alongside
+        a smaller string must push the turn over budget and spill the string."""
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        big_image_url = "data:image/png;base64," + ("A" * 180_000)
+        msgs = [
+            {
+                "role": "tool",
+                "tool_call_id": "t1",
+                "content": [
+                    {"type": "text", "text": "screenshot captured"},
+                    {"type": "image_url", "image_url": {"url": big_image_url}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "t2", "content": "x" * 50_000},
+        ]
+        # ~180K image + 50K string > 200K budget. With len(list)==2 the old
+        # code measured the image as ~2 chars and never triggered.
+        enforce_turn_budget(msgs, env=env, config=BudgetConfig(turn_budget=200_000))
+        # The image list is left inline (not spillable)...
+        assert isinstance(msgs[0]["content"], list)
+        # ...and the string result is spilled to bring the turn under budget.
+        assert PERSISTED_OUTPUT_TAG in msgs[1]["content"]
+
+    def test_multimodal_list_not_selected_as_spill_candidate(self):
+        """A multimodal list result is never passed to the string-only
+        persistence path, even when it is the largest content in the turn."""
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        big_image_url = "data:image/png;base64," + ("A" * 260_000)
+        msgs = [
+            {
+                "role": "tool",
+                "tool_call_id": "t1",
+                "content": [
+                    {"type": "text", "text": "huge screenshot"},
+                    {"type": "image_url", "image_url": {"url": big_image_url}},
+                ],
+            },
+        ]
+        # Over budget, but the only result is a list — nothing safe to spill.
+        enforce_turn_budget(msgs, env=env, config=BudgetConfig(turn_budget=200_000))
+        # Content stays an intact list; no string-write was attempted on it.
+        assert isinstance(msgs[0]["content"], list)
+        env.execute.assert_not_called()
+
 
 # ── Per-tool threshold integration ────────────────────────────────────
 

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -22,6 +22,7 @@ Defense against context-window overflow operates at three levels:
    where many medium-sized results combine to overflow context.
 """
 
+import json
 import logging
 import os
 import shlex
@@ -178,6 +179,28 @@ def maybe_persist_tool_result(
     )
 
 
+def _content_size(content) -> int:
+    """Character size of a tool-result message ``content`` payload.
+
+    ``content`` is usually a plain string, but vision-capable tools
+    (computer_use, browser screenshots) return an OpenAI-style multimodal
+    content *list* — e.g. ``[{"type": "text", ...}, {"type": "image_url",
+    "image_url": {"url": "data:image/png;base64,..."}}]``. Calling ``len()``
+    on such a list counts the number of blocks (~2), not the payload size, so
+    a multi-MB base64 image would register as ~2 chars and slip under the
+    aggregate budget — exactly the case the budget exists to catch. Serialise
+    list/other content so the base64 image data is counted at its real size.
+    """
+    if isinstance(content, str):
+        return len(content)
+    if content is None:
+        return 0
+    try:
+        return len(json.dumps(content, default=str))
+    except Exception:
+        return len(str(content))
+
+
 def enforce_turn_budget(
     tool_messages: list[dict],
     env=None,
@@ -195,9 +218,15 @@ def enforce_turn_budget(
     total_size = 0
     for i, msg in enumerate(tool_messages):
         content = msg.get("content", "")
-        size = len(content)
+        size = _content_size(content)
         total_size += size
-        if PERSISTED_OUTPUT_TAG not in content:
+        # Only plain-string results can be spilled to disk. Multimodal
+        # content lists (image_url parts) still count toward the aggregate
+        # above so other results spill to make room, but they are never
+        # selected as spill candidates: maybe_persist_tool_result /
+        # _write_to_sandbox operate on strings, and persistence already
+        # bypasses multimodal results upstream.
+        if isinstance(content, str) and PERSISTED_OUTPUT_TAG not in content:
             candidates.append((i, size))
 
     if total_size <= config.turn_budget:


### PR DESCRIPTION
## What does this PR do?

The Layer 3 per-turn aggregate budget (`enforce_turn_budget` in
`tools/tool_result_storage.py`) sized every tool result with `len(content)`.
That is correct for plain strings, but tool-result `content` can also be an
OpenAI-style multimodal list — `[{"type": "text", ...}, {"type": "image_url",
"image_url": {"url": "data:image/png;base64,..."}}]` — which vision-capable
tools (computer_use, browser screenshots) produce. For a list, `len()` returns
the number of blocks (~2), not the character size, so a multi-MB base64 image
contributed ~2 chars to the aggregate. The 200K budget therefore never fired on
the exact turns it exists to protect: image-heavy ones. The companion
`PERSISTED_OUTPUT_TAG not in content` check had the same defect — on a list it
tests block membership, not a substring.

A second consequence followed: because the image's true weight was invisible,
a small *string* result in the same turn could be selected and spilled to disk
while the giant image was left inline. Worse, had a list ever been chosen as a
spill candidate it would have been handed to the string-only persistence path
(`maybe_persist_tool_result` / `_write_to_sandbox`), which `len()`-checks and
streams the value as stdin.

The approach is to measure size faithfully and to keep the spill path
string-only, mirroring the upstream rule that persistence bypasses multimodal
results.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tool_result_storage.py`: added `_content_size()`, which returns
  `len()` for strings and a JSON-serialised length for lists/other payloads so
  base64 image data is counted at its real size; `enforce_turn_budget` now uses
  it for the aggregate total.
- `tools/tool_result_storage.py`: restricted spill-candidate selection to
  `isinstance(content, str)` results, so multimodal lists still count toward the
  budget (forcing other results to spill) but are never passed to the
  string-only persistence path.
- `tests/tools/test_tool_result_storage.py`: added two regression tests — a
  large base64 image plus a string now pushes the turn over budget and spills
  the string while leaving the image list intact; and a list-only over-budget
  turn is left untouched with no sandbox write attempted.

## How to Test

1. `pytest tests/tools/test_tool_result_storage.py -q` — 50 passed, 1 skipped.
2. The two new tests in `TestEnforceTurnBudget` fail before the change
   (`len(list)` measures ~2, so the budget never triggers) and pass after it.
3. `ruff check tools/tool_result_storage.py tests/tools/test_tool_result_storage.py`
   and `python scripts/check-windows-footguns.py tools/tool_result_storage.py`
   both pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A