### PR TITLE
fix(gemini-cloudcode): attach usageMetadata to streaming finish chunk so token accounting isn't dropped

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -564,7 +564,21 @@ def _translate_stream_event(
         mapped = _map_gemini_finish_reason(finish_reason_raw)
         if tool_call_counter[0] > 0:
             mapped = "tool_calls"
-        chunks.append(_make_stream_chunk(model=model, finish_reason=mapped))
+        finish_chunk = _make_stream_chunk(model=model, finish_reason=mapped)
+        # Attach usage from this event's usageMetadata so the streaming loop
+        # records token counts (mirrors the non-streaming path in
+        # _translate_gemini_response and the native adapter's streaming path).
+        usage_meta = inner.get("usageMetadata") or {}
+        if usage_meta:
+            finish_chunk.usage = SimpleNamespace(
+                prompt_tokens=int(usage_meta.get("promptTokenCount") or 0),
+                completion_tokens=int(usage_meta.get("candidatesTokenCount") or 0),
+                total_tokens=int(usage_meta.get("totalTokenCount") or 0),
+                prompt_tokens_details=SimpleNamespace(
+                    cached_tokens=int(usage_meta.get("cachedContentTokenCount") or 0),
+                ),
+            )
+        chunks.append(finish_chunk)
     return chunks
 
 

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -910,6 +910,40 @@ class TestTranslateStreamEvent:
         )
         assert chunks[-1].choices[0].finish_reason == "tool_calls"
 
+    def test_finish_chunk_carries_usage_metadata(self):
+        """The terminal streaming chunk must surface usageMetadata so the
+        streaming reducer records token counts. Without it the default
+        streaming Code Assist path drops 100% of token/cost accounting (the
+        non-streaming path already extracts usage; this keeps streaming in
+        line — mirrors the native adapter's streaming path).
+        """
+        from agent.gemini_cloudcode_adapter import _translate_stream_event
+
+        event = {
+            "response": {
+                "candidates": [{"finishReason": "STOP"}],
+                "usageMetadata": {
+                    "promptTokenCount": 1000,
+                    "candidatesTokenCount": 50,
+                    "totalTokenCount": 1100,
+                    "cachedContentTokenCount": 200,
+                },
+            }
+        }
+        chunks = _translate_stream_event(
+            event, model="gemini-2.5-flash", tool_call_counter=[0],
+        )
+        # Replicate the streaming reducer's usage capture.
+        usage_obj = None
+        for c in chunks:
+            if getattr(c, "usage", None):
+                usage_obj = c.usage
+        assert usage_obj is not None
+        assert usage_obj.prompt_tokens == 1000
+        assert usage_obj.completion_tokens == 50
+        assert usage_obj.total_tokens == 1100
+        assert usage_obj.prompt_tokens_details.cached_tokens == 200
+
 
 class TestMakeStreamChunk:
     def test_reasoning_only_chunk_has_content_none(self):


### PR DESCRIPTION
## What does this PR do?

The Gemini Code Assist (cloudcode) streaming adapter builds its terminal chunk via `_make_stream_chunk`, which hardcodes `usage=None`, and never attaches `usageMetadata`. So on the **default streaming path** every turn loses token accounting — the streaming reducer captures usage only via `getattr(chunk, "usage", None)`, so session token totals, estimated cost, cache-hit %, and the `update_token_counts` DB write all record zero.

The non-streaming cloudcode path (`_translate_gemini_response`) already extracts `usageMetadata` correctly, and the native Gemini adapter's streaming path was given the same extraction in `ba8337464`; this brings the cloudcode streaming finish chunk in line by reading `inner.get("usageMetadata")` (the same envelope level the non-streaming path uses) and surfacing prompt/completion/total/cached token counts.

> Audited siblings: confirmed the non-streaming cloudcode path (`_translate_gemini_response`) already surfaces usage, and the native adapter's streaming path mirrors this exact shape (`ba8337464`). Thinking-token (`thoughtsTokenCount`) accounting is intentionally left out of scope — that is the separate in-flight #48712 concern on the native adapter.

## Related Issue

<!-- Net-new bug found by reading the adapter; no filed issue. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/gemini_cloudcode_adapter.py`: in `_translate_stream_event`, after building the finish chunk, attach `usage` from this event's `usageMetadata` (prompt/completion/total + cached) — mirroring the non-streaming cloudcode path and the native adapter's streaming path.
- `tests/agent/test_gemini_cloudcode.py`: added a regression test that feeds a streaming finish event with `usageMetadata` to `_translate_stream_event` and asserts the reduced chunk carries the correct token counts.

## How to Test

1. Run the new regression test: `pytest tests/agent/test_gemini_cloudcode.py::TestTranslateStreamEvent::test_finish_chunk_carries_usage_metadata -q`.
2. It feeds a finish event carrying `usageMetadata` and replicates the streaming reducer's usage capture, asserting `prompt_tokens==1000`, `completion_tokens==50`, `total_tokens==1100`, `cached_tokens==200`.
3. Verified fails before the fix (`usage_obj` stays `None`) and passes after. Full file: `pytest tests/agent/test_gemini_cloudcode.py -q` → 89 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A