### PR TITLE
fix(tools): match self-overlapping old_string non-overlappingly in patch_replace

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -167,6 +167,33 @@ class TestReplaceAll:
         assert new == "ccc bbb ccc"
 
 
+class TestSelfOverlappingPattern:
+    """A self-overlapping old_string (e.g. ``--`` inside ``------``) must be
+    matched non-overlappingly. Counting overlapping occurrences used to inflate
+    the match count and corrupt the rewritten content."""
+
+    def test_separator_run_replace_all(self):
+        # Six dashes contain three non-overlapping "--", not five overlapping.
+        new, count, _, err = fuzzy_find_and_replace("------", "--", "-", replace_all=True)
+        assert err is None
+        assert count == 3
+        assert new == "---"
+
+    def test_repeated_char_run_replace_all(self):
+        new, count, _, err = fuzzy_find_and_replace("aaaa", "aa", "X", replace_all=True)
+        assert err is None
+        assert count == 2
+        assert new == "XX"
+
+    def test_overlap_not_reported_as_ambiguous(self):
+        # "aaa" holds a single non-overlapping "aa", so the unique-match path
+        # should succeed instead of erroring with a false "Found 2 matches".
+        new, count, _, err = fuzzy_find_and_replace("aaa", "aa", "X", replace_all=False)
+        assert err is None
+        assert count == 1
+        assert new == "Xa"
+
+
 class TestUnicodeNormalized:
     """Tests for the unicode_normalized strategy (Bug 5)."""
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -325,7 +325,15 @@ def _apply_replacements(content: str, matches: List[Tuple[int, int]],
     sorted_matches = sorted(matches, key=lambda x: x[0], reverse=True)
 
     result = content
+    # Defense-in-depth against overlapping ranges from any strategy: applying
+    # two ranges that share characters would clobber each other and corrupt
+    # the output. Walking from the end, skip any match whose end reaches into
+    # a range we have already replaced.
+    prev_start: Optional[int] = None
     for start, end in sorted_matches:
+        if prev_start is not None and end > prev_start:
+            continue
+        prev_start = start
         if old_string is not None:
             file_region = content[start:end]
             adjusted = _reindent_replacement(file_region, old_string, new_string)
@@ -341,7 +349,19 @@ def _apply_replacements(content: str, matches: List[Tuple[int, int]],
 # =============================================================================
 
 def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
-    """Strategy 1: Exact string match."""
+    """Strategy 1: Exact string match.
+
+    Matches are non-overlapping: after each hit we advance past the whole
+    match rather than a single character. Advancing by one allowed a
+    self-overlapping pattern (e.g. ``--`` in ``------``) to report
+    overlapping ranges, which inflated the match count and corrupted the
+    file when those ranges were spliced together during replacement.
+    """
+    # An empty pattern would make ``find`` return the same position forever;
+    # guard against it so the loop always makes progress.
+    if not pattern:
+        return []
+
     matches = []
     start = 0
     while True:
@@ -349,7 +369,7 @@ def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
         if pos == -1:
             break
         matches.append((pos, pos + len(pattern)))
-        start = pos + 1
+        start = pos + len(pattern)
     return matches
 
 


### PR DESCRIPTION
## What does this PR do?

The exact-match strategy that backs `patch_replace` walked the content one
character at a time after every hit (`start = pos + 1`). For a pattern that
overlaps itself — separator or fill runs such as `----`, `====`, `###`,
repeated tokens, or short whitespace runs that models frequently target with
`replace_all` — this produced overlapping `(start, end)` ranges. The replacement
step then spliced each of those ranges into the string with raw slicing and no
overlap guard, so adjacent ranges clobbered one another and the file was
silently rewritten with corrupted content while the tool reported success with
an inflated match count. The same overlap also produced false-positive
"Found N matches" ambiguity errors that refused legitimately single-intent
edits on the default (non-`replace_all`) path.

This changes `_strategy_exact` to advance past the whole match
(`start = pos + len(pattern)`) so occurrences are counted and replaced
non-overlappingly, which is the standard semantics for find-and-replace. As
defense-in-depth, `_apply_replacements` now skips any range that overlaps one
it has already applied, protecting the splice step regardless of which strategy
produced the matches. An empty-pattern guard was also added so the new advance
can never spin in place.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/fuzzy_match.py`: in `_strategy_exact`, advance the search cursor by
  `len(pattern)` instead of `1` so matches no longer overlap; bail out early on
  an empty pattern to keep the loop making progress.
- `tools/fuzzy_match.py`: in `_apply_replacements`, skip any match whose range
  overlaps an already-applied one while splicing from the end of the string.
- `tests/tools/test_fuzzy_match.py`: add `TestSelfOverlappingPattern` covering
  the separator run (`------` → `---`), a repeated-character run, and the
  non-overlapping uniqueness case that previously errored as ambiguous.

## How to Test

1. Before the fix, `fuzzy_find_and_replace("------", "--", "-", replace_all=True)`
   returns `("-", 5, ...)` (corrupted content, wrong count) and
   `fuzzy_find_and_replace("aaa", "aa", "X")` errors with "Found 2 matches".
2. After the fix, the first call returns `("---", 3, ...)` and the second
   replaces the single non-overlapping match, returning `("Xa", 1, ...)`.
3. Run `pytest tests/tools/test_fuzzy_match.py -q` — all tests pass, including
   the new `TestSelfOverlappingPattern` cases.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A