### PR TITLE
fix(security): sanitize Kanban dashboard markdown HTML at the render sink

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -334,6 +334,48 @@
     );
     return html;
   }
+  const MARKDOWN_ALLOWED_TAGS = new Set([
+    "a",
+    "code",
+    "em",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "li",
+    "p",
+    "pre",
+    "strong",
+    "ul",
+  ]);
+  function escapeAttribute(value) {
+    return escapeHtml(value).replace(/`/g, "&#96;");
+  }
+  function sanitizeMarkdownAttrs(tag, attrs) {
+    if (tag === "a") {
+      const hrefMatch =
+        /\shref=(["'])(.*?)\1/i.exec(attrs) ||
+        /\shref=([^\s>]+)/i.exec(attrs);
+      const href = hrefMatch ? (hrefMatch[2] || hrefMatch[1] || "").trim() : "";
+      if (!/^(https?:\/\/|mailto:)/i.test(href)) return "";
+      return ` href="${escapeAttribute(href)}" target="_blank" rel="noopener noreferrer"`;
+    }
+    if (tag === "pre" && /\sclass=(["'])hermes-kanban-md-code\1/i.test(attrs)) {
+      return ' class="hermes-kanban-md-code"';
+    }
+    return "";
+  }
+  function sanitizeMarkdownHtml(html) {
+    return String(html || "").replace(
+      /<\/?([a-zA-Z][A-Za-z0-9-]*)([^>]*)>/g,
+      (match, rawTag, attrs) => {
+        const tag = rawTag.toLowerCase();
+        if (!MARKDOWN_ALLOWED_TAGS.has(tag)) return "";
+        if (/^<\s*\//.test(match)) return `</${tag}>`;
+        return `<${tag}${sanitizeMarkdownAttrs(tag, attrs || "")}>`;
+      },
+    );
+  }
 
   function MarkdownBlock(props) {
     const enabled = props.enabled !== false;
@@ -342,7 +384,7 @@
     }
     return h("div", {
       className: "hermes-kanban-md",
-      dangerouslySetInnerHTML: { __html: renderMarkdown(props.source || "") },
+      dangerouslySetInnerHTML: { __html: sanitizeMarkdownHtml(renderMarkdown(props.source || "")) },
     });
   }
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -247,6 +247,19 @@ def test_dashboard_initial_board_uses_backend_current_when_unpinned():
     assert 'readSelectedBoard() || "default"' not in js
 
 
+def test_dashboard_markdown_html_is_sanitized_before_render():
+    """Markdown rendering must sanitize HTML before dangerouslySetInnerHTML."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert "function sanitizeMarkdownHtml(html)" in js
+    assert "MARKDOWN_ALLOWED_TAGS" in js
+    assert "sanitizeMarkdownHtml(renderMarkdown(props.source || \"\"))" in js
+    assert "dangerouslySetInnerHTML: { __html: renderMarkdown(props.source || \"\") }" not in js
+
+
 # ---------------------------------------------------------------------------
 # GET /tasks/:id returns body + comments + events + links
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds a defense-in-depth, allowlist-based HTML sanitizer at the Kanban dashboard's markdown render sink. Salvage of #39949 by @zapabob, cherry-picked onto current `main` with authorship preserved.

## Context
The dashboard renders task/comment markdown via `dangerouslySetInnerHTML`. Current `main` is **not** vulnerable — `renderMarkdown()` escapes all input first, escapes fenced-code on re-insert, and allowlists links to http(s)/mailto (this is why #31934 is closeable as already-fixed). This PR adds a second, sink-level guard so the surface stays safe even if `renderMarkdown` ever regresses: a final allowlist pass on the produced HTML.

## Changes
- `plugins/kanban/dashboard/dist/index.js` (the shipped bundle — this plugin has no separate TS source, so editing `dist/` is the correct path):
  - `MARKDOWN_ALLOWED_TAGS` — `a, code, em, h1–h4, li, p, pre, strong, ul`; any other tag is stripped.
  - `sanitizeMarkdownAttrs` — `<a>` keeps only an http(s)/mailto `href` (+ `target`/`rel`); `<pre>` keeps only the known `hermes-kanban-md-code` class; all other attributes dropped.
  - `MarkdownBlock` routes `renderMarkdown(...)` output through `sanitizeMarkdownHtml(...)` before the sink.
- `tests/plugins/test_kanban_dashboard_plugin.py`: sanitizer coverage.

## Validation
| | Result |
|---|---|
| `tests/plugins/test_kanban_dashboard_plugin.py` | 96/96 pass |
| Node E2E (render→sanitize) | `<script>`, `<img onerror>`, `<div onclick>`, `javascript:` links → all neutralized (escaped or stripped); bold/code/safe-links preserved. No live scriptable HTML survives. |

Closes #31934.

## Infographic

![kanban-markdown-sanitizer](https://v3b.fal.media/files/b/0a9f39cd/PuDDQXfs_hZ7vnz3yMoYi_A2IHzTCc.png)
