### PR TITLE
fix(config): store JSON array/object values from config set as native YAML

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6776,6 +6776,18 @@ def set_config_value(key: str, value: str):
         value = int(value)
     elif value.replace('.', '', 1).isdigit():
         value = float(value)
+    elif value.lstrip()[:1] in {'[', '{'}:
+        # JSON array/object literal — store as a native list/dict so callers
+        # that expect structured config (e.g. mcp_servers.<name>.args) get a
+        # real YAML list, not a JSON-encoded string. Only applied when the
+        # value actually parses as a JSON list/object; anything else (a plain
+        # string that merely starts with a bracket) is left untouched.
+        try:
+            parsed = json.loads(value)
+        except (ValueError, TypeError):
+            parsed = None
+        if isinstance(parsed, (list, dict)):
+            value = parsed
 
     _set_nested(user_config, key, value)
     

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -301,3 +301,33 @@ class TestSecretRedactionInDisplay:
 
         captured = capsys.readouterr()
         assert "Set model.reasoning_effort = high" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# JSON array/object literals — regression tests for #50168
+# ---------------------------------------------------------------------------
+
+class TestJsonLiteralValues:
+    """A JSON array/object value must be stored as a native YAML list/dict so
+    consumers like mcp_servers.<name>.args receive a real list, not a
+    JSON-encoded string.
+    """
+
+    def test_json_array_becomes_native_list(self, _isolated_hermes_home):
+        import yaml
+        set_config_value("mcp_servers.mimir.args", '["--db","/path/to/db"]')
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["mcp_servers"]["mimir"]["args"] == ["--db", "/path/to/db"]
+
+    def test_json_object_becomes_native_dict(self, _isolated_hermes_home):
+        import yaml
+        set_config_value("mcp_servers.mimir.env", '{"DB_PATH":"/path"}')
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["mcp_servers"]["mimir"]["env"] == {"DB_PATH": "/path"}
+
+    def test_plain_string_with_leading_bracket_is_untouched(self, _isolated_hermes_home):
+        """A non-JSON value that merely starts with '[' stays a string."""
+        import yaml
+        set_config_value("some.note", "[draft] remember this")
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["some"]["note"] == "[draft] remember this"


### PR DESCRIPTION
## Summary

Fixes #50168. `hermes config set mcp_servers.<name>.args '["--db","/path"]'` stored the value as a JSON-encoded **string** instead of a YAML list, because `set_config_value` only coerced `bool`/`int`/`float`. The MCP client then rejected the args:

```
Input should be a valid list [type=list_type, input_value='["--db","/path/to/db"]', input_type=str]
```

This breaks every MCP server configured through `config set`; the only workaround was `mcp remove` + `mcp add`, which has no `--yes` flag and can't be automated.

## Fix

When the value is a JSON array/object literal that parses cleanly, store the parsed `list`/`dict` so it round-trips as native YAML:

```yaml
mcp_servers:
  mimir:
    args:
    - --db
    - /path/to/db
```

A plain string that merely starts with `[`/`{` but isn't valid JSON is left untouched, so existing string values (e.g. `"[draft] note"`) are unaffected.

## Tests

`tests/hermes_cli/test_set_config_value.py::TestJsonLiteralValues`:
- JSON array → native list
- JSON object → native dict
- non-JSON leading-bracket string → unchanged
