### PR TITLE
docs(gemini): label google-gemini-cli as paid Code Assist only (consumer sunset)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3093,8 +3093,8 @@ OPTIONAL_ENV_VARS = {
         "advanced": True,
     },
     "HERMES_GEMINI_PROJECT_ID": {
-        "description": "GCP project ID for paid Gemini tiers (free tier auto-provisions)",
-        "prompt": "GCP project ID for Gemini OAuth (leave empty for free tier)",
+        "description": "GCP project ID for the Gemini Code Assist OAuth provider (paid/Enterprise license required since the 2026-06-18 consumer sunset)",
+        "prompt": "GCP project ID for Gemini Code Assist OAuth (paid tier)",
         "url": None,
         "password": False,
         "category": "provider",

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -634,12 +634,17 @@ def _model_flow_minimax_oauth(config, current_model="", args=None):
     print(f"\u2713 Using MiniMax model: {selected}")
 
 def _model_flow_google_gemini_cli(_config, current_model=""):
-    """Google Gemini OAuth (PKCE) via Cloud Code Assist — supports free AND paid tiers.
+    """Google Gemini OAuth (PKCE) via Cloud Code Assist — requires a PAID tier.
+
+    NOTE: Google sunset the consumer (free / Google One / AI Pro) Code Assist
+    endpoint on 2026-06-18. This provider now only works for accounts with a
+    paid Gemini Code Assist / Enterprise license. Consumer users should use the
+    `google-antigravity` provider instead.
 
     Flow:
-      1. Show upfront warning about Google's ToS stance (per opencode-gemini-auth).
+      1. Show upfront warning about Google's ToS stance + the consumer sunset.
       2. If creds missing, run PKCE browser OAuth via agent.google_oauth.
-      3. Resolve project context (env -> config -> auto-discover -> free tier).
+      3. Resolve project context (env -> config -> auto-discover).
       4. Prompt user to pick a model.
       5. Save to ~/.hermes/config.yaml.
     """
@@ -654,10 +659,15 @@ def _model_flow_google_gemini_cli(_config, current_model=""):
     from hermes_cli.models import _PROVIDER_MODELS
 
     print()
-    print("⚠  Google considers using the Gemini CLI OAuth client with third-party")
-    print("   software a policy violation. Some users have reported account")
-    print("   restrictions. You can use your own API key via 'gemini' provider")
-    print("   for the lowest-risk experience.")
+    print("⚠  Requires a PAID Gemini Code Assist / Enterprise license.")
+    print("   Google sunset the consumer (free / Google One / AI Pro) Code Assist")
+    print("   endpoint on 2026-06-18 — if you're on a consumer plan, cancel and")
+    print("   pick 'Google Antigravity (OAuth)' instead.")
+    print()
+    print("⚠  Google also considers using the Gemini CLI OAuth client with")
+    print("   third-party software a policy violation. Some users have reported")
+    print("   account restrictions. You can use your own API key via the 'gemini'")
+    print("   provider for the lowest-risk experience.")
     print()
     try:
         proceed = input("Continue with OAuth login? [y/N]: ").strip().lower()
@@ -687,7 +697,9 @@ def _model_flow_google_gemini_cli(_config, current_model=""):
             print(f"  Using GCP project: {project_id}")
         else:
             print(
-                "  No GCP project configured — free tier will be auto-provisioned on first request."
+                "  No GCP project configured — set one via the GCP project prompt "
+                "in setup, or the GOOGLE_CLOUD_PROJECT env var. A paid Code Assist "
+                "license is required for requests to succeed."
             )
     except Exception as exc:
         print(f"Failed to resolve Gemini credentials: {exc}")

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1037,7 +1037,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
-    ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (Code Assist OAuth flow)"),
+    ProviderEntry("google-gemini-cli", "Google Gemini (OAuth, paid Code Assist)",   "Google Gemini via OAuth + Code Assist (requires a paid Gemini Code Assist / Enterprise license; consumer tiers were sunset June 18 — use Google Antigravity instead)"),
     ProviderEntry("google-antigravity", "Google Antigravity (OAuth)", "Google Antigravity via OAuth + Code Assist (Gemini 3.5/3.1, Claude, GPT-OSS where entitled)"),
     ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (V3, R1, coder, direct API)"),
     ProviderEntry("xai",            "xAI",                      "xAI Grok (Direct API)"),

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -126,7 +126,7 @@ Good defaults:
 | **AWS Bedrock** | Claude, Nova, Llama, DeepSeek via native Converse API | IAM role or `aws configure` ([guide](../guides/aws-bedrock.md)) |
 | **Azure Foundry** | Azure AI Foundry-hosted models | Set `AZURE_FOUNDRY_API_KEY` + `AZURE_FOUNDRY_BASE_URL` |
 | **Google AI Studio** | Gemini models via direct API | Set `GOOGLE_API_KEY` / `GEMINI_API_KEY` |
-| **Google Gemini (OAuth)** | Gemini via the `google-gemini-cli` OAuth flow — no key needed | `hermes model` → Google Gemini (OAuth) |
+| **Google Gemini (OAuth, paid Code Assist)** | Gemini via the `google-gemini-cli` OAuth flow — requires a paid Code Assist license (consumer tiers sunset 2026-06-18; use Antigravity instead) | `hermes model` → Google Gemini (OAuth, paid Code Assist) |
 | **xAI** | Grok models via direct API | Set `XAI_API_KEY` |
 | **xAI Grok OAuth** | SuperGrok / Premium+ subscription, no API key needed | `hermes model` → xAI Grok OAuth |
 | **NovitaAI** | Multi-model API gateway | Set `NOVITA_API_KEY` |

--- a/website/docs/guides/google-gemini.md
+++ b/website/docs/guides/google-gemini.md
@@ -106,10 +106,20 @@ Hermes also has a `google-gemini-cli` provider:
 
 ```bash
 hermes model
-# → Choose "Google Gemini (OAuth)"
+# → Choose "Google Gemini (OAuth, paid Code Assist)"
 ```
 
-This uses browser PKCE login and the Cloud Code Assist backend. It can be useful for users who want Gemini CLI-style OAuth, but Hermes shows an explicit warning because Google may treat use of the Gemini CLI OAuth client from third-party software as a policy violation. For production or lowest-risk usage, prefer the API-key provider above.
+This uses browser PKCE login and the Cloud Code Assist backend.
+
+:::warning Paid Code Assist only
+Google sunset the **consumer** (free / Google One / Gemini AI Pro) Code Assist
+endpoint on 2026-06-18, so `google-gemini-cli` now works only with a paid
+**Gemini Code Assist / Enterprise** license. Consumer users should pick the
+**`google-antigravity`** provider instead. Hermes also shows a policy warning
+because Google may treat use of the Gemini CLI OAuth client from third-party
+software as a policy violation. For production or lowest-risk usage, prefer the
+API-key provider above.
+:::
 
 Hermes also supports `google-antigravity` for Antigravity Code Assist:
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -40,7 +40,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **DeepSeek** | `DEEPSEEK_API_KEY` in `~/.hermes/.env` (provider: `deepseek`) |
 | **Hugging Face** | `HF_TOKEN` in `~/.hermes/.env` (provider: `huggingface`, aliases: `hf`) |
 | **Google / Gemini** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) in `~/.hermes/.env` (provider: `gemini`) |
-| **Google Gemini (OAuth)** | `hermes model` → "Google Gemini (OAuth)" (provider: `google-gemini-cli`, free tier supported, browser PKCE login) |
+| **Google Gemini (OAuth, paid Code Assist)** | `hermes model` → "Google Gemini (OAuth, paid Code Assist)" (provider: `google-gemini-cli`; requires a paid Code Assist / Enterprise license — consumer tiers were sunset 2026-06-18, use **Google Antigravity (OAuth)** instead, browser PKCE login) |
 | **OpenAI API (direct)** | `OPENAI_API_KEY` in `~/.hermes/.env` (provider: `openai-api`, optional `OPENAI_BASE_URL`) |
 | **Azure AI Foundry** | `hermes model` → "Azure AI Foundry" (provider: `azure-foundry`; uses Azure OpenAI / Foundry endpoint and key) |
 | **AWS Bedrock** | `hermes model` → "AWS Bedrock" (provider: `bedrock`; standard AWS credentials chain via boto3) |
@@ -594,19 +594,28 @@ The base URL can be overridden with `HF_BASE_URL`.
 
 ### Google Gemini via OAuth (`google-gemini-cli`)
 
+:::warning Consumer tiers sunset (2026-06-18)
+Google shut down the **consumer** (free / Google One / Gemini AI Pro) Code
+Assist endpoint on June 18, 2026. The `google-gemini-cli` provider now works
+**only** for accounts with a paid **Gemini Code Assist / Enterprise** license.
+If you're on a consumer plan, use the **`google-antigravity`** provider
+instead — it's Google's consumer successor and reuses the same Code Assist
+backend with the Antigravity OAuth client.
+:::
+
 The `google-gemini-cli` provider uses Google's Cloud Code Assist backend — the
-same API that Google's own `gemini-cli` tool uses. This supports both the
-**free tier** (generous daily quota for personal accounts) and **paid tiers**
-(Standard/Enterprise via a GCP project).
+same API that Google's own `gemini-cli` tool used. Since the consumer sunset it
+requires a **paid** Gemini Code Assist / Enterprise license attached to a GCP
+project.
 
 **Quick start:**
 
 ```bash
 hermes model
-# → pick "Google Gemini (OAuth)"
-# → see policy warning, confirm
+# → pick "Google Gemini (OAuth, paid Code Assist)"
+# → see paid-tier + policy warnings, confirm
 # → browser opens to accounts.google.com, sign in
-# → done — Hermes auto-provisions your free tier on first request
+# → set HERMES_GEMINI_PROJECT_ID / GOOGLE_CLOUD_PROJECT to your licensed project
 ```
 
 Hermes ships Google's **public** `gemini-cli` desktop OAuth client by default —
@@ -635,11 +644,11 @@ need to install `gemini-cli` or register your own GCP OAuth client.
 
 | Your situation | What to do |
 |---|---|
-| Personal Google account, want free tier | Nothing — sign in, start chatting |
-| Workspace / Standard / Enterprise account | Set `HERMES_GEMINI_PROJECT_ID` or `GOOGLE_CLOUD_PROJECT` to your GCP project ID |
+| Consumer plan (free / Google One / Gemini AI Pro) | Not supported here since 2026-06-18 — use the `google-antigravity` provider instead |
+| Workspace / Standard / Enterprise account with a paid Code Assist license | Set `HERMES_GEMINI_PROJECT_ID` or `GOOGLE_CLOUD_PROJECT` to your licensed GCP project ID |
 | VPC-SC-protected org | Hermes detects `SECURITY_POLICY_VIOLATED` and forces `standard-tier` automatically |
 
-Free tier auto-provisions a Google-managed project on first use. No GCP setup required.
+A paid Code Assist / Enterprise license on the configured GCP project is required — there is no longer a free tier to auto-provision.
 
 **Quota monitoring:**
 


### PR DESCRIPTION
## Summary
Labels the `google-gemini-cli` OAuth provider as **paid Code Assist only** across every user-facing surface, after Google sunset the consumer (free / Google One / Gemini AI Pro) Code Assist endpoint on 2026-06-18. Labeling-only change — no code path removed; the provider still works for paid / Enterprise license holders.

Previously the model picker, setup flow, config prompt, and docs all advertised "free tier supported" / "auto-provisioned on first request", which is misleading now that consumer access is gone.

## Changes
- `hermes_cli/models.py` — picker label `Google Gemini (OAuth)` → `Google Gemini (OAuth, paid Code Assist)`; description states the paid-license requirement and points consumers to `google-antigravity`.
- `hermes_cli/model_setup_flows.py` — setup flow leads with a paid-tier + sunset warning and the Antigravity pointer; the "free tier auto-provisioned" line replaced with a paid-license note.
- `hermes_cli/config.py` — `HERMES_GEMINI_PROJECT_ID` description/prompt no longer mention a free tier.
- Docs (`integrations/providers.md`, `guides/google-gemini.md`, `getting-started/quickstart.md`) — sunset admonition, corrected tiers table, updated labels.

## Validation
| Check | Result |
|---|---|
| `test_gemini_provider`, `test_provider_catalog`, `test_config`, `test_provider_parity` | 162 pass |
| Picker label renders the new paid-tier string (verified via real import) | pass |

`google-antigravity` (added in #50454) is the consumer successor; this PR just makes the gemini-cli path's paid requirement explicit.

## Infographic

![gemini-cli-paid-tier](https://v3b.fal.media/files/b/0a9f3fc3/pSm-g7FRokqfnn657ZCFn_20o0gqDK.png)
