### PR TITLE
fix(cron): isolate a malformed next_run_at so one job can't wedge the tick

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1301,9 +1301,39 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                     needs_save = True
                     break
 
-        raw_next_run_dt = datetime.fromisoformat(next_run)
         schedule = job.get("schedule", {})
         kind = schedule.get("kind")
+
+        # A non-empty but malformed next_run_at (truncated, migrated, or
+        # hand-edited into jobs.json — e.g. "soon" or "2026-13-99") would
+        # otherwise raise ValueError here. Because this loop runs for every
+        # enabled job on every tick and the exception escapes get_due_jobs()
+        # and tick() (the tick's only try/finally just releases the file lock),
+        # a single poisoned record aborts the WHOLE tick before any due job is
+        # dispatched — and re-poisons it identically on every subsequent tick,
+        # permanently wedging all cron jobs until the file is hand-repaired.
+        # Degrade just this one job instead: recompute from its schedule when
+        # possible, otherwise skip it. Mirrors the existing poison-pill guards
+        # in _resolve_origin (#18722) and load_jobs's JSON auto-repair.
+        try:
+            raw_next_run_dt = datetime.fromisoformat(next_run)
+        except (ValueError, TypeError):
+            recovered_next = compute_next_run(schedule, now.isoformat())
+            logger.warning(
+                "Job '%s' has unparseable next_run_at=%r; %s",
+                job.get("name", job["id"]),
+                next_run,
+                f"recomputing from schedule -> {recovered_next}"
+                if recovered_next
+                else "no schedule recovery available, skipping this run",
+            )
+            if recovered_next:
+                for rj in raw_jobs:
+                    if rj["id"] == job["id"]:
+                        rj["next_run_at"] = recovered_next
+                        needs_save = True
+                        break
+            continue
 
         next_run_dt = _ensure_aware(raw_next_run_dt)
         # Migration repair: a cron job persists next_run_at as an absolute

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -938,6 +938,84 @@ class TestGetDueJobs:
         due = get_due_jobs()
         assert [j["id"] for j in due] == ["cron-same-tz"]
 
+    def test_malformed_next_run_at_does_not_wedge_other_jobs(self, tmp_cron_dir, monkeypatch):
+        """A single poisoned next_run_at must not abort the whole tick.
+
+        Before the guard, an unparseable (but non-empty) next_run_at raised
+        ValueError out of get_due_jobs()/tick(), so one corrupt record stopped
+        EVERY scheduled job from running and re-crashed identically each tick.
+        The bad record must now degrade to itself: it is recomputed/skipped
+        while sibling jobs still fire normally.
+        """
+        now = datetime(2026, 3, 18, 10, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        def _job(job_id, next_run_at):
+            return {
+                "id": job_id,
+                "name": job_id,
+                "prompt": "...",
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+                "schedule_display": "every 1h",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-03-18T09:00:00+00:00",
+                "next_run_at": next_run_at,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }
+
+        # Poisoned job is listed first so an unguarded crash would happen before
+        # the genuinely-due sibling is ever evaluated.
+        save_jobs([
+            _job("poisoned", "soon"),
+            _job("healthy", (now - timedelta(minutes=5)).isoformat()),
+        ])
+
+        due = get_due_jobs()  # must not raise
+        assert [j["id"] for j in due] == ["healthy"]
+
+        # The poisoned recurring job is repaired from its schedule rather than
+        # left to crash forever, so it can fire on a future tick.
+        repaired = get_job("poisoned")["next_run_at"]
+        assert repaired not in (None, "soon")
+        from cron.jobs import _ensure_aware
+        assert _ensure_aware(datetime.fromisoformat(repaired)) > now
+
+    def test_malformed_next_run_at_one_shot_is_skipped(self, tmp_cron_dir, monkeypatch):
+        """A one-shot job with a corrupt next_run_at can't be recomputed, so it
+        is skipped (not fired, not crashing) — and other jobs keep working."""
+        now = datetime(2026, 3, 18, 10, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs([{
+            "id": "oneshot-bad",
+            "name": "oneshot-bad",
+            "prompt": "...",
+            "schedule": {"kind": "once", "run_at": "2026-13-99", "display": "broken"},
+            "schedule_display": "broken",
+            "repeat": {"times": 1, "completed": 0},
+            "enabled": True,
+            "state": "scheduled",
+            "paused_at": None,
+            "paused_reason": None,
+            "created_at": "2026-03-18T09:00:00+00:00",
+            "next_run_at": "2026-13-99",  # parses past the falsiness check, then fails
+            "last_run_at": None,
+            "last_status": None,
+            "last_error": None,
+            "deliver": "local",
+            "origin": None,
+        }])
+
+        assert get_due_jobs() == []  # must not raise
+
     def test_interval_job_with_stale_offset_is_unaffected(self, tmp_cron_dir, monkeypatch):
         """The offset-repair guard is cron-only; interval jobs never take it.
 


### PR DESCRIPTION
## What does this PR do?

`_get_due_jobs_locked()` (reached from `get_due_jobs()` on every tick)
parsed each job's `next_run_at` with a bare
`datetime.fromisoformat(next_run)`. The value is only checked for
falsiness beforehand, so any non-empty but malformed timestamp — a
truncated/migrated value, or something hand-edited into `jobs.json`
like `"soon"` or `"2026-13-99"` — raised `ValueError`. That exception
escapes `get_due_jobs()` and `tick()` (the tick's only `try/finally`
just releases the file lock), aborting the entire tick before any due
job is dispatched. Because the poisoned record is re-loaded on the next
tick, it crashes identically every time and permanently wedges *all*
cron jobs until someone hand-repairs the file.

This is the same poison-pill class the code already guards elsewhere —
`_resolve_origin` (#18722) and `load_jobs`'s JSON auto-repair — the
`next_run_at` parse was simply missed, and it has the widest blast
radius since it runs for every enabled job on every tick.

The fix wraps that one parse and degrades the bad job to itself:
recompute its `next_run_at` from the schedule when possible (recurring
jobs recover and fire on a future tick), otherwise log and skip it.
Healthy jobs in the same tick are unaffected. I kept the change to the
single highest-impact parse rather than broadening it, to keep the
behavior change small and well-tested.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py`: in `_get_due_jobs_locked()`, guard
  `datetime.fromisoformat(next_run)` with `try/except (ValueError,
  TypeError)`; on failure, recompute `next_run_at` from the schedule
  (reusing the existing `needs_save` persistence path) or skip the job,
  with a warning. Moved the `schedule`/`kind` lookup above the parse so
  recovery can use it.
- `tests/cron/test_jobs.py`: added
  `test_malformed_next_run_at_does_not_wedge_other_jobs` (a poisoned
  recurring record listed first must not stop a healthy sibling from
  firing, and is repaired to a future time) and
  `test_malformed_next_run_at_one_shot_is_skipped` (a one-shot that
  can't be recomputed is skipped without raising).

## How to Test

1. Put a job with a non-empty but invalid `next_run_at` (e.g. `"soon"`)
   ahead of a genuinely-due job in `jobs.json`.
2. Before the fix, `get_due_jobs()` raises `ValueError` and the tick
   dispatches nothing; after the fix it returns the healthy job and the
   bad record's `next_run_at` is recomputed from its schedule.
3. `pytest tests/cron/test_jobs.py -q` — 94 passing, including the two
   new tests. I also confirmed both new tests fail on the pre-fix code
   with the exact `ValueError`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the cron tests and they pass (`tests/cron/test_jobs.py`); the wider suite has pre-existing failures from a missing `httpx` in my env, unrelated to this change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A