### PR TITLE
feat(delegation): support per-call child model overrides

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5232,6 +5232,8 @@ class AIAgent:
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             toolsets=function_args.get("toolsets"),
+            model=function_args.get("model"),
+            reasoning_effort=function_args.get("reasoning_effort"),
             tasks=function_args.get("tasks"),
             max_iterations=function_args.get("max_iterations"),
             acp_command=function_args.get("acp_command"),

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -69,6 +69,10 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("model", props)
+        self.assertIn("reasoning_effort", props)
+        self.assertIn("model", props["tasks"]["items"]["properties"])
+        self.assertIn("reasoning_effort", props["tasks"]["items"]["properties"])
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -1201,6 +1205,119 @@ class TestDelegationProviderIntegration(unittest.TestCase):
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_call_model_override_reaches_child_agent(self, mock_creds, mock_cfg):
+        """A single delegate_task call can override the configured child model."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "deepseek-v4-flash",
+            "provider": "deepseek",
+        }
+        mock_creds.return_value = {
+            "model": "gpt-5.4-mini",
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex/responses",
+            "api_key": "codex-key",
+            "api_mode": "codex_responses",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="Use a cheaper GPT lane",
+                model={"provider": "openai-codex", "model": "gpt-5.4-mini"},
+                parent_agent=parent,
+            )
+
+            mock_creds.assert_called_once()
+            cfg_arg = mock_creds.call_args.args[0]
+            self.assertEqual(cfg_arg["provider"], "openai-codex")
+            self.assertEqual(cfg_arg["model"], "gpt-5.4-mini")
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "gpt-5.4-mini")
+            self.assertEqual(kwargs["provider"], "openai-codex")
+            self.assertEqual(kwargs["api_mode"], "codex_responses")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_call_model_only_override_reuses_delegation_provider(self, mock_creds, mock_cfg):
+        """A model-only per-call override keeps the configured delegation provider."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "deepseek-v4-flash",
+            "provider": "deepseek",
+        }
+        mock_creds.return_value = {
+            "model": "deepseek-chat",
+            "provider": "deepseek",
+            "base_url": "https://api.deepseek.com",
+            "api_key": "deepseek-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="Use alternate configured-provider model",
+                model={"model": "deepseek-chat"},
+                parent_agent=parent,
+            )
+
+            cfg_arg = mock_creds.call_args.args[0]
+            self.assertEqual(cfg_arg["provider"], "deepseek")
+            self.assertEqual(cfg_arg["model"], "deepseek-chat")
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "deepseek-chat")
+            self.assertEqual(kwargs["provider"], "deepseek")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_call_model_only_override_can_inherit_parent_provider(self, mock_creds, mock_cfg):
+        """A model-only override can fall back to parent credentials when no delegation provider exists."""
+        mock_cfg.return_value = {"max_iterations": 45, "provider": "", "model": ""}
+        mock_creds.return_value = {
+            "model": "anthropic/claude-sonnet-4-5",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="Use parent-provider alternate model",
+                model={"model": "anthropic/claude-sonnet-4-5"},
+                parent_agent=parent,
+            )
+
+            cfg_arg = mock_creds.call_args.args[0]
+            self.assertEqual(cfg_arg["model"], "anthropic/claude-sonnet-4-5")
+            self.assertEqual(cfg_arg.get("provider"), "")
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "anthropic/claude-sonnet-4-5")
+            self.assertEqual(kwargs["provider"], parent.provider)
+            self.assertEqual(kwargs["base_url"], parent.base_url)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
     def test_cross_provider_delegation(self, mock_creds, mock_cfg):
         """Parent on Nous, subagent on OpenRouter — full credential switch."""
         mock_cfg.return_value = {
@@ -1395,6 +1512,104 @@ class TestDelegationProviderIntegration(unittest.TestCase):
                 self.assertEqual(call.kwargs.get("override_base_url"), "https://openrouter.ai/api/v1")
                 self.assertEqual(call.kwargs.get("override_api_key"), "sk-or-batch")
                 self.assertEqual(call.kwargs.get("override_api_mode"), "chat_completions")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_batch_mode_can_mix_per_task_models(self, mock_creds, mock_cfg):
+        """Batch tasks may route different children to different configured models."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "deepseek-v4-flash",
+            "provider": "deepseek",
+        }
+        mock_creds.side_effect = [
+            {
+                "model": "deepseek-v4-flash",
+                "provider": "deepseek",
+                "base_url": "https://api.deepseek.com/v1",
+                "api_key": "ds-key",
+                "api_mode": "chat_completions",
+            },
+            {
+                "model": "gpt-5.4-mini",
+                "provider": "openai-codex",
+                "base_url": "https://chatgpt.com/backend-api/codex/responses",
+                "api_key": "codex-key",
+                "api_mode": "codex_responses",
+            },
+        ]
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_child = MagicMock()
+            mock_build.return_value = mock_child
+            mock_run.return_value = {
+                "task_index": 0, "status": "completed",
+                "summary": "Done", "api_calls": 1, "duration_seconds": 1.0
+            }
+
+            tasks = [
+                {
+                    "goal": "cheap reasoning",
+                    "model": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+                    "reasoning_effort": "low",
+                },
+                {
+                    "goal": "cheap GPT worker",
+                    "model": {"provider": "openai-codex", "model": "gpt-5.4-mini"},
+                    "reasoning_effort": "minimal",
+                },
+            ]
+            delegate_task(tasks=tasks, parent_agent=parent)
+
+            self.assertEqual(mock_creds.call_count, 2)
+            self.assertEqual(mock_creds.call_args_list[0].args[0]["provider"], "deepseek")
+            self.assertEqual(mock_creds.call_args_list[0].args[0]["reasoning_effort"], "low")
+            self.assertEqual(mock_creds.call_args_list[1].args[0]["provider"], "openai-codex")
+            self.assertEqual(mock_creds.call_args_list[1].args[0]["model"], "gpt-5.4-mini")
+            self.assertEqual(mock_creds.call_args_list[1].args[0]["reasoning_effort"], "minimal")
+            self.assertEqual(mock_build.call_args_list[0].kwargs.get("model"), "deepseek-v4-flash")
+            self.assertEqual(mock_build.call_args_list[0].kwargs.get("override_reasoning_effort"), "low")
+            self.assertEqual(mock_build.call_args_list[1].kwargs.get("model"), "gpt-5.4-mini")
+            self.assertEqual(mock_build.call_args_list[1].kwargs.get("override_provider"), "openai-codex")
+            self.assertEqual(mock_build.call_args_list[1].kwargs.get("override_reasoning_effort"), "minimal")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_single_task_reasoning_effort_reaches_child_agent(self, mock_creds, mock_cfg):
+        """Top-level reasoning_effort applies to a single delegated task."""
+        mock_cfg.return_value = {"max_iterations": 45, "reasoning_effort": "high"}
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            mock_child._delegate_saved_tool_names = []
+            mock_child._credential_pool = None
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.model = "test"
+            mock_build.return_value = mock_child
+
+            delegate_task(
+                goal="Use cheap reasoning",
+                reasoning_effort="low",
+                parent_agent=parent,
+            )
+
+            cfg_arg = mock_creds.call_args.args[0]
+            self.assertEqual(cfg_arg["reasoning_effort"], "low")
+            self.assertEqual(mock_build.call_args.kwargs.get("override_reasoning_effort"), "low")
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")
@@ -1964,6 +2179,23 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 
     @patch("tools.delegate_tool._load_config")
     @patch("run_agent.AIAgent")
+    def test_per_call_reasoning_effort_overrides_config(self, MockAgent, mock_cfg):
+        """A per-call override wins over delegation.reasoning_effort config."""
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "high"}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        _build_child_agent(
+            task_index=0, goal="test", context=None, toolsets=None,
+            model=None, max_iterations=50, parent_agent=parent,
+            task_count=1, override_reasoning_effort="minimal",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "minimal"})
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
     def test_override_reasoning_effort_none_disables(self, MockAgent, mock_cfg):
         """delegation.reasoning_effort: 'none' disables thinking for subagents."""
         mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "none"}
@@ -2035,6 +2267,27 @@ class TestDispatchDelegateTask(unittest.TestCase):
             _, kwargs = mock_build.call_args
             self.assertEqual(kwargs["override_acp_command"], "claude")
             self.assertEqual(kwargs["override_acp_args"], ["--acp", "--stdio"])
+
+    def test_agent_dispatch_forwards_model_and_reasoning(self):
+        """The AIAgent dispatch helper forwards the public schema fields."""
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)
+        with patch("tools.delegate_tool.delegate_task") as mock_delegate:
+            mock_delegate.return_value = '{"results": []}'
+            result = agent._dispatch_delegate_task({
+                "goal": "route me",
+                "model": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+                "reasoning_effort": "low",
+            })
+
+        self.assertEqual(result, '{"results": []}')
+        self.assertEqual(
+            mock_delegate.call_args.kwargs["model"],
+            {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        )
+        self.assertEqual(mock_delegate.call_args.kwargs["reasoning_effort"], "low")
+        self.assertIs(mock_delegate.call_args.kwargs["parent_agent"], agent)
 
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -986,6 +986,9 @@ def _build_child_agent(
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    # Per-call reasoning override. When omitted, delegation.reasoning_effort
+    # from config (if any) still applies.
+    override_reasoning_effort: Optional[str] = None,
     # Per-call role controlling whether the child can further delegate.
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
@@ -1024,6 +1027,9 @@ def _build_child_agent(
     tui_depth = max(0, child_depth - 1)  # 0 = first-level child for the UI
 
     delegation_cfg = _load_config()
+    if override_reasoning_effort not in (None, ""):
+        delegation_cfg = dict(delegation_cfg)
+        delegation_cfg["reasoning_effort"] = str(override_reasoning_effort).strip()
 
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
@@ -2062,10 +2068,54 @@ def _recover_tasks_from_json_string(
     return parsed, None
 
 
+def _merge_model_override(
+    cfg: Dict[str, Any],
+    model_override: Any,
+) -> tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Return a delegation config copy with a per-call model override applied.
+
+    The public tool schema accepts ``model={"provider": ..., "model": ...}``.
+    Keeping this as a config-shaped merge lets the existing runtime provider
+    resolver remain the single credential/transport authority for children.
+    """
+    if model_override in (None, ""):
+        return dict(cfg), None
+
+    if not isinstance(model_override, dict):
+        return None, "model override must be an object with at least a 'model' field."
+
+    merged = dict(cfg)
+    requested_model = str(model_override.get("model") or "").strip()
+    if not requested_model:
+        return None, "model override must include a non-empty 'model' field."
+    merged["model"] = requested_model
+
+    if "provider" in model_override:
+        requested_provider = str(model_override.get("provider") or "").strip()
+        if not requested_provider:
+            return None, "model override 'provider' must be non-empty when provided."
+        merged["provider"] = requested_provider
+
+    return merged, None
+
+
+def _merge_reasoning_effort_override(
+    cfg: Dict[str, Any],
+    reasoning_effort: Optional[str],
+) -> Dict[str, Any]:
+    if reasoning_effort in (None, ""):
+        return cfg
+    merged = dict(cfg)
+    merged["reasoning_effort"] = str(reasoning_effort).strip()
+    return merged
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
+    model: Optional[Dict[str, Any]] = None,
+    reasoning_effort: Optional[str] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
@@ -2078,8 +2128,8 @@ def delegate_task(
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, toolsets, model, role)
+      - Batch:  provide tasks array [{goal, context, toolsets, model, role}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
@@ -2143,16 +2193,6 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
-
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
@@ -2173,7 +2213,14 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "model": model,
+                "reasoning_effort": reasoning_effort,
+                "role": top_role,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2214,6 +2261,19 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            task_cfg, cfg_error = _merge_model_override(cfg, t.get("model") or model)
+            if cfg_error:
+                return tool_error(f"Task {i}: {cfg_error}")
+            task_cfg = _merge_reasoning_effort_override(
+                task_cfg,
+                t.get("reasoning_effort") or reasoning_effort,
+            )
+            # Resolve delegation credentials (provider:model pair) per task so
+            # a batch can fan out across multiple configured providers/models.
+            try:
+                creds = _resolve_delegation_credentials(task_cfg, parent_agent)
+            except ValueError as exc:
+                return tool_error(str(exc))
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
@@ -2235,6 +2295,7 @@ def delegate_task(
                     if task_acp_args is not None
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
+                override_reasoning_effort=task_cfg.get("reasoning_effort"),
                 role=effective_role,
             )
             # Override with correct parent tool names (before child construction mutated global)
@@ -2926,7 +2987,7 @@ def _build_top_level_description() -> str:
         f"Orchestrators are bounded by max_spawn_depth={max_depth} for this "
         f"user and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
-        "- Subagent model is NOT selectable per call: children inherit the parent model (plus its fallback chain) unless you pin all subagents to a model via delegation.provider / delegation.model in config.yaml.\n"
+        "- Subagent model can be overridden per call with model={provider, model}; otherwise children use delegation.provider/delegation.model or inherit the parent.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
         "- Results are always returned as an array, one entry per task."
     )
@@ -3051,6 +3112,26 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "model": {
+                "type": "object",
+                "properties": {
+                    "provider": {"type": "string"},
+                    "model": {"type": "string"},
+                },
+                "required": ["model"],
+                "description": (
+                    "Per-call model override. Pass {'provider': 'deepseek', "
+                    "'model': 'deepseek-v4-flash'} or another configured "
+                    "provider/model. If provider is omitted, Hermes reuses "
+                    "delegation.provider when configured; otherwise the child "
+                    "inherits the parent's provider credentials."
+                ),
+            },
+            "reasoning_effort": {
+                "type": "string",
+                "enum": ["none", "minimal", "low", "medium", "high", "xhigh"],
+                "description": "Per-call reasoning effort override for this subagent.",
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -3065,6 +3146,20 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
+                        },
+                        "model": {
+                            "type": "object",
+                            "properties": {
+                                "provider": {"type": "string"},
+                                "model": {"type": "string"},
+                            },
+                            "required": ["model"],
+                            "description": "Per-task model override. Overrides the top-level model for this task only.",
+                        },
+                        "reasoning_effort": {
+                            "type": "string",
+                            "enum": ["none", "minimal", "low", "medium", "high", "xhigh"],
+                            "description": "Per-task reasoning effort override.",
                         },
                         "acp_command": {
                             "type": "string",
@@ -3165,6 +3260,8 @@ registry.register(
         goal=args.get("goal"),
         context=args.get("context"),
         toolsets=args.get("toolsets"),
+        model=args.get("model"),
+        reasoning_effort=args.get("reasoning_effort"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),


### PR DESCRIPTION
## Summary
- add per-call `delegate_task` model overrides via `model={provider, model}`
- add top-level and per-task `reasoning_effort` overrides
- resolve delegation credentials per task so batch delegation can fan out across configured providers/models
- forward the new public schema fields through `AIAgent._dispatch_delegate_task`

## Validation
- `python -m py_compile tools/delegate_tool.py run_agent.py tests/tools/test_delegate.py`
- `python -m pytest tests/tools/test_delegate.py::TestDelegateRequirements::test_schema_valid tests/tools/test_delegate.py::TestDelegationProviderIntegration::test_per_call_model_override_reaches_child_agent tests/tools/test_delegate.py::TestDelegationProviderIntegration::test_per_call_model_only_override_reuses_delegation_provider tests/tools/test_delegate.py::TestDelegationProviderIntegration::test_per_call_model_only_override_can_inherit_parent_provider tests/tools/test_delegate.py::TestDelegationProviderIntegration::test_batch_mode_can_mix_per_task_models tests/tools/test_delegate.py::TestDelegationProviderIntegration::test_single_task_reasoning_effort_reaches_child_agent tests/tools/test_delegate.py::TestDelegationReasoningEffort::test_per_call_reasoning_effort_overrides_config tests/tools/test_delegate.py::TestDispatchDelegateTask::test_agent_dispatch_forwards_model_and_reasoning -o 'addopts=' -q` → 8 passed
- `python -m pytest tests/tools/test_delegate.py -o 'addopts=' -q -k 'not heartbeat_does_not_trip_idle_stale_while_inside_tool'` → 146 passed, 1 deselected
- `python -m pytest tests/cli/test_cli_interrupt_subagent.py tests/run_agent/test_tool_executor_contextvar_propagation.py -o 'addopts=' -q` → 6 passed
- direct provider smoke: `openai-codex/gpt-5.4-mini` → `GPT54_MINI_DIRECT_OK`
- e2e delegation smoke: DeepSeek child override → `DEEPSEEK_PARENT_OVERRIDE_OK`
- e2e mixed batch smoke produced both task completion markers: `BATCH_SYNC_DEEPSEEK_OK`, `BATCH_SYNC_GPT54_OK`

## Known unrelated test failure
`tests/tools/test_delegate.py::TestDelegateHeartbeat::test_heartbeat_does_not_trip_idle_stale_while_inside_tool` is currently failing on `origin/main` as well as this branch. Verified in a separate disposable verifier worktree reset to `origin/main`:

```text
HEAD is now at 87ab37338 test(url-safety): cover IPv6 scope-ID strip + fail-closed in URL guards
FAILED tests/tools/test_delegate.py::TestDelegateHeartbeat::test_heartbeat_does_not_trip_idle_stale_while_inside_tool
```

This PR leaves that heartbeat test untouched.
