### PR TITLE
fix(gateway): pass target user's HERMES_HOME to _build_service_path_dirs for system units

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2412,10 +2412,6 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         # checks the correct ~/.hermes/node/bin (not root's ~/hermes when
         # running under sudo).
         path_entries = _build_service_path_dirs(hermes_home=hermes_home)
-        if resolved_node:
-            resolved_node_dir = str(Path(resolved_node).resolve().parent)
-            if resolved_node_dir not in path_entries:
-                path_entries.append(resolved_node_dir)
         # Remap all paths that may resolve under the calling user's home
         # (e.g. /root/) to the target user's home so the service can
         # actually access them.
@@ -2429,6 +2425,14 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         path_entries.extend(_build_user_local_paths(Path(home_dir), path_entries))
         path_entries.extend(_build_wsl_interop_paths(path_entries))
         path_entries.extend(common_bin_paths)
+        if resolved_node:
+            # Resolve + remap to the target user's home so we don't
+            # leak the calling user's node path (e.g. root's nvm dir)
+            # into the target user's systemd unit.
+            node_dir = str(Path(resolved_node).resolve().parent)
+            remapped_node_dir = _remap_path_for_user(node_dir, home_dir)
+            if remapped_node_dir not in path_entries:
+                path_entries.append(remapped_node_dir)
         sane_path = ":".join(path_entries)
         return f"""[Unit]
 Description={SERVICE_DESCRIPTION}

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2309,8 +2309,16 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
         return str(current_hermes)
 
 
-def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
-    """Build PATH directory list for service units, excluding non-existent dirs."""
+def _build_service_path_dirs(
+    project_root: Path | None = None,
+    hermes_home: str | Path | None = None,
+) -> list[str]:
+    """Build PATH directory list for service units, excluding non-existent dirs.
+
+    When *hermes_home* is provided it is used in place of ``get_hermes_home()``
+    so callers that know the target user (e.g. ``generate_systemd_unit(system=True)``
+    running under sudo) can check the correct home directory instead of root's.
+    """
     if project_root is None:
         project_root = PROJECT_ROOT
 
@@ -2332,11 +2340,11 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
-    hermes_home = get_hermes_home()
-    hermes_node = hermes_home / "node" / "bin"
+    resolved_home = Path(hermes_home) if hermes_home else get_hermes_home()
+    hermes_node = resolved_home / "node" / "bin"
     if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
-    hermes_nm = hermes_home / "node_modules" / ".bin"
+    hermes_nm = resolved_home / "node_modules" / ".bin"
     if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
@@ -2377,12 +2385,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     detected_venv = _detect_venv_dir()
     venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
 
-    path_entries = _build_service_path_dirs()
     resolved_node = shutil.which("node")
-    if resolved_node:
-        resolved_node_dir = str(Path(resolved_node).resolve().parent)
-        if resolved_node_dir not in path_entries:
-            path_entries.append(resolved_node_dir)
 
     common_bin_paths = [
         "/usr/local/sbin",
@@ -2405,6 +2408,14 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         username, group_name, home_dir = _system_service_identity(run_as_user)
         hermes_home = _hermes_home_for_target_user(home_dir)
         profile_arg = _profile_arg_for_target_user(hermes_home, home_dir)
+        # Use the target user's HERMES_HOME so _build_service_path_dirs
+        # checks the correct ~/.hermes/node/bin (not root's ~/hermes when
+        # running under sudo).
+        path_entries = _build_service_path_dirs(hermes_home=hermes_home)
+        if resolved_node:
+            resolved_node_dir = str(Path(resolved_node).resolve().parent)
+            if resolved_node_dir not in path_entries:
+                path_entries.append(resolved_node_dir)
         # Remap all paths that may resolve under the calling user's home
         # (e.g. /root/) to the target user's home so the service can
         # actually access them.
@@ -2453,6 +2464,11 @@ WantedBy=multi-user.target
 
     hermes_home = str(get_hermes_home().resolve())
     profile_arg = _profile_arg(hermes_home)
+    path_entries = _build_service_path_dirs()
+    if resolved_node:
+        resolved_node_dir = str(Path(resolved_node).resolve().parent)
+        if resolved_node_dir not in path_entries:
+            path_entries.append(resolved_node_dir)
     path_entries.extend(_build_user_local_paths(Path.home(), path_entries))
     path_entries.extend(_build_wsl_interop_paths(path_entries))
     path_entries.extend(common_bin_paths)

--- a/tests/hermes_cli/test_gateway_service_paths.py
+++ b/tests/hermes_cli/test_gateway_service_paths.py
@@ -77,3 +77,112 @@ def test_generate_systemd_unit_includes_target_user_node_bin(tmp_path, monkeypat
         f"System unit PATH should include {target_node_bin}"
     )
 
+
+def test_systemd_unit_roundtrip_sudo_path_matches(tmp_path):
+    """PATH in system unit generated under sudo must match user expectation.
+
+    When ``sudo hermes gateway install --system`` generates a unit, every
+    PATH entry must be identical to what the real user would generate —
+    otherwise the "outdated service definition" warning is perpetual
+    because the self-heal also runs under sudo.
+    """
+    import re
+
+    root_home = tmp_path / "root"
+    user_home = tmp_path / "home" / "hermes"
+    user_hermes = user_home / ".hermes"
+    user_node_bin = user_hermes / "node" / "bin"
+    user_node_bin.mkdir(parents=True)
+
+    from hermes_cli.gateway import generate_systemd_unit
+
+    def _extract_path(unit_text: str) -> list[str]:
+        m = re.search(r'Environment="PATH=([^"]+)"', unit_text)
+        return m.group(1).split(":") if m else []
+
+    # Shared mocks (same venv, python, working dir for both)
+    common = [
+        patch("hermes_cli.gateway._detect_venv_dir", return_value=None),
+        patch("hermes_cli.gateway.get_python_path", return_value="/usr/bin/python3"),
+        patch("hermes_cli.gateway._stable_service_working_dir", return_value=str(user_hermes)),
+        patch("hermes_cli.gateway._system_service_identity",
+              return_value=("hermes", "hermes", str(user_home))),
+        patch("hermes_cli.gateway._hermes_home_for_target_user",
+              return_value=str(user_hermes)),
+        patch("hermes_cli.gateway._profile_arg_for_target_user", return_value=""),
+        patch("hermes_cli.gateway.shutil.which", return_value=None),
+    ]
+
+    # Generate as "sudo" (Path.home() = /root)
+    with patch("pathlib.Path.home", return_value=root_home), \
+         patch("hermes_cli.gateway.get_hermes_home", return_value=root_home / ".hermes"):
+        for p in common:
+            p.start()
+        sudo_unit = generate_systemd_unit(system=True)
+        for p in common:
+            p.stop()
+
+    # Generate as real user (Path.home() = /home/hermes)
+    with patch("pathlib.Path.home", return_value=user_home), \
+         patch("hermes_cli.gateway.get_hermes_home", return_value=user_hermes):
+        for p in common:
+            p.start()
+        user_unit = generate_systemd_unit(system=True)
+        for p in common:
+            p.stop()
+
+    sudo_path = _extract_path(sudo_unit)
+    user_path = _extract_path(user_unit)
+
+    assert sudo_path == user_path, (
+        f"PATH entries must match regardless of calling user:\n"
+        f"  sudo:  {sudo_path}\n"
+        f"  user:  {user_path}"
+    )
+    assert str(user_node_bin) in sudo_path, (
+        f"Target user's {user_node_bin} must be in PATH"
+    )
+
+
+
+def test_system_unit_no_caller_node_leakage(tmp_path):
+    """Root's node path must not leak into the target user's systemd unit.
+
+    When the calling user (root/sudo) has a node binary under its own home
+    (e.g. nvm install), the remapped path under the target user's home may
+    not exist.  The resolved node path must be remapped to the target user's
+    home but should not be blindly appended without remapping.
+    """
+    root_home = tmp_path / "root"
+    user_home = tmp_path / "home" / "hermes"
+    user_hermes = user_home / ".hermes"
+    # Target user has NO node/bin
+    (user_hermes / "node").mkdir(parents=True)
+
+    # Root has a node binary under its own home (e.g. nvm)
+    root_node = root_home / ".nvm" / "versions" / "node" / "v22" / "bin"
+    root_node.mkdir(parents=True)
+
+    from hermes_cli.gateway import generate_systemd_unit
+
+    with patch("pathlib.Path.home", return_value=root_home), \
+         patch("hermes_cli.gateway.get_hermes_home", return_value=root_home / ".hermes"), \
+         patch("hermes_cli.gateway._system_service_identity",
+               return_value=("hermes", "hermes", str(user_home))), \
+         patch("hermes_cli.gateway._hermes_home_for_target_user",
+               return_value=str(user_hermes)), \
+         patch("hermes_cli.gateway._profile_arg_for_target_user",
+               return_value=""), \
+         patch("hermes_cli.gateway.shutil.which",
+               return_value=str(root_node / "node")):
+        unit = generate_systemd_unit(system=True)
+
+    # The remapped path may exist or not — but the raw root path must
+    # never appear in the generated unit.
+    raw_root_path = str(root_node)
+    assert raw_root_path not in unit, (
+        f"Root's node path ({raw_root_path}) must not leak into the "
+        "target user's systemd unit"
+    )
+
+

--- a/tests/hermes_cli/test_gateway_service_paths.py
+++ b/tests/hermes_cli/test_gateway_service_paths.py
@@ -28,3 +28,52 @@ def test_service_path_includes_hermes_home_node_modules(tmp_path):
     with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"):
         dirs = _build_service_path_dirs(project_root=tmp_path)
     assert str(hermes_nm) in dirs
+
+
+def test_service_path_uses_explicit_hermes_home_over_get_hermes_home(tmp_path):
+    """When hermes_home is passed, it is used instead of get_hermes_home()."""
+    target_home = tmp_path / "target_user" / ".hermes"
+    target_node = target_home / "node" / "bin"
+    target_node.mkdir(parents=True)
+
+    default_home = tmp_path / "calling_user" / ".hermes"
+    (default_home / "node").mkdir(parents=True)
+    # No node/bin under default_home — only target_home has it
+
+    from hermes_cli.gateway import _build_service_path_dirs
+    with patch("hermes_cli.gateway.get_hermes_home", return_value=default_home):
+        dirs = _build_service_path_dirs(
+            project_root=tmp_path, hermes_home=str(target_home)
+        )
+    assert str(target_node) in dirs, (
+        "Should find node/bin under the explicit hermes_home, "
+        "not the default get_hermes_home() path"
+    )
+
+
+def test_generate_systemd_unit_includes_target_user_node_bin(tmp_path, monkeypatch):
+    """System-scoped unit should include node/bin from the target user's home."""
+    target_home = tmp_path / "home" / "hermes"
+    target_hermes = target_home / ".hermes"
+    target_node_bin = target_hermes / "node" / "bin"
+    target_node_bin.mkdir(parents=True)
+
+    from hermes_cli.gateway import generate_systemd_unit
+
+    with patch("hermes_cli.gateway._system_service_identity") as mock_identity:
+        mock_identity.return_value = ("hermes", "hermes", str(target_home))
+        with patch(
+            "hermes_cli.gateway._hermes_home_for_target_user",
+            return_value=str(target_hermes),
+        ):
+            with patch(
+                "hermes_cli.gateway._profile_arg_for_target_user",
+                return_value="",
+            ):
+                unit = generate_systemd_unit(system=True)
+
+    assert "PATH=" in unit, "System unit should have a PATH environment variable"
+    assert str(target_node_bin) in unit, (
+        f"System unit PATH should include {target_node_bin}"
+    )
+


### PR DESCRIPTION
## Summary

When generating a system-scoped systemd unit under `sudo`, `_build_service_path_dirs()` calls `get_hermes_home()` which resolves to `/root/.hermes`. It then checks `/root/.hermes/node/bin` for existence — which never exists — so the path entry is silently omitted from the generated unit.

The non-system path (`hermes gateway status` as the real user) correctly detects `~/.hermes/node/bin` exists and expects it in the unit, producing a **perpetual "outdated service definition" warning** that the restart auto-refresh can never fix — because the restart also runs under `sudo` and generates the same wrong unit.

## Root Cause

`_build_service_path_dirs()` hardcodes `get_hermes_home()` for detecting `~/.hermes/node/bin` and `~/.hermes/node_modules/.bin`. Under `sudo`, this resolves to `/root/.hermes` instead of the target user's home. The system-scope remapping at line 2417 (`_remap_path_for_user`) can't fix entries that were never collected in the first place.

## Fix

- `_build_service_path_dirs()` accepts an optional `hermes_home` parameter. When provided, it uses that instead of `get_hermes_home()`.
- `generate_systemd_unit(system=True)` now passes the target user's remapped `hermes_home` (already computed at line 2414 via `_hermes_home_for_target_user`) to `_build_service_path_dirs()`.
- The non-system path continues to use `get_hermes_home()` as before.

## Test Plan

- [x] New test: `test_service_path_uses_explicit_hermes_home_over_get_hermes_home` — verifies the `hermes_home` parameter takes precedence over `get_hermes_home()` when provided
- [x] New test: `test_generate_systemd_unit_includes_target_user_node_bin` — end-to-end verification that `generate_systemd_unit(system=True)` includes `node/bin` from the target user's home
- [x] All 3 existing `test_gateway_service_paths` tests continue to pass
- [x] Manually verified: under `sudo`, generated unit now includes `/home/<user>/.hermes/node/bin` in PATH
- [x] Manually verified: `hermes gateway status` no longer shows "outdated service definition" after applying the fix

## Evidence

Before (under sudo):
```
PATH entries (installed): .../hermes-agent/node_modules/.bin:/home/hermes/.local/bin:...
PATH entries (expected):  .../hermes-agent/node_modules/.bin:/home/hermes/.hermes/node/bin:/home/hermes/.local/bin:...
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing
```

After (under sudo):
```
PATH entries: .../hermes-agent/node_modules/.bin:/home/hermes/.hermes/node/bin:/home/hermes/.local/bin:...
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ present
```