### PR TITLE
fix(web_server): broaden exception catch in _resolve_restart_drain_timeout

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -155,7 +155,7 @@ def _resolve_restart_drain_timeout() -> float:
     try:
         from hermes_cli.gateway import _get_restart_drain_timeout
         return _get_restart_drain_timeout()
-    except ImportError:
+    except Exception:
         from gateway.restart import DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
         return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
 


### PR DESCRIPTION
## What does this PR do?
`_resolve_restart_drain_timeout()` only caught `ImportError`, but its sibling `_warm_gateway_module()` catches broad `Exception` for the same import chain. A non-`ImportError` failure (e.g. module-chain init error on cold start) propagated and broke the liveness endpoint instead of falling back to the documented default timeout.

## Type of Change
- [x] Bug fix

## Changes Made
`hermes_cli/web_server.py:158`: changed `except ImportError` to `except Exception` in `_resolve_restart_drain_timeout`, matching `_warm_gateway_module`'s existing broad-catch behavior for the same import.

## How to Test
1. Simulate a non-ImportError failure in the `hermes_cli.gateway` import chain.
2. Confirm `get_status()` liveness endpoint returns the default timeout instead of raising.