### PR TITLE
fix(state): order conversation replay by id, not timestamp

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3101,7 +3101,15 @@ class SessionDB:
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
                 "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp "
                 f"FROM messages WHERE session_id IN ({placeholders})"
-                f"{active_clause} ORDER BY timestamp, id",
+                # Order by AUTOINCREMENT id (true insertion order), NOT timestamp:
+                # append_message stamps rows with time.time(), which is not
+                # monotonic (WSL2, NTP steps, VM/laptop sleep resume). A later
+                # row can carry an earlier timestamp than its predecessor, and
+                # ORDER BY timestamp would then sort an assistant tool_calls row
+                # after its tool response, breaking tool-call/response adjacency
+                # and triggering an HTTP 400 on replay. This matches get_messages
+                # — see c03acca50 for the original fix.
+                f"{active_clause} ORDER BY id",
                 tuple(session_ids),
             ).fetchall()
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -721,6 +721,48 @@ class TestMessageStorage:
         assert conv[1]["content"] == "Hi!"
         assert isinstance(conv[1]["timestamp"], float)
 
+    def test_get_messages_as_conversation_orders_by_id_not_timestamp(self, db):
+        """Replay must follow AUTOINCREMENT id (insertion order), never the
+        wall-clock timestamp.
+
+        ``append_message`` stamps each row with ``time.time()``, which is not
+        monotonic — on WSL2, after an NTP step, or when a VM/laptop resumes
+        from sleep the clock can jump backwards mid-conversation. A later
+        row then carries an *earlier* timestamp than the row before it. If
+        ``get_messages_as_conversation`` ordered by ``timestamp`` it would
+        sort an assistant ``tool_calls`` row after its ``tool`` response,
+        orphaning the tool call and triggering an HTTP 400 on the next
+        completion. Ordering by ``id`` keeps the real insertion order
+        regardless of clock skew. See c03acca50.
+        """
+        db.create_session(session_id="s1", source="cli")
+
+        # Simulate a clock regression across a single tool round-trip: the
+        # assistant tool_calls row is inserted first but stamped LATER than
+        # the tool response that follows it.
+        tool_calls = [
+            {"id": "call_1", "function": {"name": "web_search", "arguments": "{}"}},
+        ]
+        db.append_message(
+            "s1", role="assistant", content="", tool_calls=tool_calls,
+            timestamp=1000.0,
+        )
+        db.append_message(
+            "s1", role="tool", content="result", tool_name="web_search",
+            tool_call_id="call_1", timestamp=999.0,
+        )
+        db.append_message("s1", role="user", content="thanks", timestamp=998.0)
+
+        conv = db.get_messages_as_conversation("s1")
+
+        # Insertion order is preserved even though timestamps decrease.
+        assert [m["role"] for m in conv] == ["assistant", "tool", "user"]
+        # The tool response stays immediately after the assistant tool_calls
+        # row — the adjacency invariant the model API enforces.
+        assert conv[0]["tool_calls"][0]["id"] == "call_1"
+        assert conv[1]["role"] == "tool"
+        assert conv[1]["tool_call_id"] == "call_1"
+
     def test_platform_message_id_round_trips(self, db):
         """Platform-side message ids (yuanbao msg_id, telegram update_id, …)
         survive append → get_messages_as_conversation under the


### PR DESCRIPTION
## What does this PR do?

Restores `SessionDB.get_messages_as_conversation()` to order rows by the
`messages.id` AUTOINCREMENT primary key instead of `timestamp, id`. This
method is the canonical conversation-replay path fed back to the model on
gateway session restore, CLI `/resume`, `/branch`, `/undo`, the ACP adapter,
the TUI gateway, and `api_server` — every surface that rebuilds history from
the SQLite store.

`append_message()` stamps each row with `time.time()`, which is not
monotonic: on WSL2, after an NTP step, or when a VM/laptop resumes from
sleep the wall clock can jump backwards mid-conversation, so a
later-inserted row can carry an earlier timestamp than the row before it.
With `ORDER BY timestamp, id`, replay then sorts an assistant `tool_calls`
row *after* its `tool` response, orphaning the tool call and breaking the
tool-call/response adjacency invariant the model API enforces — the next
completion fails with an HTTP 400.

Commit c03acca50 already fixed exactly this by switching to `ORDER BY id`
(true insertion order), but bd7fc8fdc ("inject stable human-readable
message timestamps") reverted this one method back to `ORDER BY timestamp,
id`. It was the last message-loading path in `hermes_state.py` still
ordering by timestamp — `get_messages`, `get_messages_around`,
`get_anchored_view`, and `list_recent_user_messages` all order by `id`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: change the `get_messages_as_conversation()` query from
  `ORDER BY timestamp, id` to `ORDER BY id`, matching `get_messages()`, and
  add a comment explaining the non-monotonic `time.time()` hazard and citing
  c03acca50 so the line is not reverted a third time.
- `tests/test_hermes_state.py`: add
  `test_get_messages_as_conversation_orders_by_id_not_timestamp`, which
  appends an assistant `tool_calls` row, its `tool` response, and a user row
  with *decreasing* explicit timestamps (a simulated clock regression) and
  asserts replay returns them in insertion order with the tool response still
  adjacent to its tool call.

## How to Test

1. Check out this branch.
2. Run `python3 -m pytest tests/test_hermes_state.py -q` — all 279 tests pass.
3. Reproduction proof: temporarily restore `ORDER BY timestamp, id` on the
   query and re-run the new test — it fails with the rows reordered to
   `['user', 'tool', 'assistant']`, orphaning the `call_1` tool call.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A