### PR TITLE
fix(acp): ignore idle cancel before next prompt

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1211,16 +1211,32 @@ class HermesACPAgent(acp.Agent):
     async def cancel(self, session_id: str, **kwargs: Any) -> None:
         state = self.session_manager.get_session(session_id)
         if state and state.cancel_event:
+            should_interrupt = False
             with state.runtime_lock:
-                if state.is_running and state.current_prompt_text:
+                should_interrupt = bool(state.is_running)
+                if should_interrupt and state.current_prompt_text:
                     state.interrupted_prompt_text = state.current_prompt_text
-            state.cancel_event.set()
-            try:
-                if getattr(state, "agent", None) and hasattr(state.agent, "interrupt"):
-                    state.agent.interrupt()
-            except Exception:
-                logger.debug("Failed to interrupt ACP session %s", session_id, exc_info=True)
-            logger.info("Cancelled session %s", session_id)
+            if should_interrupt:
+                state.cancel_event.set()
+                try:
+                    if getattr(state, "agent", None) and hasattr(state.agent, "interrupt"):
+                        state.agent.interrupt()
+                except Exception:
+                    logger.debug("Failed to interrupt ACP session %s", session_id, exc_info=True)
+                logger.info("Cancelled session %s", session_id)
+            else:
+                # Some ACP clients send a best-effort cancel immediately before
+                # submitting the next prompt, even when the previous turn is
+                # already idle. Treat that as a no-op; otherwise a stale
+                # AIAgent interrupt poisons the next prompt and it returns
+                # interrupted_by_user without ever calling the model.
+                state.cancel_event.clear()
+                try:
+                    if getattr(state, "agent", None) and hasattr(state.agent, "clear_interrupt"):
+                        state.agent.clear_interrupt()
+                except Exception:
+                    logger.debug("Failed to clear idle ACP interrupt for %s", session_id, exc_info=True)
+                logger.info("Ignored idle cancel for session %s", session_id)
 
     async def fork_session(
         self,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -339,9 +339,10 @@ class TestSessionOps:
         assert update.used == 25_000
 
     @pytest.mark.asyncio
-    async def test_cancel_sets_event(self, agent):
+    async def test_running_cancel_sets_event(self, agent):
         resp = await agent.new_session(cwd=".")
         state = agent.session_manager.get_session(resp.session_id)
+        state.is_running = True
         assert not state.cancel_event.is_set()
         await agent.cancel(session_id=resp.session_id)
         assert state.cancel_event.is_set()

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -18,12 +18,25 @@ class FakeAgent:
         self.valid_tool_names = set()
         self.steers = []
         self.runs = []
+        self.interrupted = False
+        self.interrupt_calls = 0
+        self.clear_interrupt_calls = 0
 
     def steer(self, text):
         self.steers.append(text)
         return True
 
+    def interrupt(self):
+        self.interrupted = True
+        self.interrupt_calls += 1
+
+    def clear_interrupt(self):
+        self.interrupted = False
+        self.clear_interrupt_calls += 1
+
     def run_conversation(self, *, user_message, conversation_history, task_id, **kwargs):
+        if self.interrupted:
+            return {"final_response": "", "messages": list(conversation_history or []), "interrupted": True}
         self.runs.append(user_message)
         messages = list(conversation_history or [])
         messages.append({"role": "user", "content": user_message})
@@ -196,3 +209,34 @@ async def test_acp_prompt_drains_queued_turns_after_current_run():
     assert state.queued_prompts == []
     agent_messages = [u for _sid, u in conn.updates if getattr(u, "session_update", None) == "agent_message_chunk"]
     assert len(agent_messages) >= 2
+
+
+@pytest.mark.asyncio
+async def test_acp_idle_cancel_does_not_poison_next_prompt():
+    acp_agent, state, fake, _conn = make_agent_and_state()
+
+    await acp_agent.cancel(state.session_id)
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="second question")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert fake.runs == ["second question"]
+    assert fake.interrupt_calls == 0
+    assert fake.clear_interrupt_calls == 1
+    assert not state.cancel_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_acp_running_cancel_still_interrupts_current_prompt():
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    state.is_running = True
+    state.current_prompt_text = "long first question"
+
+    await acp_agent.cancel(state.session_id)
+
+    assert fake.interrupt_calls == 1
+    assert fake.clear_interrupt_calls == 0
+    assert state.cancel_event.is_set()
+    assert state.interrupted_prompt_text == "long first question"


### PR DESCRIPTION
## Summary
- Treat ACP `cancel` requests received while a session is already idle as no-ops.
- Clear any stale cancel/interrupt state in that idle path so the next prompt is not immediately reported as interrupted.
- Add regression coverage for both idle-cancel and true running-cancel behavior.

## Root cause
Some ACP clients, observed with Xcode, can send a best-effort `cancel` immediately before submitting the next prompt. Hermes previously always set the session cancel event and called `agent.interrupt()` whenever a cancel request arrived, even if `state.is_running` was already false.

That stale interrupt then poisoned the next `session/prompt`: `run_conversation()` saw the pending interrupt before calling the model and returned `interrupted_by_user`. In Xcode this surfaced as:

```text
Error: JSON-RPC Internal Error (code -32603)
The server encountered an internal error processing the request.
```

## Fix
Only propagate cancel to the agent when the ACP session is actively running. If the session is idle, clear the cancel event and any stale agent interrupt instead.

This preserves real cancellation behavior for in-flight prompts while avoiding a stale idle cancel affecting the next user prompt.

## Test plan
```bash
uv run --extra acp --extra dev python -m pytest tests/acp_adapter/test_acp_commands.py -q -o 'addopts='
# 8 passed
```
