### PR TITLE
docs(agents): fix stale platform adapter path in token-lock note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1175,7 +1175,7 @@ automatically scope to the active profile.
    a unique credential (bot token, API key), call `acquire_scoped_lock()` from
    `gateway.status` in the `connect()`/`start()` method and `release_scoped_lock()` in
    `disconnect()`/`stop()`. This prevents two profiles from using the same credential.
-   See `gateway/platforms/telegram.py` for the canonical pattern.
+   See `plugins/platforms/irc/adapter.py` for the canonical pattern.
 
 6. **Profile operations are HOME-anchored, not HERMES_HOME-anchored** — `_get_profiles_root()`
    returns `Path.home() / ".hermes" / "profiles"`, NOT `get_hermes_home() / "profiles"`.


### PR DESCRIPTION
The token-lock note in `AGENTS.md` referenced a stale adapter path:

`gateway/platforms/telegram.py`

That file no longer exists. Platform adapters now live under:

`plugins/platforms/<name>/adapter.py`

The Telegram adapter also no longer demonstrates the scoped-lock pattern described in this note.

This PR updates the reference to:

`plugins/platforms/irc/adapter.py`

The IRC adapter shows the canonical pattern by acquiring the scoped lock in `connect()` and releasing it in `disconnect()`. It is also already referenced as a canonical example in `ADDING_A_PLATFORM.md`.

Documentation-only change:

* one file changed
* one line updated
* no runtime behavior changes
* no config behavior changes
