### PR TITLE
fix(tui-gateway): close AIAgent instances to release resources (#50197)

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -508,9 +508,16 @@ def _teardown_session(session: dict | None, *, end_reason: str = "tui_close") ->
     except Exception:
         pass
     try:
-        agent = session.get("agent")
-        if agent is not None and hasattr(agent, "close"):
-            agent.close()
+        if agent is not None:
+            # Bug #50197: drain memory provider before closing
+            if hasattr(agent, "shutdown_memory_provider"):
+                session_messages = getattr(agent, "_session_messages", None)
+                if isinstance(session_messages, list):
+                    agent.shutdown_memory_provider(session_messages)
+                else:
+                    agent.shutdown_memory_provider()
+            if hasattr(agent, "close"):
+                agent.close()
     except Exception:
         pass
     # NOTE: the slash-worker is closed inside _finalize_session (the single
@@ -7481,12 +7488,20 @@ def _(rid, params: dict) -> dict:
         try:
             from run_agent import AIAgent
 
-            result = AIAgent(
+            agent = AIAgent(
                 **_background_agent_kwargs(session["agent"], task_id)
-            ).run_conversation(
-                user_message=text,
-                task_id=task_id,
             )
+            try:
+                result = agent.run_conversation(
+                    user_message=text,
+                    task_id=task_id,
+                )
+            finally:
+                # Bug #50197: close ephemeral background agent
+                try:
+                    agent.close()
+                except Exception:
+                    pass
             _emit(
                 "background.complete",
                 parent,
@@ -7592,14 +7607,22 @@ def _(rid, params: dict) -> dict:
                 parent,
                 {"task_id": task_id, "text": f"Starting hidden restart agent{history_note}"},
             )
-            result = AIAgent(
+            agent = AIAgent(
                 **_ephemeral_preview_agent_kwargs(session["agent"], task_id),
                 **_preview_restart_callbacks(parent, task_id),
-            ).run_conversation(
-                user_message=prompt,
-                task_id=task_id,
-                conversation_history=parent_history or None,
             )
+            try:
+                result = agent.run_conversation(
+                    user_message=prompt,
+                    task_id=task_id,
+                    conversation_history=parent_history or None,
+                )
+            finally:
+                # Bug #50197: close ephemeral preview-restart agent
+                try:
+                    agent.close()
+                except Exception:
+                    pass
             text = (
                 result.get("final_response", str(result))
                 if isinstance(result, dict)


### PR DESCRIPTION
## Summary

Fixes the three `tui_gateway/server.py` leak sites from #50197. Companion to PR #50206 which addresses the `batch_runner.py` site.

## Related Issue

Fixes #50197 (tui_gateway sites)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Three sites in `tui_gateway/server.py` were leaking `AIAgent` resources:

1. **`_teardown_session`** — called `agent.close()` but never `shutdown_memory_provider()`, leaving memory provider sessions orphaned. Now drains the memory provider before closing, matching the gold-standard `_cleanup_agent_resources` pattern from `gateway/run.py`.

2. **`prompt.background`** — created an inline `AIAgent(...).run_conversation()` with zero cleanup in the `finally` block. Now stores the agent and calls `agent.close()` in a `try/finally`.

3. **`preview.restart`** — same inline pattern with no agent cleanup. Now stores the agent and calls `agent.close()` in a `try/finally`.

All cleanup is best-effort (wrapped in `try/except Exception: pass`).

## How to Test

```bash
source .venv/bin/activate
python -m pytest tests/test_tui_gateway_server.py -q
```

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] This PR changes only what it is supposed to change
- [x] Syntax verified: `python -m py_compile tui_gateway/server.py` passes

### Documentation

- [x] I updated or added related documentation (docstrings, comments)
