### PR TITLE
fix(cli): auto-restore a deleted ui-tui workspace before TUI launch

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1650,6 +1650,22 @@ def _find_bundled_tui(hermes_cli_dir: Path | None = None) -> Path | None:
     return bundled if bundled.is_file() else None
 
 
+def _exit_missing_tui_workspace(tui_dir: Path) -> "NoReturn":
+    """Abort TUI launch with a recovery hint when the workspace checkout is missing."""
+    print(
+        "Error: the TUI workspace is missing from this Hermes checkout.\n"
+        f"Expected directory: {tui_dir}\n"
+        "This usually means `hermes update` left tracked ui-tui files deleted.\n"
+        "Recovery:\n"
+        "  1. From the Hermes checkout, run `git restore -- ui-tui`\n"
+        "  2. Run `npm install --silent --no-fund --no-audit --progress=false`\n"
+        "  3. Retry `hermes --tui`\n"
+        "If the checkout is still inconsistent, run `hermes update --force`.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
 def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     """TUI: --dev → tsx src; else node dist (HERMES_TUI_DIR prebuilt or esbuild)."""
     _ensure_tui_node()
@@ -1682,6 +1698,9 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             file=sys.stderr,
         )
         sys.exit(1)
+
+    if not ext_dir and not tui_dir.is_dir():
+        _exit_missing_tui_workspace(tui_dir)
 
     # 1. Prebuilt bundle (nix / packaged release): just run it.
     if not tui_dev:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5999,6 +5999,43 @@ def _kill_stale_dashboard_processes(
 _warn_stale_dashboard_processes = _kill_stale_dashboard_processes
 
 
+def _atomic_replace_dir(src: str, dst: str) -> None:
+    """Replace directory *dst* with *src* without leaving *dst* half-deleted.
+
+    The naive ``rmtree(dst); copytree(src, dst)`` has a destructive window: if
+    the copy fails partway (common on the Windows ZIP-update path, which only
+    runs because file I/O is already flaky on that machine), the old directory
+    is already gone and nothing replaced it — the install is left with a
+    deleted tree (issue #49145, where ``ui-tui/`` vanished and broke the TUI).
+
+    Instead, stage the new copy into a sibling temp dir first; only once that
+    fully succeeds do we swap it in. A failure during staging raises with the
+    original *dst* still intact.
+    """
+    staging = f"{dst}.hermes-update-staging"
+    backup = f"{dst}.hermes-update-old"
+    # Clear any leftovers from a previously-interrupted update.
+    for leftover in (staging, backup):
+        if os.path.exists(leftover):
+            shutil.rmtree(leftover, ignore_errors=True)
+
+    # 1. Stage the new copy. If this fails, dst is untouched.
+    shutil.copytree(src, staging)
+    # 2. Swap: move the live dir aside, move staging into place. Both moves are
+    #    same-filesystem renames; if the second fails we restore the backup.
+    if os.path.exists(dst):
+        os.rename(dst, backup)
+    try:
+        os.rename(staging, dst)
+    except OSError:
+        if os.path.exists(backup) and not os.path.exists(dst):
+            os.rename(backup, dst)  # roll back to the original
+        raise
+    # 3. New dir is in place; drop the old one (best-effort — never fatal).
+    if os.path.exists(backup):
+        shutil.rmtree(backup, ignore_errors=True)
+
+
 def _update_via_zip(args):
     """Update Hermes Agent by downloading a ZIP archive.
 
@@ -6084,9 +6121,9 @@ def _update_via_zip(args):
             src = os.path.join(extracted, item)
             dst = os.path.join(str(PROJECT_ROOT), item)
             if os.path.isdir(src):
-                if os.path.exists(dst):
-                    shutil.rmtree(dst)
-                shutil.copytree(src, dst)
+                # Atomic-ish replace: never leave dst half-deleted if the copy
+                # fails partway (the failure mode behind #49145 on Windows).
+                _atomic_replace_dir(src, dst)
             else:
                 shutil.copy2(src, dst)
             update_count += 1

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1650,8 +1650,50 @@ def _find_bundled_tui(hermes_cli_dir: Path | None = None) -> Path | None:
     return bundled if bundled.is_file() else None
 
 
-def _exit_missing_tui_workspace(tui_dir: Path) -> "NoReturn":
-    """Abort TUI launch with a recovery hint when the workspace checkout is missing."""
+def _restore_tui_workspace(tui_dir: Path) -> bool:
+    """Try to restore a missing ``ui-tui/`` from git, returning True on success.
+
+    On Windows an antivirus / NTFS filter driver can leave tracked ``ui-tui/``
+    files deleted in the working tree after ``hermes update`` (HEAD stays
+    intact; the files just vanish — see issue #49145). Those files are tracked,
+    so ``git restore`` puts them back deterministically. Best-effort: returns
+    False (rather than raising) when git is unavailable, this isn't a checkout,
+    or the restore leaves the directory still missing — the caller then prints
+    the manual-recovery message.
+    """
+    git = shutil.which("git")
+    if not git or not (tui_dir.parent / ".git").exists():
+        return False
+    try:
+        subprocess.run(
+            [git, "restore", "--", tui_dir.name],
+            cwd=str(tui_dir.parent),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return False
+    return tui_dir.is_dir()
+
+
+def _ensure_tui_workspace(tui_dir: Path) -> None:
+    """Ensure ``ui-tui/`` exists before any npm/node subprocess uses it as cwd.
+
+    Without this, a missing workspace falls through to ``subprocess.run(...,
+    cwd=<missing ui-tui>)``, which crashes with ``NotADirectoryError``
+    (``WinError 267`` on Windows) instead of a usable message (#49145). We
+    first try to self-heal via ``git restore``; only if that can't recover the
+    directory do we abort with concrete manual-recovery steps.
+    """
+    if tui_dir.is_dir():
+        return
+
+    if _restore_tui_workspace(tui_dir):
+        if not os.environ.get("HERMES_QUIET"):
+            print(f"Restored missing TUI workspace: {tui_dir}")
+        return
+
     print(
         "Error: the TUI workspace is missing from this Hermes checkout.\n"
         f"Expected directory: {tui_dir}\n"
@@ -1699,8 +1741,8 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         )
         sys.exit(1)
 
-    if not ext_dir and not tui_dir.is_dir():
-        _exit_missing_tui_workspace(tui_dir)
+    if not ext_dir:
+        _ensure_tui_workspace(tui_dir)
 
     # 1. Prebuilt bundle (nix / packaged release): just run it.
     if not tui_dev:

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -327,6 +327,27 @@ def test_make_tui_argv_decodes_dev_prebuild_with_utf8_replace(
     _assert_utf8_replace_capture(calls[0][1])
 
 
+def test_make_tui_argv_exits_with_recovery_hint_when_workspace_missing(
+    tmp_path: Path, main_mod, monkeypatch, capsys
+) -> None:
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+
+    def fail_which(_name: str) -> str:
+        raise AssertionError("node/npm lookup must not run when ui-tui is missing")
+
+    monkeypatch.setattr(main_mod.shutil, "which", fail_which)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._make_tui_argv(tmp_path / "ui-tui", tui_dev=False)
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "TUI workspace is missing" in err
+    assert "git restore -- ui-tui" in err
+    assert "hermes update --force" in err
+
+
 # ── _workspace_root helper ──────────────────────────────────────────
 
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -327,16 +327,20 @@ def test_make_tui_argv_decodes_dev_prebuild_with_utf8_replace(
     _assert_utf8_replace_capture(calls[0][1])
 
 
-def test_make_tui_argv_exits_with_recovery_hint_when_workspace_missing(
+def test_make_tui_argv_exits_with_recovery_hint_when_workspace_unrecoverable(
     tmp_path: Path, main_mod, monkeypatch, capsys
 ) -> None:
+    """Missing ui-tui + no git checkout → clean error, never touches node/npm."""
     monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
     monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
 
-    def fail_which(_name: str) -> str:
+    # No .git beside ui-tui → _restore_tui_workspace bails, fallback message fires.
+    def which(name: str) -> str | None:
+        if name == "git":
+            return "/usr/bin/git"
         raise AssertionError("node/npm lookup must not run when ui-tui is missing")
 
-    monkeypatch.setattr(main_mod.shutil, "which", fail_which)
+    monkeypatch.setattr(main_mod.shutil, "which", which)
 
     with pytest.raises(SystemExit) as exc:
         main_mod._make_tui_argv(tmp_path / "ui-tui", tui_dev=False)
@@ -346,6 +350,47 @@ def test_make_tui_argv_exits_with_recovery_hint_when_workspace_missing(
     assert "TUI workspace is missing" in err
     assert "git restore -- ui-tui" in err
     assert "hermes update --force" in err
+
+
+def test_make_tui_argv_restores_missing_workspace_from_git(
+    tmp_path: Path, main_mod, monkeypatch, capsys
+) -> None:
+    """Missing ui-tui in a git checkout self-heals via `git restore` and continues."""
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.delenv("HERMES_QUIET", raising=False)
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+
+    tui_dir = tmp_path / "ui-tui"
+    (tmp_path / ".git").mkdir()  # mark tmp_path as a checkout
+
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    restore_calls: list[tuple[list[str], object]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        # Simulate `git restore -- ui-tui` materialising the directory.
+        if cmd[:2] == ["/usr/bin/git", "restore"]:
+            restore_calls.append((cmd, kwargs.get("cwd")))
+            tui_dir.mkdir(exist_ok=True)
+            (tui_dir / "dist").mkdir()
+            (tui_dir / "dist" / "entry.js").write_text("// bundle")
+            (tui_dir / "package.json").write_text("{}")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+    # node_modules present + lockfile-in-sync so we skip the install/build path
+    # and land straight on the node dist/entry.js return.
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod, "_is_termux_startup_environment", lambda: False)
+
+    argv, cwd = main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert restore_calls, "expected a `git restore` attempt"
+    assert restore_calls[0][0] == ["/usr/bin/git", "restore", "--", "ui-tui"]
+    assert restore_calls[0][1] == str(tmp_path)
+    assert argv[-1] == str(tui_dir / "dist" / "entry.js")
+    assert cwd == tui_dir
+    assert "Restored missing TUI workspace" in capsys.readouterr().out
 
 
 # ── _workspace_root helper ──────────────────────────────────────────

--- a/tests/hermes_cli/test_update_zip_atomic_replace.py
+++ b/tests/hermes_cli/test_update_zip_atomic_replace.py
@@ -1,0 +1,84 @@
+"""Regression: the ZIP-update directory replace must never leave a half-deleted tree.
+
+Issue #49145: on Windows the ZIP-update path did ``rmtree(dst); copytree(...)``.
+A copy that failed partway (file locks / flaky I/O — the very conditions the ZIP
+path exists to work around) left the directory deleted with nothing copied back,
+which broke ``hermes --tui`` because ``ui-tui/`` had vanished.
+
+``_atomic_replace_dir`` stages the new copy first and only swaps it in on full
+success, so a mid-copy failure leaves the original directory intact.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.main import _atomic_replace_dir
+
+
+def test_atomic_replace_swaps_content_on_success(tmp_path: Path) -> None:
+    src = tmp_path / "src" / "ui-tui"
+    src.mkdir(parents=True)
+    (src / "new.txt").write_text("NEW")
+
+    dst = tmp_path / "install" / "ui-tui"
+    dst.mkdir(parents=True)
+    (dst / "old.txt").write_text("OLD")
+
+    _atomic_replace_dir(str(src), str(dst))
+
+    assert (dst / "new.txt").read_text() == "NEW"
+    assert not (dst / "old.txt").exists()
+    # No staging/backup siblings left behind.
+    assert not (dst.parent / "ui-tui.hermes-update-staging").exists()
+    assert not (dst.parent / "ui-tui.hermes-update-old").exists()
+
+
+def test_atomic_replace_leaves_original_intact_when_copy_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    src = tmp_path / "src" / "ui-tui"
+    src.mkdir(parents=True)
+    (src / "a.txt").write_text("A")
+
+    dst = tmp_path / "install" / "ui-tui"
+    dst.mkdir(parents=True)
+    (dst / "keep.txt").write_text("PRECIOUS")
+
+    def boom(*_a, **_k):
+        raise OSError("[WinError 5] Access is denied")
+
+    monkeypatch.setattr(shutil, "copytree", boom)
+
+    with pytest.raises(OSError):
+        _atomic_replace_dir(str(src), str(dst))
+
+    # The whole point: the live directory survives a failed update untouched.
+    assert dst.is_dir()
+    assert (dst / "keep.txt").read_text() == "PRECIOUS"
+    assert not (dst.parent / "ui-tui.hermes-update-staging").exists()
+
+
+def test_atomic_replace_clears_stale_staging_leftovers(tmp_path: Path) -> None:
+    """A previously-interrupted update can leave staging/backup dirs behind."""
+    src = tmp_path / "src" / "ui-tui"
+    src.mkdir(parents=True)
+    (src / "new.txt").write_text("NEW")
+
+    dst = tmp_path / "install" / "ui-tui"
+    dst.mkdir(parents=True)
+
+    stale_staging = dst.parent / "ui-tui.hermes-update-staging"
+    stale_backup = dst.parent / "ui-tui.hermes-update-old"
+    stale_staging.mkdir()
+    stale_backup.mkdir()
+    (stale_staging / "junk").write_text("junk")
+
+    _atomic_replace_dir(str(src), str(dst))
+
+    assert (dst / "new.txt").read_text() == "NEW"
+    assert not stale_staging.exists()
+    assert not stale_backup.exists()


### PR DESCRIPTION
## Summary

`hermes update` can no longer leave a Hermes install with a deleted directory, and `hermes --tui` self-heals if it ever finds itself in that state.

Root cause of #49145: the Windows ZIP-update path replaced each directory with `rmtree(dst)` then `copytree(src, dst)`. If the copy failed partway — common on that path, which only runs *because* file I/O is already flaky on the machine — the directory was left deleted with nothing copied back. `ui-tui/` vanishing is what made `hermes --tui` crash with `WinError 267`, but the destructive window hit every top-level directory.

This is not antivirus eating files — it's our own non-atomic replace.

## Changes

- `hermes_cli/main.py`
  - **Root cause:** `_atomic_replace_dir()` stages the new copy into a sibling temp dir and only swaps it in on full success (restoring the original on failure). The ZIP-update loop uses it, so a failed update leaves the live tree untouched instead of half-deleted.
  - **Defense-in-depth:** before the TUI uses `ui-tui/` as a subprocess cwd, `_ensure_tui_workspace()` self-heals a still-missing workspace in a git checkout via `git restore -- ui-tui`, falling back to a clear manual-recovery message only when git can't recover it. This rescues anyone already broken by an older version.
- `tests/hermes_cli/test_update_zip_atomic_replace.py`: a mid-copy failure leaves the original directory intact; happy-path swaps content; stale staging leftovers are cleared.
- `tests/hermes_cli/test_tui_npm_install.py`: TUI launcher self-heals via `git restore`; clean error + no node/npm lookup when unrecoverable.

## Validation

| | Before | After |
|---|---|---|
| ZIP update, copy fails mid-directory | dir deleted, nothing restored | original dir intact, error raised |
| `hermes --tui`, `ui-tui/` missing in checkout | `WinError 267` crash | `git restore` recovers it, TUI launches |
| `hermes --tui`, `ui-tui/` missing, no checkout | `WinError 267` crash | clean error + recovery steps |

- E2E: real git checkout (restore recovers deleted tracked `ui-tui/`); real `_atomic_replace_dir` with a forced mid-copy `OSError` leaves the original tree + content intact, no orphan staging dirs.
- `scripts/run_tests.sh tests/hermes_cli/test_update_zip_atomic_replace.py tests/hermes_cli/test_tui_npm_install.py tests/hermes_cli/test_update_zip_symlink_reject.py` — 34 passed.
- `ruff check` clean.

## Credit

Builds on @konsisumer's missing-workspace guard from #49191 (cherry-picked, authorship preserved). This adds the root-cause atomic-replace fix on top and upgrades the launcher guard from print-and-exit to self-healing.

Fixes #49145. Supersedes #49191.

## Infographic

![auto-restore-ui-tui](https://v3b.fal.media/files/b/0a9f3942/gEs4dJpoA9_gO64dYT0Up_gSHALdo5.png)
