### PR TITLE
fix(security): quote HERMES_TIMEZONE in remote code execution (#8007)

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -174,6 +174,47 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
         self.assertIn("rm -rf /data/data/com.termux/files/usr/tmp/hermes_exec_", cleanup_cmd)
         self.assertNotIn("mkdir -p /tmp/hermes_exec_", mkdir_cmd)
 
+    def test_timezone_shell_quoted_in_remote_execution(self):
+        """HERMES_TIMEZONE must be shell-quoted in remote env_prefix to prevent injection."""
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+
+            def get_temp_dir(self):
+                return "/tmp"
+
+            def execute(self, command, cwd=None, timeout=None):
+                self.commands.append((command, cwd, timeout))
+                if "command -v python3" in command:
+                    return {"output": "OK\n"}
+                if "python3 script.py" in command:
+                    return {"output": "hello\n", "returncode": 0}
+                return {"output": ""}
+
+        env = FakeEnv()
+        fake_thread = MagicMock()
+
+        malicious_tz = "US/Eastern; echo PWNED"
+
+        with patch("tools.code_execution_tool._load_config",
+                   return_value={"timeout": 30, "max_tool_calls": 5}), \
+             patch("tools.code_execution_tool._get_or_create_env",
+                   return_value=(env, "ssh")), \
+             patch("tools.code_execution_tool._ship_file_to_remote"), \
+             patch("tools.code_execution_tool.threading.Thread",
+                   return_value=fake_thread), \
+             patch.dict(os.environ, {"HERMES_TIMEZONE": malicious_tz}):
+            result = json.loads(_execute_remote("print('hello')", "task-1", ["terminal"]))
+
+        self.assertEqual(result["status"], "success")
+        run_cmd = next(cmd for cmd, _, _ in env.commands if "python3 script.py" in cmd)
+        # The TZ value must be shell-quoted — it should NOT contain unescaped semicolons
+        self.assertNotIn("TZ=US/Eastern; echo PWNED", run_cmd,
+                         "TZ value with shell metacharacters must not appear unquoted")
+        # shlex.quote wraps values containing special characters in single quotes
+        self.assertIn("TZ='US/Eastern; echo PWNED'", run_cmd,
+                      "TZ value must be wrapped in single quotes by shlex.quote()")
+
 
 @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
 class TestExecuteCode(unittest.TestCase):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -961,7 +961,7 @@ def _execute_remote(
         )
         tz = os.getenv("HERMES_TIMEZONE", "").strip()
         if tz:
-            env_prefix += f" TZ={tz}"
+            env_prefix += f" TZ={shlex.quote(tz)}"
 
         # Execute the script on the remote backend
         logger.info("Executing code on %s backend (task %s)...",


### PR DESCRIPTION
## Summary
The remote `execute_code` path no longer interpolates `HERMES_TIMEZONE` into the shell command unquoted — `shlex.quote` neutralizes any shell metacharacters.

Root cause: in `_execute_remote`, `env_prefix += f" TZ={tz}"` injected the raw `HERMES_TIMEZONE` value into the command string run on the remote backend. A value containing `;`, `$()`, etc. could break out of the intended command. (Defense-in-depth: `HERMES_TIMEZONE` is internal config, not LLM-controllable, and the local-exec path already sets `TZ` via an env dict — but the remote path should never interpolate a raw value into a shell string.)

## Changes
- `tools/code_execution_tool.py`: `TZ={tz}` → `TZ={shlex.quote(tz)}` in the remote env prefix (`shlex` already imported).
- `tests/tools/test_code_execution.py`: regression test asserting a `TZ` value with shell metacharacters is single-quoted, not interpolated raw.

## Validation
| | Before | After |
|---|---|---|
| `HERMES_TIMEZONE = "US/Eastern; echo PWNED"` | injected raw into remote shell command | `shlex.quote`'d to a single literal value |
| `tests/tools/test_code_execution.py` | — | 69/69 pass |

Salvaged from #8007 by @Dusk1e — commit cherry-picked onto current main with authorship preserved.

## Infographic

![tz-shell-quote-fix](https://v3b.fal.media/files/b/0a9f3f20/LVSZf7A1EKGdrtr3xVM43_NiUe8ieT.png)
