### PR TITLE
fix(mcp): reset _tool_loop_count on all error paths in SamplingHandler

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1096,6 +1096,7 @@ class SamplingHandler:
                 self.server_name, self.max_rpm,
             )
             self.metrics["errors"] += 1
+            self._tool_loop_count = 0
             return self._error(
                 f"Sampling rate limit exceeded for server '{self.server_name}' "
                 f"({self.max_rpm} requests/minute)"
@@ -1116,6 +1117,7 @@ class SamplingHandler:
                 self.server_name, resolved_model,
             )
             self.metrics["errors"] += 1
+            self._tool_loop_count = 0
             return self._error(
                 f"Model '{resolved_model}' not allowed for server "
                 f"'{self.server_name}'. Allowed: {', '.join(self.allowed_models)}"
@@ -1174,12 +1176,14 @@ class SamplingHandler:
             )
         except asyncio.TimeoutError:
             self.metrics["errors"] += 1
+            self._tool_loop_count = 0
             return self._error(
                 f"Sampling LLM call timed out after {self.timeout}s "
                 f"for server '{self.server_name}'"
             )
         except Exception as exc:
             self.metrics["errors"] += 1
+            self._tool_loop_count = 0
             return self._error(
                 f"Sampling LLM call failed: {_sanitize_error(_exc_str(exc))}"
             )
@@ -1187,6 +1191,7 @@ class SamplingHandler:
         # Guard against empty choices (content filtering, provider errors)
         if not getattr(response, "choices", None):
             self.metrics["errors"] += 1
+            self._tool_loop_count = 0
             return self._error(
                 f"LLM returned empty response (no choices) for server "
                 f"'{self.server_name}'"


### PR DESCRIPTION
## What does this PR do?
`SamplingHandler._tool_loop_count` was only reset in `_build_text_result` (happy path) and when the loop limit was exceeded. On five error paths the counter was never cleared, causing it to leak into the next unrelated request and triggering a spurious 'tool loop limit exceeded' error prematurely.

## Type of Change
- [x] Bug fix

## Changes Made
Added `self._tool_loop_count = 0` before `return self._error(...)` on all five error paths in `SamplingHandler.__call__`:
- Rate limit exceeded
- Disallowed model
- `asyncio.TimeoutError`
- Generic exception
- Empty choices (no response)

## How to Test
1. Configure an MCP server with `max_tool_rounds > 1`.
2. Trigger a sampling timeout or rate-limit error mid-conversation.
3. Confirm the next request does not hit 'tool loop limit exceeded' prematurely.