### PR TITLE
fix(process): capture final output tail of background commands on non-local backends

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "290880780+vondelomlo@users.noreply.github.com": "vondelomlo",  # terminal poller final-tail capture
     "liaoshiwu@gmail.com": "de1tydev",  # PR #10158 salvage (poll read-only for notify_on_complete watcher; #10156)
     "szzhoujiarui@gmail.com": "szzhoujiarui-sketch",  # cron model.default salvage co-author (#45550)
     "rayjun0412@gmail.com": "rayjun",  # cron model.default salvage co-author (#43952)

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -621,6 +621,7 @@ class TestSpawnEnvSanitization:
                 self._responses = iter([
                     {"output": "hello\n"},
                     {"output": "1\n"},
+                    {"output": "hello\n"},
                     {"output": "0\n"},
                 ])
 
@@ -642,7 +643,65 @@ class TestSpawnEnvSanitization:
 
         assert env.commands[0][0] == "cat '/path with spaces/hermes_bg.log' 2>/dev/null"
         assert env.commands[1][0] == "kill -0 \"$(cat '/path with spaces/hermes_bg.pid' 2>/dev/null)\" 2>/dev/null; echo $?"
-        assert env.commands[2][0] == "cat '/path with spaces/hermes_bg.exit' 2>/dev/null"
+        # On exit, a final log read precedes the exit-code read so the tail is
+        # captured with the same quoting.
+        assert env.commands[2][0] == "cat '/path with spaces/hermes_bg.log' 2>/dev/null"
+        assert env.commands[3][0] == "cat '/path with spaces/hermes_bg.exit' 2>/dev/null"
+
+    def test_env_poller_captures_output_tail_written_before_exit(self, registry):
+        """Output produced between the last poll and process exit must survive.
+
+        Regression: the poller only re-read the log at the top of each 2s
+        iteration.  When the same iteration detected exit it jumped straight to
+        the exit-code read and finished, dropping anything the process wrote in
+        the final window — the most important tail (test summaries, build
+        results, completion markers) right when notify_on_complete fires.
+        """
+        session = _make_session(sid="proc_tail")
+        session.exited = False
+
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+                self._responses = iter([
+                    # First poll: only the partial prefix is on disk.
+                    {"output": "building...\n"},
+                    # kill -0: process already gone (non-zero).
+                    {"output": "1\n"},
+                    # Final log read on exit: now the full tail is flushed.
+                    {"output": "building...\nALL TESTS PASSED\n"},
+                    # Exit-code file.
+                    {"output": "0\n"},
+                ])
+
+            def execute(self, command, **kwargs):
+                self.commands.append((command, kwargs))
+                return next(self._responses)
+
+        env = FakeEnv()
+        watched = []
+
+        with patch("tools.process_registry.time.sleep", return_value=None), \
+            patch.object(registry, "_move_to_finished"), \
+            patch.object(
+                registry,
+                "_check_watch_patterns",
+                side_effect=lambda s, delta: watched.append(delta),
+            ):
+            registry._env_poller_loop(
+                session,
+                env,
+                "/tmp/hermes_bg.log",
+                "/tmp/hermes_bg.pid",
+                "/tmp/hermes_bg.exit",
+            )
+
+        # The final tail is present in the buffer, not just the prefix.
+        assert "ALL TESTS PASSED" in session.output_buffer
+        assert session.output_buffer == "building...\nALL TESTS PASSED\n"
+        assert session.exit_code == 0
+        # The newly flushed tail is scanned for watch patterns as a delta.
+        assert any("ALL TESTS PASSED" in d for d in watched)
 
 
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -829,7 +829,34 @@ class ProcessRegistry:
                 )
                 check_output = check.get("output", "").strip()
                 if check_output and check_output.splitlines()[-1].strip() != "0":
-                    # Process has exited -- get exit code captured by the wrapper shell.
+                    # Process has exited.  Do one final read of the log file
+                    # before finishing: output written between this iteration's
+                    # `cat` (above) and the process's actual exit only lives on
+                    # disk now and would otherwise be dropped from the buffer.
+                    # This is the tail that matters most (test summaries, build
+                    # results, final tracebacks) and is exactly what
+                    # notify_on_complete reports.  Mirrors the local backends,
+                    # where _reader_loop drains stdout to EOF and
+                    # _reconcile_local_exit does a final non-blocking drain.
+                    final_result = env.execute(
+                        f"cat {quoted_log_path} 2>/dev/null", timeout=10
+                    )
+                    final_output = final_result.get("output", "")
+                    if final_output:
+                        final_delta = (
+                            final_output[prev_output_len:]
+                            if len(final_output) > prev_output_len
+                            else ""
+                        )
+                        prev_output_len = len(final_output)
+                        with session._lock:
+                            session.output_buffer = final_output
+                            if len(session.output_buffer) > session.max_output_chars:
+                                session.output_buffer = session.output_buffer[-session.max_output_chars:]
+                        if final_delta:
+                            self._check_watch_patterns(session, final_delta)
+
+                    # get exit code captured by the wrapper shell.
                     exit_result = env.execute(
                         f"cat {quoted_exit_path} 2>/dev/null",
                         timeout=5,


### PR DESCRIPTION
## What does this PR do?

Stops the background poller from dropping a command's final output on
every non-local backend (Docker, SSH, Modal, Daytona, Singularity).

`_env_poller_loop` only re-read the sandbox log at the top of each 2s
poll. When the same iteration detected exit via `kill -0`, it jumped
straight to the exit-code read and finished — never re-reading the log.
Anything the process wrote between that last `cat` and its actual exit
landed on disk but was never pulled back into `output_buffer`, so it
vanished. That is the tail that matters most (test summaries, build
results, final tracebacks, completion markers) and it disappeared
exactly when `notify_on_complete` fires. Fast jobs that finish inside
one poll window lose almost everything.

The local backends already do this right — `_reader_loop` drains stdout
to EOF and `_reconcile_local_exit` does a final non-blocking drain. The
remote poller was missing the equivalent final read. Now, on exit
detection, it does one last `cat` of the log, applies the same
`max_output_chars` truncation, and feeds the newly flushed delta to the
watch-pattern scanner before finishing.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py`: in `_env_poller_loop`, add a final log
  read in the exit-detection branch before `_move_to_finished`, with the
  same truncation and watch-pattern delta handling as the in-loop read.
- `tests/tools/test_process_registry.py`: new regression test
  `test_env_poller_captures_output_tail_written_before_exit`; updated
  `test_env_poller_quotes_temp_paths_with_spaces` for the extra log read.
- `scripts/release.py`: add author email to `AUTHOR_MAP`.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_process_registry.py` — 72 pass.
2. New test fails without the fix: the poller keeps only the first poll's
   prefix and drops `ALL TESTS PASSED` written before exit.
3. With the fix, `output_buffer` holds the full tail and the delta is
   scanned for watch patterns.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A