### PR TITLE
fix(agent): record cwd for TUI sessions

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1310,7 +1310,7 @@ def _ensure_session_db_row(session: dict) -> None:
             source=_session_source(session),
             model=row_model,
             model_config=model_config or None,
-            cwd=_session_cwd(session) if session.get("explicit_cwd") else None,
+            cwd=_session_cwd(session),
         )
     except Exception:
         logger.debug("failed to persist desktop session row", exc_info=True)


### PR DESCRIPTION
## Bug: TUI sessions don't record cwd — Desktop groups them under default workspace

`_launch_cwd_for_session()` in `run_agent.py` only records cwd when `source == "cli"`. TUI sessions (`source == "tui"`) get `cwd = NULL`, so the Desktop GUI cannot group them by workspace — they all land in the default/"No workspace" group.

### Steps to reproduce

1. `cd ~/Documents/pa && hermes --tui`
2. Start a new session
3. Open Desktop GUI — the session appears under the default workspace, not under a "pa" workspace

### Root cause

`run_agent.py:80`:

```python
def _launch_cwd_for_session(source: str) -> Optional[str]:
    if source != "cli":  # <-- TUI excluded
        return None
```

All TUI sessions in `state.db` show `cwd = /Users/lestroy` (home) or NULL, regardless of the actual launch directory.

### Suggested fix

```python
if source not in ("cli", "tui"):
    return None
```

### Related issues

- #42228 — compressed sessions losing cwd (different bug, but related)
- #40297 — workspace selectable per session
- #48782 — WebUI ignoring cwd from state.db
