### PR TITLE
fix(agent): re-apply skill environment filter on snapshot fast path

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1082,7 +1082,11 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-_SKILLS_SNAPSHOT_VERSION = 1
+# v2: snapshot entries gained an ``environments`` field so the fast path can
+# re-apply the environment relevance gate. Bumping the version invalidates v1
+# snapshots that predate the field (they would otherwise be treated as having
+# no environment tags and leak environment-gated skills).
+_SKILLS_SNAPSHOT_VERSION = 2
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1170,12 +1174,22 @@ def _build_snapshot_entry(
     if isinstance(platforms, str):
         platforms = [platforms]
 
+    # Persist the environment relevance tags too. Both ``platforms`` and
+    # ``environments`` are runtime-dependent offer-time filters that must be
+    # re-evaluated on every snapshot read (the snapshot is a single shared
+    # file reused across sessions/processes whose environment differs), so the
+    # raw tags — not a baked-in boolean — have to survive into the snapshot.
+    environments = frontmatter.get("environments") or []
+    if isinstance(environments, str):
+        environments = [environments]
+
     return {
         "skill_name": skill_name,
         "category": category,
         "frontmatter_name": str(frontmatter.get("name", skill_name)),
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
+        "environments": [str(e).strip() for e in environments if str(e).strip()],
         "conditions": extract_skill_conditions(frontmatter),
     }
 
@@ -1313,6 +1327,16 @@ def build_skills_system_prompt(
             frontmatter_name = entry.get("frontmatter_name") or skill_name
             platforms = entry.get("platforms") or []
             if not skill_matches_platform({"platforms": platforms}):
+                continue
+            # Re-apply the environment relevance gate that the cold path runs
+            # via _parse_skill_file. Environment-incompatible skills are still
+            # written to the snapshot (the cold path appends every entry before
+            # its is_compatible check), so without this an environment-only
+            # skill — e.g. a kanban-only skill tagged ``environments: [kanban]``
+            # — would leak into the index of a non-kanban session the moment the
+            # snapshot fast path takes over from the cold scan.
+            environments = entry.get("environments") or []
+            if not skill_matches_environment({"environments": environments}):
                 continue
             if frontmatter_name in disabled or skill_name in disabled:
                 continue

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -522,6 +522,57 @@ class TestBuildSkillsSystemPrompt:
         assert "imessage" in result
         assert "Send iMessages" in result
 
+    def test_environment_gated_skill_hidden_via_snapshot_fast_path(
+        self, monkeypatch, tmp_path
+    ):
+        """Environment relevance must hold on the snapshot fast path too.
+
+        Regression: the cold scan filters out environment-incompatible skills
+        but still writes every entry to the shared disk snapshot. The snapshot
+        fast path re-applied the platform gate but not the environment gate, so
+        a kanban-only skill (``environments: [kanban]``) leaked into the index
+        of a non-kanban session as soon as the fast path took over. This test
+        forces the fast path (clears only the in-process cache, keeps the
+        snapshot) and asserts the skill stays hidden.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Force every known environment to read as inactive, deterministically,
+        # without touching config.yaml or process env vars.
+        monkeypatch.setattr(
+            "agent.skill_utils._ENV_DETECT_CACHE",
+            {"kanban": False, "docker": False, "s6": False},
+        )
+
+        skills_dir = tmp_path / "skills" / "ops"
+
+        kanban_skill = skills_dir / "kanban-worker"
+        kanban_skill.mkdir(parents=True)
+        (kanban_skill / "SKILL.md").write_text(
+            "---\nname: kanban-worker\ndescription: Drive the kanban board\n"
+            "environments: [kanban]\n---\n"
+        )
+
+        uni_skill = skills_dir / "web-search"
+        uni_skill.mkdir()
+        (uni_skill / "SKILL.md").write_text(
+            "---\nname: web-search\ndescription: Search the web\n---\n"
+        )
+
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        # First build: cold path (no snapshot) — writes the snapshot.
+        cold = build_skills_system_prompt()
+        assert "web-search" in cold
+        assert "kanban-worker" not in cold
+
+        # Drop only the in-process LRU cache so the next call is served from the
+        # disk snapshot (the fast path), keeping the snapshot on disk.
+        clear_skills_system_prompt_cache(clear_snapshot=False)
+
+        warm = build_skills_system_prompt()
+        assert "web-search" in warm
+        assert "kanban-worker" not in warm
+
     def test_excludes_disabled_skills(self, monkeypatch, tmp_path):
         """Skills in the user's disabled list should not appear in the system prompt."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## What does this PR do?

The skills index that gets built into the system prompt honours an
"environment relevance" gate: a skill can declare `environments: [kanban]`,
`[docker]`, or `[s6]` in its frontmatter, and `skill_matches_environment()`
hides it from sessions where that runtime environment isn't active (a
kanban-only skill shouldn't clutter the index of an ordinary CLI session, for
example). This is purely an offer-time filter — explicit loads via `skill_view`
or `--skills` still bypass it — but on the offer surfaces it is supposed to be
authoritative.

`build_skills_system_prompt()` has two code paths. The cold path scans every
`SKILL.md` on disk and applies the gate through `_parse_skill_file()`. To make
later builds cheap it then writes a snapshot of the parsed metadata to a single
shared file (`~/.hermes/.skills_prompt_snapshot.json`) and every subsequent
build is served from that snapshot. The problem is that the cold path appends
every skill's entry to the snapshot *before* it checks compatibility, so
environment-incompatible skills are still written out — and the snapshot fast
path re-applied the platform gate but never re-applied the environment gate. It
couldn't have, because the snapshot entry didn't carry the skill's
`environments` tags at all.

The practical consequence is that the environment filter works on the very
first cold build and then silently stops working for the life of the snapshot.
Because the snapshot is a single shared file reused across processes whose
runtime environment differs, a kanban-only skill leaks into the index of a
non-kanban session the moment the fast path takes over (and, symmetrically, a
skill hidden once stays exposed). Environment detection is genuinely
per-process state — env vars, container markers, the active kanban profile — so
the correct fix is to re-evaluate it on every read rather than bake a boolean
into the snapshot, exactly as the platform gate already does.

This change persists each skill's `environments` tags into the snapshot entry
and re-applies `skill_matches_environment()` on the fast path right after the
existing platform check, restoring parity between the two paths. The snapshot
schema version is bumped so any v1 snapshot written before this change (which
lacks the new field, and would otherwise be read as "no environment tags") is
invalidated and rebuilt.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py`: `_build_snapshot_entry()` now records a normalized
  `environments` list alongside the existing `platforms` list so the gate's
  inputs survive into the snapshot.
- `agent/prompt_builder.py`: the snapshot fast path in
  `build_skills_system_prompt()` now calls `skill_matches_environment()` after
  the platform check, mirroring the cold path.
- `agent/prompt_builder.py`: bumped `_SKILLS_SNAPSHOT_VERSION` from 1 to 2 so
  pre-existing snapshots without the `environments` field are discarded and
  regenerated.
- `tests/agent/test_prompt_builder.py`: added
  `test_environment_gated_skill_hidden_via_snapshot_fast_path`, which forces the
  fast path and asserts a kanban-only skill stays hidden in a non-kanban
  session.

## How to Test

1. With every runtime environment inactive (no kanban task/board, not inside a
   container), create two skills under `~/.hermes/skills/`: one tagged
   `environments: [kanban]` and one with no environment tag.
2. Build the skills index once to populate the disk snapshot, then drop only the
   in-process cache and build again so the snapshot fast path serves the result.
3. Confirm the kanban-only skill is absent from both builds while the untagged
   skill is present. The added test automates exactly this, and it fails on
   `main` (the kanban skill leaks on the second build) and passes with this fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A