### PR TITLE
fix(dashboard): honor explicit websocket origins

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10987,6 +10987,39 @@ _VALID_CHANNEL_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 # Starlette's TestClient reports the peer as "testclient"; treat it as
 # loopback so tests don't need to rewrite request scope.
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
+_WS_ALLOWED_ORIGINS_ENV = "HERMES_DASHBOARD_WS_ALLOWED_ORIGINS"
+
+
+def _origin_matches_pattern(origin: str, pattern: str) -> bool:
+    """Return True when a browser Origin matches an explicit allowlist entry.
+
+    Entries must be full exact origins (``https://dashboard.example.org``).
+    Wildcards are intentionally unsupported here: this hook bypasses the normal
+    same-host Origin check for loopback dashboards behind a trusted proxy, so a
+    broad shared-domain pattern would weaken the DNS-rebinding guard.
+    """
+    parsed_origin = urllib.parse.urlparse(origin.rstrip("/"))
+    parsed_pattern = urllib.parse.urlparse(pattern.strip().rstrip("/"))
+    if parsed_origin.scheme not in {"http", "https"}:
+        return False
+    if parsed_pattern.scheme not in {"http", "https"}:
+        return False
+    if parsed_origin.scheme.lower() != parsed_pattern.scheme.lower():
+        return False
+
+    origin_netloc = parsed_origin.netloc.lower()
+    pattern_netloc = parsed_pattern.netloc.lower()
+    if not origin_netloc or not pattern_netloc or "*" in pattern_netloc:
+        return False
+    return origin_netloc == pattern_netloc
+
+
+def _ws_origin_is_explicitly_allowed(origin: str) -> bool:
+    """Check operator-configured public origins for proxied loopback dashboards."""
+    for pattern in os.environ.get(_WS_ALLOWED_ORIGINS_ENV, "").split(","):
+        if pattern.strip() and _origin_matches_pattern(origin, pattern):
+            return True
+    return False
 
 
 def _ws_client_reason(ws: "WebSocket") -> Optional[str]:
@@ -11081,6 +11114,8 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
         return f"origin_mismatch origin={origin} bound={bound_host}"
 
     if not _is_accepted_host(parsed.netloc, bound_host):
+        if _ws_origin_is_explicitly_allowed(origin):
+            return None
         return f"origin_mismatch origin={origin} bound={bound_host}"
     return None
 

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -443,6 +443,48 @@ class TestWsHostOriginGuardOrigins:
         ws = self._ws(origin="http://evil.test", host="127.0.0.1:8080")
         assert web_server._ws_host_origin_is_allowed(ws) is False
 
+    def test_loopback_proxy_origin_allowed_when_explicitly_configured(
+        self, loopback_app, monkeypatch
+    ):
+        """Loopback dashboards exposed through a trusted tunnel keep the public
+        browser Origin while the proxy rewrites Host to 127.0.0.1.
+
+        Operators must explicitly opt the exact public origin in; otherwise the
+        rebinding guard continues to reject mismatched http(s) origins.
+        """
+        monkeypatch.setenv(
+            web_server._WS_ALLOWED_ORIGINS_ENV,
+            "https://dashboard.example.org",
+        )
+        ws = self._ws(
+            origin="https://dashboard.example.org",
+            host="127.0.0.1:8080",
+        )
+        assert web_server._ws_host_origin_is_allowed(ws) is True
+
+    def test_loopback_proxy_origin_wrong_scheme_still_rejected(
+        self, loopback_app, monkeypatch
+    ):
+        monkeypatch.setenv(
+            web_server._WS_ALLOWED_ORIGINS_ENV,
+            "https://dashboard.example.org",
+        )
+        ws = self._ws(origin="http://dashboard.example.org", host="127.0.0.1:8080")
+        assert web_server._ws_host_origin_is_allowed(ws) is False
+
+    def test_loopback_proxy_wildcard_origin_still_rejected(
+        self, loopback_app, monkeypatch
+    ):
+        monkeypatch.setenv(
+            web_server._WS_ALLOWED_ORIGINS_ENV,
+            "https://*.trycloudflare.com",
+        )
+        ws = self._ws(
+            origin="https://quiet-river.trycloudflare.com",
+            host="127.0.0.1:8080",
+        )
+        assert web_server._ws_host_origin_is_allowed(ws) is False
+
     def test_explicit_non_loopback_file_origin_allowed(self, insecure_explicit_host_app):
         """Packaged Hermes Desktop also uses file:// when connecting to a
         Tailscale/LAN dashboard bind.


### PR DESCRIPTION
## Summary
- Honor exact public dashboard origins configured via `HERMES_DASHBOARD_WS_ALLOWED_ORIGINS` for WebSocket Origin checks.
- Keep wildcard/shared-domain entries rejected so the DNS-rebinding guard is not weakened.
- Add regression coverage for loopback dashboards exposed through trusted reverse proxies/tunnels.

## Motivation
A loopback-bound dashboard exposed through a trusted proxy can load the HTTP UI while `/api/pty` WebSocket upgrades fail with `Session ended` / close code `1006`: the proxy forwards to `127.0.0.1`, but the browser Origin remains the public dashboard URL.

## Test plan
- `python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_dashboard_auth_ws_auth.py`
- `python -m pytest tests/hermes_cli/test_dashboard_auth_ws_auth.py -q -o 'addopts='`

Closes #50365
