### PR TITLE
fix(api): allow hermes update for git/pip installs inside containers

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1311,13 +1311,34 @@ def _dashboard_local_update_managed_externally() -> bool:
     in-browser local update action. Keep this dashboard capability separate
     from install-method detection: manual git/pip installs inside containers can
     still behave like their actual install method in the CLI.
+
+    However, when the install method is ``git`` or ``pip`` (a manual install
+    inside a container — e.g. a bind-mounted git checkout in the hermes-webui
+    image), the dashboard's ``hermes update`` button is the correct update
+    path and should not be suppressed. Only block updates for installs whose
+    lifecycle is truly owned by the container image (``docker`` stamp or
+    hosted ``/opt/data`` layout).
     """
+    if _default_hermes_root_is_opt_data():
+        return True
     try:
         from hermes_constants import is_container
 
-        return is_container()
+        if not is_container():
+            return False
     except Exception:
         return False
+    # We are inside a container, but the install may still be self-managed.
+    # If the install method is git or pip, the dashboard update button works
+    # and should be offered. Only block for docker/nixos/homebrew installs
+    # whose lifecycle is owned by the outer image/package manager.
+    try:
+        method = detect_install_method(PROJECT_ROOT)
+        if method in ("git", "pip"):
+            return False
+    except Exception:
+        pass
+    return True
 
 
 def _managed_files_policy(request: Request, *, create_root: bool = True) -> ManagedFilesPolicy:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -104,6 +104,7 @@ AUTHOR_MAP = {
     "804436395@qq.com": "LaPhilosophie",
     "maxmitcham@mac.home": "maxtrigify",
     "ccook@nvms.com": "ccook1963",
+    "libre-7@users.noreply.github.com": "libre-7",
     "kristian@agrointel.no": "kristianvast",
     "thomas.paquette@gmail.com": "RyTsYdUp",
     "techxacm@gmail.com": "ProgramCaiCai",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -263,8 +263,31 @@ class TestWebServerEndpoints:
         import hermes_cli.web_server as web_server
 
         monkeypatch.setattr(hermes_constants, "is_container", lambda: True)
+        # A docker install inside a container should be managed externally.
+        monkeypatch.setattr(web_server, "detect_install_method", lambda _root: "docker")
 
         assert web_server._dashboard_local_update_managed_externally() is True
+
+    def test_dashboard_update_capability_allows_git_in_container(self, monkeypatch):
+        """A git checkout inside a container (e.g. bind-mounted in hermes-webui)
+        should still offer dashboard updates — the checkout is self-managed."""
+        import hermes_constants
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(hermes_constants, "is_container", lambda: True)
+        monkeypatch.setattr(web_server, "detect_install_method", lambda _root: "git")
+
+        assert web_server._dashboard_local_update_managed_externally() is False
+
+    def test_dashboard_update_capability_allows_pip_in_container(self, monkeypatch):
+        """A pip install inside a container should also offer dashboard updates."""
+        import hermes_constants
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(hermes_constants, "is_container", lambda: True)
+        monkeypatch.setattr(web_server, "detect_install_method", lambda _root: "pip")
+
+        assert web_server._dashboard_local_update_managed_externally() is False
 
     @staticmethod
     def _provider_field_map(payload):
@@ -1011,6 +1034,8 @@ class TestWebServerEndpoints:
             spawned = True
             raise AssertionError("docker update guard should not spawn hermes update")
 
+        # Bypass the managed-externally gate so we reach the docker install check.
+        monkeypatch.setattr(web_server, "_dashboard_local_update_managed_externally", lambda: False)
         monkeypatch.setattr(web_server, "detect_install_method", lambda _root: "docker")
         monkeypatch.setattr(web_server, "_spawn_hermes_action", fail_spawn)
         web_server._ACTION_PROCS.pop("hermes-update", None)


### PR DESCRIPTION
## Summary

`_dashboard_local_update_managed_externally()` in `hermes_cli/web_server.py` blocked all container environments from the update API, even when the install method was `git` or `pip` (e.g. a bind-mounted git checkout in the `hermes-webui` image). The function's own docstring acknowledged that "manual git/pip installs inside containers can still behave like their actual install method in the CLI" — but the code did not honor it.

## User impact

This was observed through the third-party [hermes-webui](https://github.com/nesquena/hermes-webui) project, which reads `can_update_hermes` from the gateway's `/api/status` endpoint. The code being fixed lives in the official dashboard's API server (`hermes_cli/web_server.py`), which serves the same endpoints to any client — the built-in dashboard, hermes-webui, or any other frontend that consumes the gateway API.

## Problem

Commit b1d6a5788 ("Detect containerized dashboard update management") changed the function to call `is_container()` and block updates for any containerized environment. This regressed the two-container `hermes-webui` setup, where:

1. The WebUI runs in a Docker container (`/.dockerenv` exists → `is_container()` returns `True`)
2. The agent source is a git checkout bind-mounted from the host
3. `detect_install_method()` correctly returns `"git"`
4. The update button calls `hermes update`, which does `git pull --ff origin main` — this works fine

The block affected three endpoints:
- `POST /api/hermes/update` — returns `dashboard_update_managed_externally` error
- `GET /api/hermes/update/check` — returns `can_apply: false`
- `GET /api/status` — sets `can_update_hermes: false`

## Fix

`_dashboard_local_update_managed_externally()` now checks the install method after confirming it is inside a container:

1. `_default_hermes_root_is_opt_data()` → block (hosted `/opt/data` layout, unchanged)
2. `is_container()` returns `False` → allow (non-container host, unchanged)
3. `is_container()` returns `True` + `detect_install_method()` returns `"git"` or `"pip"` → **allow** (self-managed install inside a container)
4. `is_container()` returns `True` + any other install method → block (docker/nixos/homebrew, lifecycle owned by outer image)

This is complementary to #48594 / #48598 / #48695, which fix false-positive `is_container()` on hosts that merely have Docker installed. This PR fixes the separate case where `is_container()` is **correctly** `True` but the install is still self-managed.

## Changes

- `hermes_cli/web_server.py`: Add install-method check after container detection in `_dashboard_local_update_managed_externally()`
- `tests/hermes_cli/test_web_server.py`: Update existing test to mock `detect_install_method`, add regression tests for git/pip-in-container, fix docker-guidance test to mock the gate
- `scripts/release.py`: Add `libre-7` to `AUTHOR_MAP` for contributor attribution

## Testing

```
pytest tests/hermes_cli/test_web_server.py -o addopts= -q     # 308 passed
pytest tests/hermes_cli/test_dashboard_admin_endpoints.py -o addopts= -q  # 70 passed
```

Verified against four scenarios:

| Scenario | Result | Expected |
|---|---|---|
| Hosted `/opt/data` layout | blocked | ✅ image owns lifecycle |
| Container + docker install | blocked | ✅ image owns lifecycle |
| Container + git install | allowed | ✅ checkout is self-managed |
| Non-container host | allowed | ✅ normal host update |

Refs #48594