### PR TITLE
fix(windows): prefer cmd npm shim on PATH fallback

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -290,13 +290,41 @@ def find_hermes_node_executable(command: str) -> str | None:
     return None
 
 
+def find_node_executable_on_path(command: str) -> str | None:
+    """Return a Node/npm executable from PATH with Windows shim ordering.
+
+    ``shutil.which("npm")`` can resolve an extensionless npm shim before the
+    ``.cmd`` shim on Windows. Python's CreateProcess cannot execute that shim
+    directly, so prefer the launchable variants explicitly for Hermes-owned
+    subprocesses.
+    """
+    if sys.platform != "win32":
+        return shutil.which(command)
+
+    command_str = str(command)
+    has_path_separator = any(
+        sep and sep in command_str for sep in (os.sep, os.altsep, "/", "\\")
+    )
+    if has_path_separator:
+        return command_str if Path(command_str).is_file() else None
+
+    for name in _candidate_node_command_names(command_str):
+        for directory in os.environ.get("PATH", "").split(os.pathsep):
+            if not directory:
+                continue
+            candidate = Path(directory) / name
+            if candidate.is_file():
+                return str(candidate)
+    return None
+
+
 def find_node_executable(command: str) -> str | None:
     """Resolve a Node.js command, preferring Hermes-managed installs.
 
     This is for Hermes-owned subprocesses that should not be broken by a bad,
     missing, or elevation-triggering system Node/npm on PATH.
     """
-    return find_hermes_node_executable(command) or shutil.which(command)
+    return find_hermes_node_executable(command) or find_node_executable_on_path(command)
 
 
 def with_hermes_node_path(env: dict[str, str] | None = None) -> dict[str, str]:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -9,6 +9,8 @@ import hermes_constants
 from hermes_constants import (
     VALID_REASONING_EFFORTS,
     find_hermes_node_executable,
+    find_node_executable,
+    find_node_executable_on_path,
     get_default_hermes_root,
     get_hermes_home,
     iter_hermes_node_dirs,
@@ -130,6 +132,35 @@ class TestHermesManagedNode:
         monkeypatch.setenv("HERMES_HOME", str(home))
 
         assert find_hermes_node_executable("npm") == str(npm_cmd)
+
+    def test_windows_path_fallback_prefers_npm_cmd(self, tmp_path, monkeypatch):
+        bin_dir = tmp_path / "nodejs"
+        bin_dir.mkdir()
+        extensionless = bin_dir / "npm"
+        powershell = bin_dir / "npm.ps1"
+        npm_cmd = bin_dir / "npm.cmd"
+        extensionless.write_text("#!/usr/bin/env node\n")
+        powershell.write_text("Write-Output npm\n")
+        npm_cmd.write_text("@echo off\n")
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.setenv("PATH", str(bin_dir))
+
+        assert find_node_executable_on_path("npm") == str(npm_cmd)
+
+    def test_windows_node_executable_falls_back_to_safe_path_shim(self, tmp_path, monkeypatch):
+        home = tmp_path / "hermes"
+        home.mkdir()
+        bin_dir = tmp_path / "nodejs"
+        bin_dir.mkdir()
+        extensionless = bin_dir / "npm"
+        npm_cmd = bin_dir / "npm.cmd"
+        extensionless.write_text("#!/usr/bin/env node\n")
+        npm_cmd.write_text("@echo off\n")
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("PATH", str(bin_dir))
+
+        assert find_node_executable("npm") == str(npm_cmd)
 
     def test_with_hermes_node_path_prepends_existing_managed_dirs(self, tmp_path, monkeypatch):
         home = tmp_path / "hermes"


### PR DESCRIPTION
## What does this PR do?

Fixes Windows Node/npm resolution for Hermes-owned subprocesses when Hermes-managed Node/npm is unavailable and the resolver falls back to system PATH.

`find_node_executable("npm")` already prefers the Hermes-managed `%LOCALAPPDATA%\hermes\node\npm.cmd` path from #49254. If that managed npm is missing or not under the active Hermes home, the fallback still used bare `shutil.which("npm")`. On Windows/NVM installs that can resolve an extensionless `npm` shim before `npm.cmd`, and Python `CreateProcess` rejects that shim with `OSError: [WinError 193] %1 is not a valid Win32 application`.

This PR keeps managed Node/npm first, then makes the PATH fallback use the same Windows-safe command ordering: `npm.cmd`, `npm.exe`, then `npm`.

## Related Issue

Fixes the Desktop rebuild/update failure reported in Discord thread `1518299421673128166`.

Related follow-up to #49254.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_constants.py`: add `find_node_executable_on_path()` so Windows PATH fallback scans launchable Node/npm shims in the same safe order used by the Hermes-managed resolver.
- `hermes_constants.py`: route `find_node_executable()` through the new PATH fallback after the managed lookup.
- `tests/test_hermes_constants.py`: add Windows fallback coverage for PATH entries containing `npm`, `npm.ps1`, and `npm.cmd`, asserting Hermes selects `npm.cmd`.

## How to Test

1. On Windows, use an NVM-style Node install where PATH contains `npm`, `npm.ps1`, and `npm.cmd`, and Hermes-managed npm is absent or not under the active Hermes home.
2. Run `hermes desktop` or trigger a Desktop update rebuild.
3. Hermes should pass `npm.cmd` to the Desktop dependency install instead of the extensionless `npm` shim, avoiding `WinError 193` from `CreateProcess`.

Validation in this checkout:
- `python -m py_compile hermes_constants.py tests/test_hermes_constants.py`
- Lightweight local resolver simulation with `sys.platform = "win32"`, PATH containing `npm`, `npm.ps1`, and `npm.cmd`, and no managed npm present.

Not run:
- `pytest tests/ -q` was not run in this WSL checkout because local full pytest runs are currently avoided here; CI should cover the added unit tests.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I have tested on my platform: WSL/Linux local resolver simulation only; Windows runtime validation still needed

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Original failing stack shape from the support thread:

`hermes desktop` reaches `_run_npm_install_deterministic(npm, PROJECT_ROOT, ...)`, then Python `subprocess.run([npm, "ci"], ...)` fails in `_winapi.CreateProcess` with `OSError: [WinError 193] %1 is not a valid Win32 application`.
