### PR TITLE
fix(approval): check cron_mode before HERMES_EXEC_ASK in check_all_command_guards

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1414,6 +1414,28 @@ def check_all_command_guards(command: str, env_type: str,
     if _command_matches_permanent_allowlist(command):
         return {"approved": True, "message": None}
 
+    # Cron sessions: respect cron_mode config.
+    # Check BEFORE the is_cli/is_gateway/is_ask branching because
+    # HERMES_EXEC_ASK leaks from the gateway process env into cron jobs
+    # (cron runs inside the gateway), which would otherwise bypass the
+    # cron guard and submit a pending approval with no listener (#34519).
+    if env_var_enabled("HERMES_CRON_SESSION"):
+        if _get_cron_approval_mode() == "deny":
+            # Run detection to get a description for the block message
+            is_dangerous, _pk, description = detect_dangerous_command(command)
+            if is_dangerous:
+                return {
+                    "approved": False,
+                    "message": (
+                        f"BLOCKED: Command flagged as dangerous ({description}) "
+                        "but cron jobs run without a user present to approve it. "
+                        "Find an alternative approach that avoids this command. "
+                        "To allow dangerous commands in cron jobs, set "
+                        "approvals.cron_mode: approve in config.yaml."
+                    ),
+                }
+        return {"approved": True, "message": None}
+
     is_cli = env_var_enabled("HERMES_INTERACTIVE")
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
@@ -1421,22 +1443,6 @@ def check_all_command_guards(command: str, env_type: str,
     # Preserve the existing non-interactive behavior: outside CLI/gateway/ask
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:
-        # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
-            if _get_cron_approval_mode() == "deny":
-                # Run detection to get a description for the block message
-                is_dangerous, _pk, description = detect_dangerous_command(command)
-                if is_dangerous:
-                    return {
-                        "approved": False,
-                        "message": (
-                            f"BLOCKED: Command flagged as dangerous ({description}) "
-                            "but cron jobs run without a user present to approve it. "
-                            "Find an alternative approach that avoids this command. "
-                            "To allow dangerous commands in cron jobs, set "
-                            "approvals.cron_mode: approve in config.yaml."
-                        ),
-                    }
         return {"approved": True, "message": None}
 
     # --- Phase 1: Gather findings from both checks ---


### PR DESCRIPTION
## Problem

Cron jobs running inside the gateway process hit a 300s approval timeout ("BLOCKED: Command timed out without user response") when executing commands flagged by the security scan, even with `approvals.cron_mode: allow` set in config.

## Root Cause

`HERMES_EXEC_ASK=1` is set by the gateway process at startup (`gateway/run.py:1644`). Since cron jobs run inside the gateway, they inherit this env var.

In `check_all_command_guards()`, the cron guard was nested inside:
```python
if not is_cli and not is_gateway and not is_ask:
    # Cron sessions: respect cron_mode config
    if env_var_enabled("HERMES_CRON_SESSION"):
        ...
```

Because `is_ask = env_var_enabled("HERMES_EXEC_ASK")` was `True` (leaked from the gateway env), the `not is_ask` condition was `False`, so the entire cron guard block was unreachable.

Instead, the code fell through to:
```python
if is_gateway or is_ask:
    # gateway/ask approval path — submits pending approval
```

Since cron jobs have no user present to respond, the pending approval timed out after 300s.

## Fix

Move the `HERMES_CRON_SESSION` cron_mode check **before** the `is_cli/is_gateway/is_ask` branching, matching the pattern already used in `check_execute_code_guard()` (line ~1714).

## Why `check_dangerous_command()` is NOT affected

`check_dangerous_command()` uses `if not is_cli and not is_gateway:` — no `not is_ask` — so its cron guard runs correctly regardless of `HERMES_EXEC_ASK`.

## Testing

- Created a cron job that runs a security-scan-flagged command (`python3 /root/venice/scripts/tg_send.py`)
- Before fix: 300s timeout, "BLOCKED: Command timed out without user response"
- After fix: command executes immediately (auto-approved via `cron_mode: allow`), no timeout
- Also verified `cron_mode: deny` still blocks dangerous commands correctly
