### PR TITLE
fix(security): handle IPv6 scope IDs in URL safety checks to prevent bypass (#25961)

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -164,6 +164,31 @@ class TestIsSafeUrl:
         ]):
             assert is_safe_url("http://[::ffff:169.254.169.254]/") is False
 
+    def test_ipv6_scope_id_link_local_blocked(self):
+        """fe80::1%eth0 — a scope-ID-bearing link-local address must not bypass
+        the guard. ``ipaddress.ip_address`` rejects the ``%scope`` suffix, so
+        the scope must be stripped before the block check rather than skipped.
+        """
+        with patch("socket.getaddrinfo", return_value=[
+            (10, 1, 6, "", ("fe80::1%eth0", 0, 0, 0)),
+        ]):
+            assert is_safe_url("http://[fe80::1%eth0]/") is False
+
+    def test_ipv6_scope_id_loopback_blocked(self):
+        """::1%lo — scoped IPv6 loopback must still be blocked."""
+        with patch("socket.getaddrinfo", return_value=[
+            (10, 1, 6, "", ("::1%lo", 0, 0, 0)),
+        ]):
+            assert is_safe_url("http://[::1%lo]/") is False
+
+    def test_unparseable_ip_after_scope_strip_fails_closed(self):
+        """An address that is still unparseable after stripping the scope ID
+        must fail closed (block), not be silently skipped."""
+        with patch("socket.getaddrinfo", return_value=[
+            (10, 1, 6, "", ("not-an-ip%garbage", 0, 0, 0)),
+        ]):
+            assert is_safe_url("http://example.invalid/") is False
+
     def test_unspecified_address_blocked(self):
         """0.0.0.0 — unspecified address, can bind to all interfaces."""
         with patch("socket.getaddrinfo", return_value=[
@@ -489,6 +514,15 @@ class TestIsAlwaysBlockedUrl:
         """Attacker-controlled hostname resolving to IMDS still blocks."""
         with patch("socket.getaddrinfo", return_value=[
             (2, 1, 6, "", ("169.254.169.254", 0)),
+        ]):
+            assert is_always_blocked_url("http://attacker-controlled.example.com/") is True
+
+    def test_scope_id_imds_in_floor_blocked(self):
+        """A scope-ID suffix on an IPv4-mapped IMDS address resolving in the
+        always-blocked floor must be caught after the scope is stripped, not
+        skipped as unparseable."""
+        with patch("socket.getaddrinfo", return_value=[
+            (10, 1, 6, "", ("::ffff:169.254.169.254%eth0", 0, 0, 0)),
         ]):
             assert is_always_blocked_url("http://attacker-controlled.example.com/") is True
 

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -282,9 +282,12 @@ def is_always_blocked_url(url: str) -> bool:
 
         for _family, _, _, _, sockaddr in addr_info:
             ip_str = sockaddr[0]
+            if '%' in ip_str:
+                ip_str = ip_str.split('%')[0]
             try:
                 resolved = ipaddress.ip_address(ip_str)
             except ValueError:
+                logger.warning("Unparseable IP address %r for hostname %s — skipping address", sockaddr[0], hostname)
                 continue
             if resolved in _ALWAYS_BLOCKED_IPS or any(
                 resolved in net for net in _ALWAYS_BLOCKED_NETWORKS
@@ -353,10 +356,14 @@ def is_safe_url(url: str) -> bool:
 
         for family, _, _, _, sockaddr in addr_info:
             ip_str = sockaddr[0]
+            if '%' in ip_str:
+                ip_str = ip_str.split('%')[0]
             try:
                 ip = ipaddress.ip_address(ip_str)
             except ValueError:
-                continue
+                # Still unparseable after scope ID strip — fail closed
+                logger.warning("Blocked request — unparseable IP address %r for hostname %s", sockaddr[0], hostname)
+                return False
 
             # Always block cloud metadata IPs and link-local, even with toggle on
             if ip in _ALWAYS_BLOCKED_IPS or any(ip in net for net in _ALWAYS_BLOCKED_NETWORKS):


### PR DESCRIPTION
## Summary
A hostname that resolves to a scope-ID-bearing IPv6 address (e.g. `fe80::1%eth0`) can no longer bypass the SSRF guards — the scope is stripped before parsing, and a still-unparseable address fails closed.

Root cause: `ipaddress.ip_address("fe80::1%eth0")` raises `ValueError`, and both block-check loops in `tools/url_safety.py` caught that with `except ValueError: continue` — silently skipping the address. In `is_safe_url` that's a fail-open (a scoped link-local/private address slips the private-IP guard); in the `is_always_blocked_url` metadata floor, a scoped IPv4-mapped IMDS address slips the floor.

## Changes
- `tools/url_safety.py`: strip the `%scope` suffix (`ip_str.split('%')[0]`) before `ipaddress.ip_address()` in both `is_always_blocked_url` and `is_safe_url`; `is_safe_url` now fails closed (`return False`) on a residual unparseable address instead of `continue`; warning logged on the unparseable path.
- `tests/tools/test_url_safety.py`: 4 regression tests — scoped link-local + scoped loopback blocked by `is_safe_url`, still-unparseable address fails closed, scoped IPv4-mapped IMDS caught by the always-blocked floor.

## Validation
| | Before | After |
|---|---|---|
| `fe80::1%eth0` via `is_safe_url` | skipped → allowed | scope stripped → blocked |
| `::1%lo` via `is_safe_url` | skipped → allowed | blocked |
| unparseable after strip | skipped → allowed | fail-closed (blocked) |
| `::ffff:169.254.169.254%eth0` via floor | skipped | blocked |
| `tests/tools/test_url_safety.py` | — | 122/122 pass |

Salvaged from #25961 by @sprmn24 — fix commit cherry-picked onto current main with authorship preserved; regression tests added on top.

## Infographic

![ipv6-scope-id-url-guard](https://v3b.fal.media/files/b/0a9f3ac9/tQVlwWtfpD7cmpchkSyg0_1TII3t7q.png)
