### PR TITLE
fix(pricing): resolve versioned Bedrock profile IDs

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -685,7 +685,8 @@ def _normalize_bedrock_model_name(model: str) -> str:
     e.g. ``us.anthropic.claude-opus-4-7``.  The pricing table is keyed on the
     bare ``anthropic.claude-*`` id, so the prefix must be stripped before the
     lookup or every cross-region session prices as unknown.  Also normalizes
-    dot-notation version numbers (``4.7`` → ``4-7``).
+    dot-notation version numbers (``4.7`` → ``4-7``) and the documented
+    trailing date, revision, and profile components (``-20250514-v1:0``).
     """
     name = model.lower().strip()
     for prefix in (
@@ -704,6 +705,12 @@ def _normalize_bedrock_model_name(model: str) -> str:
             name = name[len(prefix):]
             break
     name = re.sub(r"(\d+)\.(\d+)", r"\1-\2", name)
+    # Bedrock inference profile IDs append these documented components to the
+    # foundation model ID. Strip only the trailing forms, not arbitrary model
+    # name continuations that could be a distinct SKU.
+    name = re.sub(r":\d+$", "", name)
+    name = re.sub(r"-v\d+$", "", name)
+    name = re.sub(r"-\d{8}$", "", name)
     return name
 
 
@@ -745,20 +752,6 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
             entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
             if entry:
                 return entry
-        bedrock_entries = (
-            (known_model, known_entry)
-            for (provider, known_model), known_entry in _OFFICIAL_DOCS_PRICING.items()
-            if provider == route.provider
-        )
-        for known_model, known_entry in sorted(
-            bedrock_entries,
-            key=lambda item: len(item[0]),
-            reverse=True,
-        ):
-            if normalized == known_model or normalized.startswith(
-                (f"{known_model}-", f"{known_model}:")
-            ):
-                return known_entry
     return None
 
 

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -681,15 +681,25 @@ def _normalize_bedrock_model_name(model: str) -> str:
     """Normalize a Bedrock model id to its bare foundation-model form.
 
     Bedrock cross-region inference profiles prefix the foundation model id
-    with a region scope (``us.`` / ``global.`` / ``eu.`` / ``ap.`` / ``jp.``),
+    with a region scope (``us.`` / ``global.`` / ``eu.`` / ``apac.`` / ...),
     e.g. ``us.anthropic.claude-opus-4-7``.  The pricing table is keyed on the
     bare ``anthropic.claude-*`` id, so the prefix must be stripped before the
-    lookup or every cross-region session prices as unknown.  Mirrors the
-    prefix list in ``bedrock_adapter.is_anthropic_bedrock_model``.  Also
-    normalizes dot-notation version numbers (``4.7`` → ``4-7``).
+    lookup or every cross-region session prices as unknown.  Also normalizes
+    dot-notation version numbers (``4.7`` → ``4-7``).
     """
     name = model.lower().strip()
-    for prefix in ("us.", "global.", "eu.", "ap.", "jp."):
+    for prefix in (
+        "global.",
+        "us.",
+        "eu.",
+        "ap.",
+        "apac.",
+        "jp.",
+        "ca.",
+        "sa.",
+        "me.",
+        "af.",
+    ):
         if name.startswith(prefix):
             name = name[len(prefix):]
             break
@@ -735,6 +745,20 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
             entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
             if entry:
                 return entry
+        bedrock_entries = (
+            (known_model, known_entry)
+            for (provider, known_model), known_entry in _OFFICIAL_DOCS_PRICING.items()
+            if provider == route.provider
+        )
+        for known_model, known_entry in sorted(
+            bedrock_entries,
+            key=lambda item: len(item[0]),
+            reverse=True,
+        ):
+            if normalized == known_model or normalized.startswith(
+                (f"{known_model}-", f"{known_model}:")
+            ):
+                return known_entry
     return None
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -324,16 +324,34 @@ def test_bedrock_pricing_supports_less_common_inference_profile_prefixes():
     """AWS also exposes profile scopes beyond us./global./eu.; those should
     not silently fall through to unknown pricing.
     """
+    bare = get_pricing_entry("anthropic.claude-haiku-4-5", provider="bedrock")
     entry = get_pricing_entry(
         "apac.anthropic.claude-haiku-4-5-20251001-v1:0",
         provider="bedrock",
     )
 
+    assert bare is not None
     assert entry is not None
-    assert float(entry.input_cost_per_million) == 0.8
-    assert float(entry.output_cost_per_million) == 4.0
-    assert float(entry.cache_read_cost_per_million) == 0.08
-    assert float(entry.cache_write_cost_per_million) == 1.0
+    for field in (
+        "input_cost_per_million",
+        "output_cost_per_million",
+        "cache_read_cost_per_million",
+        "cache_write_cost_per_million",
+    ):
+        assert getattr(entry, field) == getattr(bare, field)
+
+
+def test_bedrock_unknown_model_continuation_does_not_use_base_pricing():
+    """Unrecognized Bedrock SKUs must remain unknown rather than inheriting a
+    similarly named model family's price.
+    """
+    assert (
+        get_pricing_entry(
+            "anthropic.claude-sonnet-4-6-experimental",
+            provider="bedrock",
+        )
+        is None
+    )
 
 
 def test_bedrock_claude_cached_session_estimates_cost_not_unknown():

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -299,6 +299,43 @@ def test_bedrock_cross_region_profile_prefix_resolves_to_pricing():
         assert scoped.cache_read_cost_per_million == bare.cache_read_cost_per_million
 
 
+def test_bedrock_versioned_inference_profile_resolves_to_bare_pricing():
+    """Bedrock profile IDs may include the provider's dated version suffix.
+
+    The pricing table intentionally uses shorter model-family IDs, so the
+    lookup needs a longest-prefix fallback after stripping the region scope.
+    """
+    bare = get_pricing_entry("anthropic.claude-sonnet-4-6", provider="bedrock")
+    assert bare is not None
+
+    for model in (
+        "us.anthropic.claude-sonnet-4-6-20250514-v1:0",
+        "global.anthropic.claude-sonnet-4-6-20250514-v1:0",
+    ):
+        scoped = get_pricing_entry(model, provider="bedrock")
+        assert scoped is not None, model
+        assert scoped.input_cost_per_million == bare.input_cost_per_million
+        assert scoped.output_cost_per_million == bare.output_cost_per_million
+        assert scoped.cache_read_cost_per_million == bare.cache_read_cost_per_million
+        assert scoped.cache_write_cost_per_million == bare.cache_write_cost_per_million
+
+
+def test_bedrock_pricing_supports_less_common_inference_profile_prefixes():
+    """AWS also exposes profile scopes beyond us./global./eu.; those should
+    not silently fall through to unknown pricing.
+    """
+    entry = get_pricing_entry(
+        "apac.anthropic.claude-haiku-4-5-20251001-v1:0",
+        provider="bedrock",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.8
+    assert float(entry.output_cost_per_million) == 4.0
+    assert float(entry.cache_read_cost_per_million) == 0.08
+    assert float(entry.cache_write_cost_per_million) == 1.0
+
+
 def test_bedrock_claude_cached_session_estimates_cost_not_unknown():
     """A Bedrock Claude session with cache hits must produce a dollar estimate,
     not ``unknown`` — the user-visible symptom in #50295.


### PR DESCRIPTION
## Summary

Follow-up to #50307 and the now-closed #50295.

#50307 fixed the main `/usage` failure for Bedrock Claude cache tokens and exact cross-region profile IDs such as `us.anthropic.claude-sonnet-4-5`. Two profile shapes can still miss the official pricing table:

- versioned Bedrock profile IDs, e.g. `us.anthropic.claude-sonnet-4-6-20250514-v1:0`
- less common AWS profile scopes such as `apac.`

Those IDs normalize to a valid Bedrock Claude model family, but the lookup only tried an exact key. Since the pricing snapshot is keyed by the shorter model-family ID (`anthropic.claude-sonnet-4-6`), these still fell through to `None`.

This PR leaves the cache pricing rows from #50307 alone and only tightens the Bedrock pricing lookup.

## Changes

- Expand the Bedrock inference-profile prefix list to include `global.`, `us.`, `eu.`, `ap.`, `apac.`, `jp.`, `ca.`, `sa.`, `me.`, and `af.`.
- Add a longest-prefix fallback for Bedrock official-docs pricing entries so versioned IDs resolve to their bare table row.
- Add regression tests for versioned `us.` / `global.` Claude profile IDs and an `apac.` Claude Haiku profile ID.

## Validation

Before this patch on current `origin/main`:

| Model | Pricing lookup |
|---|---|
| `us.anthropic.claude-sonnet-4-6` | resolves |
| `us.anthropic.claude-sonnet-4-6-20250514-v1:0` | misses |
| `global.anthropic.claude-sonnet-4-6-20250514-v1:0` | misses |
| `apac.anthropic.claude-haiku-4-5-20251001-v1:0` | misses |

Tests run:

- `python3 -m pytest tests/agent/test_usage_pricing.py -q` -> 17 passed
- `python3 -m ruff check agent/usage_pricing.py tests/agent/test_usage_pricing.py`
- `git diff --check`
- `python3 -m py_compile agent/usage_pricing.py tests/agent/test_usage_pricing.py`

Note: `bash scripts/run_tests.sh tests/agent/test_usage_pricing.py` could not run in this local checkout because the wrapper requires a `.venv` or `venv` directory.
