### PR TITLE
fix(gateway): don't lazy-install SDKs for unconfigured platforms on startup (desktop stuck at 94%)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1907,12 +1907,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         from gateway.platform_registry import platform_registry
         for entry in platform_registry.plugin_entries():
             try:
-                if not entry.check_fn():
-                    continue
+                platform = Platform(entry.name)
             except Exception as e:
-                logger.debug("check_fn for %s raised: %s", entry.name, e)
+                logger.debug("unknown platform name %r: %s", entry.name, e)
                 continue
-            platform = Platform(entry.name)
             existing_cfg = config.platforms.get(platform)
             # Respect an explicit ``enabled: false`` (YAML / gateway.json /
             # dashboard PUT).  ``_enabled_explicit`` is set in
@@ -1996,6 +1994,22 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                             entry.name,
                         )
                         continue
+            # Verify dependencies LAST — only for platforms that are already
+            # enabled or passed the credential gate above.  For adapter plugins
+            # ``check_fn`` lazy-INSTALLS the platform SDK (pip) as a side
+            # effect, so running it as an unconditional sweep over every
+            # registered platform made ``load_gateway_config()`` pip-install
+            # Discord/Telegram/Slack/Feishu/Dingtalk on every call — including
+            # the desktop/dashboard readiness probe (``GET /api/status``, which
+            # awaits this synchronously) — even when the user configured none
+            # of them.  That blocked startup until every install finished and
+            # caused the desktop app to time out and boot-loop (stuck at 94%).
+            try:
+                if not entry.check_fn():
+                    continue
+            except Exception as e:
+                logger.debug("check_fn for %s raised: %s", entry.name, e)
+                continue
             if platform not in config.platforms:
                 config.platforms[platform] = PlatformConfig()
             config.platforms[platform].enabled = True

--- a/tests/gateway/test_startup_no_eager_platform_install.py
+++ b/tests/gateway/test_startup_no_eager_platform_install.py
@@ -1,0 +1,100 @@
+"""Regression tests: ``_apply_env_overrides`` must not lazy-install platform
+SDKs for platforms the user has not configured.
+
+For adapter plugins, ``PlatformEntry.check_fn`` doubles as the lazy-installer
+(it pip-installs the platform SDK as a side effect — see e.g.
+``plugins/platforms/discord/adapter.py::check_discord_requirements``).  The
+enablement sweep in ``_apply_env_overrides`` used to call ``check_fn`` for
+*every* registered plugin platform unconditionally, so a single
+``load_gateway_config()`` — which the desktop/dashboard readiness probe
+(``GET /api/status``) awaits synchronously — pip-installed Discord, Telegram,
+Slack, Feishu and Dingtalk even with ``platforms: none``.  That blocked
+startup until every install finished and made the desktop app time out and
+boot-loop (stuck at 94%).
+
+The fix consults the cheap ``is_connected`` credential check FIRST and only
+runs the install-triggering ``check_fn`` for platforms that are already
+enabled or actually configured.  These tests pin that contract.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+from gateway.platform_registry import PlatformEntry, platform_registry
+
+
+@pytest.fixture
+def isolated_registry():
+    """Run with a registry containing only the entries the test registers."""
+    original = dict(platform_registry._entries)
+    platform_registry._entries.clear()
+    try:
+        # ``_apply_env_overrides`` calls ``discover_plugins()`` (idempotent),
+        # which would re-register the real bundled platforms and clobber the
+        # fakes below.  Neutralize it so the test controls the registry.
+        with patch("hermes_cli.plugins.discover_plugins", lambda *a, **k: None):
+            yield platform_registry
+    finally:
+        platform_registry._entries.clear()
+        platform_registry._entries.update(original)
+
+
+def _register_fake_platform(name, *, check_fn, is_connected):
+    platform_registry.register(
+        PlatformEntry(
+            name=name,
+            label=name.title(),
+            adapter_factory=lambda cfg: MagicMock(),
+            check_fn=check_fn,
+            is_connected=is_connected,
+            source="plugin",
+        )
+    )
+
+
+def test_unconfigured_platform_is_not_probed_for_install(isolated_registry):
+    # is_connected reports "no credentials" → the platform must be skipped
+    # without ever calling check_fn (which would lazy-install the SDK).
+    check_fn = MagicMock(return_value=True)
+    _register_fake_platform(
+        "discord", check_fn=check_fn, is_connected=lambda cfg: False
+    )
+
+    config = GatewayConfig()
+    _apply_env_overrides(config)
+
+    check_fn.assert_not_called()
+    assert not config.platforms.get(Platform.DISCORD, PlatformConfig()).enabled
+
+
+def test_configured_platform_is_still_installed_and_enabled(isolated_registry):
+    # is_connected reports "credentials present" → check_fn must run (so the
+    # SDK is verified/installed) and the platform is auto-enabled, exactly as
+    # before the fix.
+    check_fn = MagicMock(return_value=True)
+    _register_fake_platform(
+        "discord", check_fn=check_fn, is_connected=lambda cfg: True
+    )
+
+    config = GatewayConfig()
+    _apply_env_overrides(config)
+
+    check_fn.assert_called_once()
+    assert config.platforms[Platform.DISCORD].enabled is True
+
+
+def test_failed_install_does_not_enable_configured_platform(isolated_registry):
+    # Credentials present but the SDK genuinely cannot be installed/imported
+    # (check_fn returns False) → platform must not be enabled.
+    check_fn = MagicMock(return_value=False)
+    _register_fake_platform(
+        "discord", check_fn=check_fn, is_connected=lambda cfg: True
+    )
+
+    config = GatewayConfig()
+    _apply_env_overrides(config)
+
+    check_fn.assert_called_once()
+    assert not config.platforms.get(Platform.DISCORD, PlatformConfig()).enabled


### PR DESCRIPTION
## Summary
Hermes Desktop no longer boot-loops at 94% on a fresh machine: the gateway startup config load stops lazy-installing platform SDKs the user never configured.

**Root cause:** In `_apply_env_overrides`, the plugin-platform enablement sweep called `entry.check_fn()` first, unconditionally, for every registered adapter — *before* the `is_connected` credential gate. For adapter plugins `check_fn` doubles as the lazy installer (`check_discord_requirements` → `tools.lazy_deps.ensure("platform.discord")`, etc.), so a single `load_gateway_config()` pip-installed Discord/Telegram/Slack/Feishu/Dingtalk on every launch even with `platforms: none`. The desktop/dashboard readiness probe (`GET /api/status`) awaits that synchronously, so the backend never went ready, the app timed out, killed it, and restarted — stuck at 94%.

## Changes
- `gateway/config.py`: move the install-triggering `entry.check_fn()` call to run **last**, only for platforms that pass the cheap `is_connected` credential gate (or are already enabled). Unconfigured platforms are skipped without ever invoking `check_fn`.
- `tests/gateway/test_startup_no_eager_platform_install.py`: regression coverage — unconfigured → never probed; configured → installed + enabled; install-fails → not enabled.

## Validation
| | Before (origin/main) | After |
|---|---|---|
| `check_fn` invoked on `_apply_env_overrides` with no credentials | **21 platforms** (dingtalk, discord, slack, feishu, telegram, …) | **0 platforms** |
| Lazy pip installs on desktop readiness probe | every adapter SDK | none |

E2E-verified against real `_apply_env_overrides` with a temp `HERMES_HOME` and all credential env vars stripped: zero `check_fn` calls / zero lazy-installs on the fixed path, vs all 21 adapters probed on origin/main. `tests/gateway/test_config.py` + the new regression file: 70/70 pass.

Salvaged from #50141 (cherry-picked, authorship preserved). Original reporter: @beatkapo.

## Infographic

![desktop-94-percent-lazy-install-fix](https://v3b.fal.media/files/b/0a9f3d2c/Mik1fKVx9hAX8NhpNkHou_8tIiNVF3.png)
