### PR TITLE
fix(skills): re-check environment gate on snapshot fast path

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1082,7 +1082,7 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-_SKILLS_SNAPSHOT_VERSION = 1
+_SKILLS_SNAPSHOT_VERSION = 2
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1170,12 +1170,17 @@ def _build_snapshot_entry(
     if isinstance(platforms, str):
         platforms = [platforms]
 
+    environments = frontmatter.get("environments") or []
+    if isinstance(environments, str):
+        environments = [environments]
+
     return {
         "skill_name": skill_name,
         "category": category,
         "frontmatter_name": str(frontmatter.get("name", skill_name)),
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
+        "environments": [str(e).strip() for e in environments if str(e).strip()],
         "conditions": extract_skill_conditions(frontmatter),
     }
 
@@ -1313,6 +1318,10 @@ def build_skills_system_prompt(
             frontmatter_name = entry.get("frontmatter_name") or skill_name
             platforms = entry.get("platforms") or []
             if not skill_matches_platform({"platforms": platforms}):
+                continue
+            if not skill_matches_environment(
+                {"environments": entry.get("environments") or []}
+            ):
                 continue
             if frontmatter_name in disabled or skill_name in disabled:
                 continue

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -522,6 +522,51 @@ class TestBuildSkillsSystemPrompt:
         assert "imessage" in result
         assert "Send iMessages" in result
 
+    def test_environment_gating_survives_snapshot_fast_path(
+        self, monkeypatch, tmp_path
+    ):
+        """An env-gated skill hidden on the cold scan must stay hidden when the
+        prompt is rebuilt from the disk snapshot.
+
+        The snapshot fast path re-checks platforms but used to forget the
+        environment gate, so kanban/s6-only skills leaked back into the index
+        on every process after the first.
+        """
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "ops"
+
+        gated_skill = skills_dir / "s6-supervisor"
+        gated_skill.mkdir(parents=True)
+        (gated_skill / "SKILL.md").write_text(
+            "---\nname: s6-supervisor\ndescription: Manage s6 services\n"
+            "environments: [s6]\n---\n"
+        )
+
+        uni_skill = skills_dir / "web-search"
+        uni_skill.mkdir()
+        (uni_skill / "SKILL.md").write_text(
+            "---\nname: web-search\ndescription: Search the web\n---\n"
+        )
+
+        from unittest.mock import patch
+
+        # s6 environment inactive: the gated skill must never be offered.
+        with patch("agent.skill_utils._detect_environment", return_value=False):
+            # Cold path: full scan, writes the snapshot.
+            cold = build_skills_system_prompt()
+            assert "web-search" in cold
+            assert "s6-supervisor" not in cold
+
+            # Drop only the in-process cache so the rebuild is served from the
+            # disk snapshot (the fast path), not a fresh filesystem scan.
+            clear_skills_system_prompt_cache()
+            warm = build_skills_system_prompt()
+
+        assert "web-search" in warm
+        assert "s6-supervisor" not in warm
+
     def test_excludes_disabled_skills(self, monkeypatch, tmp_path):
         """Skills in the user's disabled list should not appear in the system prompt."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
The skills index has two paths that must agree on visibility: the cold
filesystem scan and the disk-snapshot fast path used on every subsequent
process. The cold scan hides skills whose `environments:` tag is inactive
(e.g. s6/kanban-only skills), but it still writes those entries into the
snapshot. The fast path re-checked `platforms` yet forgot `environments`,
so env-gated skills leaked back into the system prompt on every build
served from the snapshot — which is the common case.

Persist `environments` in the snapshot entry and re-check
`skill_matches_environment` on the fast path, mirroring the existing
platform handling. Bump the snapshot version so stale snapshots lacking
the field are rebuilt instead of treated as env-unconstrained.

## What does this PR do?

Fixes environment-gated skills (`environments: [s6]`, `[kanban]`, `[docker]`)
leaking into the skills index when the prompt is rebuilt from the disk
snapshot. The cold scan excluded them but the snapshot fast path did not.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py`: store `environments` in `_build_snapshot_entry`; re-check `skill_matches_environment` on the snapshot fast path in `build_skills_system_prompt`; bump `_SKILLS_SNAPSHOT_VERSION` 1 → 2.
- `tests/agent/test_prompt_builder.py`: regression test that an env-gated skill stays hidden across the snapshot fast path.

## How to Test

1. Add a skill with `environments: [s6]` outside an s6 container.
2. Build the index once (cold scan) — skill is absent.
3. Rebuild from the snapshot — before this fix the skill reappears; after, it stays absent.
4. `pytest tests/agent/test_prompt_builder.py -q`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A