### PR TITLE
feat(hindsight): configurable embedded daemon health grace timeout

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -17,6 +17,7 @@ Config via environment variables:
   HINDSIGHT_MODE                   — cloud or local (default: cloud)
   HINDSIGHT_TIMEOUT                — API request timeout in seconds (default: 120)
   HINDSIGHT_IDLE_TIMEOUT           — embedded daemon idle timeout seconds; 0 disables shutdown (default: 300)
+  HINDSIGHT_EMBED_PORT_HEALTH_GRACE_TIMEOUT — seconds to wait for a slow embedded daemon /health before treating it as stale (default: 30; set via config.json port_health_grace_timeout)
   HINDSIGHT_RETAIN_TAGS            — comma-separated tags attached to retained memories
   HINDSIGHT_RETAIN_OBSERVATION_SCOPES — observation scoping for retained memories: per_tag/combined/all_combinations, or a JSON list of tag-lists for custom scopes
   HINDSIGHT_RETAIN_SOURCE          — metadata source value attached to retained memories
@@ -84,6 +85,43 @@ def _parse_int_setting(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         logger.warning("Invalid integer Hindsight setting %r; using default %s", value, default)
         return default
+
+
+# Env var the embedded daemon manager reads (at import time, as a module-level
+# constant) to size the grace window it waits for a slow /health before
+# declaring a daemon stale and killing it. Default upstream is 30s; on
+# resource-contended hosts a busy daemon can exceed a single 2s health check
+# and get needlessly killed + restarted (issue #13125 comment thread). We
+# surface it as plugin config so users can raise it without hand-setting an
+# env var, consistent with "config.json, not raw env vars".
+_PORT_HEALTH_GRACE_ENV = "HINDSIGHT_EMBED_PORT_HEALTH_GRACE_TIMEOUT"
+
+
+def _export_port_health_grace_timeout(config: dict[str, Any]) -> None:
+    """Export the embedded-daemon health grace timeout to the process env.
+
+    Must run BEFORE ``hindsight_embed.daemon_embed_manager`` is imported,
+    because the package reads the env var into a module-level constant at
+    import time. We only set it when the user configured a value AND the
+    env var isn't already set, so an explicit env override always wins.
+    """
+    raw = config.get("port_health_grace_timeout")
+    if raw is None or raw == "":
+        return
+    try:
+        seconds = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid Hindsight port_health_grace_timeout %r; ignoring.", raw
+        )
+        return
+    if seconds < 0:
+        logger.warning(
+            "Negative Hindsight port_health_grace_timeout %r; ignoring.", raw
+        )
+        return
+    # setdefault: an explicit env var the operator set wins over config.
+    os.environ.setdefault(_PORT_HEALTH_GRACE_ENV, repr(seconds))
 
 
 def _check_local_runtime() -> tuple[bool, str | None]:
@@ -968,6 +1006,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
+            {"key": "port_health_grace_timeout", "description": "Seconds to wait for a slow daemon /health before treating it as stale (raise on busy/low-resource hosts; blank uses the 30s default)", "default": "", "when": {"mode": "local_embedded"}},
         ]
 
     def _get_client(self):
@@ -1228,6 +1267,9 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._mode == "local":
             self._mode = "local_embedded"
         if self._mode == "local_embedded":
+            # Export the daemon health grace timeout BEFORE importing
+            # daemon_embed_manager (which reads it at import time).
+            _export_port_health_grace_timeout(self._config)
             available, reason = _check_local_runtime()
             if not available:
                 logger.warning(

--- a/tests/plugins/test_hindsight_health_grace_timeout.py
+++ b/tests/plugins/test_hindsight_health_grace_timeout.py
@@ -1,0 +1,64 @@
+"""Embedded-daemon health grace timeout export (issue #13125 comment thread).
+
+On resource-contended hosts the embedded Hindsight daemon can exceed a single
+2s /health check and get needlessly killed + restarted. Upstream exposes the
+grace window via HINDSIGHT_EMBED_PORT_HEALTH_GRACE_TIMEOUT (read at import
+time). The plugin surfaces it as a config.json knob and exports it to the
+process env BEFORE daemon_embed_manager is imported.
+"""
+
+import importlib
+
+import pytest
+
+hindsight = importlib.import_module("plugins.memory.hindsight")
+_export = hindsight._export_port_health_grace_timeout
+_ENV = hindsight._PORT_HEALTH_GRACE_ENV
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv(_ENV, raising=False)
+
+
+def test_configured_value_exported(monkeypatch):
+    _export({"port_health_grace_timeout": 60})
+    import os
+
+    assert float(os.environ[_ENV]) == 60.0
+
+
+def test_string_value_parsed(monkeypatch):
+    _export({"port_health_grace_timeout": "45"})
+    import os
+
+    assert float(os.environ[_ENV]) == 45.0
+
+
+def test_blank_and_missing_are_noops(monkeypatch):
+    import os
+
+    _export({})
+    assert _ENV not in os.environ
+    _export({"port_health_grace_timeout": ""})
+    assert _ENV not in os.environ
+    _export({"port_health_grace_timeout": None})
+    assert _ENV not in os.environ
+
+
+def test_invalid_and_negative_ignored(monkeypatch):
+    import os
+
+    _export({"port_health_grace_timeout": "not-a-number"})
+    assert _ENV not in os.environ
+    _export({"port_health_grace_timeout": -5})
+    assert _ENV not in os.environ
+
+
+def test_explicit_env_wins_over_config(monkeypatch):
+    import os
+
+    monkeypatch.setenv(_ENV, "99")
+    _export({"port_health_grace_timeout": 60})
+    # setdefault must not clobber an operator-set env override.
+    assert os.environ[_ENV] == "99"


### PR DESCRIPTION
## Summary
Users on busy / low-resource hosts can now raise the embedded Hindsight daemon's health grace timeout from `config.json` instead of hand-setting a raw env var, so a momentarily-slow daemon under load isn't needlessly killed and restarted.

Background: the embedded daemon's `/health` is checked with a hardcoded 2s timeout upstream. On contended hosts a busy daemon can exceed that for a single check; upstream `hindsight-embed` already waits a grace window (`HINDSIGHT_EMBED_PORT_HEALTH_GRACE_TIMEOUT`, default 30s) before treating it as stale and killing+restarting — but that env var is read into a module-level constant *at import time*, and there was no Hermes-side way to set it short of exporting the raw var. Reported in the #13125 comment thread (@GusBot69's production deployment).

## Changes
- `plugins/memory/hindsight/__init__.py`:
  - New `port_health_grace_timeout` config option. `initialize()` exports it to `HINDSIGHT_EMBED_PORT_HEALTH_GRACE_TIMEOUT` **before** `daemon_embed_manager` is imported (the import-time read is the contract). `os.environ.setdefault` so an operator's explicit env override always wins. Invalid / negative / blank values are ignored (fall back to upstream's 30s).
  - Surfaced in `hermes memory setup` for `local_embedded` mode, and documented in the module env-var header.
- `tests/plugins/test_hindsight_health_grace_timeout.py`: new — covers value export, string parsing, blank/missing no-op, invalid/negative ignored, and env-override precedence.

## Validation
| input | result |
|---|---|
| `port_health_grace_timeout: 60` | env `= 60.0` |
| env already set | env override wins (config ignored) |
| blank / missing / invalid / negative | no-op → upstream 30s default |

- `scripts/run_tests.sh tests/plugins/test_hindsight_health_grace_timeout.py` → 5 passed
- E2E in a real interpreter: env var is set **before** the runtime/daemon-manager import (ordering contract holds).
- ruff clean, base 0 behind main.

Note: the underlying 2s `is_running()` check and the kill decision live in the third-party `hindsight-embed` package, not in this repo — the worst of the loop (killing on one slow check) is already mitigated upstream via the grace window. This PR is the Hermes-side lever to tune that window.

## Infographic

![hindsight-health-grace-timeout](https://v3b.fal.media/files/b/0a9f389a/bqlK3mHZ7bjR7vrh2XBOq_LcYbh4D1.png)
