### PR TITLE
fix(desktop): tolerate missing memory provider config endpoint

### DIFF
--- a/apps/desktop/src/app/settings/provider-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/provider-config-panel.test.tsx
@@ -5,6 +5,7 @@ import type { MemoryProviderConfig } from '@/types/hermes'
 
 const getMemoryProviderConfig = vi.fn()
 const saveMemoryProviderConfig = vi.fn()
+const notifyError = vi.fn()
 
 vi.mock('@/hermes', () => ({
   getMemoryProviderConfig: (provider: string) => getMemoryProviderConfig(provider),
@@ -13,7 +14,7 @@ vi.mock('@/hermes', () => ({
 
 vi.mock('@/store/notifications', () => ({
   notify: vi.fn(),
-  notifyError: vi.fn()
+  notifyError: (err: unknown, fallback: string) => notifyError(err, fallback)
 }))
 
 function hindsightSchema(overrides: Partial<MemoryProviderConfig['fields'][number]>[] = []): MemoryProviderConfig {
@@ -138,5 +139,15 @@ describe('ProviderConfigPanel', () => {
 
     await waitFor(() => expect(getMemoryProviderConfig).toHaveBeenCalledWith('builtin'))
     expect(container.querySelector('section')).toBeNull()
+  })
+
+  it('silently hides provider settings when an older backend lacks the config endpoint', async () => {
+    getMemoryProviderConfig.mockRejectedValue(new Error('No such API endpoint: /api/memory/providers/mnemosyne/config'))
+
+    const { container } = await renderPanel('mnemosyne')
+
+    await waitFor(() => expect(getMemoryProviderConfig).toHaveBeenCalledWith('mnemosyne'))
+    expect(container.querySelector('section')).toBeNull()
+    expect(notifyError).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/settings/provider-config-panel.tsx
+++ b/apps/desktop/src/app/settings/provider-config-panel.tsx
@@ -20,6 +20,15 @@ function seedValues(config: MemoryProviderConfig): Record<string, string> {
   )
 }
 
+function isProviderConfigEndpointUnavailable(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : typeof err === 'string' ? err : ''
+
+  return (
+    /no such api endpoint|endpoint is likely missing/i.test(message) ||
+    (/\b404\b/.test(message) && /\/api\/memory\/providers\/[^/]+\/config/.test(message))
+  )
+}
+
 function FieldControl({
   field,
   value,
@@ -95,6 +104,15 @@ export function ProviderConfigPanel({ provider }: { provider: string }) {
       setConfig(next)
       setValues(seedValues(next))
     } catch (err) {
+      if (isProviderConfigEndpointUnavailable(err)) {
+        // Older/remote Hermes backends may not expose the generic config API yet.
+        // Treat that the same as a provider with no declared config surface.
+        setConfig({ name: provider, label: provider, fields: [] })
+        setValues({})
+
+        return
+      }
+
       notifyError(err, 'Memory provider settings failed to load')
       setConfig(null)
     }

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSessionMessages, listAllProfileSessions, listSessions } from './hermes'
+import {
+  getMemoryProviderConfig,
+  getSessionMessages,
+  listAllProfileSessions,
+  listSessions,
+  setApiRequestProfile
+} from './hermes'
 
 const emptySessionsResponse = {
   limit: 0,
@@ -21,6 +27,7 @@ describe('Hermes REST session helpers', () => {
   })
 
   afterEach(() => {
+    setApiRequestProfile(null)
     vi.restoreAllMocks()
     Reflect.deleteProperty(window, 'hermesDesktop')
   })
@@ -55,6 +62,18 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
+    })
+  })
+
+  it('tags memory provider config reads for the selected profile backend', async () => {
+    api.mockResolvedValue({ name: 'mnemosyne', label: 'mnemosyne', fields: [] })
+    setApiRequestProfile('work')
+
+    await getMemoryProviderConfig('mnemosyne')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/memory/providers/mnemosyne/config',
+      profile: 'work'
     })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -343,6 +343,7 @@ export function saveHermesConfig(config: HermesConfigRecord): Promise<{ ok: bool
 
 export function getMemoryProviderConfig(provider: string): Promise<MemoryProviderConfig> {
   return window.hermesDesktop.api<MemoryProviderConfig>({
+    ...profileScoped(),
     path: `/api/memory/providers/${encodeURIComponent(provider)}/config`
   })
 }
@@ -352,6 +353,7 @@ export function saveMemoryProviderConfig(
   values: Record<string, string>
 ): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
+    ...profileScoped(),
     path: `/api/memory/providers/${encodeURIComponent(provider)}/config`,
     method: 'PUT',
     body: { values }


### PR DESCRIPTION
## Summary
- Hide the desktop memory-provider config panel when the backend does not expose the generic provider config endpoint, instead of showing a false error toast.
- Route memory-provider config GET/PUT requests through the selected desktop profile, matching the rest of profile-scoped settings.
- Add regression coverage for missing endpoint handling and profile-scoped provider config reads.

## Test plan
- `npm run test:ui -- src/app/settings/provider-config-panel.test.tsx src/hermes.test.ts`
- `npm run typecheck`
- `npx eslint src/hermes.ts src/hermes.test.ts src/app/settings/provider-config-panel.tsx src/app/settings/provider-config-panel.test.tsx`

## Notes
Observed from desktop settings with `memory.provider=mnemosyne`: the UI tried to load `/api/memory/providers/mnemosyne/config` and showed a persistent error toast when that endpoint was unavailable. Providers without a declared config surface already render nothing when the backend returns an empty schema; this makes unavailable provider-config endpoints follow the same no-panel behavior.
