### PR TITLE
fix(acp): bind originating session id in per-session ContextVar

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1460,18 +1460,23 @@ class HermesACPAgent(acp.Agent):
 
         def _run_agent() -> dict:
             nonlocal previous_approval_cb, previous_interactive, edit_approval_token, previous_session_id
-            # Bind HERMES_SESSION_KEY for this session so per-session caches
-            # (e.g. the interactive sudo password cache in tools.terminal_tool)
-            # scope to the ACP session rather than leaking across sessions
-            # that land on the same reused executor thread. This call runs
-            # inside a contextvars.copy_context() below, so the ContextVar
-            # write is isolated from other concurrent ACP sessions.
+            # Bind HERMES_SESSION_KEY *and* HERMES_SESSION_ID for this session so
+            # per-session state (the interactive sudo password cache in
+            # tools.terminal_tool, and the originating-session stamp read by
+            # tools like kanban_create) scopes to the ACP session rather than
+            # leaking across sessions that land on the same reused executor
+            # thread. This call runs inside a contextvars.copy_context() below,
+            # so the ContextVar writes are isolated from other concurrent ACP
+            # sessions — unlike the process-global os.environ mirror set below,
+            # which two concurrent prompts would clobber.
             try:
                 from gateway.session_context import (
                     clear_session_vars,
                     set_session_vars,
                 )
-                session_tokens = set_session_vars(session_key=session_id)
+                session_tokens = set_session_vars(
+                    session_key=session_id, session_id=session_id
+                )
             except Exception:
                 session_tokens = None
                 clear_session_vars = None  # type: ignore[assignment]
@@ -1494,11 +1499,12 @@ class HermesACPAgent(acp.Agent):
             # and the non-interactive auto-approve path must not fire.
             previous_interactive = os.environ.get("HERMES_INTERACTIVE")
             os.environ["HERMES_INTERACTIVE"] = "1"
-            # Propagate the originating ACP session id to tools that want to
-            # tag side-effects with it (e.g. ``kanban_create`` stamps it on
-            # the new task so clients can render a per-session board). Save
-            # and restore around the agent call so a re-used executor thread
-            # never leaks one session's id into the next session's tools.
+            # Legacy process-global mirror of the originating ACP session id for
+            # tools/hosts that still read os.environ directly. The ContextVar set
+            # via set_session_vars() above is the concurrency-safe source of
+            # truth (read through get_session_env); this env mirror is kept only
+            # for non-ContextVar-aware readers. Save and restore around the agent
+            # call so a re-used executor thread doesn't leave a stale id behind.
             previous_session_id = os.environ.get("HERMES_SESSION_ID")
             os.environ["HERMES_SESSION_ID"] = session_id
             try:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1251,6 +1251,48 @@ class TestPrompt:
         assert os.environ.get("HERMES_SESSION_ID") == "outer-sess"
 
     @pytest.mark.asyncio
+    async def test_prompt_binds_session_id_in_isolated_contextvar(self, agent, monkeypatch):
+        """The originating ACP session id must reach tools through the
+        per-session ContextVar (concurrency-safe), not only the process-global
+        ``os.environ`` mirror. Reading it via ``get_session_env`` inside the
+        agent loop must return the active session even after a *concurrent*
+        session has clobbered ``os.environ`` — otherwise tools like
+        ``kanban_create`` would stamp the wrong id when two ACP sessions run on
+        the shared executor at once."""
+        from gateway.session_context import get_session_env
+
+        monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        captured: dict[str, str] = {}
+
+        def mock_run(user_message, conversation_history=None, task_id=None, **kwargs):
+            # Simulate a second ACP session, running concurrently on another
+            # executor thread, overwriting the shared process-global env.
+            os.environ["HERMES_SESSION_ID"] = "other-concurrent-session"
+            # Despite the clobber, the ContextVar-aware accessor must still
+            # resolve to *this* session's id.
+            captured["ctx"] = get_session_env("HERMES_SESSION_ID")
+            return {"final_response": "ok", "messages": []}
+
+        state.agent.run_conversation = mock_run
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="hi")]
+        await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert captured["ctx"] == new_resp.session_id, (
+            "HERMES_SESSION_ID must resolve to the originating ACP session via "
+            "the isolated ContextVar even when os.environ was overwritten by a "
+            "concurrent session"
+        )
+
+    @pytest.mark.asyncio
     async def test_prompt_does_not_duplicate_streamed_final_message(self, agent):
         """If ACP already streamed response chunks, final_response should not be sent again."""
         new_resp = await agent.new_session(cwd=".")

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -753,10 +753,16 @@ def _handle_create(args: dict, **kw) -> str:
     body = args.get("body")
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
-    # Stamp the originating session id when the agent loop runs under
-    # ACP (which sets HERMES_SESSION_ID before invoking tools). NULL on
-    # CLI / dashboard paths and on legacy hosts that don't set the env.
-    session_id = args.get("session_id") or os.environ.get("HERMES_SESSION_ID")
+    # Stamp the originating session id when the agent loop runs under ACP
+    # (which binds HERMES_SESSION_ID in a per-session ContextVar before invoking
+    # tools). Read it through get_session_env so concurrent ACP sessions sharing
+    # the process-global os.environ don't leak each other's id; get_session_env
+    # falls back to os.environ for CLI / legacy hosts. NULL on CLI / dashboard
+    # paths that don't set it at all.
+    from gateway.session_context import get_session_env
+    # ``get_session_env`` returns "" (not None) when unset; normalize so an
+    # absent id stays NULL rather than being stored as an empty string.
+    session_id = args.get("session_id") or get_session_env("HERMES_SESSION_ID") or None
     priority = args.get("priority")
     # Resolve workspace. If the caller passed one explicitly, honor it.
     # Otherwise, a dispatcher-spawned worker (HERMES_KANBAN_TASK set)


### PR DESCRIPTION
## What does this PR do?

Under ACP, `kanban_create` (and any tool reading the originating session id)
could stamp the wrong session onto a created task when two editor sessions
prompt at the same time. The ACP server runs every prompt on a shared
`ThreadPoolExecutor`, and the originating session id was propagated only
through the process-global `os.environ["HERMES_SESSION_ID"]`. Two concurrent
prompts overwrite each other's value, so a tool firing in session A can read
session B's id. On top of that, `set_session_vars(session_key=session_id)`
left the `HERMES_SESSION_ID` ContextVar explicitly set to "", which shadows
the os.environ fallback — so `get_session_env("HERMES_SESSION_ID")` returned
an empty string even for a single session.

The server already wraps each prompt in `contextvars.copy_context()` precisely
so per-session state stays isolated across the reused executor threads, but the
session id never used that isolated channel. This change routes it through the
ContextVar that the copied context already protects, and has the kanban reader
consult the ContextVar-aware accessor instead of raw `os.environ`. The
process-global env mirror is kept as a best-effort fallback for legacy readers.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/server.py`: pass `session_id=session_id` to `set_session_vars()`
  inside `_run_agent` so the originating ACP session id is bound in the
  per-session `HERMES_SESSION_ID` ContextVar, which `contextvars.copy_context()`
  isolates across concurrent executor threads. Clarified the comments to mark
  the `os.environ` write as a legacy mirror, not the source of truth.
- `tools/kanban_tools.py`: read the originating session id in `_handle_create`
  via `get_session_env("HERMES_SESSION_ID")` (ContextVar-first, os.environ
  fallback) and normalize the empty-string default back to `None` so an absent
  id still stores as NULL.
- `tests/acp/test_server.py`: add a regression test asserting the id resolves
  to the active session through the isolated ContextVar even after a concurrent
  session overwrites `os.environ`.

## How to Test

1. `python -m pytest tests/acp/test_server.py -k "session_id or isolated_contextvar" -q`
   — the new `test_prompt_binds_session_id_in_isolated_contextvar` passes, and
   the existing os.environ-contract tests still pass.
2. Revert only `acp_adapter/server.py` and re-run: the new test fails with
   `'' == <session id>`, demonstrating the empty-ContextVar / leak bug.
3. `python -m pytest tests/tools/test_kanban_tools.py -k session_id -q` — the
   kanban stamping tests (env set / arg override / unset → NULL) still pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites (`tests/acp/`, `tests/tools/test_kanban_tools.py`) and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A