### PR TITLE
fix: skip Node when it can't launch on older macOS

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -880,9 +880,18 @@ install_node() {
     export PATH="$HERMES_HOME/node/bin:$PATH"
 
     local installed_ver
-    installed_ver=$("$HERMES_HOME/node/bin/node" --version 2>/dev/null)
-    log_success "Node.js $installed_ver installed to ~/.hermes/node/"
-    HAS_NODE=true
+    # `|| true` keeps bash 5's `set -e` from killing the insatll if node won't run.
+    # This can happen on older macOS versions where the bundled Node is too new for the OS.
+    # The install can still complete successfully without Node.
+    installed_ver=$("$HERMES_HOME/node/bin/node" --version 2>/dev/null) || true
+    if [ -n "$installed_ver" ]; then
+        log_success "Node.js $installed_ver installed to ~/.hermes/node/"
+        HAS_NODE=true
+    else
+        # install_node_deps() will see HAS_NODE=false and skip cleanly.
+        log_warn "Node.js binary will not run on this OS (likely too-old macOS); continuing without Node"
+        HAS_NODE=false
+    fi
 }
 
 check_network_prerequisites() {


### PR DESCRIPTION
## Summary

On macOS older than Big Sur, `scripts/install.sh` exits silently mid-`install_node()`. The user sees the install stuck at "Extracting to ~/.hermes/node/..." with no warning and no further output.

## Symptom

```text
→ Downloading node-v22.23.0-darwin-x64.tar.xz...
→ Extracting to ~/.hermes/node/...
# ← installer exits here with no errors
```

Trying to run the extracted `node` binary crashes with a segmentation fault: 

```text
$ ~/.hermes/node/bin/node --version
dyld: lazy symbol binding failed: Symbol not found: ____chkstk_darwin
  Referenced from: /Users/u/.hermes/node/bin/node (which was built for Mac OS X 11.0)
  Expected in: /usr/lib/libSystem.B.dylib
```

`____chkstk_darwin` was added to libSystem in macOS 10.15. Node 22's official Darwin binaries are built against the macOS 11 SDK and won't launch on anything older.

## Root cause

The install script is already built to keep going without Node. `install_node_deps()` returns immediately if `HAS_NODE=false`. The bug is in one line of `install_node()`:

```bash
installed_ver=$("$HERMES_HOME/node/bin/node" --version 2>/dev/null)
```

Bash 5 propagates a failing command substitution through a variable assignment under `set -e`. Node exits 134, the assignment inherits that status, `set -e` kills the script before `HAS_NODE` is set either way. Older bash doesn't propagate this, which is why the bug is invisible on most Linux distros and on macOS itself when the script is run through Apple's default `/bin/bash` 3.2.

## Fix

Guard with `|| true` and branch explicitly on whether Node ran. On failure, set `HAS_NODE=false` so downstream skips work as already designed.

```diff
     local installed_ver
-    installed_ver=$("$HERMES_HOME/node/bin/node" --version 2>/dev/null)
-    log_success "Node.js $installed_ver installed to ~/.hermes/node/"
-    HAS_NODE=true
+    # `|| true` keeps bash 5's `set -e` from killing us if node won't run.
+    installed_ver=$("$HERMES_HOME/node/bin/node" --version 2>/dev/null) || true
+    if [ -n "$installed_ver" ]; then
+        log_success "Node.js $installed_ver installed to ~/.hermes/node/"
+        HAS_NODE=true
+    else
+        # HAS_NODE=false makes install_node_deps() skip cleanly.
+        log_warn "Node.js binary will not run on this OS (likely too-old macOS); continuing without Node"
+        HAS_NODE=false
+    fi
 }
```

## Test plan

- [x] macOS 10.13.6 / bash 5.3.9: installer completes, Hermes CLI works, 73 bundled skills synced, browser tools skipped
- [x] Patch applies cleanly against current `main`
- [ ] Modern macOS / bash 3.2 or 5: no behavior change expected — `|| true` is a no-op when Node succeeds
- [ ] Linux: no behavior change expected

Browser automation still won't work on pre-10.15 macOS. 
