### PR TITLE
fix(security): reject path traversal in SessionEntry session fields + resilient load (#9560)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -576,7 +576,7 @@ class SessionEntry:
         session_key = data["session_key"]
         session_id = data["session_id"]
 
-        # Validate path-sensitive fields to prevent directory traversal attacks
+        # Validate path-sensitive fields to prevent directory traversal (CWE-22)
         for _field, _val in (("session_key", session_key), ("session_id", session_id)):
             if _val and (".." in str(_val) or str(_val).startswith(("/", "\\"))):
                 raise ValueError(
@@ -786,12 +786,11 @@ class SessionStore:
             try:
                 with open(sessions_file, "r", encoding="utf-8") as f:
                     data = json.load(f)
-                    for key, entry_data in data.items():
-                        try:
-                            self._entries[key] = SessionEntry.from_dict(entry_data)
-                        except (ValueError, KeyError):
-                            # Skip entries with unknown/removed platform values
-                            continue
+                for key, entry_data in data.items():
+                    try:
+                        self._entries[key] = SessionEntry.from_dict(entry_data)
+                    except (ValueError, KeyError) as e:
+                        print(f"[gateway] Warning: Skipping invalid session entry {key!r}: {e}")
             except Exception as e:
                 print(f"[gateway] Warning: Failed to load sessions: {e}")
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -573,9 +573,19 @@ class SessionEntry:
             except (TypeError, ValueError):
                 last_resume_marked_at = None
 
+        session_key = data["session_key"]
+        session_id = data["session_id"]
+
+        # Validate path-sensitive fields to prevent directory traversal attacks
+        for _field, _val in (("session_key", session_key), ("session_id", session_id)):
+            if _val and (".." in str(_val) or str(_val).startswith(("/", "\\"))):
+                raise ValueError(
+                    f"Invalid {_field}: potential directory traversal detected"
+                )
+
         return cls(
-            session_key=data["session_key"],
-            session_id=data["session_id"],
+            session_key=session_key,
+            session_id=session_id,
             created_at=datetime.fromisoformat(data["created_at"]),
             updated_at=datetime.fromisoformat(data["updated_at"]),
             origin=origin,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -12,7 +12,6 @@ import hashlib
 import logging
 import os
 import json
-import re
 import threading
 import uuid
 from pathlib import Path
@@ -67,10 +66,27 @@ from .whatsapp_identity import (
 )
 from utils import atomic_replace
 
-# Matches any value that could escape the sessions directory as a file path.
-# Covers: directory traversal (..),  Unix/Windows absolute paths (/  \),
-# and Windows drive-letter paths (C:/ D:\\ etc.).
-_TRAVERSAL_RE = re.compile(r'\.\.|^[/\\]|^[A-Za-z]:')
+# Session keys/ids flow into filesystem paths downstream (e.g.
+# ``sessions_dir / f"{session_id}.json"`` in hermes_state, request-dump
+# filenames in agent_runtime_helpers). Any value that could escape the
+# sessions directory as a path must be rejected at the entry boundary.
+# Rejects: parent traversal (``..``), a path separator anywhere (``/`` or
+# ``\``, so a non-leading Windows separator can't slip through), and a
+# leading Windows drive letter (``C:``). Legitimate session keys are
+# colon-delimited multi-segment ids (``agent:main:<platform>:...``) and
+# never contain these, so there are no false positives in practice.
+def _is_path_unsafe(value: object) -> bool:
+    """Return True if ``value`` could traverse outside the sessions dir."""
+    if not value:
+        return False
+    s = str(value)
+    if ".." in s or "/" in s or "\\" in s:
+        return True
+    # Leading Windows drive path, e.g. "C:\..." or "d:/...". A bare "x:"
+    # with no following separator isn't a usable absolute path, and the
+    # separator forms are already caught above — but keep an explicit guard
+    # for the drive-letter prefix in case a separator was normalized away.
+    return len(s) >= 2 and s[0].isalpha() and s[1] == ":"
 
 
 @dataclass
@@ -584,7 +600,7 @@ class SessionEntry:
 
         # Validate path-sensitive fields to prevent directory traversal (CWE-22)
         for _field, _val in (("session_key", session_key), ("session_id", session_id)):
-            if _val and _TRAVERSAL_RE.search(str(_val)):
+            if _is_path_unsafe(_val):
                 raise ValueError(
                     f"Invalid {_field}: potential directory traversal detected"
                 )
@@ -796,7 +812,7 @@ class SessionStore:
                     try:
                         self._entries[key] = SessionEntry.from_dict(entry_data)
                     except (ValueError, KeyError) as e:
-                        print(f"[gateway] Warning: Skipping invalid session entry {key!r}: {e}")
+                        logger.warning("Skipping invalid session entry %r: %s", key, e)
             except Exception as e:
                 print(f"[gateway] Warning: Failed to load sessions: {e}")
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -12,6 +12,7 @@ import hashlib
 import logging
 import os
 import json
+import re
 import threading
 import uuid
 from pathlib import Path
@@ -65,6 +66,11 @@ from .whatsapp_identity import (
     normalize_whatsapp_identifier,  # noqa: F401 - re-exported for gateway.session callers
 )
 from utils import atomic_replace
+
+# Matches any value that could escape the sessions directory as a file path.
+# Covers: directory traversal (..),  Unix/Windows absolute paths (/  \),
+# and Windows drive-letter paths (C:/ D:\\ etc.).
+_TRAVERSAL_RE = re.compile(r'\.\.|^[/\\]|^[A-Za-z]:')
 
 
 @dataclass
@@ -578,7 +584,7 @@ class SessionEntry:
 
         # Validate path-sensitive fields to prevent directory traversal (CWE-22)
         for _field, _val in (("session_key", session_key), ("session_id", session_id)):
-            if _val and (".." in str(_val) or str(_val).startswith(("/", "\\"))):
+            if _val and _TRAVERSAL_RE.search(str(_val)):
                 raise ValueError(
                     f"Invalid {_field}: potential directory traversal detected"
                 )

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "mediratta01.pally@gmail.com": "orbisai0security",  # PR #9560 salvage (session.py path-traversal guard, V-009)
     "panghuer023@users.noreply.github.com": "panghuer023",  # PR #37994 salvage (interrupt unblocks pending gateway approval; #8697)
     "w.a.t.s.o.n.mk10@gmail.com": "natehale",  # PR #48678 salvage (typing indicator lingers after final reply)
     "0x0sec@gmail.com": "kn8-codes",  # PR #48422 salvage (rich messages opt-in default off)

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1095,6 +1095,15 @@ class TestSessionEntryFromDictTraversalValidation:
         with pytest.raises(ValueError, match="session_id"):
             SessionEntry.from_dict(self._entry(session_id="D:\\path\\to\\file"))
 
+    def test_session_id_non_leading_separator_raises(self):
+        """A path separator anywhere — not just leading — must be rejected,
+        since a non-leading backslash is still a Windows traversal vector."""
+        from gateway.session import SessionEntry
+        with pytest.raises(ValueError, match="session_id"):
+            SessionEntry.from_dict(self._entry(session_id="good\\..\\bad"))
+        with pytest.raises(ValueError, match="session_key"):
+            SessionEntry.from_dict(self._entry(session_key="agent:main:good/sub"))
+
 
 class TestEnsureLoadedSkipsInvalidEntries:
     """Regression: one bad sessions.json entry must not block valid entries from loading."""

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1046,6 +1046,78 @@ class TestWhatsAppIdentifierPublicHelpers:
         assert canonical_whatsapp_identifier("") == ""
 
 
+class TestSessionEntryFromDictTraversalValidation:
+    """Regression: from_dict must reject traversal sequences in session_key/session_id."""
+
+    BASE = {
+        "session_key": "agent:main:local:dm",
+        "session_id": "abc123",
+        "created_at": "2026-01-01T00:00:00",
+        "updated_at": "2026-01-01T00:00:00",
+    }
+
+    def _entry(self, **overrides):
+        from gateway.session import SessionEntry
+        return {**self.BASE, **overrides}
+
+    def test_valid_entry_loads(self):
+        from gateway.session import SessionEntry
+        entry = SessionEntry.from_dict(self._entry())
+        assert entry.session_id == "abc123"
+
+    def test_session_id_dotdot_raises(self):
+        from gateway.session import SessionEntry
+        with pytest.raises(ValueError, match="session_id"):
+            SessionEntry.from_dict(self._entry(session_id="../../etc/passwd"))
+
+    def test_session_key_dotdot_raises(self):
+        from gateway.session import SessionEntry
+        with pytest.raises(ValueError, match="session_key"):
+            SessionEntry.from_dict(self._entry(session_key="agent:main:../../secret"))
+
+    def test_session_id_absolute_unix_raises(self):
+        from gateway.session import SessionEntry
+        with pytest.raises(ValueError, match="session_id"):
+            SessionEntry.from_dict(self._entry(session_id="/etc/passwd"))
+
+    def test_session_id_absolute_windows_raises(self):
+        from gateway.session import SessionEntry
+        with pytest.raises(ValueError, match="session_id"):
+            SessionEntry.from_dict(self._entry(session_id="\\windows\\system32\\config"))
+
+
+class TestEnsureLoadedSkipsInvalidEntries:
+    """Regression: one bad sessions.json entry must not block valid entries from loading."""
+
+    def test_invalid_entry_skipped_valid_entry_loads(self, tmp_path):
+        import json
+        from gateway.session import SessionStore
+        from gateway.config import GatewayConfig
+
+        sessions_file = tmp_path / "sessions.json"
+        sessions_file.write_text(json.dumps({
+            "bad:key": {
+                "session_key": "bad:key",
+                "session_id": "../../evil",
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+            },
+            "agent:main:local:dm": {
+                "session_key": "agent:main:local:dm",
+                "session_id": "good123",
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+            },
+        }), encoding="utf-8")
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._ensure_loaded()
+
+        assert "bad:key" not in store._entries
+        assert "agent:main:local:dm" in store._entries
+        assert store._entries["agent:main:local:dm"].session_id == "good123"
+
+
 class TestSessionStoreEntriesAttribute:
     """Regression: /reset must access _entries, not _sessions."""
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1085,6 +1085,16 @@ class TestSessionEntryFromDictTraversalValidation:
         with pytest.raises(ValueError, match="session_id"):
             SessionEntry.from_dict(self._entry(session_id="\\windows\\system32\\config"))
 
+    def test_session_id_windows_drive_letter_raises(self):
+        from gateway.session import SessionEntry
+        with pytest.raises(ValueError, match="session_id"):
+            SessionEntry.from_dict(self._entry(session_id="C:/windows/system32"))
+
+    def test_session_id_windows_drive_backslash_raises(self):
+        from gateway.session import SessionEntry
+        with pytest.raises(ValueError, match="session_id"):
+            SessionEntry.from_dict(self._entry(session_id="D:\\path\\to\\file"))
+
 
 class TestEnsureLoadedSkipsInvalidEntries:
     """Regression: one bad sessions.json entry must not block valid entries from loading."""


### PR DESCRIPTION
## Summary
Untrusted session entries can no longer carry a `session_key`/`session_id` that escapes the sessions directory, and one corrupt entry no longer blocks the rest of `sessions.json` from loading.

Root cause: `SessionEntry.from_dict` accepted `session_key`/`session_id` verbatim, and those values flow into filesystem paths downstream (`hermes_state.py`: `sessions_dir / f"{session_id}.json"`; `agent_runtime_helpers.py`: `request_dump_{session_id}_*.json`). A value like `../../etc` was a real CWE-22 traversal vector. Separately, a single malformed entry inside the `with open()` block aborted the whole load.

## Changes
- `gateway/session.py`: validate `session_key`/`session_id` in `from_dict` via an explicit `_is_path_unsafe()` helper — rejects parent traversal (`..`), a path separator **anywhere** (`/` or `\`, so a non-leading Windows separator can't slip through), and a leading drive letter (`C:`). Drops the now-unused `import re`. The per-entry skip in `_ensure_loaded_locked` moved out of the file-open block and now logs via `logger.warning` (matching module conventions) so one bad entry is skipped, not fatal.
- `tests/gateway/test_session.py`: traversal rejection tests (`..`, absolute Unix/Windows, drive-letter, non-leading separator) + resilience test that a bad entry is skipped while valid entries still load.
- `scripts/release.py`: AUTHOR_MAP entry for the contributor.

## Validation
| | Before | After |
|---|---|---|
| `session_id = ../../etc/passwd` | accepted → reaches path sink | `ValueError`, rejected |
| `session_id = good\..\bad` (non-leading sep) | accepted | rejected |
| one corrupt entry in `sessions.json` | aborts entire load | skipped + logged, rest load |
| `tests/gateway/test_session.py` | — | 88/88 pass |

Salvaged from #9560 by @orbisai0security — the three V-009 commits cherry-picked onto current main with authorship preserved; the guard was simplified to a helper, the per-entry log switched to `logger`, and the separator check hardened on top.

## Infographic

![session-field-traversal-guard](https://v3b.fal.media/files/b/0a9f3b4c/rPAvEyW2_qcqhCbtWTZZf_NQIXfETI.png)
