### PR TITLE
fix(agent): surface reasoning as response when model returns empty content

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4347,12 +4347,11 @@ def run_conversation(
                                ". No fallback providers configured.")
                         )
 
-                if reasoning_text and final_response != "(empty)":
-                    # Reasoning text was set as the response above —
-                    # no need for the "(empty)" fallback.
-                    break
-                else:
-                    final_response = "(empty)"
+                    if reasoning_text:
+                        # Reasoning was already set as the response above.
+                        pass
+                    else:
+                        final_response = "(empty)"
                     break
                 
                 # Reset retry counter/signature on successful content

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4347,6 +4347,11 @@ def run_conversation(
                                ". No fallback providers configured.")
                         )
 
+                if reasoning_text and final_response != "(empty)":
+                    # Reasoning text was set as the response above —
+                    # no need for the "(empty)" fallback.
+                    break
+                else:
                     final_response = "(empty)"
                     break
                 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4310,6 +4310,7 @@ def run_conversation(
                     # the user with no visible output at all.
                     if reasoning_text:
                         assistant_msg["content"] = reasoning_text
+                        final_response = reasoning_text
                         # No sentinel — the reasoning becomes the response.
                     else:
                         assistant_msg["content"] = "(empty)"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4213,16 +4213,16 @@ def run_conversation(
                         or getattr(assistant_message, "reasoning_details", None)
                         or _has_inline_thinking
                     )
-                    if _has_structured and agent._thinking_prefill_retries < 2:
+                    if _has_structured and agent._thinking_prefill_retries < 3:
                         agent._thinking_prefill_retries += 1
                         logger.info(
                             "Thinking-only response (no visible content) — "
-                            "prefilling to continue (%d/2)",
+                            "prefilling to continue (%d/3)",
                             agent._thinking_prefill_retries,
                         )
                         agent._buffer_status(
                             f"↻ Thinking-only response — prefilling to continue "
-                            f"({agent._thinking_prefill_retries}/2)"
+                            f"({agent._thinking_prefill_retries}/3)"
                         )
                         interim_msg = agent._build_assistant_message(
                             assistant_message, "incomplete"
@@ -4301,13 +4301,24 @@ def run_conversation(
                     reasoning_text = agent._extract_reasoning(assistant_message)
                     agent._drop_trailing_empty_response_scaffolding(messages)
                     assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                    assistant_msg["content"] = "(empty)"
-                    # This is a user-facing failure sentinel for the gateway,
-                    # not real assistant content. Persisting it makes later
-                    # "continue" turns replay assistant("(empty)") as if it
-                    # were a meaningful model response, which can keep long
-                    # tool-heavy sessions stuck in empty-response loops.
-                    assistant_msg["_empty_terminal_sentinel"] = True
+                    # When the model produces reasoning (thinking) but no
+                    # visible text, surface the reasoning as the response
+                    # rather than returning "(empty)".  DeepSeek V4 Flash
+                    # (opencode-go) and similar reasoning models routinely
+                    # return reasoning_content with empty content — the
+                    # old behaviour of discarding it after all retries left
+                    # the user with no visible output at all.
+                    if reasoning_text:
+                        assistant_msg["content"] = reasoning_text
+                        # No sentinel — the reasoning becomes the response.
+                    else:
+                        assistant_msg["content"] = "(empty)"
+                        # This is a user-facing failure sentinel for the gateway,
+                        # not real assistant content. Persisting it makes later
+                        # "continue" turns replay assistant("(empty)") as if it
+                        # were a meaningful model response, which can keep long
+                        # tool-heavy sessions stuck in empty-response loops.
+                        assistant_msg["_empty_terminal_sentinel"] = True
                     messages.append(assistant_msg)
 
                     if reasoning_text:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3647,9 +3647,9 @@ class TestRunConversation:
             {"role": "assistant", "content": "old answer"},
         ]
 
-        # 6 responses: original + 2 prefill + 3 retries after prefill exhaustion
+        # 7 responses: original + 3 prefill + 3 retries after prefill exhaustion
         with (
-            patch.object(agent, "_interruptible_api_call", side_effect=[empty_resp] * 6),
+            patch.object(agent, "_interruptible_api_call", side_effect=[empty_resp] * 7),
             patch.object(agent, "_compress_context") as mock_compress,
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
@@ -3659,23 +3659,23 @@ class TestRunConversation:
 
         mock_compress.assert_not_called()  # no compression triggered
         assert result["completed"] is True
-        # #34452: the bare "(empty)" sentinel is now replaced by a
-        # user-visible end-of-turn explanation so the failure isn't silent.
+        # Reasoning text is surfaced as the response instead of "(empty)"
+        # when the model returns reasoning_content with empty content.
         assert result["final_response"] != "(empty)"
-        assert "No reply:" in result["final_response"]
+        assert result["final_response"] == "reasoning only"
         assert result["turn_exit_reason"] == "empty_response_exhausted"
-        assert result["api_calls"] == 6  # 1 original + 2 prefill + 3 retries
+        assert result["api_calls"] == 7  # 1 original + 3 prefill + 3 retries
 
     def test_reasoning_only_response_prefill_then_empty(self, agent):
-        """Structured reasoning-only triggers prefill (2), then retries (3), then (empty)."""
+        """Structured reasoning-only triggers prefill (3), then retries (3), then reasoning fallback."""
         self._setup_agent(agent)
         empty_resp = _mock_response(
             content=None,
             finish_reason="stop",
             reasoning_content="structured reasoning answer",
         )
-        # 6 responses: 1 original + 2 prefill + 3 retries after prefill exhaustion
-        agent.client.chat.completions.create.side_effect = [empty_resp] * 6
+        # 7 responses: 1 original + 3 prefill + 3 retries after prefill exhaustion
+        agent.client.chat.completions.create.side_effect = [empty_resp] * 7
         with (
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
@@ -3683,10 +3683,10 @@ class TestRunConversation:
         ):
             result = agent.run_conversation("answer me")
         assert result["completed"] is True
-        # #34452: explanation replaces the bare "(empty)" sentinel.
+        # Reasoning text is surfaced instead of "(empty)".
         assert result["final_response"] != "(empty)"
-        assert "No reply:" in result["final_response"]
-        assert result["api_calls"] == 6  # 1 original + 2 prefill + 3 retries
+        assert result["final_response"] == "structured reasoning answer"
+        assert result["api_calls"] == 7  # 1 original + 3 prefill + 3 retries
 
     def test_reasoning_only_prefill_succeeds_on_continuation(self, agent):
         """When prefill continuation produces content, it becomes the final response."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3640,7 +3640,7 @@ class TestRunConversation:
         empty_resp = _mock_response(
             content=None,
             finish_reason="stop",
-            reasoning_content="reasoning only",
+            reasoning_content="reasoning only content from model",
         )
         prefill = [
             {"role": "user", "content": "old question"},
@@ -3662,7 +3662,7 @@ class TestRunConversation:
         # Reasoning text is surfaced as the response instead of "(empty)"
         # when the model returns reasoning_content with empty content.
         assert result["final_response"] != "(empty)"
-        assert result["final_response"] == "reasoning only"
+        assert result["final_response"] == "reasoning only content from model"
         assert result["turn_exit_reason"] == "empty_response_exhausted"
         assert result["api_calls"] == 7  # 1 original + 3 prefill + 3 retries
 


### PR DESCRIPTION
**Problem:** Users on reasoning models (DeepSeek V4 Flash via opencode-go) frequently see the model produce thinking/reasoning (streamed live) but then get zero visible output. The conversation eventually shows "(empty)" or nothing at all.

**Root cause:** DeepSeek V4 Flash returns responses with `reasoning_content` populated but `content` empty. The conversation loop had 5 cumulative retries for this (2 thinking-prefill retries + 3 empty-response retries). After exhausting all retries, the reasoning was extracted via `_extract_reasoning()` and logged, but then **discarded** -- the assistant message content was hardcoded to `"(empty)"`.

This also explained the "slow reading" issue: when the model spends minutes thinking and then all that thinking is discarded, it looks like the agent read the message but produced nothing.

**Fix (two changes):**

1. When all retries are exhausted and `reasoning_text` exists, use it as the assistant message content instead of `"(empty)"`. The user sees the model's thinking output, which is far better than nothing.

2. Increased thinking-prefill retries from 2 to 3, giving the model one more chance to return visible text before falling through to the empty-response retry loop.

Also includes status/label updates to match the new retry count.
