### PR TITLE
fix(tui): guard inline gateway RPC handlers from crashing the stdio loop

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1458,6 +1458,30 @@ def test_dispatch_long_handler_exception_produces_error_response(capture):
     assert "kaboom" in written["error"]["message"]
 
 
+def test_dispatch_inline_handler_exception_produces_error_response(server):
+    """An exception inside an inline (non-long) handler must return a JSON-RPC
+    error rather than propagating.
+
+    The inline path is reached bare from tui_gateway.entry's stdin loop, so an
+    unguarded exception (e.g. int() over a malformed `cols` in terminal.resize)
+    would unwind out of the loop and kill the whole gateway subprocess, taking
+    the live Ink TUI session with it. dispatch() must convert it to an error
+    response, the same as the pool path does for long handlers.
+    """
+
+    def boom(rid, params):
+        raise ValueError("invalid literal for int() with base 10: 'abc'")
+
+    server._methods["terminal.resize"] = boom
+
+    resp = server.dispatch({"id": "r5", "method": "terminal.resize", "params": {"cols": "abc"}})
+
+    assert resp is not None
+    assert resp["id"] == "r5"
+    assert resp["error"]["code"] == -32000
+    assert "abc" in resp["error"]["message"]
+
+
 def test_dispatch_unknown_long_method_still_goes_inline(server):
     """Method name not in _LONG_HANDLERS takes the sync path even if handler is slow."""
     server._methods["some.method"] = lambda rid, params: server._ok(rid, {"ok": True})

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -916,7 +916,17 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
 
         _rid, method, _params = normalized
         if method not in _LONG_HANDLERS:
-            return handle_request(req)
+            try:
+                return handle_request(req)
+            except Exception as exc:
+                # The inline path runs on the dispatcher loop in
+                # tui_gateway.entry, which calls dispatch() bare. An unguarded
+                # handler exception (e.g. int() over a malformed client param in
+                # terminal.resize / session.create) would unwind out of the
+                # stdin loop and kill the whole gateway subprocess — for the Ink
+                # TUI that drops the live session and any in-flight turn. Convert
+                # it to a JSON-RPC error, matching the pool path below.
+                return _err(_rid, -32000, f"handler error: {exc}")
 
         # Snapshot the context so the pool worker sees the bound transport.
         ctx = contextvars.copy_context()


### PR DESCRIPTION
## What does this PR do?

`tui_gateway.dispatch()` routes long-running handlers onto a thread pool
and runs everything else inline. The pool path already wraps the handler
in try/except and turns any exception into a `-32000` JSON-RPC error, but
the inline branch called `handle_request(req)` bare. That return value is
handed straight back to `tui_gateway.entry`'s `for raw in sys.stdin` loop,
which also calls `dispatch()` without a guard — so an exception raised by
an inline handler unwinds all the way out of the stdin loop and terminates
the gateway subprocess.

`_normalize_request` only validates the JSON-RPC envelope (object request,
string method, object params); it does not validate param value types.
Several inline handlers coerce client-supplied params with `int()` —
`terminal.resize` (`int(params.get("cols", 80))`) and `session.create`
among them. A single malformed value such as `{"cols": "abc"}` raises
`ValueError`, and for the Ink TUI (whose backend is the stdio gateway) the
whole live session dies with "gateway exited", losing any in-flight turn.
`terminal.resize` is emitted automatically on resize, so a garbled value
from any client is enough to trip it.

The fix mirrors the existing pool-path guard: wrap the inline branch and
convert handler exceptions into a per-request `-32000` error. This keeps
one bad request from taking down the session, and matches the WS transport,
which is already immune because it wraps `dispatch` in try/except. I kept
the guard narrow (inline branch only) rather than wrapping the whole entry
loop, so the change stays local to the code that actually lacked it and
the loop's existing broken-pipe handling is untouched.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: wrap the inline (non-`_LONG_HANDLERS`) branch of
  `dispatch()` in try/except and return a `-32000` JSON-RPC error on failure,
  matching the pool path so a raising handler can no longer kill the gateway.
- `tests/tui_gateway/test_protocol.py`: add
  `test_dispatch_inline_handler_exception_produces_error_response`, mirroring
  the existing pool-path exception test for the inline path.

## How to Test

1. `scripts/run_tests.sh tests/tui_gateway/test_protocol.py` — all pass
   (64 tests).
2. The new test registers a `terminal.resize` handler that raises on a
   malformed `cols` and asserts `dispatch()` returns a `-32000` error instead
   of propagating. Reverting the `server.py` change makes it fail with the
   raw `ValueError` escaping `dispatch()` — the exact crash path being fixed.
3. `ruff check tui_gateway/server.py tests/tui_gateway/test_protocol.py` and
   `python scripts/check-windows-footguns.py --all` both clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A