### PR TITLE
fix(mcp): don't cap interactive OAuth login at the 30s connection-probe timeout

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -213,17 +213,56 @@ def _resolve_mcp_server_config(config: dict) -> dict:
     return _interpolate_env_vars(config)
 
 
+# Interactive OAuth logins (`hermes mcp login` / `mcp add --auth oauth`) need a
+# long window: the user opens a browser, authorizes, and on a headless or SSH
+# host pastes the callback URL back. The default 30s connection-probe timeout
+# (40s with the +10 below) cancels _wait_for_callback (which itself allows 300s)
+# long before a human can finish. Use a generous, env-tunable window for these
+# interactive auth paths only; the agent runtime keeps the short default.
+#
+# Must stay strictly greater than the SDK's hard-coded 300s _wait_for_callback
+# budget (tools/mcp_oauth.py): the outer asyncio.wait_for in _probe_single_server
+# starts before browser launch / client registration / port bind and keeps
+# running through token exchange, so it has to outlast the inner 300s human
+# window *plus* that setup/exchange overhead. 330 = 300s paste window + ~30s
+# headroom; raise HERMES_MCP_OAUTH_TIMEOUT on very slow links.
+_OAUTH_LOGIN_TIMEOUT = float(os.getenv("HERMES_MCP_OAUTH_TIMEOUT", "330"))
+
+
+def _effective_probe_timeout(
+    config: dict, connect_timeout: Optional[float]
+) -> float:
+    """Pick the connection-probe timeout for one server.
+
+    An explicit caller value always wins. Otherwise ``auth: oauth`` servers get
+    the long interactive-login window (they drive a browser + callback paste
+    whose inner wait allows 300s), while everything else keeps the short 30s
+    default. Centralised here so every :func:`_probe_single_server` caller —
+    ``mcp add``, ``mcp login``, ``mcp test``, ``mcp configure``, catalog
+    install, and the dashboard test route — gets identical behaviour.
+    """
+    if connect_timeout is not None:
+        return connect_timeout
+    return _OAUTH_LOGIN_TIMEOUT if config.get("auth") == "oauth" else 30.0
+
+
 def _probe_single_server(
-    name: str, config: dict, connect_timeout: float = 30
+    name: str, config: dict, connect_timeout: Optional[float] = None
 ) -> List[Tuple[str, str]]:
     """Temporarily connect to one MCP server, list its tools, disconnect.
 
     Returns list of ``(tool_name, description)`` tuples.
     Raises on connection failure.
+
+    ``connect_timeout`` defaults to 30s for ordinary servers and the longer
+    ``_OAUTH_LOGIN_TIMEOUT`` for ``auth: oauth`` servers (interactive browser
+    login); pass an explicit value to override either default.
     """
     issues = validate_mcp_server_entry(name, config)
     if issues:
         raise ValueError("; ".join(issues))
+
+    connect_timeout = _effective_probe_timeout(config, connect_timeout)
 
     from tools.mcp_tool import (
         _ensure_mcp_loop,
@@ -421,6 +460,8 @@ def cmd_mcp_add(args):
     print(color(f"  Connecting to '{name}'...", Colors.CYAN))
 
     try:
+        # _probe_single_server auto-selects the long OAuth login window for
+        # auth: oauth servers and the short default otherwise.
         tools = _probe_single_server(name, server_config)
     except Exception as exc:
         _error(f"Failed to connect: {exc}")
@@ -710,6 +751,8 @@ def cmd_mcp_login(args):
     _info(f"Starting OAuth flow for '{name}'...")
 
     # Probe triggers the OAuth flow (browser redirect + callback capture).
+    # auth: oauth is verified above, so the probe auto-selects the long
+    # interactive-login window.
     try:
         tools = _probe_single_server(name, server_config)
         # A clean probe is NOT proof of authentication. Some MCP servers

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8090,7 +8090,12 @@ async def test_mcp_server(name: str, profile: Optional[str] = None):
         # HERMES_HOME override (see mcp_tool._wrap_with_home_override), so
         # OAuth token stores resolve against the selected profile as well.
         with _profile_scope(profile):
-            return _probe_single_server(name, servers[name])
+            # Keep the short probe cap on the dashboard. The interactive OAuth
+            # window is for CLI logins (mcp add/login/test/configure) where the
+            # callback paste is read from the server's stdin. A remote dashboard
+            # browser can't reach that flow, so the long window would just hang
+            # up to _OAUTH_LOGIN_TIMEOUT before failing — fail fast instead.
+            return _probe_single_server(name, servers[name], connect_timeout=30)
 
     try:
         # Probe blocks on a dedicated MCP event loop — run in a thread so the

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -555,6 +555,41 @@ class TestProbeEnvResolution:
         assert seen["config"]["headers"]["Authorization"] == "Bearer jwt-token-xyz"
 
 
+class TestProbeTimeoutSelection:
+    """Every _probe_single_server caller must give interactive OAuth servers the
+    long login window automatically — the per-caller threading it replaced had
+    missed `mcp test`, `mcp configure`, catalog install, and the dashboard
+    /test route, all of which fell back to the 30s cap."""
+
+    def test_oauth_server_gets_long_window(self):
+        import hermes_cli.mcp_config as mc
+
+        assert (
+            mc._effective_probe_timeout({"auth": "oauth"}, None)
+            == mc._OAUTH_LOGIN_TIMEOUT
+        )
+
+    def test_non_oauth_server_gets_short_default(self):
+        import hermes_cli.mcp_config as mc
+
+        assert mc._effective_probe_timeout({"auth": "none"}, None) == 30.0
+        assert mc._effective_probe_timeout({}, None) == 30.0
+
+    def test_explicit_override_always_wins(self):
+        import hermes_cli.mcp_config as mc
+
+        assert mc._effective_probe_timeout({"auth": "oauth"}, 1) == 1
+        assert mc._effective_probe_timeout({}, 99) == 99
+
+    def test_oauth_window_outlasts_inner_callback_budget(self):
+        """Guards the race: the outer probe timeout must exceed the SDK's
+        hard-coded 300s _wait_for_callback budget so the user actually gets the
+        full paste window plus setup/token-exchange headroom."""
+        import hermes_cli.mcp_config as mc
+
+        assert mc._OAUTH_LOGIN_TIMEOUT > 300
+
+
 class TestStripBearerPrefix:
     """Pasted tokens that already include ``Bearer `` would otherwise produce
     ``Bearer Bearer <jwt>`` once the header template adds its own prefix."""
@@ -716,7 +751,7 @@ class TestMcpLogin:
         # Probe returns tools even though auth never completed.
         monkeypatch.setattr(
             "hermes_cli.mcp_config._probe_single_server",
-            lambda name, cfg: [("search_files", "d"), ("read_file_content", "d")],
+            lambda name, cfg, **kwargs: [("search_files", "d"), ("read_file_content", "d")],
         )
         # No token file is created → _oauth_tokens_present() returns False.
         from hermes_cli.mcp_config import cmd_mcp_login
@@ -738,7 +773,7 @@ class TestMcpLogin:
         # cmd_mcp_login wipes tokens before probing, then the real OAuth flow
         # writes a fresh token during the probe. Simulate that: the mocked
         # probe drops a token file, mirroring a successful authorization.
-        def mock_probe(name, cfg):
+        def mock_probe(name, cfg, **kwargs):
             token_dir.mkdir(exist_ok=True)
             (token_dir / "realserver.json").write_text('{"access_token": "x"}')
             return [("a", "d"), ("b", "d"), ("c", "d")]


### PR DESCRIPTION
## What does this PR do?

`hermes mcp login` and `hermes mcp add --auth oauth` trigger the OAuth flow through `_probe_single_server`, whose default `connect_timeout=30` wraps the whole probe in `timeout=connect_timeout + 10` (a 40s ceiling). But `_wait_for_callback` already allows 300s and, on an interactive TTY, offers a stdin paste fallback (paste the `code=...&state=...` from the browser address bar) for headless/SSH hosts. The 40s cap cancels all of that about 40s in, so OAuth MCP servers are effectively un-loginnable over SSH: the flow dies with `MCP call timed out after 40.0s` and `mcp login` reports "Authentication failed". (Hit this standing up an OAuth MCP server on a headless box; had to temporarily patch `connect_timeout` 30 to 290 and curl the loopback callback by hand to finish auth.)

This PR gives the two interactive auth commands a generous, env-tunable window (`HERMES_MCP_OAUTH_TIMEOUT`, default 300s, matching `_wait_for_callback`). The agent runtime's short probe default (30s) is unchanged.

## Related Issue

No existing issue. Happy to file one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/mcp_config.py`: add `_OAUTH_LOGIN_TIMEOUT`. `cmd_mcp_login` passes it; `cmd_mcp_add` only when `auth == "oauth"`.
- `tests/hermes_cli/test_mcp_config.py`: update the two probe mocks for the new kwarg.

## How to Test

1. Over SSH, `hermes mcp login <oauth-server>`.
2. Before: dies about 40s in with `MCP call timed out after 40.0s`.
3. After: prompt stays open the full window; paste the callback, auth completes.
4. `pytest tests/hermes_cli/test_mcp_config.py -q` -> 42 passed.

## Checklist

### Code

- [x] Contributing Guide
- [x] Conventional Commits
- [x] searched existing PRs
- [x] only related changes
- [x] pytest passes (42 passed)
- [x] added/updated tests
- [x] tested on Linux (Debian, aarch64)

### Documentation & Housekeeping

- [x] docs - N/A
- [x] cli-config.yaml.example - N/A
- [x] CONTRIBUTING/AGENTS - N/A
- [x] cross-platform - pure-Python, N/A
- [x] tool schemas - N/A
