### PR TITLE
fix(mcp): surface resolved binary and spawn PATH in hermes mcp test

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -262,6 +262,30 @@ def _probe_single_server(
     return tools_found
 
 
+def _describe_stdio_spawn(config: dict) -> Tuple[str, Optional[str], str]:
+    """Resolve a stdio server's command exactly as the gateway spawn does.
+
+    Returns ``(raw_command, resolved_abs_command_or_None, effective_path)``.
+
+    Mirrors ``EnabledMCPServer._connect``: build the same filtered environment
+    via ``_build_safe_env`` and resolve the command via ``_resolve_stdio_command``
+    so ``hermes mcp test`` can surface the absolute binary path and the ``PATH``
+    the real spawn would use. The probe and the gateway share this resolution
+    code, but each inherits its own process ``PATH`` — so a server can test
+    healthy yet fail to ``exec`` under the gateway's (typically more minimal)
+    ``PATH``. Surfacing both makes that discrepancy visible instead of silent
+    (#50395).
+    """
+    from tools.mcp_tool import _build_safe_env, _resolve_stdio_command
+
+    raw = str(config.get("command") or "")
+    safe_env = _build_safe_env(config.get("env"))
+    resolved, resolved_env = _resolve_stdio_command(raw, safe_env)
+    effective_path = resolved_env.get("PATH", "") or ""
+    is_resolved = bool(raw) and os.sep in resolved
+    return raw, (resolved if is_resolved else None), effective_path
+
+
 def _oauth_tokens_present(name: str) -> bool:
     """Return True if an OAuth token file exists on disk for ``name``.
 
@@ -623,6 +647,23 @@ def cmd_mcp_test(args):
     else:
         cmd = cfg.get("command", "?")
         _info(f"Transport: stdio → {cmd}")
+        # Surface the resolved binary and the PATH this spawn uses. The probe
+        # and the gateway share the resolution code but inherit different
+        # process PATHs, so a green test can still mask a gateway-only
+        # "exec: <cmd>: not found". Make the resolution visible (#50395).
+        raw_cmd, resolved_cmd, spawn_path = _describe_stdio_spawn(
+            _resolve_mcp_server_config(cfg)
+        )
+        if resolved_cmd:
+            _info(f"Resolved binary: {resolved_cmd}")
+        elif raw_cmd:
+            _warning(
+                f"'{raw_cmd}' is not on the spawn PATH — the gateway may fail "
+                f"with \"exec: {raw_cmd}: not found\" even if this test passes "
+                f"(the gateway can inherit a more minimal PATH than this command)."
+            )
+        if spawn_path:
+            _info(f"Spawn PATH: {spawn_path}")
 
     # Show auth info (masked)
     auth_type = cfg.get("auth", "")

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -754,3 +754,33 @@ class TestMcpLogin:
 
         assert "Authenticated — 3 tool(s) available" in out
         assert "no OAuth token" not in out
+
+
+# ---------------------------------------------------------------------------
+# stdio spawn resolution diagnostics (#50395)
+# ---------------------------------------------------------------------------
+
+class TestDescribeStdioSpawn:
+    """`hermes mcp test` surfaces the resolved binary + PATH the gateway spawn
+    would use, so a green test cannot silently mask a gateway-only
+    "exec: <cmd>: not found".
+    """
+
+    def test_absolute_command_resolves(self):
+        import os, sys
+        from hermes_cli.mcp_config import _describe_stdio_spawn
+        raw, resolved, path = _describe_stdio_spawn(
+            {"command": sys.executable, "env": {"PATH": os.path.dirname(sys.executable)}}
+        )
+        assert raw == sys.executable
+        assert resolved == sys.executable
+        assert path
+
+    def test_missing_command_is_unresolved(self):
+        from hermes_cli.mcp_config import _describe_stdio_spawn
+        raw, resolved, path = _describe_stdio_spawn(
+            {"command": "definitely_no_such_bin_xyz", "env": {"PATH": "/nonexistent_dir_zzz"}}
+        )
+        assert raw == "definitely_no_such_bin_xyz"
+        assert resolved is None
+        assert path == "/nonexistent_dir_zzz"


### PR DESCRIPTION
## Summary

Addresses #50395. `hermes mcp test <server>` could report a stdio server **✓ healthy** while the gateway failed to spawn it with `exec: <cmd>: not found` — masking the real cause for hours and sending debugging in the wrong direction.

The probe and the gateway already share the same spawn resolution (`_build_safe_env` + `_resolve_stdio_command`), so this is **not** a code divergence — each process simply inherits its own `PATH`. A `docker exec`-invoked `mcp test` sees a fuller `PATH` (e.g. `/usr/local/bin`) and resolves a bare command, while the gateway runs with a more minimal `PATH` and fails. The test had no way to reveal that.

## Fix

Make the resolution visible. For stdio servers, `hermes mcp test` now:

- prints the **resolved absolute binary** the spawn would use, and the **effective spawn PATH**;
- **warns** when the command can't be resolved on that PATH — i.e. the exact gateway-only `exec: <cmd>: not found` it would otherwise hide.

The resolution reuses the gateway's own `_build_safe_env` + `_resolve_stdio_command`, so what's shown is what the real spawn computes. The connection probe itself is unchanged.

Example (stdio):
```
Transport: stdio → perseus
Resolved binary: /usr/local/bin/perseus
Spawn PATH: /usr/local/bin:/usr/bin:/bin
```
…or, when unresolved:
```
⚠ 'perseus' is not on the spawn PATH — the gateway may fail with "exec: perseus: not found" even if this test passes ...
```

## Tests

`tests/hermes_cli/test_mcp_config.py::TestDescribeStdioSpawn` covers the resolved (absolute command) and unresolved (missing binary on a controlled PATH) cases. Full `test_mcp_config.py` suite stays green (44 passed).
