### PR TITLE
fix(patch): count V4A context-hint occurrences non-overlapping

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -463,9 +463,52 @@ class TestCountOccurrences:
     def test_basic(self):
         from tools.patch_parser import _count_occurrences
         assert _count_occurrences("aaa", "a") == 3
-        assert _count_occurrences("aaa", "aa") == 2
         assert _count_occurrences("hello world", "xyz") == 0
         assert _count_occurrences("", "x") == 0
+
+    def test_self_overlapping_pattern_counted_non_overlapping(self):
+        """Self-overlapping patterns must be counted non-overlapping, per the
+        docstring. Counting overlaps inflates the addition-only ambiguity guard
+        and rejects hints that actually anchor a single, unique location."""
+        from tools.patch_parser import _count_occurrences
+        # "aa" fits twice in "aaaa" without overlap (positions 0 and 2).
+        assert _count_occurrences("aaaa", "aa") == 2
+        # "aa" anchors exactly one non-overlapping spot in "aaa".
+        assert _count_occurrences("aaa", "aa") == 1
+        # Blank-line and repeated-token hints are common and self-overlapping.
+        assert _count_occurrences("\n\n\n", "\n\n") == 1
+        assert _count_occurrences("}}}", "}}") == 1
+
+    def test_empty_pattern_terminates(self):
+        """An empty pattern must not loop forever."""
+        from tools.patch_parser import _count_occurrences
+        assert _count_occurrences("abc", "") == 4
+
+    def test_addition_only_self_overlapping_hint_not_ambiguous(self):
+        """Regression: an addition-only hunk whose context hint occurs once but
+        self-overlaps must not be rejected as ambiguous."""
+        patch = """\
+*** Begin Patch
+*** Update File: src/app.py
+@@ }} @@
++    extra = 1
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+
+        class FakeFileOps:
+            written = None
+            def read_file_raw(self, path):
+                # The hint "}}" appears once but self-overlaps inside "}}}".
+                return SimpleNamespace(content="data = {{}}}\n", error=None)
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(ops, file_ops)
+        assert result.success is True, result.message
+        assert "extra = 1" in file_ops.written
 
 
 class TestParseErrorSignalling:

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -233,7 +233,11 @@ def _count_occurrences(text: str, pattern: str) -> int:
         if pos == -1:
             break
         count += 1
-        start = pos + 1
+        # Advance past the whole match so self-overlapping patterns (e.g.
+        # "\n\n", repeated indentation) are counted non-overlapping, as the
+        # docstring promises. max(1, ...) guards against an empty pattern,
+        # which would otherwise never advance and loop forever.
+        start = pos + max(1, len(pattern))
     return count
 
 


### PR DESCRIPTION
`_count_occurrences` advanced its scan by one char (`start = pos + 1`)
after each match, so self-overlapping patterns were over-counted even
though the docstring promises a non-overlapping count. The addition-only
hunk guard treats `occurrences > 1` as an ambiguous context hint and
rejects the patch — so a hint that occurs exactly once but self-overlaps
(blank lines `\n\n`, repeated tokens like `}}`, indentation) was counted
as 2+ and the edit was refused, even though apply uses `str.find()` and
would place it unambiguously.

Advance past the whole match instead, with a `max(1, len)` guard so an
empty pattern can't spin forever.

## What does this PR do?

Fixes spurious "ambiguous context hint" rejections of valid addition-only
V4A patches caused by `_count_occurrences` counting overlapping matches.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/patch_parser.py`: `_count_occurrences` advances by `max(1, len(pattern))` so matches are counted non-overlapping.
- `tests/tools/test_patch_parser.py`: corrected the non-overlapping assertion, added counter cases (`\n\n`, `}}`, empty pattern) and an end-to-end test that a once-but-overlapping hint applies instead of being rejected.

## How to Test

1. `pytest tests/tools/test_patch_parser.py -q`
2. Before the fix, `_count_occurrences("aaa", "aa")` returns 2 and the new addition-only hunk test fails with an "ambiguous" error.
3. After the fix it returns 1 and the patch applies.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A