### PR TITLE
fix(config): honor model.api_base for custom providers (alias to base_url)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5468,23 +5468,44 @@ def _normalize_root_model_keys(config: Dict[str, Any]) -> Dict[str, Any]:
     ``model.*`` key is empty — they never override an existing value.
     After migration the root-level keys are removed so they can't cause
     confusion on subsequent loads.
+
+    Also aliases ``api_base`` → ``base_url`` (issue #8919). ``api_base`` is the
+    intuitive name OpenAI-SDK / LiteLLM users reach for, and ``hermes config set``
+    blindly accepts any dotted key — so ``model.api_base`` got written, confirmed,
+    and then silently ignored by the runtime resolver (which reads only
+    ``model.base_url``), causing requests to fall back to OpenRouter. We migrate
+    the alias to the canonical key (fallback-only — never override an explicit
+    ``base_url``) and drop the alias so it can't confuse later loads.
     """
-    # Only act if there are root-level keys to migrate
-    has_root = any(config.get(k) for k in ("provider", "base_url", "context_length"))
-    if not has_root:
+    # Only act if there are root-level keys (or an api_base alias) to migrate
+    model_in = config.get("model")
+    model_has_alias = isinstance(model_in, dict) and model_in.get("api_base")
+    has_root = any(
+        config.get(k) for k in ("provider", "base_url", "context_length", "api_base")
+    )
+    if not has_root and not model_has_alias:
         return config
 
     config = dict(config)
     model = config.get("model")
     if not isinstance(model, dict):
         model = {"default": model} if model else {}
-        config["model"] = model
+    else:
+        model = dict(model)
+    config["model"] = model
 
     for key in ("provider", "base_url", "context_length"):
         root_val = config.get(key)
         if root_val and not model.get(key):
             model[key] = root_val
         config.pop(key, None)
+
+    # api_base is an alias for base_url, at the root OR inside model.
+    for alias_val in (config.get("api_base"), model.get("api_base")):
+        if alias_val and not model.get("base_url"):
+            model["base_url"] = alias_val
+    config.pop("api_base", None)
+    model.pop("api_base", None)
 
     return config
 
@@ -6778,7 +6799,15 @@ def set_config_value(key: str, value: str):
         value = float(value)
 
     _set_nested(user_config, key, value)
-    
+    # Normalize the api_base → base_url alias at set-time too (issue #8919),
+    # so a fresh `hermes config set model.api_base ...` lands on the canonical
+    # key the runtime resolver actually reads, instead of being silently
+    # ignored. Mirrors the load-time migration in _normalize_root_model_keys.
+    _alias_norm = key.strip().lower()
+    if _alias_norm in ("model.api_base", "api_base"):
+        user_config = _normalize_root_model_keys(user_config)
+        key = "model.base_url"
+        print("  (note: 'api_base' is an alias — saved as model.base_url)")
     # Write only user config back (not the full merged defaults)
     ensure_hermes_home()
     from utils import atomic_yaml_write

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -589,6 +589,38 @@ class TestRootLevelProviderOverride:
         assert result["model"]["provider"] == "correct-provider"
         assert "provider" not in result  # root key still cleaned up
 
+    def test_normalize_model_api_base_aliases_to_base_url(self):
+        """model.api_base is migrated to model.base_url (issue #8919)."""
+        from hermes_cli.config import _normalize_root_model_keys
+
+        config = {
+            "model": {
+                "provider": "custom",
+                "api_base": "http://localhost:4000",
+                "api_key": "my-key",
+                "default": "default",
+            },
+        }
+        result = _normalize_root_model_keys(config)
+        assert result["model"]["base_url"] == "http://localhost:4000"
+        assert "api_base" not in result["model"]  # alias cleaned up
+
+    def test_normalize_api_base_does_not_override_base_url(self):
+        """An explicit model.base_url is never overridden by api_base."""
+        from hermes_cli.config import _normalize_root_model_keys
+
+        config = {
+            "model": {
+                "provider": "custom",
+                "api_base": "http://wrong:9999",
+                "base_url": "http://localhost:4000",
+                "default": "default",
+            },
+        }
+        result = _normalize_root_model_keys(config)
+        assert result["model"]["base_url"] == "http://localhost:4000"
+        assert "api_base" not in result["model"]
+
     def test_normalize_root_context_length_migrates_to_model(self):
         """Root-level context_length is migrated into the model section."""
         from hermes_cli.config import _normalize_root_model_keys


### PR DESCRIPTION
## Summary
A bare `custom` provider configured via `model.api_base` is now honored at runtime instead of silently falling back to OpenRouter.

**Root cause:** `hermes config set` writes any dotted key without validation, so `model.api_base` (the intuitive name OpenAI-SDK / LiteLLM users reach for) got written and confirmed — but the runtime resolver (`resolve_runtime_provider`) reads only `model.base_url`. The custom endpoint was never read; requests resolved to `https://openrouter.ai/api/v1` with an empty key → 401, zero hits to the custom endpoint. (issue #8919)

## Changes
- `hermes_cli/config.py` — `_normalize_root_model_keys` now aliases `api_base` → `base_url` (root level and inside `model:`), fallback-only so it never overrides an explicit `base_url`, and drops the alias key. This migrates existing broken configs at load time.
- `hermes_cli/config.py` — `set_config_value` normalizes the alias at set-time too, with a notice, so `hermes config set model.api_base ...` lands on the canonical key.
- `tests/cli/test_cli_init.py` — alias migration + non-override coverage.

## Validation
Reproduced the issue's exact repro against a temp `HERMES_HOME`, real config loader + real `resolve_runtime_provider`:

| config | base_url resolved | api_key |
|---|---|---|
| `model.api_base` (before) | `https://openrouter.ai/api/v1` | *(empty)* |
| `model.api_base` (after) | `http://localhost:4000` | ✓ |
| legacy file w/ `model.api_base` | `http://localhost:4000` | ✓ |
| `api_base` + explicit `base_url` | `http://localhost:4000` (base_url wins) | ✓ |

Targeted tests: `tests/cli/test_cli_init.py` 43✓, `tests/hermes_cli/test_config*.py` 159✓.

Note: the reporter's secondary `hermes config get` symptom is a non-existent subcommand (it's `config show`), already doc-fixed on main.

Closes #8919.


## Infographic

![mgs-codec api_base alias fix](https://v3b.fal.media/files/b/0a9f3999/g5ALPRCQDSHiiB4UWDb0J_n4k2VHJZ.png)
