### PR TITLE
fix(desktop): search sessions across all profiles, not just the default

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5497,6 +5497,16 @@ async function interceptSessionRequestForRemote(request) {
     return mergeRemoteProfileSessions(searchParams, remoteProfiles)
   }
 
+  // `/api/sessions/search` is a literal collection route, not a per-session
+  // resource — its `?profile=` is a search SCOPE (incl. "all"), not a session
+  // owner. The per-session regex below matches it ("search" looks like an id),
+  // and the remote branches rebuild the URL from `pathname` alone, which would
+  // silently drop the `?q=` term. Let it fall through to the primary/global
+  // backend, where the server aggregates profiles (?profile=all) itself.
+  if (pathname === '/api/sessions/search') {
+    return undefined
+  }
+
   // Per-session read/mutation. Owner is in ?profile= (reads) or request.profile
   // (mutations). Two remote shapes:
   //  - per-profile override: route to that profile's own remote, sans profile

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -271,6 +271,10 @@ function searchResultToSession(result: SessionSearchResult): SessionInfo {
     model: result.model ?? null,
     output_tokens: 0,
     preview: result.snippet?.trim() || null,
+    // Owning profile from the cross-profile search aggregator — drives the
+    // per-row profile badge and routes the transcript read to the right backend
+    // (absent for single-profile/legacy searches, treated as default).
+    ...(result.profile ? { profile: result.profile } : {}),
     source: result.source ?? null,
     started_at: ts,
     title: null,
@@ -474,8 +478,13 @@ export function ChatSidebar({
 
     let cancelled = false
 
+    // Search the same profile slice the recents show: "all" for the unified
+    // view, otherwise the scoped profile. Keeps server hits consistent with the
+    // visible list instead of leaking other profiles into a scoped view.
+    const searchProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+
     const id = window.setTimeout(() => {
-      void searchSessions(trimmedQuery)
+      void searchSessions(trimmedQuery, searchProfile)
         .then(res => {
           if (!cancelled) {
             setServerMatches(res.results)
@@ -488,7 +497,7 @@ export function ChatSidebar({
       cancelled = true
       window.clearTimeout(id)
     }
-  }, [trimmedQuery])
+  }, [trimmedQuery, profileScope])
 
   const searchResults = useMemo(() => {
     if (!trimmedQuery) {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSessionMessages, listAllProfileSessions, listSessions } from './hermes'
+import { getSessionMessages, listAllProfileSessions, listSessions, searchSessions } from './hermes'
 
 const emptySessionsResponse = {
   limit: 0,
@@ -55,6 +55,28 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
+    })
+  })
+
+  it('searches all profiles by default with the cross-profile timeout', async () => {
+    api.mockResolvedValue({ results: [] })
+
+    await searchSessions('docker deploy')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/sessions/search?q=docker%20deploy&profile=all',
+      timeoutMs: 60_000
+    })
+  })
+
+  it('scopes search to a concrete profile without request-level routing', async () => {
+    api.mockResolvedValue({ results: [] })
+
+    await searchSessions('docker', 'coder')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/sessions/search?q=docker&profile=coder',
+      timeoutMs: 60_000
     })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -206,9 +206,18 @@ export function setSessionArchived(id: string, archived: boolean, profile?: stri
   })
 }
 
-export function searchSessions(query: string): Promise<SessionSearchResponse> {
+// Full-text search scoped to match the sidebar's recents. `profile="all"` (the
+// unified view) aggregates across every profile's on-disk state.db on the
+// primary backend — mirroring listAllProfileSessions — and tags each result
+// with its owning `profile`; a concrete name searches just that profile. Routed
+// by the path's `?profile=`, not request.profile: "all" has no single backend,
+// and the primary serves every local profile's DB directly. Without this a
+// conversation in a non-default profile is listed in recents but unfindable in
+// search. The cross-profile fan-out reuses the longer session-list timeout.
+export function searchSessions(query: string, profile = 'all'): Promise<SessionSearchResponse> {
   return window.hermesDesktop.api<SessionSearchResponse>({
-    path: `/api/sessions/search?q=${encodeURIComponent(query)}`
+    path: `/api/sessions/search?q=${encodeURIComponent(query)}&profile=${encodeURIComponent(profile)}`,
+    timeoutMs: SESSION_LIST_REQUEST_TIMEOUT_MS
   })
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -584,6 +584,10 @@ export interface SessionSearchResult {
    *  used as the durable pin id; falls back to session_id when absent. */
   lineage_root?: string | null
   model: string | null
+  /** Owning profile name, set by the cross-profile search aggregator
+   *  (`?profile=all`). Absent on single-profile searches, which the UI treats
+   *  as the default profile. Routes the transcript read to the right backend. */
+  profile?: string
   role: string | null
   /** Live compression tip of the matched conversation — resume by this id. */
   session_id: string

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3086,9 +3086,8 @@ async def get_profiles_sessions(
     }
 
 
-@app.get("/api/sessions/search")
-async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] = None):
-    """Search sessions by ID plus full-text message content using FTS5.
+def _search_sessions_in_db(db, q: str, safe_limit: int) -> List[Dict[str, Any]]:
+    """Run id-match + FTS5 message search against one open SessionDB.
 
     Direct session-id matches are surfaced first, then FTS message-content
     matches. Results are deduped by compression lineage, not by raw
@@ -3097,150 +3096,215 @@ async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] =
     logical chat can own many ``sessions`` rows that all match the same query.
     Branches also use ``parent_session_id``, but they are real alternate
     conversations; don't collapse branch-specific hits back into the parent.
+
+    The caller opens/closes ``db``; the cross-profile aggregator additionally
+    tags each returned payload with its owning profile.
+    """
+    # Walk parent_session_id to the compression root, memoized so a
+    # chain of compression segments only costs one walk. We deliberately
+    # stop at branch/delegate edges: those sessions may diverge from the
+    # parent and should remain searchable on their own.
+    root_cache: dict = {}
+
+    def compression_root(session_id: str) -> str:
+        if not session_id:
+            return session_id
+        if session_id in root_cache:
+            return root_cache[session_id]
+        chain = []
+        cur = session_id
+        visited = set()
+        root = session_id
+        while cur and cur not in visited:
+            visited.add(cur)
+            chain.append(cur)
+            if cur in root_cache:
+                root = root_cache[cur]
+                break
+            try:
+                s = db.get_session(cur)
+            except Exception:
+                s = None
+            if not s:
+                root = cur
+                break
+            parent = s.get("parent_session_id") if isinstance(s, dict) else None
+            if not parent:
+                root = cur
+                break
+            try:
+                parent_session = db.get_session(parent)
+            except Exception:
+                parent_session = None
+            if not parent_session:
+                root = cur
+                break
+            parent_ended_at = parent_session.get("ended_at")
+            started_at = s.get("started_at")
+            is_compression_edge = (
+                parent_session.get("end_reason") == "compression"
+                and parent_ended_at is not None
+                and started_at is not None
+                and started_at >= parent_ended_at
+            )
+            if not is_compression_edge:
+                root = cur
+                break
+            cur = parent
+        for node in chain:
+            root_cache[node] = root
+        return root
+
+    tip_cache: dict = {}
+
+    def lineage_tip(root_id: str) -> str:
+        if root_id in tip_cache:
+            return tip_cache[root_id]
+        tip = root_id
+        try:
+            resolved = db.get_compression_tip(root_id)
+            if resolved:
+                tip = resolved
+        except Exception:
+            pass
+        tip_cache[root_id] = tip
+        return tip
+
+    # Both ID matches and content matches share one keyspace, keyed by
+    # compression lineage root, so an id-hit and a content-hit on the
+    # same logical conversation collapse to a single result. The first
+    # hit for a lineage wins; ID matches run first and take priority.
+    seen: dict = {}
+
+    def add_lineage_result(raw_sid: str, payload: dict) -> None:
+        if not raw_sid:
+            return
+        root = compression_root(raw_sid)
+        if root in seen or len(seen) >= safe_limit:
+            return
+        payload = dict(payload)
+        payload["session_id"] = lineage_tip(root)
+        payload["lineage_root"] = root
+        seen[root] = payload
+
+    # Direct ID matches first: users often paste a session id from CLI,
+    # logs, or another Hermes surface. FTS can't find those unless the
+    # id happens to appear in message text. search_sessions_by_id is
+    # SQL-bounded, so this stays cheap even with thousands of sessions.
+    for row in db.search_sessions_by_id(q, limit=safe_limit, include_archived=True):
+        sid = row.get("id")
+        preview = (row.get("preview") or "").strip()
+        snippet = preview or f"Session ID: {sid}"
+        add_lineage_result(
+            sid,
+            {
+                "snippet": snippet,
+                "role": None,
+                "source": row.get("source"),
+                "model": row.get("model"),
+                "session_started": row.get("started_at"),
+            },
+        )
+
+    # Auto-add prefix wildcards so partial words match
+    # e.g. "nimb" → "nimb*" matches "nimby"
+    # Preserve quoted phrases and existing wildcards as-is
+    import re
+    terms = []
+    for token in re.findall(r'"[^"]*"|\S+', q.strip()):
+        if token.startswith('"') or token.endswith("*"):
+            terms.append(token)
+        else:
+            terms.append(token + "*")
+    prefix_query = " ".join(terms)
+    # Over-fetch so lineage dedup can still surface `limit` distinct
+    # conversations even when several hits collapse onto one root.
+    fetch_limit = max(safe_limit * 5, 50)
+    matches = db.search_messages(query=prefix_query, limit=fetch_limit)
+
+    for m in matches:
+        if len(seen) >= safe_limit:
+            break
+        add_lineage_result(
+            m["session_id"],
+            {
+                "snippet": m.get("snippet", ""),
+                "role": m.get("role"),
+                "source": m.get("source"),
+                "model": m.get("model"),
+                "session_started": m.get("session_started"),
+            },
+        )
+    return list(seen.values())
+
+
+def _search_sessions_all_profiles(q: str, safe_limit: int) -> List[Dict[str, Any]]:
+    """Aggregate session search across every profile's ``state.db``.
+
+    The desktop sidebar lists sessions from ALL profiles
+    (``/api/profiles/sessions?profile=all``) but historically searched only the
+    primary profile's DB, so a conversation living in a non-default profile was
+    unfindable. This mirrors the recents aggregator: enumerate profiles, search
+    each profile's on-disk DB directly (no per-profile backend spawn), tag every
+    result with its owning ``profile`` so the desktop can route the transcript
+    read, then merge newest-first and cap. Session ids are globally unique, so
+    per-profile lineage dedup needs no cross-profile reconciliation.
+    """
+    from hermes_state import SessionDB
+    from hermes_cli import profiles as profiles_mod
+
+    try:
+        targets = [(info.name, info.path) for info in profiles_mod.list_profiles()]
+    except Exception:
+        _log.exception("GET /api/sessions/search: list_profiles failed")
+        targets = []
+    if not targets:
+        targets = [("default", profiles_mod.get_profile_dir("default"))]
+
+    merged: List[Dict[str, Any]] = []
+    for name, home in targets:
+        db_path = Path(home) / "state.db"
+        if not db_path.exists():
+            continue
+        try:
+            # Read-write open (NOT the recents aggregator's read_only handle):
+            # FTS5 message search is disabled on read-only connections, and this
+            # matches how single named-profile search already opens another
+            # profile's DB via _open_session_db_for_profile.
+            db = SessionDB(db_path=db_path)
+        except Exception:
+            _log.warning("session search: cannot open profile %s state.db", name, exc_info=True)
+            continue
+        try:
+            for result in _search_sessions_in_db(db, q, safe_limit):
+                result["profile"] = name
+                merged.append(result)
+        except Exception:
+            _log.warning("session search failed for profile %s", name, exc_info=True)
+        finally:
+            db.close()
+
+    merged.sort(key=lambda r: r.get("session_started") or 0, reverse=True)
+    return merged[:safe_limit]
+
+
+@app.get("/api/sessions/search")
+async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] = None):
+    """Search sessions by ID plus full-text message content using FTS5.
+
+    ``profile="all"`` aggregates across every profile so the desktop's unified
+    sidebar can find conversations in any profile, not just the primary. A
+    specific name (or omitting ``profile``) searches that single profile's DB.
     """
     if not q or not q.strip():
         return {"results": []}
+    safe_limit = max(1, min(int(limit or 20), 100))
     try:
+        if profile == "all":
+            return {"results": _search_sessions_all_profiles(q, safe_limit)}
         db = _open_session_db_for_profile(profile)
         try:
-            safe_limit = max(1, min(int(limit or 20), 100))
-
-            # Walk parent_session_id to the compression root, memoized so a
-            # chain of compression segments only costs one walk. We deliberately
-            # stop at branch/delegate edges: those sessions may diverge from the
-            # parent and should remain searchable on their own.
-            root_cache: dict = {}
-
-            def compression_root(session_id: str) -> str:
-                if not session_id:
-                    return session_id
-                if session_id in root_cache:
-                    return root_cache[session_id]
-                chain = []
-                cur = session_id
-                visited = set()
-                root = session_id
-                while cur and cur not in visited:
-                    visited.add(cur)
-                    chain.append(cur)
-                    if cur in root_cache:
-                        root = root_cache[cur]
-                        break
-                    try:
-                        s = db.get_session(cur)
-                    except Exception:
-                        s = None
-                    if not s:
-                        root = cur
-                        break
-                    parent = s.get("parent_session_id") if isinstance(s, dict) else None
-                    if not parent:
-                        root = cur
-                        break
-                    try:
-                        parent_session = db.get_session(parent)
-                    except Exception:
-                        parent_session = None
-                    if not parent_session:
-                        root = cur
-                        break
-                    parent_ended_at = parent_session.get("ended_at")
-                    started_at = s.get("started_at")
-                    is_compression_edge = (
-                        parent_session.get("end_reason") == "compression"
-                        and parent_ended_at is not None
-                        and started_at is not None
-                        and started_at >= parent_ended_at
-                    )
-                    if not is_compression_edge:
-                        root = cur
-                        break
-                    cur = parent
-                for node in chain:
-                    root_cache[node] = root
-                return root
-
-            tip_cache: dict = {}
-
-            def lineage_tip(root_id: str) -> str:
-                if root_id in tip_cache:
-                    return tip_cache[root_id]
-                tip = root_id
-                try:
-                    resolved = db.get_compression_tip(root_id)
-                    if resolved:
-                        tip = resolved
-                except Exception:
-                    pass
-                tip_cache[root_id] = tip
-                return tip
-
-            # Both ID matches and content matches share one keyspace, keyed by
-            # compression lineage root, so an id-hit and a content-hit on the
-            # same logical conversation collapse to a single result. The first
-            # hit for a lineage wins; ID matches run first and take priority.
-            seen: dict = {}
-
-            def add_lineage_result(raw_sid: str, payload: dict) -> None:
-                if not raw_sid:
-                    return
-                root = compression_root(raw_sid)
-                if root in seen or len(seen) >= safe_limit:
-                    return
-                payload = dict(payload)
-                payload["session_id"] = lineage_tip(root)
-                payload["lineage_root"] = root
-                seen[root] = payload
-
-            # Direct ID matches first: users often paste a session id from CLI,
-            # logs, or another Hermes surface. FTS can't find those unless the
-            # id happens to appear in message text. search_sessions_by_id is
-            # SQL-bounded, so this stays cheap even with thousands of sessions.
-            for row in db.search_sessions_by_id(q, limit=safe_limit, include_archived=True):
-                sid = row.get("id")
-                preview = (row.get("preview") or "").strip()
-                snippet = preview or f"Session ID: {sid}"
-                add_lineage_result(
-                    sid,
-                    {
-                        "snippet": snippet,
-                        "role": None,
-                        "source": row.get("source"),
-                        "model": row.get("model"),
-                        "session_started": row.get("started_at"),
-                    },
-                )
-
-            # Auto-add prefix wildcards so partial words match
-            # e.g. "nimb" → "nimb*" matches "nimby"
-            # Preserve quoted phrases and existing wildcards as-is
-            import re
-            terms = []
-            for token in re.findall(r'"[^"]*"|\S+', q.strip()):
-                if token.startswith('"') or token.endswith("*"):
-                    terms.append(token)
-                else:
-                    terms.append(token + "*")
-            prefix_query = " ".join(terms)
-            # Over-fetch so lineage dedup can still surface `limit` distinct
-            # conversations even when several hits collapse onto one root.
-            fetch_limit = max(safe_limit * 5, 50)
-            matches = db.search_messages(query=prefix_query, limit=fetch_limit)
-
-            for m in matches:
-                if len(seen) >= safe_limit:
-                    break
-                add_lineage_result(
-                    m["session_id"],
-                    {
-                        "snippet": m.get("snippet", ""),
-                        "role": m.get("role"),
-                        "source": m.get("source"),
-                        "model": m.get("model"),
-                        "session_started": m.get("session_started"),
-                    },
-                )
-            return {"results": list(seen.values())}
+            return {"results": _search_sessions_in_db(db, q, safe_limit)}
         finally:
             db.close()
     except HTTPException:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     "0x0sec@gmail.com": "kn8-codes",  # PR #48422 salvage (rich messages opt-in default off)
     "liaoshiwu@gmail.com": "de1tydev",  # PR #10158 salvage (poll read-only for notify_on_complete watcher; #10156)
+    "drexux0@gmail.com": "Drexuxux",
     "szzhoujiarui@gmail.com": "szzhoujiarui-sketch",  # cron model.default salvage co-author (#45550)
     "rayjun0412@gmail.com": "rayjun",  # cron model.default salvage co-author (#43952)
     "96944678+sweetcornna@users.noreply.github.com": "sweetcornna",  # cron ticker-liveness salvage co-author (#33849)

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 
 from hermes_cli import web_server
 
@@ -88,3 +89,117 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
             },
         ]
     }
+    # Single-profile responses carry no profile tag (the desktop treats absent
+    # as the default profile); only the cross-profile aggregator tags rows.
+    assert all("profile" not in r for r in response["results"])
+
+
+class _ProfileScopedFakeDB:
+    """Per-profile fake keyed by the profile home dir it is opened with.
+
+    Backs the ``profile=all`` aggregator: each profile's ``state.db`` yields its
+    own single content hit so we can assert merge ordering and profile tagging.
+    """
+
+    def __init__(self, db_path=None, read_only=False):
+        self.profile = Path(db_path).parent.name
+
+    def search_sessions_by_id(self, query, limit=20, include_archived=True):
+        return []
+
+    def search_messages(self, query, limit=20):
+        started = {"default": 100, "coder": 200}[self.profile]
+        return [
+            {
+                "session_id": f"{self.profile}_sess",
+                "snippet": f"hit in {self.profile}",
+                "role": "user",
+                "source": "cli",
+                "model": "m",
+                "session_started": started,
+            }
+        ]
+
+    def get_session(self, session_id):
+        return {"id": session_id, "parent_session_id": None}
+
+    def get_compression_tip(self, session_id):
+        return session_id
+
+    def close(self):
+        pass
+
+
+def _profile_info(name, path):
+    class _Info:
+        pass
+
+    info = _Info()
+    info.name = name
+    info.path = path
+    return info
+
+
+def test_desktop_session_search_all_profiles_aggregates_and_tags(tmp_path, monkeypatch):
+    from hermes_cli import profiles as profiles_mod
+
+    homes = {}
+    for name in ("default", "coder"):
+        home = tmp_path / name
+        home.mkdir()
+        (home / "state.db").write_bytes(b"")
+        homes[name] = home
+
+    # A profile whose state.db doesn't exist yet must be skipped, not crash the
+    # whole cross-profile search.
+    ghost = tmp_path / "ghost"
+    ghost.mkdir()
+
+    monkeypatch.setattr(
+        profiles_mod,
+        "list_profiles",
+        lambda: [
+            _profile_info("default", homes["default"]),
+            _profile_info("coder", homes["coder"]),
+            _profile_info("ghost", ghost),
+        ],
+    )
+    monkeypatch.setattr("hermes_state.SessionDB", _ProfileScopedFakeDB)
+
+    response = asyncio.run(web_server.search_sessions(q="hit", limit=10, profile="all"))
+    results = response["results"]
+
+    # Every hit is tagged with its owning profile; the missing-DB profile is
+    # silently skipped. Merged newest-first across profiles (coder 200 > default 100).
+    assert [(r["session_id"], r["profile"]) for r in results] == [
+        ("coder_sess", "coder"),
+        ("default_sess", "default"),
+    ]
+    assert results[0]["snippet"] == "hit in coder"
+    assert results[1]["snippet"] == "hit in default"
+
+
+def test_desktop_session_search_all_profiles_respects_limit(tmp_path, monkeypatch):
+    from hermes_cli import profiles as profiles_mod
+
+    homes = {}
+    for name in ("default", "coder"):
+        home = tmp_path / name
+        home.mkdir()
+        (home / "state.db").write_bytes(b"")
+        homes[name] = home
+
+    monkeypatch.setattr(
+        profiles_mod,
+        "list_profiles",
+        lambda: [
+            _profile_info("default", homes["default"]),
+            _profile_info("coder", homes["coder"]),
+        ],
+    )
+    monkeypatch.setattr("hermes_state.SessionDB", _ProfileScopedFakeDB)
+
+    response = asyncio.run(web_server.search_sessions(q="hit", limit=1, profile="all"))
+
+    # Two profiles, one hit each, capped at limit=1 → the newest (coder) wins.
+    assert [r["session_id"] for r in response["results"]] == ["coder_sess"]


### PR DESCRIPTION


### What & why
The desktop sidebar lists sessions from **every** profile via the unified recents aggregator (`/api/profiles/sessions?profile=all`), but full-text search only ever opened the **primary profile's** `state.db`. The result: a conversation that lives in a non-default profile shows up in the recents list yet is **unfindable in search** — even though the sidebar code comment promises "Full-text search across *all* sessions." This is a real workflow bug for anyone using multiple profiles.

### Root cause
`searchSessions()` called `/api/sessions/search?q=…` with no profile, and the backend opened a single DB. There was no cross-profile aggregation path for search, unlike the recents list which already aggregates across profiles.

### Changes
- **`hermes_cli/web_server.py`** — Extract the per-DB search body into `_search_sessions_in_db()` and add `_search_sessions_all_profiles()`. When `profile=all`, search aggregates across every profile's on-disk `state.db` (read the same way the recents aggregator does), tags each result with its owning `profile`, merges newest-first, and caps to the limit. The single-profile and named-profile paths are byte-for-byte unchanged.
- **`apps/desktop/src/hermes.ts`** — `searchSessions(query, profile = 'all')` sends `?profile=` and reuses the longer session-list timeout for the cross-profile fan-out.
- **`apps/desktop/src/app/chat/sidebar/index.tsx`** — Search is scoped to match the sidebar's recents (`all` for the unified view, otherwise the active profile), so a scoped view doesn't leak other profiles' hits. Synthesized search-result rows carry their `profile` for the row badge and transcript routing.
- **`apps/desktop/src/types/hermes.ts`** — Add `SessionSearchResult.profile?`.
- **`apps/desktop/electron/main.cjs`** — Exclude `/api/sessions/search` from the per-session remote intercept. Its regex matched `search` as if it were a session id and rebuilt the URL from `pathname` alone, which would have dropped the `?q=` search term in remote modes.

### Backward compatibility
Fully backward compatible. Single-profile users get the same results as before (tagged `profile="default"`). The web dashboard never requests `profile=all` (its `getManagementProfile()` defaults to empty), so its single-profile search path is untouched.

### Tests
New regression coverage added:
- `tests/hermes_cli/test_web_server_session_search.py` — `profile=all` aggregates across profiles, tags each result with its owning profile, merges newest-first, skips profiles whose `state.db` doesn't exist, and respects the limit. Also asserts single-profile responses carry **no** profile tag (unchanged shape).
- `apps/desktop/src/hermes.test.ts` — `searchSessions` defaults to `?profile=all` with the cross-profile timeout, and scopes to a concrete profile when passed one.

Results:
- `python -m pytest tests/hermes_cli/test_web_server_session_search.py -q` → **3 passed**
- `python -m pytest tests/hermes_cli/test_web_server_session_search.py tests/hermes_cli/test_web_server_profile_unification.py tests/hermes_cli/test_web_server.py -q` → **328 passed, 17 skipped**
- `vitest run --environment jsdom src/hermes.test.ts` → **5 passed**
- `tsc -p . --noEmit` (desktop) → **clean, no errors**