### PR TITLE
feat(gateway): load gateway-only context files

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3810,17 +3810,57 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return []
 
     @staticmethod
+    def _load_gateway_context_files() -> str:
+        """Load gateway-only context files as ephemeral system context.
+
+        These files are the gateway analogue of SOUL.md/MEMORY.md: they apply
+        only to messaging gateway sessions and must never be appended to the
+        user's current message. Keeping them on the ephemeral-system rail
+        prevents short gateway turns like "." or "ok" from being semantically
+        dominated by surface-specific operating policy.
+        """
+        blocks: list[str] = []
+        gateway_context_dir = _hermes_home / "gateway"
+        for filename in ("SOUL.gateway.md", "MEMORY.gateway.md"):
+            path = gateway_context_dir / filename
+            try:
+                if not path.exists() or not path.is_file():
+                    continue
+                content = path.read_text(encoding="utf-8").strip()
+            except Exception as exc:
+                logger.warning("Failed to load gateway context file %s: %s", path, exc)
+                continue
+            if content:
+                blocks.append(f"## {filename}\n{content}")
+
+        if not blocks:
+            return ""
+
+        header = (
+            "[Gateway-only context files - system context for messaging gateway "
+            "turns, not the user's current request. Do not acknowledge these "
+            "files unless the user asks about gateway context.]"
+        )
+        return f"{header}\n\n" + "\n\n".join(blocks)
+
+    @staticmethod
     def _load_ephemeral_system_prompt() -> str:
-        """Load ephemeral system prompt from config or env var.
+        """Load ephemeral system prompt from config/env plus gateway context files.
         
-        Checks HERMES_EPHEMERAL_SYSTEM_PROMPT env var first, then falls back to
-        agent.system_prompt in ~/.hermes/config.yaml.
+        HERMES_EPHEMERAL_SYSTEM_PROMPT still overrides agent.system_prompt from
+        config.yaml, preserving the existing user-configured prompt precedence.
+        Gateway context files are additive and remain on the system/context rail.
         """
         prompt = os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
-        if prompt:
-            return prompt
-        cfg = _load_gateway_runtime_config()
-        return str(cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
+        if not prompt:
+            cfg = _load_gateway_runtime_config()
+            prompt = str(cfg_get(cfg, "agent", "system_prompt", default="") or "")
+
+        parts = [prompt.strip()] if str(prompt or "").strip() else []
+        gateway_context = GatewayRunner._load_gateway_context_files()
+        if gateway_context:
+            parts.append(gateway_context)
+        return "\n\n".join(parts).strip()
 
     @staticmethod
     def _load_reasoning_config() -> dict | None:

--- a/tests/gateway/test_gateway_context_files.py
+++ b/tests/gateway/test_gateway_context_files.py
@@ -1,0 +1,68 @@
+"""Gateway-only context file loading."""
+
+from __future__ import annotations
+
+import gateway.run as gateway_run
+
+
+def test_gateway_context_files_are_loaded_from_gateway_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    gateway_dir = tmp_path / "gateway"
+    gateway_dir.mkdir()
+    (gateway_dir / "SOUL.gateway.md").write_text("gateway identity rule", encoding="utf-8")
+    (gateway_dir / "MEMORY.gateway.md").write_text("gateway memory fact", encoding="utf-8")
+
+    prompt = gateway_run.GatewayRunner._load_gateway_context_files()
+
+    assert "Gateway-only context files" in prompt
+    assert "not the user's current request" in prompt
+    assert "## SOUL.gateway.md" in prompt
+    assert "gateway identity rule" in prompt
+    assert "## MEMORY.gateway.md" in prompt
+    assert "gateway memory fact" in prompt
+
+
+def test_gateway_context_files_ignore_missing_and_blank_files(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    gateway_dir = tmp_path / "gateway"
+    gateway_dir.mkdir()
+    (gateway_dir / "SOUL.gateway.md").write_text("   \n", encoding="utf-8")
+
+    assert gateway_run.GatewayRunner._load_gateway_context_files() == ""
+
+
+def test_ephemeral_prompt_appends_gateway_context_to_config_prompt(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {"agent": {"system_prompt": "base gateway prompt"}},
+    )
+    gateway_dir = tmp_path / "gateway"
+    gateway_dir.mkdir()
+    (gateway_dir / "SOUL.gateway.md").write_text("file-only gateway policy", encoding="utf-8")
+
+    prompt = gateway_run.GatewayRunner._load_ephemeral_system_prompt()
+
+    assert prompt.startswith("base gateway prompt")
+    assert "file-only gateway policy" in prompt
+
+
+def test_env_ephemeral_prompt_overrides_config_but_keeps_gateway_context(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "env gateway prompt")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {"agent": {"system_prompt": "config prompt should not appear"}},
+    )
+    gateway_dir = tmp_path / "gateway"
+    gateway_dir.mkdir()
+    (gateway_dir / "MEMORY.gateway.md").write_text("gateway memory rail", encoding="utf-8")
+
+    prompt = gateway_run.GatewayRunner._load_ephemeral_system_prompt()
+
+    assert prompt.startswith("env gateway prompt")
+    assert "config prompt should not appear" not in prompt
+    assert "gateway memory rail" in prompt

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -137,9 +137,12 @@ The gateway reads configuration from multiple sources:
 |--------|-----------------|
 | `~/.hermes/.env` | API keys, bot tokens, platform credentials |
 | `~/.hermes/config.yaml` | Model settings, tool configuration, display options |
+| `~/.hermes/gateway/SOUL.gateway.md` and `~/.hermes/gateway/MEMORY.gateway.md` | Gateway-only ephemeral system context for messaging turns |
 | Environment variables | Override any of the above |
 
 Unlike the CLI (which uses `load_cli_config()` with hardcoded defaults), the gateway reads `config.yaml` directly via YAML loader. This means config keys that exist in the CLI's defaults dict but not in the user's config file may behave differently between CLI and gateway.
+
+`GatewayRunner._load_ephemeral_system_prompt()` combines `HERMES_EPHEMERAL_SYSTEM_PROMPT` or `agent.system_prompt` with any non-empty gateway context files. Those files stay on the ephemeral system/context rail; they are not written into the user's message or persisted transcript.
 
 ## Platform Adapters
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -107,6 +107,19 @@ flowchart TB
 
 Each platform adapter receives messages, routes them through a per-chat session store, and dispatches them to the AIAgent for processing. The gateway also runs the cron scheduler, ticking every 60 seconds to execute any due jobs.
 
+## Gateway-only context files
+
+Messaging surfaces often need behavior that should not affect local CLI sessions: delivery rules, mobile-friendly formatting, platform-specific artifact policy, or other gateway-only operating guidance. Put that guidance in profile-scoped files under your Hermes home:
+
+```text
+~/.hermes/gateway/SOUL.gateway.md
+~/.hermes/gateway/MEMORY.gateway.md
+```
+
+When the gateway starts, Hermes appends any non-empty files from that directory to the gateway's ephemeral system context. They apply only to gateway turns, are not appended to the user's current message, and are additive to `HERMES_EPHEMERAL_SYSTEM_PROMPT` / `agent.system_prompt`.
+
+Use these files for durable messaging-surface policy. Do not put secrets in them. Restart the gateway after creating or editing them so the running process reloads the context.
+
 ## Intentional Silence Tokens
 
 For group chats, hooks, and automation flows, Hermes supports explicit silence tokens. If the agent's final response is exactly one supported token, the gateway suppresses outbound delivery and sends nothing to the chat.


### PR DESCRIPTION
## Summary

Adds a gateway-only context rail for messaging sessions.

When Hermes is running through the messaging gateway, the gateway now automatically loads profile-scoped context files:

```text
~/.hermes/gateway/SOUL.gateway.md
~/.hermes/gateway/MEMORY.gateway.md
```

and appends their contents to the gateway ephemeral system prompt.

## Why

Some instructions are specific to messaging surfaces: mobile/chat formatting, artifact delivery policy, platform behavior, or other gateway-only operating guidance. Before this, users had to approximate that with hooks such as `pre_llm_call`, which inject into the current user message. That creates bad mechanics: a short message like `ok` or `.` can become semantically dominated by the injected policy text.

This PR keeps durable gateway policy on the system/context rail instead:

```text
incoming user message stays clean
~/.hermes/gateway/*.gateway.md -> gateway ephemeral system context
```

## Behavior

- Gateway sessions load non-empty `SOUL.gateway.md` and `MEMORY.gateway.md` from `~/.hermes/gateway/`.
- The files are additive to `HERMES_EPHEMERAL_SYSTEM_PROMPT` or `agent.system_prompt`.
- `HERMES_EPHEMERAL_SYSTEM_PROMPT` still overrides `agent.system_prompt` exactly as before.
- Gateway context files are not appended to the user's current message and are not persisted as transcript turns.
- CLI sessions are unaffected.
- Missing or blank files are ignored.

## Files changed

- `gateway/run.py`: adds `GatewayRunner._load_gateway_context_files()` and appends the result inside `_load_ephemeral_system_prompt()`.
- `tests/gateway/test_gateway_context_files.py`: regression coverage for loading, blank/missing files, config prompt precedence, and env prompt override behavior.
- `website/docs/user-guide/messaging/index.md`: user-facing docs for gateway-only context files.
- `website/docs/developer-guide/gateway-internals.md`: internals docs for the prompt rail.

## Test Plan

- `python3 -m py_compile gateway/run.py tests/gateway/test_gateway_context_files.py`
- `uv run --python 3.11 --with pytest --with pytest-asyncio --with pytest-xdist python -m pytest -q -o 'addopts=' tests/gateway/test_gateway_context_files.py tests/gateway/test_runtime_config_env_expansion.py`
