### PR TITLE
fix(skills): allow canonical external skill precedence

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -19,8 +19,9 @@ from agent.runtime_cwd import resolve_agent_cwd
 from agent.skill_utils import (
     extract_skill_conditions,
     extract_skill_description,
-    get_all_skills_dirs,
+    external_skills_precede_local,
     get_disabled_skill_names,
+    get_external_skills_dirs,
     iter_skill_index_files,
     parse_frontmatter,
     skill_matches_environment,
@@ -1267,7 +1268,8 @@ def build_skills_system_prompt(
     descriptions are dropped, and a footer note explains the demotion.
     """
     skills_dir = get_skills_dir()
-    external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
+    external_dirs = get_external_skills_dirs()
+    external_precedence = external_skills_precede_local()
 
     if not skills_dir.exists() and not external_dirs:
         return ""
@@ -1285,6 +1287,7 @@ def build_skills_system_prompt(
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
+        external_precedence,
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
@@ -1298,7 +1301,10 @@ def build_skills_system_prompt(
             return cached
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+    # Only use the local-dir snapshot when local skills have precedence.  If a
+    # canonical external dir is configured to shadow local copies, scan in
+    # effective resolution order so the prompt index and skill_view agree.
+    snapshot = None if external_precedence else _load_skills_snapshot(skills_dir)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
@@ -1330,26 +1336,41 @@ def build_skills_system_prompt(
             for k, v in (snapshot.get("category_descriptions") or {}).items()
         }
     else:
-        # Cold path: full filesystem scan + write snapshot for next time
+        # Cold path: full filesystem scan + write snapshot for next time.  In
+        # external-precedence mode, scan external dirs first and skip duplicate
+        # local names so canonical/team skills appear in the mandatory index.
         skill_entries: list[dict] = []
-        for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
-            is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
-            entry = _build_snapshot_entry(skill_file, skills_dir, frontmatter, desc)
-            skill_entries.append(entry)
-            if not is_compatible:
+        seen_frontmatter_names: set[str] = set()
+        local_scan_dirs = [skills_dir]
+        if external_precedence:
+            local_scan_dirs = [*external_dirs, skills_dir]
+
+        for scan_dir in local_scan_dirs:
+            if not scan_dir.exists():
                 continue
-            skill_name = entry["skill_name"]
-            if entry["frontmatter_name"] in disabled or skill_name in disabled:
-                continue
-            if not _skill_should_show(
-                extract_skill_conditions(frontmatter),
-                available_tools,
-                available_toolsets,
-            ):
-                continue
-            skills_by_category.setdefault(entry["category"], []).append(
-                (entry["frontmatter_name"], entry["description"])
-            )
+            for skill_file in iter_skill_index_files(scan_dir, "SKILL.md"):
+                is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
+                entry = _build_snapshot_entry(skill_file, scan_dir, frontmatter, desc)
+                if scan_dir == skills_dir:
+                    skill_entries.append(entry)
+                if not is_compatible:
+                    continue
+                skill_name = entry["skill_name"]
+                frontmatter_name = entry["frontmatter_name"]
+                if frontmatter_name in seen_frontmatter_names:
+                    continue
+                if frontmatter_name in disabled or skill_name in disabled:
+                    continue
+                if not _skill_should_show(
+                    extract_skill_conditions(frontmatter),
+                    available_tools,
+                    available_toolsets,
+                ):
+                    continue
+                seen_frontmatter_names.add(frontmatter_name)
+                skills_by_category.setdefault(entry["category"], []).append(
+                    (frontmatter_name, entry["description"])
+                )
 
         # Read category-level DESCRIPTION.md files
         for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
@@ -1365,12 +1386,13 @@ def build_skills_system_prompt(
             except Exception as e:
                 logger.debug("Could not read skill description %s: %s", desc_file, e)
 
-        _write_skills_snapshot(
-            skills_dir,
-            _build_skills_manifest(skills_dir),
-            skill_entries,
-            category_descriptions,
-        )
+        if not external_precedence:
+            _write_skills_snapshot(
+                skills_dir,
+                _build_skills_manifest(skills_dir),
+                skill_entries,
+                category_descriptions,
+            )
 
     # ── External skill directories ─────────────────────────────────────
     # Scan external dirs directly (no snapshot caching — they're read-only
@@ -1381,7 +1403,7 @@ def build_skills_system_prompt(
         for name, _desc in cat_skills:
             seen_skill_names.add(name)
 
-    for ext_dir in external_dirs:
+    for ext_dir in ([] if external_precedence else external_dirs):
         if not ext_dir.exists():
             continue
         for skill_file in iter_skill_index_files(ext_dir, "SKILL.md"):

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -496,15 +496,37 @@ def get_external_skills_dirs() -> List[Path]:
     return result
 
 
-def get_all_skills_dirs() -> List[Path]:
-    """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
+def external_skills_precede_local() -> bool:
+    """Return whether configured external skill dirs should shadow local skills.
 
-    The local dir is always first (and always included even if it doesn't exist
-    yet — callers handle that).  External dirs follow in config order.
+    By default, the editable local ``~/.hermes/skills`` directory wins so
+    existing installations keep their historical behavior.  Operators that mount
+    a canonical read-only skill corpus (for example a shared team/MarrowKeep
+    mirror) can set ``skills.external_dirs_precedence: true`` so the prompt
+    index, ``skills_list``, and ``skill_view`` all resolve duplicates from the
+    canonical external source first.
     """
-    dirs = [get_skills_dir()]
-    dirs.extend(get_external_skills_dirs())
-    return dirs
+    parsed = _load_raw_config()
+    skills_cfg = parsed.get("skills") if isinstance(parsed, dict) else None
+    if not isinstance(skills_cfg, dict):
+        return False
+    return bool(skills_cfg.get("external_dirs_precedence", False))
+
+
+def get_all_skills_dirs() -> List[Path]:
+    """Return skill directories in effective resolution order.
+
+    Local skills normally come first for backward compatibility.  When
+    ``skills.external_dirs_precedence`` is true, external dirs come first so a
+    canonical read-only skill corpus can override stale local shims/copies.
+    The local dir is always included even if it doesn't exist yet — callers
+    handle that.
+    """
+    local = get_skills_dir()
+    external = get_external_skills_dirs()
+    if external_skills_precede_local():
+        return [*external, local]
+    return [local, *external]
 
 
 # ── Condition extraction ──────────────────────────────────────────────────

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1977,6 +1977,10 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # When true, configured external_dirs are searched before the editable
+        # local ~/.hermes/skills dir.  Use this for read-only canonical/team
+        # skill mirrors that should override stale local copies.
+        "external_dirs_precedence": False,
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -102,6 +102,16 @@ class TestGetAllSkillsDirs:
         assert result[0] == hermes_home / "skills"
         assert result[1] == external_skills_dir.resolve()
 
+    def test_external_precedence_puts_external_first(self, hermes_home, external_skills_dir):
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_skills_dir}\n  external_dirs_precedence: true\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.skill_utils import get_all_skills_dirs
+            result = get_all_skills_dirs()
+        assert result[0] == external_skills_dir.resolve()
+        assert result[1] == hermes_home / "skills"
+
 
 class TestExternalSkillsInFindAll:
     def test_external_skills_found(self, hermes_home, external_skills_dir):
@@ -139,6 +149,27 @@ class TestExternalSkillsInFindAll:
         assert len(matching) == 1
         assert matching[0]["description"] == "Local version"
 
+    def test_external_precedence_overrides_local(self, hermes_home, external_skills_dir):
+        """Configured canonical external skill dirs can shadow local copies."""
+        local_skills = hermes_home / "skills"
+        local_skill = local_skills / "my-external-skill"
+        local_skill.mkdir(parents=True)
+        (local_skill / "SKILL.md").write_text(
+            "---\nname: my-external-skill\ndescription: Local version\n---\n\nLocal.\n"
+        )
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_skills_dir}\n  external_dirs_precedence: true\n"
+        )
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            from tools.skills_tool import _find_all_skills
+            skills = _find_all_skills()
+        matching = [s for s in skills if s["name"] == "my-external-skill"]
+        assert len(matching) == 1
+        assert matching[0]["description"] == "A skill from an external directory"
+
 
 class TestExternalSkillView:
     def test_skill_view_finds_external(self, hermes_home, external_skills_dir):
@@ -154,3 +185,47 @@ class TestExternalSkillView:
             result = json.loads(skill_view("my-external-skill"))
         assert result["success"] is True
         assert "external things" in result["content"]
+
+    def test_skill_view_uses_external_when_precedence_enabled(self, hermes_home, external_skills_dir):
+        local_skills = hermes_home / "skills"
+        local_skill = local_skills / "my-external-skill"
+        local_skill.mkdir(parents=True)
+        (local_skill / "SKILL.md").write_text(
+            "---\nname: my-external-skill\ndescription: Local version\n---\n\nLocal only.\n"
+        )
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_skills_dir}\n  external_dirs_precedence: true\n"
+        )
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            from tools.skills_tool import skill_view
+            result = json.loads(skill_view("my-external-skill"))
+        assert result["success"] is True
+        assert "external things" in result["content"]
+        assert "Local only" not in result["content"]
+
+    def test_prompt_index_uses_external_when_precedence_enabled(self, hermes_home, external_skills_dir):
+        local_skills = hermes_home / "skills"
+        local_skill = local_skills / "my-external-skill"
+        local_skill.mkdir(parents=True)
+        (local_skill / "SKILL.md").write_text(
+            "---\nname: my-external-skill\ndescription: Local version\n---\n\nLocal only.\n"
+        )
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_skills_dir}\n  external_dirs_precedence: true\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.prompt_builder import (
+                build_skills_system_prompt,
+                clear_skills_system_prompt_cache,
+            )
+            from agent.skill_utils import _external_dirs_cache_clear
+
+            _external_dirs_cache_clear()
+            clear_skills_system_prompt_cache(clear_snapshot=True)
+            prompt = build_skills_system_prompt()
+
+        assert "my-external-skill: A skill from an external directory" in prompt
+        assert "my-external-skill: Local version" not in prompt

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -618,11 +618,20 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # Load disabled set once (not per-skill)
     disabled = set() if skip_disabled else _get_disabled_skill_names()
 
-    # Scan local dir first, then external dirs (local takes precedence)
+    # Scan in effective resolution order.  Local wins by default;
+    # skills.external_dirs_precedence lets canonical external mirrors win.
+    from agent.skill_utils import external_skills_precede_local
+
+    external_dirs = get_external_skills_dirs()
     dirs_to_scan = []
-    if SKILLS_DIR.exists():
-        dirs_to_scan.append(SKILLS_DIR)
-    dirs_to_scan.extend(get_external_skills_dirs())
+    if external_skills_precede_local():
+        dirs_to_scan.extend(external_dirs)
+        if SKILLS_DIR.exists():
+            dirs_to_scan.append(SKILLS_DIR)
+    else:
+        if SKILLS_DIR.exists():
+            dirs_to_scan.append(SKILLS_DIR)
+        dirs_to_scan.extend(external_dirs)
 
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
@@ -964,7 +973,10 @@ def skill_view(
             if bare:
                 local_category_name = f"{namespace}/{bare}"
 
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import (
+            external_skills_precede_local,
+            get_external_skills_dirs,
+        )
 
         # The categorized fall-through form (namespace/bare) joins onto each
         # search dir too; re-validate it since `bare` is not namespace-checked.
@@ -980,11 +992,19 @@ def skill_view(
                     ensure_ascii=False,
                 )
 
-        # Build list of all skill directories to search
+        # Build list of all skill directories to search in effective
+        # resolution order.  Local wins by default; canonical external mirrors
+        # can opt into shadowing local copies via config.
+        external_dirs = get_external_skills_dirs()
         all_dirs = []
-        if SKILLS_DIR.exists():
-            all_dirs.append(SKILLS_DIR)
-        all_dirs.extend(get_external_skills_dirs())
+        if external_skills_precede_local():
+            all_dirs.extend(external_dirs)
+            if SKILLS_DIR.exists():
+                all_dirs.append(SKILLS_DIR)
+        else:
+            if SKILLS_DIR.exists():
+                all_dirs.append(SKILLS_DIR)
+            all_dirs.extend(external_dirs)
 
         if not all_dirs:
             return json.dumps(
@@ -1085,23 +1105,26 @@ def skill_view(
                 "Skill name collision for '%s': %d candidates — %s",
                 name, len(candidates), "; ".join(paths),
             )
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": (
-                        f"Ambiguous skill name '{name}': {len(candidates)} skills "
-                        "match across your local skills dir and external_dirs. "
-                        "Refusing to guess — load one explicitly by its categorized path."
-                    ),
-                    "matches": paths,
-                    "hint": (
-                        "Pass the full relative path instead of the bare name "
-                        "(e.g., 'category/skill-name'), or rename one of the "
-                        "colliding skills so each name is unique."
-                    ),
-                },
-                ensure_ascii=False,
-            )
+            if not external_skills_precede_local():
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            f"Ambiguous skill name '{name}': {len(candidates)} skills "
+                            "match across your local skills dir and external_dirs. "
+                            "Refusing to guess — load one explicitly by its categorized path."
+                        ),
+                        "matches": paths,
+                        "hint": (
+                            "Pass the full relative path instead of the bare name "
+                            "(e.g., 'category/skill-name'), or rename one of the "
+                            "colliding skills so each name is unique. Set "
+                            "skills.external_dirs_precedence=true only when a "
+                            "configured external dir is the canonical source."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
 
         if candidates:
             skill_dir, skill_md = candidates[0]


### PR DESCRIPTION
## Summary
- add `skills.external_dirs_precedence` so configured external skill dirs can intentionally shadow local `~/.hermes/skills` copies
- make the mandatory skill prompt index, `skills_list`, and `skill_view` use the same effective resolution order
- keep the existing local-first behavior as the default for backward compatibility

## Why
Teams/operators can mount a read-only canonical skill corpus (for example a shared team or MarrowKeep-style mirror) while still keeping local runtime shims. Without an explicit precedence knob, the prompt can steer agents toward stale local copies instead of canonical external skills.

## Tests
- `uv run --with pytest python -m pytest tests/agent/test_external_skills.py tests/agent/test_prompt_builder.py tests/tools/test_skills_tool.py -q -o 'addopts='`
