### PR TITLE
fix(security): fail-closed when WebSocket peer is empty in loopback mode (#15544)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11005,7 +11005,12 @@ def _ws_client_reason(ws: "WebSocket") -> Optional[str]:
         return None
     client_host = ws.client.host if ws.client else ""
     if not client_host:
-        return None
+        # Fail-closed: a loopback-bound dashboard with auth disabled must
+        # not accept a WebSocket with no identifiable peer. ASGI servers
+        # behind a misconfigured proxy or unix socket can deliver
+        # ws.client == None or "" — treating that as "allowed" would let
+        # an unidentified peer reach a loopback-only surface.
+        return f"missing_or_empty_peer bound={bound_host or '?'}"
     if client_host in _LOOPBACK_HOSTS:
         return None
     return f"peer_not_loopback peer={client_host} bound={bound_host or '?'}"
@@ -11047,7 +11052,10 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
         return True
     client_host = ws.client.host if ws.client else ""
     if not client_host:
-        return True
+        # Fail-closed: see _ws_client_reason for rationale. An empty
+        # client_host on a loopback-bound dashboard with auth disabled
+        # must be rejected, not accepted as a default-allow.
+        return False
     return client_host in _LOOPBACK_HOSTS
 
 

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -398,6 +398,62 @@ class TestWsRequestIsAllowedGated:
         ws.headers = {"host": "evil.example.com"}
         assert web_server._ws_request_is_allowed(ws) is False
 
+    # -- security: empty / missing peer must fail closed in loopback mode --
+    # Regression for the fail-open default-allow where
+    # ``ws.client is None`` or ``ws.client.host == ""`` was treated as
+    # "allowed" on a loopback-bound dashboard with auth disabled. ASGI
+    # servers behind a misconfigured proxy or a unix-socket transport can
+    # deliver either shape, so both must be rejected explicitly.
+
+    def test_empty_client_host_rejected_in_loopback_mode(self, loopback_app):
+        """An empty ws.client.host must be rejected on a loopback bind."""
+        ws = _fake_ws(query={}, client_host="")
+        ws.headers = {"host": "127.0.0.1:8080"}
+        assert web_server._ws_client_is_allowed(ws) is False
+        assert web_server._ws_request_is_allowed(ws) is False
+
+    def test_missing_client_object_rejected_in_loopback_mode(self, loopback_app):
+        """ws.client is None must be rejected on a loopback bind."""
+        ws = _fake_ws(query={}, client_host="")
+        ws.client = None  # ASGI servers can omit the client tuple entirely
+        ws.headers = {"host": "127.0.0.1:8080"}
+        assert web_server._ws_client_is_allowed(ws) is False
+        assert web_server._ws_request_is_allowed(ws) is False
+
+    def test_empty_client_host_reason_is_block(self, loopback_app):
+        """_ws_client_reason must return a block reason for an empty peer,
+        not ``None`` (which the dispatcher treats as ``allowed``)."""
+        ws = _fake_ws(query={}, client_host="")
+        ws.headers = {"host": "127.0.0.1:8080"}
+        reason = web_server._ws_client_reason(ws)
+        assert reason is not None
+        assert "missing_or_empty_peer" in reason
+
+    def test_empty_client_host_still_allowed_in_insecure_public_mode(
+        self, insecure_public_app
+    ):
+        """The empty-peer fail-closed guard must only apply to loopback
+        binds. With an explicit ``--host 0.0.0.0 --insecure`` opt-in, the
+        loopback-only peer restriction does not run at all, so the empty
+        peer case bypasses the new guard the same way a legitimate LAN
+        peer does. Without this, the fix would regress the public-bind
+        path the dashboard relies on."""
+        ws = _fake_ws(query={}, client_host="")
+        ws.headers = {
+            "host": "192.168.0.222:9120",
+            "origin": "http://192.168.0.222:9120",
+        }
+        assert web_server._ws_client_is_allowed(ws) is True
+
+    def test_empty_client_host_still_allowed_in_gated_mode(self, gated_app):
+        """The empty-peer fail-closed guard must not apply when the OAuth
+        gate is active (``auth_required=True``). Gated mode rewrites
+        ``ws.client.host`` via ``proxy_headers=True``, and the ticket is
+        the auth, so peer-IP is irrelevant on that path."""
+        ws = _fake_ws(query={}, client_host="")
+        ws.headers = {"host": "dashboard.example.com"}
+        assert web_server._ws_client_is_allowed(ws) is True
+
 
 class TestWsHostOriginGuardOrigins:
     """The WS Origin guard must let the packaged desktop shell connect.


### PR DESCRIPTION
## Summary
A WebSocket with no identifiable peer (`ws.client is None` or `host == ""`) is now rejected on a loopback-bound, auth-disabled dashboard instead of being default-allowed.

Root cause: both `_ws_client_reason` and `_ws_client_is_allowed` returned "allowed" (`None` / `True`) when `client_host` was empty. On a loopback bind whose only auth is the legacy `?token=` query param, an ASGI server behind a misconfigured reverse proxy or a unix-socket transport can deliver an empty/None client, letting an unidentified peer through — a fail-open default-allow.

## Changes
- `hermes_cli/web_server.py`: empty `client_host` now fails closed — `_ws_client_reason` returns a `missing_or_empty_peer` reason and `_ws_client_is_allowed` returns `False`. Scoped to the loopback path only; the explicit non-loopback `--insecure` bind and the OAuth-gated path early-return before this check, so public/LAN/gated peers are unaffected.
- `tests/hermes_cli/test_dashboard_auth_ws_auth.py`: 5 regression tests covering empty host rejected, None-client rejected, the block reason, and still-allowed under both `--insecure` and gated modes.

## Validation
| | Before | After |
|---|---|---|
| empty/None peer on loopback bind | allowed (fail-open) | rejected (fail-closed) |
| `--insecure` non-loopback bind | allowed | allowed (unchanged) |
| OAuth-gated bind | allowed | allowed (unchanged) |
| `tests/hermes_cli/test_dashboard_auth_ws_auth.py` | — | 50/50 pass |

Salvaged from #15544 by @memosr — commit cherry-picked onto current main with authorship preserved.

## Infographic

![websocket-empty-peer-fail-closed](https://v3b.fal.media/files/b/0a9f39b3/KKfE-tcdLSM2bEiovFyG5_62GdIBbg.png)
