### PR TITLE
fix(photon): restart sidecar on upstream connection drops

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -94,6 +94,18 @@ _PHOTON_RETRYABLE_PATTERNS = (
     "reset reason: overflow",
 )
 
+# Photon / Spectrum upstream failures that mean the sidecar's gRPC/iMessage
+# session is suspect.  These trigger adapter reconnect/restart for the NEXT
+# message, but never a retry of the send that observed the failure.
+_PHOTON_UPSTREAM_FAILURE_PATTERNS = (
+    "connection dropped",
+    "connectionerror",
+    "stream interrupted",
+    "upstream connection dropped",
+    "upstream connect error",
+    "reset reason: overflow",
+)
+
 # Minimum seconds between typing-indicator calls for the same chat.
 # iMessage is a personal channel — suppressing rapid repeats reduces
 # upstream gRPC pressure during Photon overflow events.
@@ -237,6 +249,8 @@ class PhotonAdapter(BasePlatformAdapter):
         self._inbound_task: Optional[asyncio.Task] = None
         self._inbound_running = False
         self._http_client: Optional["httpx.AsyncClient"] = None
+        self._gateway_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._upstream_unhealthy_notified = False
         # Lightweight in-memory dedup. The gRPC stream is at-least-once, so we
         # may see the same messageId more than once (e.g. after a reconnect).
         self._seen_messages: Dict[str, float] = {}
@@ -345,6 +359,8 @@ class PhotonAdapter(BasePlatformAdapter):
 
         client = httpx.AsyncClient(timeout=30.0)
         self._http_client = client
+        self._gateway_loop = asyncio.get_running_loop()
+        self._upstream_unhealthy_notified = False
 
         # The sidecar holds the gRPC stream for BOTH directions, so it is
         # required now (not just for outbound).
@@ -419,7 +435,10 @@ class PhotonAdapter(BasePlatformAdapter):
                     "GET", url, headers=headers, timeout=None,
                 ) as resp:
                     if resp.status_code != 200:
-                        raise RuntimeError(f"/inbound returned {resp.status_code}")
+                        body = (await resp.aread()).decode("utf-8", "replace")[:500]
+                        raise RuntimeError(
+                            f"/inbound returned {resp.status_code}: {body}"
+                        )
                     backoff = 1.0  # reset on a successful connect
                     async for line in resp.aiter_lines():
                         if not self._inbound_running:
@@ -437,6 +456,9 @@ class PhotonAdapter(BasePlatformAdapter):
                     "[photon] inbound stream dropped (%s); reconnecting in %.1fs",
                     e, backoff,
                 )
+                if self._is_upstream_failure(str(e)):
+                    await self._mark_upstream_unhealthy(str(e))
+                    break
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
 
@@ -852,7 +874,10 @@ class PhotonAdapter(BasePlatformAdapter):
                 line = await loop.run_in_executor(None, stdout.readline)
                 if not line:
                     break
-                logger.info("[photon-sidecar] %s", line.decode("utf-8", "replace").rstrip())
+                text = line.decode("utf-8", "replace").rstrip()
+                logger.info("[photon-sidecar] %s", text)
+                if self._is_upstream_failure(text):
+                    await self._mark_upstream_unhealthy(text)
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("[photon-sidecar] supervisor exited: %s", e)
         if self._inbound_running:
@@ -1234,6 +1259,50 @@ class PhotonAdapter(BasePlatformAdapter):
         lowered = error.lower()
         return any(pat in lowered for pat in _PHOTON_RETRYABLE_PATTERNS)
 
+    @staticmethod
+    def _is_upstream_failure(error: Optional[str]) -> bool:
+        if not error:
+            return False
+        lowered = error.lower()
+        if "handler error" in lowered and "connection" not in lowered:
+            return False
+        return any(pat in lowered for pat in _PHOTON_UPSTREAM_FAILURE_PATTERNS)
+
+    async def _mark_upstream_unhealthy(self, reason: str) -> None:
+        """Mark Photon unhealthy so GatewayRunner reconnects/restarts it.
+
+        This is intentionally a self-heal trigger only. The send/read that
+        observed the failure is allowed to fail; we never retry the same
+        iMessage operation because Photon may have accepted it before surfacing
+        a transport error.
+        """
+        if not self._inbound_running:
+            return
+        if self._upstream_unhealthy_notified or self._fatal_error_code:
+            return
+        self._upstream_unhealthy_notified = True
+        message = f"Photon upstream connection unhealthy: {reason[:300]}"
+        logger.warning("[photon] %s", message)
+        self._set_fatal_error(
+            "PHOTON_UPSTREAM_DROPPED",
+            message,
+            retryable=True,
+        )
+
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:  # pragma: no cover - async callers have a loop
+            current_loop = None
+        gateway_loop = self._gateway_loop
+        if (
+            gateway_loop is not None
+            and gateway_loop is not current_loop
+            and not gateway_loop.is_closed()
+        ):
+            asyncio.run_coroutine_threadsafe(self._notify_fatal_error(), gateway_loop)
+            return
+        await self._notify_fatal_error()
+
     async def _send_with_retry(
         self,
         chat_id: str,
@@ -1243,66 +1312,22 @@ class PhotonAdapter(BasePlatformAdapter):
         max_retries: int = 1,
         base_delay: float = 2.0,
     ) -> SendResult:
-        """Retry sends without the generic Markdown banner.
+        """Single-shot send for Photon/iMessage.
 
-        Photon replies are markdown (rendered by iMessage) or stripped plain
-        text under ``PHOTON_MARKDOWN=false`` — either way the gateway's
-        generic banner never applies.
+        Do not retry or send a plain-text fallback: Photon can accept/deliver
+        an iMessage and still return an upstream transport error. Retrying the
+        same response risks duplicate bubbles. Upstream failures instead mark
+        the adapter unhealthy so the gateway reconnects for the next message.
         """
-        text = self.format_message(content)
         result = await self.send(
             chat_id=chat_id,
-            content=text,
+            content=content,
             reply_to=reply_to,
             metadata=metadata,
         )
-        if result.success:
-            return result
-
-        error_str = result.error or ""
-        is_network = result.retryable or self._is_retryable_error(error_str)
-        if not is_network and self._is_timeout_error(error_str):
-            return result
-
-        if is_network:
-            for attempt in range(1, max_retries + 1):
-                delay = base_delay * (2 ** (attempt - 1))
-                logger.warning(
-                    "[photon] Send failed (attempt %d/%d, retrying in %.1fs): %s",
-                    attempt, max_retries, delay, error_str,
-                )
-                await asyncio.sleep(delay)
-                result = await self.send(
-                    chat_id=chat_id,
-                    content=text,
-                    reply_to=reply_to,
-                    metadata=metadata,
-                )
-                if result.success:
-                    return result
-                error_str = result.error or ""
-                if not (result.retryable or self._is_retryable_error(error_str)):
-                    break
-            else:
-                logger.error(
-                    "[photon] Failed to deliver response after %d retries: %s",
-                    max_retries, error_str,
-                )
-                return result
-
-        logger.warning(
-            "[photon] Send failed: %s - retrying plain-text message",
-            error_str,
-        )
-        fallback_result = await self.send(
-            chat_id=chat_id,
-            content=text[: self.MAX_MESSAGE_LENGTH],
-            reply_to=reply_to,
-            metadata=metadata,
-        )
-        if not fallback_result.success:
-            logger.error("[photon] Plain-text retry also failed: %s", fallback_result.error)
-        return fallback_result
+        if not result.success:
+            result.retryable = False
+        return result
 
     async def _sidecar_send(self, space_id: str, text: str) -> SendResult:
         if len(text) > self.MAX_MESSAGE_LENGTH:
@@ -1319,7 +1344,7 @@ class PhotonAdapter(BasePlatformAdapter):
         try:
             data = await self._sidecar_call("/send", body)
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=str(e), retryable=False)
         self._record_sent_message(data.get("messageId"))
         return SendResult(success=True, message_id=data.get("messageId"))
 
@@ -1368,7 +1393,7 @@ class PhotonAdapter(BasePlatformAdapter):
         try:
             data = await self._sidecar_call("/send-attachment", body)
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=str(e), retryable=False)
         self._record_sent_message(data.get("messageId"))
         return SendResult(success=True, message_id=data.get("messageId"))
 
@@ -1383,18 +1408,23 @@ class PhotonAdapter(BasePlatformAdapter):
         # _http_client directly — it always runs on the gateway's loop.
         url = f"http://{self._sidecar_bind}:{self._sidecar_port}{path}"
         headers = {"X-Hermes-Sidecar-Token": self._sidecar_token}
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.post(url, json=body, headers=headers)
-        if resp.status_code != 200:
-            raise RuntimeError(
-                f"Photon sidecar {path} returned {resp.status_code}: {resp.text[:200]}"
-            )
-        data = resp.json() or {}
-        if not data.get("ok"):
-            raise RuntimeError(
-                f"Photon sidecar {path} reported error: {data.get('error')}"
-            )
-        return data
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.post(url, json=body, headers=headers)
+            if resp.status_code != 200:
+                raise RuntimeError(
+                    f"Photon sidecar {path} returned {resp.status_code}: {resp.text[:200]}"
+                )
+            data = resp.json() or {}
+            if not data.get("ok"):
+                raise RuntimeError(
+                    f"Photon sidecar {path} reported error: {data.get('error')}"
+                )
+            return data
+        except Exception as e:
+            if self._is_upstream_failure(str(e)):
+                await self._mark_upstream_unhealthy(str(e))
+            raise
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -416,13 +416,27 @@ function badRequest(res, msg) {
   res.end(JSON.stringify({ ok: false, error: msg }));
 }
 
-function serverError(res) {
+function isUpstreamConnectionError(error) {
+  const text = (error && (error.stack || error.message) ? error.stack || error.message : String(error || "")).toLowerCase();
+  return (
+    text.includes("connection dropped") ||
+    text.includes("connectionerror") ||
+    text.includes("stream interrupted") ||
+    text.includes("upstream connect error") ||
+    text.includes("reset reason: overflow")
+  );
+}
+
+function serverError(res, error = null) {
   res.statusCode = 500;
   res.setHeader("Content-Type", "application/json");
   // Don't leak stack traces or raw exception text to the caller — even
   // though we listen on loopback, the supervisor logs the real error
-  // and the client only needs a generic failure signal.
-  res.end(JSON.stringify({ ok: false, error: "internal sidecar error" }));
+  // and the client only needs a classified failure signal.
+  const message = isUpstreamConnectionError(error)
+    ? "upstream connection dropped"
+    : "internal sidecar error";
+  res.end(JSON.stringify({ ok: false, error: message }));
 }
 
 function ok(res, data) {
@@ -667,7 +681,7 @@ const server = http.createServer(async (req, res) => {
     );
     // serverError() intentionally returns a generic message — see its
     // body for the rationale.
-    return serverError(res);
+    return serverError(res, e);
   }
 });
 

--- a/tests/plugins/platforms/photon/test_upstream_recovery.py
+++ b/tests/plugins/platforms/photon/test_upstream_recovery.py
@@ -1,0 +1,193 @@
+"""Photon upstream failure recovery tests.
+
+These tests assert the safety contract for iMessage delivery: upstream failures
+mark the adapter unhealthy so the gateway reconnects/restarts the sidecar for
+future messages, but the failing outbound operation is not retried.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from plugins.platforms.photon.adapter import PhotonAdapter
+import plugins.platforms.photon.adapter as photon_adapter
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Dict[str, Any] | None = None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+    async def aread(self) -> bytes:
+        return self.text.encode("utf-8")
+
+
+class _FakePostClient:
+    def __init__(self, response: _FakeResponse, calls: List[Tuple[str, Dict[str, Any]]]):
+        self._response = response
+        self._calls = calls
+
+    async def __aenter__(self) -> "_FakePostClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def post(self, url: str, json: Dict[str, Any], headers: Dict[str, str]) -> _FakeResponse:
+        self._calls.append((url, json))
+        return self._response
+
+
+class _FakeInboundStream:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self._response
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class _FakeInboundClient:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+
+    def stream(self, method: str, url: str, headers: Dict[str, str], timeout: Any = None) -> _FakeInboundStream:
+        return _FakeInboundStream(self._response)
+
+
+@pytest.fixture
+def adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    cfg = PlatformConfig(enabled=True, token="", extra={})
+    instance = PhotonAdapter(cfg)
+    instance._http_client = object()  # type: ignore[assignment]
+    instance._inbound_running = True
+    return instance
+
+
+def _capture_fatal_notify(adapter: PhotonAdapter) -> List[Tuple[str | None, str | None]]:
+    calls: List[Tuple[str | None, str | None]] = []
+
+    async def _notify() -> None:
+        calls.append((adapter.fatal_error_code, adapter.fatal_error_message))
+
+    adapter._notify_fatal_error = _notify  # type: ignore[method-assign]
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_sidecar_call_upstream_failure_marks_unhealthy_once(
+    adapter: PhotonAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    notify_calls = _capture_fatal_notify(adapter)
+    post_calls: List[Tuple[str, Dict[str, Any]]] = []
+    response = _FakeResponse(
+        200,
+        {"ok": False, "error": "upstream connection dropped"},
+    )
+    monkeypatch.setattr(
+        photon_adapter.httpx,
+        "AsyncClient",
+        lambda timeout=30.0: _FakePostClient(response, post_calls),
+    )
+
+    with pytest.raises(RuntimeError, match="upstream connection dropped"):
+        await adapter._sidecar_call("/send", {"spaceId": "+15555550100", "text": "hi"})
+    with pytest.raises(RuntimeError, match="upstream connection dropped"):
+        await adapter._sidecar_call("/typing", {"spaceId": "+15555550100"})
+
+    assert len(post_calls) == 2
+    assert notify_calls == [("PHOTON_UPSTREAM_DROPPED", adapter.fatal_error_message)]
+    assert "upstream connection" in (adapter.fatal_error_message or "")
+    assert adapter.fatal_error_retryable is True
+
+
+@pytest.mark.asyncio
+async def test_sidecar_call_non_upstream_error_does_not_mark_unhealthy(
+    adapter: PhotonAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    notify_calls = _capture_fatal_notify(adapter)
+    response = _FakeResponse(400, text="message not found")
+    monkeypatch.setattr(
+        photon_adapter.httpx,
+        "AsyncClient",
+        lambda timeout=30.0: _FakePostClient(response, []),
+    )
+
+    with pytest.raises(RuntimeError, match="message not found"):
+        await adapter._sidecar_call("/react", {"spaceId": "+1"})
+
+    assert notify_calls == []
+    assert adapter.fatal_error_code is None
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_is_single_shot_and_not_retryable(
+    adapter: PhotonAdapter,
+) -> None:
+    calls: List[Tuple[str, str]] = []
+
+    async def _send(chat_id: str, content: str, reply_to=None, metadata=None) -> SendResult:
+        calls.append((chat_id, content))
+        return SendResult(success=False, error="Connection dropped", retryable=True)
+
+    adapter.send = _send  # type: ignore[method-assign]
+
+    result = await adapter._send_with_retry("+15555550100", "hello")
+
+    assert calls == [("+15555550100", "hello")]
+    assert result.success is False
+    assert result.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_sidecar_send_failure_does_not_retry(
+    adapter: PhotonAdapter,
+) -> None:
+    calls: List[Tuple[str, Dict[str, Any]]] = []
+
+    async def _boom(path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        calls.append((path, body))
+        raise RuntimeError("upstream connection dropped")
+
+    adapter._sidecar_call = _boom  # type: ignore[method-assign]
+
+    result = await adapter._sidecar_send("+15555550100", "hello")
+
+    assert calls == [("/send", {"spaceId": "+15555550100", "text": "hello", "format": "markdown"})]
+    assert result.success is False
+    assert result.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_inbound_upstream_failure_marks_unhealthy_and_stops_loop(
+    adapter: PhotonAdapter,
+) -> None:
+    notify_calls = _capture_fatal_notify(adapter)
+    adapter._http_client = _FakeInboundClient(
+        _FakeResponse(503, text="[upstream] Connection dropped")
+    )  # type: ignore[assignment]
+
+    await adapter._inbound_loop()
+
+    assert notify_calls == [("PHOTON_UPSTREAM_DROPPED", adapter.fatal_error_message)]
+    assert adapter.fatal_error_retryable is True
+
+
+def test_sidecar_classifies_upstream_failures() -> None:
+    assert PhotonAdapter._is_upstream_failure("[upstream] Connection dropped")
+    assert PhotonAdapter._is_upstream_failure("[spectrum.stream] stream interrupted; reconnecting")
+    assert PhotonAdapter._is_upstream_failure("photon-sidecar: handler error: ConnectionError")
+    assert not PhotonAdapter._is_upstream_failure("photon-sidecar: handler error: invalid JSON body")


### PR DESCRIPTION
## Summary
- Marks Photon/iMessage upstream gRPC failures (`Connection dropped`, `stream interrupted`, upstream overflow/connect errors) as retryable fatal adapter failures so GatewayRunner disconnects and queues a reconnect/restart for the next message.
- Preserves no-retry outbound semantics for Photon by making `_send_with_retry` single-shot and forcing failed `SendResult.retryable = False`.
- Classifies sidecar handler failures as `upstream connection dropped` only for known upstream connection symptoms, while keeping other sidecar errors generic.
- Adds regression tests for outbound no-retry behavior, upstream unhealthy notification idempotency, inbound stream failure recovery, and failure classification.

## Acceptance criteria
- [x] Preserve no-retry outbound iMessage send semantics.
- [x] Upstream connection/stream failures mark Photon unhealthy so gateway reconnects/restarts sidecar.
- [x] Tests added for recovery and no-retry behavior.
- [x] Relevant tests run with real output.

## Tests run
- `scripts/run_tests.sh tests/plugins/platforms/photon tests/tools/test_send_message_react.py` — failed before collection because the worktree-local `.venv` was Python 3.9 and missing pytest (`No module named pytest`; project requires Python >=3.11). I did not replace that `.venv` after the destructive cleanup command was denied.
- `env -i PATH="$PATH" HOME="$HOME" TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 PYTHONDONTWRITEBYTECODE=1 /tmp/hermes-agent-test-venv-photon311/bin/python scripts/run_tests_parallel.py tests/plugins/platforms/photon tests/tools/test_send_message_react.py` — 114 passed, 0 failed.
- `/tmp/hermes-agent-test-venv-photon311/bin/python -m ruff check plugins/platforms/photon/adapter.py tests/plugins/platforms/photon/test_upstream_recovery.py` — passed.
- `node --check plugins/platforms/photon/sidecar/index.mjs` — passed.
- `git diff --check` / `git diff --cached --check` — passed.

## Risk / rollback
- Risk: upstream error matching is intentionally narrow but still string-based; false positives would cause a Photon sidecar reconnect, not duplicate delivery.
- Rollback: revert this commit to return to existing sidecar/inbound reconnect behavior.

## Follow-ups
- Consider a longer-term structured health event from the sidecar instead of parsing SDK log text.
