### PR TITLE
fix(cli/windows): include Hermes-managed Node dir in session PATH prefill

### DIFF
--- a/hermes_cli/stdio.py
+++ b/hermes_cli/stdio.py
@@ -229,6 +229,12 @@ def _augment_path_with_known_tools() -> None:
         os.path.join(local_appdata, "hermes", "git", "cmd"),
         os.path.join(local_appdata, "hermes", "git", "bin"),
         os.path.join(local_appdata, "hermes", "git", "usr", "bin"),
+        # Hermes-managed portable Node directory — install.ps1 unpacks
+        # portable Node to %LOCALAPPDATA%\hermes\node and persists it to the
+        # User PATH (Install-Node), same as the Git dirs above.  Mirror it so
+        # first-session npm/node/npx spawns resolve before the User-PATH
+        # broadcast reaches a fresh shell.
+        os.path.join(local_appdata, "hermes", "node"),
         # Hermes venv Scripts directory — host of the hermes.exe shim itself,
         # also where any pip-installed console scripts land.  Usually already
         # on PATH when the user invokes hermes, but harmless to include.

--- a/tests/hermes_cli/test_stdio_path_augment.py
+++ b/tests/hermes_cli/test_stdio_path_augment.py
@@ -1,0 +1,68 @@
+"""Tests for hermes_cli.stdio._augment_path_with_known_tools.
+
+On Windows, the installer (scripts/install.ps1) persists its managed tool
+directories to the *User* PATH, but that broadcast does not reach the
+already-running shell the user launches ``hermes`` from. To smooth over that
+first-launch gap, ``_augment_path_with_known_tools`` prepends the known
+Hermes-managed tool directories to the current process PATH so spawned
+subprocesses resolve them immediately.
+
+These tests force the Windows branch headlessly and assert the managed Node
+directory (``%LOCALAPPDATA%\\hermes\\node``) is one of the mirrored entries —
+it is persisted to the User PATH by Install-Node exactly like the Git dirs.
+"""
+
+import os
+
+from hermes_cli import stdio
+
+
+def test_augment_path_includes_managed_node_dir(tmp_path, monkeypatch):
+    """The Hermes-managed portable Node dir must be prefilled onto PATH.
+
+    Install-Node (scripts/install.ps1) unpacks portable Node to
+    ``%LOCALAPPDATA%\\hermes\\node`` and persists it to the User PATH, the same
+    way it persists the Git dirs. ``_augment_path_with_known_tools`` must mirror
+    it so first-session ``node``/``npm``/``npx`` spawns resolve before the
+    User-PATH broadcast reaches a fresh shell.
+    """
+    # Force the Windows branch without running on Windows.
+    monkeypatch.setattr(stdio, "is_windows", lambda: True)
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+
+    # The managed Node dir exists on disk (the loop is os.path.isdir-guarded).
+    node_dir = tmp_path / "hermes" / "node"
+    node_dir.mkdir(parents=True)
+
+    # A second mirrored dir, to prove the test exercises the real loop and is
+    # not a tautology that would pass even if the Node entry were removed.
+    git_cmd_dir = tmp_path / "hermes" / "git" / "cmd"
+    git_cmd_dir.mkdir(parents=True)
+
+    # Clear PATH so the managed dirs are genuinely absent before the call.
+    monkeypatch.setenv("PATH", r"C:\Windows\System32")
+
+    stdio._augment_path_with_known_tools()
+
+    resulting = os.environ["PATH"].split(os.pathsep)
+    assert str(node_dir) in resulting
+    # The pre-existing mirrored entry still works — locks the contract.
+    assert str(git_cmd_dir) in resulting
+
+
+def test_augment_path_skips_managed_node_dir_when_absent(tmp_path, monkeypatch):
+    """No-op for the Node dir when it does not exist on disk.
+
+    The loop is guarded by ``os.path.isdir``; a missing managed Node dir must
+    never be prepended (this is what keeps the prefill harmless on installs
+    that did not use portable Node).
+    """
+    monkeypatch.setattr(stdio, "is_windows", lambda: True)
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    # Deliberately do NOT create hermes/node on disk.
+    monkeypatch.setenv("PATH", r"C:\Windows\System32")
+
+    stdio._augment_path_with_known_tools()
+
+    node_dir = tmp_path / "hermes" / "node"
+    assert str(node_dir) not in os.environ["PATH"].split(os.pathsep)

--- a/tests/hermes_cli/test_stdio_path_augment.py
+++ b/tests/hermes_cli/test_stdio_path_augment.py
@@ -28,6 +28,11 @@ def test_augment_path_includes_managed_node_dir(tmp_path, monkeypatch):
     """
     # Force the Windows branch without running on Windows.
     monkeypatch.setattr(stdio, "is_windows", lambda: True)
+    # Force Windows PATH semantics too: the production code splits/joins PATH
+    # with os.pathsep, so on a non-Windows runner (os.pathsep == ":") a Windows
+    # drive path like ``C:\Windows\System32`` would be split at the ``C:``
+    # prefix and the assertions below would pass/fail for the wrong reason.
+    monkeypatch.setattr(os, "pathsep", ";")
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
 
     # The managed Node dir exists on disk (the loop is os.path.isdir-guarded).
@@ -39,7 +44,8 @@ def test_augment_path_includes_managed_node_dir(tmp_path, monkeypatch):
     git_cmd_dir = tmp_path / "hermes" / "git" / "cmd"
     git_cmd_dir.mkdir(parents=True)
 
-    # Clear PATH so the managed dirs are genuinely absent before the call.
+    # Clear PATH so the managed dirs are genuinely absent before the call. With
+    # ``;`` as the separator this stays a single pre-existing entry.
     monkeypatch.setenv("PATH", r"C:\Windows\System32")
 
     stdio._augment_path_with_known_tools()
@@ -48,6 +54,10 @@ def test_augment_path_includes_managed_node_dir(tmp_path, monkeypatch):
     assert str(node_dir) in resulting
     # The pre-existing mirrored entry still works — locks the contract.
     assert str(git_cmd_dir) in resulting
+    # The managed dirs must be *prepended* ahead of the pre-existing PATH so
+    # they win resolution, not merely appended somewhere after it.
+    assert resulting.index(str(node_dir)) < resulting.index(r"C:\Windows\System32")
+    assert resulting.index(str(git_cmd_dir)) < resulting.index(r"C:\Windows\System32")
 
 
 def test_augment_path_skips_managed_node_dir_when_absent(tmp_path, monkeypatch):
@@ -58,6 +68,9 @@ def test_augment_path_skips_managed_node_dir_when_absent(tmp_path, monkeypatch):
     that did not use portable Node).
     """
     monkeypatch.setattr(stdio, "is_windows", lambda: True)
+    # Force Windows PATH semantics so the seeded drive path is not split at the
+    # ``C:`` prefix on a non-Windows runner (os.pathsep would otherwise be ":").
+    monkeypatch.setattr(os, "pathsep", ";")
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
     # Deliberately do NOT create hermes/node on disk.
     monkeypatch.setenv("PATH", r"C:\Windows\System32")


### PR DESCRIPTION
## What does this PR do?

On Windows, `_augment_path_with_known_tools()` (`hermes_cli/stdio.py`) prefills the
running install session's PATH with the Hermes-managed tool directories that
`scripts/install.ps1` persists to the User PATH, so first-launch subprocesses
resolve `git`/`rg`/`bash` before the User-PATH broadcast reaches a fresh shell.
The portable **Node** directory (`%LOCALAPPDATA%\hermes\node`) was missing from
that list even though Install-Node persists it to the User PATH exactly like the
Git dirs (`install.ps1` Install-Node, ~L915-921). As a result, on a fresh
portable-Node install, `node`/`npm`/`npx` are not on PATH for subprocesses Hermes
spawns in the install session (npx-launched MCP servers, `npx agent-browser`,
etc.) — while git/ripgrep are. This adds the one missing entry so the prefill
fully mirrors the installer, as the function's own docstring requires.

> Audited the other directories `install.ps1` persists to the User PATH (git
> cmd/bin/usr-bin, the hermes-agent venv Scripts dir, WinGet Links) — all are
> already present in `candidate_dirs`; the portable `node` dir was the only
> omission. No further widening needed (the list keys off `LOCALAPPDATA`; adding
> `HERMES_HOME` support would be a separate, scope-widening change).

## Related Issue

No filed issue — code-originated fix found by auditing `candidate_dirs` against
the User-PATH entries `scripts/install.ps1` persists.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/stdio.py`: add `%LOCALAPPDATA%\hermes\node` to `candidate_dirs` in
  `_augment_path_with_known_tools()`, grouped with the other portable-runtime
  dirs, so the session-PATH prefill mirrors the installer's managed-tool User
  PATH additions. (The existing loop is `os.path.isdir`-guarded and de-dupes
  against the current PATH, so the entry is a no-op when the dir is absent or
  already present.)
- `tests/hermes_cli/test_stdio_path_augment.py`: new regression test.

## How to Test

1. New regression test `tests/hermes_cli/test_stdio_path_augment.py`: forces the
   Windows branch, points `LOCALAPPDATA` at a temp dir with `hermes\node` created
   on disk, clears PATH, calls `_augment_path_with_known_tools()`, and asserts
   the managed Node dir is prepended. A companion assertion confirms an existing
   mirrored dir (`hermes\git\cmd`) is still prepended (so the test exercises the
   real loop, not a tautology).
2. **Fails before** this change (the Node dir is never a candidate → not
   prepended) and **passes after** — verified both directions by stashing/
   restoring the production hunk.
3. Run: `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_stdio_path_augment.py -v` → 2 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the focused touched-area set (tests/hermes_cli/test_stdio_path_augment.py); the change is Windows-PATH-only -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Windows branch forced headlessly via monkeypatch)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows-only path; no-op on POSIX (function returns early) and when the dir is absent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A