### PR TITLE
fix(desktop): reject cross-wired runtime-id cache on resume (wrong chat loads on session switch)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getSessionMessages } from '@/hermes'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
 import { $currentCwd, $messages, $resumeFailedSessionId, setMessages, setResumeFailedSessionId } from '@/store/session'
 
@@ -255,5 +256,149 @@ describe('resumeSession failure recovery', () => {
     await runResume(requestGateway)
 
     expect($resumeFailedSessionId.get()).toBeNull()
+  })
+})
+
+interface CacheHarnessProps {
+  onReady: (resume: (storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) => void
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
+  sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
+  selectedStoredSessionIdRef: MutableRefObject<string | null>
+}
+
+// Harness that lets the test own the two cache maps so it can pre-seed a
+// cross-wired runtime-id mapping and observe whether the warm fast-path trusts
+// it. Mirrors the production wiring from use-session-state-cache.
+function CacheHarness({
+  onReady,
+  requestGateway,
+  runtimeIdByStoredSessionIdRef,
+  sessionStateByRuntimeIdRef,
+  selectedStoredSessionIdRef
+}: CacheHarnessProps) {
+  const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+  const actions = useSessionActions({
+    activeSessionId: null,
+    activeSessionIdRef: ref<string | null>(null),
+    busyRef: ref(false),
+    creatingSessionRef: ref(false),
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    navigate: vi.fn() as never,
+    requestGateway,
+    runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionId: null,
+    selectedStoredSessionIdRef,
+    sessionStateByRuntimeIdRef,
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: (_sessionId, updater) => updater({} as ClientSessionState)
+  })
+
+  useEffect(() => {
+    onReady(actions.resumeSession)
+  }, [actions.resumeSession, onReady])
+
+  return null
+}
+
+function clientState(storedSessionId: string | null): ClientSessionState {
+  return { ...createClientSessionState(storedSessionId), messages: [] }
+}
+
+describe('resumeSession warm-cache mapping integrity', () => {
+  afterEach(() => {
+    cleanup()
+    setResumeFailedSessionId(null)
+    setMessages([])
+    vi.restoreAllMocks()
+  })
+
+  it('rejects a cross-wired runtime mapping and falls through to a full resume', async () => {
+    // A recycled runtime id ('rt-recycled') is mapped to 'stored-A' but its
+    // cached state actually belongs to a DIFFERENT session ('stored-B') — the
+    // exact "open chat A, chat B loads" corruption a reaped/respawned pooled
+    // backend can leave behind.
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-recycled']])
+    }
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-recycled', clientState('stored-B')]])
+    }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+
+    // session.resume must be reached (proving the fast-path was rejected) and
+    // returns the correct rebind for stored-A.
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.resume') {
+        return { session_id: 'rt-A-fresh', resumed: params?.session_id, messages: [], info: {} } as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(getSessionMessages).mockResolvedValue({ messages: [] } as never)
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <CacheHarness
+        onReady={r => (resume = r)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    // The fast-path did NOT short-circuit on the cross-wired cache — the full
+    // resume RPC ran.
+    const resumeCalls = requestGateway.mock.calls.filter(([method]) => method === 'session.resume')
+    expect(resumeCalls.length).toBe(1)
+    expect(resumeCalls[0][1]).toMatchObject({ session_id: 'stored-A' })
+
+    // The corrupt mapping was purged so it can't mis-resolve again.
+    expect(runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)
+    expect(sessionStateByRuntimeIdRef.current.has('rt-recycled')).toBe(false)
+  })
+
+  it('honours a warm cache entry whose stored id matches (no needless refetch)', async () => {
+    // Correctly-wired mapping: 'rt-A' ↔ 'stored-A'. The fast-path should trust
+    // it and never reach session.resume (only the lightweight usage probe).
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', clientState('stored-A')]])
+    }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.usage') {
+        return { input: 0, output: 0, total: 0 } as never
+      }
+
+      return {} as never
+    })
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <CacheHarness
+        onReady={r => (resume = r)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    // Fast-path served the session from cache: no full resume RPC, mapping intact.
+    const methods = requestGateway.mock.calls.map(([method]) => method)
+    expect(methods).not.toContain('session.resume')
+    expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -613,7 +613,26 @@ export function useSessionActions({
       await ensureGatewayProfile(sessionProfile)
 
       const cachedRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
-      const cachedState = cachedRuntimeId && sessionStateByRuntimeIdRef.current.get(cachedRuntimeId)
+      const cachedStateRaw = cachedRuntimeId && sessionStateByRuntimeIdRef.current.get(cachedRuntimeId)
+
+      // Cross-check the cached state still BELONGS to the session we're resuming
+      // before trusting the warm fast-path. The runtime-id mapping can go stale
+      // and resolve to a live-but-DIFFERENT session: a pooled profile backend
+      // idle-reaped and respawned (pruneSecondaryGateways) re-mints runtime ids,
+      // and a recycled id can land on another stored session's cache entry. The
+      // existing `session.usage` 404 guard below only catches a runtime id that
+      // is fully DEAD — a recycled id still 200s, so without this check the
+      // fast-path paints the wrong transcript under the current route (the
+      // "open a chat, a different chat loads" bug). If the cache entry claims a
+      // different stored id, the mapping is cross-wired: drop both sides and
+      // fall through to a full resume that rebinds a correct runtime id.
+      const cachedState =
+        cachedStateRaw && cachedStateRaw.storedSessionId === storedSessionId ? cachedStateRaw : null
+
+      if (cachedRuntimeId && cachedStateRaw && !cachedState) {
+        runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+        sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
+      }
 
       if (cachedRuntimeId && cachedState) {
         const stored = $sessions.get().find(session => session.id === storedSessionId)


### PR DESCRIPTION
## Symptom

Opening a chat in the desktop sidebar sometimes loads a **different** chat's transcript. Reproduced twice against the same long-running session before tracing it. The route is correct (`/:storedSessionId`) and the DB is intact — only the rendered transcript is wrong.

## Root cause

`resumeSession`'s warm-cache fast-path (`use-session-actions.ts`) short-circuits a full resume when it finds a cached runtime for the stored session:

```ts
const cachedRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
const cachedState = cachedRuntimeId && sessionStateByRuntimeIdRef.current.get(cachedRuntimeId)
if (cachedRuntimeId && cachedState) {
  setActiveSessionId(cachedRuntimeId)   // paints cachedState.messages
  ...
}
```

It trusts the `storedSessionId -> runtimeId -> ClientSessionState` mapping without verifying the cached state still **belongs** to the session being resumed. A pooled profile backend that gets idle-reaped and respawned (`pruneSecondaryGateways`) re-mints runtime ids; a recycled id can resolve to a **live-but-different** session's cache entry. The only existing guard is the `session.usage` 404 below it — that catches a runtime id that is fully **dead**, but a recycled id still `200`s, so the fast-path happily paints the wrong transcript under the current route.

This is a **pre-existing bug from the initial desktop app (#20059)** — both the `runtimeIdByStoredSessionId` mapping and the unguarded fast-path have been there since the app first landed. It is not introduced by the recent session-switch perf work (#49807), which left those lines untouched.

## Fix

Cross-check that the cached state's `storedSessionId` matches the session being resumed before trusting the fast-path. On mismatch the mapping is cross-wired — drop both stale map entries and fall through to a full resume that rebinds a correct runtime id.

```ts
const cachedState =
  cachedStateRaw && cachedStateRaw.storedSessionId === storedSessionId ? cachedStateRaw : null

if (cachedRuntimeId && cachedStateRaw && !cachedState) {
  runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
  sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
}
```

The full-resume path is unaffected: it already guards the final paint with `isCurrentResume()` (request-id + `selectedStoredSessionIdRef` match), so only the cached fast-path was missing the belongs-to check.

## Tests

Two new cases in `use-session-actions.test.tsx`, driven through a harness that owns the two cache maps so it can pre-seed a cross-wired mapping:

- **rejects a cross-wired runtime mapping and falls through to a full resume** — seeds `stored-A -> rt-recycled` whose cached state claims `stored-B`, asserts `session.resume` runs for `stored-A` and both stale map entries are purged.
- **honours a warm cache entry whose stored id matches (no needless refetch)** — correctly-wired `rt-A <-> stored-A`, asserts the fast-path serves from cache and never hits `session.resume` (no perf regression).

All 9 tests in the file pass; full `src/app/session/` suite (89 tests) green; `tsc --noEmit` clean.
