### PR TITLE
fix(research): make batch tool-stat field order deterministic

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -62,7 +62,16 @@ _WORKER_CONFIG = {}
 # This stays in sync automatically when new tools are added to TOOL_TO_TOOLSET_MAP.
 # Used for consistent schema in Arrow/Parquet (HuggingFace datasets) and for
 # filtering corrupted entries during trajectory combination.
-ALL_POSSIBLE_TOOLS = set(TOOL_TO_TOOLSET_MAP.keys())
+#
+# Kept as a *sorted tuple* rather than a bare ``set``. The normalization helpers
+# below build the per-record ``tool_stats`` / ``tool_error_counts`` dicts by
+# iterating this collection, so its iteration order becomes the field order in
+# every emitted batch shard. Workers run in spawned processes (the default
+# start method on macOS/Windows), each with its own ``PYTHONHASHSEED``, so a
+# ``set`` would iterate in a different order per worker. Different field orders
+# across shards make HuggingFace ``datasets`` reject the combined load with a
+# struct schema mismatch — the exact failure this normalization exists to avoid.
+ALL_POSSIBLE_TOOLS = tuple(sorted(TOOL_TO_TOOLSET_MAP.keys()))
 
 # Default stats for tools that weren't used
 DEFAULT_TOOL_STATS = {'count': 0, 'success': 0, 'failure': 0}
@@ -1029,8 +1038,9 @@ class BatchRunner:
         combined_file = self.output_dir / "trajectories.jsonl"
         print(f"\n📦 Combining ALL batch files into {combined_file.name}...")
         
-        # Valid tools auto-derived from model_tools.py — no manual updates needed
-        VALID_TOOLS = ALL_POSSIBLE_TOOLS
+        # Valid tools auto-derived from model_tools.py — no manual updates needed.
+        # Materialize a set for O(1) membership in the per-entry filter below.
+        VALID_TOOLS = set(ALL_POSSIBLE_TOOLS)
         
         total_entries = 0
         filtered_entries = 0

--- a/tests/test_batch_runner_normalize.py
+++ b/tests/test_batch_runner_normalize.py
@@ -1,0 +1,73 @@
+"""Tests for batch_runner tool-stat normalization — deterministic field order.
+
+The per-record ``tool_stats`` / ``tool_error_counts`` dicts must have a stable
+key order across processes so the JSONL shards combine into a single Arrow/Parquet
+schema when loaded with HuggingFace ``datasets``. Workers are spawned (fresh
+``PYTHONHASHSEED`` each), so iterating an unordered ``set`` would emit shards with
+different struct field orders and break the combined load.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from batch_runner import (
+    ALL_POSSIBLE_TOOLS,
+    _normalize_tool_stats,
+    _normalize_tool_error_counts,
+)
+
+
+def test_all_possible_tools_is_ordered_and_sorted():
+    """ALL_POSSIBLE_TOOLS must be an ordered, sorted sequence (not a bare set)."""
+    assert isinstance(ALL_POSSIBLE_TOOLS, tuple)
+    assert list(ALL_POSSIBLE_TOOLS) == sorted(ALL_POSSIBLE_TOOLS)
+    # Still usable for membership in the trajectory-combine filter.
+    assert all(tool in ALL_POSSIBLE_TOOLS for tool in ALL_POSSIBLE_TOOLS)
+
+
+def test_normalize_tool_stats_key_order_is_deterministic():
+    """Output key order is the sorted canonical order, regardless of input order."""
+    expected_known = sorted(ALL_POSSIBLE_TOOLS)
+
+    sample = next(iter(ALL_POSSIBLE_TOOLS))
+    raw = {sample: {"count": 3, "success": 2, "failure": 1}}
+
+    normalized = _normalize_tool_stats(raw)
+
+    # Every known tool is present and the leading keys follow the canonical order.
+    known_keys = [k for k in normalized if k in set(ALL_POSSIBLE_TOOLS)]
+    assert known_keys == expected_known
+    # The populated tool keeps its values; the rest default to zeros.
+    assert normalized[sample] == {"count": 3, "success": 2, "failure": 1}
+    other = next(t for t in ALL_POSSIBLE_TOOLS if t != sample)
+    assert normalized[other] == {"count": 0, "success": 0, "failure": 0}
+
+
+def test_normalize_tool_stats_independent_of_input_dict_order():
+    """Same set of tools in different input orders yields identical key order."""
+    a, b = ALL_POSSIBLE_TOOLS[0], ALL_POSSIBLE_TOOLS[-1]
+    forward = _normalize_tool_stats({a: {"count": 1, "success": 1, "failure": 0},
+                                     b: {"count": 2, "success": 2, "failure": 0}})
+    reverse = _normalize_tool_stats({b: {"count": 2, "success": 2, "failure": 0},
+                                     a: {"count": 1, "success": 1, "failure": 0}})
+    assert list(forward.keys()) == list(reverse.keys())
+
+
+def test_normalize_tool_stats_appends_unexpected_tools():
+    """Hallucinated tool names are preserved after the canonical block."""
+    raw = {"definitely_not_a_real_tool": {"count": 1, "success": 0, "failure": 1}}
+    normalized = _normalize_tool_stats(raw)
+    assert "definitely_not_a_real_tool" in normalized
+    canonical = list(ALL_POSSIBLE_TOOLS)
+    assert list(normalized.keys())[: len(canonical)] == canonical
+
+
+def test_normalize_tool_error_counts_key_order_is_deterministic():
+    """Error-count normalization shares the same deterministic ordering."""
+    sample = next(iter(ALL_POSSIBLE_TOOLS))
+    normalized = _normalize_tool_error_counts({sample: 4})
+    known_keys = [k for k in normalized if k in set(ALL_POSSIBLE_TOOLS)]
+    assert known_keys == sorted(ALL_POSSIBLE_TOOLS)
+    assert normalized[sample] == 4


### PR DESCRIPTION
`ALL_POSSIBLE_TOOLS` was a `set`. The tool-stat normalizers build each
record's `tool_stats` and `tool_error_counts` by iterating it, so set
iteration order became the struct field order in every batch shard.

Workers run in spawned processes, each with its own `PYTHONHASHSEED`.
A set therefore iterates in a different order per worker, so shards land
with different field orders. Loading them together with HuggingFace
`datasets` then fails with a struct schema mismatch — the exact failure
this normalization exists to prevent.

Switch the canonical list to a sorted tuple so every worker emits the
same field order. Membership in the combine filter still uses a set, so
that hot path stays O(1).

## What does this PR do?

Fixes non-deterministic field ordering in normalized batch trajectory
records. Worker processes are spawned, so an unordered `set` produced
shards whose `tool_stats` / `tool_error_counts` struct fields appeared in
different orders. Combining those shards with HuggingFace `datasets`
raised a schema mismatch. A sorted tuple makes the order stable across
all workers.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `batch_runner.py`: `ALL_POSSIBLE_TOOLS` is now `tuple(sorted(...))`
  instead of `set(...)`, giving the normalizers a stable iteration order.
- `batch_runner.py`: the trajectory-combine filter materializes a set
  from it (`VALID_TOOLS = set(ALL_POSSIBLE_TOOLS)`) to keep membership O(1).
- `tests/test_batch_runner_normalize.py`: new tests asserting the canonical
  list is ordered and that both normalizers emit deterministic, input-order
  independent keys.

## How to Test

1. `pytest tests/test_batch_runner_normalize.py tests/test_batch_runner_checkpoint.py -q` — all pass.
2. Call `_normalize_tool_stats` with inputs in different key orders; the
   output key order is identical and matches `sorted(ALL_POSSIBLE_TOOLS)`.
3. `ruff check batch_runner.py` and `python scripts/check-windows-footguns.py batch_runner.py` are clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — spawn-process ordering is the root cause
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A