### PR TITLE
fix(desktop): stop killing background processes on plain interrupt / queue-send

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, type ComposerAttachment } from '@/store/composer'
+import { $backgroundStatusBySession, reconcileBackgroundProcesses } from '@/store/composer-status'
+import { $gateway } from '@/store/gateway'
 import { $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -652,6 +654,101 @@ describe('usePromptActions restoreToMessage', () => {
     await handle!.restoreToMessage('missing')
 
     expect(requestGateway).not.toHaveBeenCalled()
+  })
+})
+
+describe('usePromptActions cancelRun preserves background work', () => {
+  // Regression: promoting a queued message while busy (or hitting Stop) routes
+  // through cancelRun. cancelRun is a PLAIN interrupt — the conversation
+  // timeline is preserved — so it must NOT kill the session's background
+  // processes. The backend's session.interrupt deliberately leaves
+  // terminal(background=true) processes running; the renderer used to call
+  // resetSessionBackground() here, which issued process.kill for every running
+  // process and nuked the user's in-flight background work on every queue-send.
+  beforeEach(() => {
+    $busy.set(false)
+    $backgroundStatusBySession.set({})
+    $messages.set([
+      { id: 'u1', role: 'user', parts: [textPart('first prompt')] },
+      { id: 'a1', role: 'assistant', parts: [textPart('first answer')] }
+    ])
+  })
+
+  afterEach(() => {
+    cleanup()
+    $busy.set(false)
+    $messages.set([])
+    $backgroundStatusBySession.set({})
+    $gateway.set(null)
+    vi.restoreAllMocks()
+  })
+
+  function seedRunningBackgroundProcess() {
+    // A live background process attributed to this runtime session.
+    reconcileBackgroundProcesses(RUNTIME_SESSION_ID, [
+      { command: 'sleep 600', session_id: 'proc_live_1', status: 'running' }
+    ] as never)
+  }
+
+  function installRecordingGateway(): { calls: { method: string; params?: Record<string, unknown> }[] } {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    $gateway.set({
+      request: async (method: string, params?: Record<string, unknown>) => {
+        calls.push({ method, params })
+        return {} as never
+      }
+    } as never)
+    return { calls }
+  }
+
+  it('does NOT kill running background processes on a plain interrupt', async () => {
+    seedRunningBackgroundProcess()
+    const gateway = installRecordingGateway()
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        seedMessages={$messages.get()}
+      />
+    )
+
+    await handle!.cancelRun()
+
+    // The interrupt itself must still be sent to the backend...
+    expect(requestGateway).toHaveBeenCalledWith('session.interrupt', { session_id: RUNTIME_SESSION_ID })
+    // ...but NO process.kill may be issued by the cancel path.
+    expect(gateway.calls.some(c => c.method === 'process.kill')).toBe(false)
+    // ...and the running row must survive in the UI (work still alive).
+    const rows = $backgroundStatusBySession.get()[RUNTIME_SESSION_ID] ?? []
+    expect(rows.map(r => r.id)).toEqual(['proc_live_1'])
+    expect(rows[0]!.state).toBe('running')
+  })
+
+  it('still kills background processes on a true rewind (restoreToMessage)', async () => {
+    // Contrast case: restore/edit abandons the spawning turns, so killing the
+    // now-orphaned background processes there remains correct.
+    seedRunningBackgroundProcess()
+    const gateway = installRecordingGateway()
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        seedMessages={$messages.get()}
+      />
+    )
+
+    await handle!.restoreToMessage('u1')
+
+    expect(gateway.calls.some(c => c.method === 'process.kill' && c.params?.process_id === 'proc_live_1')).toBe(true)
+    expect($backgroundStatusBySession.get()[RUNTIME_SESSION_ID] ?? []).toEqual([])
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -1432,7 +1432,15 @@ export function usePromptActions({
 
     clearSessionTodos(sessionId)
     clearSessionSubagents(sessionId)
-    resetSessionBackground(sessionId)
+    // NOTE: do NOT call resetSessionBackground() here. A plain interrupt
+    // (the Stop button, or promoting a queued message via "send now while
+    // busy") preserves the conversation timeline — it does not discard turns.
+    // The backend's session.interrupt deliberately does NOT kill the session's
+    // background processes (terminal(background=true) is meant to outlive a
+    // turn), so the renderer must not kill them either. resetSessionBackground
+    // belongs only on the true rewind paths (restoreToMessage / editMessage),
+    // where the spawning turns are genuinely abandoned. Calling it here nuked
+    // the user's in-flight background work on every queue-send / Stop.
 
     try {
       await requestGateway('session.interrupt', { session_id: sessionId })


### PR DESCRIPTION
## Summary

In the desktop app, **sending a queued message while the agent is busy** (the queue panel's "send now") — and pressing **Stop** — kills every running background process in the session. A `terminal(background=true)` server/build/long-running job started earlier gets `process.kill`'d the moment you promote a queued message. The work just vanishes.

## Root cause

The queue "send now while busy" button calls `onCancel()` → `cancelRun()` (`apps/desktop/src/app/session/hooks/use-prompt-actions.ts`). The Stop button calls `cancelRun()` directly. `cancelRun()` called:

```ts
clearSessionTodos(sessionId)
clearSessionSubagents(sessionId)
resetSessionBackground(sessionId)   // <-- the bug
```

`resetSessionBackground()` is **rewind cleanup**. Its own docstring:

> *Rewind cleanup: a restore/edit discards the turns that spawned these processes, so they belong to an abandoned timeline. Kill the live ones and drop every row.*

It iterates the session's background processes and issues `gateway.request('process.kill', …)` for each running one (`store/composer-status.ts`). That's correct for **restore/edit**, where the spawning turns are genuinely discarded. But `cancelRun()` is a **plain interrupt** — the conversation timeline is preserved, the user is just promoting a queued message or stopping the current turn. Killing background work there is wrong.

The backend already gets this right: `session.interrupt` → `AIAgent.interrupt()` deliberately does **not** call `process_registry.kill_all()`. Background processes are designed to outlive a turn (that's the entire point of `terminal(background=true)`). The renderer was unilaterally killing processes the backend intentionally keeps alive.

## Fix

Remove the `resetSessionBackground(sessionId)` call from `cancelRun()`. The two genuine rewind paths — `restoreToMessage()` and `editMessage()` — keep it, because there the abandoned-timeline kill is correct.

One-line behavioral change; the rest of the diff is the comment explaining why the call must not be reintroduced, plus the regression test.

## Test

Added `usePromptActions cancelRun preserves background work` to `use-prompt-actions.test.tsx`, asserting the invariant both directions:

- **`cancelRun`** seeds a running background process, runs the cancel, and asserts (a) `session.interrupt` is still sent, (b) **no** `process.kill` is issued, (c) the running row survives.
- **`restoreToMessage`** (contrast) asserts the rewind path **still** kills the now-orphaned process.

Verified **RED** before the fix (the `process.kill` assertion fails — `expected false, got true`) and **GREEN** after.

```
✓ src/app/session/hooks/use-prompt-actions.test.tsx (35 tests)
✓ src/store/composer-status.test.ts / composer-queue.test.ts / subagents.test.ts (28 tests)
tsc --noEmit: 0 errors
```

No new lint problems introduced (the pre-existing `perfectionist/sort-named-imports` error on `use-prompt-actions.ts` is present on `main` independent of this change).

## Scope

Renderer-only. No backend, schema, prompt, or tool-surface changes. Does not touch prompt caching or message-role alternation.
