### PR TITLE
feat(agent): add model.preload eager/lazy toggle for local model loading

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1486,9 +1486,22 @@ def init_agent(
     # AFTER the custom_providers branch so per-model overrides aren't lost.
     agent._config_context_length = _config_context_length
 
+    # ``model.preload`` selects eager vs lazy loading for local models:
+    #   true  (default): eagerly preload the model — here on build, and on
+    #          switch — with at least Hermes' minimum context. The original
+    #          LM Studio behavior; keeps the model ready and context probing
+    #          accurate.
+    #   false (lazy): never preload; the model loads on the first real request
+    #          via the server's native JIT. Opening or switching a session
+    #          never spins one up — practical for single-GPU, multi-model setups.
+    # The gate lives in _ensure_lmstudio_runtime_loaded, so the call below is a
+    # no-op in lazy mode.
+    agent._model_preload = (
+        bool(_model_cfg.get("preload", True))
+        if isinstance(_model_cfg, dict)
+        else True
+    )
     agent._ensure_lmstudio_runtime_loaded(_config_context_length)
-
-
 
     # Select context engine: config-driven (like memory providers).
     # 1. Check config.yaml context.engine setting

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1619,6 +1619,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     )
 
     # ── LM Studio: preload before probing context length ──
+    # Eager mode only — honors model.preload (a no-op in lazy mode), so
+    # switching a session's model never spins it up until it's actually used.
     agent._ensure_lmstudio_runtime_loaded()
 
     # ── Update context compressor ──

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -221,7 +221,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   // Persist a single agent.* default by round-tripping the whole config record
   // (PUT /api/config replaces it) — optimistic, with rollback on failure.
   const writeAgentDefault = useCallback(
-    async (key: string, value: string) => {
+    async (key: string, value: boolean | string) => {
       if (!config) {
         return
       }
@@ -523,6 +523,23 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
               </label>
             )}
           </div>
+        )}
+        {config && (
+          <label className="mt-3 flex items-start gap-2 text-xs">
+            <span className="shrink-0">Preload model</span>
+            <Switch
+              checked={getNested(config, 'model_preload') !== false}
+              onCheckedChange={checked => void writeAgentDefault('model_preload', checked)}
+              size="xs"
+            />
+            <span className="text-muted-foreground">
+              Eager vs lazy local-model loading. On (default): preload the model up front —
+              when you open it or switch to it — with Hermes’ minimum context. Off (lazy):
+              never preload; it loads on your first message via the server’s own JIT/Auto-Evict,
+              so opening or switching a session never spins it up. Turn off if you run several
+              local models on one GPU.
+            </span>
+          </label>
         )}
         {error && <div className="mt-2 text-xs text-destructive">{error}</div>}
         {switchStaleAux.length > 0 && (

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -72,6 +72,24 @@ model:
   #
 # max_tokens: 8192
 
+  # ── Local model loading (LM Studio / Ollama / vLLM / llama.cpp) ────────────
+  #
+  # preload: eager vs lazy loading of local models (LM Studio / Ollama / vLLM).
+  #   Default: true (eager — the original behavior).
+  #   - true  (eager): Hermes preloads the model (with at least its minimum
+  #            context) as soon as you open or switch to it, so it's ready and
+  #            context-length probing is accurate.
+  #   - false (lazy):  Hermes never preloads; the model loads on your first
+  #            message via the server's own JIT/auto-evict. Opening or switching
+  #            a session never spins up a model. Recommended if you run several
+  #            local models but can hold only one in VRAM at a time. With LM
+  #            Studio, enable JIT loading + "Auto-Evict" so models swap cleanly.
+  #            Note: in lazy mode LM Studio uses each model's saved context
+  #            window — set that per-model, or set context_length above, if the
+  #            default is too small.
+  #
+  # preload: false
+
   # ── Custom request headers (optional) ─────────────────────────────────────
   #
   # default_headers: extra HTTP headers sent on every request to an

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -475,6 +475,17 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Context window override (0 = auto-detect from model metadata)",
         "category": "general",
     },
+    "model_preload": {
+        "type": "boolean",
+        "description": (
+            "Eager vs lazy loading for local models (LM Studio / Ollama / vLLM). "
+            "On (default): preload the model up front when you open or switch to "
+            "it. Off (lazy): never preload — it loads on your first message via "
+            "the server's native JIT/Auto-Evict, so opening or switching a session "
+            "never spins it up. Turn off if you run several local models on one GPU."
+        ),
+        "category": "general",
+    },
     "terminal.backend": {
         "type": "select",
         "description": "Terminal execution backend",
@@ -663,11 +674,13 @@ CONFIG_SCHEMA = _build_schema_from_config(DEFAULT_CONFIG)
 # by the normalize/denormalize cycle.  Insert model_context_length right after
 # the "model" key so it renders adjacent in the frontend.
 _mcl_entry = _SCHEMA_OVERRIDES["model_context_length"]
+_preload_entry = _SCHEMA_OVERRIDES["model_preload"]
 _ordered_schema: Dict[str, Dict[str, Any]] = {}
 for _k, _v in CONFIG_SCHEMA.items():
     _ordered_schema[_k] = _v
     if _k == "model":
         _ordered_schema["model_context_length"] = _mcl_entry
+        _ordered_schema["model_preload"] = _preload_entry
 CONFIG_SCHEMA = _ordered_schema
 
 
@@ -3268,8 +3281,10 @@ def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
         ctx_len = model_val.get("context_length", 0)
         config["model"] = model_val.get("default", model_val.get("name", ""))
         config["model_context_length"] = ctx_len if isinstance(ctx_len, int) else 0
+        config["model_preload"] = bool(model_val.get("preload", True))
     else:
         config["model_context_length"] = 0
+        config["model_preload"] = True
     return config
 
 
@@ -3977,6 +3992,10 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
         except (TypeError, ValueError):
             ctx_override = 0
 
+    # Extract model_preload (default True). Only persisted when disabled, so a
+    # default config stays clean and ``model`` can remain a bare string.
+    preload_val = bool(config.pop("model_preload", True))
+
     model_val = config.get("model")
     if isinstance(model_val, str) and model_val:
         # Read the current disk config to recover model subkeys
@@ -3991,14 +4010,21 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
                     disk_model["context_length"] = ctx_override
                 else:
                     disk_model.pop("context_length", None)
+                # preload defaults to True — only write the key when disabled
+                if preload_val:
+                    disk_model.pop("preload", None)
+                else:
+                    disk_model["preload"] = False
                 config["model"] = disk_model
-            # Model was previously a bare string — upgrade to dict if
-            # user is setting a context_length override
-            elif ctx_override > 0:
-                config["model"] = {
-                    "default": model_val,
-                    "context_length": ctx_override,
-                }
+            # Model was previously a bare string — upgrade to dict if the user
+            # set a context_length override or disabled preload
+            elif ctx_override > 0 or not preload_val:
+                new_model: Dict[str, Any] = {"default": model_val}
+                if ctx_override > 0:
+                    new_model["context_length"] = ctx_override
+                if not preload_val:
+                    new_model["preload"] = False
+                config["model"] = new_model
         except Exception:
             pass  # can't read disk config — just use the string form
     return config

--- a/run_agent.py
+++ b/run_agent.py
@@ -669,7 +669,15 @@ class AIAgent:
     def _ensure_lmstudio_runtime_loaded(self, config_context_length: Optional[int] = None) -> None:
         """
         Preload the LM Studio model with at least Hermes' minimum context.
+
+        Eager/lazy is controlled by ``model.preload`` (default eager). In lazy
+        mode (``preload: false``) this is a no-op everywhere, so the model is
+        never preloaded — it loads on the first real request via the server's
+        native JIT. In eager mode it runs on agent build, model switch, and
+        before the first request.
         """
+        if not getattr(self, "_model_preload", True):
+            return
         if (self.provider or "").strip().lower() != "lmstudio":
             return
         try:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3950,6 +3950,81 @@ class TestModelContextLengthSchema:
         assert "category" in entry
 
 
+class TestModelPreloadConfig:
+    """Tests for model.preload <-> model_preload (normalize/denormalize + schema).
+
+    Mirrors the model_context_length virtual field: surfaced to the web UI as a
+    top-level boolean and round-tripped into the model dict on save.
+    """
+
+    def test_normalize_surfaces_preload_false(self):
+        from hermes_cli.web_server import _normalize_config_for_web
+
+        cfg = {"model": {"default": "local/test-model", "provider": "lmstudio", "preload": False}}
+        result = _normalize_config_for_web(cfg)
+        assert result["model"] == "local/test-model"
+        assert result["model_preload"] is False
+
+    def test_normalize_defaults_preload_true(self):
+        from hermes_cli.web_server import _normalize_config_for_web
+
+        # dict without a preload key
+        assert _normalize_config_for_web(
+            {"model": {"default": "local/test-model"}}
+        )["model_preload"] is True
+        # bare string model
+        assert _normalize_config_for_web({"model": "local/test-model"})["model_preload"] is True
+
+    def test_denormalize_writes_preload_false_preserving_subkeys(self):
+        from hermes_cli.web_server import _denormalize_config_from_web
+        from hermes_cli.config import save_config
+
+        save_config({"model": {"default": "local/test-model", "provider": "lmstudio", "base_url": ""}})
+        result = _denormalize_config_from_web({
+            "model": "local/test-model",
+            "model_preload": False,
+            "model_context_length": 0,
+        })
+        assert isinstance(result["model"], dict)
+        assert result["model"]["preload"] is False
+        assert result["model"]["provider"] == "lmstudio"  # subkeys preserved
+        assert "model_preload" not in result  # virtual field removed
+
+    def test_denormalize_true_omits_preload_key(self):
+        from hermes_cli.web_server import _denormalize_config_from_web
+        from hermes_cli.config import save_config
+
+        save_config({"model": {"default": "local/test-model", "provider": "lmstudio", "preload": False}})
+        result = _denormalize_config_from_web({
+            "model": "local/test-model",
+            "model_preload": True,
+            "model_context_length": 0,
+        })
+        assert isinstance(result["model"], dict)
+        assert "preload" not in result["model"]  # default true -> key omitted
+
+    def test_denormalize_upgrades_bare_string_when_preload_disabled(self):
+        from hermes_cli.web_server import _denormalize_config_from_web
+        from hermes_cli.config import save_config
+
+        save_config({"model": "local/test-model"})
+        result = _denormalize_config_from_web({
+            "model": "local/test-model",
+            "model_preload": False,
+            "model_context_length": 0,
+        })
+        assert isinstance(result["model"], dict)
+        assert result["model"]["preload"] is False
+
+    def test_schema_has_model_preload_boolean_after_context_length(self):
+        from hermes_cli.web_server import CONFIG_SCHEMA
+
+        assert CONFIG_SCHEMA["model_preload"]["type"] == "boolean"
+        keys = list(CONFIG_SCHEMA.keys())
+        # order: model -> model_context_length -> model_preload
+        assert keys[keys.index("model") + 2] == "model_preload"
+
+
 class TestModelInfoEndpoint:
     """Tests for GET /api/model/info endpoint."""
 

--- a/tests/run_agent/test_lmstudio_preload.py
+++ b/tests/run_agent/test_lmstudio_preload.py
@@ -1,0 +1,143 @@
+"""Tests for local-model preload gating (``model.preload``).
+
+Opening or switching a session must never force-load a model on a local
+server (it would evict / OOM the model another session is using). Loading is
+lazy — it happens only on a real request — and can be disabled entirely with
+``model.preload: false`` so the server's own JIT/lazy loading manages the model.
+
+The OpenAI client and tool loading are mocked so no network calls are made.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names):
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _build_agent(model_cfg):
+    """Construct an AIAgent with a patched config ``model`` section."""
+    cfg = {"agent": {}, "model": model_cfg}
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("terminal"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value=cfg),
+    ):
+        a = AIAgent(
+            model="openai/gpt-4o-mini",
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        return a
+
+
+def _fake_agent(provider="lmstudio", preload=True, **overrides):
+    """Minimal object exposing only what _ensure_lmstudio_runtime_loaded reads."""
+    base = dict(
+        provider=provider,
+        _model_preload=preload,
+        model="local/test-model",
+        base_url="http://127.0.0.1:1234/v1",
+        api_key="",
+        _config_context_length=None,
+        context_compressor=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# ── Agent build / config parsing ──────────────────────────────────────────
+
+
+def test_build_invokes_preload_hook():
+    """Eager mode (default): agent build invokes the preload hook.
+
+    The hook itself is a no-op off-provider or in lazy mode (see the gating
+    tests below); this just asserts the eager call site is wired on build.
+    """
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("terminal"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value={"agent": {}, "model": {}}),
+        patch.object(AIAgent, "_ensure_lmstudio_runtime_loaded") as spy,
+    ):
+        AIAgent(
+            model="openai/gpt-4o-mini",
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        spy.assert_called()
+
+
+def test_model_preload_defaults_true():
+    agent = _build_agent(model_cfg={})
+    assert agent._model_preload is True
+
+
+def test_model_preload_reads_false_from_config():
+    agent = _build_agent(model_cfg={"preload": False})
+    assert agent._model_preload is False
+
+
+# ── Lazy load gating (the chat-completion path) ───────────────────────────
+
+
+def test_preload_disabled_skips_load():
+    with patch("hermes_cli.models.ensure_lmstudio_model_loaded") as load:
+        AIAgent._ensure_lmstudio_runtime_loaded(_fake_agent(preload=False))
+        load.assert_not_called()
+
+
+def test_preload_enabled_loads_lmstudio():
+    with patch(
+        "hermes_cli.models.ensure_lmstudio_model_loaded", return_value=64000
+    ) as load:
+        AIAgent._ensure_lmstudio_runtime_loaded(_fake_agent(preload=True))
+        load.assert_called_once()
+
+
+def test_non_lmstudio_provider_never_loads():
+    with patch("hermes_cli.models.ensure_lmstudio_model_loaded") as load:
+        AIAgent._ensure_lmstudio_runtime_loaded(
+            _fake_agent(provider="openai", preload=True)
+        )
+        load.assert_not_called()
+
+
+def test_missing_flag_defaults_to_load():
+    """Agents predating the flag (no _model_preload attribute) still load."""
+    fake = _fake_agent(preload=True)
+    del fake._model_preload
+    with patch(
+        "hermes_cli.models.ensure_lmstudio_model_loaded", return_value=64000
+    ) as load:
+        AIAgent._ensure_lmstudio_runtime_loaded(fake)
+        load.assert_called_once()

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -897,7 +897,16 @@ hermes model
 # If LM Studio server auth is enabled, enter LM_API_KEY when prompted
 ```
 
-Hermes will automatically load a LM Studio model with 64K context length
+By default (`model.preload: true`, eager) Hermes preloads the LM Studio model
+with at least 64K context as soon as you select or switch to it.
+
+**Running several local models, one at a time?** If you can hold only one model
+in VRAM, set `model.preload: false` (lazy) in your config. Hermes then never
+preloads — the model loads on your first message via LM Studio's own JIT loading
+plus "Auto-Evict", so opening or switching a session never spins one up, and
+models swap cleanly. In lazy mode LM Studio uses each model's saved context
+window, so set that per-model (below) or set `model.context_length` if the
+default is too small.
 
 To change context length in LM Studio:
 


### PR DESCRIPTION
## What & why

Local-model loading on the LM Studio path uses the explicit load API (`POST /api/v1/models/load`) to preload the model with Hermes' minimum context (≥64K), and it's wired to fire **eagerly** — on agent build and on model switch — via `AIAgent._ensure_lmstudio_runtime_loaded()`. That's intentional (it ensures an adequate context window and accurate context probing), but it has an unintended consequence for single-GPU users: opening a *past* session that used a *different* local model force-loads that model just to review it — OOM-ing the server, or (with LM Studio Auto-Evict) evicting the model the active session is using.

## Change

Add a **`model.preload`** flag (boolean, **default `true`** — existing behavior) that selects eager vs lazy local-model loading:

- **`true` (eager, default):** preload on build/switch with ≥64K context — unchanged from today.
- **`false` (lazy):** never preload; the model loads on the first real request via the server's native JIT/Auto-Evict, so opening or switching a session never spins one up. Practical when you run several local models but can hold only one in VRAM.

The gate lives in `_ensure_lmstudio_runtime_loaded`, so all three call sites (build, switch, first request) are no-ops in lazy mode. **Default behavior is unchanged** — this is purely additive/opt-in.

Surfaced as a toggle in both UIs:
- **Dashboard → Config** — a top-level `model_preload` schema field (mirrors the existing `model_context_length` virtual field; normalize/denormalize round-trips it into `model.preload`).
- **Desktop → Settings → Model** — a "Preload model" switch.

Server-agnostic in effect: other backends are already lazy (Ollama loads via inference; vLLM/SGLang serve one fixed model), so this only adds an explicit eager/lazy choice on the LM Studio path plus a uniform opt-out.

## How to test

Unit tests:
- `pytest tests/run_agent/test_lmstudio_preload.py` — eager build wires the preload hook; the hook no-ops when `preload` is false or the provider isn't LM Studio; flag parsing + default-true back-compat.
- `pytest tests/hermes_cli/test_web_server.py -k "ModelPreload or ModelContextLength"` — `model_preload` normalize/denormalize round-trip + schema placement.

Manual (LM Studio, two models, only one fits in VRAM):
1. Load model A; start a session on it.
2. Open a past session that used model B.
   - `model.preload: true` (default): B is preloaded (existing behavior).
   - `model.preload: false`: opening B loads nothing; B loads via JIT only when you send your first message, and Auto-Evict swaps A out cleanly.

## Platforms tested

Windows (desktop app rebuilt + exercised manually). The change is HTTP/config/Python-level with no platform-specific code, so Linux/macOS/WSL2 should behave identically.

## Notes

- Default is eager, so existing setups are unaffected — lazy is opt-in.
- The eager loading was added intentionally in the LM Studio integration; this PR keeps it as the default and just makes it selectable.
