### PR TITLE
fix(skills): coerce scalar tool/toolset conditions to lists

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -510,6 +510,32 @@ def get_all_skills_dirs() -> List[Path]:
 # ── Condition extraction ──────────────────────────────────────────────────
 
 
+def _normalize_condition_list(value: Any) -> List[str]:
+    """Coerce a frontmatter condition value into a list of tool/toolset names.
+
+    Frontmatter may declare a condition as a scalar
+    (``requires_tools: web_search``) or a list
+    (``requires_tools: [web_search]``). Mirror the ``platforms`` handling and
+    accept both — a bare string becomes a single-element list. Without this,
+    downstream iteration in ``_skill_should_show`` walks the *characters* of a
+    scalar string, silently mis-gating the skill (a ``requires_*`` skill is
+    hidden even when its tool is present; a ``fallback_for_*`` skill is shown
+    even when the primary tool is present).
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [value]
+    elif not isinstance(value, (list, tuple)):
+        return []
+    out: List[str] = []
+    for item in value:
+        text = str(item).strip()
+        if text:
+            out.append(text)
+    return out
+
+
 def extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, List]:
     """Extract conditional activation fields from parsed frontmatter."""
     metadata = frontmatter.get("metadata")
@@ -520,10 +546,10 @@ def extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, List]:
     if not isinstance(hermes, dict):
         hermes = {}
     return {
-        "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
-        "requires_toolsets": hermes.get("requires_toolsets", []),
-        "fallback_for_tools": hermes.get("fallback_for_tools", []),
-        "requires_tools": hermes.get("requires_tools", []),
+        "fallback_for_toolsets": _normalize_condition_list(hermes.get("fallback_for_toolsets")),
+        "requires_toolsets": _normalize_condition_list(hermes.get("requires_toolsets")),
+        "fallback_for_tools": _normalize_condition_list(hermes.get("fallback_for_tools")),
+        "requires_tools": _normalize_condition_list(hermes.get("requires_tools")),
     }
 
 

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -69,6 +69,63 @@ def test_metadata_missing_entirely():
     }
 
 
+def test_scalar_condition_coerced_to_single_element_list():
+    """A scalar condition value must become a one-element list, not be iterated
+    per-character. Mirrors how ``platforms`` already coerces str -> [str]."""
+    frontmatter = {
+        "metadata": {
+            "hermes": {
+                "requires_tools": "web_search",
+                "fallback_for_toolsets": "coding",
+            }
+        }
+    }
+    result = extract_skill_conditions(frontmatter)
+    assert result["requires_tools"] == ["web_search"]
+    assert result["fallback_for_toolsets"] == ["coding"]
+    assert result["requires_toolsets"] == []
+    assert result["fallback_for_tools"] == []
+
+
+def test_condition_list_entries_are_stringified_and_stripped():
+    """List entries are coerced to trimmed strings; blanks are dropped."""
+    frontmatter = {
+        "metadata": {
+            "hermes": {
+                "requires_tools": ["  web_search  ", "", "patch"],
+            }
+        }
+    }
+    result = extract_skill_conditions(frontmatter)
+    assert result["requires_tools"] == ["web_search", "patch"]
+
+
+def test_scalar_requires_tools_does_not_hide_skill_when_tool_present():
+    """End-to-end: a scalar ``requires_tools`` must gate on the whole tool name.
+
+    Before coercion, ``_skill_should_show`` iterated the characters of the
+    string ``"web_search"`` and hid the skill even when ``web_search`` was
+    available; a fallback skill was likewise shown even when its primary tool
+    existed."""
+    from agent.prompt_builder import _skill_should_show
+
+    requires = extract_skill_conditions(
+        {"metadata": {"hermes": {"requires_tools": "web_search"}}}
+    )
+    # web_search IS available -> the skill should be shown.
+    assert _skill_should_show(requires, {"web_search"}, set()) is True
+    # web_search is NOT available -> the skill should be hidden.
+    assert _skill_should_show(requires, {"patch"}, set()) is False
+
+    fallback = extract_skill_conditions(
+        {"metadata": {"hermes": {"fallback_for_tools": "terminal"}}}
+    )
+    # terminal IS available -> the fallback skill should be hidden.
+    assert _skill_should_show(fallback, {"terminal"}, set()) is False
+    # terminal is NOT available -> the fallback skill should be shown.
+    assert _skill_should_show(fallback, {"patch"}, set()) is True
+
+
 def test_iter_skill_index_files_prunes_dependency_dirs(tmp_path):
     real = tmp_path / "real-skill"
     real.mkdir()


### PR DESCRIPTION
A skill can gate its visibility with metadata.hermes.requires_tools,
requires_toolsets, fallback_for_tools, and fallback_for_toolsets. The
docs show these as lists, but YAML happily accepts a scalar
(`requires_tools: web_search`). extract_skill_conditions returned that
scalar untouched, and _skill_should_show then iterated it — walking the
*characters* of the string. So `requires_tools: web_search` hid the
skill even when web_search was available (none of "w", "e", "b"... is a
tool), and `fallback_for_tools: terminal` showed the fallback even when
terminal was present. The `platforms` field already coerces str -> list;
conditions did not, which is the inconsistency this fixes.

extract_skill_conditions now normalizes every condition value the same
way platforms is normalized: a bare string becomes a one-element list,
non-string scalars are dropped, and list entries are stringified,
trimmed, and de-blanked. Both the cold filesystem scan and the disk
snapshot fast path read conditions through this function, so both paths
gate correctly after the fix.

## What does this PR do?

Fixes skill visibility gating when a skill declares its tool/toolset
conditions as a YAML scalar instead of a list. Scalars are now coerced
to single-element lists, matching the existing `platforms` behavior, so
`requires_*` and `fallback_for_*` gate on the whole tool name rather
than per character.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_utils.py`: add `_normalize_condition_list()` and route
  all four condition fields in `extract_skill_conditions()` through it
  (scalar -> `[scalar]`, stringify/trim/drop blanks, non-list/non-str
  -> `[]`).
- `tests/agent/test_skill_utils.py`: cover scalar coercion, list
  stringify/strip, and end-to-end `_skill_should_show` gating for both
  `requires_tools` and `fallback_for_tools`.

## How to Test

1. `python3 -m pytest tests/agent/test_skill_utils.py tests/agent/test_prompt_builder.py -q` — all pass.
2. Repro before the fix: `extract_skill_conditions({"metadata": {"hermes": {"requires_tools": "web_search"}}})` yields `requires_tools="web_search"`, and `_skill_should_show(..., {"web_search"}, set())` returns False (skill wrongly hidden).
3. After the fix: the same call yields `["web_search"]` and `_skill_should_show` returns True; a scalar `fallback_for_tools: terminal` now correctly hides the fallback when `terminal` is available.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the test suite and the affected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A