### PR TITLE
fix(desktop): treat dropped folders as context refs

### DIFF
--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { type DroppedFile, partitionDroppedFiles } from './use-composer-actions'
+import { type DroppedFile, isDroppedOsDirectory, partitionDroppedFiles } from './use-composer-actions'
 
 // A Finder/Explorer drop carries a native File handle; an in-app drag (project
 // tree, gutter line ref) is path-only. The split decides whether a drop becomes
@@ -53,5 +53,41 @@ describe('partitionDroppedFiles', () => {
 
   it('returns empty groups for an empty drop', () => {
     expect(partitionDroppedFiles([])).toEqual({ inAppRefs: [], osDrops: [] })
+  })
+})
+
+describe('isDroppedOsDirectory', () => {
+  it('detects Finder/Explorer folder drops before file.attach sees them as files', async () => {
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readDir: async () => ({ entries: [] }) }
+    })
+
+    await expect(isDroppedOsDirectory(osDrop('/tmp/hermes-folder-drop'))).resolves.toBe(true)
+  })
+
+  it('keeps normal file drops on the file upload path', async () => {
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readDir: async () => ({ entries: [], error: 'ENOTDIR' }) }
+    })
+
+    await expect(isDroppedOsDirectory(osDrop('/tmp/report.pdf'))).resolves.toBe(false)
+  })
+
+  it('does not probe path-only in-app refs', async () => {
+    let probed = false
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        readDir: async () => {
+          probed = true
+          return { entries: [] }
+        }
+      }
+    })
+
+    await expect(isDroppedOsDirectory(inAppRef('src'))).resolves.toBe(false)
+    expect(probed).toBe(false)
   })
 })

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -12,6 +12,7 @@ import {
   setComposerTerminalSelection
 } from '@/store/composer'
 import { notify, notifyError } from '@/store/notifications'
+import { $connection } from '@/store/session'
 
 import type { ImageDetachResponse } from '../../types'
 
@@ -209,6 +210,38 @@ export function partitionDroppedFiles(candidates: DroppedFile[]): {
   }
 
   return { osDrops, inAppRefs }
+}
+
+/**
+ * Finder/Explorer folder drops still arrive with a native File handle, so the
+ * OS-drop split correctly routes them through the attachment path. Before
+ * treating that handle as a file, ask the local Desktop bridge whether the
+ * resolved path is actually a directory.
+ */
+export async function isDroppedOsDirectory(candidate: DroppedFile): Promise<boolean> {
+  if (candidate.isDirectory) {
+    return true
+  }
+
+  const filePath = candidate.path.trim()
+
+  if (!candidate.file || !filePath) {
+    return false
+  }
+
+  const readDir = window.hermesDesktop?.readDir
+
+  if (!readDir) {
+    return false
+  }
+
+  try {
+    const result = await readDir(filePath)
+
+    return !result.error
+  } catch {
+    return false
+  }
 }
 
 interface ComposerActionsOptions {
@@ -506,6 +539,26 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
           !knownPath && window.hermesDesktop?.getPathForFile ? window.hermesDesktop.getPathForFile(file) : ''
 
         const filePath = knownPath || fallbackPath || ''
+        const isDirectoryDrop = await isDroppedOsDirectory({ file, isDirectory, path: filePath })
+
+        if (isDirectoryDrop) {
+          if ($connection.get()?.mode === 'remote') {
+            lastFailure = `Cannot attach local folder ${filePath || file.name || 'folder'} to a remote gateway. Use a folder path that exists on the remote host.`
+
+            continue
+          }
+
+          if (filePath && attachContextFolderPath(filePath)) {
+            attached = true
+
+            continue
+          }
+
+          lastFailure = `Could not attach folder ${filePath || file.name || ''}`
+
+          continue
+        }
+
         const isImage = file.type.startsWith('image/') || isImagePath(file.name) || (filePath && isImagePath(filePath))
 
         if (isImage) {


### PR DESCRIPTION
## Summary

- Detect File-bearing OS drops that resolve to directories before treating them as file uploads.
- Attach local dropped folders as folder context refs instead of routing them through `file.attach`.
- Show an actionable warning for local folder drops while connected to a remote gateway, where the remote host cannot read the local folder path.

## Why

Dragging a folder from the OS can arrive in the renderer with a native `File` handle. The previous split treated every File-bearing drop as a file/image attachment candidate. For folders, that eventually called `file.attach` with a directory path and no uploaded bytes, producing the gateway error:

```text
file not found on gateway and no data_url provided
```

The fix probes the resolved path with the Desktop filesystem bridge before the file/image branch. If the path is a directory, the composer handles it as folder context.

## Test plan

```text
npm run test:ui -- src/app/chat/hooks/use-composer-actions.test.ts
# 8 tests passed

npm run typecheck
# tsc -p . --noEmit
```
