### PR TITLE
fix(fallback): resolve custom provider api_key from credential pool

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3804,6 +3804,25 @@ def resolve_provider_client(
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
                 custom_key = os.getenv(custom_key_env, "").strip()
+            # Fall back to credential pool when config/env has no key.
+            # The pool holds per-provider secrets (manual, env-seeded, etc.)
+            # and is the authoritative source in profile-inheritance mode.
+            if not custom_key:
+                try:
+                    from agent.credential_pool import load_pool as _pool_load
+                    # Provider name may have been normalized (custom: prefix
+                    # stripped). The pool indexes on the custom: name, so try
+                    # both the normalized and original forms.
+                    for _pool_name in {provider, original_provider}:
+                        _pool = _pool_load(_pool_name)
+                        if _pool and _pool.has_credentials():
+                            _pool_entry = _pool.select()
+                            if _pool_entry:
+                                custom_key = str(getattr(_pool_entry, "runtime_api_key", "") or "").strip()
+                                if custom_key:
+                                    break
+                except Exception:
+                    pass
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(


### PR DESCRIPTION
## What does this PR do?

When `resolve_provider_client` can't find an `api_key` in config or environment variables for a custom provider, it now falls back to the credential pool. This is the authoritative source in profile-inheritance mode — env-seeded and manual credentials live there, not in per-profile `.env` files.

The fix tries both the normalized provider name and the original (with `custom:` prefix) to handle the pool's indexing scheme.

## Related Issue

Fixes credential pool lookup failure for custom providers when the `api_key` is stored in the pool but not in config/env.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Added credential pool fallback in `resolve_provider_client` when config/env has no `api_key` for custom providers. Tries both normalized and `custom:`-prefixed provider names.

## How to Test

1. Configure a custom provider (e.g. `custom:opencode`) with `api_key` stored in the credential pool but NOT in config.yaml or env vars
2. Before this fix: custom provider fails with missing API key
3. After this fix: custom provider resolves the key from the credential pool and connects successfully

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've tested on my platform: Ubuntu 24.04 (ARM, Oracle Cloud)

### Documentation & Housekeeping

- [x] N/A — no config key changes, no doc changes needed for this internal fallback