### PR TITLE
fix(photon): handle iMessage rich links in sidecar and adapter

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -617,6 +617,19 @@ class PhotonAdapter(BasePlatformAdapter):
             text = "\n".join(part for part in text_parts if part).strip()
             if not text:
                 text = "(attachment)" if media_urls else "[Photon empty group received]"
+        elif ctype == "richlink":
+            url = content.get("url") or ""
+            title = content.get("title") or ""
+            summary = content.get("summary") or ""
+            parts = []
+            if title:
+                parts.append(title)
+            if summary and summary != title:
+                parts.append(summary)
+            if url:
+                parts.append(url)
+            text = "\n".join(parts) if parts else url or "[Photon richlink with no URL]"
+            mtype = MessageType.TEXT
         else:
             text = f"[Photon content type not handled: {ctype}]"
             mtype = MessageType.TEXT

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -303,6 +303,28 @@ async function normalizeContent(content) {
     }
     return { type: "group", items };
   }
+  if (content.type === "richlink") {
+    // Rich links carry a URL plus optional async title/summary accessors.
+    // Resolve them eagerly so the Python adapter gets a plain text payload.
+    const out = { type: "richlink", url: content.url || "" };
+    if (typeof content.title === "function") {
+      try {
+        const title = await content.title();
+        if (title) out.title = title;
+      } catch { /* accessor may fail if metadata fetch didn't complete */ }
+    } else if (typeof content.title === "string") {
+      out.title = content.title;
+    }
+    if (typeof content.summary === "function") {
+      try {
+        const summary = await content.summary();
+        if (summary) out.summary = summary;
+      } catch { /* same — metadata fetch may not have completed */ }
+    } else if (typeof content.summary === "string") {
+      out.summary = content.summary;
+    }
+    return out;
+  }
   if (content.type === "reaction") {
     return {
       type: "reaction",

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -305,7 +305,8 @@ async function normalizeContent(content) {
   }
   if (content.type === "richlink") {
     // Rich links carry a URL plus optional async title/summary accessors.
-    // Resolve them eagerly so the Python adapter gets a plain text payload.
+    // Resolve them eagerly so the Python adapter receives a structured
+    // {type, url, title?, summary?} object with plain string values.
     const out = { type: "richlink", url: content.url || "" };
     if (typeof content.title === "function") {
       try {

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -334,6 +334,104 @@ async def test_on_inbound_line_ignores_bad_json(monkeypatch: pytest.MonkeyPatch)
     assert captured == []
 
 
+def _richlink_event(
+    url: str = "https://example.com/article",
+    title: str | None = "Example Article",
+    summary: str | None = "A summary of the article",
+    msg_id: str = "spc-msg-rl",
+) -> Dict[str, Any]:
+    content: Dict[str, Any] = {"type": "richlink", "url": url}
+    if title is not None:
+        content["title"] = title
+    if summary is not None:
+        content["summary"] = summary
+    return {
+        "messageId": msg_id,
+        "space": {"id": "+155****4567", "type": "dm", "phone": "+155****4567"},
+        "sender": {"id": "+155****4567"},
+        "content": content,
+        "timestamp": "2026-05-14T19:06:32.000Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_dispatch_richlink_with_title_and_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_richlink_event(
+        url="https://example.com/article",
+        title="Example Article",
+        summary="A summary of the article",
+    ))
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.message_type == MessageType.TEXT
+    lines = event.text.split("\n")
+    assert "Example Article" in lines
+    assert "A summary of the article" in lines
+    assert "https://example.com/article" in lines
+
+
+@pytest.mark.asyncio
+async def test_dispatch_richlink_url_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_richlink_event(
+        url="https://example.com/bare",
+        title=None,
+        summary=None,
+    ))
+
+    assert len(captured) == 1
+    assert captured[0].text == "https://example.com/bare"
+    assert captured[0].message_type == MessageType.TEXT
+
+
+@pytest.mark.asyncio
+async def test_dispatch_richlink_summary_same_as_title(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When summary duplicates title, it should not appear twice."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_richlink_event(
+        url="https://example.com/dup",
+        title="Same Text",
+        summary="Same Text",
+    ))
+
+    assert len(captured) == 1
+    text = captured[0].text
+    lines = text.split("\n")
+    assert lines.count("Same Text") == 1
+    assert "https://example.com/dup" in lines
+
+
+@pytest.mark.asyncio
+async def test_dispatch_richlink_no_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_richlink_event(
+        url="",
+        title="Some Title",
+        summary=None,
+    ))
+
+    assert len(captured) == 1
+    assert "Some Title" in captured[0].text
+
+
 def test_is_duplicate_window(monkeypatch: pytest.MonkeyPatch) -> None:
     adapter = _make_adapter(monkeypatch)
     assert adapter._is_duplicate("id-1") is False


### PR DESCRIPTION
## What does this PR do?

iMessage rich links (the URL preview bubbles iOS creates when you share a link) were not handled by the Photon plugin. Both the sidecar normalizer and the Python adapter lacked a case for the `richlink` content type, so every rich link fell through to the catch-all branch and produced:

```
[Photon content type not handled: richlink]
```

The agent never saw the URL, title, or any useful metadata. This PR adds a `richlink` case to both the sidecar and the adapter so rich links are normalized to text (title + summary + URL).

## Related Issue

Fixes #50336

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/photon/sidecar/index.mjs` — Added `richlink` case to `normalizeContent()` that extracts URL and resolves async `title()` / `summary()` accessors from spectrum-ts
- `plugins/platforms/photon/adapter.py` — Added `richlink` case before the `else` catch-all that formats title + summary + URL as text

## How to Test

1. Start the gateway with `hermes gateway start`
2. Send a rich link (share any URL from Safari/News/etc. via iMessage) to your Photon line
3. Verify the agent receives the title, summary, and URL instead of `[Photon content type not handled: richlink]`

Tested on macOS 26.5.1 with a live iMessage rich link. Before: agent received placeholder. After: agent received full title, summary, and URL.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — unable to run from inside the gateway process
- [ ] I've added tests for my changes — plugin code requires a live Photon connection to exercise end-to-end; can add a unit test if reviewers want one
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've considered cross-platform impact — no OS-specific code in either change — or N/A
- [x] No config keys, tool schemas, or docs changed — or N/A

## Screenshots / Logs

Before fix (gateway log):
```
inbound message: platform=photon msg='[Photon content type not handled: richlink]'
```

After fix (agent receives):
```
The Greek God Method May be the Most Efficient Way to Build an Aesthetic Physique After 40
Coach Alain Gonzalez says this is the secret to building an X-frame physique
https://www.menshealth.com/uk/building-muscle/train-smarter/a71623780/greek-god-method-after-40/
```
