### PR TITLE
fix: prevent orphaned tool_calls on keyboard interrupt (HTTP 400 on DeepSeek/Anthropic)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1250,6 +1250,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 )
                 _spinner_result = function_result
             except KeyboardInterrupt:
+                # Record the interrupted tool result before re-raising, so the
+                # conversation history doesn't get an orphaned tool_call with
+                # no matching tool_result (which causes HTTP 400 from strict
+                # providers like DeepSeek and Anthropic).
+                messages.append(make_tool_result_message(
+                    function_name,
+                    f"[Tool execution interrupted — {function_name} was cancelled by keyboard interrupt]",
+                    getattr(tool_call, "id", "") or "",
+                ))
                 function_result = _emit_cancelled_terminal_post_tool_call(
                     agent,
                     function_name=function_name,
@@ -1291,6 +1300,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     tool_request_middleware_trace=list(middleware_trace),
                 )
             except KeyboardInterrupt:
+                # Record the interrupted tool result before re-raising, so the
+                # conversation history doesn't get an orphaned tool_call with
+                # no matching tool_result (which causes HTTP 400 from strict
+                # providers like DeepSeek and Anthropic).
+                messages.append(make_tool_result_message(
+                    function_name,
+                    f"[Tool execution interrupted — {function_name} was cancelled by keyboard interrupt]",
+                    getattr(tool_call, "id", "") or "",
+                ))
                 _emit_cancelled_terminal_post_tool_call(
                     agent,
                     function_name=function_name,


### PR DESCRIPTION
## Summary

When a tool execution is interrupted via **KeyboardInterrupt** (Ctrl+C), the assistant message with `tool_calls` is already in the conversation history but has no matching `tool_result`. Strict providers like **DeepSeek** and **Anthropic** enforce `tool_call`/`tool_result` pairing — an orphaned `tool_call` causes **HTTP 400** on the next API request.

This fix inserts a synthetic `tool_result` message in both `except KeyboardInterrupt` handlers in `execute_tool_calls_sequential()` before re-raising, ensuring the conversation history remains consistent.

## Background

This is a well-documented constraint:

- **DeepSeek API docs**: Every `tool_call` must be followed by a `tool` message with the matching `tool_call_id` ([api-docs.deepseek.com/guides/tool_calls](https://api-docs.deepseek.com/guides/tool_calls))
- **Anthropic**: "Each `tool_result` block must have a corresponding `tool_use` block in the previous message" — HTTP 400 if violated ([claude-code issue #15205](https://github.com/anthropics/claude-code/issues/15205))
- **Portkey.ai**: "An assistant message with `tool_calls` must be followed by tool messages responding to each `tool_call_id`" ([docs](https://portkey.ai/error-library/tool-call-response-error-10067))
- **OpenClaw**: 6+ open issues on the same problem (#7527, #7329, #6788, #3860, #8536, #10932)

## Changes

`agent/tool_executor.py` — 2 blocks, +18 lines total

## Testing

```
$ pytest tests/run_agent/test_agent_guardrails.py -x -q
35 passed in 4.80s ✅
```