### PR TITLE
fix(email): resolve IMAP/SMTP host from config.extra and validate before connecting (#49736)

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -159,14 +159,16 @@ def _is_automated_sender(address: str, headers: dict) -> bool:
     return False
     
 def check_email_requirements() -> bool:
-    """Check if email platform dependencies are available."""
-    addr = os.getenv("EMAIL_ADDRESS")
-    pwd = os.getenv("EMAIL_PASSWORD")
-    imap = os.getenv("EMAIL_IMAP_HOST")
-    smtp = os.getenv("EMAIL_SMTP_HOST")
-    if not all([addr, pwd, imap, smtp]):
-        return False
-    return True
+    """Check if email platform settings are available and non-blank.
+
+    Treats blank/whitespace-only values as missing so an abandoned setup that
+    left empty ``EMAIL_*`` keys in ``.env`` does not enable the platform (#40715).
+    """
+    addr = os.getenv("EMAIL_ADDRESS", "").strip()
+    pwd = os.getenv("EMAIL_PASSWORD", "").strip()
+    imap = os.getenv("EMAIL_IMAP_HOST", "").strip()
+    smtp = os.getenv("EMAIL_SMTP_HOST", "").strip()
+    return all([addr, pwd, imap, smtp])
 
 
 def _decode_header_value(raw: str) -> str:
@@ -418,10 +420,19 @@ class EmailAdapter(BasePlatformAdapter):
             if not value
         ]
         if missing:
-            logger.error(
-                "[Email] Not configured — missing %s. Set it via `hermes gateway "
-                "setup` (env) or platforms.email in config.yaml.",
-                ", ".join(missing),
+            message = (
+                "Not configured — missing "
+                + ", ".join(missing)
+                + ". Set it via `hermes gateway setup` (env) or platforms.email "
+                "in config.yaml."
+            )
+            logger.error("[Email] %s", message)
+            # Mark non-retryable so the gateway does NOT keep reconnecting against
+            # an empty host. A blank-but-present env var (e.g. ``EMAIL_IMAP_HOST=``)
+            # used to slip past the startup gate and drive an indefinite retry
+            # loop that leaked memory until the host OOM-killed (#40715).
+            self._set_fatal_error(
+                "email_missing_configuration", message, retryable=False
             )
             return False
 

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -307,11 +307,20 @@ class EmailAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
 
-        self._address = os.getenv("EMAIL_ADDRESS", "")
+        # Resolve connection settings from the env vars first, then fall back to
+        # PlatformConfig.extra (address/imap_host/smtp_host) — the canonical dict
+        # gateway.config populates and that the "connected" check, the
+        # send-helper, and `hermes config show` already read. Without the
+        # fallback a config.yaml-only setup left these empty. Host/address values
+        # are stripped: a stray space or newline made IMAP4_SSL raise the
+        # misleading ``[Errno 8] nodename nor servname`` (an unresolvable name)
+        # instead of an obvious "host not set" error.
+        extra = config.extra or {}
+        self._address = (os.getenv("EMAIL_ADDRESS", "") or extra.get("address", "")).strip()
         self._password = os.getenv("EMAIL_PASSWORD", "")
-        self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
+        self._imap_host = (os.getenv("EMAIL_IMAP_HOST", "") or extra.get("imap_host", "")).strip()
         self._imap_port = env_int("EMAIL_IMAP_PORT", 993)
-        self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
+        self._smtp_host = (os.getenv("EMAIL_SMTP_HOST", "") or extra.get("smtp_host", "")).strip()
         self._smtp_port = env_int("EMAIL_SMTP_PORT", 587)
         self._poll_interval = env_int("EMAIL_POLL_INTERVAL", 15)
 
@@ -319,7 +328,6 @@ class EmailAdapter(BasePlatformAdapter):
         #   platforms:
         #     email:
         #       skip_attachments: true
-        extra = config.extra or {}
         self._skip_attachments = extra.get("skip_attachments", False)
 
         # Track message IDs we've already processed to avoid duplicates
@@ -396,6 +404,27 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
+        # Validate up front so a missing host surfaces as an actionable config
+        # error instead of IMAP4_SSL("") raising the cryptic
+        # ``[Errno 8] nodename nor servname provided, or not known``.
+        missing = [
+            name
+            for name, value in (
+                ("EMAIL_ADDRESS", self._address),
+                ("EMAIL_PASSWORD", self._password),
+                ("EMAIL_IMAP_HOST", self._imap_host),
+                ("EMAIL_SMTP_HOST", self._smtp_host),
+            )
+            if not value
+        ]
+        if missing:
+            logger.error(
+                "[Email] Not configured — missing %s. Set it via `hermes gateway "
+                "setup` (env) or platforms.email in config.yaml.",
+                ", ".join(missing),
+            )
+            return False
+
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -120,6 +120,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "devran.an12@gmail.com": "devorun",
     "xtpeeps@qq.com": "x7peeps",
     "sommerhoff@gmail.com": "andressommerhoff",
     "pwnda.zhang@dbappsecurity.com.cn": "x7peeps",

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1392,5 +1392,68 @@ class TestConnectSmtp(unittest.TestCase):
         self.assertIs(_socket.getaddrinfo, original_getaddrinfo)
 
 
+class TestConnectionConfigResolution(unittest.TestCase):
+    """Host/address resolution and pre-connect validation (#49736)."""
+
+    def test_host_and_address_whitespace_stripped(self):
+        """A stray space/newline must not reach IMAP4_SSL as part of the host.
+
+        Whitespace in the host produced the misleading
+        ``[Errno 8] nodename nor servname`` (unresolvable name) instead of a
+        successful connection.
+        """
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import EmailAdapter
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "  hermes@test.com\n",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": " imap.test.com ",
+            "EMAIL_SMTP_HOST": "smtp.test.com\n",
+        }, clear=False):
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        self.assertEqual(adapter._imap_host, "imap.test.com")
+        self.assertEqual(adapter._smtp_host, "smtp.test.com")
+        self.assertEqual(adapter._address, "hermes@test.com")
+
+    def test_falls_back_to_platform_config_extra(self):
+        """When env vars are absent, settings come from PlatformConfig.extra —
+        the same dict gateway.config populates and `hermes config show` reads."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import EmailAdapter
+        cfg = PlatformConfig(enabled=True)
+        cfg.extra.update({
+            "address": "hermes@test.com",
+            "imap_host": "imap.test.com",
+            "smtp_host": "smtp.test.com",
+        })
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "", "EMAIL_IMAP_HOST": "", "EMAIL_SMTP_HOST": "",
+            "EMAIL_PASSWORD": "secret",
+        }, clear=False):
+            adapter = EmailAdapter(cfg)
+        self.assertEqual(adapter._imap_host, "imap.test.com")
+        self.assertEqual(adapter._smtp_host, "smtp.test.com")
+        self.assertEqual(adapter._address, "hermes@test.com")
+
+    def test_connect_aborts_without_attempting_imap_when_host_missing(self):
+        """A missing host returns False without the cryptic DNS error."""
+        import asyncio
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import EmailAdapter
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }, clear=False):
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+
+        with patch("imaplib.IMAP4_SSL") as mock_imap:
+            result = asyncio.run(adapter.connect())
+
+        self.assertFalse(result)
+        mock_imap.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1436,7 +1436,8 @@ class TestConnectionConfigResolution(unittest.TestCase):
         self.assertEqual(adapter._address, "hermes@test.com")
 
     def test_connect_aborts_without_attempting_imap_when_host_missing(self):
-        """A missing host returns False without the cryptic DNS error."""
+        """A missing host returns False without the cryptic DNS error, and marks
+        the failure non-retryable so the gateway stops reconnecting (#40715)."""
         import asyncio
         from gateway.config import PlatformConfig
         from plugins.platforms.email.adapter import EmailAdapter
@@ -1453,6 +1454,32 @@ class TestConnectionConfigResolution(unittest.TestCase):
 
         self.assertFalse(result)
         mock_imap.assert_not_called()
+        # The OOM fix (#40715): a blank host must NOT leave the platform in the
+        # retryable reconnect loop — it is a permanent config error.
+        self.assertTrue(adapter.has_fatal_error)
+        self.assertEqual(adapter.fatal_error_code, "email_missing_configuration")
+        self.assertFalse(adapter.fatal_error_retryable)
+        self.assertIn("EMAIL_IMAP_HOST", adapter.fatal_error_message or "")
+
+    def test_blank_present_env_vars_are_not_required(self):
+        """Blank/whitespace EMAIL_* values must read as missing (#40715) — an
+        abandoned setup with empty keys must not enable the platform."""
+        from plugins.platforms.email.adapter import check_email_requirements
+        for blank in ("", "   ", "\n"):
+            with patch.dict(os.environ, {
+                "EMAIL_ADDRESS": blank, "EMAIL_PASSWORD": blank,
+                "EMAIL_IMAP_HOST": blank, "EMAIL_SMTP_HOST": blank,
+            }, clear=False):
+                self.assertFalse(check_email_requirements())
+
+    def test_all_settings_present_satisfies_requirements(self):
+        """The connected check passes only when all four settings are non-blank."""
+        from plugins.platforms.email.adapter import check_email_requirements
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com", "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com", "EMAIL_SMTP_HOST": "smtp.test.com",
+        }, clear=False):
+            self.assertTrue(check_email_requirements())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
The email gateway adapter now resolves the IMAP/SMTP host and address from `PlatformConfig.extra` (the dict a `config.yaml`-only setup populates) in addition to env vars, strips surrounding whitespace, validates required fields before connecting, and marks a missing-config failure as **non-retryable** so the gateway stops reconnecting against an empty host. A config-only install works, a stray space/newline no longer surfaces as the misleading `[Errno 8] nodename nor servname`, and a blank-but-present setup no longer drives an indefinite retry loop that leaks memory until the host OOM-kills.

Salvage of #49805 by @devorun (fixes #49736), with the #40715 blank-env / retry-loop OOM fix folded in (credits @zerone0x #40745 and @liuhao1024 #40829).

## Root cause
- **#49736 (cryptic DNS error):** `EmailAdapter.__init__` read host/address straight from env vars with no `.strip()` and never consulted `config.extra` for them (only `skip_attachments`). A config-only setup left the hosts empty, and a whitespace-padded host reached `IMAP4_SSL("…\n")`, which `getaddrinfo` rejects as an unresolvable name (`EAI_NONAME`) — failing in milliseconds with no DNS lookup.
- **#40715 (OOM retry loop):** blank-but-present `EMAIL_*` keys read as set, the platform turned on, and `connect()` looped forever against an empty host (memory growth → OOM on small hosts). The connect guard returned only a soft `False`, leaving the platform in the retryable reconnect path.

## Changes
- `plugins/platforms/email/adapter.py`:
  - resolve `address`/`imap_host`/`smtp_host` from env → `config.extra` fallback, stripped;
  - pre-connect validation now calls `_set_fatal_error(..., retryable=False)` so a missing host is a permanent config error, not a reconnect loop;
  - `check_email_requirements()` treats blank/whitespace-only values as missing, so an abandoned setup with empty keys does not enable the platform.
- `tests/gateway/test_email.py`: whitespace strip, `config.extra` fallback, abort-without-IMAP, non-retryable fatal-error assertion, and blank-env rejection.
- `scripts/release.py`: map salvage author email.

## Validation
| Path | Before | After |
|---|---|---|
| Padded env host (`" imap…\n"`) | `IMAP4_SSL` → `[Errno 8] nodename nor servname` | stripped, connects |
| `config.yaml`-only host | empty host, cryptic error | read from `config.extra`, connects |
| Missing host | cryptic error, **retryable** reconnect loop → OOM | **non-retryable** fatal error, no IMAP call, loop stops |
| Blank-but-present `EMAIL_*` | platform enabled, retries empty host | read as missing, platform off |
| env + extra both set | n/a | env wins (precedence preserved) |

- `scripts/run_tests.sh tests/gateway/test_email.py` → 73/73 pass.
- E2E with real imports against temp `HERMES_HOME`: strip, `config.extra` fallback, pre-connect abort (IMAP4_SSL not called), **non-retryable** fatal error, blank-reject, and env-over-extra precedence all verified.

Closes #49736 and #40715. Supersedes duplicates #49810 (@r266-tech), #40745 (@zerone0x), #40829 (@liuhao1024).

## Infographic

![email-gateway-fix](https://v3b.fal.media/files/b/0a9f3980/58TdvQBPXHHE-bMjz49KU_a24eoRGa.png)
