### PR TITLE
fix(kanban): respect disabled toolsets

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -142,6 +142,41 @@ def test_kanban_tools_visible_with_toolset_config(monkeypatch, tmp_path):
     assert kanban == expected, f"expected {expected}, got {kanban}"
 
 
+def test_blank_slate_disabled_kanban_overrides_legacy_toolset(monkeypatch, tmp_path):
+    """Blank Slate's explicit CLI config and disabled list suppress stale legacy
+    ``toolsets: [kanban]`` so Kanban-only skills/tools do not leak back in.
+    """
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+platform_toolsets:
+  cli:
+    - file
+    - terminal
+toolsets:
+  - kanban
+agent:
+  disabled_toolsets:
+    - kanban
+""".lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import tools.kanban_tools  # ensure registered
+    from tools.registry import invalidate_check_fn_cache, registry
+    from toolsets import resolve_toolset
+
+    invalidate_check_fn_cache()
+    schema = registry.get_definitions(set(resolve_toolset("hermes-cli")), quiet=True)
+    names = {s["function"].get("name") for s in schema if "function" in s}
+    kanban = {n for n in names if n and n.startswith("kanban_")}
+    assert kanban == set()
+
+
 # ---------------------------------------------------------------------------
 # Handler happy paths
 # ---------------------------------------------------------------------------

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -55,7 +55,20 @@ def _profile_has_kanban_toolset() -> bool:
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
-        toolsets = cfg.get("toolsets", [])
+        agent_cfg = cfg.get("agent") or {}
+        disabled_toolsets = {str(ts) for ts in agent_cfg.get("disabled_toolsets") or []}
+        if "kanban" in disabled_toolsets:
+            return False
+
+        platform_toolsets = cfg.get("platform_toolsets") or {}
+        cli_toolsets = platform_toolsets.get("cli")
+        if isinstance(cli_toolsets, list):
+            return "kanban" in {str(ts) for ts in cli_toolsets}
+
+        # Legacy orchestrator profiles used top-level ``toolsets: [kanban]``.
+        # Keep that working, but only when the newer per-platform config has
+        # not made an explicit CLI selection.
+        toolsets = {str(ts) for ts in cfg.get("toolsets", [])}
         return "kanban" in toolsets
     except Exception:
         return False


### PR DESCRIPTION
## What does this PR do?

Fixes the Kanban activation check so Blank Slate and other explicit CLI toolset configs can suppress stale legacy `toolsets: [kanban]` state.

Before this change, `_profile_has_kanban_toolset()` read only the top-level `toolsets` list. That meant a profile with explicit `platform_toolsets.cli: [file, terminal]` and `agent.disabled_toolsets: [kanban]` could still be treated as Kanban-active if stale legacy config still contained `toolsets: [kanban]`. Since Kanban skills declare `environments: [kanban]`, that stale state could expose `kanban-orchestrator` / `kanban-worker` even when the actual CLI toolset resolution had Kanban disabled.

The new precedence is:

1. `agent.disabled_toolsets` suppresses Kanban.
2. Explicit `platform_toolsets.cli` is authoritative.
3. Legacy top-level `toolsets: [kanban]` still works when no explicit CLI toolset list exists.

## Related Issue

No GitHub issue. Found while investigating a Discord support report about Blank Slate still showing Kanban skills.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/kanban_tools.py` so `_profile_has_kanban_toolset()` respects `agent.disabled_toolsets` and explicit `platform_toolsets.cli` before falling back to legacy top-level `toolsets`.
- Added `tests/tools/test_kanban_tools.py` coverage for the Blank Slate/stale legacy config case where Kanban should remain disabled.

## How to Test

1. Create an isolated Hermes home with `platform_toolsets.cli: [file, terminal]`, stale `toolsets: [kanban]`, and `agent.disabled_toolsets: [kanban]`.
2. Confirm `_profile_has_kanban_toolset()` returns `False` and Kanban-only skills are not returned by `_find_all_skills()`.
3. Confirm a legacy profile with only `toolsets: [kanban]` still returns `True` and keeps Kanban skills visible.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux checkout with isolated temp `HERMES_HOME`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

- `.venv/bin/python -m py_compile tools/kanban_tools.py tests/tools/test_kanban_tools.py` passed.
- `git diff --check -- tools/kanban_tools.py tests/tools/test_kanban_tools.py` passed.
- Isolated temp-home validation:
  - `toolsets: [kanban]` legacy profile -> `_profile_has_kanban_toolset() == True`, Kanban skills visible.
  - `platform_toolsets.cli: [file, terminal]` + stale `toolsets: [kanban]` + `agent.disabled_toolsets: [kanban]` -> `_profile_has_kanban_toolset() == False`, Kanban skills hidden.
- Focused pytest was not run because this checkout's venv rejects `-j 4`, and local repo guidance says not to run pytest without `-j 4`.
