### PR TITLE
feat(goal): require approval before gateway goal execution

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14115,6 +14115,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             user_input = _seed
                         else:
                             continue
+
+                    if not _file_drop and isinstance(user_input, str):
+                        if self._maybe_handle_goal_draft_reply(user_input):
+                            continue
                     
                     # Expand paste references back to full content
                     _paste_ref_re = re.compile(r'\[Pasted text #\d+: \d+ lines \u2192 (.+?)\]')

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5302,6 +5302,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Returns True if at least one adapter connected successfully.
         """
         logger.info("Starting Hermes Gateway...")
+        if not hasattr(self, "_background_tasks") or self._background_tasks is None:
+            self._background_tasks = set()
         try:
             self._gateway_loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -10500,7 +10502,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             return 20
 
-    def _get_goal_manager_for_event(self, event: "MessageEvent"):
+    def _get_goal_manager_for_event(
+        self,
+        event: "MessageEvent",
+        *,
+        create_session: bool = True,
+    ):
         """Return a GoalManager bound to the session for this gateway event.
 
         Returns ``(manager, session_entry)`` or ``(None, None)`` if the
@@ -10512,9 +10519,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("goal manager unavailable: %s", exc)
             return None, None
         try:
-            session_entry = self.session_store.get_or_create_session(event.source)
+            if create_session:
+                session_entry = self.session_store.get_or_create_session(event.source)
+            else:
+                lookup = None
+                if hasattr(self.session_store.__class__, "get_existing_session"):
+                    lookup = getattr(self.session_store, "get_existing_session", None)
+                if callable(lookup):
+                    session_entry = lookup(event.source)
+                else:
+                    # Lightweight test doubles often expose a prebuilt entry
+                    # without implementing the full GatewaySessionStore API.
+                    # Use it only when present on the instance itself; do not
+                    # trigger MagicMock.__getattr__ and accidentally create a
+                    # mock session.
+                    session_entry = vars(self.session_store).get("entry")
         except Exception as exc:
             logger.debug("goal manager: session lookup failed: %s", exc)
+            return None, None
+        if session_entry is None:
             return None, None
         sid = getattr(session_entry, "session_id", None) or ""
         if not sid:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7935,6 +7935,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _cmd_def = _resolve_cmd(command) if command else None
         canonical = _cmd_def.name if _cmd_def else command
 
+        if not command:
+            pending_goal_reply = await self._handle_pending_goal_reply(event)
+            if pending_goal_reply is not None:
+                return pending_goal_reply
+
         # Expand alias quick commands before built-in dispatch so targets like
         # /model openai/gpt-5.5 --provider openrouter reach the /model handler.
         # Preserve built-in precedence; aliases only need early handling when

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1043,6 +1043,21 @@ class SessionStore:
 
         return entry
 
+    def get_existing_session(self, source: SessionSource) -> Optional[SessionEntry]:
+        """Return the current entry for ``source`` without creating or resetting.
+
+        Some gateway probes need to check optional per-session side state
+        before deciding whether an inbound message should start a real agent
+        turn. Those probes must not call :meth:`get_or_create_session`,
+        because creating a session is itself user-visible state and can bypass
+        early-return paths such as Telegram topic-mode lobby reminders or the
+        active-session limit.
+        """
+        session_key = self._generate_session_key(source)
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._entries.get(session_key)
+
     def update_session(
         self,
         session_key: str,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1797,7 +1797,7 @@ class GatewaySlashCommandsMixin:
             return t("gateway.goal.resumed", goal=state.goal)
 
         if lower in {"clear", "stop", "done"}:
-            had = mgr.has_goal()
+            had = mgr.has_goal() or mgr.has_pending_draft()
             mgr.clear()
             try:
                 adapter = self.adapters.get(event.source.platform) if event.source else None
@@ -1808,30 +1808,50 @@ class GatewaySlashCommandsMixin:
                 logger.debug("goal clear: pending continuation cleanup failed: %s", exc)
             return t("gateway.goal_cleared") if had else t("gateway.no_active_goal")
 
-        # Otherwise — treat the remaining text as the new goal.
+        # Otherwise — create a pending Goal Packet draft. Do not queue the
+        # autonomous kickoff until the user replies with natural-language approval.
         try:
-            state = mgr.set(args)
+            from hermes_cli.goals import render_goal_draft_notice
+            draft = mgr.draft(args)
         except ValueError as exc:
             return t("gateway.goal.invalid", error=str(exc))
 
-        # Queue the goal text as an immediate first turn so the agent
-        # starts making progress. The post-turn hook takes over after.
-        adapter = self.adapters.get(event.source.platform) if event.source else None
-        _quick_key = self._session_key_for_source(event.source) if event.source else None
-        if adapter and _quick_key:
-            try:
-                kickoff_event = MessageEvent(
-                    text=state.goal,
-                    message_type=MessageType.TEXT,
-                    source=event.source,
-                    message_id=event.message_id,
-                    channel_prompt=event.channel_prompt,
-                )
-                self._enqueue_fifo(_quick_key, kickoff_event, adapter)
-            except Exception as exc:
-                logger.debug("goal kickoff enqueue failed: %s", exc)
+        return render_goal_draft_notice(draft)
 
-        return t("gateway.goal.set", budget=state.max_turns, goal=state.goal)
+    async def _handle_pending_goal_reply(self, event: "MessageEvent") -> Optional[str]:
+        """Handle natural-language approve/edit/cancel replies to a Goal Packet."""
+        text = (getattr(event, "text", "") or "").strip()
+        if not text or text.startswith("/"):
+            return None
+
+        mgr, _session_entry = self._get_goal_manager_for_event(event)
+        if mgr is None or not mgr.has_pending_draft():
+            return None
+
+        result = mgr.handle_draft_reply(text)
+        action = result.get("action")
+        if action == "none":
+            return None
+
+        if action == "approve":
+            state = result.get("state")
+            goal_text = getattr(state, "goal", "") or ""
+            adapter = self.adapters.get(event.source.platform) if event.source else None
+            _quick_key = self._session_key_for_source(event.source) if event.source else None
+            if adapter and _quick_key and goal_text:
+                try:
+                    kickoff_event = MessageEvent(
+                        text=goal_text,
+                        message_type=MessageType.TEXT,
+                        source=event.source,
+                        message_id=event.message_id,
+                        channel_prompt=event.channel_prompt,
+                    )
+                    self._enqueue_fifo(_quick_key, kickoff_event, adapter)
+                except Exception as exc:
+                    logger.debug("goal approval kickoff enqueue failed: %s", exc)
+
+        return result.get("message") or ""
 
     async def _handle_subgoal_command(self, event: "MessageEvent") -> str:
         """Handle /subgoal for gateway platforms (mirror of CLI handler).

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1824,7 +1824,10 @@ class GatewaySlashCommandsMixin:
         if not text or text.startswith("/"):
             return None
 
-        mgr, _session_entry = self._get_goal_manager_for_event(event)
+        mgr, _session_entry = self._get_goal_manager_for_event(
+            event,
+            create_session=False,
+        )
         if mgr is None or not mgr.has_pending_draft():
             return None
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1859,7 +1859,7 @@ class CLICommandsMixin:
             return
 
         if lower in {"clear", "stop", "done"}:
-            had = mgr.has_goal()
+            had = mgr.has_goal() or mgr.has_pending_draft()
             mgr.clear()
             if had:
                 _cprint("  ✓ Goal cleared.")
@@ -1867,25 +1867,45 @@ class CLICommandsMixin:
                 _cprint(f"  {_DIM}No active goal.{_RST}")
             return
 
-        # Otherwise treat the arg as the goal text.
+        # Otherwise treat the arg as a draft that needs natural-language approval.
         try:
-            state = mgr.set(arg)
+            from hermes_cli.goals import render_goal_draft_notice
+            draft = mgr.draft(arg)
         except ValueError as exc:
             _cprint(f"  Invalid goal: {exc}")
             return
 
-        _cprint(f"  ⊙ Goal set ({state.max_turns}-turn budget): {state.goal}")
-        _cprint(
-            f"  {_DIM}After each turn, a judge model will check if the goal is done. "
-            f"Hermes keeps working until it is, you pause/clear it, or the budget is "
-            f"exhausted. Use /goal status, /goal pause, /goal resume, /goal clear.{_RST}"
-        )
-        # Kick the loop off immediately so the user doesn't have to send a
-        # separate message after setting the goal.
-        try:
-            self._pending_input.put(state.goal)
-        except Exception:
-            pass
+        _cprint(render_goal_draft_notice(draft))
+
+    def _maybe_handle_goal_draft_reply(self, user_input: str) -> bool:
+        """Consume natural-language replies to a pending Goal Packet.
+
+        Returns True when the input was handled as approve/edit/cancel instead
+        of being sent to the agent as normal chat.
+        """
+        from cli import _cprint, _looks_like_slash_command
+
+        if not isinstance(user_input, str) or _looks_like_slash_command(user_input):
+            return False
+        mgr = self._get_goal_manager()
+        if mgr is None or not mgr.has_pending_draft():
+            return False
+        result = mgr.handle_draft_reply(user_input)
+        action = result.get("action")
+        if action == "none":
+            return False
+        message = result.get("message") or ""
+        if message:
+            _cprint(message)
+        if action == "approve":
+            state = result.get("state")
+            goal_text = getattr(state, "goal", "")
+            if goal_text:
+                try:
+                    self._pending_input.put(goal_text)
+                except Exception:
+                    pass
+        return True
 
     def _handle_subgoal_command(self, cmd: str) -> None:
         """Dispatch /subgoal subcommands.

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -359,7 +359,8 @@ def _get_session_db() -> Optional[Any]:
         from hermes_constants import get_hermes_home
         from hermes_state import SessionDB
 
-        home = str(get_hermes_home())
+        home_path = get_hermes_home()
+        home = str(home_path)
     except Exception as exc:  # pragma: no cover
         logger.debug("GoalManager: SessionDB bootstrap failed (%s)", exc)
         return None
@@ -368,7 +369,7 @@ def _get_session_db() -> Optional[Any]:
     if cached is not None:
         return cached
     try:
-        db = SessionDB()
+        db = SessionDB(home_path / "state.db")
     except Exception as exc:  # pragma: no cover
         logger.debug("GoalManager: SessionDB() raised (%s)", exc)
         return None

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -194,6 +194,142 @@ class GoalState:
         return "\n".join(f"- {i}. {text}" for i, text in enumerate(self.subgoals, start=1))
 
 
+@dataclass
+class GoalDraft:
+    """Pending Goal Packet awaiting user approval.
+
+    Unlike ``GoalState``, this is not an active standing goal. It exists so
+    ``/goal <text>`` can show a clarified packet first and only start the
+    autonomous loop after the user replies in natural language.
+    """
+
+    raw_goal: str
+    packet: str
+    revision: int = 1
+    status: str = "pending"       # pending | approved | cleared
+    created_at: float = 0.0
+    updated_at: float = 0.0
+    edits: List[str] = field(default_factory=list)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), ensure_ascii=False)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "GoalDraft":
+        data = json.loads(raw)
+        edits_raw = data.get("edits") or []
+        edits: List[str] = []
+        if isinstance(edits_raw, list):
+            edits = [str(e).strip() for e in edits_raw if str(e).strip()]
+        return cls(
+            raw_goal=str(data.get("raw_goal") or ""),
+            packet=str(data.get("packet") or ""),
+            revision=int(data.get("revision", 1) or 1),
+            status=str(data.get("status") or "pending"),
+            created_at=float(data.get("created_at", 0.0) or 0.0),
+            updated_at=float(data.get("updated_at", 0.0) or 0.0),
+            edits=edits,
+        )
+
+
+def build_goal_packet(raw_goal: str, *, edits: Optional[List[str]] = None, revision: int = 1) -> str:
+    """Build the approval-gated Goal Packet used before starting ``/goal``.
+
+    This is deterministic by design: command handlers can create the safety
+    packet without making an extra model call, and the eventual active goal
+    contains the same packet the user approved.
+    """
+    raw_goal = (raw_goal or "").strip()
+    if not raw_goal:
+        raise ValueError("goal text is empty")
+    clean_edits = [str(e).strip() for e in (edits or []) if str(e).strip()]
+    edits_block = "없음"
+    if clean_edits:
+        edits_block = "\n".join(f"- v{i + 2}: {text}" for i, text in enumerate(clean_edits))
+    return (
+        f"🧭 Goal Packet v{revision}\n\n"
+        "## 1. 원래 요청\n"
+        f"> {raw_goal}\n\n"
+        "## 2. 정리된 목표\n"
+        f"- {raw_goal}\n\n"
+        "## 3. 작업 범위\n"
+        "- 대상: 요청에 직접 관련된 파일, 설정, 문서, 실행 상태\n"
+        "- 포함: 선행 확인, 필요한 최소 변경, 검증, 최종 보고\n"
+        "- 제외: 불필요한 리팩터링, 대량 이동/삭제, 외부 전송, 시크릿 노출\n\n"
+        "## 4. 완료조건 / Definition of Done\n"
+        "- [ ] 요청한 결과가 실제로 수행되거나, 불가능한 경우 근거와 대안을 보고\n"
+        "- [ ] 변경 사항이 있으면 변경 파일과 핵심 diff를 보고\n"
+        "- [ ] 가능한 테스트/검증을 실행하고 결과를 보고\n\n"
+        "## 5. 검증 계획\n"
+        "- 관련 파일/설정/상태를 도구로 확인\n"
+        "- 코드 변경은 가능한 한 타깃 테스트를 실행\n"
+        "- 검증 불가 시 이유와 남은 리스크를 명시\n\n"
+        "## 6. 안전 경계\n"
+        "- 삭제, 대량 이동, 서비스 재시작, 외부 메시지 전송, 시크릿 조회는 별도 승인 전 금지\n"
+        "- 기존 동작과 무관한 정리/개선은 하지 않음\n\n"
+        "## 7. 사용자 수정 요청\n"
+        f"{edits_block}\n\n"
+        "## 8. 응답 규칙\n"
+        "- 진행/좋아/ㄱ/승인: 이 Goal Packet으로 시작\n"
+        "- 수정 내용: Goal Packet을 반영해 다시 제시\n"
+        "- 취소/삭제/없던 걸로: 초안 폐기"
+    )
+
+
+def render_goal_draft_notice(draft: GoalDraft) -> str:
+    return (
+        f"{draft.packet}\n\n"
+        "진행할까요?\n"
+        "답장 예: `진행` / `수정: ...` / `취소`"
+    )
+
+
+def _preview_goal(text: str, limit: int = 120) -> str:
+    text = " ".join(str(text or "").split())
+    if len(text) <= limit:
+        return text
+    return text[:limit - 1] + "…"
+
+
+def render_goal_approved_notice(state: GoalState) -> str:
+    return (
+        f"⊙ Goal set ({state.max_turns}-turn budget): {_preview_goal(state.goal)}\n"
+        "승인된 Goal Packet으로 시작합니다. "
+        "Controls: /goal status · /goal pause · /goal resume · /goal clear"
+    )
+
+
+def _normalize_draft_reply(text: str) -> str:
+    text = " ".join(str(text or "").strip().lower().split())
+    return text.strip("`'\".,!?;:()[]{}")
+
+
+def classify_goal_draft_reply(text: str) -> str:
+    """Classify a natural-language reply to a pending Goal Packet.
+
+    Returns ``approve``, ``cancel``, or ``edit``. Approval is intentionally
+    exact-match only: replies like "진행하되 위키는 빼" should be treated as an
+    edit, not as approval.
+    """
+    norm = _normalize_draft_reply(text)
+    approve = {
+        "진행", "진행해", "좋아", "좋습니다", "승인", "승인해", "ㄱ",
+        "해", "시작", "시작해", "ok", "okay", "yes", "y", "go", "go ahead",
+        "approve", "approved", "start",
+    }
+    cancel = {
+        "취소", "취소해", "삭제", "삭제해", "없던 걸로", "없던걸로", "그만",
+        "clear", "cancel", "discard", "stop", "nevermind", "never mind",
+    }
+    if norm in approve:
+        return "approve"
+    if norm in cancel:
+        return "cancel"
+    if re.fullmatch(r"취소(?:해|할래|합니다|할게|요)?", norm):
+        return "cancel"
+    return "edit"
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Persistence (SessionDB state_meta)
 # ──────────────────────────────────────────────────────────────────────
@@ -201,6 +337,10 @@ class GoalState:
 
 def _meta_key(session_id: str) -> str:
     return f"goal:{session_id}"
+
+
+def _draft_meta_key(session_id: str) -> str:
+    return f"goal_draft:{session_id}"
 
 
 _DB_CACHE: Dict[str, Any] = {}
@@ -315,6 +455,55 @@ def migrate_goal_to_session(old_session_id: str, new_session_id: str, *, reason:
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("GoalManager: goal migration failed: %s", exc)
         return False
+
+
+def load_goal_draft(session_id: str) -> Optional[GoalDraft]:
+    """Load a pending Goal Packet draft for a session, if one exists."""
+    if not session_id:
+        return None
+    db = _get_session_db()
+    if db is None:
+        return None
+    try:
+        raw = db.get_meta(_draft_meta_key(session_id))
+    except Exception as exc:
+        logger.debug("GoalManager: get draft meta failed: %s", exc)
+        return None
+    if not raw:
+        return None
+    try:
+        draft = GoalDraft.from_json(raw)
+    except Exception as exc:
+        logger.warning("GoalManager: could not parse stored goal draft for %s: %s", session_id, exc)
+        return None
+    if draft.status != "pending":
+        return None
+    if not draft.packet.strip():
+        return None
+    return draft
+
+
+def save_goal_draft(session_id: str, draft: GoalDraft) -> None:
+    """Persist a Goal Packet draft to SessionDB. No-op if DB unavailable."""
+    if not session_id:
+        return
+    db = _get_session_db()
+    if db is None:
+        return
+    try:
+        db.set_meta(_draft_meta_key(session_id), draft.to_json())
+    except Exception as exc:
+        logger.debug("GoalManager: set draft meta failed: %s", exc)
+
+
+def clear_goal_draft(session_id: str) -> None:
+    """Mark a pending Goal Packet draft cleared (preserved for audit)."""
+    draft = load_goal_draft(session_id)
+    if draft is None:
+        return
+    draft.status = "cleared"
+    draft.updated_at = time.time()
+    save_goal_draft(session_id, draft)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -527,12 +716,19 @@ class GoalManager:
         self.session_id = session_id
         self.default_max_turns = int(default_max_turns or DEFAULT_MAX_TURNS)
         self._state: Optional[GoalState] = load_goal(session_id)
+        self._draft: Optional[GoalDraft] = load_goal_draft(session_id)
 
     # --- introspection ------------------------------------------------
 
     @property
     def state(self) -> Optional[GoalState]:
         return self._state
+
+    def pending_draft(self) -> Optional[GoalDraft]:
+        return self._draft
+
+    def has_pending_draft(self) -> bool:
+        return self._draft is not None and self._draft.status == "pending"
 
     def is_active(self) -> bool:
         return self._state is not None and self._state.status == "active"
@@ -543,6 +739,8 @@ class GoalManager:
     def status_line(self) -> str:
         s = self._state
         if s is None or s.status in {"cleared",}:
+            if self.has_pending_draft():
+                return f"Pending Goal Packet v{self._draft.revision}: {_preview_goal(self._draft.raw_goal)}"
             return "No active goal. Set one with /goal <text>."
         turns = f"{s.turns_used}/{s.max_turns} turns"
         sub = f", {len(s.subgoals)} subgoal{'s' if len(s.subgoals) != 1 else ''}" if s.subgoals else ""
@@ -571,7 +769,88 @@ class GoalManager:
         )
         self._state = state
         save_goal(self.session_id, state)
+        if self._draft is not None:
+            clear_goal_draft(self.session_id)
+            self._draft = None
         return state
+
+    def draft(self, raw_goal: str) -> GoalDraft:
+        raw_goal = (raw_goal or "").strip()
+        if not raw_goal:
+            raise ValueError("goal text is empty")
+        now = time.time()
+        draft = GoalDraft(
+            raw_goal=raw_goal,
+            packet=build_goal_packet(raw_goal, revision=1),
+            revision=1,
+            status="pending",
+            created_at=now,
+            updated_at=now,
+        )
+        self._draft = draft
+        save_goal_draft(self.session_id, draft)
+        return draft
+
+    def revise_draft(self, feedback: str) -> GoalDraft:
+        feedback = (feedback or "").strip()
+        if not feedback:
+            raise ValueError("draft revision text is empty")
+        draft = self._draft or load_goal_draft(self.session_id)
+        if draft is None:
+            raise RuntimeError("no pending goal draft")
+        edits = [*draft.edits, feedback]
+        draft.edits = edits
+        draft.revision += 1
+        draft.packet = build_goal_packet(draft.raw_goal, edits=edits, revision=draft.revision)
+        draft.updated_at = time.time()
+        self._draft = draft
+        save_goal_draft(self.session_id, draft)
+        return draft
+
+    def approve_draft(self) -> GoalState:
+        draft = self._draft or load_goal_draft(self.session_id)
+        if draft is None:
+            raise RuntimeError("no pending goal draft")
+        draft.status = "approved"
+        draft.updated_at = time.time()
+        save_goal_draft(self.session_id, draft)
+        self._draft = None
+        return self.set(draft.packet)
+
+    def clear_draft(self) -> None:
+        if self._draft is None:
+            clear_goal_draft(self.session_id)
+            return
+        self._draft.status = "cleared"
+        self._draft.updated_at = time.time()
+        save_goal_draft(self.session_id, self._draft)
+        self._draft = None
+
+    def handle_draft_reply(self, reply: str) -> Dict[str, Any]:
+        draft = self._draft or load_goal_draft(self.session_id)
+        if draft is None:
+            return {"action": "none", "message": ""}
+        self._draft = draft
+        action = classify_goal_draft_reply(reply)
+        if action == "approve":
+            state = self.approve_draft()
+            return {
+                "action": "approve",
+                "state": state,
+                "message": render_goal_approved_notice(state),
+            }
+        if action == "cancel":
+            self.clear_draft()
+            return {
+                "action": "cancel",
+                "message": "✓ Goal Packet 초안을 취소했습니다.",
+            }
+        edited = self.revise_draft(reply)
+        return {
+            "action": "edit",
+            "draft": edited,
+            "message": render_goal_draft_notice(edited),
+        }
 
     def pause(self, reason: str = "user-paused") -> Optional[GoalState]:
         if not self._state:
@@ -592,11 +871,11 @@ class GoalManager:
         return self._state
 
     def clear(self) -> None:
-        if self._state is None:
-            return
-        self._state.status = "cleared"
-        save_goal(self.session_id, self._state)
-        self._state = None
+        if self._state is not None:
+            self._state.status = "cleared"
+            save_goal(self.session_id, self._state)
+            self._state = None
+        self.clear_draft()
 
     def mark_done(self, reason: str) -> None:
         if not self._state:
@@ -934,6 +1213,7 @@ def run_kanban_goal_loop(
 
 __all__ = [
     "GoalState",
+    "GoalDraft",
     "GoalManager",
     "CONTINUATION_PROMPT_TEMPLATE",
     "CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE",
@@ -942,10 +1222,17 @@ __all__ = [
     "KANBAN_GOAL_CONTINUATION_TEMPLATE",
     "KANBAN_GOAL_FINALIZE_TEMPLATE",
     "DEFAULT_MAX_TURNS",
+    "build_goal_packet",
+    "render_goal_draft_notice",
+    "render_goal_approved_notice",
+    "classify_goal_draft_reply",
     "load_goal",
     "save_goal",
     "clear_goal",
     "migrate_goal_to_session",
+    "load_goal_draft",
+    "save_goal_draft",
+    "clear_goal_draft",
     "judge_goal",
     "run_kanban_goal_loop",
 ]

--- a/tests/gateway/test_goal_max_turns_config.py
+++ b/tests/gateway/test_goal_max_turns_config.py
@@ -54,7 +54,22 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
     response = await GatewayRunner._handle_goal_command(runner, event)
 
     try:
-        assert "⊙ Goal set (7-turn budget): ship the benchmark" in response
+        assert "Goal Packet" in response
+        assert "ship the benchmark" in response
+        state = goals.GoalManager("sid-gateway-goal-config").state
+        assert state is None
+
+        approve_event = MessageEvent(
+            text="진행",
+            message_type=MessageType.TEXT,
+            source=event.source,
+            message_id="msg-goal-config-approve",
+        )
+        approved = await GatewayRunner._handle_pending_goal_reply(runner, approve_event)
+        assert approved is not None
+        assert "⊙ Goal set (7-turn budget):" in approved
+        assert "ship the benchmark" in approved
+
         state = goals.GoalManager("sid-gateway-goal-config").state
         assert state is not None
         assert state.max_turns == 7

--- a/tests/gateway/test_goal_max_turns_config.py
+++ b/tests/gateway/test_goal_max_turns_config.py
@@ -1,6 +1,5 @@
+import asyncio
 import uuid
-
-import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
@@ -26,64 +25,67 @@ class _FakeSessionStore:
         return "agent:main:discord:channel:goal-config"
 
 
-@pytest.mark.asyncio
-async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monkeypatch):
+def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monkeypatch):
     """Gateway /goal should honor top-level goals.max_turns from config.yaml."""
-    home = tmp_path / ".hermes"
-    home.mkdir()
-    (home / "config.yaml").write_text("goals:\n  max_turns: 7\n", encoding="utf-8")
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    override_token = set_hermes_home_override(home)
-    goals._DB_CACHE.clear()
-    session_id = f"sid-gateway-goal-config-{uuid.uuid4().hex}"
 
-    runner = object.__new__(GatewayRunner)
-    runner.config = GatewayConfig(
-        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
-    )
-    runner.session_store = _FakeSessionStore(session_id)
-    runner.adapters = {}
-    runner._queued_events = {}
-
-    event = MessageEvent(
-        text="/goal ship the benchmark",
-        message_type=MessageType.TEXT,
-        source=SessionSource(
-            platform=Platform.DISCORD,
-            chat_id="chat-goal-config",
-            chat_type="channel",
-            user_id="user-goal-config",
-        ),
-        message_id="msg-goal-config",
-    )
-
-    try:
-        response = await GatewayRunner._handle_goal_command(runner, event)
-
-        assert "Goal Packet" in response
-        assert "ship the benchmark" in response
-        state = goals.GoalManager(session_id).state
-        assert state is None
-
-        approve_event = MessageEvent(
-            text="진행",
-            message_type=MessageType.TEXT,
-            source=event.source,
-            message_id="msg-goal-config-approve",
-        )
-        approved = await GatewayRunner._handle_pending_goal_reply(runner, approve_event)
-        assert approved is not None
-        assert "⊙ Goal set (7-turn budget):" in approved
-        assert "ship the benchmark" in approved
-
-        state = goals.GoalManager(session_id).state
-        assert state is not None
-        assert state.max_turns == 7
-    finally:
-        try:
-            goals.clear_goal(session_id)
-            goals.clear_goal_draft(session_id)
-        except Exception:
-            pass
-        reset_hermes_home_override(override_token)
+    async def _run():
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text("goals:\n  max_turns: 7\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        override_token = set_hermes_home_override(home)
         goals._DB_CACHE.clear()
+        session_id = f"sid-gateway-goal-config-{uuid.uuid4().hex}"
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
+        )
+        runner.session_store = _FakeSessionStore(session_id)
+        runner.adapters = {}
+        runner._queued_events = {}
+
+        event = MessageEvent(
+            text="/goal ship the benchmark",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="chat-goal-config",
+                chat_type="channel",
+                user_id="user-goal-config",
+            ),
+            message_id="msg-goal-config",
+        )
+
+        try:
+            response = await GatewayRunner._handle_goal_command(runner, event)
+
+            assert "Goal Packet" in response
+            assert "ship the benchmark" in response
+            state = goals.GoalManager(session_id).state
+            assert state is None
+
+            approve_event = MessageEvent(
+                text="진행",
+                message_type=MessageType.TEXT,
+                source=event.source,
+                message_id="msg-goal-config-approve",
+            )
+            approved = await GatewayRunner._handle_pending_goal_reply(runner, approve_event)
+            assert approved is not None
+            assert "⊙ Goal set (7-turn budget):" in approved
+            assert "ship the benchmark" in approved
+
+            state = goals.GoalManager(session_id).state
+            assert state is not None
+            assert state.max_turns == 7
+        finally:
+            try:
+                goals.clear_goal(session_id)
+                goals.clear_goal_draft(session_id)
+            except Exception:
+                pass
+            reset_hermes_home_override(override_token)
+            goals._DB_CACHE.clear()
+
+    asyncio.run(_run())

--- a/tests/gateway/test_goal_max_turns_config.py
+++ b/tests/gateway/test_goal_max_turns_config.py
@@ -1,19 +1,23 @@
+import uuid
+
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from hermes_cli import goals
 
 
 class _FakeSessionEntry:
-    session_id = "sid-gateway-goal-config"
+    def __init__(self, session_id: str):
+        self.session_id = session_id
 
 
 class _FakeSessionStore:
-    def __init__(self):
-        self.entry = _FakeSessionEntry()
+    def __init__(self, session_id: str):
+        self.entry = _FakeSessionEntry(session_id)
 
     def get_or_create_session(self, source):
         return self.entry
@@ -29,13 +33,15 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
     home.mkdir()
     (home / "config.yaml").write_text("goals:\n  max_turns: 7\n", encoding="utf-8")
     monkeypatch.setenv("HERMES_HOME", str(home))
+    override_token = set_hermes_home_override(home)
     goals._DB_CACHE.clear()
+    session_id = f"sid-gateway-goal-config-{uuid.uuid4().hex}"
 
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
         platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
     )
-    runner.session_store = _FakeSessionStore()
+    runner.session_store = _FakeSessionStore(session_id)
     runner.adapters = {}
     runner._queued_events = {}
 
@@ -51,12 +57,12 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
         message_id="msg-goal-config",
     )
 
-    response = await GatewayRunner._handle_goal_command(runner, event)
-
     try:
+        response = await GatewayRunner._handle_goal_command(runner, event)
+
         assert "Goal Packet" in response
         assert "ship the benchmark" in response
-        state = goals.GoalManager("sid-gateway-goal-config").state
+        state = goals.GoalManager(session_id).state
         assert state is None
 
         approve_event = MessageEvent(
@@ -70,8 +76,14 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
         assert "⊙ Goal set (7-turn budget):" in approved
         assert "ship the benchmark" in approved
 
-        state = goals.GoalManager("sid-gateway-goal-config").state
+        state = goals.GoalManager(session_id).state
         assert state is not None
         assert state.max_turns == 7
     finally:
+        try:
+            goals.clear_goal(session_id)
+            goals.clear_goal_draft(session_id)
+        except Exception:
+            pass
+        reset_hermes_home_override(override_token)
         goals._DB_CACHE.clear()

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -213,6 +213,64 @@ class TestGoalManager:
         with pytest.raises(ValueError):
             mgr.set("   ")
 
+    def test_draft_goal_waits_for_natural_language_approval(self, hermes_home):
+        """New /goal text must create a pending Goal Packet, not start immediately."""
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="draft-sid-1", default_max_turns=4)
+        draft = mgr.draft("세컨브레인 개선")
+
+        assert mgr.state is None
+        assert not mgr.is_active()
+        assert mgr.pending_draft() is not None
+        assert draft.raw_goal == "세컨브레인 개선"
+        assert "Goal Packet" in draft.packet
+        assert "세컨브레인 개선" in draft.packet
+        assert "진행" in draft.packet
+
+        state = mgr.approve_draft()
+        assert state.goal == draft.packet
+        assert state.status == "active"
+        assert state.max_turns == 4
+        assert mgr.pending_draft() is None
+
+    def test_goal_draft_classifier_avoids_single_letter_and_negated_cancel(self, hermes_home):
+        from hermes_cli.goals import classify_goal_draft_reply
+
+        assert classify_goal_draft_reply("고") == "edit"
+        assert classify_goal_draft_reply("취소하지 말고 진행해") == "edit"
+        assert classify_goal_draft_reply("취소할게") == "cancel"
+        assert classify_goal_draft_reply("진행") == "approve"
+
+    def test_goal_draft_reply_edit_and_cancel_are_natural_language(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="draft-sid-2")
+        first = mgr.draft("사업 자동화 개선")
+        first_revision = first.revision
+
+        result = mgr.handle_draft_reply("위키는 빼고 Daily Note만 해")
+        edited = mgr.pending_draft()
+        assert result["action"] == "edit"
+        assert edited is not None
+        assert edited.revision == first_revision + 1
+        assert "위키는 빼고 Daily Note만 해" in edited.packet
+        assert mgr.state is None
+
+        result = mgr.handle_draft_reply("삭제해")
+        assert result["action"] == "cancel"
+        assert mgr.pending_draft() is None
+        assert mgr.state is None
+
+    def test_goal_draft_persists_across_managers(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        GoalManager(session_id="draft-persist").draft("장기 작업")
+        reloaded = GoalManager(session_id="draft-persist").pending_draft()
+
+        assert reloaded is not None
+        assert reloaded.raw_goal == "장기 작업"
+
     def test_pause_and_resume(self, hermes_home):
         from hermes_cli.goals import GoalManager
 

--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -79,6 +79,12 @@ def _call(server, method, **params):
     return handler(1, params)
 
 
+def _set_active_goal(session_key: str, text: str):
+    from hermes_cli.goals import GoalManager
+
+    return GoalManager(session_key).set(text)
+
+
 # ── command.dispatch /goal ────────────────────────────────────────────
 
 
@@ -103,28 +109,27 @@ def test_goal_status_alias_shows_status(server, session):
     assert "No active goal" in r["result"]["output"]
 
 
-def test_goal_set_returns_send_with_notice(server, session):
+def test_goal_set_returns_pending_packet_without_kickoff(server, session):
     sid, session_key, _ = session
     r = _call(server, "command.dispatch", name="goal", arg="build a rocket", session_id=sid)
     result = r["result"]
-    assert result["type"] == "send"
-    assert result["message"] == "build a rocket"
-    assert "notice" in result
-    assert "Goal set" in result["notice"]
-    assert "20-turn budget" in result["notice"]
+    assert result["type"] == "exec"
+    assert "Goal Packet" in result["output"]
+    assert "build a rocket" in result["output"]
+    assert "진행" in result["output"]
 
-    # Persisted in SessionDB
     from hermes_cli.goals import GoalManager
 
     mgr = GoalManager(session_key)
-    assert mgr.state is not None
-    assert mgr.state.goal == "build a rocket"
-    assert mgr.state.status == "active"
+    assert mgr.state is None
+    draft = mgr.pending_draft()
+    assert draft is not None
+    assert draft.raw_goal == "build a rocket"
 
 
 def test_goal_pause_after_set(server, session):
     sid, session_key, _ = session
-    _call(server, "command.dispatch", name="goal", arg="write a story", session_id=sid)
+    _set_active_goal(session_key, "write a story")
     r = _call(server, "command.dispatch", name="goal", arg="pause", session_id=sid)
     assert r["result"]["type"] == "exec"
     assert "paused" in r["result"]["output"].lower()
@@ -136,7 +141,7 @@ def test_goal_pause_after_set(server, session):
 
 def test_goal_resume_reactivates(server, session):
     sid, session_key, _ = session
-    _call(server, "command.dispatch", name="goal", arg="write a story", session_id=sid)
+    _set_active_goal(session_key, "write a story")
     _call(server, "command.dispatch", name="goal", arg="pause", session_id=sid)
     r = _call(server, "command.dispatch", name="goal", arg="resume", session_id=sid)
     assert r["result"]["type"] == "exec"
@@ -149,7 +154,7 @@ def test_goal_resume_reactivates(server, session):
 
 def test_goal_clear_removes_active_goal(server, session):
     sid, session_key, _ = session
-    _call(server, "command.dispatch", name="goal", arg="write a story", session_id=sid)
+    _set_active_goal(session_key, "write a story")
     r = _call(server, "command.dispatch", name="goal", arg="clear", session_id=sid)
     assert r["result"]["type"] == "exec"
     assert "cleared" in r["result"]["output"].lower()
@@ -166,12 +171,12 @@ def test_goal_clear_removes_active_goal(server, session):
 
 
 def test_goal_stop_and_done_are_clear_aliases(server, session):
-    sid, _, _ = session
-    _call(server, "command.dispatch", name="goal", arg="first goal", session_id=sid)
+    sid, session_key, _ = session
+    _set_active_goal(session_key, "first goal")
     r = _call(server, "command.dispatch", name="goal", arg="stop", session_id=sid)
     assert "cleared" in r["result"]["output"].lower()
 
-    _call(server, "command.dispatch", name="goal", arg="second goal", session_id=sid)
+    _set_active_goal(session_key, "second goal")
     r = _call(server, "command.dispatch", name="goal", arg="done", session_id=sid)
     assert "cleared" in r["result"]["output"].lower()
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6222,6 +6222,32 @@ def _(rid, params: dict) -> dict:
                     db.replace_messages(session["session_key"], truncated)
                 except Exception as exc:
                     print(f"[tui_gateway] prompt.submit: replace_messages failed: {exc}", file=sys.stderr)
+        if isinstance(text, str) and not text.strip().startswith("/"):
+            try:
+                from hermes_cli.goals import GoalManager
+
+                goals_cfg = _load_cfg().get("goals") or {}
+                max_turns = int(goals_cfg.get("max_turns", 20) or 20)
+                mgr = GoalManager(
+                    session_id=session.get("session_key") or "",
+                    default_max_turns=max_turns,
+                )
+                if mgr.has_pending_draft():
+                    result = mgr.handle_draft_reply(text)
+                    action = result.get("action")
+                    message = result.get("message") or ""
+                    if message:
+                        _emit("status.update", sid, {"kind": "goal", "text": message})
+                    if action == "approve":
+                        state = result.get("state")
+                        text = getattr(state, "goal", "") or text
+                    elif action in {"edit", "cancel"}:
+                        return _ok(rid, {"status": "handled"})
+            except Exception as exc:
+                print(
+                    f"[tui_gateway] goal draft reply handling failed: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
         session["running"] = True
         session["last_active"] = time.time()
         _start_inflight_turn(session, text)
@@ -8961,7 +8987,7 @@ def _(rid, params: dict) -> dict:
                 },
             )
         if lower in {"clear", "stop", "done"}:
-            had = mgr.has_goal()
+            had = mgr.has_goal() or mgr.has_pending_draft()
             mgr.clear()
             return _ok(
                 rid,
@@ -8971,25 +8997,15 @@ def _(rid, params: dict) -> dict:
                 },
             )
 
-        # Otherwise — treat the remaining text as the new goal.
+        # Otherwise — create a pending Goal Packet draft. Do not kick off the
+        # autonomous loop until the user replies with natural-language approval.
         try:
-            state = mgr.set(arg)
+            from hermes_cli.goals import render_goal_draft_notice
+            draft = mgr.draft(arg)
         except ValueError as exc:
             return _err(rid, 4004, f"invalid goal: {exc}")
 
-        notice = (
-            f"⊙ Goal set ({state.max_turns}-turn budget): {state.goal}\n"
-            "I'll keep working until the goal is done, you pause/clear it, or the budget is exhausted.\n"
-            "Controls: /goal status · /goal pause · /goal resume · /goal clear"
-        )
-        # Send the goal text as the kickoff prompt. The TUI client sees
-        # {type: send, notice, message} → renders `notice` as a sys line,
-        # then submits `message` as a user turn. The post-turn judge
-        # wired in _run_prompt_submit takes over from there.
-        return _ok(
-            rid,
-            {"type": "send", "notice": notice, "message": state.goal},
-        )
+        return _ok(rid, {"type": "exec", "output": render_goal_draft_notice(draft)})
 
     if name == "undo":
         # /undo [N]: back up N user turns (default 1), soft-delete the


### PR DESCRIPTION
## Summary

Normalize the live gateway delta into a small PR based on current `origin/main`.

This PR keeps only the currently-live `/goal` safety behavior and its follow-up gateway fix, instead of the larger assistant-ops PR stack:

- require a Goal Packet approval step before `/goal <text>` starts autonomous execution
- avoid creating a new gateway session while probing for pending Goal Packet replies
- make the gateway goal config test runnable without `pytest-asyncio` in local environments

## Why

The live Hermes checkout was previously running a large branch (`feat/gateway-assistant-ops-main`) containing unrelated assistant-ops work. I normalized the live checkout to `origin/main + 3 commits` and verified the service after restart.

This PR captures that minimal live delta so the runtime can be reconciled with upstream cleanly.

## Verification

Run in `/home/idhoons/hermes` after switching the live checkout to this branch:

```bash
venv/bin/python -m py_compile \
  hermes_cli/goals.py \
  gateway/run.py \
  gateway/session.py \
  gateway/slash_commands.py \
  cli.py \
  tui_gateway/server.py \
  tests/gateway/test_goal_max_turns_config.py
```

Result: passed.

```bash
venv/bin/python -m pytest \
  tests/hermes_cli/test_goals.py \
  tests/gateway/test_goal_max_turns_config.py \
  tests/tui_gateway/test_goal_command.py \
  -q -o 'addopts='
```

Result: `71 passed, 8 warnings`.

Also checked:

- `git diff --check`: passed before the final test-portability commit
- live `hermes.service` restart: passed
- `/health`: `status=ok`
- `/health/detailed`: Telegram, Discord, and API server connected

## Live runtime evidence

After normalization and restart:

- live branch: `runtime/normal-main-goal-hotfix-20260622-071056`
- live head: `198153c2e`
- divergence from `origin/main`: `0 3`
- backup of previous large runtime branch: `backup/runtime-gateway-assistant-ops-main-before-normalize-20260622-071056`

## Relationship to #50099

This is the small hotfix/safety subset extracted from the larger assistant-ops PR stack. It intentionally does **not** include the broader `/parallel_review`, tmux worker room, Obsidian root browser, Discord context expansion, or Telegram quick-add menu changes from #50099.
