### PR TITLE
fix(tools): block search_files pattern flag injection in rg/grep

### DIFF
--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -216,3 +216,62 @@ class TestSplitToolDiagnostics:
         assert diagnostics == ""
         assert "--" in payload
         assert "a.py-6-after" in payload
+
+
+@pytest.mark.parametrize("method", _METHODS)
+class TestSearchPatternFlagInjection:
+    """The search_files pattern must never be parsed as an rg/grep flag.
+
+    ``_escape_shell_arg`` single-quotes the pattern, which blocks *shell*
+    injection but does nothing about *argument* injection: a token like
+    ``--pre=/bin/sh`` is still handed to ripgrep, which parses it as a flag.
+    ``--pre=CMD`` makes rg run CMD as a preprocessor on every searched file —
+    arbitrary command execution driven entirely by the model/prompt-controlled
+    pattern. The fix inserts a literal ``--`` end-of-options marker before the
+    pattern so everything after it is a positional operand.
+    """
+
+    def test_leading_dash_pattern_does_not_execute_a_command(
+        self, method, tmp_path
+    ):
+        # A real, executable preprocessor that drops a sentinel file if it ever
+        # runs. On vulnerable code rg's `--pre` would invoke it; with the `--`
+        # guard the token is just a search string and the sentinel never appears.
+        sentinel = tmp_path / "rg_pwned.txt"
+        pre = tmp_path / "pre.sh"
+        pre.write_text(
+            "#!/bin/sh\n"
+            f"echo pwned > {sentinel}\n"
+            'cat "$1"\n'
+        )
+        os.chmod(pre, 0o755)
+
+        # Give the search a real file to scan so rg/grep actually walk the tree.
+        tree = tmp_path / "tree"
+        tree.mkdir()
+        (tree / "f.txt").write_text("needle here\n")
+
+        injection = f"--pre={pre}"
+        res = _search(_ops(tree), method, injection, tree)
+
+        assert not sentinel.exists(), (
+            "search_files pattern was executed as an rg/grep flag — "
+            "argument injection / RCE is not contained"
+        )
+        # The pattern is a flag-shaped literal that matches nothing in the tree,
+        # so this is a clean empty result, never a swallowed flag error.
+        assert res.error is None
+        assert not res.matches
+
+    def test_leading_dash_pattern_is_searched_literally(self, method, tmp_path):
+        # When the dash-prefixed token genuinely appears in a file it must be
+        # found as ordinary text rather than consumed as an option.
+        tree = tmp_path / "tree"
+        tree.mkdir()
+        (tree / "hit.txt").write_text("config: --pre=value\n")
+
+        res = _search(_ops(tree), method, "--pre=value", tree)
+
+        assert res.error is None
+        assert len(res.matches) == 1
+        assert res.matches[0].path.endswith("hit.txt")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2192,10 +2192,16 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
         
-        # Add pattern and path
+        # Add pattern and path. The leading `--` is an end-of-options marker:
+        # without it a pattern like `--pre=/bin/sh` is shell-escaped (so it is
+        # safe from shell injection) but ripgrep still parses it as a FLAG, and
+        # `--pre=CMD` runs CMD as a preprocessor on every searched file — i.e.
+        # arbitrary command execution driven by the search_files pattern arg.
+        # `--` forces everything after it to be treated as positional operands.
+        cmd_parts.append("--")
         cmd_parts.append(self._escape_shell_arg(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
-        
+
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,
         # so we grab generously and filter in Python.
@@ -2322,10 +2328,14 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")
         
-        # Add pattern and path
+        # Add pattern and path. The leading `--` is an end-of-options marker so
+        # a pattern that begins with a dash (e.g. `-f/etc/passwd`, which would
+        # otherwise make grep read its pattern list FROM that file) is treated
+        # as a literal search term rather than a flag. Mirrors the rg path.
+        cmd_parts.append("--")
         cmd_parts.append(self._escape_shell_arg(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
-        
+
         # Fetch generously so we can compute total before slicing
         fetch_limit = limit + offset + (200 if context > 0 else 0)
         cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])


### PR DESCRIPTION
## What does this PR do?

The `search_files` content search built the ripgrep/grep command line by
shell-escaping the model-supplied `pattern` and appending it as a positional
argument with no end-of-options separator. Single-quoting via
`_escape_shell_arg` blocks *shell* injection, but the escaped token is still
handed to rg/grep as one argv element, which the tool happily parses as a
*flag* when it starts with a dash.

Before: a single `search_files` call with `pattern="--pre=/path/to/script"`
reached `_search_with_rg` as `rg ... '--pre=/path/to/script' <path>`. ripgrep
treats `--pre=CMD` as a preprocessor and runs CMD on every searched file, so
the pattern argument alone executes arbitrary commands on the host with the
agent's privileges. I confirmed this live: `rg --line-number --no-heading
--with-filename '--pre=/tmp/pre.sh' needle <tree>` ran the script. Because
`search_files` is in the default-enabled `file` toolset and is the agent's
primary code-search tool, a prompt-injected instruction in a page or file the
agent is asked to search can drive it. The grep fallback was injectable too
(e.g. `-f<file>` reads the pattern list from an arbitrary file).

After: a literal `--` end-of-options marker is inserted immediately before the
pattern in both `_search_with_rg` and `_search_with_grep`, so `--pre=...`,
`-f...`, and any other dash-prefixed token are treated as ordinary search
terms. A `--pre=value` pattern now matches that literal text and never starts
a preprocessor.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/file_operations.py`: insert a `--` end-of-options token before the
  escaped pattern/path in `_search_with_rg` (line ~2196) and
  `_search_with_grep` (line ~2326); document why escaping alone is
  insufficient.
- `tests/tools/test_search_error_guard.py`: add `TestSearchPatternFlagInjection`,
  parametrized over both backends — one test drops a real executable
  preprocessor and asserts a `--pre=<script>` pattern never runs it, another
  asserts a dash-prefixed token is searched literally.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_search_error_guard.py` — all pass.
2. Revert just the two `cmd_parts.append("--")` lines and rerun: the new
   `TestSearchPatternFlagInjection` cases fail (rg reports
   `preprocessor command could not start`, proving the flag was parsed).
3. Manual: `rg --line-number --no-heading --with-filename -- '--pre=/bin/sh'
   <dir>` treats `--pre=/bin/sh` as a literal pattern instead of executing it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A