### PR TITLE
fix(matrix): align approval deny prompt emoji (#50429)

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2047,7 +2047,7 @@ class MatrixAdapter(BasePlatformAdapter):
             f"{scope_choices}Reply `!approve` to execute once, or `!deny` to cancel.\n\n"
             "You can also click the reaction to approve:\n"
             "✅ = approve\n"
-            "❎ = deny"
+            "❌ = deny"
         )
 
         result = await self.send(chat_id, text, metadata=metadata)

--- a/tests/gateway/test_matrix_exec_approval.py
+++ b/tests/gateway/test_matrix_exec_approval.py
@@ -25,6 +25,11 @@ class TestMatrixExecApprovalReactions:
         )
 
         assert result.success is True
+        send_call = adapter.send.await_args
+        assert send_call is not None
+        sent_text = send_call.args[1]
+        assert "❌ = deny" in sent_text
+        assert "❎ = deny" not in sent_text
         assert adapter._approval_prompt_by_session["sess-1"] == "$evt1"
         assert adapter._approval_prompts_by_event["$evt1"].session_key == "sess-1"
         assert adapter._send_reaction.await_count == 3


### PR DESCRIPTION
## Summary

- Align the Matrix exec approval prompt's deny label with the actual seeded Matrix reaction.
- The prompt now shows `❌ = deny`, matching the clickable `❌` reaction instead of displaying the mismatched `❎` glyph.
- Add a regression assertion through `MatrixAdapter.send_exec_approval()` so the sent prompt text and seeded reactions stay consistent.

## Verification

- RED on upstream/main: `tests/gateway/test_matrix_exec_approval.py::TestMatrixExecApprovalReactions::test_send_exec_approval_registers_prompt_and_seeds_reactions` failed because the prompt contained `❎ = deny` and lacked `❌ = deny`.
- GREEN after fix/rebase:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/gateway/test_matrix_exec_approval.py tests/gateway/test_matrix_approval_reaction_fail_closed.py -v -o addopts= --tb=short`
  - Result: `6 passed in 0.19s`

## Competitor / duplicate check

- Same-author issue search: no open Tranquil-Flow PRs referencing #50429.
- Same-author branch search: no open `fix/50429*` PRs.
- Open PR search for issue #50429: none found.
- Keyword search for Matrix approval deny emoji: none found.

Auto-published by Moonsong via Path B automated pipeline.
