### PR TITLE
fix(desktop): keep optimistic user message after sleep/wake session recovery

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -56,6 +56,7 @@ function Harness({
   busyRef,
   onReady,
   onSeedState,
+  onUpdateSession,
   refreshSessions,
   requestGateway,
   resumeStoredSession,
@@ -65,6 +66,7 @@ function Harness({
   busyRef?: MutableRefObject<boolean>
   onReady: (handle: HarnessHandle) => void
   onSeedState?: (state: Record<string, unknown>) => void
+  onUpdateSession?: (sessionId: string, state: Record<string, unknown>) => void
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
@@ -96,11 +98,12 @@ function Harness({
     selectedStoredSessionIdRef,
     startFreshSessionDraft: () => undefined,
     sttEnabled: false,
-    updateSessionState: (_sessionId, updater) => {
+    updateSessionState: (sessionId, updater) => {
       // Seed with interrupted:true so we can prove a fresh submit clears it.
       const next = updater(stateRef.current) as unknown as Record<string, unknown>
       stateRef.current = next as never
       onSeedState?.(next)
+      onUpdateSession?.(sessionId, next)
 
       return next as never
     }
@@ -892,6 +895,50 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
     expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID })
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'message after wake' })
+  })
+
+  it('re-seeds the optimistic user turn under the recovered runtime id (so the prompt is not orphaned)', async () => {
+    // The reply streams in tagged with the recovered runtime id, and the message
+    // stream keys strictly off that id — so the optimistic user message (first
+    // seeded under the stale id) must be migrated to recoveredId. Otherwise it
+    // stays stranded under the defunct session and disappears from the live
+    // transcript while only the assistant reply renders.
+    const updates: { messages: { id?: string; role?: string }[]; sessionId: string }[] = []
+    let submitAttempts = 0
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        submitAttempts += 1
+        if (submitAttempts === 1) {
+          throw new Error('session not found')
+        }
+        return {} as never
+      }
+      if (method === 'session.resume') {
+        return { session_id: RECOVERED_SESSION_ID } as never
+      }
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onUpdateSession={(sessionId, state) =>
+          updates.push({ messages: (state.messages as { id?: string; role?: string }[]) ?? [], sessionId })
+        }
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={STORED_SESSION_ID}
+      />
+    )
+
+    expect(await handle!.submitText('message after wake')).toBe(true)
+
+    // A session-state write keyed by the recovered id must carry the user turn.
+    const recoveredSeed = updates.find(
+      u => u.sessionId === RECOVERED_SESSION_ID && u.messages.some(m => m.role === 'user')
+    )
+    expect(recoveredSeed).toBeDefined()
   })
 
   it('resumes the stored session and retries once when session.interrupt reports "session not found"', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -719,6 +719,16 @@ export function usePromptActions({
 
             if (recoveredId) {
               activeSessionIdRef.current = recoveredId
+              // The optimistic user message was staged under the now-defunct
+              // runtime id, but the gateway will stream this turn's reply tagged
+              // with recoveredId — and use-message-stream keys strictly off that
+              // id, so updateSessionState(recoveredId, …) builds a FRESH session
+              // view with no user turn. Re-key the local id and re-seed the
+              // optimistic message under recoveredId so the prompt stays in the
+              // live transcript (seedOptimistic is idempotent), and so the
+              // catch-block error fallback below targets the recovered session.
+              sessionId = recoveredId
+              seedOptimistic(recoveredId)
               await withSessionBusyRetry(() => requestGateway('prompt.submit', { session_id: recoveredId, text }))
             } else {
               submitErr = firstErr


### PR DESCRIPTION
## What does this PR do?

When the desktop app sends a prompt after the gateway's in-memory session
was evicted (laptop sleep/wake, idle reap, or a gateway restart), the first
`prompt.submit` fails with "session not found". `submitPromptText` already
recovers this: it resumes the durable stored session, gets a fresh runtime id,
and retries the send. The problem is what happens to the user's message.

The optimistic user turn is seeded under the *original* runtime id via
`seedOptimistic(sessionId)`. On the recovery path we set
`activeSessionIdRef.current = recoveredId` and re-submit under `recoveredId`,
but we never re-seed the optimistic message there and never update the local
`sessionId`. The gateway then streams `message.start/delta/complete` tagged
with `recoveredId`, and the message stream keys strictly off that id, so
`updateSessionState(recoveredId, …)` builds a fresh session view with no user
turn. The result: the assistant reply renders, but the prompt the user just
sent vanishes from the live transcript (it sits orphaned under the defunct id).

Why seed instead of something heavier? `seedOptimistic` is idempotent and
already builds the message from the post-sync attachment refs, so re-running it
under `recoveredId` is enough to migrate the turn — no separate rewrite needed.
Reassigning the local `sessionId` also makes the catch-block error fallback and
`clearComposerAttachments` target the recovered session rather than the stale
one.

This only touches the existing recovery branch; the normal send path and the
non-recoverable-error path are unchanged.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions.ts`: in the
  session-not-found recovery branch of `submitPromptText`, after obtaining
  `recoveredId`, reassign the local `sessionId = recoveredId` and call
  `seedOptimistic(recoveredId)` before the retry `prompt.submit`, so the
  optimistic user turn is migrated to the recovered runtime id.
- `apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx`: add an
  `onUpdateSession(sessionId, state)` hook to the test Harness (it now exposes
  which runtime id each state write targets) and a regression test asserting a
  session-state write keyed by the recovered id carries the user turn.

## How to Test

1. From `apps/desktop`, run `npx vitest run --environment jsdom src/app/session/hooks/use-prompt-actions.test.tsx`.
2. The new test "re-seeds the optimistic user turn under the recovered runtime id
   (so the prompt is not orphaned)" passes; reverting the source change makes it
   fail with `expected undefined to be defined` (no state write lands on the
   recovered id), proving it pins the bug.
3. Manual: open a desktop chat, let the gateway session be evicted (sleep/wake or
   restart the gateway), send a prompt — the user message stays in the transcript
   alongside the streamed reply instead of disappearing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a TypeScript-only change; ran the desktop vitest suite instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A