### PR TITLE
fix: improve CLI prompt labels and markdown flow

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2218,6 +2218,58 @@ def _preserve_windows_dot_segments_for_markdown(text: str) -> str:
     return _WINDOWS_PATH_WITH_DOT_SEGMENT_RE.sub(_protect, text)
 
 
+_MARKDOWN_BLOCK_START_RE = re.compile(
+    r"^\s*(?:#{1,6}\s|[-+*]\s|[-+*]\s*\[[ xX]\]\s|\d+[.)]\s|>|```|~~~|\|)"
+)
+
+
+def _flow_soft_wrapped_markdown_paragraphs(text: str) -> str:
+    """Collapse model hard-wraps inside plain prose paragraphs.
+
+    Models often emit ~80-column prose even when the classic CLI response panel
+    is much wider. Treat single newlines between plain paragraph lines as soft
+    wraps so Rich can wrap against the actual panel width, while leaving markdown
+    structure (lists, headings, blockquotes, code fences, tables) alone.
+    """
+    lines = str(text or "").split("\n")
+    out: list[str] = []
+    paragraph: list[str] = []
+    in_fence = False
+
+    def flush_paragraph() -> None:
+        nonlocal paragraph
+        if paragraph:
+            out.append(" ".join(part.strip() for part in paragraph))
+            paragraph = []
+
+    for line in lines:
+        stripped = line.strip()
+        fence = stripped.startswith(("```", "~~~"))
+        if in_fence:
+            flush_paragraph()
+            out.append(line)
+            if fence:
+                in_fence = False
+            continue
+        if fence:
+            flush_paragraph()
+            out.append(line)
+            in_fence = True
+            continue
+        if not stripped:
+            flush_paragraph()
+            out.append(line)
+            continue
+        if line[:1].isspace() or _MARKDOWN_BLOCK_START_RE.match(line):
+            flush_paragraph()
+            out.append(line)
+            continue
+        paragraph.append(line)
+
+    flush_paragraph()
+    return "\n".join(out)
+
+
 def _terminal_width_for_streaming() -> int:
     """Display cells available inside the streamed response box.
 
@@ -2253,6 +2305,10 @@ def _render_final_assistant_content(text: str, mode: str = "render"):
     panel_width = max(20, cols - 12)
 
     normalized_mode = str(mode or "render").strip().lower()
+    if normalized_mode == "raw":
+        return _rich_text_from_ansi(text or "")
+
+    text = _flow_soft_wrapped_markdown_paragraphs(text or "")
     if normalized_mode == "strip":
         # Strip first — inline markdown inside cells (`code`, **bold**, ~~strike~~)
         # changes cell display width — then re-align so the column padding
@@ -2260,8 +2316,6 @@ def _render_final_assistant_content(text: str, mode: str = "render"):
         return _RichText(
             realign_markdown_tables(_strip_markdown_syntax(text), panel_width)
         )
-    if normalized_mode == "raw":
-        return _rich_text_from_ansi(text or "")
 
     # `render` mode: Rich's Markdown renderer handles CJK width via wcwidth
     # internally, so a pre-pass through realign_markdown_tables would just
@@ -11814,12 +11868,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         symbol = (symbol or "❯ ").rstrip() + " "
 
-        # Prepend profile name when not default
+        # Prepend profile name when not default. Skins may override the visible
+        # prompt label while keeping the underlying profile identity unchanged
+        # (for example, a named operating skin on a Linear-team profile).
         try:
             from hermes_cli.profiles import get_active_profile_name
             profile = get_active_profile_name()
             if profile not in {"default", "custom"}:
-                symbol = f"{profile} {symbol}"
+                profile_label = profile
+                try:
+                    from hermes_cli.skin_engine import get_active_skin
+                    override = str(get_active_skin().get_branding("prompt_profile_label", "") or "").strip()
+                    if override:
+                        profile_label = override
+                except Exception:
+                    pass
+                symbol = f"{profile_label} {symbol}"
         except Exception:
             pass
         stripped = symbol.rstrip()

--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -3,13 +3,48 @@ from io import StringIO
 from rich.console import Console
 from rich.markdown import Markdown
 
-from cli import _render_final_assistant_content
+from cli import _flow_soft_wrapped_markdown_paragraphs, _render_final_assistant_content
 
 
 def _render_to_text(renderable) -> str:
     buf = StringIO()
     Console(file=buf, width=80, force_terminal=False, color_system=None).print(renderable)
     return buf.getvalue()
+
+
+def test_soft_wrapped_plain_paragraphs_flow_to_panel_width():
+    renderable = _render_final_assistant_content(
+        "This paragraph was hard wrapped by a model\n"
+        "even though the terminal panel has room.",
+        mode="strip",
+    )
+
+    output = _render_to_text(renderable)
+    assert "This paragraph was hard wrapped by a model even though" in output
+    assert "model\neven" not in output
+
+
+def test_soft_wrap_flow_preserves_markdown_blocks():
+    text = (
+        "Plain prose line one\n"
+        "plain prose line two\n\n"
+        "- list item one\n"
+        "- list item two\n"
+        "| A | B |\n"
+        "|---|---|\n"
+        "| 1 | 2 |\n"
+        "```\n"
+        "code line one\n"
+        "code line two\n"
+        "```"
+    )
+
+    flowed = _flow_soft_wrapped_markdown_paragraphs(text)
+
+    assert "Plain prose line one plain prose line two" in flowed
+    assert "- list item one\n- list item two" in flowed
+    assert "| A | B |\n|---|---|\n| 1 | 2 |" in flowed
+    assert "code line one\ncode line two" in flowed
 
 
 def test_final_assistant_content_uses_markdown_renderable():

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -56,6 +56,17 @@ class TestCliSkinPromptIntegration:
         with patch("hermes_cli.skin_engine.get_active_prompt_symbol", return_value="⚔ "):
             assert cli._get_tui_prompt_fragments() == [("class:sudo-prompt", "🔑 ⚔ ")]
 
+    def test_skin_prompt_profile_label_overrides_profile_name(self):
+        cli = _make_cli_stub()
+
+        skin = SimpleNamespace(
+            get_branding=lambda key, fallback="": "sandra" if key == "prompt_profile_label" else fallback
+        )
+        with patch("hermes_cli.skin_engine.get_active_prompt_symbol", return_value="Σ "), \
+             patch("hermes_cli.skin_engine.get_active_skin", return_value=skin), \
+             patch("hermes_cli.profiles.get_active_profile_name", return_value="team-aip"):
+            assert cli._get_tui_prompt_fragments() == [("class:prompt", "sandra Σ ")]
+
     def test_build_tui_style_dict_uses_skin_overrides(self):
         cli = _make_cli_stub()
 


### PR DESCRIPTION
## Summary
- allow skins to override the visible profile label in the interactive prompt while preserving the underlying profile identity
- flow soft-wrapped prose paragraphs before final markdown rendering
- preserve markdown block structures such as lists, tables, and fenced code

## Verification
- uv run --extra dev pytest tests/test_cli_skin_integration.py tests/cli/test_cli_markdown_rendering.py -q
- uv run --extra dev python -m py_compile cli.py
- uv run --extra dev pytest tests/cli tests/test_cli_skin_integration.py -q (broader slice exposed unrelated/order-dependent failures: resume quiet stderr passes in isolation; later worktree setup hit OS Errno 24 too many open files)
