### PR TITLE
feat(plugins): add ctx.profile_name for session-agnostic profile access

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -315,6 +315,28 @@ class PluginContext:
             self._llm = PluginLlm(plugin_id=plugin_id)
         return self._llm
 
+    # -- profile awareness --------------------------------------------------
+
+    @property
+    def profile_name(self) -> str:
+        """Return the active Hermes profile name (e.g. ``"default"``).
+
+        Derived from ``HERMES_HOME`` via
+        :func:`hermes_cli.profiles.get_active_profile_name`, so it works in
+        every execution context — interactive CLI, gateway, and
+        kanban-spawned worker sessions alike — without depending on
+        ``_cli_ref`` (which is ``None`` outside an interactive CLI run).
+
+        Returns ``"default"`` for the default profile, the profile id when
+        running under ``~/.hermes/profiles/<name>``, or ``"custom"`` when
+        ``HERMES_HOME`` points somewhere unrecognized.
+        """
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            return get_active_profile_name()
+        except Exception:
+            return "default"
+
     # -- tool registration --------------------------------------------------
 
     def register_tool(

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1867,3 +1867,38 @@ class TestPluginDebugLogging:
             plugins_mod._PLUGINS_DEBUG = original_debug
             plugins_mod.logger.setLevel(original_level)
             plugins_mod.logger.handlers = original_handlers
+
+
+class TestPluginContextProfileName:
+    """ctx.profile_name resolves from HERMES_HOME in every context."""
+
+    def _ctx(self):
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        return PluginContext(manifest, mgr)
+
+    def test_default_profile(self, tmp_path, monkeypatch):
+        """HERMES_HOME at the root resolves to 'default'."""
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        assert self._ctx().profile_name == "default"
+
+    def test_named_profile(self, tmp_path, monkeypatch):
+        """HERMES_HOME under profiles/<name> resolves to that name."""
+        prof = tmp_path / ".hermes" / "profiles" / "coder"
+        prof.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(prof))
+        assert self._ctx().profile_name == "coder"
+
+    def test_works_without_cli_ref(self, tmp_path, monkeypatch):
+        """profile_name does not depend on _cli_ref (None in worker sessions)."""
+        prof = tmp_path / ".hermes" / "profiles" / "worker1"
+        prof.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(prof))
+        ctx = self._ctx()
+        assert ctx._manager._cli_ref is None
+        assert ctx.profile_name == "worker1"


### PR DESCRIPTION
## Summary
Plugins can now read the active profile name from `PluginContext` via `ctx.profile_name`, in any execution context.

Previously there was no API for this. The workaround seen in the community — reaching into `ctx._manager._cli_ref` — only works in an interactive CLI session: `_cli_ref` is set exactly once (`cli.py`, in the interactive `run()` loop) and is `None` in the gateway and in **kanban-spawned worker sessions** (`hermes -p <profile> chat -q ...`), which is exactly where per-profile awareness matters most.

## Changes
- `hermes_cli/plugins.py`: add `PluginContext.profile_name` property, wrapping `hermes_cli.profiles.get_active_profile_name()` (derives from `HERMES_HOME`, no `_cli_ref` dependency).
- `tests/hermes_cli/test_plugins.py`: cover default profile, named profile, and the `_cli_ref is None` (worker) case.

## Validation
| Context | `_cli_ref` | `ctx.profile_name` |
|---|---|---|
| Interactive CLI | set | resolves |
| Gateway | None | resolves |
| Kanban worker (`chat -q`) | None | resolves (E2E verified → `kanban-worker`) |

89/89 tests pass in `tests/hermes_cli/test_plugins.py`. E2E-verified with real imports against a temp profile-scoped `HERMES_HOME` and `_cli_ref = None`.

Reported by @Smithangshu on Discord.

## Infographic

![ctx-profile-name](https://v3b.fal.media/files/b/0a9f38b5/Z-FH7D73uwLCE7S2rQsB8_hZQZoOH8.png)
