### PR TITLE
fix(compressor): remove logging.basicConfig from library class __init__

### DIFF
--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -352,11 +352,6 @@ class TrajectoryCompressor:
         # Initialize OpenRouter client
         self._init_summarizer()
         
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
     
     def _init_tokenizer(self):


### PR DESCRIPTION
## Summary

Remove `logging.basicConfig()` call from `TrajectoryCompressor.__init__()`.

**Problem**: `logging.basicConfig()` in library code overrides the root logger configuration every time the class is instantiated. This causes:
- Inconsistent log formatting when the compressor is used alongside other logging config in the gateway
- The compressor's format string (`%(asctime)s - %(levelname)s - %(message)s`) replaces whatever the application had configured
- `basicConfig()` is a no-op after the first call, but the first call may come from the compressor before the app configures logging

**Fix**: Remove the `logging.basicConfig()` call. Library code should use `logging.getLogger(__name__)` and let the application entry point configure the root logger.

## Changes
- `trajectory_compressor.py`: Remove 5 lines (`logging.basicConfig(...)` block)

## Test plan
- [ ] Verify `TrajectoryCompressor` still logs correctly when root logger is configured by the application
- [ ] No import errors
- [ ] CI passes