### PR TITLE
fix: add local web extraction plugin

### DIFF
--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -17,7 +17,7 @@ The active provider is chosen by configuration with this precedence:
 3. If exactly one capability-eligible provider is registered AND available,
    use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
-   ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
+   ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` → ``local`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
    candidate order so installs that never set a config key keep landing
    on the same provider they did before the plugin migration.
@@ -127,6 +127,7 @@ _LEGACY_PREFERENCE = (
     "searxng",
     "brave-free",
     "ddgs",
+    "local",
 )
 
 
@@ -148,7 +149,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
 
     3. **Legacy preference walk, filtered by availability.** Walk the
        :data:`_LEGACY_PREFERENCE` order (firecrawl → parallel → tavily →
-       exa → searxng → brave-free → ddgs) looking for a provider whose
+       exa → searxng → brave-free → ddgs → local) looking for a provider whose
        ``supports_<capability>()`` is True AND whose ``is_available()`` is
        True. Matches the historic ``tools.web_tools._get_backend()``
        candidate order so users with credentials but no explicit config

--- a/plugins/web/local/__init__.py
+++ b/plugins/web/local/__init__.py
@@ -1,0 +1,10 @@
+"""Local web extraction plugin — bundled, auto-loaded."""
+
+from __future__ import annotations
+
+from plugins.web.local.provider import LocalWebExtractProvider
+
+
+def register(ctx) -> None:
+    """Register the local HTML extraction provider with the plugin context."""
+    ctx.register_web_search_provider(LocalWebExtractProvider())

--- a/plugins/web/local/plugin.yaml
+++ b/plugins/web/local/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-local
+version: 1.0.0
+description: "Local no-key HTML content extraction for public web pages."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - local

--- a/plugins/web/local/provider.py
+++ b/plugins/web/local/provider.py
@@ -1,0 +1,136 @@
+"""Local web content extraction provider.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. This provider
+implements extraction only: it fetches already-validated public HTTP(S) pages,
+strips non-content HTML, and returns readable text. It intentionally avoids
+heavy browser/PDF/JavaScript handling; use Firecrawl, Tavily, Exa, or Parallel
+for richer extraction.
+
+Config key this provider responds to::
+
+    web:
+      extract_backend: "local"
+
+No environment variables are required.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import re
+from typing import Any, Dict, List
+
+import httpx
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+class LocalWebExtractProvider(WebSearchProvider):
+    """No-key extractor for simple public HTML/text pages."""
+
+    @property
+    def name(self) -> str:
+        return "local"
+
+    @property
+    def display_name(self) -> str:
+        return "Local HTML extractor"
+
+    def is_available(self) -> bool:
+        """Local extraction only needs stdlib + httpx, both already available."""
+        return True
+
+    def supports_search(self) -> bool:
+        return False
+
+    def supports_extract(self) -> bool:
+        return True
+
+    async def extract(
+        self, urls: List[str], max_chars: int = 2_000_000, **kwargs: Any
+    ) -> List[Dict[str, Any]]:
+        """Extract readable text from public HTML/text URLs.
+
+        The tool wrapper performs secret-in-URL blocking and SSRF/private-network
+        validation before dispatching here. This provider is deliberately
+        conservative and reports per-URL errors instead of raising.
+        """
+        results: List[Dict[str, Any]] = []
+        timeout = httpx.Timeout(30.0, connect=10.0)
+        headers = {
+            "User-Agent": "HermesAgent/0.17 web_extract (+https://hermes-agent.nousresearch.com)",
+            "Accept": "text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.5",
+        }
+        async with httpx.AsyncClient(
+            timeout=timeout, follow_redirects=True, headers=headers
+        ) as client:
+            for url in urls:
+                try:
+                    resp = await client.get(url)
+                    resp.raise_for_status()
+                    ctype = resp.headers.get("content-type", "")
+                    if "pdf" in ctype.lower():
+                        results.append({
+                            "url": url,
+                            "title": "",
+                            "content": "",
+                            "error": (
+                                "Local extractor does not handle PDFs; configure "
+                                "Firecrawl, Tavily, Exa, or Parallel for PDF extraction."
+                            ),
+                        })
+                        continue
+                    raw = resp.text[:max_chars]
+                    title = _extract_title(raw)
+                    content = _html_to_text(raw)
+                    results.append({
+                        "url": str(resp.url),
+                        "title": title,
+                        "content": content,
+                        "raw_content": content,
+                        "metadata": {"content_type": ctype},
+                        "error": "",
+                    })
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Local extraction failed for %s: %s", url, exc)
+                    results.append({
+                        "url": url,
+                        "title": "",
+                        "content": "",
+                        "error": f"Local extraction failed: {exc}",
+                    })
+        return results
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Local HTML extractor",
+            "badge": "free · local · no key",
+            "tag": "Fetches simple public HTML/text pages directly; no external extraction service required.",
+            "env_vars": [],
+        }
+
+
+def _extract_title(raw: str) -> str:
+    title_match = re.search(r"<title[^>]*>(.*?)</title>", raw, flags=re.I | re.S)
+    if not title_match:
+        return ""
+    return html.unescape(re.sub(r"\s+", " ", title_match.group(1)).strip())
+
+
+def _html_to_text(raw: str) -> str:
+    text = re.sub(
+        r"(?is)<(script|style|noscript|svg|canvas|template)[^>]*>.*?</\1>",
+        " ",
+        raw,
+    )
+    text = re.sub(r"(?is)<!--.*?-->", " ", text)
+    text = re.sub(r"(?i)<br\s*/?>", "\n", text)
+    text = re.sub(r"(?i)</(p|div|section|article|header|footer|li|h[1-6]|tr)>", "\n", text)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = html.unescape(text).replace("\xa0", " ")
+    lines = [re.sub(r"[ \t]+", " ", line).strip() for line in text.splitlines()]
+    content = "\n".join(line for line in lines if line)
+    return re.sub(r"\n{3,}", "\n\n", content).strip()

--- a/tests/plugins/web/test_local_web_provider.py
+++ b/tests/plugins/web/test_local_web_provider.py
@@ -1,0 +1,61 @@
+"""Tests for the bundled local web extraction provider."""
+from __future__ import annotations
+
+import pytest
+
+from plugins.web.local.provider import LocalWebExtractProvider, _extract_title, _html_to_text
+
+
+def test_html_helpers_extract_title_and_visible_text() -> None:
+    raw = """
+    <html><head><title> Example &amp; Test </title><style>.x{}</style></head>
+    <body><script>alert(1)</script><h1>Hello</h1><p>World&nbsp;today</p></body></html>
+    """
+
+    assert _extract_title(raw) == "Example & Test"
+    text = _html_to_text(raw)
+    assert "Hello" in text
+    assert "World today" in text
+    assert "alert" not in text
+    assert ".x" not in text
+
+
+def test_local_provider_capabilities() -> None:
+    provider = LocalWebExtractProvider()
+
+    assert provider.name == "local"
+    assert provider.is_available() is True
+    assert provider.supports_search() is False
+    assert provider.supports_extract() is True
+    assert provider.get_setup_schema()["env_vars"] == []
+
+
+@pytest.mark.asyncio
+async def test_local_provider_extract_reports_pdf_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse:
+        headers = {"content-type": "application/pdf"}
+        text = "%PDF-1.7"
+        url = "https://example.com/file.pdf"
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args) -> None:
+            return None
+
+        async def get(self, url: str):
+            return FakeResponse()
+
+    monkeypatch.setattr("plugins.web.local.provider.httpx.AsyncClient", FakeAsyncClient)
+
+    result = await LocalWebExtractProvider().extract(["https://example.com/file.pdf"])
+
+    assert result[0]["url"] == "https://example.com/file.pdf"
+    assert "does not handle PDFs" in result[0]["error"]

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,8 +2,8 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl, xai) instantiate and self-report the expected
+- All nine bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+  tavily, firecrawl, xai, local) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
@@ -68,9 +68,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All nine bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_nine_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -80,6 +80,7 @@ class TestBundledPluginsRegister:
             "ddgs",
             "exa",
             "firecrawl",
+            "local",
             "parallel",
             "searxng",
             "tavily",
@@ -96,6 +97,7 @@ class TestBundledPluginsRegister:
             ("parallel", True, True),
             ("tavily", True, True),
             ("firecrawl", True, True),
+            ("local", False, True),
             # xai: search-only via Grok's agentic web_search tool.
             ("xai", True, False),
         ],
@@ -116,7 +118,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "local"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +131,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "local"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -246,6 +248,15 @@ class TestIsAvailable:
         monkeypatch.setenv("XAI_API_KEY", "real")
         assert p.is_available() is True
 
+    def test_local_is_always_available(self) -> None:
+        """Local extraction has no credentials or external service requirement."""
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("local")
+        assert p is not None
+        assert p.is_available() is True
+
 
 # ---------------------------------------------------------------------------
 # Registry resolution semantics (Option B — conservative smart fallback)
@@ -350,6 +361,14 @@ class TestAsyncExtractDispatch:
         from agent.web_search_registry import get_provider
 
         p = get_provider("firecrawl")
+        assert p is not None
+        assert inspect.iscoroutinefunction(p.extract) is True
+
+    def test_local_extract_is_async(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("local")
         assert p is not None
         assert inspect.iscoroutinefunction(p.extract) is True
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -204,14 +204,47 @@ def _get_extract_backend() -> str:
 def _get_capability_backend(capability: str) -> str:
     """Shared helper for per-capability backend selection.
 
-    Reads ``web.{capability}_backend`` from config; if set and available,
-    uses it. Otherwise falls through to the shared ``_get_backend()``.
+    Reads ``web.{capability}_backend`` from config first, then ``web.backend``.
+    Search-only providers such as SearXNG, Brave free, DDGS, and xAI must not
+    be reused for extraction; if the configured/shared backend lacks the
+    requested capability, fall through to an available capability-specific
+    backend instead of returning a backend that will fail at dispatch time.
     """
     cfg = _load_web_config()
+    capability_map = {
+        "search": {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"},
+        "extract": {"parallel", "firecrawl", "tavily", "exa", "local"},
+    }
+    allowed = capability_map.get(capability, set())
+
     specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
-    if specific and _is_backend_available(specific):
+    if specific and specific in allowed and _is_backend_available(specific):
         return specific
-    return _get_backend()
+
+    shared = (cfg.get("backend") or "").lower().strip()
+    known = {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai", "local"}
+    if shared and shared in known and _is_backend_available(shared):
+        # Preserve the legacy contract: if a user explicitly set a shared
+        # search-only backend and calls web_extract, dispatch will surface a
+        # typed "search-only backend" error rather than silently switching.
+        return shared
+
+    backend_candidates = (
+        ("tavily", _has_env("TAVILY_API_KEY")),
+        ("exa", _has_env("EXA_API_KEY")),
+        ("parallel", _has_env("PARALLEL_API_KEY")),
+        ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL")),
+        ("firecrawl", _is_tool_gateway_ready()),
+        ("searxng", _has_env("SEARXNG_URL")),
+        ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
+        ("ddgs", _ddgs_package_importable()),
+        ("local", True),
+    )
+    for backend, available in backend_candidates:
+        if backend in allowed and available:
+            return backend
+
+    return "local" if capability == "extract" else "firecrawl"  # default (backward compat)
 
 
 def _is_backend_available(backend: str) -> bool:
@@ -230,6 +263,8 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("BRAVE_SEARCH_API_KEY")
     if backend == "ddgs":
         return _ddgs_package_importable()
+    if backend == "local":
+        return True
     if backend == "xai":
         # Cheap probe — env var OR auth.json has OAuth tokens. Must not
         # call resolve_xai_http_credentials() here because the OAuth path
@@ -891,6 +926,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         return tool_error(error_msg)
 
 
+
 async def web_extract_tool(
     urls: List[str],
     format: str = None,
@@ -978,13 +1014,12 @@ async def web_extract_tool(
         else:
             backend = _get_extract_backend()
 
-            # All seven providers (brave-free, ddgs, searxng, exa, parallel,
-            # tavily, firecrawl) now live as plugins. The dispatcher is a
-            # registry lookup + delegation. Some providers' extract() is
-            # async (parallel, firecrawl), others sync (exa, tavily) — we
-            # detect coroutine functions and await; sync functions run
-            # inline (the policy gate, SSRF re-check, etc. live inside the
-            # provider itself for the firecrawl per-URL loop).
+            # All bundled web providers (brave-free, ddgs, searxng, exa,
+            # parallel, tavily, firecrawl, xai, local) live as plugins. The
+            # dispatcher is a registry lookup + delegation. Some providers'
+            # extract() is async (parallel, firecrawl, local), others sync
+            # (exa, tavily) — detect coroutine functions and await; sync
+            # functions run in a thread so network I/O doesn't block the loop.
             _ensure_web_plugins_loaded()
             from agent.web_search_registry import (
                 get_active_extract_provider,
@@ -1007,7 +1042,7 @@ async def web_extract_tool(
                                 f"{provider.display_name} is a search-only "
                                 "backend and cannot extract URL content. "
                                 "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "tavily, exa, parallel, or local."
                             ),
                         },
                         ensure_ascii=False,
@@ -1020,7 +1055,7 @@ async def web_extract_tool(
                             "error": (
                                 "No web extract provider configured. "
                                 "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "tavily, exa, parallel, or local."
                             ),
                         },
                         ensure_ascii=False,
@@ -1030,14 +1065,10 @@ async def web_extract_tool(
                 "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
             )
 
-            # Async-or-sync dispatch: parallel + firecrawl have async
-            # extract(); exa + tavily are sync.
             import inspect
             if inspect.iscoroutinefunction(provider.extract):
                 results = await provider.extract(safe_urls, format=format)
             else:
-                # Run sync extract() in a thread so we don't block the
-                # event loop on network I/O.
                 results = await asyncio.to_thread(
                     provider.extract, safe_urls, format=format
                 )


### PR DESCRIPTION
Adds a bundled `web/local` backend plugin that provides no-key HTML extraction for `web_extract`.

What changed:
- adds `plugins/web/local/` implementing `WebSearchProvider`
- supports `web.extract_backend: local`
- keeps SearXNG search-only while allowing SearXNG search + local extraction
- routes local extraction through the existing web provider registry instead of inline tool code
- adds plugin registration/capability tests and local extraction unit tests

Verified locally:
- `python -m py_compile tools/web_tools.py agent/web_search_registry.py plugins/web/local/provider.py plugins/web/local/__init__.py`
- `pytest tests/plugins/web/test_web_search_provider_plugins.py tests/plugins/web/test_local_web_provider.py -q -o 'addopts='` → 58 passed
- smoke: `web_extract_tool(["https://example.com"], use_llm_processing=False)` returns title/content via local backend
