### PR TITLE
Add configurable desktop font size

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -2,6 +2,7 @@ import { type MutableRefObject, useCallback, useState } from 'react'
 
 import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
+import { applyConfiguredFontSize } from '@/lib/font-size'
 import {
   $currentCwd,
   setAvailablePersonalities,
@@ -32,6 +33,8 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
   const refreshHermesConfig = useCallback(async () => {
     try {
       const [config, defaults] = await Promise.all([getHermesConfig(), getHermesConfigDefaults().catch(() => ({}))])
+
+      applyConfiguredFontSize(config)
 
       const personality = normalizePersonalityValue(
         typeof config.display?.personality === 'string' ? config.display.personality : ''

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -281,6 +281,7 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   toolsets: 'Enabled Toolsets',
   timezone: 'Timezone',
   display: {
+    fontSize: 'Font Size',
     personality: 'Personality',
     showReasoning: 'Reasoning Blocks'
   },
@@ -432,6 +433,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   modelContextLength: "Leave at 0 to use the selected model's detected context window.",
   fallbackProviders: 'Backup provider:model entries to try if the default model fails.',
   display: {
+    fontSize: 'Base UI font size in pixels. Use 0 to keep the default.',
     personality: 'Default assistant style for new sessions.',
     showReasoning: 'Show reasoning sections when the backend provides them.'
   },
@@ -515,7 +517,7 @@ export const SECTIONS: DesktopConfigSection[] = [
     id: 'appearance',
     label: 'Appearance',
     icon: Palette,
-    keys: []
+    keys: ['display.font_size']
   },
   {
     id: 'workspace',

--- a/apps/desktop/src/lib/font-size.test.ts
+++ b/apps/desktop/src/lib/font-size.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { applyConfiguredFontSize, normalizeUiFontSize } from './font-size'
+
+describe('normalizeUiFontSize', () => {
+  it('keeps 0 as default', () => {
+    expect(normalizeUiFontSize(0)).toBe(0)
+    expect(normalizeUiFontSize('')).toBe(0)
+  })
+
+  it('clamps positive values to the supported UI range', () => {
+    expect(normalizeUiFontSize(9)).toBe(10)
+    expect(normalizeUiFontSize(18)).toBe(18)
+    expect(normalizeUiFontSize('20')).toBe(20)
+    expect(normalizeUiFontSize(100)).toBe(32)
+  })
+})
+
+describe('applyConfiguredFontSize', () => {
+  afterEach(() => {
+    document.documentElement.style.removeProperty('font-size')
+  })
+
+  it('applies a configured root font size', () => {
+    expect(applyConfiguredFontSize({ display: { font_size: 18 } })).toBe(18)
+    expect(document.documentElement.style.fontSize).toBe('18px')
+  })
+
+  it('removes the inline override for the default value', () => {
+    document.documentElement.style.fontSize = '20px'
+    expect(applyConfiguredFontSize({ display: { font_size: 0 } })).toBe(0)
+    expect(document.documentElement.style.fontSize).toBe('')
+  })
+})

--- a/apps/desktop/src/lib/font-size.ts
+++ b/apps/desktop/src/lib/font-size.ts
@@ -1,0 +1,23 @@
+import type { HermesConfig } from '@/types/hermes'
+
+const MIN_FONT_SIZE = 10
+const MAX_FONT_SIZE = 32
+
+export function normalizeUiFontSize(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(n)) return 0
+  const rounded = Math.round(n)
+  if (rounded <= 0) return 0
+  return Math.min(Math.max(rounded, MIN_FONT_SIZE), MAX_FONT_SIZE)
+}
+
+export function applyConfiguredFontSize(config: HermesConfig): number {
+  const fontSize = normalizeUiFontSize(config.display?.font_size)
+  const root = document.documentElement
+  if (fontSize > 0) {
+    root.style.fontSize = `${fontSize}px`
+  } else {
+    root.style.removeProperty('font-size')
+  }
+  return fontSize
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -206,6 +206,7 @@ export interface HermesConfig {
     service_tier?: string
   }
   display?: {
+    font_size?: number
     personality?: string
     skin?: string
   }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1533,6 +1533,8 @@ DEFAULT_CONFIG = {
     
     "display": {
         "compact": False,
+        # Desktop/web UI base font size in px. 0 keeps the packaged CSS default.
+        "font_size": 0,
         "personality": "",
         "resume_display": "full",
         # Recap tuning for /resume and startup resume. The defaults match the
@@ -6477,6 +6479,7 @@ def show_config():
     print()
     print(color("◆ Display", Colors.CYAN, Colors.BOLD))
     display = config.get('display', {})
+    print(f"  Font size:    {display.get('font_size') or 'default'}")
     print(f"  Personality:  {display.get('personality') or 'none'}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
     print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -514,6 +514,11 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "How resumed sessions display history",
         "options": ["minimal", "full", "off"],
     },
+    "display.font_size": {
+        "type": "number",
+        "description": "Desktop/web UI base font size in px (0 = default)",
+        "category": "display",
+    },
     "display.busy_input_mode": {
         "type": "select",
         "description": "Input behavior while agent is running",

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -966,6 +966,11 @@ class TestCliRefreshIntervalConfig:
         assert DEFAULT_CONFIG["display"]["cli_refresh_interval"] == 1.0
 
 
+class TestDisplayFontSizeConfig:
+    def test_default_config_keeps_font_size_default(self):
+        assert DEFAULT_CONFIG["display"]["font_size"] == 0
+
+
 class TestDiscordChannelPromptsConfig:
     def test_default_config_includes_discord_channel_prompts(self):
         assert DEFAULT_CONFIG["discord"]["channel_prompts"] == {}

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2657,6 +2657,14 @@ class TestBuildSchemaFromConfig:
             assert "options" in entry
             assert "local" in entry["options"]
 
+    def test_display_font_size_schema(self):
+        from hermes_cli.web_server import CONFIG_SCHEMA
+
+        entry = CONFIG_SCHEMA["display.font_size"]
+        assert entry["type"] == "number"
+        assert entry["category"] == "display"
+        assert "0 = default" in entry["description"]
+
     def test_empty_prefix_produces_correct_keys(self):
         from hermes_cli.web_server import _build_schema_from_config
         test_config = {"model": "test", "nested": {"key": "val"}}


### PR DESCRIPTION
## Summary
- add `display.font_size` to the default config and generated config schema
- expose the option in the desktop Appearance settings
- apply the configured font size to the desktop/web root element while preserving the packaged default when set to `0`
- add focused tests for the config/schema default and desktop font-size helper

## Validation
- `python -m py_compile hermes_cli\config.py hermes_cli\web_server.py`
- direct config/schema assertion for `display.font_size`
- `npm.cmd --workspace apps/desktop run typecheck`
- `npm.cmd --workspace apps/desktop run test:ui -- src/lib/font-size.test.ts`

## Notes
Hermes Desktop already has GUI zoom plus Ctrl/Cmd +/-/0 shortcuts in `apps/desktop/electron/main.cjs`; this PR adds the missing config-driven base font size control as the complementary accessibility option.