### PR TITLE
fix(file): anchor device symlink guard to task cwd (dropped commit from #34466)

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -170,6 +170,33 @@ class TestDevicePathBlocking(unittest.TestCase):
         self.assertIn("device file", result["error"])
         mock_ops.assert_not_called()
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_read_file_tool_rejects_task_cwd_relative_device_alias_symlink(self, mock_ops):
+        if not os.path.exists("/dev/stdin"):
+            self.skipTest("/dev/stdin is not available on this platform")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = os.path.join(tmpdir, "workspace")
+            process_cwd = os.path.join(tmpdir, "process")
+            os.mkdir(workspace)
+            os.mkdir(process_cwd)
+            link_path = os.path.join(workspace, "stdin-link")
+            try:
+                os.symlink("/dev/../dev/stdin", link_path)
+            except OSError as exc:
+                self.skipTest(f"symlink unavailable: {exc}")
+
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(process_cwd)
+                with patch.dict(os.environ, {"TERMINAL_CWD": workspace}, clear=False):
+                    result = json.loads(read_file_tool("stdin-link", task_id="dev_rel_link_test"))
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertIn("error", result)
+        self.assertIn("device file", result["error"])
+        mock_ops.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Character-count limits

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -302,14 +302,17 @@ def _is_blocked_device_path(path: str) -> bool:
     return False
 
 
-def _is_blocked_device(filepath: str) -> bool:
+def _is_blocked_device(filepath: str, base_dir: str | Path | None = None) -> bool:
     """Return True if the path would hang the process (infinite output or blocking input).
 
     Check the literal path first so aliases like /dev/stdin are caught before
     they resolve to terminal-specific paths. Then check each symlink hop before
     the final resolved path so aliases to devices cannot bypass the guard.
     """
-    normalized = os.path.normpath(os.path.expanduser(filepath))
+    expanded = os.path.expanduser(filepath)
+    if base_dir is not None and not os.path.isabs(expanded):
+        expanded = os.path.join(os.fspath(base_dir), expanded)
+    normalized = os.path.normpath(expanded)
     if _is_blocked_device_path(normalized):
         return True
 
@@ -807,7 +810,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
         # blocking on input).  Pure path check — no I/O.
-        if _is_blocked_device(path):
+        device_base = None if Path(path).expanduser().is_absolute() else _resolve_base_dir(task_id)
+        if _is_blocked_device(path, base_dir=device_base):
             return json.dumps({
                 "error": (
                     f"Cannot read '{path}': this is a device file that would "


### PR DESCRIPTION
## Summary
Picks up the second commit of PR #34466 that was dropped during the #50221 salvage. The `read_file` device guard now anchors relative device-path checks to the task cwd before the symlink-hop walk, closing a residual bypass that the first commit (already on main) left open.

## Root cause
#50221 cherry-picked only commit 1 (`harden read_file device alias blocking`). The author force-pushed a follow-up commit (`acee75a8`, announced in a PR comment, not the body) that I missed. That follow-up fixes the case where the symlink-hop walk interpreted a **relative** workspace symlink against the Python process cwd instead of the task cwd — so a relative symlink to `/dev/../dev/stdin` in a session where `TERMINAL_CWD` is the workspace would miss the blocked device target before `read_file`'s own task-cwd resolution.

## Changes
- `tools/file_tools.py`: `_is_blocked_device(filepath, base_dir=None)` joins relative paths to `base_dir` before normpath; `read_file_tool` passes `_resolve_base_dir(task_id)` for non-absolute inputs. Absolute paths and the final realpath fallback unchanged.
- `tests/tools/test_file_read_guards.py`: regression test for a task-cwd-relative device-alias symlink with process cwd != task cwd.

## Validation
| | Before (main) | After |
|---|---|---|
| relative `/dev/../dev/stdin` symlink, `TERMINAL_CWD`=workspace, process cwd elsewhere | guard misses target | BLOCKED |
| `tests/tools/test_file_read_guards.py` | 41 passed | 42 passed |

E2E: built the exact bypass (workspace symlink → `/dev/../dev/stdin`, chdir to a different process cwd, `TERMINAL_CWD` set) and confirmed `read_file_tool` returns "device file" and never reaches the read sink.

Picks up the dropped commit from PR #34466 by @egilewski. Refs #10141, #29158.

## Infographic
![read_file device guard task-cwd anchor](https://v3b.fal.media/files/b/0a9f3862/YqfPvtqdNn6vYqB2BkDT-_ANub4QYr.png)
