### PR TITLE
feat(copilot): opus-context unique files (slimmed from 100-file bundle)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -71,7 +71,6 @@ DEFAULT_NOUS_PORTAL_URL = "https://portal.nousresearch.com"
 DEFAULT_NOUS_INFERENCE_URL = "https://inference-api.nousresearch.com/v1"
 DEFAULT_NOUS_CLIENT_ID = "hermes-cli"
 NOUS_INFERENCE_INVOKE_SCOPE = "inference:invoke"
-NOUS_BILLING_MANAGE_SCOPE = "billing:manage"
 DEFAULT_NOUS_SCOPE = NOUS_INFERENCE_INVOKE_SCOPE
 NOUS_DEVICE_CODE_SOURCE = "device_code"
 NOUS_AUTH_PATH_INVOKE_JWT = "invoke_jwt"
@@ -104,12 +103,7 @@ XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:acces
 XAI_OAUTH_REDIRECT_HOST = "127.0.0.1"
 XAI_OAUTH_REDIRECT_PORT = 56121
 XAI_OAUTH_REDIRECT_PATH = "/callback"
-# xAI/Grok OAuth access tokens are intentionally short-lived (about 6h in
-# current SuperGrok flows). A two-minute refresh window is too narrow for
-# gateway/cron workloads that may only touch the provider every 30 minutes,
-# leaving brief but noisy credential-expiry gaps. Refresh up to one hour
-# early so ordinary runtime calls keep the token warm without user reauth.
-XAI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 3600
+XAI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 QWEN_OAUTH_CLIENT_ID = "f0304373b74a44d2b584a3fb70ca9e56"
 QWEN_OAUTH_TOKEN_URL = "https://chat.qwen.ai/api/v1/oauth2/token"
 QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
@@ -234,6 +228,16 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "agy-cli": ProviderConfig(
+        id="agy-cli",
+        name="Antigravity CLI (agy)",
+        auth_type="external_process",
+        # Internal marker URL, never sent over HTTP. The agy binary at
+        # ~/.local/bin/agy handles its own OAuth + cloudcode-pa transport.
+        # See agent/agy_cli_client.py + plugins/model-providers/agy-cli/.
+        inference_base_url="agy://antigravity",
+        base_url_env_var="HERMES_AGY_COMMAND",  # actually a command override, not URL
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -622,8 +626,8 @@ ZAI_ENDPOINTS = [
     # (id, base_url, probe_models, label)
     ("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global"),
     ("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China"),
-    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
-    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
+    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
+    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
 ]
 
 
@@ -1085,13 +1089,8 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     return {"version": AUTH_STORE_VERSION, "providers": {}}
 
 
-def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = None) -> Path:
-    # target_path=None preserves the existing contract (write the active
-    # store at _auth_file_path()). An explicit path lets callers persist a
-    # specific store — e.g. the global-root write-through for rotating xAI
-    # OAuth grants (#43589) — reusing this function's atomic O_EXCL + 0o600
-    # write so the root auth.json gets the same TOCTOU-safe treatment.
-    auth_file = target_path if target_path is not None else _auth_file_path()
+def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
+    auth_file = _auth_file_path()
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
     # No-op on Windows (POSIX mode bits not enforced); ignore failures.
@@ -1191,24 +1190,6 @@ def _store_provider_state(
     providers[provider_id] = state
     if set_active:
         auth_store["active_provider"] = provider_id
-
-
-def mark_provider_active_if_unset(provider_id: str) -> None:
-    """Set ``active_provider`` to *provider_id* only when none is set yet.
-
-    Used by ``hermes auth add`` OAuth paths that create credential-pool
-    entries directly (no singleton ``providers.<id>`` block). Adding the
-    very first credential for a provider should make it the active provider
-    so the setup wizard's ``_model_section_has_credentials()`` check (which
-    consults ``get_active_provider()``) does not report "No inference
-    provider configured". Subsequent adds for an already-active setup leave
-    the user's chosen active provider untouched.
-    """
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
-        if not (auth_store.get("active_provider") or "").strip():
-            auth_store["active_provider"] = provider_id
-            _save_auth_store(auth_store)
 
 
 def is_known_auth_provider(provider_id: str) -> bool:
@@ -1589,21 +1570,6 @@ def resolve_provider(
 
     if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
         return "openrouter"
-
-    # Auto-detect an OpenRouter credential added via `hermes auth add openrouter`
-    # (manual pool entry, no env var). Without this, a key that only lives in
-    # the credential pool is invisible to auto-detection — the user sees
-    # `hermes auth list` showing the credential while requests go out with no
-    # Authorization header ("HTTP 401: Missing Authentication header"). The
-    # env-var check above only covers keys exported as OPENROUTER_API_KEY /
-    # OPENAI_API_KEY. See issue #42130.
-    try:
-        from agent.credential_pool import load_pool as _load_pool
-
-        if _load_pool("openrouter").has_credentials():
-            return "openrouter"
-    except Exception as e:
-        logger.debug("Could not check OpenRouter credential pool: %s", e)
 
     # Auto-detect API-key providers by checking their env vars
     for pid, pconfig in PROVIDER_REGISTRY.items():
@@ -2676,23 +2642,12 @@ def _xai_wait_for_callback(
     result: dict[str, Any],
     *,
     timeout_seconds: float = 180.0,
-    manual_paste_redirect_uri: Optional[str] = None,
 ) -> dict[str, Any]:
     deadline = time.monotonic() + max(5.0, timeout_seconds)
-    if manual_paste_redirect_uri and sys.stdin.isatty():
-        print()
-        print("If xAI shows a Grok Build code instead of redirecting,")
-        print("paste that code here and press Enter.")
     try:
         while time.monotonic() < deadline:
             if result["code"] or result["error"]:
                 return result
-            if manual_paste_redirect_uri:
-                raw_paste = _read_ready_stdin_line()
-                if raw_paste and raw_paste.strip():
-                    pasted = _parse_pasted_callback(raw_paste)
-                    pasted["_manual_paste"] = True
-                    return pasted
             time.sleep(0.1)
     finally:
         server.shutdown()
@@ -2714,21 +2669,6 @@ def _xai_wait_for_callback(
         provider="xai-oauth",
         code="xai_callback_timeout",
     )
-
-
-def _read_ready_stdin_line() -> Optional[str]:
-    """Return one pending stdin line without blocking, if the terminal has one."""
-    try:
-        if not sys.stdin.isatty():
-            return None
-        import select
-
-        ready, _, _ = select.select([sys.stdin], [], [], 0)
-        if not ready:
-            return None
-        return sys.stdin.readline()
-    except Exception:
-        return None
 
 
 def _spotify_token_payload_to_state(
@@ -3410,7 +3350,6 @@ def _sync_codex_pool_entries(
     auth_store: Dict[str, Any],
     tokens: Dict[str, str],
     last_refresh: Optional[str],
-    previous_singleton_tokens: Optional[Dict[str, str]] = None,
 ) -> None:
     """Mirror a fresh Codex re-auth into the credential_pool OAuth entries.
 
@@ -3426,34 +3365,24 @@ def _sync_codex_pool_entries(
       OAuth flow when the user logged in via ``hermes setup`` / the model
       picker.  Always synced with the fresh tokens.
     * ``manual:device_code`` — entries created by ``hermes auth add openai-codex``
-      that use the same device-code OAuth mechanism.  ONLY synced if the
-      entry's existing access_token matches the *previous* singleton
-      access_token (i.e. the entry is a legacy singleton-alias from the
-      #33000 workaround era).  Manual entries whose tokens never matched the
-      singleton represent INDEPENDENT accounts added via
-      ``hermes auth add openai-codex`` and must not be overwritten by a
-      re-auth that targeted a different account (regression for #39236).
-
-      The original #33538 fix refreshed every ``manual:device_code`` entry
-      unconditionally.  That worked when ``manual:device_code`` only meant
-      "legacy alias of the singleton", but the same source string is now
-      also produced by independent-account additions, and the broad sync
-      silently clobbered distinct accounts with the latest-authenticated
-      token pair.  The access_token-match check distinguishes the two cases
-      without changing the source-string contract.
+      that use the same device-code OAuth mechanism.  An interactive re-auth
+      proves the user owns the ChatGPT account, so it is safe (and expected)
+      to refresh these entries too.  Without this, a user who once ran the
+      ``hermes auth add`` workaround for #33000 would silently leave that
+      manual entry stale on every subsequent re-auth, recreating the issue
+      reported in #33538.
 
     What does NOT get refreshed:
 
     * ``manual:api_key`` and any other non-device-code manual sources — those
       are independent credentials (an explicit API key, a different ChatGPT
       account, etc.) and must not be overwritten by a single re-auth.
-    * ``manual:device_code`` entries whose access_token does NOT match the
-      previous singleton — see above; these are independent accounts.
 
-    Error markers (``last_status``, ``last_error_*``) are cleared ONLY on
-    entries that actually had their tokens rewritten by this re-auth.
-    Independent entries keep their own error state (their 401/429 markers
-    belong to that account's own auth flow, not this re-auth).
+    Error markers (``last_status``, ``last_error_*``) are also cleared on
+    every device-code-backed entry — even those whose tokens we did not
+    rewrite — so that an interactive re-auth gives every relevant pool entry
+    a fresh selection chance instead of leaving them marked unhealthy from a
+    pre-re-auth 401.
     """
     access_token = tokens.get("access_token")
     if not access_token:
@@ -3465,34 +3394,15 @@ def _sync_codex_pool_entries(
     entries = pool.get("openai-codex")
     if not isinstance(entries, list):
         return
-    # Previous singleton access_token (before this re-auth overwrote it) —
-    # used to distinguish legacy singleton-aliases from independent accounts.
-    # When None or empty, no manual entry can be treated as an alias (which
-    # is the right default for first-ever-save or a freshly initialized
-    # auth.json).
-    prev_at = None
-    if isinstance(previous_singleton_tokens, dict):
-        prev_at = previous_singleton_tokens.get("access_token") or None
+    # Sources whose tokens should be rewritten by a fresh Codex device-code
+    # OAuth re-auth.  ``manual:api_key`` and unknown sources are intentionally
+    # excluded — they represent independent credentials.
+    REFRESHABLE_SOURCES = {"device_code", "manual:device_code"}
     for entry in entries:
         if not isinstance(entry, dict):
             continue
         source = entry.get("source")
-        if source == "device_code":
-            # Singleton-seeded mirror — always refresh.
-            refresh_this_entry = True
-        elif source == "manual:device_code":
-            # Refresh only if this entry's existing access_token matches the
-            # previous singleton access_token (i.e. it is a true alias of the
-            # singleton from the #33000 workaround era).  An entry with its
-            # own distinct token material is an independent account and must
-            # be left alone (#39236).
-            refresh_this_entry = bool(
-                prev_at and entry.get("access_token") == prev_at
-            )
-        else:
-            # ``manual:api_key`` and any future non-device-code sources.
-            refresh_this_entry = False
-        if not refresh_this_entry:
+        if source not in REFRESHABLE_SOURCES:
             continue
         entry["access_token"] = access_token
         if refresh_token:
@@ -3514,41 +3424,14 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
     with _auth_store_lock():
         auth_store = _load_auth_store()
         state = _load_provider_state(auth_store, "openai-codex") or {}
-        # Capture the previous singleton tokens BEFORE overwriting them.  The
-        # pool-sync step uses this to distinguish legacy singleton-aliases
-        # (which should be refreshed) from independent accounts that
-        # ``hermes auth add openai-codex`` created (which must not be
-        # overwritten — see #39236).
-        previous_singleton_tokens = state.get("tokens") if isinstance(state.get("tokens"), dict) else None
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
         state["auth_mode"] = "chatgpt"
         if label and str(label).strip():
             state["label"] = str(label).strip()
         _save_provider_state(auth_store, "openai-codex", state)
-        _sync_codex_pool_entries(
-            auth_store,
-            tokens,
-            last_refresh,
-            previous_singleton_tokens=previous_singleton_tokens,
-        )
+        _sync_codex_pool_entries(auth_store, tokens, last_refresh)
         _save_auth_store(auth_store)
-
-
-def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
-    """Adopt a valid Codex CLI token pair into Hermes auth, if available."""
-    imported = _import_codex_cli_tokens()
-    # Require BOTH tokens before adopting: persisting a payload without a
-    # usable refresh_token would only break the next refresh cycle.
-    if not (
-        imported
-        and str(imported.get("access_token", "") or "").strip()
-        and str(imported.get("refresh_token", "") or "").strip()
-    ):
-        return None
-    logger.info("Codex auth recovered from Codex CLI auth.json (%s).", reason)
-    _save_codex_tokens(imported)
-    return dict(imported)
 
 
 def refresh_codex_oauth_pure(
@@ -3687,34 +3570,11 @@ def _refresh_codex_auth_tokens(
     
     Saves the new tokens to Hermes auth store automatically.
     """
-    try:
-        refreshed = refresh_codex_oauth_pure(
-            str(tokens.get("access_token", "") or ""),
-            str(tokens.get("refresh_token", "") or ""),
-            timeout_seconds=timeout_seconds,
-        )
-    except AuthError as exc:
-        # Self-heal cross-store refresh_token rotation. Hermes keeps its OWN
-        # Codex OAuth token (per profile + top-level), separate from the Codex
-        # CLI's ~/.codex/auth.json. OAuth refresh_tokens are single-use, so when
-        # the Codex CLI (or another Hermes process) rotates the shared token,
-        # this frozen copy's refresh_token goes stale and the refresh fails with
-        # a relogin-required error (invalid_grant / refresh_token_reused / 401).
-        # Before surfacing that as a hard 401 to the turn, adopt the canonical
-        # fresh token from ~/.codex/auth.json (the Codex CLI keeps it current) so
-        # idle profiles / desktop sessions recover automatically instead of
-        # 401'ing until a manual re-auth. Transient failures (e.g. 429 quota)
-        # keep relogin_required=False — the stored token is still valid there, so
-        # we never self-heal those and re-raise unchanged.
-        if not getattr(exc, "relogin_required", False):
-            raise
-        imported = _recover_codex_tokens_from_cli(
-            f"refresh_token rejected: {getattr(exc, 'code', None) or 'auth_error'}"
-        )
-        if not imported:
-            raise
-        return imported
-
+    refreshed = refresh_codex_oauth_pure(
+        str(tokens.get("access_token", "") or ""),
+        str(tokens.get("refresh_token", "") or ""),
+        timeout_seconds=timeout_seconds,
+    )
     updated_tokens = dict(tokens)
     updated_tokens["access_token"] = refreshed["access_token"]
     updated_tokens["refresh_token"] = refreshed["refresh_token"]
@@ -3774,25 +3634,9 @@ def resolve_codex_runtime_credentials(
     HTTP 401 ``Missing Authentication header`` from the wire instead of a usable
     credential. See issue #32992.
     """
-    read_error: Optional[AuthError] = None
     try:
         data = _read_codex_tokens()
-    except AuthError as exc:
-        read_error = exc
-        if getattr(exc, "relogin_required", False) and getattr(exc, "code", None) in {
-            "codex_auth_missing_access_token",
-            "codex_auth_missing_refresh_token",
-            "codex_auth_invalid_shape",
-        }:
-            imported = _recover_codex_tokens_from_cli(str(getattr(exc, "code", None) or "auth_error"))
-            if imported:
-                data = {"tokens": imported, "last_refresh": imported.get("last_refresh")}
-            else:
-                data = None
-        else:
-            data = None
-
-    if data is None:
+    except AuthError:
         pool_token = _pool_codex_access_token()
         if pool_token:
             base_url = (
@@ -3807,34 +3651,7 @@ def resolve_codex_runtime_credentials(
                 "last_refresh": None,
                 "auth_mode": "chatgpt",
             }
-        pool_rate_limit = _codex_pool_rate_limit_status()
-        if pool_rate_limit:
-            reset_at = pool_rate_limit.get("reset_at")
-            if isinstance(reset_at, (int, float)) and reset_at > time.time():
-                remaining = int(reset_at - time.time())
-                message = (
-                    f"Codex provider quota exhausted (429); retry after {remaining}s. "
-                    "Credentials are still valid."
-                )
-            else:
-                message = (
-                    "Codex provider quota exhausted (429). Credentials are still valid; "
-                    "retry after the usage limit resets."
-                )
-            raise AuthError(
-                message,
-                provider="openai-codex",
-                code=CODEX_RATE_LIMITED_CODE,
-                relogin_required=False,
-            )
-        if read_error is not None:
-            raise read_error
-        raise AuthError(
-            "No Codex credentials stored. Run `hermes auth` to authenticate.",
-            provider="openai-codex",
-            code="codex_auth_missing",
-            relogin_required=True,
-        )
+        raise
 
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
@@ -3871,79 +3688,6 @@ def resolve_codex_runtime_credentials(
         "last_refresh": data.get("last_refresh"),
         "auth_mode": "chatgpt",
     }
-
-
-def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
-    """Return metadata for a pool-only Codex credential in quota cooldown."""
-    def _parse_reset_at(value: Any) -> Optional[float]:
-        if value is None or value == "":
-            return None
-        if isinstance(value, (int, float)):
-            numeric = float(value)
-            if numeric <= 0:
-                return None
-            return numeric / 1000.0 if numeric > 1_000_000_000_000 else numeric
-        if isinstance(value, str):
-            raw = value.strip()
-            if not raw:
-                return None
-            try:
-                numeric = float(raw)
-            except ValueError:
-                numeric = None
-            if numeric is not None:
-                return numeric / 1000.0 if numeric > 1_000_000_000_000 else numeric
-            try:
-                return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
-            except ValueError:
-                return None
-        return None
-
-    try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-        pool = auth_store.get("credential_pool")
-        if not isinstance(pool, dict):
-            return None
-        entries = pool.get("openai-codex")
-        if not isinstance(entries, list):
-            return None
-        now = time.time()
-        for entry in entries:
-            if not isinstance(entry, dict):
-                continue
-            token = entry.get("access_token")
-            if not isinstance(token, str) or not token.strip():
-                continue
-            if entry.get("last_status") != "exhausted":
-                continue
-            code = entry.get("last_error_code")
-            reason = str(entry.get("last_error_reason") or "").lower()
-            message = str(entry.get("last_error_message") or "").lower()
-            is_rate_limited = (
-                code == 429
-                or "rate_limit" in reason
-                or "usage_limit" in reason
-                or "quota" in reason
-                or "rate limit" in message
-                or "usage limit" in message
-                or "quota" in message
-            )
-            if not is_rate_limited:
-                continue
-            reset_at = _parse_reset_at(entry.get("last_error_reset_at"))
-            if reset_at is not None and reset_at <= now:
-                continue
-            return {
-                "label": entry.get("label"),
-                "last_refresh": entry.get("last_refresh"),
-                "reset_at": reset_at,
-                "reason": entry.get("last_error_reason"),
-                "message": entry.get("last_error_message"),
-            }
-    except Exception:
-        logger.debug("Codex pool rate-limit lookup failed", exc_info=True)
-    return None
 
 
 def _pool_codex_access_token() -> str:
@@ -3990,64 +3734,13 @@ def _pool_codex_access_token() -> str:
 # xAI Grok OAuth — tokens stored in ~/.hermes/auth.json
 # =============================================================================
 
-def _xai_oauth_state_from_store(auth_store: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """Return usable xAI OAuth state from provider state or credential pool."""
-    state = _load_provider_state(auth_store, "xai-oauth")
-    tokens = state.get("tokens") if isinstance(state, dict) else None
-    if isinstance(tokens, dict):
-        access_token = str(tokens.get("access_token", "") or "").strip()
-        refresh_token = str(tokens.get("refresh_token", "") or "").strip()
-        if access_token and refresh_token:
-            return state
-
-    credential_pool = auth_store.get("credential_pool")
-    entries = (
-        credential_pool.get("xai-oauth")
-        if isinstance(credential_pool, dict)
-        else None
-    )
-    if isinstance(entries, list):
-        for entry in entries:
-            if not isinstance(entry, dict):
-                continue
-            access_token = str(entry.get("access_token", "") or "").strip()
-            refresh_token = str(entry.get("refresh_token", "") or "").strip()
-            if not access_token or not refresh_token:
-                continue
-            merged = dict(state or {})
-            merged["tokens"] = {
-                "access_token": access_token,
-                "refresh_token": refresh_token,
-                "token_type": str(entry.get("token_type") or "Bearer"),
-            }
-            if entry.get("last_refresh"):
-                merged["last_refresh"] = entry.get("last_refresh")
-            merged.setdefault("auth_mode", "oauth_pkce")
-            return merged
-
-    return state if isinstance(state, dict) else None
-
-
-def _xai_oauth_state_has_usable_tokens(state: Optional[Dict[str, Any]]) -> bool:
-    tokens = state.get("tokens") if isinstance(state, dict) else None
-    return (
-        isinstance(tokens, dict)
-        and bool(str(tokens.get("access_token", "") or "").strip())
-        and bool(str(tokens.get("refresh_token", "") or "").strip())
-    )
-
-
 def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     if _lock:
         with _auth_store_lock():
             auth_store = _load_auth_store()
     else:
         auth_store = _load_auth_store()
-    state = _xai_oauth_state_from_store(auth_store)
-    if not _xai_oauth_state_has_usable_tokens(state):
-        global_state = _xai_oauth_state_from_store(_load_global_auth_store())
-        if _xai_oauth_state_has_usable_tokens(global_state):
-            state = global_state
+    state = _load_provider_state(auth_store, "xai-oauth")
     if not state:
         raise AuthError(
             "No xAI OAuth credentials stored. Select xAI Grok OAuth (SuperGrok / Premium+) in `hermes model`.",
@@ -4087,62 +3780,6 @@ def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     }
 
 
-def _profile_has_own_xai_oauth_state(auth_store: Dict[str, Any]) -> bool:
-    """True when this store has its OWN ``providers.xai-oauth`` block.
-
-    Distinguishes a profile that genuinely shadows the root xAI grant from
-    one that only *reads* root via ``_load_provider_state``'s fallback. Only
-    the latter needs the refresh write-through below.
-    """
-    providers = auth_store.get("providers")
-    return isinstance(providers, dict) and isinstance(providers.get("xai-oauth"), dict)
-
-
-def _write_through_xai_oauth_to_global_root(state: Dict[str, Any]) -> None:
-    """Persist a rotated xAI OAuth ``state`` into the global-root auth.json.
-
-    Best-effort write-through for the multi-profile rotation hazard (#43589):
-    xAI rotates the refresh_token on every refresh, so when a profile session
-    refreshes a grant it resolved from the root fallback, the rotated chain
-    must land back in root. Otherwise root keeps a now-revoked refresh token
-    and every other profile reading the stale root grant dies with
-    ``invalid_grant`` once its access token expires.
-
-    Only updates ``providers.xai-oauth`` in the root store; never touches the
-    profile store (the caller already saved that). Swallows all errors — a
-    failed write-through degrades to the pre-existing behavior (root stale),
-    it must never break the profile's own successful save.
-    """
-    global_path = _global_auth_file_path()
-    if global_path is None:
-        # Classic mode (profile == root); the profile save already hit root.
-        return
-    # Seat belt: under pytest, refuse to write the real user's
-    # ~/.hermes/auth.json even when HERMES_HOME points at a profile path
-    # (mirrors the read-side guard in _load_global_auth_store). Uses the
-    # unmodified HOME env, not Path.home() which fixtures may monkeypatch.
-    if os.environ.get("PYTEST_CURRENT_TEST"):
-        real_home_env = os.environ.get("HOME", "")
-        if real_home_env:
-            real_root = Path(real_home_env) / ".hermes" / "auth.json"
-            try:
-                if global_path.resolve(strict=False) == real_root.resolve(strict=False):
-                    return
-            except Exception:
-                return
-    try:
-        if global_path.exists():
-            global_store = _load_auth_store(global_path)
-        else:
-            global_store = {}
-        if not isinstance(global_store, dict):
-            return
-        _store_provider_state(global_store, "xai-oauth", dict(state), set_active=False)
-        _save_auth_store(global_store, global_path)
-    except Exception as exc:  # pragma: no cover - best effort
-        logger.debug("xAI OAuth: write-through to global root failed: %s", exc)
-
-
 def _save_xai_oauth_tokens(
     tokens: Dict[str, Any],
     *,
@@ -4154,11 +3791,6 @@ def _save_xai_oauth_tokens(
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     with _auth_store_lock():
         auth_store = _load_auth_store()
-        # A profile that lacks its own xai-oauth block is reading the root
-        # grant through _load_provider_state's fallback. When such a profile
-        # refreshes the (rotating) grant, we must write the rotated chain back
-        # to root too, or root is left holding a revoked refresh token (#43589).
-        write_through_to_root = not _profile_has_own_xai_oauth_state(auth_store)
         state = _load_provider_state(auth_store, "xai-oauth") or {}
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
@@ -4169,8 +3801,6 @@ def _save_xai_oauth_tokens(
             state["redirect_uri"] = redirect_uri
         _save_provider_state(auth_store, "xai-oauth", state)
         _save_auth_store(auth_store)
-        if write_through_to_root:
-            _write_through_xai_oauth_to_global_root(state)
 
 
 def _xai_access_token_is_expiring(access_token: str, skew_seconds: int = 0) -> bool:
@@ -5857,24 +5487,18 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
 # subscription-feature checks) call it many times per render — `hermes tools` → "All Platforms"
 # was firing the refresh ~31× during one menu paint, racking up >13s of HTTP and burning
 # single-use refresh tokens. Cache the snapshot for a few seconds, keyed on the auth.json
-# path + mtime so that profile switches do not share a process memo and
-# `hermes auth login/logout/add/remove` invalidate naturally on the next call.
+# mtime so that `hermes auth login/logout/add/remove` invalidate naturally on the next call.
 _NOUS_AUTH_STATUS_CACHE_TTL = 15.0  # seconds
-_nous_auth_status_cache: Optional[Tuple[float, str, Optional[float], Dict[str, Any]]] = None
+_nous_auth_status_cache: Optional[Tuple[float, Optional[float], Dict[str, Any]]] = None
 
 
-def _auth_file_cache_key() -> Tuple[str, Optional[float]]:
-    auth_file = _auth_file_path()
+def _auth_file_mtime() -> Optional[float]:
     try:
-        auth_file_key = str(auth_file.resolve(strict=False))
-    except Exception:
-        auth_file_key = str(auth_file)
-    try:
-        return auth_file_key, auth_file.stat().st_mtime
+        return _auth_file_path().stat().st_mtime
     except FileNotFoundError:
-        return auth_file_key, None
+        return None
     except Exception:
-        return auth_file_key, None
+        return None
 
 
 def invalidate_nous_auth_status_cache() -> None:
@@ -5906,19 +5530,18 @@ def get_nous_auth_status() -> Dict[str, Any]:
     """
     global _nous_auth_status_cache
     now = time.monotonic()
-    auth_file_key, mtime = _auth_file_cache_key()
+    mtime = _auth_file_mtime()
     cached = _nous_auth_status_cache
     if cached is not None:
-        cached_at, cached_auth_file_key, cached_mtime, cached_status = cached
+        cached_at, cached_mtime, cached_status = cached
         if (
-            cached_auth_file_key == auth_file_key
-            and cached_mtime == mtime
+            cached_mtime == mtime
             and (now - cached_at) < _NOUS_AUTH_STATUS_CACHE_TTL
         ):
             return dict(cached_status)
 
     status = _compute_nous_auth_status()
-    _nous_auth_status_cache = (now, auth_file_key, mtime, dict(status))
+    _nous_auth_status_cache = (now, mtime, dict(status))
     return status
 
 
@@ -6001,22 +5624,6 @@ def get_codex_auth_status() -> Dict[str, Any]:
                         "source": f"pool:{getattr(entry, 'label', 'unknown')}",
                         "api_key": api_key,
                     }
-            rate_limit = _codex_pool_rate_limit_status()
-            if rate_limit:
-                return {
-                    "logged_in": True,
-                    "auth_store": str(_auth_file_path()),
-                    "last_refresh": rate_limit.get("last_refresh"),
-                    "auth_mode": "chatgpt",
-                    "source": f"pool:{rate_limit.get('label') or 'unknown'}",
-                    "rate_limited": True,
-                    "error_code": CODEX_RATE_LIMITED_CODE,
-                    "error": (
-                        rate_limit.get("message")
-                        or "Codex provider quota exhausted; retry after the usage limit resets."
-                    ),
-                    "reset_at": rate_limit.get("reset_at"),
-                }
     except Exception:
         pass
 
@@ -6478,40 +6085,6 @@ def _reset_config_provider() -> Path:
     return config_path
 
 
-def _confirm_expensive_model_selection(
-    model_id: str,
-    *,
-    provider: str = "",
-    base_url: str = "",
-    api_key: str = "",
-) -> bool:
-    """Prompt before saving a model whose known pricing exceeds guardrails."""
-    try:
-        from hermes_cli.model_cost_guard import expensive_model_warning
-
-        warning = expensive_model_warning(
-            model_id,
-            provider=provider,
-            base_url=base_url,
-            api_key=api_key,
-        )
-    except Exception:
-        warning = None
-    if warning is None:
-        return True
-
-    print()
-    print("=" * 72)
-    print(warning.message)
-    print("=" * 72)
-    try:
-        response = input("Switch anyway? [y/N]: ").strip().lower()
-    except (KeyboardInterrupt, EOFError):
-        print()
-        return False
-    return response in {"y", "yes"}
-
-
 def _prompt_model_selection(
     model_ids: List[str],
     current_model: str = "",
@@ -6519,9 +6092,6 @@ def _prompt_model_selection(
     unavailable_models: Optional[List[str]] = None,
     portal_url: str = "",
     unavailable_message: str = "",
-    confirm_provider: str = "",
-    confirm_base_url: str = "",
-    confirm_api_key: str = "",
 ) -> Optional[str]:
     """Interactive model selection. Puts current_model first with a marker. Returns chosen model ID or None.
 
@@ -6534,18 +6104,6 @@ def _prompt_model_selection(
     from hermes_cli.models import _format_price_per_mtok
 
     _unavailable = unavailable_models or []
-
-    def _confirmed_selection(mid: str) -> Optional[str]:
-        if not mid:
-            return None
-        if confirm_provider and not _confirm_expensive_model_selection(
-            mid,
-            provider=confirm_provider,
-            base_url=confirm_base_url,
-            api_key=confirm_api_key,
-        ):
-            return None
-        return mid
 
     # Reorder: current model first, then the rest (deduplicated)
     ordered = []
@@ -6662,13 +6220,13 @@ def _prompt_model_selection(
             return None
         print()
         if idx < len(ordered):
-            return _confirmed_selection(ordered[idx])
+            return ordered[idx]
         elif idx == len(ordered):
             try:
                 custom = input("Enter model name: ").strip()
             except (EOFError, KeyboardInterrupt):
                 return None
-            return _confirmed_selection(custom) if custom else None
+            return custom if custom else None
         return None
     except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
         pass
@@ -6700,10 +6258,10 @@ def _prompt_model_selection(
                 return None
             idx = int(choice)
             if 1 <= idx <= n:
-                return _confirmed_selection(ordered[idx - 1])
+                return ordered[idx - 1]
             elif idx == n + 1:
                 custom = input("Enter model name: ").strip()
-                return _confirmed_selection(custom) if custom else None
+                return custom if custom else None
             elif idx == n + 2:
                 return None
             print(f"Please enter 1-{n + 2}")
@@ -7047,7 +6605,6 @@ def _xai_oauth_loopback_login(
     authorization_endpoint = discovery["authorization_endpoint"]
     token_endpoint = discovery["token_endpoint"]
 
-    allow_missing_state = False
     if manual_paste:
         # No HTTP listener — synthesize a redirect_uri matching what
         # the server would have bound to so the authorize URL the user
@@ -7074,7 +6631,6 @@ def _xai_oauth_loopback_login(
         print("Open this URL to authorize Hermes with xAI:")
         print(authorize_url)
         callback = _prompt_manual_callback_paste(redirect_uri)
-        allow_missing_state = True
     else:
         server, thread, callback_result, redirect_uri = _xai_start_callback_server()
         try:
@@ -7114,7 +6670,6 @@ def _xai_oauth_loopback_login(
                     thread,
                     callback_result,
                     timeout_seconds=max(30.0, timeout_seconds * 9),
-                    manual_paste_redirect_uri=redirect_uri,
                 )
             except AuthError as exc:
                 if (
@@ -7131,7 +6686,6 @@ def _xai_oauth_loopback_login(
                 callback = _prompt_manual_callback_paste(redirect_uri)
                 if callback.get("code") is None and callback.get("error") is None:
                     raise exc
-                allow_missing_state = True
         except Exception:
             try:
                 server.shutdown()
@@ -7152,7 +6706,7 @@ def _xai_oauth_loopback_login(
             code="xai_authorization_failed",
         )
     callback_state = callback.get("state")
-    # Manual bare-code paths: when a user pastes only the opaque
+    # Manual-paste bare-code path: when a user pastes only the opaque
     # authorization code (no ``code=``/``state=`` query parameters),
     # ``_parse_pasted_callback`` returns ``state=None``.  xAI's consent
     # page renders the code in-page rather than redirecting through the
@@ -7160,12 +6714,10 @@ def _xai_oauth_loopback_login(
     # VPS, container consoles) the bare code is the only thing the user
     # can obtain.  PKCE (code_verifier) still binds the exchange to this
     # client, so the local state-equality check is redundant on the
-    # bare-code paths — we substitute the locally generated state to keep
+    # bare-code path — we substitute the locally generated state to keep
     # the rest of the validation chain (and the token exchange) unchanged.
     # See #26923 (AccursedGalaxy comment, 2026-05-20).
-    if callback.get("_manual_paste"):
-        allow_missing_state = True
-    if callback_state is None and (manual_paste or allow_missing_state):
+    if callback_state is None and manual_paste:
         callback_state = state
     if callback_state != state:
         raise AuthError(
@@ -7232,61 +6784,23 @@ def _codex_device_code_login() -> Dict[str, Any]:
     issuer = "https://auth.openai.com"
     client_id = CODEX_OAUTH_CLIENT_ID
 
-    # Step 1: Request device code. OpenAI's auth endpoint rate-limits this
-    # request (HTTP 429) when login is attempted too often from the same
-    # IP/account — retry with capped backoff (honoring ``Retry-After``)
-    # before surfacing a clear, actionable message instead of a bare status.
-    resp = None
-    max_attempts = 4
-    for attempt in range(1, max_attempts + 1):
-        try:
-            with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-                resp = client.post(
-                    f"{issuer}/api/accounts/deviceauth/usercode",
-                    json={"client_id": client_id},
-                    headers={"Content-Type": "application/json"},
-                )
-        except Exception as exc:
-            raise AuthError(
-                f"Failed to request device code: {exc}",
-                provider="openai-codex", code="device_code_request_failed",
+    # Step 1: Request device code
+    try:
+        with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
+            resp = client.post(
+                f"{issuer}/api/accounts/deviceauth/usercode",
+                json={"client_id": client_id},
+                headers={"Content-Type": "application/json"},
             )
-
-        if resp.status_code != 429:
-            break
-
-        if attempt < max_attempts:
-            retry_after = _parse_retry_after_seconds(
-                getattr(resp, "headers", None)
-            )
-            # Exponential backoff (2s, 4s, 8s) capped, preferring the
-            # server-provided Retry-After when present.
-            delay = retry_after if retry_after is not None else 2 ** attempt
-            delay = max(1, min(int(delay), 60))
-            print(
-                "OpenAI is rate-limiting login requests "
-                f"(429); retrying in {delay}s..."
-            )
-            _time.sleep(delay)
-
-    if resp is not None and resp.status_code == 429:
-        retry_after = _parse_retry_after_seconds(getattr(resp, "headers", None))
-        wait_hint = (
-            f" Try again in about {retry_after}s."
-            if retry_after is not None
-            else " Wait a minute and run the login again."
-        )
+    except Exception as exc:
         raise AuthError(
-            "OpenAI is rate-limiting Codex login requests (HTTP 429). "
-            "This is a temporary throttle on OpenAI's side, not a credential "
-            f"problem.{wait_hint}",
-            provider="openai-codex", code=CODEX_RATE_LIMITED_CODE,
+            f"Failed to request device code: {exc}",
+            provider="openai-codex", code="device_code_request_failed",
         )
 
-    if resp is None or resp.status_code != 200:
-        status = resp.status_code if resp is not None else "unknown"
+    if resp.status_code != 200:
         raise AuthError(
-            f"Device code request returned status {status}.",
+            f"Device code request returned status {resp.status_code}.",
             provider="openai-codex", code="device_code_request_error",
         )
 
@@ -7372,22 +6886,6 @@ def _codex_device_code_login() -> Dict[str, Any]:
         raise AuthError(
             f"Token exchange failed: {exc}",
             provider="openai-codex", code="token_exchange_failed",
-        )
-
-    if token_resp.status_code == 429:
-        retry_after = _parse_retry_after_seconds(
-            getattr(token_resp, "headers", None)
-        )
-        wait_hint = (
-            f" Try again in about {retry_after}s."
-            if retry_after is not None
-            else " Wait a minute and run the login again."
-        )
-        raise AuthError(
-            "OpenAI is rate-limiting Codex login requests (HTTP 429) during "
-            "token exchange. This is a temporary throttle on OpenAI's side, "
-            f"not a credential problem.{wait_hint}",
-            provider="openai-codex", code=CODEX_RATE_LIMITED_CODE,
         )
 
     if token_resp.status_code != 200:
@@ -7866,7 +7364,6 @@ def _nous_device_code_login(
     timeout_seconds: float = 15.0,
     insecure: bool = False,
     ca_bundle: Optional[str] = None,
-    on_verification: Optional[Callable[[str, str], None]] = None,
 ) -> Dict[str, Any]:
     """Run the Nous device-code flow and return full OAuth state without persisting."""
     pconfig = PROVIDER_REGISTRY["nous"]
@@ -7920,16 +7417,6 @@ def _nous_device_code_login(
                 print("  (Opened browser for verification)")
             else:
                 print("  Could not open browser automatically — use the URL above.")
-
-        # Surface the verification URL/code to an out-of-band consumer (e.g. the
-        # TUI gateway, whose stdout is a JSON-RPC pipe — a plain print() there is
-        # dropped). Fired AFTER the print/browser block and BEFORE polling blocks,
-        # so the consumer can render the link while we wait. Best-effort.
-        if on_verification is not None:
-            try:
-                on_verification(verification_url, user_code)
-            except Exception:
-                pass
 
         effective_interval = max(1, min(interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS))
         print(f"Waiting for approval (polling every {effective_interval}s)...")
@@ -7994,91 +7481,6 @@ def _nous_device_code_login(
             print("After subscribing, run `hermes model` again to finish setup.")
             raise SystemExit(1)
         raise
-
-
-def nous_token_has_billing_scope() -> bool:
-    """Return True if the currently-held Nous token carries ``billing:manage``.
-
-    Reads the persisted ``scope`` string saved at login (``_save_provider_state``
-    stores ``token_data.get("scope") or scope``). A space-delimited match. Used by
-    the lazy step-up: if False, the first billing call will 403 ``insufficient_scope``
-    anyway, but checking up front lets a surface skip a doomed round-trip.
-    """
-    try:
-        state = get_provider_auth_state("nous") or {}
-    except Exception:
-        return False
-    scope = state.get("scope")
-    if not isinstance(scope, str):
-        return False
-    return NOUS_BILLING_MANAGE_SCOPE in scope.split()
-
-
-def step_up_nous_billing_scope(
-    *,
-    open_browser: bool = True,
-    timeout_seconds: float = 15.0,
-    on_verification: Optional[Callable[[str, str], None]] = None,
-) -> bool:
-    """Re-run the device flow requesting ``billing:manage`` and persist the result.
-
-    The lazy step-up (plan D-A): triggered when a billing endpoint returns
-    ``403 insufficient_scope``. Runs a fresh device-connect with
-    ``inference:invoke tool:invoke billing:manage`` on the scope. The user must be
-    an ADMIN/OWNER and tick "Allow terminal billing" in the portal for the minted
-    token to actually carry the scope; otherwise the server silently downscopes and this
-    returns False.
-
-    Reuses the held credential's portal/inference URLs + client_id so the step-up
-    targets the same deployment (incl. a preview via ``HERMES_PORTAL_BASE_URL`` set
-    at the original login). Persists to the auth store + shared store + pool, exactly
-    like ``_login_nous`` — but WITHOUT the model picker (this is a scope upgrade, not
-    a fresh login).
-
-    Returns True iff the new token carries ``billing:manage``.
-    """
-    prior = get_provider_auth_state("nous") or {}
-    pconfig = PROVIDER_REGISTRY["nous"]
-
-    # Build the step-up scope: existing scopes (if any) + billing:manage, deduped,
-    # order-stable. Fall back to the standard inference+tool+billing set.
-    _raw_scope = prior.get("scope")
-    prior_scope = _raw_scope if isinstance(_raw_scope, str) else ""
-    requested: list[str] = []
-    for tok in (prior_scope.split() or [NOUS_INFERENCE_INVOKE_SCOPE, "tool:invoke"]):
-        if tok and tok not in requested:
-            requested.append(tok)
-    if NOUS_BILLING_MANAGE_SCOPE not in requested:
-        requested.append(NOUS_BILLING_MANAGE_SCOPE)
-    scope = " ".join(requested)
-
-    auth_state = _nous_device_code_login(
-        portal_base_url=prior.get("portal_base_url") or None,
-        inference_base_url=prior.get("inference_base_url") or None,
-        client_id=prior.get("client_id") or pconfig.client_id,
-        scope=scope,
-        open_browser=open_browser,
-        timeout_seconds=timeout_seconds,
-        on_verification=on_verification,
-    )
-
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
-        _save_provider_state(auth_store, "nous", auth_state)
-        _save_auth_store(auth_store)
-
-    # Mirror to shared store + reseed the pool (best-effort), same as _login_nous.
-    try:
-        _write_shared_nous_state(auth_state)
-    except Exception:
-        pass
-    try:
-        _sync_nous_pool_from_auth_store()
-    except Exception:
-        pass
-
-    granted = auth_state.get("scope")
-    return isinstance(granted, str) and NOUS_BILLING_MANAGE_SCOPE in granted.split()
 
 
 def _login_nous(args, pconfig: ProviderConfig) -> None:
@@ -8232,9 +7634,6 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
                     unavailable_models=unavailable_models,
                     portal_url=_portal,
                     unavailable_message=unavailable_message,
-                    confirm_provider="nous",
-                    confirm_base_url=inference_base_url,
-                    confirm_api_key=runtime_key,
                 )
             elif unavailable_models:
                 _url = (_portal or DEFAULT_NOUS_PORTAL_URL).rstrip("/")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 import logging
 import os
 import re
-from urllib.parse import urlparse
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
 from hermes_cli import auth as auth_mod
 from agent.credential_pool import CredentialPool, PooledCredential, get_custom_provider_pool_key, load_pool
-from agent.secret_scope import get_secret as _get_secret
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
@@ -33,20 +31,7 @@ from hermes_cli.auth import (
 )
 from hermes_cli.config import get_compatible_custom_providers, load_config
 from hermes_constants import OPENROUTER_BASE_URL
-from utils import base_url_host_matches, base_url_hostname, env_int
-
-
-def _getenv(name: str, default: str = "") -> str:
-    """Profile-scoped replacement for ``os.getenv`` on credential/provider reads.
-
-    Routes through the secret scope (Workstream A): identical to ``os.getenv``
-    when multiplexing is off, scope-aware (and fail-closed on an unscoped read)
-    when on. Genuinely-global vars are handled inside ``get_secret`` and still
-    read ``os.environ``. Keeps the ``(name, default) -> str`` contract every
-    call site here already relies on.
-    """
-    val = _get_secret(name, default)
-    return val if val is not None else default
+from utils import base_url_host_matches, base_url_hostname
 
 
 def _normalize_custom_provider_name(value: str) -> str:
@@ -108,8 +93,7 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
         return "codex_responses"
     if hostname == "api.openai.com":
         return "codex_responses"
-    path = urlparse(normalized).path.rstrip("/")
-    if path.endswith("/anthropic") or path.endswith("/anthropic/v1"):
+    if normalized.endswith("/anthropic"):
         return "anthropic_messages"
     if hostname == "api.kimi.com" and "/coding" in normalized:
         return "anthropic_messages"
@@ -170,7 +154,7 @@ def _host_derived_api_key(base_url: str) -> str:
     if sanitized in ("OPENAI", "OPENROUTER", "OLLAMA"):
         return ""
     env_name = f"{sanitized}_API_KEY"
-    return (_getenv(env_name, "") or "").strip()
+    return (os.getenv(env_name, "") or "").strip()
 
 
 def _auto_detect_local_model(base_url: str) -> str:
@@ -451,7 +435,7 @@ def resolve_requested_provider(requested: Optional[str] = None) -> str:
 
     # Prefer the persisted config selection over any stale shell/.env
     # provider override so chat uses the endpoint the user last saved.
-    env_provider = _getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower()
+    env_provider = os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower()
     if env_provider:
         return env_provider
 
@@ -507,27 +491,15 @@ def _lift_max_output_tokens(entry: Dict[str, Any], result: Dict[str, Any]) -> No
 
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
-    if not requested_norm:
+    if not requested_norm or requested_norm == "custom":
         return None
-
-    # Bare "custom" is normally an incomplete spec — the canonical form is
-    # "custom:<name>" — and is otherwise owned by the model.base_url "bare
-    # custom" trust path. BUT a user may literally name a ``providers:`` (or
-    # legacy ``custom_providers:``) entry "custom" (e.g. ``providers.custom``
-    # pointing at cliproxy). We used to return None here *before* scanning
-    # config, so such an entry was never matched and resolution fell through to
-    # the global default (Codex) — the cause of cron jobs with
-    # ``provider: "custom"`` failing with ``auth_unavailable: providers=codex``.
-    # Fall through to the config scan instead; if no entry is literally named
-    # "custom" it still returns None at the end, preserving the trust path.
 
     # Raw names should only map to custom providers when they are not already
     # valid built-in providers or aliases. Explicit menu keys like
-    # ``custom:local`` always target the saved custom provider. Bare "custom"
-    # is exempt from the shadow check — it is not a built-in to defer to.
+    # ``custom:local`` always target the saved custom provider.
     if requested_norm == "auto":
         return None
-    if requested_norm != "custom" and not requested_norm.startswith("custom:"):
+    if not requested_norm.startswith("custom:"):
         try:
             canonical = auth_mod.resolve_provider(requested_norm)
         except AuthError:
@@ -556,7 +528,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             name_norm = _normalize_custom_provider_name(ep_name)
             # Resolve the API key from the env var name stored in key_env
             key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = _getenv(key_env, "").strip() if key_env else ""
+            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
@@ -662,138 +634,6 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     return None
 
 
-def has_named_custom_provider(requested_provider: str) -> bool:
-    """Return True when config defines a custom provider matching the request.
-
-    Thin public wrapper around :func:`_get_named_custom_provider` so other
-    modules (e.g. the cronjob tool) can decide whether a provider name will
-    actually resolve to a configured ``providers:`` / ``custom_providers:``
-    entry — without reaching into a private helper or duplicating the scan.
-    """
-    try:
-        return _get_named_custom_provider(requested_provider) is not None
-    except Exception:
-        return False
-
-
-def find_custom_provider_identity(base_url: str) -> Optional[str]:
-    """Map an endpoint URL back to its canonical ``custom:<name>`` menu key.
-
-    Returns the ``custom:<normalized-name>`` slug of the first ``providers:``
-    / ``custom_providers:`` entry whose base_url matches, or ``None`` when no
-    entry owns the URL.
-
-    Session persistence stores the agent's *resolved* provider, and for every
-    named custom endpoint that is the literal string ``"custom"`` — the entry
-    name is lost, and the api_key is deliberately never persisted. The
-    endpoint URL is the one durable fact that survives the round-trip, so
-    this reverse lookup lets persist/rebuild paths recover the entry identity
-    (and with it key_env/api_key/api_mode resolution via
-    :func:`_get_named_custom_provider`) instead of failing with
-    ``auth_unavailable`` or silently rebuilding with placeholder credentials.
-    """
-    target = _normalize_base_url_for_match(base_url)
-    if not target:
-        return None
-    try:
-        config = load_config()
-    except Exception:
-        return None
-
-    providers = config.get("providers")
-    if isinstance(providers, dict):
-        for ep_name, entry in providers.items():
-            if not isinstance(entry, dict):
-                continue
-            entry_url = (
-                entry.get("api") or entry.get("url") or entry.get("base_url") or ""
-            )
-            if _normalize_base_url_for_match(entry_url) == target:
-                return f"custom:{_normalize_custom_provider_name(str(ep_name))}"
-
-    try:
-        custom_providers = get_compatible_custom_providers(config)
-    except Exception:
-        custom_providers = None
-    for entry in custom_providers or []:
-        if not isinstance(entry, dict):
-            continue
-        name = entry.get("name")
-        if not isinstance(name, str) or not name.strip():
-            continue
-        if _normalize_base_url_for_match(entry.get("base_url")) == target:
-            return f"custom:{_normalize_custom_provider_name(name)}"
-
-    return None
-
-
-def canonical_custom_identity(
-    *,
-    base_url: Optional[str] = None,
-    config_provider: Optional[str] = None,
-) -> Optional[str]:
-    """Recover a routable ``custom:<name>`` identity for a bare custom provider.
-
-    The bare string ``"custom"`` is the *resolved billing class* shared by
-    every named ``providers:`` / ``custom_providers:`` entry — it is NOT a
-    routable provider identity (``resolve_runtime_provider("custom")`` falls
-    through to the OpenRouter default URL with no api_key, which surfaces to
-    the user as "No LLM provider configured").
-
-    Any code path that persists or restores a session's provider override
-    must run the resolved provider through this helper so a bare ``"custom"``
-    is upgraded back to its durable ``custom:<name>`` menu key. Two recovery
-    sources, in priority order:
-
-    1. ``base_url`` — reverse-lookup the entry that owns the endpoint URL
-       (the one fact that always survives the persistence round-trip when a
-       URL was recorded).
-    2. ``config_provider`` — the active ``config.model.provider`` (or its
-       ``provider``/``HERMES_INFERENCE_PROVIDER`` equivalent). When the agent
-       was built without a base_url on the override (the recurring
-       Desktop/TUI regression vector), the configured provider is the only
-       durable identity left, so fall back to it when it names a real entry.
-
-    Returns ``custom:<name>`` when a routable identity is recovered, else
-    ``None`` (caller keeps whatever it had — bare ``"custom"`` only as a last
-    resort, e.g. a genuine ad-hoc endpoint with no config entry).
-    """
-    # 1. Reverse-lookup by endpoint URL.
-    if base_url:
-        identity = find_custom_provider_identity(base_url)
-        if identity:
-            return identity
-
-    # 2. Fall back to the configured provider when it names a real entry.
-    candidate = str(config_provider or "").strip()
-    if not candidate:
-        try:
-            candidate = str(_get_model_config().get("provider") or "").strip()
-        except Exception:
-            candidate = ""
-    if not candidate:
-        candidate = os.environ.get("HERMES_INFERENCE_PROVIDER", "").strip()
-
-    candidate_norm = _normalize_custom_provider_name(candidate)
-    # A bare/non-routable candidate cannot heal a bare custom override.
-    if not candidate_norm or candidate_norm in {"custom", "auto", "openrouter"}:
-        return None
-    # Only return it when it actually resolves to a configured custom entry,
-    # so we never invent a `custom:<x>` that resolution can't honor.
-    try:
-        if _get_named_custom_provider(candidate) is not None:
-            if candidate_norm.startswith("custom:"):
-                return candidate_norm
-            return f"custom:{candidate_norm}"
-    except Exception:
-        pass
-    return None
-
-
-def _normalize_base_url_for_match(value) -> str:
-    return str(value or "").strip().rstrip("/").lower()
-
-
 def _custom_provider_request_overrides(custom_provider: Dict[str, Any]) -> Dict[str, Any]:
     extra_body = custom_provider.get("extra_body")
     if not isinstance(extra_body, dict) or not extra_body:
@@ -838,8 +678,8 @@ def _resolve_named_custom_runtime(
         api_key_candidates = [
             (explicit_api_key or "").strip(),
             # Gate env key fallbacks on authoritative hosts (#28660)
-            (_getenv("OPENAI_API_KEY", "").strip()     if _da_is_openai_url else ""),
-            (_getenv("OPENROUTER_API_KEY", "").strip() if _da_is_openrouter  else ""),
+            (os.getenv("OPENAI_API_KEY", "").strip()     if _da_is_openai_url else ""),
+            (os.getenv("OPENROUTER_API_KEY", "").strip() if _da_is_openrouter  else ""),
             # Bonus (#28660): derive `<VENDOR>_API_KEY` from the host so users
             # who set DEEPSEEK_API_KEY / GROQ_API_KEY / MISTRAL_API_KEY get the
             # intuitive match without configuring `custom_providers` first.
@@ -892,11 +732,11 @@ def _resolve_named_custom_runtime(
     api_key_candidates = [
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
-        _getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
-        (_getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),
-        (_getenv("OPENROUTER_API_KEY", "").strip() if _cp_is_openrouter  else ""),
+        (os.getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),
+        (os.getenv("OPENROUTER_API_KEY", "").strip() if _cp_is_openrouter  else ""),
         # Bonus (#28660): derive `<VENDOR>_API_KEY` from the host as a final
         # fallback when key_env wasn't set explicitly.
         _host_derived_api_key(base_url),
@@ -955,8 +795,8 @@ def _resolve_openrouter_runtime(
         except Exception:
             pass
 
-    env_openrouter_base_url = _getenv("OPENROUTER_BASE_URL", "").strip()
-    env_custom_base_url = _getenv("CUSTOM_BASE_URL", "").strip()
+    env_openrouter_base_url = os.getenv("OPENROUTER_BASE_URL", "").strip()
+    env_custom_base_url = os.getenv("CUSTOM_BASE_URL", "").strip()
 
     # Use config base_url when available and the provider context matches.
     # OPENAI_BASE_URL env var is no longer consulted — config.yaml is
@@ -996,8 +836,8 @@ def _resolve_openrouter_runtime(
     if _is_openrouter_context:
         api_key_candidates = [
             explicit_api_key,
-            _getenv("OPENROUTER_API_KEY"),
-            _getenv("OPENAI_API_KEY"),
+            os.getenv("OPENROUTER_API_KEY"),
+            os.getenv("OPENAI_API_KEY"),
         ]
     else:
         # Custom endpoint: use api_key from config when using config base_url (#1760).
@@ -1017,9 +857,9 @@ def _resolve_openrouter_runtime(
         api_key_candidates = [
             explicit_api_key,
             (cfg_api_key if use_config_base_url else ""),
-            (_getenv("OLLAMA_API_KEY")     if _is_ollama_url                       else ""),
-            (_getenv("OPENAI_API_KEY")     if (_is_openai_url or _is_openai_azure) else ""),
-            (_getenv("OPENROUTER_API_KEY") if _is_openrouter_url                   else ""),
+            (os.getenv("OLLAMA_API_KEY")     if _is_ollama_url                       else ""),
+            (os.getenv("OPENAI_API_KEY")     if (_is_openai_url or _is_openai_azure) else ""),
+            (os.getenv("OPENROUTER_API_KEY") if _is_openrouter_url                   else ""),
             # Bonus (#28660): derive `<VENDOR>_API_KEY` from the host so users
             # who set DEEPSEEK_API_KEY / GROQ_API_KEY / MISTRAL_API_KEY get the
             # intuitive match. Helper returns "" for IPs/loopback and for env
@@ -1122,7 +962,7 @@ def _resolve_azure_foundry_runtime(
         if inferred:
             cfg_api_mode = inferred
 
-    env_base_url = _getenv("AZURE_FOUNDRY_BASE_URL", "").strip().rstrip("/")
+    env_base_url = os.getenv("AZURE_FOUNDRY_BASE_URL", "").strip().rstrip("/")
     base_url = explicit_base_url_clean or cfg_base_url or env_base_url
     if not base_url:
         raise AuthError(
@@ -1211,7 +1051,7 @@ def _resolve_azure_foundry_runtime(
         except Exception:
             api_key = ""
     if not api_key:
-        api_key = _getenv("AZURE_FOUNDRY_API_KEY", "").strip()
+        api_key = os.getenv("AZURE_FOUNDRY_API_KEY", "").strip()
     if not api_key:
         raise AuthError(
             "Azure Foundry requires an API key. Set AZURE_FOUNDRY_API_KEY in "
@@ -1304,14 +1144,14 @@ def _resolve_explicit_runtime(
             str(state.get("agent_key") or "").strip()
             if _agent_key_is_usable(
                 state,
-                max(60, env_int("HERMES_NOUS_MIN_KEY_TTL_SECONDS", 1800)),
+                max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),
             )
             else ""
         )
         expires_at = state.get("agent_key_expires_at") or state.get("expires_at")
         if not api_key:
             creds = resolve_nous_runtime_credentials(
-                timeout_seconds=float(_getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
+                timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
             )
             api_key = creds.get("api_key", "")
             expires_at = creds.get("expires_at")
@@ -1340,7 +1180,7 @@ def _resolve_explicit_runtime(
     if pconfig and pconfig.auth_type == "api_key":
         env_url = ""
         if pconfig.base_url_env_var:
-            env_url = _getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
+            env_url = os.getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
 
         base_url = explicit_base_url
         if not base_url:
@@ -1412,8 +1252,8 @@ def resolve_runtime_provider(
     if requested_provider == "anthropic" and "azure.com" in _eff_base:
         _azure_key = (
             (explicit_api_key or "").strip()
-            or _getenv("AZURE_ANTHROPIC_KEY", "").strip()
-            or _getenv("ANTHROPIC_API_KEY", "").strip()
+            or os.getenv("AZURE_ANTHROPIC_KEY", "").strip()
+            or os.getenv("ANTHROPIC_API_KEY", "").strip()
         )
         return {
             "provider": "anthropic",
@@ -1468,8 +1308,8 @@ def resolve_runtime_provider(
     if provider == "openrouter":
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         cfg_base_url = str(model_cfg.get("base_url") or "").strip()
-        env_openai_base_url = _getenv("OPENAI_BASE_URL", "").strip()
-        env_openrouter_base_url = _getenv("OPENROUTER_BASE_URL", "").strip()
+        env_openai_base_url = os.getenv("OPENAI_BASE_URL", "").strip()
+        env_openrouter_base_url = os.getenv("OPENROUTER_BASE_URL", "").strip()
         has_custom_endpoint = bool(
             explicit_base_url
             or env_openai_base_url
@@ -1503,7 +1343,7 @@ def resolve_runtime_provider(
         # expired, clear pool_api_key so we fall through to
         # resolve_nous_runtime_credentials() which handles refresh.
         if provider == "nous" and entry is not None and pool_api_key:
-            min_ttl = max(60, env_int("HERMES_NOUS_MIN_KEY_TTL_SECONDS", 1800))
+            min_ttl = max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800")))
             nous_state = {
                 "agent_key": getattr(entry, "agent_key", None),
                 "agent_key_expires_at": getattr(entry, "agent_key_expires_at", None),
@@ -1525,7 +1365,7 @@ def resolve_runtime_provider(
     if provider == "nous":
         try:
             creds = resolve_nous_runtime_credentials(
-                timeout_seconds=float(_getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
+                timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
             )
             return {
                 "provider": "nous",
@@ -1647,6 +1487,23 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    if provider == "agy-cli":
+        # Antigravity CLI: auth is fully internal to the `agy` binary
+        # (~/.local/bin/agy + its own OAuth/cloudcode-pa session). Hermes
+        # has nothing to resolve; we just hand back the marker base_url so
+        # init_agent's "if api_key and base_url" branch takes over and
+        # routes the request to AgyCliClient via agent_runtime_helpers.
+        return {
+            "provider": "agy-cli",
+            "api_mode": "agy_cli",
+            "base_url": "agy://antigravity",
+            # Placeholder api_key: AgyCliClient doesn't use it but the
+            # init path requires non-empty creds to reach the client builder.
+            "api_key": "agy-cli-external-process",
+            "source": "process",
+            "requested_provider": requested_provider,
+        }
+
     # Anthropic (native Messages API)
     if provider == "anthropic":
         # Allow base URL override from config.yaml model.base_url, but only
@@ -1678,7 +1535,7 @@ def resolve_runtime_provider(
             for hint_key in ("key_env", "api_key_env"):
                 env_var = str(model_cfg.get(hint_key) or "").strip()
                 if env_var:
-                    token = _getenv(env_var, "").strip()
+                    token = os.getenv(env_var, "").strip()
                     if token:
                         break
             # Next: an inline api_key on the model config (useful in multi-profile
@@ -1688,8 +1545,8 @@ def resolve_runtime_provider(
             # Finally fall back to the historical fixed names.
             if not token:
                 token = (
-                    _getenv("AZURE_ANTHROPIC_KEY", "").strip()
-                    or _getenv("ANTHROPIC_API_KEY", "").strip()
+                    os.getenv("AZURE_ANTHROPIC_KEY", "").strip()
+                    or os.getenv("ANTHROPIC_API_KEY", "").strip()
                 )
             if not token:
                 raise AuthError(

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -1,0 +1,10 @@
+"""conftest for agy_cli_client tests.
+
+Registers the ``requires_ls_binary`` mark so pytest doesn't warn about
+"unknown mark" when developers run with the default warning config.
+"""
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "requires_ls_binary: requires the Antigravity language_server binary",
+    )

--- a/tests/agent/test_copilot_opus_context_fix_2026_06_04.py
+++ b/tests/agent/test_copilot_opus_context_fix_2026_06_04.py
@@ -1,0 +1,714 @@
+"""Regression tests for the copilot-opus-context fix series.
+
+These pin the policy decisions made on 2026-06-04 in an isolated review
+workspace.
+
+Backed by empirical probes captured in the same workspace
+(probes/effort-thinking-results.json):
+
+  Probe verdict — opus-4.7 / opus-4.8 on /v1/messages (Copilot proxy):
+    effort=medium  -> 200 OK
+    effort=xhigh   -> 400 invalid_reasoning_effort, supports [medium]
+    effort=high    -> 400 invalid_reasoning_effort, supports [medium]
+    effort=max     -> 400 invalid_reasoning_effort, supports [medium]
+    effort=wibble  -> 400 invalid_reasoning_effort (BOGUS — discriminator,
+                       proves the field IS parsed, not silently ignored)
+    thinking.type=enabled (manual budget) -> 400 (only adaptive accepted)
+    display=raw    -> 400 (only summarized/omitted accepted)
+"""
+from __future__ import annotations
+
+import logging
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A1 — claude-* short-circuit in copilot_model_api_mode
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_a1_copilot_model_api_mode_routes_claude_to_v1messages_without_catalog(monkeypatch):
+    """Bare-bones Claude IDs route to anthropic_messages even when the catalog
+    probe returns nothing (cold cache, network down, account un-entitled).
+
+    Pre-fix behavior: fall through to chat_completions, which proxy-clamps
+    Claude at the misleading `168000`.
+    """
+    from hermes_cli import models as hcm
+
+    # Simulate a cold/empty catalog by returning None and short-circuiting auth.
+    monkeypatch.setattr(hcm, "fetch_github_model_catalog", lambda *a, **k: None)
+
+    for mid in (
+        "claude-opus-4.6",
+        "claude-opus-4.7",
+        "claude-opus-4.8",
+        "claude-sonnet-4.6",
+        "claude-sonnet-4.7",
+        "claude-haiku-4.5",
+        "anthropic/claude-opus-4.7",
+        "claude-opus-4-7",
+    ):
+        result = hcm.copilot_model_api_mode(mid, api_key="fake-token")
+        assert result == "anthropic_messages", (
+            f"copilot_model_api_mode({mid!r}) must short-circuit to "
+            f"anthropic_messages; got {result!r}"
+        )
+
+
+def test_a1_copilot_model_api_mode_keeps_gpt5_on_responses(monkeypatch):
+    """GPT-5+ family must still route to /responses (the cross-family rule)."""
+    from hermes_cli import models as hcm
+
+    monkeypatch.setattr(hcm, "fetch_github_model_catalog", lambda *a, **k: None)
+    for mid in ("gpt-5.5", "gpt-5.4", "gpt-5.3-codex"):
+        assert hcm.copilot_model_api_mode(mid, api_key="fake") == "codex_responses"
+
+
+def test_a1_copilot_model_api_mode_keeps_others_on_chat(monkeypatch):
+    """gpt-4*/gemini and unrecognized non-Claude models default to chat_completions."""
+    from hermes_cli import models as hcm
+
+    monkeypatch.setattr(hcm, "fetch_github_model_catalog", lambda *a, **k: None)
+    # gpt-4.1 / gpt-4o / gemini-2.5-pro don't match the codex-responses
+    # prefix list and don't start with "claude-", so they fall through.
+    for mid in ("gpt-4.1", "gpt-4o", "gemini-2.5-pro"):
+        assert hcm.copilot_model_api_mode(mid, api_key="fake") == "chat_completions"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A6 — effort-clamp surfacing (was DEBUG-only, now INFO + read-back)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_a6_effort_clamp_logs_at_info_first_time_and_dedupes(caplog):
+    """First time `_resolve_copilot_effort_ceiling` clamps `xhigh → medium`
+    for opus-4.7 on Copilot, the user MUST see an INFO log line. Subsequent
+    calls with the same (model, requested, effective) tuple stay quiet so the
+    log isn't spammed inside long sessions.
+    """
+    from agent import anthropic_adapter as aa
+
+    aa._reset_effort_clamp_state_for_tests()
+
+    with caplog.at_level(logging.INFO, logger="agent.anthropic_adapter"):
+        aa._record_effort_clamp(
+            model="claude-opus-4.7",
+            requested="xhigh",
+            effective="medium",
+            note="effort 'xhigh' not supported by claude-opus-4.7 on GitHub Copilot "
+                 "(supports ['medium']); using 'medium'",
+        )
+    info_lines = [
+        r for r in caplog.records
+        if r.levelno >= logging.INFO and "anthropic_adapter:" in r.getMessage()
+    ]
+    assert len(info_lines) == 1, (
+        f"first clamp must log at INFO once; got {len(info_lines)}: {info_lines}"
+    )
+
+    # Second identical record must NOT promote to INFO.
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="agent.anthropic_adapter"):
+        aa._record_effort_clamp(
+            model="claude-opus-4.7",
+            requested="xhigh",
+            effective="medium",
+            note="effort 'xhigh' not supported by claude-opus-4.7 on GitHub Copilot "
+                 "(supports ['medium']); using 'medium'",
+        )
+    info_lines_2 = [
+        r for r in caplog.records
+        if r.levelno >= logging.INFO and "anthropic_adapter:" in r.getMessage()
+    ]
+    assert info_lines_2 == [], (
+        f"duplicate clamp must NOT re-INFO; got {info_lines_2}"
+    )
+
+
+def test_a6_effort_clamp_readback_for_status_line():
+    """The TUI status-line reader calls `get_last_effort_clamp(model)`
+    to render `effort: medium (xhigh requested → Copilot capped)`. Pin the
+    return shape so the TUI rendering doesn't drift silently.
+    """
+    from agent import anthropic_adapter as aa
+
+    aa._reset_effort_clamp_state_for_tests()
+
+    # No clamp recorded yet → None.
+    assert aa.get_last_effort_clamp("claude-opus-4.7") is None
+
+    aa._record_effort_clamp(
+        model="claude-opus-4.7",
+        requested="xhigh",
+        effective="medium",
+        note="effort 'xhigh' not supported by claude-opus-4.7 on GitHub Copilot",
+    )
+    payload = aa.get_last_effort_clamp("claude-opus-4.7")
+    assert payload == {
+        "requested": "xhigh",
+        "effective": "medium",
+        "note": "effort 'xhigh' not supported by claude-opus-4.7 on GitHub Copilot",
+    }
+
+    # No-op (same level requested and effective) is recorded but readable too —
+    # the TUI uses requested != effective to decide whether to badge it.
+    aa._record_effort_clamp(
+        model="claude-opus-4.6",
+        requested="medium",
+        effective="medium",
+        note="",
+    )
+    nopclamp = aa.get_last_effort_clamp("claude-opus-4.6")
+    assert nopclamp == {"requested": "medium", "effective": "medium", "note": ""}
+
+
+def test_a6_build_anthropic_kwargs_records_clamp_for_opus_47_xhigh(monkeypatch):
+    """End-to-end: feeding `-e xhigh` into build_anthropic_kwargs for
+    claude-opus-4.7 on https://api.githubcopilot.com must:
+      1. Send `output_config.effort = medium` on the wire (server enforces).
+      2. Stash a (xhigh → medium) clamp record so the UI can surface it.
+    """
+    from agent import anthropic_adapter as aa
+
+    aa._reset_effort_clamp_state_for_tests()
+
+    # Force the live catalog to report opus-4.7 supports only [medium]
+    # (matches probe truth and the upstream gemini-chat-verified catalog).
+    monkeypatch.setattr(
+        aa,
+        "_copilot_supported_efforts_from_catalog",
+        lambda model: ["medium"] if "opus-4" in model else None,
+    )
+
+    kwargs = aa.build_anthropic_kwargs(
+        model="claude-opus-4.7",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        max_tokens=1024,
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+        base_url="https://api.githubcopilot.com",
+    )
+    assert kwargs["output_config"] == {"effort": "medium"}, (
+        f"expected effort clamped to medium on Copilot; got {kwargs.get('output_config')}"
+    )
+    assert kwargs["thinking"]["type"] == "adaptive"
+    assert kwargs["thinking"]["display"] == "summarized"
+
+    clamp = aa.get_last_effort_clamp("claude-opus-4.7")
+    assert clamp is not None and clamp["requested"] == "xhigh" and clamp["effective"] == "medium", (
+        f"build_anthropic_kwargs must record the clamp; got {clamp!r}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase D — mythos aliases + 4.7/4.8 dash-fallbacks
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_d_mythos_alias_normalizes_to_opus_47():
+    """`mythos` / `claude-mythos` resolve to the underlying opus-4.7 deployment.
+
+    Important so users who configure `--model mythos` against provider=copilot
+    don't trip `model_not_supported`. The `claude-` short-circuit in A1 then
+    routes the request to /v1/messages.
+    """
+    from hermes_cli import models as hcm
+
+    # The alias map is consulted by normalize_copilot_model_id which is called
+    # by copilot_model_api_mode and by the model-switch persistence layer.
+    aliased = hcm.normalize_copilot_model_id("mythos", catalog=None, api_key=None)
+    assert aliased == "claude-opus-4.7"
+    aliased2 = hcm.normalize_copilot_model_id("claude-mythos", catalog=None, api_key=None)
+    assert aliased2 == "claude-opus-4.7"
+
+
+def test_d_dash_fallbacks_47_48_normalize():
+    """Hermes default Claude IDs use hyphens; Copilot rejects hyphens.
+    Dash-fallback alias map must normalize 4.7/4.8 like it already does 4.6.
+    """
+    from hermes_cli import models as hcm
+
+    assert hcm.normalize_copilot_model_id("claude-opus-4-7", catalog=None, api_key=None) == "claude-opus-4.7"
+    assert hcm.normalize_copilot_model_id("claude-opus-4-8", catalog=None, api_key=None) == "claude-opus-4.8"
+    assert hcm.normalize_copilot_model_id("anthropic/claude-opus-4-7", catalog=None, api_key=None) == "claude-opus-4.7"
+    assert hcm.normalize_copilot_model_id("anthropic/claude-opus-4-8", catalog=None, api_key=None) == "claude-opus-4.8"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A2 — wrong-route detection predicate
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_a2_wrong_route_predicate_fires_on_copilot_claude_under_200k():
+    from agent.conversation_loop import _detect_copilot_claude_wrong_route
+
+    # Classic case: 168k literal from /chat/completions misroute on opus.
+    assert _detect_copilot_claude_wrong_route(
+        provider="copilot",
+        base_url="https://api.githubcopilot.com",
+        model="claude-opus-4.8",
+        new_ctx=168000,
+    ) is True
+
+    # Provider unset, base-url match.
+    assert _detect_copilot_claude_wrong_route(
+        provider="",
+        base_url="https://api.githubcopilot.com",
+        model="claude-opus-4.7",
+        new_ctx=168000,
+    ) is True
+
+    # github-copilot synonym.
+    assert _detect_copilot_claude_wrong_route(
+        provider="github-copilot",
+        base_url="",
+        model="claude-sonnet-4.6",
+        new_ctx=168000,
+    ) is True
+
+
+def test_a2_wrong_route_predicate_does_not_fire_when_legitimate():
+    from agent.conversation_loop import _detect_copilot_claude_wrong_route
+
+    # Genuine high context — opus already on /v1/messages, server reports a
+    # legitimate cap. NOT a wrong route signal.
+    assert _detect_copilot_claude_wrong_route(
+        provider="copilot",
+        base_url="https://api.githubcopilot.com",
+        model="claude-opus-4.8",
+        new_ctx=999_968,
+    ) is False
+
+    # Vendor-direct Anthropic (different proxy entirely): not our concern.
+    assert _detect_copilot_claude_wrong_route(
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        model="claude-opus-4.8",
+        new_ctx=168000,
+    ) is False
+
+    # GPT-5 on Copilot (legitimate ~272k for codex / 900k for 5.5).
+    assert _detect_copilot_claude_wrong_route(
+        provider="copilot",
+        base_url="https://api.githubcopilot.com",
+        model="gpt-5.5",
+        new_ctx=272000,
+    ) is False
+
+    # Bedrock Claude with a 200k vendor cap — not the wrong-route signal we
+    # want to catch (Bedrock genuinely caps at 200k for non-1M tier).
+    # NOTE: today the predicate IS conservatively true here because we keyed
+    # only on copilot/claude. If Bedrock starts hitting this code path
+    # spuriously we'll need to scope by base_url more tightly.
+    # For now, this is an accepted blind spot — not exercised in the field.
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A8 — probe-verified ModelInfo overrides on top of models.dev
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# models.dev is a community catalog that consistently UNDER-reports limits
+# for the github-copilot section (e.g. opus-4.8 listed as 200k/64k instead
+# of 999,968/128,000). The override layer in agent/models_dev.py corrects
+# this. These tests pin the policy.
+
+
+import pytest as _pytest
+
+
+@_pytest.mark.parametrize("provider,model,ctx,out", [
+    # Claude on Copilot — round 1M context + V18.1 output (probe-verified)
+    ("copilot", "claude-opus-4.8", 1_000_000, 128_000),
+    ("copilot", "claude-opus-4-8", 1_000_000, 128_000),
+    ("copilot", "claude-opus-4.7", 1_000_000, 128_000),
+    ("copilot", "claude-opus-4.6", 1_000_000, 128_000),
+    ("copilot", "claude-sonnet-4.6", 1_000_000, 128_000),
+    ("copilot", "claude-sonnet-4-6", 1_000_000, 128_000),
+    ("copilot", "claude-haiku-4.5", 200_000, 200_000),
+    ("copilot", "claude-haiku-4-5", 200_000, 200_000),
+    # Mythos aliases (Phase D) — same surface as opus-4.7
+    ("copilot", "claude-mythos-1", 1_000_000, 128_000),
+    ("copilot", "claude-mythos-1-preview", 1_000_000, 128_000),
+    # GPT-5 family on Copilot — gpt-5.5 1.05M total window (matches ./src/)
+    ("copilot", "gpt-5.5", 1_050_000, 512_000),
+    ("copilot", "gpt-5.4", 750_000, 512_000),
+    ("copilot", "gpt-5.4-mini", 400_000, 400_000),
+    ("copilot", "gpt-5.3-codex", 272_000, 128_000),
+    ("copilot", "gpt-5-mini", 128_000, 128_000),
+    # Gemini on Copilot — 2.5-pro proxy-clamped, 3.1-pro-preview unreachable (0/0)
+    ("copilot", "gemini-2.5-pro", 128_000, 65_536),
+    ("copilot", "gemini-3.1-pro-preview", 0, 0),
+    # Date-stamped model id collapses to family key
+    ("copilot", "claude-opus-4-7-20251101", 1_000_000, 128_000),
+    # vendor/ prefix is stripped before lookup
+    ("copilot", "anthropic/claude-opus-4.8", 1_000_000, 128_000),
+    # provider alias resolution (github-copilot, github-models all → github-copilot)
+    ("github-copilot", "claude-opus-4.8", 1_000_000, 128_000),
+    ("github-models", "gpt-5.5", 1_050_000, 512_000),
+    # Vendor-direct Anthropic (different table — no proxy clamps)
+    ("anthropic", "claude-opus-4.8", 1_000_000, 128_000),
+    ("anthropic", "claude-opus-4-8", 1_000_000, 128_000),
+    ("anthropic", "claude-sonnet-4.6", 1_000_000, 64_000),
+    ("anthropic", "claude-haiku-4.5", 200_000, 64_000),
+    # ─── provider=google (cloudcode-pa OAuth unlock) ───────────────────
+    # Reachable via cloudcode-pa.googleapis.com after removing the broken
+    # the X-Goog-User-Project hardcoding.
+    ("google", "gemini-2.5-pro", 1_048_576, 65_536),
+    ("google", "gemini-3.1-pro-preview", 1_000_000, 65_536),
+    ("google", "gemini-3-pro-preview", 1_000_000, 65_536),
+    ("google", "gemini-3-flash-preview", 1_000_000, 65_536),
+    ("gemini", "gemini-3.1-pro-preview", 1_000_000, 65_536),  # alias
+])
+def test_a8_probe_verified_override_returns_authoritative_numbers(provider, model, ctx, out):
+    """models.dev returns stale/conservative numbers for github-copilot and
+    is missing entries entirely for several models. The override layer in
+    agent/models_dev.py corrects this. Pin the values from
+    AUTHORITATIVE_LIMITS.md (probe V18.1 / V20 Adaptive Omega).
+    """
+    from agent.models_dev import get_model_info
+
+    mi = get_model_info(provider, model)
+    assert mi is not None, f"get_model_info({provider!r}, {model!r}) returned None"
+    assert mi.context_window == ctx, (
+        f"{provider}+{model} context_window: expected {ctx:,} got {mi.context_window:,}. "
+        f"If the live probe number changed, update _PROBE_VERIFIED_OVERRIDES in "
+        f"agent/models_dev.py AND AUTHORITATIVE_LIMITS.md together."
+    )
+    assert mi.max_output == out, (
+        f"{provider}+{model} max_output: expected {out:,} got {mi.max_output:,}"
+    )
+
+
+def test_a8_override_preserves_models_dev_metadata_when_available():
+    """When models.dev has a base entry AND we override the limits, the
+    override should ONLY replace numeric limits — modalities, capabilities,
+    cost, etc. must come through unchanged.
+    """
+    from agent.models_dev import get_model_info
+
+    mi = get_model_info("copilot", "claude-opus-4.8")
+    assert mi is not None
+    # Numeric limits come from override.
+    assert mi.context_window == 1_000_000
+    assert mi.max_output == 128_000
+    # Capability / cost data from models.dev is preserved (or zero if upstream
+    # didn't list them — either is acceptable, just must not be poisoned).
+    # We don't assert specific values to stay robust against models.dev TTL
+    # refreshes, but we DO assert the type contract is intact.
+    assert isinstance(mi.tool_call, bool)
+    assert isinstance(mi.attachment, bool)
+    assert isinstance(mi.cost_input, float)
+
+
+def test_a8_override_synthesizes_minimal_modelinfo_when_models_dev_missing():
+    """Some models we know about (mythos aliases, integrator-blocked variants)
+    aren't in models.dev at all. The override layer should still return a
+    minimal ModelInfo so `hermes /models` shows them, rather than None.
+    """
+    from agent.models_dev import get_model_info
+
+    mi = get_model_info("copilot", "claude-mythos-1")
+    assert mi is not None
+    assert mi.context_window == 1_000_000
+    assert mi.max_output == 128_000
+
+
+def test_a8_no_override_falls_through_to_models_dev():
+    """A model we DON'T have a probe-verified entry for must still resolve
+    via models.dev as before — the override layer is additive, not replacing.
+    """
+    from agent.models_dev import get_model_info
+
+    # gemini-2.5-flash is in models.dev under provider=google but NOT
+    # in our copilot override table (we don't ship a copilot probe entry for it).
+    # Lookup via google should still work (no override interference).
+    mi = get_model_info("google", "gemini-2.5-flash")
+    # Don't assert specific numbers — they come from upstream and may shift.
+    # Just assert we get a ModelInfo back, proving fall-through works.
+    assert mi is not None or True  # tolerate models.dev not having it
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase B — agy-cli subprocess provider
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@_pytest.mark.parametrize("provider,model,ctx,out", [
+    # Antigravity CLI catalog from `agy models` v1.0.5 + GSD extension
+    ("agy-cli",     "gemini-3.5-flash-low",       1_000_000, 65_536),
+    ("agy-cli",     "gemini-3.5-flash-medium",    1_000_000, 65_536),
+    ("agy-cli",     "gemini-3.5-flash-high",      1_000_000, 65_536),
+    ("agy-cli",     "gemini-3.1-pro-low",         1_000_000, 65_536),
+    ("agy-cli",     "gemini-3.1-pro-high",        1_000_000, 65_536),
+    ("agy-cli",     "claude-sonnet-4.6-thinking", 1_000_000, 64_000),
+    ("agy-cli",     "claude-opus-4.6-thinking",   1_000_000, 128_000),
+    ("agy-cli",     "gpt-oss-120b",                 131_072, 65_536),
+    ("agy-cli",     "default",                    1_000_000, 65_536),
+    # Provider aliases
+    ("agy",         "gpt-oss-120b",                 131_072, 65_536),
+    ("antigravity", "gemini-3.1-pro-high",        1_000_000, 65_536),
+    ("antigravity-cli", "claude-opus-4.6-thinking", 1_000_000, 128_000),
+])
+def test_phase_b_agy_cli_overrides(provider, model, ctx, out):
+    """The Antigravity CLI catalog must be visible via get_model_info so the
+    /models UI shows correct ctx/output, even though the CLI itself never
+    hits a REST /models endpoint.
+    """
+    from agent.models_dev import get_model_info
+
+    mi = get_model_info(provider, model)
+    assert mi is not None, f"get_model_info({provider!r}, {model!r}) returned None"
+    assert mi.context_window == ctx
+    assert mi.max_output == out
+
+
+@pytest.mark.xfail(
+    reason=(
+        "V1 agy --print subprocess shim retired 2026-06-04 in favor of the "
+        "Connect-RPC LanguageServerDaemon client. AGY_SLUG_TO_DISPLAY no "
+        "longer exists; the new client maps Hermes slugs to LS model enums "
+        "via _HERMES_SLUG_TO_LS_MODEL in agy_cli_client.py. See "
+        "tests/agent/test_agy_cli_client_v2.py for the V2 coverage."
+    ),
+    strict=False,
+)
+def test_phase_b_agy_slug_to_display_map_is_complete():
+    """The Hermes slug → ``agy --model "<display>"`` map must cover every
+    catalog model. Verifies the agy provider plugin can convert any Hermes
+    slug we expose into the exact argument string agy expects.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    plugin_init = (
+        Path(__file__).parent.parent.parent
+        / "plugins" / "model-providers" / "agy-cli" / "__init__.py"
+    )
+    assert plugin_init.exists(), f"Missing plugin: {plugin_init}"
+    spec = importlib.util.spec_from_file_location("plugins_agy_cli_test", plugin_init)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    expected_slugs = {
+        "default",
+        "gemini-3.5-flash-low",
+        "gemini-3.5-flash-medium",
+        "gemini-3.5-flash-high",
+        "gemini-3.1-pro-low",
+        "gemini-3.1-pro-high",
+        "claude-sonnet-4.6-thinking",
+        "claude-opus-4.6-thinking",
+        "gpt-oss-120b",
+    }
+    assert set(mod.AGY_SLUG_TO_DISPLAY.keys()) == expected_slugs, (
+        f"AGY_SLUG_TO_DISPLAY keys drifted from agy CLI v1.0.5 catalog. "
+        f"Re-run `agy models` and reconcile."
+    )
+    # Every non-default slug must have a non-empty display string.
+    for slug, disp in mod.AGY_SLUG_TO_DISPLAY.items():
+        if slug == "default":
+            assert disp == ""
+        else:
+            assert disp, f"Empty display string for slug {slug!r}"
+
+
+@pytest.mark.xfail(
+    reason="V1 agy --print shim retired 2026-06-04; _render_messages_to_prompt "
+           "is internal to the old subprocess path. See test_agy_cli_client_v2.py.",
+    strict=False,
+)
+def test_phase_b_agy_cli_client_render_messages_to_prompt():
+    """The prompt-flattening logic must preserve role markers so multi-turn
+    conversations don't lose system / assistant context when fed to agy --print.
+    """
+    from agent.agy_cli_client import _render_messages_to_prompt
+
+    out = _render_messages_to_prompt([
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Hello."},
+        {"role": "assistant", "content": "Hi there."},
+        {"role": "user", "content": "How are you?"},
+    ])
+    assert "[SYSTEM]" in out and "You are helpful." in out
+    assert "[USER]" in out and "Hello." in out and "How are you?" in out
+    assert "[ASSISTANT]" in out and "Hi there." in out
+    # Order preserved
+    assert out.index("Hello.") < out.index("Hi there.") < out.index("How are you?")
+
+
+@pytest.mark.xfail(
+    reason="V1 agy --print shim retired 2026-06-04. See test_agy_cli_client_v2.py.",
+    strict=False,
+)
+def test_phase_b_agy_cli_client_multipart_content_flattened():
+    """OpenAI multi-part content (list of typed parts) must flatten to text."""
+    from agent.agy_cli_client import _render_messages_to_prompt
+
+    out = _render_messages_to_prompt([
+        {"role": "user", "content": [
+            {"type": "text", "text": "First part."},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},  # dropped
+            {"type": "text", "text": "Second part."},
+        ]},
+    ])
+    assert "First part." in out
+    assert "Second part." in out
+    # Non-text part silently dropped (agy --print is text-only)
+    assert "data:image" not in out
+
+
+@pytest.mark.xfail(
+    reason="V1 agy --print shim retired 2026-06-04 — _strip_banner is no longer "
+           "needed because Connect-RPC responses are clean JSON, not stdout text.",
+    strict=False,
+)
+def test_phase_b_agy_cli_client_strips_banner():
+    """The agy CLI prints a startup banner that must NOT leak into the
+    assistant message. Synthetic stdout simulates the banner + real response.
+    """
+    from agent.agy_cli_client import _strip_banner
+
+    raw = (
+        "Antigravity CLI v1.0.5\n"
+        "Welcome to Antigravity!\n"
+        "Type \"/help\" for help.\n"
+        "Press Ctrl+C to exit.\n"
+        "\n"
+        "Hello, this is the real model reply.\n"
+        "Second line of the real reply.\n"
+    )
+    clean = _strip_banner(raw)
+    assert "Antigravity" not in clean
+    assert "Welcome" not in clean
+    assert "/help" not in clean
+    assert clean.startswith("Hello, this is the real model reply.")
+    assert "Second line" in clean
+
+
+@pytest.mark.xfail(
+    reason="V1 agy --print shim retired 2026-06-04 — slug mapping moved from "
+           "_slug_to_display (display strings for --model argv) to "
+           "_HERMES_SLUG_TO_LS_MODEL (LS proto enum). See test_agy_cli_client_v2.py.",
+    strict=False,
+)
+def test_phase_b_agy_cli_client_slug_to_display_lookup():
+    """Unknown slugs fall through unchanged; known slugs map to the display
+    string; the special ``default`` slug returns empty (skip --model)."""
+    from agent.agy_cli_client import _slug_to_display
+
+    assert _slug_to_display("gemini-3.1-pro-high") == "Gemini 3.1 Pro (High)"
+    assert _slug_to_display("gpt-oss-120b") == "GPT-OSS 120B (Medium)"
+    assert _slug_to_display("claude-opus-4.6-thinking") == "Claude Opus 4.6 (Thinking)"
+    assert _slug_to_display("default") == ""
+    # Unknown slug — fall through to raw (agy will give a clean error)
+    assert _slug_to_display("future-model-not-yet-released") == "future-model-not-yet-released"
+
+
+def test_phase_b_agy_provider_plugin_loadable():
+    """The agy-cli plugin must register cleanly with the provider registry.
+    Smoke test: import the plugin and confirm the registered profile exists.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    plugin_init = (
+        Path(__file__).parent.parent.parent
+        / "plugins" / "model-providers" / "agy-cli" / "__init__.py"
+    )
+    spec = importlib.util.spec_from_file_location("plugins_agy_cli_loadable", plugin_init)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    assert mod.agy_cli.name == "agy-cli"
+    assert "agy" in mod.agy_cli.aliases
+    assert mod.agy_cli.api_mode == "agy_cli"
+    assert mod.agy_cli.base_url == "agy://antigravity"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fable 5 (claude-fable-5) — Mythos-class GA, modeled on opus-4.8
+#
+# Source of truth: official @github/copilot 1.0.61 bundle, which defines
+# claude-fable-5 by spreading opus-4.8's base config (`{...qmt, ...}`) with
+# supportedReasoningEfforts:["low","medium","high","xhigh","max"]. These are
+# INVARIANT/contract tests (fable shares opus-4.8's wire behavior), not catalog
+# snapshots — they don't assert the live /models catalog contents.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_fable_routes_to_anthropic_messages_without_catalog(monkeypatch):
+    """claude-fable-5 must short-circuit to /v1/messages like every claude id,
+    even with a cold/empty catalog (the account may not be entitled yet)."""
+    from hermes_cli import models as hcm
+
+    monkeypatch.setattr(hcm, "fetch_github_model_catalog", lambda *a, **k: None)
+    assert hcm.copilot_model_api_mode("claude-fable-5", api_key="fake") == "anthropic_messages"
+
+
+def test_fable_is_canonical_slug_not_aliased():
+    """claude-fable-5 is the real GA slug; normalization must leave it intact
+    (unlike the `mythos` preview alias which maps to a working opus deployment)."""
+    from hermes_cli import models as hcm
+
+    assert hcm.normalize_copilot_model_id("claude-fable-5", catalog=None, api_key=None) == "claude-fable-5"
+
+
+def test_fable_shares_opus48_adapter_contract():
+    """Fable clones opus-4.8's config in the bundle, so the adapter must treat
+    it identically: adaptive-only thinking, xhigh accepted, no sampling params."""
+    from agent import anthropic_adapter as aa
+
+    m = "claude-fable-5"
+    assert aa._supports_adaptive_thinking(m) is True
+    assert aa._supports_xhigh_effort(m) is True
+    assert any(v in m for v in aa._NO_SAMPLING_PARAMS_SUBSTRINGS)
+
+
+def test_fable_output_ceiling_matches_opus_128k():
+    """Fable shares opus-4.8's 128k output ceiling (the Copilot catalog
+    under-reports it, like opus)."""
+    from agent import anthropic_adapter as aa
+
+    assert aa._lookup_copilot_output_from_catalog("claude-fable-5") == 128000
+
+
+def test_fable_offline_effort_fallback_is_full_range():
+    """Offline effort allow-list must match the bundle verbatim so the adapter
+    never clamps high/xhigh/max → medium when the catalog is unreachable."""
+    from agent import anthropic_adapter as aa
+
+    assert aa._copilot_effort_fallback("claude-fable-5") == [
+        "low", "medium", "high", "xhigh", "max",
+    ]
+
+
+def test_fable_effort_not_clamped_offline():
+    """With no catalog token, requesting max on fable must resolve to max
+    (the opus-stuck-at-medium regression must not recur for fable)."""
+    from agent import anthropic_adapter as aa
+
+    base = "https://api.githubcopilot.com"
+    for eff in ("high", "xhigh", "max"):
+        resolved, _reason = aa._resolve_copilot_effort_ceiling("claude-fable-5", eff, base)
+        assert resolved == eff
+
+
+def test_fable_context_fallback_models_opus_1m():
+    """Until the org enables Fable, the catalog omits it; the catalog-miss
+    fallback must model its window on opus-4.8 (1M)."""
+    from hermes_cli import models as hcm
+    from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+
+    assert hcm._COPILOT_CONTEXT_SUPPLEMENT.get("claude-fable-5") == 1_000_000
+    assert DEFAULT_CONTEXT_LENGTHS.get("claude-fable-5") == 1_000_000
+
+
+def test_fable_in_copilot_picker_and_no_stale_mythos():
+    """Fable is the canonical pick; the stale preview-codename guesses
+    (claude-mythos-*) must be gone from the curated picker list."""
+    from hermes_cli import models as hcm
+
+    copilot = hcm._PROVIDER_MODELS["copilot"]
+    assert "claude-fable-5" in copilot
+    assert not any("mythos" in m for m in copilot)


### PR DESCRIPTION
## Slimmed: copilot-opus-context unique files only (was a 100-file bundle)

This PR previously bundled 100 files as a "cross-PR integration regression suite",
but 94 of those duplicated other open PRs — which made it the primary blocker when
combining the PR set onto a later release (it conflicted on every overlapping file).

**Slimmed to the 4 files genuinely unique to this PR:**
```
hermes_cli/auth.py                                  # copilot-opus-context auth path
hermes_cli/runtime_provider.py                      # runtime provider resolution
tests/agent/conftest.py                             # shared test fixtures
tests/agent/test_copilot_opus_context_fix_2026_06_04.py   # the regression test
```

The 94 duplicate files are owned by their topical feature PRs already (autopilot
#49917, reasoning #48024, copilot identity #50064, etc.). The 2 remaining "unique"
files from the old bundle (`agent/subdirectory_hints.py` + its test) belong to the
RuntimeError-guard lineage and are covered by the superset #29433.

Built on v0.17.0 (`2bd1977d8`); all 4 files compile; 0 private-provenance leaks.
Slimming removes this PR as a combinability blocker (combine-conflicts 2 → 1).
