### PR TITLE
feat(curator): support reasoning effort override

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -30,7 +30,11 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set
 
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    parse_reasoning_effort,
+    resolve_reasoning_config,
+)
 from tools import skill_usage
 from utils import atomic_json_write
 
@@ -52,6 +56,7 @@ class _ReviewRuntimeBinding(NamedTuple):
     explicit_api_key: Optional[str]
     explicit_base_url: Optional[str]
     request_overrides: Dict[str, Any]
+    reasoning_config: Optional[Dict[str, Any]]
 
 
 def _merge_request_overrides(
@@ -1757,6 +1762,72 @@ def run_curator_review(
     }
 
 
+def _parse_review_reasoning_source(
+    source: str,
+    value: Any,
+    *,
+    warn_invalid: bool = True,
+) -> tuple[Optional[Dict[str, Any]], bool, bool]:
+    """Return ``(parsed, present, invalid)`` for one reasoning setting."""
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return None, False, False
+    parsed = parse_reasoning_effort(value)
+    if parsed is None:
+        if warn_invalid:
+            logger.warning(
+                "curator: invalid %s.reasoning_effort=%r; falling back",
+                source,
+                value,
+            )
+        return None, True, True
+    return parsed, True, False
+
+
+def _resolve_review_reasoning_config(
+    cfg: Dict[str, Any],
+    model: str = "",
+    *,
+    log_messages: bool = True,
+) -> Optional[Dict[str, Any]]:
+    """Resolve normalized reasoning for the curator review fork.
+
+    Canonical ``auxiliary.curator`` wins over the deprecated legacy slot. A
+    present-but-invalid canonical value skips legacy to avoid reviving stale
+    configuration, then falls back to the model-aware agent reasoning resolver.
+    """
+    aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
+    task = aux.get("curator", {}) if isinstance(aux.get("curator"), dict) else {}
+    parsed, canonical_present, canonical_invalid = _parse_review_reasoning_source(
+        "auxiliary.curator",
+        task.get("reasoning_effort"),
+        warn_invalid=log_messages,
+    )
+    if canonical_present and not canonical_invalid:
+        return parsed
+
+    curator_cfg = cfg.get("curator", {}) if isinstance(cfg.get("curator"), dict) else {}
+    legacy = (
+        curator_cfg.get("auxiliary", {})
+        if isinstance(curator_cfg.get("auxiliary"), dict)
+        else {}
+    )
+    if not canonical_present:
+        parsed, legacy_present, legacy_invalid = _parse_review_reasoning_source(
+            "curator.auxiliary",
+            legacy.get("reasoning_effort"),
+            warn_invalid=log_messages,
+        )
+        if legacy_present and not legacy_invalid:
+            if log_messages:
+                logger.info(
+                    "curator: using deprecated curator.auxiliary.reasoning_effort "
+                    "config — please migrate to auxiliary.curator.reasoning_effort"
+                )
+            return parsed
+
+    return resolve_reasoning_config(cfg, model, warn_invalid=log_messages)
+
+
 def _resolve_review_runtime(cfg: Dict[str, Any]) -> _ReviewRuntimeBinding:
     """Resolve provider/model and per-slot credentials for the curator review fork.
 
@@ -1768,7 +1839,6 @@ def _resolve_review_runtime(cfg: Dict[str, Any]) -> _ReviewRuntimeBinding:
     _main = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     _main_provider = _main.get("provider") or "auto"
     _main_model = _main.get("default") or _main.get("model") or ""
-
     # 1. Canonical aux task slot
     _aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
     _cur_task = _aux.get("curator", {}) if isinstance(_aux.get("curator"), dict) else {}
@@ -1781,6 +1851,7 @@ def _resolve_review_runtime(cfg: Dict[str, Any]) -> _ReviewRuntimeBinding:
             _strip_aux_credential(_cur_task.get("api_key")),
             _strip_aux_credential(_cur_task.get("base_url")),
             _merge_request_overrides({}, _cur_task.get("extra_body")),
+            _resolve_review_reasoning_config(cfg, _task_model),
         )
 
     # 2. Legacy curator.auxiliary.{provider,model} (deprecated, pre-unification)
@@ -1799,10 +1870,18 @@ def _resolve_review_runtime(cfg: Dict[str, Any]) -> _ReviewRuntimeBinding:
             _strip_aux_credential(_legacy.get("api_key")),
             _strip_aux_credential(_legacy.get("base_url")),
             _merge_request_overrides({}, _legacy.get("extra_body")),
+            _resolve_review_reasoning_config(cfg, str(_legacy_model)),
         )
 
     # 3. Fall through to the main chat model
-    return _ReviewRuntimeBinding(_main_provider, _main_model, None, None, {})
+    return _ReviewRuntimeBinding(
+        _main_provider,
+        _main_model,
+        None,
+        None,
+        {},
+        _resolve_review_reasoning_config(cfg, _main_model),
+    )
 
 
 def _resolve_review_model(cfg: Dict[str, Any]) -> tuple[str, str]:
@@ -1874,12 +1953,14 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     _acp_command = None
     _acp_args = None
     _model_name = ""
+    _reasoning_config = None
     try:
         from hermes_cli.config import load_config_readonly
         from hermes_cli.runtime_provider import resolve_runtime_provider
         _cfg = load_config_readonly()
         _binding = _resolve_review_runtime(_cfg)
         _provider, _model_name = _binding.provider, _binding.model
+        _reasoning_config = _binding.reasoning_config
         _rp = resolve_runtime_provider(
             requested=_provider,
             target_model=_model_name,
@@ -1899,7 +1980,14 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         _acp_command = _rp.get("command")
         _acp_args = list(_rp.get("args") or [])
         if isinstance(_rp.get("model"), str) and _rp["model"].strip():
-            _model_name = _rp["model"].strip()
+            _resolved_model = _rp["model"].strip()
+            if _resolved_model != _model_name:
+                _model_name = _resolved_model
+                _reasoning_config = _resolve_review_reasoning_config(
+                    _cfg,
+                    _model_name,
+                    log_messages=False,
+                )
     except Exception as e:
         logger.debug("Curator provider resolution failed: %s", e, exc_info=True)
 
@@ -1922,6 +2010,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             api_mode=_api_mode,
             credential_pool=_credential_pool,
             request_overrides=_request_overrides,
+            reasoning_config=_reasoning_config,
             **_agent_kwargs,
             # Umbrella-building over a large skill collection is worth a
             # high iteration ceiling — the pass typically takes 50-100

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -608,7 +608,9 @@ prompt_caching:
 #     download_timeout: 30   # Image HTTP download timeout (seconds)
 #                            # Increase for slow connections or self-hosted image servers
 #     reasoning_effort: ""   # Per-task thinking level: none, minimal, low, medium,
-#                            # high, xhigh, max, ultra. Empty = provider default.
+#                            # high, xhigh, max, ultra. Empty = provider default,
+#                            # except curator, which inherits the effective agent
+#                            # reasoning for its selected model before that default.
 #                            # Works on every auxiliary task block (vision,
 #                            # web_extract, compression, title_generation, curator,
 #                            # background_review, moa_reference, ...). Example: run
@@ -634,6 +636,14 @@ prompt_caching:
 #     model: ""
 #     timeout: 30
 #     language: ""           # empty = match the user's language; or e.g. "English"
+#
+#   # Curator LLM consolidation/review fork
+#   curator:
+#     provider: "auto"       # inherit the main chat provider/model
+#     model: ""
+#     timeout: 600            # reviews can take several minutes
+#     reasoning_effort: ""    # inherit agent.reasoning_effort, then provider default
+#                             # set "none" to disable reasoning for this fork
 #
 #   # Session search — summarizes matching past sessions
 #   session_search:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -977,7 +977,12 @@ def resolve_per_model_reasoning_effort(model: str, overrides: dict | None) -> di
     return None
 
 
-def resolve_reasoning_config(cfg: dict | None, model: str = "") -> dict | None:
+def resolve_reasoning_config(
+    cfg: dict | None,
+    model: str = "",
+    *,
+    warn_invalid: bool = True,
+) -> dict | None:
     """Resolve the effective reasoning config for *model* from a config dict.
 
     Single chokepoint for reasoning-effort resolution, shared by every
@@ -999,6 +1004,9 @@ def resolve_reasoning_config(cfg: dict | None, model: str = "") -> dict | None:
         model: The effective model for this surface/session. When empty,
                it is derived from the config's ``model`` section (string
                form, or a dict's ``default``/``model`` keys).
+        warn_invalid: Emit the invalid-global-effort warning. Callers doing a
+                      silent recomputation can disable it after the original
+                      configuration read has already logged the problem.
 
     Returns:
         The parsed reasoning config dict, or None when unset/unrecognized
@@ -1030,7 +1038,7 @@ def resolve_reasoning_config(cfg: dict | None, model: str = "") -> dict | None:
     # who explicitly disabled it.
     effort = agent_cfg.get("reasoning_effort", "")
     result = parse_reasoning_effort(effort)
-    if effort and str(effort).strip() and result is None:
+    if warn_invalid and effort and str(effort).strip() and result is None:
         import logging
         logging.getLogger(__name__).warning(
             "Unknown reasoning_effort '%s', using default (medium)", effort

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -7,6 +7,7 @@ tests run fully offline and the curator module doesn't need real credentials.
 from __future__ import annotations
 
 import importlib
+import logging
 import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -450,6 +451,104 @@ def test_cli_pin_refuses_bundled_skill(curator_env, capsys):
 
 
 
+@pytest.mark.parametrize(
+    "cfg,expected",
+    [
+        ({}, None),
+        (
+            {"agent": {"reasoning_effort": "high"}},
+            {"enabled": True, "effort": "high"},
+        ),
+        (
+            {
+                "agent": {"reasoning_effort": "high"},
+                "auxiliary": {"curator": {"reasoning_effort": "xhigh"}},
+            },
+            {"enabled": True, "effort": "xhigh"},
+        ),
+        (
+            {
+                "agent": {"reasoning_effort": "high"},
+                "auxiliary": {"curator": {"reasoning_effort": "none"}},
+            },
+            {"enabled": False},
+        ),
+        (
+            {
+                "agent": {"reasoning_effort": "high"},
+                "auxiliary": {"curator": {"reasoning_effort": False}},
+            },
+            {"enabled": False},
+        ),
+        (
+            {
+                "agent": {"reasoning_effort": "medium"},
+                "curator": {"auxiliary": {"reasoning_effort": "xhigh"}},
+            },
+            {"enabled": True, "effort": "xhigh"},
+        ),
+    ],
+)
+def test_review_reasoning_resolution(curator_env, cfg, expected):
+    curator = curator_env["curator"]
+
+    assert curator._resolve_review_reasoning_config(cfg) == expected
+
+
+def test_review_reasoning_canonical_wins_over_legacy(curator_env):
+    curator = curator_env["curator"]
+    cfg = {
+        "agent": {"reasoning_effort": "medium"},
+        "auxiliary": {"curator": {"reasoning_effort": "high"}},
+        "curator": {"auxiliary": {"reasoning_effort": "xhigh"}},
+    }
+
+    assert curator._resolve_review_reasoning_config(cfg) == {
+        "enabled": True,
+        "effort": "high",
+    }
+
+
+def test_invalid_canonical_reasoning_skips_legacy_and_falls_back_to_agent(
+    curator_env,
+    caplog,
+):
+    """A malformed canonical value must not resurrect deprecated legacy config."""
+    import logging
+
+    curator = curator_env["curator"]
+    cfg = {
+        "agent": {"reasoning_effort": "low"},
+        "auxiliary": {"curator": {"reasoning_effort": "turbo"}},
+        "curator": {"auxiliary": {"reasoning_effort": "xhigh"}},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="agent.curator"):
+        assert curator._resolve_review_reasoning_config(cfg) == {
+            "enabled": True,
+            "effort": "low",
+        }
+    assert any(
+        "invalid auxiliary.curator.reasoning_effort" in record.message
+        for record in caplog.records
+    )
+
+
+def test_legacy_review_reasoning_logs_deprecation(curator_env, caplog):
+    import logging
+
+    curator = curator_env["curator"]
+    cfg = {"curator": {"auxiliary": {"reasoning_effort": "high"}}}
+
+    with caplog.at_level(logging.INFO, logger="agent.curator"):
+        assert curator._resolve_review_reasoning_config(cfg) == {
+            "enabled": True,
+            "effort": "high",
+        }
+    assert any(
+        "deprecated curator.auxiliary.reasoning_effort" in record.message
+        for record in caplog.records
+    )
 
 
 def test_review_runtime_passes_auxiliary_curator_credentials(curator_env):
@@ -471,6 +570,87 @@ def test_review_runtime_passes_auxiliary_curator_credentials(curator_env):
     assert binding.model == "local-mini"
     assert binding.explicit_api_key == "sk-curator-only"
     assert binding.explicit_base_url == "http://localhost:11434/v1"
+
+
+def test_review_runtime_carries_resolved_reasoning(curator_env):
+    curator = curator_env["curator"]
+    binding = curator._resolve_review_runtime(
+        {
+            "agent": {"reasoning_effort": "medium"},
+            "auxiliary": {
+                "curator": {
+                    "provider": "openrouter",
+                    "model": "openai/gpt-5.4-mini",
+                    "reasoning_effort": "xhigh",
+                },
+            },
+        }
+    )
+
+    assert binding.reasoning_config == {"enabled": True, "effort": "xhigh"}
+
+
+@pytest.mark.parametrize(
+    "cfg,expected_model,expected_reasoning",
+    [
+        (
+            {
+                "model": {"provider": "openrouter", "default": "openai/gpt-5.5"},
+                "agent": {
+                    "reasoning_effort": "high",
+                    "reasoning_overrides": {"openai/gpt-5.5": "none"},
+                },
+            },
+            "openai/gpt-5.5",
+            {"enabled": False},
+        ),
+        (
+            {
+                "model": {"provider": "openrouter", "default": "openai/gpt-5.5"},
+                "agent": {
+                    "reasoning_effort": "high",
+                    "reasoning_overrides": {"openai/gpt-5.4-mini": "low"},
+                },
+                "auxiliary": {
+                    "curator": {
+                        "provider": "openrouter",
+                        "model": "openai/gpt-5.4-mini",
+                    },
+                },
+            },
+            "openai/gpt-5.4-mini",
+            {"enabled": True, "effort": "low"},
+        ),
+        (
+            {
+                "model": {"provider": "openrouter", "default": "openai/gpt-5.5"},
+                "agent": {
+                    "reasoning_effort": "high",
+                    "reasoning_overrides": {"openai/gpt-5.4-mini": "none"},
+                },
+                "auxiliary": {
+                    "curator": {
+                        "provider": "openrouter",
+                        "model": "openai/gpt-5.4-mini",
+                        "reasoning_effort": "xhigh",
+                    },
+                },
+            },
+            "openai/gpt-5.4-mini",
+            {"enabled": True, "effort": "xhigh"},
+        ),
+    ],
+)
+def test_review_runtime_uses_effective_model_reasoning_override(
+    curator_env,
+    cfg,
+    expected_model,
+    expected_reasoning,
+):
+    binding = curator_env["curator"]._resolve_review_runtime(cfg)
+
+    assert binding.model == expected_model
+    assert binding.reasoning_config == expected_reasoning
 
 
 def test_review_runtime_strips_blank_aux_credentials(curator_env):
@@ -654,6 +834,128 @@ def test_review_fork_forwards_runtime_pool_and_overrides(curator_env, monkeypatc
     assert captured["kwargs"]["request_overrides"] == fake_overrides
 
 
+def test_review_fork_passes_reasoning_when_provider_resolution_fails(
+    curator_env,
+    monkeypatch,
+):
+    """Task reasoning is config-derived and must survive runtime-provider failure."""
+    curator = curator_env["curator"]
+    import importlib
+    importlib.reload(curator)
+    captured = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "model": {"provider": "openrouter", "default": "openai/gpt-5.5"},
+            "agent": {
+                "reasoning_effort": "medium",
+                "reasoning_overrides": {"openai/gpt-5.5": "xhigh"},
+            },
+        },
+    )
+
+    def _fail_provider_resolution(**_kwargs):
+        raise RuntimeError("provider lookup unavailable")
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _fail_provider_resolution,
+    )
+
+    class _StubAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._session_messages = []
+
+        def run_conversation(self, **_kwargs):
+            return {"final_response": "ok"}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("run_agent.AIAgent", _StubAgent)
+
+    result = curator._run_llm_review("review")
+
+    assert result["error"] is None
+    assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+
+
+@pytest.mark.parametrize(
+    "cfg,provider_model,level,message",
+    [
+        (
+            {
+                "model": {"provider": "openrouter", "default": "openai/gpt-5.5"},
+                "agent": {"reasoning_effort": "low"},
+                "auxiliary": {"curator": {"reasoning_effort": "turbo"}},
+            },
+            "openai/gpt-5.5",
+            logging.WARNING,
+            "invalid auxiliary.curator.reasoning_effort",
+        ),
+        (
+            {
+                "model": {"provider": "openrouter", "default": "openai/gpt-5.5"},
+                "curator": {"auxiliary": {"reasoning_effort": "high"}},
+            },
+            "openai/gpt-5.5",
+            logging.INFO,
+            "deprecated curator.auxiliary.reasoning_effort",
+        ),
+        (
+            {
+                "model": {"provider": "custom:gateway", "default": "gateway"},
+                "agent": {"reasoning_effort": "turbo"},
+            },
+            "real-model-id",
+            logging.WARNING,
+            "Unknown reasoning_effort 'turbo'",
+        ),
+    ],
+)
+def test_review_fork_logs_reasoning_config_once(
+    curator_env,
+    monkeypatch,
+    caplog,
+    cfg,
+    provider_model,
+    level,
+    message,
+):
+    curator = curator_env["curator"]
+    import importlib
+    importlib.reload(curator)
+
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "openrouter",
+            "model": provider_model,
+        },
+    )
+
+    class _StubAgent:
+        def __init__(self, **_kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **_kwargs):
+            return {"final_response": "ok"}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("run_agent.AIAgent", _StubAgent)
+
+    with caplog.at_level(level):
+        result = curator._run_llm_review("review")
+
+    assert result["error"] is None
+    assert sum(message in record.message for record in caplog.records) == 1
+
+
 def test_review_fork_uses_runtime_model_and_output_cap(curator_env, monkeypatch):
     curator = curator_env["curator"]
     import importlib
@@ -662,11 +964,23 @@ def test_review_fork_uses_runtime_model_and_output_cap(curator_env, monkeypatch)
 
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
-        lambda: {"model": {"provider": "custom:gateway", "default": "gateway"}},
+        lambda: {
+            "model": {"provider": "custom:gateway", "default": "gateway"},
+            "agent": {
+                "reasoning_effort": "high",
+                "reasoning_overrides": {"real-model-id": "none"},
+            },
+        },
     )
     monkeypatch.setattr(
         "hermes_cli.config.load_config_readonly",
-        lambda: {"model": {"provider": "custom:gateway", "default": "gateway"}},
+        lambda: {
+            "model": {"provider": "custom:gateway", "default": "gateway"},
+            "agent": {
+                "reasoning_effort": "high",
+                "reasoning_overrides": {"real-model-id": "none"},
+            },
+        },
     )
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -697,5 +1011,4 @@ def test_review_fork_uses_runtime_model_and_output_cap(curator_env, monkeypatch)
     assert result["error"] is None
     assert captured["model"] == "real-model-id"
     assert captured["max_tokens"] == 1234
-
-
+    assert captured["reasoning_config"] == {"enabled": False}

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -43,6 +43,10 @@ def test_title_generation_present_in_default_config():
     assert tg["extra_body"] == {}
 
 
+def test_curator_reasoning_effort_is_a_schema_default():
+    curator = DEFAULT_CONFIG["auxiliary"]["curator"]
+
+    assert curator["reasoning_effort"] == ""
 
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1185,6 +1185,31 @@ class TestMigrationWriteInvariant:
         assert loaded["curator"]["enabled"] == DEFAULT_CONFIG["curator"]["enabled"]
         assert loaded["display"]["compact"] == DEFAULT_CONFIG["display"]["compact"]
 
+    def test_curator_reasoning_default_is_effective_without_materializing_auxiliary(
+        self,
+        tmp_path,
+    ):
+        """Read-time deep merge exposes the default without rewriting user YAML."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": DEFAULT_CONFIG["_config_version"],
+                    "model": {"default": "test-model", "provider": "openrouter"},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        original = config_path.read_text(encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            loaded = load_config()
+
+        assert config_path.read_text(encoding="utf-8") == original
+        assert "auxiliary" not in yaml.safe_load(original)
+        assert loaded["auxiliary"]["curator"]["reasoning_effort"] == ""
+
 
 class TestSaveConfigPartialWritePreservation:
     """Regression for #62723: partial migration writes must not drop unrelated sections."""

--- a/website/docs/user-guide/features/curator.md
+++ b/website/docs/user-guide/features/curator.md
@@ -80,12 +80,15 @@ auxiliary:
     provider: openrouter
     model: google/gemini-3-flash-preview
     timeout: 600               # generous — reviews can take several minutes
+    reasoning_effort: ""       # inherit agent.reasoning_effort, then provider default
 ```
 
 Leaving `provider: auto` (the default) routes the review pass through whatever your main chat model is, matching the behavior of every other auxiliary task.
 
+`auxiliary.curator.reasoning_effort` affects only the curator review fork. An empty value inherits the effective agent reasoning for the selected model (`agent.reasoning_overrides` first, then `agent.reasoning_effort`); if neither is set, the provider default applies. The literal `none` explicitly disables reasoning for this fork. This setting does not enable LLM consolidation by itself — use `curator.consolidate: true` or `hermes curator run --consolidate`.
+
 :::note Legacy config
-Earlier releases used a one-off `curator.auxiliary.{provider,model}` block. That path still works but emits a deprecation log line — please migrate to `auxiliary.curator` above so the curator shares the same plumbing (`hermes model`, dashboard Models tab, `base_url`, `api_key`, `timeout`, `extra_body`) as every other aux task.
+Earlier releases used a one-off `curator.auxiliary.{provider,model}` block. Provider/model and `curator.auxiliary.reasoning_effort` remain deprecated fallbacks when canonical values are absent and emit deprecation logs. Please migrate to `auxiliary.curator` above so the curator shares the same plumbing (`hermes model`, dashboard Models tab, `base_url`, `api_key`, `timeout`, `extra_body`) as every other aux task.
 :::
 
 ## CLI

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/curator.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/curator.md
@@ -72,12 +72,15 @@ auxiliary:
     provider: openrouter
     model: google/gemini-3-flash-preview
     timeout: 600               # generous — reviews can take several minutes
+    reasoning_effort: ""       # 继承 agent.reasoning_effort，然后使用 provider 默认值
 ```
 
 保持 `provider: auto`（默认值）会将审查 pass 路由到主聊天模型，与所有其他辅助任务的行为一致。
 
+`auxiliary.curator.reasoning_effort` 只影响 curator 审查 fork。空值会继承所选模型的有效 agent reasoning（优先使用 `agent.reasoning_overrides`，然后使用 `agent.reasoning_effort`）；若两者都未设置，则使用 provider 默认值。字面值 `none` 会明确禁用该 fork 的 reasoning。该设置本身不会启用 LLM consolidation——仍需设置 `curator.consolidate: true` 或运行 `hermes curator run --consolidate`。
+
 :::note 旧版配置
-早期版本使用独立的 `curator.auxiliary.{provider,model}` 块。该路径仍然有效，但会输出一条弃用日志——请迁移到上方的 `auxiliary.curator`，使 curator 与其他所有辅助任务共享相同的管道（`hermes model`、控制台 Models 标签页、`base_url`、`api_key`、`timeout`、`extra_body`）。
+早期版本使用独立的 `curator.auxiliary.{provider,model}` 块。当 canonical 值缺失时，provider/model 和 `curator.auxiliary.reasoning_effort` 仍作为已弃用 fallback 生效，并会输出弃用日志。请迁移到上方的 `auxiliary.curator`，使 curator 与其他所有辅助任务共享相同的管道（`hermes model`、控制台 Models 标签页、`base_url`、`api_key`、`timeout`、`extra_body`）。
 :::
 
 ## CLI


### PR DESCRIPTION
## What does this PR do?

Adds a curator-specific `reasoning_effort` override for the LLM consolidation/review fork, using Hermes' normalized reasoning configuration instead of provider-specific request-body hacks.

This lets users keep ordinary chat at one reasoning level while giving curator consolidation a different level, or explicitly disable curator reasoning with `none`.

## Behavior

Reasoning precedence for the curator review fork is:

1. valid, non-empty `auxiliary.curator.reasoning_effort`
2. deprecated `curator.auxiliary.reasoning_effort` when the canonical key is absent or empty
3. the selected curator model's `agent.reasoning_overrides` entry
4. valid `agent.reasoning_effort`
5. provider or transport default

Additional semantics:

- `none` and YAML `false` explicitly disable reasoning and stop fallback.
- Invalid canonical values warn once, skip deprecated legacy config, and fall back through model-aware agent defaults.
- Legacy deprecation notices are emitted once even when provider resolution rewrites the selected model.
- The final provider-resolved model is used for model-aware fallback.
- Reasoning still reaches the fork when provider resolution falls back or fails.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor

## Changes Made

- `agent/curator.py`
  - Resolves canonical, legacy, model-specific, and global reasoning settings with explicit precedence.
  - Carries normalized reasoning through `_ReviewRuntimeBinding` alongside the existing provider, model, credential, and request overrides.
  - Re-resolves model-aware fallback only when provider resolution changes the selected model, without duplicating warnings.
  - Passes `reasoning_config` into the forked `AIAgent` without disturbing credential pools, ACP settings, or output caps.
- `hermes_constants.py`
  - Adds a backward-compatible keyword-only switch for suppressing duplicate invalid-value warnings during the second resolution pass.
- Configuration
  - Uses the `auxiliary.curator.reasoning_effort` schema default already present on current `main`.
  - Keeps config version 33; the default arrives through `load_config()` deep merge without migration or user-YAML rewrites.
- Tests
  - Covers canonical and legacy precedence, selected-model overrides, provider-rewritten models, global fallback, `none`, YAML `false`, invalid values, exact-once logging, runtime binding, constructor plumbing, provider-resolution failure, schema defaults, and no-write config loading.
- Docs and example
  - Documents inheritance, model-aware overrides, explicit disable behavior, consolidation requirements, and deprecated fallback in English and zh-Hans.

## How to Test

Candidate head: `1a2276ae649298771b5a0c8aa3aa9609b77d341b`

```bash
scripts/run_tests.sh -j 8 \
  tests/agent/test_curator.py \
  tests/agent/test_curator_classification.py \
  tests/hermes_cli/test_aux_config.py \
  tests/hermes_cli/test_config.py \
  tests/cron/test_reasoning_config_per_model.py \
  tests/gateway/test_reasoning_config_per_model.py \
  tests/tui_gateway/test_reasoning_config_per_model.py \
  tests/run_agent/test_fallback_reasoning_override.py -q
```

Result:

```text
144 passed, 0 failed (8 workers)
```

Additional verification:

```text
uv run ruff check .: passed
git diff --check upstream/main..HEAD: passed
Spec-compliance review: passed
Code-quality review: passed
Official upstream/main at final rebase: f88ed6c71768cdc7ea3bfa8cf62d16654792fd2a
```

The full Python suite was run with the exact locked CI dependency set and an 8-worker cap:

```text
23,750 passed, 13 failed; one unrelated file passed on retry
```

All 13 failures reproduced exactly on pristine `f88ed6c7` in the same environment (`72 passed, 13 failed` across the seven failing files). They are pre-existing host-state/timing failures outside this PR's files.

## Scope

The refreshed PR is one commit on `upstream/main` (`f88ed6c7`), touching 8 feature files (`+469/-14`). It ports the original intent onto the current curator runtime architecture without replaying obsolete migration machinery or restoring tests pruned from current `main`.

## Checklist

### Code

- [x] Read the contributing guidance
- [x] Conventional commit message
- [x] Feature-only scope
- [x] Tests added for behavior, model-aware fallback, exact-once logging, and no-write config loading
- [x] Full repository suite run with at most 8 workers; all failures reproduced on pristine upstream

### Documentation & Housekeeping

- [x] Relevant documentation updated
- [x] `cli-config.yaml.example` updated
- [x] Cross-platform impact checked
- [x] No tool schema changes required

## Screenshots / Logs

Not applicable; this changes curator/config behavior and documentation, not UI.
