### PR TITLE
fix(gateway): use _float_env for HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7820,9 +7820,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
 
-            _telegram_followup_grace = float(
-                os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
-            )
+            _telegram_followup_grace = _float_env("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", 3.0)
             _started_at = self._running_agents_ts.get(_quick_key, 0)
             if (
                 source.platform == Platform.TELEGRAM

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -774,3 +774,55 @@ class TestLongRunningNotificationOwnership:
         assert runner._should_emit_long_running_notification(
             "sess", agent, executor_task=live_task
         ) is True
+
+
+class TestTelegramFollowupGraceEnvParsing:
+    """Regression: malformed HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS must not crash (issue #50120)."""
+
+    def test_malformed_value_falls_back_to_default(self, monkeypatch):
+        """A non-numeric env var falls back to 3.0s instead of raising ValueError."""
+        from gateway.run import _float_env
+
+        monkeypatch.setenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "abc")
+        result = _float_env("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", 3.0)
+        assert result == 3.0
+
+    def test_empty_value_falls_back_to_default(self, monkeypatch):
+        """An empty string falls back to the default."""
+        from gateway.run import _float_env
+
+        monkeypatch.setenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "")
+        result = _float_env("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", 3.0)
+        assert result == 3.0
+
+    def test_whitespace_value_falls_back_to_default(self, monkeypatch):
+        """Whitespace-only value falls back to the default."""
+        from gateway.run import _float_env
+
+        monkeypatch.setenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "  ")
+        result = _float_env("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", 3.0)
+        assert result == 3.0
+
+    def test_comma_decimal_falls_back_to_default(self, monkeypatch):
+        """Locale-style comma decimal (e.g. '1,5') falls back to default."""
+        from gateway.run import _float_env
+
+        monkeypatch.setenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "1,5")
+        result = _float_env("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", 3.0)
+        assert result == 3.0
+
+    def test_valid_value_parsed_correctly(self, monkeypatch):
+        """A valid numeric string is parsed normally."""
+        from gateway.run import _float_env
+
+        monkeypatch.setenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "5.5")
+        result = _float_env("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", 3.0)
+        assert result == 5.5
+
+    def test_unset_uses_default(self, monkeypatch):
+        """When the env var is not set, the default is returned."""
+        from gateway.run import _float_env
+
+        monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+        result = _float_env("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", 3.0)
+        assert result == 3.0


### PR DESCRIPTION
## What does this PR do?

Fixes a bare `float(os.getenv(...))` call in `gateway/run.py` that crashes the message handler when `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` is set to a non-numeric value (typo, whitespace, locale decimal).

**Root cause:** The Telegram follow-up grace window was added later (`9a9b8cd1e`) and never converted to use `_float_env`. Every other numeric env read in `gateway/run.py` already routes through `_float_env` (added in `411f586c6`), which safely falls back to the default on `ValueError`/`TypeError`. This was the last bare-`float` numeric env read.

**Fix (1 line):**
```diff
- _telegram_followup_grace = float(os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0"))
+ _telegram_followup_grace = _float_env("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", 3.0)
```

## Related Issue

Fixes #50120

## Type of Change

- [x] 🐛 Bug fix (non-breaking change)
- [x] ✅ Tests

## Changes Made

- `gateway/run.py` — Use `_float_env` instead of bare `float(os.getenv(...))`
- `tests/gateway/test_busy_session_ack.py` — Added 6 regression tests covering malformed, empty, whitespace, comma-decimal, valid, and unset values

## How to Test

```bash
python3 -m pytest tests/gateway/test_busy_session_ack.py::TestTelegramFollowupGraceEnvParsing -v
```

All 6 sync tests pass. (19 async tests in the file fail pre-existingly due to missing `pytest-asyncio`.)

## Checklist

- [x] Conventional Commits format
- [x] PR contains only changes related to this fix
- [x] Tests pass locally
- [x] Tested on: Ubuntu 24.04 (Python 3.12.3)