### PR TITLE
fix(telegram): make Bot API 10.1 rich messages opt-in (default off) (#48422)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -730,7 +730,7 @@ platform_toolsets:
 #     # allowed_chats: ["-1001234567890"]
 #     extra:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
-#       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default true, set false to force legacy MarkdownV2
+#       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2158,7 +2158,7 @@ DEFAULT_CONFIG = {
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
         "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
         "extra": {
-            "rich_messages": True,      # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set False to force legacy MarkdownV2
+            "rich_messages": False,     # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set True to opt in. Default stays legacy MarkdownV2 because rich messages can be hard to copy as plain text in Telegram clients.
         },
     },
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -489,10 +489,14 @@ class TelegramAdapter(BasePlatformAdapter):
         # Bot API 10.1 Rich Messages: render constructs the legacy MarkdownV2
         # path degrades (tables → bullet lists, task lists, <details>, block
         # math) via sendRichMessage / editMessageText's rich_message param using
-        # the raw agent markdown. Enabled by default; users can opt out for
+        # the raw agent markdown. Disabled by default so Telegram messages stay
+        # easy to copy as plain text; users can opt in for richer rendering on
         # clients that accept but render rich messages poorly via
-        # platforms.telegram.extra.rich_messages: false.
-        self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", True)
+        # platforms.telegram.extra.rich_messages: true.  Keep this opt-in:
+        # current Telegram clients can make rich messages difficult to copy
+        # as plain text, which is worse than degraded table/task-list rendering
+        # for command snippets and mobile handoffs.
+        self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", False)
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "0x0sec@gmail.com": "kn8-codes",  # PR #48422 salvage (rich messages opt-in default off)
     "liaoshiwu@gmail.com": "de1tydev",  # PR #10158 salvage (poll read-only for notify_on_complete watcher; #10156)
     "szzhoujiarui@gmail.com": "szzhoujiarui-sketch",  # cron model.default salvage co-author (#45550)
     "rayjun0412@gmail.com": "rayjun",  # cron model.default salvage co-author (#43952)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -881,7 +881,7 @@ class TestLoadGatewayConfig:
 
         assert config.platforms[Platform.TELEGRAM].extra["rich_messages"] is False
 
-    def test_load_config_default_enables_telegram_rich_messages(self, tmp_path, monkeypatch):
+    def test_load_config_default_keeps_telegram_rich_messages_opt_in(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
 
@@ -891,7 +891,7 @@ class TestLoadGatewayConfig:
 
         config = load_config()
 
-        assert config["telegram"]["extra"]["rich_messages"] is True
+        assert config["telegram"]["extra"]["rich_messages"] is False
 
     def test_bridges_telegram_extra_base_url_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -210,11 +210,34 @@ async def test_rich_messages_opt_out_accepts_string_false():
 
 
 @pytest.mark.asyncio
-async def test_rich_messages_default_is_enabled():
-    """Rich messages are on by default (Bot API 10.1); rich-eligible content
-    (tables/task lists/details/math) goes through sendRichMessage without the
-    user having to opt in."""
+async def test_rich_messages_default_is_legacy_copyable_path():
+    """Rich messages stay opt-in because current Telegram clients can make
+    Bot API rich messages hard to copy as plain text. Rich-eligible content
+    defaults to the legacy MarkdownV2 path unless the user opts in."""
     config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = TelegramAdapter(config)
+    bot = MagicMock()
+    bot.do_api_request = AsyncMock(return_value=SimpleNamespace(message_id=123))
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    bot.send_chat_action = AsyncMock()
+    adapter._bot = bot
+
+    result = await adapter.send("12345", RICH_CONTENT)
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_not_called()
+    bot.send_message.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rich_messages_can_be_opted_in():
+    """Setting platforms.telegram.extra.rich_messages: true enables native
+    Bot API rich rendering for tables/task lists/details/math."""
+    config = PlatformConfig(
+        enabled=True, token="fake-token", extra={"rich_messages": True}
+    )
     adapter = TelegramAdapter(config)
     bot = MagicMock()
     bot.do_api_request = AsyncMock(return_value=SimpleNamespace(message_id=123))

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -940,17 +940,17 @@ The rich path is skipped automatically when content exceeds the 32,768-character
 - **Small tables** are flattened into **row-group bullets** — each row becomes a readable bulleted list under the column headings. Good for 2–4 columns and short cells.
 - **Larger or wider tables** fall back to a **fenced code block** with aligned columns so nothing collapses.
 
-Rich messages are **enabled by default**. Some Telegram clients accept the Bot API payload but render it poorly; to opt out and force every reply onto the legacy MarkdownV2 path:
+Rich messages are **opt-in**. The default stays on the legacy MarkdownV2 path because current Telegram clients can make Bot API rich messages difficult to copy as plain text, which is especially painful for command snippets and mobile handoffs. To enable native rendering for tables/task lists/details/math:
 
 ```yaml
 gateway:
   platforms:
     telegram:
       extra:
-        rich_messages: false
+        rich_messages: true
 ```
 
-This setting is for client-rendering compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
+This setting is for client-rendering/copy compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
 
 **Link previews.** Telegram auto-generates link previews for URLs in bot messages. If you'd rather suppress those (long `/tools` output, agent reply that mentions ten links, etc.):
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
@@ -886,17 +886,17 @@ gateway:
 - **小表格**被展平为**行组项目符号**——每行在列标题下变为可读的项目符号列表。适合 2-4 列和短单元格。
 - **较大或较宽的表格**回退为带对齐列的**围栏代码块**，以防内容折叠。
 
-富消息**默认启用**。一些 Telegram 客户端能接收 Bot API 载荷但渲染效果很差；若要关闭并强制所有回复走旧版 MarkdownV2 路径：
+富消息现在是**选择启用**。默认保持旧版 MarkdownV2 路径，因为当前 Telegram 客户端可能让 Bot API 富消息难以作为纯文本复制，这对命令片段和移动端交接尤其麻烦。若要为表格、任务列表、折叠 `<details>` 和块级数学启用原生渲染：
 
 ```yaml
 gateway:
   platforms:
     telegram:
       extra:
-        rich_messages: false
+        rich_messages: true
 ```
 
-这个设置用于客户端渲染兼容性；当 Telegram 拒绝富消息 API 调用时，Hermes 已经会自动回退。如果你只是想在保持富消息启用的同时恢复旧版「始终使用代码块」表格行为，可在 `config.yaml` 中设置 `telegram.pretty_tables: false` 禁用表格规范化（默认：`true`）。
+这个设置用于客户端渲染/复制兼容性；当 Telegram 拒绝富消息 API 调用时，Hermes 已经会自动回退。如果你只是想在保持富消息启用的同时恢复旧版「始终使用代码块」表格行为，可在 `config.yaml` 中设置 `telegram.pretty_tables: false` 禁用表格规范化（默认：`true`）。
 
 **链接预览。** Telegram 会为机器人消息中的 URL 自动生成链接预览。如果你希望抑制这些预览（长 `/tools` 输出、提及十个链接的 Agent 回复等）：
 


### PR DESCRIPTION
## Summary
Telegram Bot API 10.1 rich messages are now **opt-in** (default off). Current Telegram clients can render rich messages as blank/unsupported bubbles and make them hard to copy as plain text — worse than the legacy MarkdownV2 path for command snippets and mobile handoffs. The default now keeps every reply on the copyable legacy path; users opt in per bot via `platforms.telegram.extra.rich_messages: true`.

Salvages #48422 by @kn8-codes, reconstructed onto current `main` (the Telegram adapter moved from `gateway/platforms/telegram.py` to `plugins/platforms/telegram/adapter.py` since the PR). Authorship preserved.

## Changes
- `plugins/platforms/telegram/adapter.py`: `_rich_messages_enabled` default `True` → `False`.
- `hermes_cli/config.py`: gateway-config `extra.rich_messages` default `True` → `False`.
- `cli-config.yaml.example`: comment updated to "default false … set true to opt in".
- `website/docs/user-guide/messaging/telegram.md` + zh-Hans i18n: docs flipped to "opt-in".
- Tests: `test_load_config_default_keeps_telegram_rich_messages_opt_in` (config default now False), `test_rich_messages_default_is_legacy_copyable_path` (rich-eligible content stays legacy by default), added `test_rich_messages_can_be_opted_in`.

## Validation
| Config | Rich-eligible content (table) |
|---|---|
| default (no `rich_messages` set) | legacy MarkdownV2 (copyable) |
| `extra.rich_messages: true` | native sendRichMessage |

- 131 targeted tests pass (`test_telegram_rich_messages.py` + `test_config.py`).
- Blast-radius checked: every other rich-path test opts in explicitly via `_make_adapter(extra={"rich_messages": True})`, so only the two default-assertion tests needed updating.

Note: the opt-in toggle is the global switch; the existing `_rich_eligible` content gate is unchanged (rich, when enabled, still only fires for tables/task-lists/details/math). This PR flips the default switch to off, not the content gating.

## Infographic

![rich-messages-opt-in](https://v3b.fal.media/files/b/0a9f37f7/vuqmmjHWM6fjBVFqmKFjy_0pQe26tm.png)
