### PR TITLE
fix(telegram): stop typing indicator lingering after final reply (#48678)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2516,11 +2516,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:
-                        # Re-trigger typing like the legacy success path does.
-                        try:
-                            await self.send_typing(chat_id, metadata=metadata)
-                        except Exception:
-                            pass  # Typing failures are non-fatal
+                        # Re-trigger typing like the legacy success path does,
+                        # but ONLY for intermediate sends. On the final reply
+                        # (metadata["notify"]) the gateway has already torn down
+                        # the typing refresh loop; re-arming Telegram's ~5s timer
+                        # here would leave the "...typing" bubble lingering after
+                        # the answer (no Bot API call cancels it). See #48678.
+                        if not (metadata or {}).get("notify"):
+                            try:
+                                await self.send_typing(chat_id, metadata=metadata)
+                            except Exception:
+                                pass  # Typing failures are non-fatal
                     return rich_result
 
             # Format and split message if needed
@@ -2745,10 +2751,16 @@ class TelegramAdapter(BasePlatformAdapter):
             # so without this the "...typing" bubble disappears mid-response
             # (especially noticeable when the agent sends intermediate progress
             # messages like "Checking:" before running tools).
-            try:
-                await self.send_typing(chat_id, metadata=metadata)
-            except Exception:
-                pass  # Typing failures are non-fatal
+            # Skip this on the FINAL reply (metadata["notify"]): the gateway has
+            # already cancelled the typing refresh loop by the time the final
+            # send returns, so re-arming Telegram's ~5s timer here would leave
+            # the indicator lingering after the answer with nothing to cancel
+            # it (Telegram exposes no stop-typing API). See #48678.
+            if not (metadata or {}).get("notify"):
+                try:
+                    await self.send_typing(chat_id, metadata=metadata)
+                except Exception:
+                    pass  # Typing failures are non-fatal
 
             return SendResult(
                 success=True,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "w.a.t.s.o.n.mk10@gmail.com": "natehale",  # PR #48678 salvage (typing indicator lingers after final reply)
     "0x0sec@gmail.com": "kn8-codes",  # PR #48422 salvage (rich messages opt-in default off)
     "liaoshiwu@gmail.com": "de1tydev",  # PR #10158 salvage (poll read-only for notify_on_complete watcher; #10156)
     "szzhoujiarui@gmail.com": "szzhoujiarui-sketch",  # cron model.default salvage co-author (#45550)

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -213,6 +213,39 @@ async def test_legacy_send_keeps_chunk_indicators_outside_fenced_code_lines(adap
             assert not re.match(r"^```\s+\(\d+/\d+\)$", line), text
 
 
+@pytest.mark.asyncio
+async def test_final_send_does_not_retrigger_typing(adapter):
+    """The final reply (metadata['notify']) must NOT re-arm Telegram's typing
+    timer. The gateway has already torn down the refresh loop by then, so a
+    re-trigger here would leave the '...typing' bubble lingering after the
+    answer (Telegram has no stop-typing API). See #48678."""
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+    adapter._bot.send_chat_action = AsyncMock()
+    adapter._rich_messages_enabled = False
+
+    result = await adapter.send("12345", "All done.", metadata={"notify": True})
+
+    assert result.success is True
+    adapter._bot.send_chat_action.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_intermediate_send_still_retriggers_typing(adapter):
+    """Intermediate/progress sends (no notify marker) keep re-triggering typing
+    so the '...typing' bubble survives across progress messages while the agent
+    is still working."""
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+    adapter._bot.send_chat_action = AsyncMock()
+    adapter._rich_messages_enabled = False
+
+    result = await adapter.send("12345", "Checking:", metadata={"expect_edits": True})
+
+    assert result.success is True
+    adapter._bot.send_chat_action.assert_awaited()
+
+
 # =========================================================================
 # format_message - bold and italic
 # =========================================================================


### PR DESCRIPTION
## Summary
The Telegram "...typing" bubble no longer lingers for ~5s after the agent's final reply. `send()` re-triggers `send_typing()` after every delivery so the indicator survives intermediate progress messages (Telegram clears typing on each delivered message) — but that re-trigger also fired on the **final** send, re-arming Telegram's ~5s timer *after* the gateway had already torn down its typing-refresh loop. Telegram exposes no stop-typing API, so nothing cancelled it.

Salvages #48678 by @natehale, whose root-cause analysis pinned the post-final-send re-trigger exactly. The fix is adapted to current `main` (the adapter relocated to `plugins/platforms/telegram/adapter.py`, and the base-adapter typing lifecycle — `_typing_paused` / `pause_typing_for_chat` / `_stop_typing_refresh` — has since landed, so the original PR's task-dict additions are no longer needed).

Closes #48678.

## Changes
- `plugins/platforms/telegram/adapter.py`: gate the post-send typing re-trigger on `not metadata.get("notify")` in both send paths (rich fast-path and legacy MarkdownV2). `notify` is set only on the final user-visible reply (`_mark_notify_metadata`); intermediate/progress sends are unmarked and still re-trigger, so the bubble stays alive mid-response.
- `tests/gateway/test_telegram_format.py`: final send (`notify=True`) does NOT call `send_chat_action`; intermediate send still does.

## Validation
| Send | `send_chat_action` re-trigger |
|---|---|
| Final reply (`notify`) | **no** — bubble clears |
| Intermediate / progress | yes — bubble persists while working |

104 tests pass in `test_telegram_format.py`; full `test_telegram_rich_messages.py` (64) green.

## Note on approach
@natehale's PR removed the re-triggers outright and re-added per-chat typing-task dicts. On current `main` those dicts duplicate the base-adapter lifecycle that already exists, and a blanket removal would also drop the *intended* intermediate-progress re-trigger. This narrows the fix to exactly the final-send case using the existing `notify` signal — same symptom fixed, no cross-platform typing-lifecycle churn.

## Infographic

![typing-stop](https://v3b.fal.media/files/b/0a9f38ed/--i6R2Tcp1WxSlbEF_v5K_AhT36Fkq.png)
