### PR TITLE
fix(cron): accept named and special-character fields in cron schedules

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -333,11 +333,25 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
             "display": f"every {minutes}m"
         }
     
-    # Check for cron expression (5 or 6 space-separated fields)
-    # Cron fields: minute hour day month weekday [year]
+    # Check for cron expression (5 classic, or 6 with seconds/year fields).
+    # Cron fields: minute hour day month weekday [year].
+    #
+    # The minute field is always numeric — digits plus the ``* , - /``
+    # operators — so requiring it to match the strict numeric shape reliably
+    # tells a cron attempt apart from free-form prose (which would otherwise
+    # be misread as a malformed cron). The remaining fields accept the full
+    # grammar croniter understands, including day/month NAMES ("MON", "JAN"),
+    # ranges and lists over those names ("mon-fri", "mon,wed,fri"), and the
+    # ``L`` / ``W`` / ``#`` / ``?`` specials. A prior char-class pre-filter
+    # only allowed ``[\d*,-/]`` in every field, which silently rejected these
+    # perfectly valid expressions (e.g. "0 9 * * MON") and surfaced them to
+    # the user as a generic "Invalid schedule" error. croniter remains the
+    # authoritative validator for whatever clears this structural check.
     parts = schedule.split()
-    if len(parts) >= 5 and all(
-        re.match(r'^[\d\*\-,/]+$', p) for p in parts[:5]
+    if (
+        5 <= len(parts) <= 6
+        and re.match(r'^[\d*,/-]+$', parts[0])
+        and all(re.match(r'^[A-Za-z0-9*,/?#-]+$', p) for p in parts[1:])
     ):
         if not HAS_CRONITER:
             raise ValueError("Cron expressions require 'croniter' package. Install with: pip install croniter")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -96,6 +96,34 @@ class TestParseSchedule:
         assert result["kind"] == "cron"
         assert result["expr"] == "0 9 * * *"
 
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "0 9 * * MON",          # weekday by name
+            "0 9 * * mon-fri",      # range over weekday names
+            "0 9 * * mon,wed,fri",  # list of weekday names
+            "30 9 * JAN *",         # month by name
+            "0 0 L * *",            # last-day-of-month special
+            "0 9 * * 5#2",          # nth-weekday special
+            "*/30 * * * * *",       # 6-field form (with seconds)
+        ],
+    )
+    def test_cron_expression_with_names_and_specials(self, expr):
+        # croniter accepts day/month names and the L/W/# specials; the parser
+        # must recognize these as cron rather than rejecting them with a
+        # generic "Invalid schedule" error (regression guard).
+        pytest.importorskip("croniter")
+        result = parse_schedule(expr)
+        assert result["kind"] == "cron"
+        assert result["expr"] == expr
+
+    def test_prose_is_not_treated_as_cron(self):
+        # A free-form sentence that happens to have 5-6 words must not be
+        # misread as a (malformed) cron expression — the numeric minute-field
+        # check keeps it on the generic-schedule error path.
+        with pytest.raises(ValueError):
+            parse_schedule("tell me about the weather now")
+
     def test_iso_timestamp(self):
         result = parse_schedule("2030-01-15T14:00:00")
         assert result["kind"] == "once"


### PR DESCRIPTION
## What does this PR do?

`parse_schedule()` is responsible for classifying a user-supplied schedule
string as a one-shot, an interval, or a cron expression. To decide whether a
string is a cron expression it ran a pre-filter that required every one of the
first five fields to match `^[\d\*\-,/]+$`. That character class only permits
digits and the `* - , /` operators, so any expression that used the rest of the
cron grammar was rejected before croniter ever saw it. In practice this meant
that perfectly valid, very common expressions such as `0 9 * * MON`,
`0 9 * * mon-fri`, `30 9 * JAN *`, and the `L` / `W` / `#` specials fell through
the cron branch entirely and ended up raising the generic "Invalid schedule"
error, even though croniter (a core dependency) accepts all of them.

This change replaces the overly strict pre-filter with a structural check that
matches the real shape of a cron expression: five or six whitespace-separated
fields, a numeric minute field (`^[\d*,/-]+$`), and remaining fields drawn from
the broader grammar croniter understands (names, ranges/lists over names, and
the `L` / `W` / `#` / `?` specials). Keying the discriminator on the numeric
minute field keeps free-form prose that happens to have five or six words from
being misread as a malformed cron, and croniter remains the authoritative
validator for anything that clears the structural check, so genuinely malformed
expressions still produce the precise "Invalid cron expression" error.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/jobs.py`: rewrote the cron-detection pre-filter in `parse_schedule()`
  so it recognizes day/month names, name ranges and lists, and the
  `L` / `W` / `#` / `?` specials, while a numeric minute-field check keeps prose
  off the cron path. croniter still validates the candidate expression.
- `tests/cron/test_jobs.py`: added a parametrized regression test covering the
  named and special-character expressions that were previously rejected, plus a
  test asserting that a five-to-six-word sentence is not treated as cron.

## How to Test

1. Before the fix, `parse_schedule("0 9 * * MON")` raises
   `ValueError: Invalid schedule ...`; after the fix it returns
   `{"kind": "cron", "expr": "0 9 * * MON", ...}`.
2. The same holds for `0 9 * * mon-fri`, `0 9 * * mon,wed,fri`,
   `30 9 * JAN *`, `0 0 L * *`, `0 9 * * 5#2`, and the 6-field form
   `*/30 * * * * *`.
3. Run `pytest tests/cron/test_jobs.py -q` — all tests pass, including the new
   `test_cron_expression_with_names_and_specials` and
   `test_prose_is_not_treated_as_cron` cases.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A