### PR TITLE
fix(memory): match holographic entity names literally instead of as LIKE patterns

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -430,25 +430,46 @@ class MemoryStore:
 
         return candidates
 
+    @staticmethod
+    def _escape_like(value: str) -> str:
+        r"""Escape LIKE wildcards so a literal string matches only itself.
+
+        ``%`` and ``_`` are LIKE metacharacters; ``\`` is our escape char.
+        Used wherever an entity name is interpolated into a LIKE pattern.
+        """
+        return (
+            value.replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        )
+
     def _resolve_entity(self, name: str) -> int:
         """Find an existing entity by name or alias (case-insensitive) or create one.
 
         Returns the entity_id.
         """
-        # Exact name match
+        # Exact name match. Use ``= ... COLLATE NOCASE`` rather than LIKE:
+        # LIKE treats ``_``/``%`` in the name as wildcards, so a quoted
+        # identifier like ``user_id`` would silently match a pre-existing,
+        # genuinely distinct entity such as ``user1id`` and collapse the two
+        # onto one entity_id — corrupting fact links and the HRR vectors
+        # baked from them. ``=`` matches literally; COLLATE NOCASE keeps the
+        # case-insensitive behaviour the docstring promises.
         row = self._conn.execute(
-            "SELECT entity_id FROM entities WHERE name LIKE ?", (name,)
+            "SELECT entity_id FROM entities WHERE name = ? COLLATE NOCASE", (name,)
         ).fetchone()
         if row is not None:
             return int(row["entity_id"])
 
-        # Search aliases — aliases stored as comma-separated; use LIKE with % boundaries
+        # Search aliases — aliases stored as comma-separated. The comma
+        # boundaries still need LIKE, but the name itself must be matched
+        # literally, so escape its wildcards and declare the escape char.
         alias_row = self._conn.execute(
-            """
+            r"""
             SELECT entity_id FROM entities
-            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%'
+            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%' ESCAPE '\'
             """,
-            (name,),
+            (self._escape_like(name),),
         ).fetchone()
         if alias_row is not None:
             return int(alias_row["entity_id"])

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -1,0 +1,94 @@
+"""Regression tests for the holographic memory store's entity resolution.
+
+Focus: ``MemoryStore._resolve_entity`` must match entity names and aliases
+*literally*. SQLite ``LIKE`` treats ``_`` and ``%`` as wildcards, so feeding a
+raw name in as a LIKE pattern silently merges distinct entities (e.g. the
+quoted identifier ``user_id`` matching a pre-existing ``user1id``), which then
+corrupts fact links and the HRR vectors derived from them.
+"""
+
+import pytest
+
+from plugins.memory.holographic.store import MemoryStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = MemoryStore(db_path=str(tmp_path / "memory_store.db"))
+    try:
+        yield s
+    finally:
+        s._conn.close()
+
+
+def _make_entity(store, name, aliases=""):
+    cur = store._conn.execute(
+        "INSERT INTO entities (name, aliases) VALUES (?, ?)", (name, aliases)
+    )
+    store._conn.commit()
+    return int(cur.lastrowid)
+
+
+def test_underscore_name_does_not_match_distinct_entity(store):
+    """``user_id`` must not resolve to a pre-existing ``user1id``.
+
+    With ``WHERE name LIKE ?`` the underscore acted as a single-char wildcard
+    and collapsed the two into one entity_id.
+    """
+    existing = _make_entity(store, "user1id")
+    resolved = store._resolve_entity("user_id")
+
+    assert resolved != existing
+    # A genuinely new, distinct entity row should have been created.
+    name = store._conn.execute(
+        "SELECT name FROM entities WHERE entity_id = ?", (resolved,)
+    ).fetchone()["name"]
+    assert name == "user_id"
+
+
+def test_percent_name_does_not_wildcard_match(store):
+    """A name containing ``%`` must be matched literally, not as a wildcard."""
+    other = _make_entity(store, "100 dollars")
+    resolved = store._resolve_entity("100%")
+
+    assert resolved != other
+
+
+def test_exact_name_match_is_case_insensitive(store):
+    """The literal match must still be case-insensitive, as documented."""
+    existing = _make_entity(store, "Guido")
+
+    assert store._resolve_entity("guido") == existing
+    assert store._resolve_entity("GUIDO") == existing
+
+
+def test_alias_match_is_literal_and_case_insensitive(store):
+    """Alias membership must match the whole comma-delimited token literally."""
+    entity = _make_entity(store, "Python", aliases="cpython,user1id")
+
+    # Exact alias resolves to the owning entity (case-insensitive).
+    assert store._resolve_entity("cpython") == entity
+    assert store._resolve_entity("CPython") == entity
+    assert store._resolve_entity("user1id") == entity
+
+    # A wildcard-shaped near-miss must NOT match the alias.
+    resolved = store._resolve_entity("user_id")
+    assert resolved != entity
+
+
+def test_distinct_quoted_identifiers_get_distinct_entities_via_add_fact(store):
+    """End-to-end: two quoted identifiers must not collapse during add_fact."""
+    store.add_fact('the column "user1id" is the primary key')
+    store.add_fact('the column "user_id" is deprecated')
+
+    names = {
+        row["name"]
+        for row in store._conn.execute("SELECT name FROM entities").fetchall()
+    }
+    assert {"user1id", "user_id"} <= names
+
+    ids = [
+        store._resolve_entity("user1id"),
+        store._resolve_entity("user_id"),
+    ]
+    assert ids[0] != ids[1]


### PR DESCRIPTION
## What does this PR do?

I noticed the holographic memory store was quietly merging entities that
should stay separate. `_resolve_entity()` looked an entity up with
`WHERE name LIKE ?` and passed the raw name straight in as the LIKE
*pattern*. In SQLite LIKE, `_` matches any single character and `%`
matches any run, so a quoted identifier like `user_id` would match a
pre-existing, genuinely different entity such as `user1id` and collapse
both onto a single entity_id. Entity names come from `_extract_entities()`,
which grabs quoted terms and AKA spans — and technical chats are full of
quoted identifiers like "user_id", 'my_var', '100%' — so this fired in
normal use. The wrong entity set then gets baked into the fact's HRR
vector and every category bank, so recall returns facts about the wrong
subject and `contradict()` mis-groups facts. The corruption is silent and
persisted in memory_store.db.

The docstring already promised a case-insensitive *exact* match, so this
was just LIKE doing more than intended. The exact-name lookup now uses
`= ? COLLATE NOCASE` (literal match, still case-insensitive), and the
alias membership test — which legitimately needs LIKE for its comma
boundaries — escapes the name's wildcards and declares an ESCAPE char so
the name portion is matched literally too.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/holographic/store.py`: `_resolve_entity()` now matches
  names with `= ? COLLATE NOCASE` instead of `LIKE ?`, and the alias query
  uses `ESCAPE '\'` with a new `_escape_like()` helper that escapes
  `%`, `_`, and `\` so entity names are treated as literals.
- `tests/plugins/memory/test_holographic_store.py`: new regression tests
  covering underscore/percent near-misses, case-insensitive exact and
  alias matches, and an end-to-end `add_fact` check that two distinct
  quoted identifiers get distinct entity ids.

## How to Test

1. Check out the branch and run `pytest tests/plugins/memory/test_holographic_store.py -q` — all pass.
2. Revert just `store.py` and rerun: the underscore/percent/alias and
   end-to-end tests fail (the old LIKE pattern merges `user_id` into
   `user1id`), proving the fix.
3. `ruff check plugins/memory/holographic/store.py` and
   `python scripts/check-windows-footguns.py --all` are clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (pre-existing failures are unrelated optional-dep imports: httpx for OpenViking)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A