### PR TITLE
feat(kanban): optional per-card verify_cmd — skip dispatch when work already passes

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -321,6 +321,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "deterministic branch. See `hermes project list`.")
     p_create.add_argument("--tenant", default=None, help="Tenant namespace")
     p_create.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
+    p_create.add_argument("--verify", default=None, dest="verify_cmd",
+                          help="Shell command run in the workspace before dispatch; "
+                               "if it exits 0 the card auto-completes without spawning "
+                               "a worker (e.g. 'pytest -q tests/foo.py').")
     p_create.add_argument("--triage", action="store_true",
                           help="Park in triage — a specifier will flesh out the spec and promote to todo")
     p_create.add_argument("--idempotency-key", default=None,
@@ -1347,6 +1351,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            verify_cmd=getattr(args, "verify_cmd", None),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -914,6 +914,11 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Optional shell command run in the workspace BEFORE dispatching a worker.
+    # If it exits 0, the dispatcher auto-completes the card (deliverables already
+    # exist / acceptance criteria already pass) instead of spawning a worker with
+    # nothing to do. NULL = no pre-dispatch check (the default).
+    verify_cmd: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -998,6 +1003,7 @@ class Task:
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
             ),
+            verify_cmd=row["verify_cmd"] if "verify_cmd" in keys else None,
         )
 
 
@@ -1175,7 +1181,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Optional pre-dispatch verify command: if set and it exits 0 in the
+    -- workspace, the dispatcher auto-completes the card instead of spawning.
+    verify_cmd           TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1947,6 +1956,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     if "model_override" not in cols:
         conn.execute("ALTER TABLE tasks ADD COLUMN model_override TEXT")
 
+    if "verify_cmd" not in cols:
+        # Optional pre-dispatch verify command (see Task.verify_cmd). Existing
+        # rows get NULL = no check, preserving prior behaviour.
+        conn.execute("ALTER TABLE tasks ADD COLUMN verify_cmd TEXT")
+
     if "goal_mode" not in cols:
         # Ralph-style goal loop toggle for the dispatched worker. 0 (the
         # default) = classic single-shot worker, preserving the behaviour
@@ -2405,6 +2419,7 @@ def create_task(
     goal_max_turns: Optional[int] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
+    verify_cmd: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
 ) -> str:
@@ -2635,8 +2650,9 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        verify_cmd
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2659,6 +2675,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        verify_cmd,
                     ),
                 )
                 for pid in parents:
@@ -6995,6 +7012,44 @@ def dispatch_once(
         )
 
 
+def _precheck_verify(conn: sqlite3.Connection, task: "Task", workspace: str) -> bool:
+    """Run a card's optional ``verify_cmd`` before dispatching a worker.
+
+    If the command exits 0 in the workspace, the deliverables already exist /
+    the acceptance criteria already pass, so auto-complete the card and tell the
+    caller to skip the spawn. Any non-zero exit, timeout, or error → return
+    False and dispatch normally (verify is advisory, never a failure path).
+    Returns True iff the task was auto-completed.
+    """
+    cmd = (getattr(task, "verify_cmd", None) or "").strip()
+    if not cmd:
+        return False
+    import subprocess
+    try:
+        proc = subprocess.run(
+            cmd, shell=True, cwd=workspace,
+            capture_output=True, text=True, timeout=300,
+        )
+    except Exception as exc:
+        _log.warning("verify_cmd for %s errored (%s); dispatching normally", task.id, exc)
+        return False
+    if proc.returncode != 0:
+        return False
+    tail = (proc.stdout or proc.stderr or "").strip()[-400:]
+    try:
+        complete_task(
+            conn, task.id,
+            result="Pre-dispatch verify_cmd passed (rc=0); auto-completed "
+                   "without spawning a worker.\n" + tail,
+            summary="verify_cmd passed — deliverables already satisfied",
+        )
+    except Exception as exc:
+        _log.warning("verify autocomplete for %s failed (%s); dispatching", task.id, exc)
+        return False
+    _log.info("task %s auto-completed by verify_cmd (no spawn)", task.id)
+    return True
+
+
 def _dispatch_once_locked(
     conn: sqlite3.Connection,
     *,
@@ -7274,6 +7329,10 @@ def _dispatch_once_locked(
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
+        # Pre-dispatch verify: if the card's verify_cmd already passes, the
+        # deliverables exist — auto-complete instead of spawning a worker.
+        if _precheck_verify(conn, claimed, str(workspace)):
+            continue
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             # Back-compat: older spawn_fn signatures accept only

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -788,6 +788,36 @@ def test_detect_crashed_workers_isolated_failure_normal_retry(
             )
 
 
+def test_precheck_verify_autocompletes_on_pass(kanban_home, tmp_path):
+    """A card's optional verify_cmd is run before dispatch: rc 0 auto-completes
+    it (deliverables already satisfied), rc!=0 / absent dispatches normally. The
+    column round-trips through create_task -> Task.from_row."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        # verify_cmd persists and round-trips.
+        tid_ok = kb.create_task(conn, title="ok", assignee="a", verify_cmd="true")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid_ok,))
+        conn.commit()
+        task_ok = kb.get_task(conn, tid_ok)
+        assert task_ok.verify_cmd == "true"
+
+        # Passing verify (rc 0) → auto-complete, returns True.
+        assert _kb._precheck_verify(conn, task_ok, str(tmp_path)) is True
+        assert kb.get_task(conn, tid_ok).status == "done"
+
+        # Failing verify (rc 1) → returns False, no completion.
+        tid_no = kb.create_task(conn, title="no", assignee="a", verify_cmd="false")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid_no,))
+        conn.commit()
+        assert _kb._precheck_verify(conn, kb.get_task(conn, tid_no), str(tmp_path)) is False
+        assert kb.get_task(conn, tid_no).status != "done"
+
+        # No verify_cmd → no-op, returns False.
+        tid_none = kb.create_task(conn, title="none", assignee="a")
+        assert _kb._precheck_verify(conn, kb.get_task(conn, tid_none), str(tmp_path)) is False
+
+
 def test_detect_crashed_workers_skips_freshly_claimed_tasks(
     kanban_home, monkeypatch,
 ):


### PR DESCRIPTION
## What
An optional, per-card pre-dispatch **verify** command. Set \`--verify \"<cmd>\"\` on a card; before the dispatcher spawns a worker, it runs the command in the card's workspace. **Exit 0 → the card auto-completes** (deliverables already exist / ACs already pass) and no worker is spawned. Non-zero / timeout / error → dispatch normally.

Complements #50386: that PR stops no-op workers from wrongly *blocking* cards; this one avoids *dispatching* a worker at all when the work is already done (re-runs after a partial build, idempotent setup, "ensure X exists" cards).

## How
- \`tasks.verify_cmd\` column (CREATE TABLE + additive \`_migrate_add_optional_columns\`; NULL default = no check, back-compat)
- \`Task.verify_cmd\` + \`from_row\` mapping; \`create_task(verify_cmd=...)\`; \`kanban create --verify\`
- \`_precheck_verify()\` helper + a hook in the **ready-task** dispatch path of \`_dispatch_once_locked\` (not the review column). **Advisory** — any non-zero exit, timeout, or error falls through to a normal spawn; never a failure path.

## Tests
- \`test_precheck_verify_autocompletes_on_pass\`: rc 0 → completed; rc!=0 / absent → no-op; column round-trips.
- 314 passing across \`test_kanban_db.py\` + \`test_kanban_tools.py\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)