### PR TITLE
feat(delegate): add per-task and top-level model parameter

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2072,6 +2072,7 @@ def delegate_task(
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    model: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2179,7 +2180,7 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role, "model": model}
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2220,12 +2221,14 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task model > top-level model > config delegation.model
+            effective_model = t.get("model") or model or creds["model"]
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=effective_model,
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
@@ -2307,7 +2310,7 @@ def delegate_task(
                 context=_t.get("context"),
                 toolsets=_t.get("toolsets") or toolsets,
                 role=_normalize_role(_t.get("role") or top_role),
-                model=creds["model"],
+                model=_t.get("model") or model or creds["model"],
                 session_key=_session_key,
                 runner=_async_runner,
                 interrupt_fn=_async_interrupt,
@@ -3042,6 +3045,15 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override (e.g. 'kimi-k2.7-code:cloud', "
+                                "'deepseek-flash-v4:cloud', 'minimax-m3:cloud'). "
+                                "Leave empty to use the top-level 'model' parameter or "
+                                "the default delegation model from config."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3095,6 +3107,15 @@ DELEGATE_TASK_SCHEMA = {
                     "Leave empty unless acp_command is explicitly provided."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Model override for the subagent (e.g. 'kimi-k2.7-code:cloud', "
+                    "'deepseek-flash-v4:cloud', 'minimax-m3:cloud', 'glm-5.2:cloud'). "
+                    "Leave empty to use the default delegation model from config "
+                    "(delegation.model). Per-task 'model' overrides this."
+                ),
+            },
         },
         "required": [],
     },
@@ -3118,6 +3139,7 @@ registry.register(
         acp_args=args.get("acp_args"),
         role=args.get("role"),
         background=args.get("background"),
+        model=args.get("model"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## What

Adds a `model` parameter to `delegate_task()` so the orchestrator can pick a specific model per delegated subtask instead of always using `delegation.model` from config.

## Changes

- **Top-level `model` parameter** on `delegate_task()` — applies to all tasks in the call
- **Per-task `model` override** in batch mode (`tasks` array) — overrides top-level
- **Precedence**: per-task `model` > top-level `model` > `config.delegation.model`
- **Schema updated** with descriptions and example model IDs

## Why

This enables multi-model orchestration in a single parallel `delegate_task` call. Example use case:

```python
delegate_task(tasks=[
    {"goal": "Analyze codebase, find pattern X", "model": "minimax-m3:cloud", "toolsets": ["terminal","search"]},
    {"goal": "Implement feature Y in views.py",   "model": "kimi-k2.7-code:cloud", "toolsets": ["file","terminal"]},
    {"goal": "Write tests for Z",                 "model": "deepseek-v4-flash:cloud", "toolsets": ["file","terminal"]},
])
```

Without this, every subtask runs on the same model, which is suboptimal when tasks have very different complexity profiles (read-only analysis vs. code generation vs. trivial verification).

## How it works

```python
# Single task
delegate_task(goal="...", model="kimi-k2.7-code:cloud")

# Batch — per-task override
delegate_task(tasks=[
    {"goal": "...", "model": "minimax-m3:cloud"},
    {"goal": "...", "model": "kimi-k2.7-code:cloud"},
])
```

The `model` value is passed through to `_build_child_agent()` / `_run_async_child()`, replacing the previous hardcoded `creds["model"]`.

## Verification

- Connectivity tested with 3 models in parallel (deepseek-v4-flash, kimi-k2.7-code, minimax-m3) — all responded correctly.
- No changes to default behavior when `model` is omitted (falls back to `creds["model"]`).

## Files changed

- `tools/delegate_tool.py` (+25, -3)