### PR TITLE
fix(cli): honor worktree_sync toggle in the TUI launch path

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1959,12 +1959,18 @@ def _launch_tui(
                 _git_repo_root,
                 _prune_stale_worktrees,
                 _setup_worktree,
+                load_cli_config,
             )
 
             repo = _git_repo_root()
             if repo:
                 _prune_stale_worktrees(repo)
-            wt_info = _setup_worktree()
+            # Honor the worktree_sync toggle here too: branch from the freshly
+            # fetched remote tip by default, but respect worktree_sync: false
+            # (branch from local HEAD — offline / pinned base). The CLI chat
+            # path already does this; the TUI launch path used to ignore it.
+            _sync_base = load_cli_config().get("worktree_sync", True)
+            wt_info = _setup_worktree(sync_base=_sync_base)
         except Exception as exc:
             print(f"✗ Failed to create TUI worktree: {exc}", file=sys.stderr)
             wt_info = None

--- a/tests/cli/test_worktree_sync_base.py
+++ b/tests/cli/test_worktree_sync_base.py
@@ -122,3 +122,37 @@ class TestSetupWorktreeSyncBase:
         info = cli._setup_worktree(str(clone))
         assert info is not None
         assert _head(info["path"]) == remote_head
+
+
+class TestTuiLaunchHonorsWorktreeSync:
+    """The TUI launch path must honor worktree_sync, like the CLI chat path.
+
+    Regression: ``hermes_cli.main._launch_tui`` called ``_setup_worktree()``
+    with no ``sync_base`` argument, so a user who set ``worktree_sync: false``
+    (to branch from local HEAD — offline / pinned base) had that toggle
+    silently ignored when launching a TUI worktree, even though the CLI chat
+    path already resolved it via ``CLI_CONFIG.get("worktree_sync", True)``.
+    """
+
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_launch_tui_forwards_worktree_sync(self, flag, monkeypatch):
+        import cli
+        from hermes_cli import main
+
+        captured = {}
+
+        def _fake_setup_worktree(*args, **kwargs):
+            captured["sync_base"] = kwargs.get("sync_base")
+            # Return None so _launch_tui hits its early ``sys.exit(1)`` right
+            # after worktree setup, before it tries to spawn the real TUI.
+            return None
+
+        monkeypatch.setattr(cli, "load_cli_config", lambda: {"worktree_sync": flag})
+        monkeypatch.setattr(cli, "_setup_worktree", _fake_setup_worktree)
+        monkeypatch.setattr(cli, "_git_repo_root", lambda: None)
+        monkeypatch.setattr(cli, "_prune_stale_worktrees", lambda *a, **k: None)
+
+        with pytest.raises(SystemExit):
+            main._launch_tui(worktree=True)
+
+        assert captured["sync_base"] is flag


### PR DESCRIPTION
## What does this PR do?

The recent #50355 change taught new worktrees to branch from the freshly
fetched remote tip, and added a `worktree_sync` config toggle so a user who is
offline (or who deliberately wants the clone's exact current state as the base)
can set `worktree_sync: false` to fall back to branching from local `HEAD`.

The catch: that toggle was only wired into the CLI chat path. The CLI chat path
reads it (`CLI_CONFIG.get("worktree_sync", True)`) and forwards it to
`_setup_worktree(sync_base=...)`, but the TUI launch path in
`hermes_cli.main._launch_tui` still called `_setup_worktree()` with no argument.
Since `sync_base` defaults to `True`, a `hermes tui -w` session always tried to
fetch and branch from the remote tip — silently ignoring `worktree_sync: false`.

So the same config key behaved two different ways depending on which entry point
you launched from: respected in `hermes chat -w`, ignored in `hermes tui -w`.
That's exactly the kind of surprise the toggle exists to prevent — picture an
offline user who set it to `false` precisely so worktree creation wouldn't stall
on `git fetch`, only to have the TUI path attempt the fetch anyway.

The fix mirrors what the chat path already does: resolve `worktree_sync` from
config and pass it through as `sync_base`, so both entry points agree.

## Related Issue

N/A — follow-up to #50355.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: in `_launch_tui`, read `worktree_sync` from
  `load_cli_config()` and forward it to `_setup_worktree(sync_base=...)` instead
  of calling `_setup_worktree()` with the implicit default. This matches the CLI
  chat path so the toggle behaves identically across both launchers.
- `tests/cli/test_worktree_sync_base.py`: add `TestTuiLaunchHonorsWorktreeSync`,
  a parametrized regression test that patches `_setup_worktree` to capture the
  forwarded `sync_base` and asserts the TUI launch path passes through both
  `worktree_sync: true` and `worktree_sync: false`.

## How to Test

1. Set `worktree_sync: false` in `~/.hermes/config.yaml`.
2. Before the fix: launching `hermes tui -w` still fetches and branches the
   worktree off the remote tip, ignoring the toggle.
3. After the fix: the TUI worktree branches from local `HEAD`, matching
   `hermes chat -w` with the same config.
4. Automated proof: `scripts/run_tests.sh tests/cli/test_worktree_sync_base.py`
   — the new test fails with the source change stashed and passes with it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new key; `worktree_sync` already documented by #50355)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A