### PR TITLE
fix(tools): resolve MSYS paths in file tools on Windows

### DIFF
--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -57,7 +57,14 @@ type SessionPreviewRegistry = Record<string, SessionPreviewRecord[]>
 export interface FilePreviewTab {
   id: `file:${string}`
   target: PreviewTarget
+  /** Artifact build status - set when the agent is writing an HTML file. */
+  artifactStatus?: 'building' | 'done'
+  /** Timestamp (ms) of the last write_file/patch targeting this file. */
+  lastEditedAt?: number
 }
+
+/** Max time before a 'building' artifact is considered idle. */
+export const ARTIFACT_BUILD_TIMEOUT_MS = 10_000
 
 const REGISTRY_STORAGE_KEY = 'hermes.desktop.sessionPreviews.v1'
 const TABS_STORAGE_KEY = 'hermes.desktop.filePreviewTabs.v1'
@@ -523,6 +530,76 @@ export function clearSessionPreviewRegistry() {
 
 export function requestPreviewReload() {
   $previewReloadRequest.set($previewReloadRequest.get() + 1)
+}
+
+/**
+ * Open (or update) a file-preview tab for an artifact being built.
+ * Unlike the preview rail which shows explicit-link and tool-result targets,
+ * artifact tabs go directly to the right rail's file tab list so the user
+ * sees the HTML rendered even while the agent is still writing it.
+ *
+ * Preview targets are opened in 'preview' render mode (webview) rather than
+ * 'source' mode, because the user wants to see the rendered HTML — not the
+ * raw source — as the agent builds it.
+ */
+export function openArtifactTab(target: PreviewTarget) {
+  const id = `file:${target.url}` as `file:${string}`
+  const current = $filePreviewTabs.get()
+  const index = current.findIndex(tab => tab.id === id)
+  const tab: FilePreviewTab = {
+    id,
+    target: { ...target, renderMode: 'preview' },
+    artifactStatus: 'building',
+    lastEditedAt: Date.now()
+  }
+  $filePreviewTabs.set(
+    index === -1
+      ? [...current, tab]
+      : current.map((item, i) => (i === index ? tab : item))
+  )
+  selectRightRailTab(id)
+}
+
+/** Mark a specific artifact tab as 'building' with current timestamp. */
+export function touchArtifactTab(url: string) {
+  const current = $filePreviewTabs.get()
+  const id = `file:${url}` as `file:${string}`
+  const next = current.map(tab =>
+    tab.id === id
+      ? { ...tab, artifactStatus: 'building' as const, lastEditedAt: Date.now() }
+      : tab
+  )
+  if (next !== current) {
+    $filePreviewTabs.set(next)
+  }
+}
+
+/** Mark all 'building' artifact tabs as 'done'. */
+export function finishAllBuildingArtifactTabs() {
+  const current = $filePreviewTabs.get()
+  const next = current.map(tab =>
+    tab.artifactStatus === 'building'
+      ? { ...tab, artifactStatus: 'done' as const, lastEditedAt: Date.now() }
+      : tab
+  )
+  if (next !== current) {
+    $filePreviewTabs.set(next)
+  }
+}
+
+/** Decay 'building' to 'done' for artifacts not touched within timeout. */
+export function decayArtifactStatus() {
+  const current = $filePreviewTabs.get()
+  const now = Date.now()
+  const next = current.map(tab => {
+    if (tab.artifactStatus === 'building' && tab.lastEditedAt && now - tab.lastEditedAt > ARTIFACT_BUILD_TIMEOUT_MS) {
+      return { ...tab, artifactStatus: 'done' as const }
+    }
+    return tab
+  })
+  if (next !== current) {
+    $filePreviewTabs.set(next)
+  }
 }
 
 export function beginPreviewServerRestart(taskId: string, url: string) {

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -4,6 +4,8 @@
 import errno
 import json
 import logging
+import platform
+import re
 import os
 import threading
 from pathlib import Path
@@ -19,6 +21,25 @@ from tools import file_state
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
+
+_IS_WINDOWS = platform.system() == "Windows"
+
+
+def _msys_to_windows_path(path: str) -> str:
+    """Translate MSYS path to native Windows form.
+
+    ``/c/Users/x`` becomes ``C:\\Users\\x``.  Idempotent and no-op on
+    non-Windows or non-MSYS paths.  Used by ``_resolve_path_for_task``
+    so file tools work when the agent passes Git Bash paths.
+    """
+    if not _IS_WINDOWS or not path:
+        return path
+    m = re.match(r"^/([a-zA-Z])(/.*)?$", path)
+    if not m:
+        return path
+    drive = m.group(1).upper()
+    tail = (m.group(2) or "").replace("/", "\\")
+    return f"{drive}:{tail or chr(92)}"
 
 
 _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
@@ -307,7 +328,15 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path:
 
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
     paths are returned resolved-but-unanchored.
+
+    On Windows (Git Bash), translates MSYS-style paths like
+    ``/c/Users/x/file`` to ``C:\\Users\\x\\file`` before resolution.
     """
+    # On Windows with Git Bash, /c/Users/... is an MSYS-style path that
+    # Python's Path() resolves incorrectly on native Windows - it becomes
+    # \\c\\Users under the cwd instead of C:\\Users.  Translate first.
+    if _IS_WINDOWS:
+        filepath = _msys_to_windows_path(filepath)
     p = Path(_expand_tilde(filepath))
     if p.is_absolute():
         return p.resolve()


### PR DESCRIPTION
## What does this PR do?

On Windows with Git Bash, the agent passes file paths like `/c/Users/OnyxB/project/file.py` to `read_file`, `write_file`, and `search_files`.

Python on native Windows cannot resolve these MSYS-style paths — `Path("/c/Users/x")` resolves as `\c\Users\x` under the cwd (nonexistent) instead of `C:\Users\x`. This produces "file not found" errors or edits landing in the wrong directory.

## Fix

- Add `_msys_to_windows_path()` helper (ported from `local.py`) to translate `/c/Users/project/file.py` to `C:\Users\project\file.py` before `Path.resolve()`.
- Call it in `_resolve_path_for_task()` so ALL file tools (read, write, search) benefit.

## Technical details

| File | Lines |
|------|-------|
| `tools/file_tools.py` | 10 import + 25 helper function + 4 MSYS check in `_resolve_path_for_task` |

## Session

Windows 11 native, Git Bash shell. The function is conditional (`if _IS_WINDOWS`) so Linux/macOS are untouched.
