### PR TITLE
[codex] Fix macOS gateway fd exhaustion paths

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -49,6 +49,11 @@ from hermes_cli.colors import Colors, color
 
 logger = logging.getLogger(__name__)
 
+# Some macOS launchd sessions default user agents to only 256 open files.
+# Browser-heavy gateway jobs and long-polling platform adapters need more headroom.
+LAUNCHD_SOFT_MAX_FILES = 4096
+LAUNCHD_HARD_MAX_FILES = 8192
+
 # =============================================================================
 # Process Management (for manual gateway runs)
 # =============================================================================
@@ -3475,6 +3480,18 @@ def generate_launchd_plist() -> str:
     
     <key>KeepAlive</key>
     <true/>
+
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>{LAUNCHD_SOFT_MAX_FILES}</integer>
+    </dict>
+
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>{LAUNCHD_HARD_MAX_FILES}</integer>
+    </dict>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -13,6 +13,7 @@ import signal
 import subprocess
 import sys
 import textwrap
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -3801,9 +3802,29 @@ def _wait_for_gateway_exit(
     return True
 
 
+def _launchd_bootstrap_with_retry(domain: str, target: str, plist_path: Path) -> None:
+    """Bootstrap a launchd job, tolerating the short bootout unload race."""
+    attempts = 5
+    for attempt in range(attempts):
+        try:
+            subprocess.run(
+                ["launchctl", "bootstrap", domain, str(plist_path)],
+                check=True,
+                timeout=30,
+            )
+            return
+        except subprocess.CalledProcessError as exc:
+            if exc.returncode != 5 or attempt == attempts - 1:
+                raise
+            time.sleep(min(0.5 * (2 ** attempt), 2.0))
+            subprocess.run(["launchctl", "bootout", target], check=False, timeout=90)
+
+
 def launchd_restart():
     label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
+    domain = _launchd_domain()
+    target = f"{domain}/{label}"
+    plist_path = get_launchd_plist_path()
     drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 
@@ -3823,23 +3844,31 @@ def launchd_restart():
                     print(
                         f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
                     )
-        subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+        if not plist_path.exists() or not launchd_plist_is_current():
+            new_plist = generate_launchd_plist()
+            if _refuse_temp_home_service_write(new_plist, "launchd plist"):
+                return
+            plist_path.parent.mkdir(parents=True, exist_ok=True)
+            plist_path.write_text(new_plist, encoding="utf-8")
+            print("↻ Updated gateway launchd service definition before restart")
+
+        # bootout/bootstrap forces launchd to re-read runtime-only plist keys
+        # such as ResourceLimits; kickstart -k alone keeps the old definition.
+        subprocess.run(["launchctl", "bootout", target], check=False, timeout=90)
+        _launchd_bootstrap_with_retry(domain, target, plist_path)
+        subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:
         if not _launchd_error_indicates_unloaded(e):
-            # Not a "job unloaded" code. If the domain is fundamentally
-            # unmanageable (error 5), degrade to detached; the old process was
-            # already drained/terminated above. Otherwise re-raise.
             if _launchctl_domain_unsupported(e.returncode):
-                _launchd_fallback_to_detached(f"launchctl kickstart exit {e.returncode}")
+                _launchd_fallback_to_detached(f"launchctl exit {e.returncode}")
                 return
             raise
         # Job not loaded — bootstrap and start fresh
         print("↻ launchd job was unloaded; reloading")
-        plist_path = get_launchd_plist_path()
         try:
             subprocess.run(
-                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+                ["launchctl", "bootstrap", domain, str(plist_path)],
                 check=True,
                 timeout=30,
             )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -83,6 +83,7 @@ from gateway.platforms.base import (
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     utf16_len,
 )
+from gateway.platforms._http_client_limits import platform_httpx_limits
 from plugins.platforms.telegram.telegram_network import (
     TelegramFallbackTransport,
     discover_fallback_ips,
@@ -1495,48 +1496,51 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return False
 
-    async def _drain_polling_connections(self) -> None:
-        """Reset the httpx connection pool used for getUpdates polling.
+    async def _drain_request_connections(self, index: int, label: str) -> None:
+        """Reset one PTB httpx request pool by index.
 
         Network errors (especially through proxies like sing-box) can leave
         httpx connections in a half-closed state that still occupy pool slots.
         After enough reconnect cycles the pool fills up entirely, causing
         ``Pool timeout: All connections in the connection pool are occupied.``
 
-        We reset ONLY ``_request[0]`` (the getUpdates request) — the general
-        request (``_request[1]``) is left untouched so concurrent
-        ``send_message`` / ``edit_message`` calls are never interrupted.
-
         Implementation note: accesses ``Bot._request[0]`` which is the
         get-updates ``BaseRequest`` in the PTB 22.x internal tuple
         ``(get_updates_request, general_request)``.  There is no public
-        accessor for the polling request; review if upgrading to PTB 23+.
+        accessor for these request pools; review if upgrading to PTB 23+.
         """
         if not (self._app and self._app.bot):
             return
         try:
-            # PTB 22.x: _request is a (get_updates, general) tuple;
-            # no public accessor exists for the polling request.
-            polling_req = self._app.bot._request[0]  # noqa: SLF001
+            # PTB 22.x: _request is a (get_updates, general) tuple.
+            request = self._app.bot._request[index]  # noqa: SLF001
         except Exception:
             return
         try:
-            await polling_req.shutdown()
+            await request.shutdown()
         except Exception:
             logger.debug(
-                "[%s] Polling request shutdown failed (non-fatal)",
-                self.name, exc_info=True,
+                "[%s] %s request shutdown failed (non-fatal)",
+                self.name, label,
+                exc_info=True,
             )
         try:
-            await polling_req.initialize()
-            logger.debug(
-                "[%s] Polling request pool drained before reconnect", self.name
-            )
+            await request.initialize()
+            logger.debug("[%s] %s request pool drained", self.name, label)
         except Exception:
             logger.debug(
-                "[%s] Polling request re-initialize failed (non-fatal)",
-                self.name, exc_info=True,
+                "[%s] %s request re-initialize failed (non-fatal)",
+                self.name, label,
+                exc_info=True,
             )
+
+    async def _drain_polling_connections(self) -> None:
+        """Reset the httpx connection pool used for getUpdates polling."""
+        await self._drain_request_connections(0, "Polling")
+
+    async def _drain_general_connections(self) -> None:
+        """Reset the httpx connection pool used for Bot API sends."""
+        await self._drain_request_connections(1, "General")
 
     async def _handle_polling_network_error(self, error: Exception) -> None:
         """Reconnect polling after a transient network interruption.
@@ -1596,6 +1600,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] Telegram polling resumed after network error (attempt %d)",
                 self.name, attempt,
             )
+            await self._drain_general_connections()
             self._polling_network_error_count = 0
             # start_polling() returning is necessary but not sufficient:
             # PTB's Updater can be left in a state where `running` is True
@@ -2154,12 +2159,24 @@ class TelegramAdapter(BasePlatformAdapter):
                     return default
 
             request_kwargs = {
-                "connection_pool_size": _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 512),
+                "connection_pool_size": _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 20),
                 "pool_timeout": _env_float("HERMES_TELEGRAM_HTTP_POOL_TIMEOUT", 8.0),
                 "connect_timeout": _env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
                 "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
             }
+            connection_pool_size = request_kwargs["connection_pool_size"]
+            httpx_kwargs = {}
+            httpx_limits = platform_httpx_limits()
+            if httpx_limits is not None:
+                max_keepalive = getattr(httpx_limits, "max_keepalive_connections", None)
+                if max_keepalive is not None:
+                    max_keepalive = min(max_keepalive, connection_pool_size)
+                httpx_kwargs["limits"] = type(httpx_limits)(
+                    max_connections=connection_pool_size,
+                    max_keepalive_connections=max_keepalive,
+                    keepalive_expiry=getattr(httpx_limits, "keepalive_expiry", None),
+                )
 
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in {"1", "true", "yes", "on"})
             fallback_ips = self._fallback_ips()
@@ -2183,21 +2200,38 @@ class TelegramAdapter(BasePlatformAdapter):
                 # polling reconnect + bot API bootstrap/delete_webhook calls.
                 request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+                    httpx_kwargs={
+                        **httpx_kwargs,
+                        "transport": TelegramFallbackTransport(fallback_ips),
+                    },
                 )
                 get_updates_request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+                    httpx_kwargs={
+                        **httpx_kwargs,
+                        "transport": TelegramFallbackTransport(fallback_ips),
+                    },
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
-                request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+                request = HTTPXRequest(
+                    **request_kwargs,
+                    proxy=proxy_url,
+                    httpx_kwargs=httpx_kwargs,
+                )
+                get_updates_request = HTTPXRequest(
+                    **request_kwargs,
+                    proxy=proxy_url,
+                    httpx_kwargs=httpx_kwargs,
+                )
             else:
                 if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
-                request = HTTPXRequest(**request_kwargs)
-                get_updates_request = HTTPXRequest(**request_kwargs)
+                request = HTTPXRequest(**request_kwargs, httpx_kwargs=httpx_kwargs)
+                get_updates_request = HTTPXRequest(
+                    **request_kwargs,
+                    httpx_kwargs=httpx_kwargs,
+                )
 
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
@@ -2709,6 +2743,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                             # Other BadRequest errors are permanent — don't retry
                             raise
+                        await self._drain_general_connections()
                         # TimedOut is also a subclass of NetworkError. A
                         # generic timeout may have reached Telegram, so don't
                         # retry; a wrapped ConnectTimeout means no connection

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2186,15 +2186,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
             }
             connection_pool_size = request_kwargs["connection_pool_size"]
+            max_keepalive_connections = min(
+                _env_int("HERMES_TELEGRAM_HTTP_MAX_KEEPALIVE", 0),
+                connection_pool_size,
+            )
             httpx_kwargs = {}
             httpx_limits = platform_httpx_limits()
             if httpx_limits is not None:
-                max_keepalive = getattr(httpx_limits, "max_keepalive_connections", None)
-                if max_keepalive is not None:
-                    max_keepalive = min(max_keepalive, connection_pool_size)
+                platform_keepalive = getattr(httpx_limits, "max_keepalive_connections", None)
+                if platform_keepalive is not None:
+                    max_keepalive_connections = min(max_keepalive_connections, platform_keepalive)
                 httpx_kwargs["limits"] = type(httpx_limits)(
                     max_connections=connection_pool_size,
-                    max_keepalive_connections=max_keepalive,
+                    max_keepalive_connections=max_keepalive_connections,
                     keepalive_expiry=getattr(httpx_limits, "keepalive_expiry", None),
                 )
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2445,6 +2445,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     self.name, topics_err, exc_info=True,
                 )
 
+            await self._drain_general_connections()
             return True
             
         except Exception as e:
@@ -2822,6 +2823,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 except Exception:
                     pass  # Typing failures are non-fatal
 
+            await self._drain_general_connections()
             return SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,
@@ -2945,6 +2947,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     message_id=int(message_id),
                     text=content,
                 )
+                await self._drain_general_connections()
                 return SendResult(success=True, message_id=message_id)
 
             formatted = self.format_message(content)
@@ -2972,6 +2975,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     message_id=int(message_id),
                     text=_plain,
                 )
+            await self._drain_general_connections()
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             err_str = str(e).lower()
@@ -3008,6 +3012,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         message_id=int(message_id),
                         text=content,
                     )
+                    await self._drain_general_connections()
                     return SendResult(success=True, message_id=message_id)
                 except Exception as retry_err:
                     await self._drain_general_connections_if_pool_exhausted(retry_err, "edit flood-control retry")
@@ -3268,6 +3273,7 @@ class TelegramAdapter(BasePlatformAdapter):
             "[%s] Overflow split delivered %d chunks; last_id=%s",
             self.name, 1 + len(continuation_ids), last_id,
         )
+        await self._drain_general_connections()
         return SendResult(
             success=True,
             message_id=last_id,
@@ -5121,7 +5127,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_id,
                 "URL photo",
             )
-            return SendResult(success=True, message_id=str(msg.message_id))
+            result = SendResult(success=True, message_id=str(msg.message_id))
+            await self._drain_general_connections()
+            return result
         except Exception as e:
             logger.warning(
                 "[%s] URL-based send_photo failed, trying file upload: %s",
@@ -5159,7 +5167,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     reply_to_id,
                     "uploaded photo",
                 )
-                return SendResult(success=True, message_id=str(msg.message_id))
+                result = SendResult(success=True, message_id=str(msg.message_id))
+                await self._drain_general_connections()
+                return result
             except Exception as e2:
                 logger.error(
                     "[%s] File upload send_photo also failed: %s",
@@ -5207,7 +5217,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_id,
                 "animation",
             )
-            return SendResult(success=True, message_id=str(msg.message_id))
+            result = SendResult(success=True, message_id=str(msg.message_id))
+            await self._drain_general_connections()
+            return result
         except Exception as e:
             logger.error(
                 "[%s] Failed to send Telegram animation, falling back to photo: %s",
@@ -5233,6 +5245,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     action="typing",
                     message_thread_id=message_thread_id,
                 )
+                await self._drain_general_connections()
             except Exception as e:
                 await self._drain_general_connections_if_pool_exhausted(e, "typing indicator")
                 # For DM topic lanes, Telegram may reject message_thread_id.
@@ -5244,6 +5257,7 @@ class TelegramAdapter(BasePlatformAdapter):
                             chat_id=int(chat_id),
                             action="typing",
                         )
+                        await self._drain_general_connections()
                         return
                     except Exception:
                         pass

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1339,6 +1339,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 _TimedOut = None
             is_timeout = (_TimedOut and isinstance(exc, _TimedOut)) or "timed out" in err_str
             is_connect_timeout = self._looks_like_connect_timeout(exc)
+            is_pool_timeout = self._looks_like_pool_timeout(exc)
+            await self._drain_general_connections_if_pool_exhausted(exc, "rich message send")
             logger.warning(
                 "[%s] sendRichMessage transient failure (no legacy resend): %s",
                 self.name, exc,
@@ -1346,7 +1348,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(
                 success=False,
                 error=str(exc),
-                retryable=(is_connect_timeout or not is_timeout),
+                retryable=(is_connect_timeout or is_pool_timeout or not is_timeout),
             )
 
         message_id = None
@@ -1423,6 +1425,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 _TimedOut = None
             is_timeout = (_TimedOut and isinstance(exc, _TimedOut)) or "timed out" in err_str
             is_connect_timeout = self._looks_like_connect_timeout(exc)
+            is_pool_timeout = self._looks_like_pool_timeout(exc)
+            await self._drain_general_connections_if_pool_exhausted(exc, "rich message edit")
             logger.warning(
                 "[%s] rich editMessageText transient failure (no legacy resend): %s",
                 self.name, exc,
@@ -1430,7 +1434,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(
                 success=False,
                 error=str(exc),
-                retryable=(is_connect_timeout or not is_timeout),
+                retryable=(is_connect_timeout or is_pool_timeout or not is_timeout),
             )
         # Telegram won't echo rich content for messages that predate the bot's
         # first rich send, so mirror the fresh-send index here too: a streamed
@@ -1490,6 +1494,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     self.name, exc,
                 )
             else:
+                await self._drain_general_connections_if_pool_exhausted(exc, "rich draft send")
                 logger.debug(
                     "[%s] sendRichMessageDraft transient failure (%s) — legacy draft this frame",
                     self.name, exc,
@@ -1541,6 +1546,21 @@ class TelegramAdapter(BasePlatformAdapter):
     async def _drain_general_connections(self) -> None:
         """Reset the httpx connection pool used for Bot API sends."""
         await self._drain_request_connections(1, "General")
+
+    async def _drain_general_connections_if_pool_exhausted(
+        self,
+        error: Exception,
+        context: str,
+    ) -> None:
+        """Reset the general Bot API pool after PTB reports pool exhaustion."""
+        if not self._looks_like_pool_timeout(error):
+            return
+        logger.warning(
+            "[%s] Telegram general request pool exhausted during %s; draining stale connections",
+            self.name,
+            context,
+        )
+        await self._drain_general_connections()
 
     async def _handle_polling_network_error(self, error: Exception) -> None:
         """Reconnect polling after a transient network interruption.
@@ -2159,7 +2179,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     return default
 
             request_kwargs = {
-                "connection_pool_size": _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 20),
+                "connection_pool_size": _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 64),
                 "pool_timeout": _env_float("HERMES_TELEGRAM_HTTP_POOL_TIMEOUT", 8.0),
                 "connect_timeout": _env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
                 "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
@@ -2935,6 +2955,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # "Message is not modified" is a no-op, not an error
                 if "not modified" in str(fmt_err).lower():
                     return SendResult(success=True, message_id=message_id)
+                await self._drain_general_connections_if_pool_exhausted(fmt_err, "formatted message edit")
                 # Fallback: strip MarkdownV2 escapes and retry as clean plain text
                 logger.warning(
                     "[%s] MarkdownV2 edit failed, falling back to plain text: %s",
@@ -2985,6 +3006,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                     return SendResult(success=True, message_id=message_id)
                 except Exception as retry_err:
+                    await self._drain_general_connections_if_pool_exhausted(retry_err, "edit flood-control retry")
                     logger.error(
                         "[%s] Edit retry failed after flood wait: %s",
                         self.name, retry_err,
@@ -3007,8 +3029,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 "temporarily unavailable",
                 "temporary failure",
                 "httpx",
+                "pool timeout",
+                "connection pool",
             )
-            _is_transient = any(m in err_str for m in _transient_markers)
+            is_pool_timeout = self._looks_like_pool_timeout(e)
+            if is_pool_timeout:
+                await self._drain_general_connections_if_pool_exhausted(e, "message edit")
+            _is_transient = is_pool_timeout or any(m in err_str for m in _transient_markers)
             if _is_transient:
                 logger.warning(
                     "[%s] Transient network error editing message %s (will retry): %s",
@@ -3075,6 +3102,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception as fmt_err:
                     if "not modified" not in str(fmt_err).lower():
+                        await self._drain_general_connections_if_pool_exhausted(
+                            fmt_err,
+                            "overflow formatted edit",
+                        )
                         logger.warning(
                             "[%s] Overflow split: MarkdownV2 first-chunk edit "
                             "failed, falling back to plain text: %s",
@@ -3102,7 +3133,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] Overflow split: first-chunk edit failed: %s",
                     self.name, e, exc_info=True,
                 )
-                return SendResult(success=False, error=str(e))
+                is_pool_timeout = self._looks_like_pool_timeout(e)
+                if is_pool_timeout:
+                    await self._drain_general_connections_if_pool_exhausted(e, "overflow first-chunk edit")
+                return SendResult(success=False, error=str(e), retryable=is_pool_timeout)
 
         # Step 2 — send each remaining chunk as a continuation message,
         # threaded as a reply to the previous so the user sees them as a
@@ -3146,6 +3180,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                     break
                 except Exception as send_err:
+                    await self._drain_general_connections_if_pool_exhausted(
+                        send_err,
+                        "overflow continuation send",
+                    )
                     if "reply message not found" in str(send_err).lower():
                         # Drop the reply anchor and try again.  Private DM
                         # topic fallback needs the anchor and topic id together;
@@ -3167,6 +3205,10 @@ class TelegramAdapter(BasePlatformAdapter):
                             )
                             break
                         except Exception as _retry_err:
+                            await self._drain_general_connections_if_pool_exhausted(
+                                _retry_err,
+                                "overflow continuation no-reply retry",
+                            )
                             logger.warning(
                                 "[%s] Overflow continuation no-reply retry failed: %s",
                                 self.name, _retry_err,
@@ -4689,6 +4731,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            await self._drain_general_connections_if_pool_exhausted(e, "voice/audio send")
             logger.error(
                 "[%s] Failed to send Telegram voice/audio, falling back to base adapter: %s",
                 self.name,
@@ -4821,6 +4864,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     self.name, chunk_idx + 1, len(chunks), e,
                     exc_info=True,
                 )
+                await self._drain_general_connections_if_pool_exhausted(e, "media group send")
                 # Fallback: send each photo in this chunk individually
                 await super().send_multiple_images(
                     chat_id, chunk, metadata, human_delay=human_delay,
@@ -4903,6 +4947,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     e,
                     exc_info=True,
                 )
+                await self._drain_general_connections_if_pool_exhausted(e, "local image photo send")
             # Fallback to sending as document (file) — no dimension limit,
             # only 50MB size limit. If even that fails, fall back to the
             # base adapter's text-only "Image: /path" rendering.
@@ -4923,6 +4968,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     doc_err,
                     exc_info=True,
                 )
+                await self._drain_general_connections_if_pool_exhausted(doc_err, "local image document fallback")
                 return await super().send_image_file(chat_id, image_path, caption, reply_to, metadata=metadata)
 
     async def send_document(
@@ -4973,6 +5019,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            await self._drain_general_connections_if_pool_exhausted(e, "document send")
             logger.warning("[%s] Failed to send document: %s", self.name, e, exc_info=True)
             return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
 
@@ -5020,6 +5067,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            await self._drain_general_connections_if_pool_exhausted(e, "video send")
             logger.warning("[%s] Failed to send video: %s", self.name, e, exc_info=True)
             return await super().send_video(chat_id, video_path, caption, reply_to, metadata=metadata)
 
@@ -5077,6 +5125,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
+            await self._drain_general_connections_if_pool_exhausted(e, "URL photo send")
             # Fallback: download and upload as file (supports up to 10MB)
             try:
                 import httpx
@@ -5114,6 +5163,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     e2,
                     exc_info=True,
                 )
+                await self._drain_general_connections_if_pool_exhausted(e2, "uploaded photo send")
                 # Final fallback: send URL as text
                 return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
 
@@ -5161,6 +5211,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
+            await self._drain_general_connections_if_pool_exhausted(e, "animation send")
             # Fallback: try as a regular photo
             return await self.send_image(chat_id, animation_url, caption, reply_to, metadata=metadata)
 
@@ -5179,6 +5230,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     message_thread_id=message_thread_id,
                 )
             except Exception as e:
+                await self._drain_general_connections_if_pool_exhausted(e, "typing indicator")
                 # For DM topic lanes, Telegram may reject message_thread_id.
                 # Fall back to sending typing without thread_id so the typing
                 # indicator at least appears in the main DM view.
@@ -5231,6 +5283,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
+            await self._drain_general_connections_if_pool_exhausted(e, "get chat info")
             return {"name": str(chat_id), "type": "dm", "error": str(e)}
 
     def format_message(self, content: str) -> str:
@@ -5891,6 +5944,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 filename = os.path.basename(getattr(file_obj, "file_path", "") or "")
             cached = cache_media_bytes(data, filename=filename, mime_type=mime, default_kind=kind)
         except Exception as exc:
+            await self._drain_general_connections_if_pool_exhausted(exc, "observed group media cache")
             logger.warning("[Telegram] Failed to cache observed group media: %s", exc, exc_info=True)
             return
 
@@ -5936,6 +5990,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 filename = os.path.basename(getattr(file_obj, "file_path", "") or "")
             cached = cache_media_bytes(data, filename=filename, mime_type=mime, default_kind=kind)
         except Exception as exc:
+            await self._drain_general_connections_if_pool_exhausted(exc, "replied-to media cache")
             logger.warning("[Telegram] Failed to cache replied-to media: %s", exc, exc_info=True)
             return
 
@@ -6414,6 +6469,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
 
             except Exception as e:
+                await self._drain_general_connections_if_pool_exhausted(e, "photo cache")
                 logger.warning("[Telegram] Failed to cache photo: %s", e, exc_info=True)
 
         # Download voice/audio messages to cache for STT transcription
@@ -6432,6 +6488,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_types = ["audio/ogg"]
                 logger.info("[Telegram] Cached user voice at %s", cached_path)
             except Exception as e:
+                await self._drain_general_connections_if_pool_exhausted(e, "voice cache")
                 logger.warning("[Telegram] Failed to cache voice: %s", e, exc_info=True)
         elif msg.audio:
             try:
@@ -6448,6 +6505,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_types = ["audio/mp3"]
                 logger.info("[Telegram] Cached user audio at %s", cached_path)
             except Exception as e:
+                await self._drain_general_connections_if_pool_exhausted(e, "audio cache")
                 logger.warning("[Telegram] Failed to cache audio: %s", e, exc_info=True)
 
         elif msg.video:
@@ -6465,6 +6523,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_types = [SUPPORTED_VIDEO_TYPES.get(ext, "video/mp4")]
                 logger.info("[Telegram] Cached user video at %s", cached_path)
             except Exception as e:
+                await self._drain_general_connections_if_pool_exhausted(e, "video cache")
                 logger.warning("[Telegram] Failed to cache video: %s", e, exc_info=True)
 
         # Download document files to cache for agent processing
@@ -6601,6 +6660,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         )
 
             except Exception as e:
+                await self._drain_general_connections_if_pool_exhausted(e, "document cache")
                 logger.warning("[Telegram] Failed to cache document: %s", e, exc_info=True)
 
         media_group_id = getattr(msg, "media_group_id", None)
@@ -6705,6 +6765,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     emoji, set_name,
                 )
         except Exception as e:
+            await self._drain_general_connections_if_pool_exhausted(e, "sticker cache")
             logger.warning("[Telegram] Sticker analysis error: %s", e, exc_info=True)
             event.text = build_sticker_injection(
                 f"a sticker with emoji {emoji}" if emoji else "a sticker",

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -461,8 +461,8 @@ async def test_send_network_error_drains_general_pool_before_retry(monkeypatch):
 
     assert result.success is True
     assert adapter._bot.send_message.await_count == 2
-    general_req.shutdown.assert_awaited_once()
-    general_req.initialize.assert_awaited_once()
+    assert general_req.shutdown.await_count == 2
+    assert general_req.initialize.await_count == 2
     polling_req.shutdown.assert_not_awaited()
     polling_req.initialize.assert_not_awaited()
 

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -305,6 +305,7 @@ async def test_connect_bounds_telegram_httpx_keepalive_pool(monkeypatch):
     captured_requests = []
 
     monkeypatch.setenv("HERMES_TELEGRAM_HTTP_POOL_SIZE", "12")
+    monkeypatch.setenv("HERMES_TELEGRAM_HTTP_MAX_KEEPALIVE", "50")
     monkeypatch.setattr(
         "plugins.platforms.telegram.adapter.platform_httpx_limits",
         lambda: FakeLimits(max_keepalive_connections=50, keepalive_expiry=2.5),
@@ -348,6 +349,67 @@ async def test_connect_bounds_telegram_httpx_keepalive_pool(monkeypatch):
         limits = kwargs["httpx_kwargs"]["limits"]
         assert limits.max_connections == 12
         assert limits.max_keepalive_connections == 12
+        assert limits.keepalive_expiry == 2.5
+
+
+@pytest.mark.asyncio
+async def test_connect_disables_telegram_httpx_keepalive_by_default(monkeypatch):
+    class FakeLimits:
+        def __init__(
+            self,
+            max_connections=None,
+            max_keepalive_connections=None,
+            keepalive_expiry=None,
+        ):
+            self.max_connections = max_connections
+            self.max_keepalive_connections = max_keepalive_connections
+            self.keepalive_expiry = keepalive_expiry
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    captured_requests = []
+
+    monkeypatch.delenv("HERMES_TELEGRAM_HTTP_MAX_KEEPALIVE", raising=False)
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.platform_httpx_limits",
+        lambda: FakeLimits(max_keepalive_connections=50, keepalive_expiry=2.5),
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.HTTPXRequest",
+        lambda **kwargs: captured_requests.append(kwargs) or MagicMock(),
+    )
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    app = SimpleNamespace(
+        bot=SimpleNamespace(delete_webhook=AsyncMock(), set_my_commands=AsyncMock()),
+        updater=SimpleNamespace(start_polling=AsyncMock(), stop=AsyncMock(), running=True),
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    assert len(captured_requests) == 2
+    for kwargs in captured_requests:
+        limits = kwargs["httpx_kwargs"]["limits"]
+        assert limits.max_keepalive_connections == 0
         assert limits.keepalive_expiry == 2.5
 
 

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -288,6 +288,69 @@ async def test_connect_clears_webhook_before_polling(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_connect_bounds_telegram_httpx_keepalive_pool(monkeypatch):
+    class FakeLimits:
+        def __init__(
+            self,
+            max_connections=None,
+            max_keepalive_connections=None,
+            keepalive_expiry=None,
+        ):
+            self.max_connections = max_connections
+            self.max_keepalive_connections = max_keepalive_connections
+            self.keepalive_expiry = keepalive_expiry
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    captured_requests = []
+
+    monkeypatch.setenv("HERMES_TELEGRAM_HTTP_POOL_SIZE", "12")
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.platform_httpx_limits",
+        lambda: FakeLimits(max_keepalive_connections=50, keepalive_expiry=2.5),
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.HTTPXRequest",
+        lambda **kwargs: captured_requests.append(kwargs) or MagicMock(),
+    )
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    app = SimpleNamespace(
+        bot=SimpleNamespace(delete_webhook=AsyncMock(), set_my_commands=AsyncMock()),
+        updater=SimpleNamespace(start_polling=AsyncMock(), stop=AsyncMock(), running=True),
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    assert len(captured_requests) == 2
+    for kwargs in captured_requests:
+        assert kwargs["connection_pool_size"] == 12
+        limits = kwargs["httpx_kwargs"]["limits"]
+        assert limits.max_connections == 12
+        assert limits.max_keepalive_connections == 12
+        assert limits.keepalive_expiry == 2.5
+
+
+@pytest.mark.asyncio
 async def test_disconnect_skips_inactive_updater_and_app(monkeypatch):
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
 
@@ -309,6 +372,36 @@ async def test_disconnect_skips_inactive_updater_and_app(monkeypatch):
     app.stop.assert_not_awaited()
     app.shutdown.assert_awaited_once()
     warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_network_error_drains_general_pool_before_retry(monkeypatch):
+    from telegram.error import NetworkError
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    polling_req = SimpleNamespace(shutdown=AsyncMock(), initialize=AsyncMock())
+    general_req = SimpleNamespace(shutdown=AsyncMock(), initialize=AsyncMock())
+    adapter._app = SimpleNamespace(
+        bot=SimpleNamespace(_request=(polling_req, general_req))
+    )
+    adapter._bot = SimpleNamespace(
+        send_message=AsyncMock(
+            side_effect=[
+                NetworkError("proxy reset"),
+                SimpleNamespace(message_id=42),
+            ]
+        )
+    )
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is True
+    assert adapter._bot.send_message.await_count == 2
+    general_req.shutdown.assert_awaited_once()
+    general_req.initialize.assert_awaited_once()
+    polling_req.shutdown.assert_not_awaited()
+    polling_req.initialize.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
 
 
 def _ensure_telegram_mock():
@@ -398,6 +399,122 @@ async def test_send_network_error_drains_general_pool_before_retry(monkeypatch):
 
     assert result.success is True
     assert adapter._bot.send_message.await_count == 2
+    general_req.shutdown.assert_awaited_once()
+    general_req.initialize.assert_awaited_once()
+    polling_req.shutdown.assert_not_awaited()
+    polling_req.initialize.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_media_pool_timeout_drains_general_pool():
+    from telegram.error import TimedOut
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    polling_req = SimpleNamespace(shutdown=AsyncMock(), initialize=AsyncMock())
+    general_req = SimpleNamespace(shutdown=AsyncMock(), initialize=AsyncMock())
+    adapter._app = SimpleNamespace(
+        bot=SimpleNamespace(_request=(polling_req, general_req))
+    )
+    adapter.handle_message = AsyncMock()
+
+    pool_error = TimedOut(
+        "Pool timeout: All connections in the connection pool are occupied. "
+        "Request was *not* sent to Telegram."
+    )
+    voice = SimpleNamespace(file_size=1024, get_file=AsyncMock(side_effect=pool_error))
+    message = SimpleNamespace(
+        message_id=101,
+        text="",
+        caption=None,
+        date=None,
+        photo=None,
+        video=None,
+        audio=None,
+        voice=voice,
+        sticker=None,
+        document=None,
+        media_group_id=None,
+        reply_to_message=None,
+        quote=None,
+        message_thread_id=None,
+        is_topic_message=False,
+        chat=SimpleNamespace(
+            id=123,
+            type="private",
+            title=None,
+            full_name="Test User",
+            is_forum=False,
+        ),
+        from_user=SimpleNamespace(id=456, full_name="Test User"),
+    )
+
+    await adapter._handle_media_message(
+        SimpleNamespace(update_id=789, message=message),
+        None,
+    )
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.message_type == MessageType.VOICE
+    general_req.shutdown.assert_awaited_once()
+    general_req.initialize.assert_awaited_once()
+    polling_req.shutdown.assert_not_awaited()
+    polling_req.initialize.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rich_send_pool_timeout_is_retryable_and_drains_general_pool():
+    from telegram.error import TimedOut
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    polling_req = SimpleNamespace(shutdown=AsyncMock(), initialize=AsyncMock())
+    general_req = SimpleNamespace(shutdown=AsyncMock(), initialize=AsyncMock())
+    adapter._app = SimpleNamespace(
+        bot=SimpleNamespace(_request=(polling_req, general_req))
+    )
+    adapter._bot = SimpleNamespace(
+        do_api_request=AsyncMock(
+            side_effect=TimedOut(
+                "Pool timeout: All connections in the connection pool are occupied. "
+                "Request was *not* sent to Telegram."
+            )
+        )
+    )
+
+    result = await adapter._try_send_rich("123", "hello", None, None)
+
+    assert result is not None
+    assert result.success is False
+    assert result.retryable is True
+    general_req.shutdown.assert_awaited_once()
+    general_req.initialize.assert_awaited_once()
+    polling_req.shutdown.assert_not_awaited()
+    polling_req.initialize.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_edit_message_pool_timeout_is_retryable_and_drains_general_pool():
+    from telegram.error import TimedOut
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    polling_req = SimpleNamespace(shutdown=AsyncMock(), initialize=AsyncMock())
+    general_req = SimpleNamespace(shutdown=AsyncMock(), initialize=AsyncMock())
+    adapter._app = SimpleNamespace(
+        bot=SimpleNamespace(_request=(polling_req, general_req))
+    )
+    adapter._bot = SimpleNamespace(
+        edit_message_text=AsyncMock(
+            side_effect=TimedOut(
+                "Pool timeout: All connections in the connection pool are occupied. "
+                "Request was *not* sent to Telegram."
+            )
+        )
+    )
+
+    result = await adapter.edit_message("123", "456", "hello")
+
+    assert result.success is False
+    assert result.retryable is True
     general_req.shutdown.assert_awaited_once()
     general_req.initialize.assert_awaited_once()
     polling_req.shutdown.assert_not_awaited()

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -181,9 +181,12 @@ def _make_mock_app():
     mock_polling_req = AsyncMock()
     mock_polling_req.shutdown = AsyncMock()
     mock_polling_req.initialize = AsyncMock()
+    mock_general_req = AsyncMock()
+    mock_general_req.shutdown = AsyncMock()
+    mock_general_req.initialize = AsyncMock()
 
     mock_bot = MagicMock()
-    mock_bot._request = (mock_polling_req, MagicMock())  # (getUpdates, general)
+    mock_bot._request = (mock_polling_req, mock_general_req)
 
     mock_updater = MagicMock()
     mock_updater.running = True
@@ -197,12 +200,8 @@ def _make_mock_app():
 
 
 @pytest.mark.asyncio
-async def test_reconnect_drains_polling_request_only():
-    """During reconnect, only the polling request (_request[0]) must be cycled.
-
-    The general request (_request[1]) must NOT be touched — doing so would
-    break concurrent send_message / edit_message calls.
-    """
+async def test_reconnect_drains_polling_then_general_request():
+    """During reconnect, stale polling and send pools should both be cycled."""
     adapter = _make_adapter()
     adapter._polling_network_error_count = 1
 
@@ -218,9 +217,10 @@ async def test_reconnect_drains_polling_request_only():
     mock_polling_req.shutdown.assert_called_once()
     mock_polling_req.initialize.assert_called_once()
 
-    # General request must NOT be touched
-    general_req.shutdown.assert_not_called()
-    general_req.initialize.assert_not_called()
+    # The general request pool can accumulate dead proxy sockets across
+    # reconnect cycles, so a successful reconnect drains it as well.
+    general_req.shutdown.assert_called_once()
+    general_req.initialize.assert_called_once()
 
     # Reconnect must still succeed
     mock_app.updater.start_polling.assert_called_once()
@@ -294,6 +294,7 @@ async def test_drain_helper_noop_without_app():
     adapter._app = None
     # Should not raise
     await adapter._drain_polling_connections()
+    await adapter._drain_general_connections()
 
 
 # ── Heartbeat probe ──────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -774,14 +774,19 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
-    def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
+    def test_launchd_restart_drains_running_gateway_before_reload(self, tmp_path, monkeypatch):
         calls = []
-        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        domain = gateway_cli._launchd_domain()
+        target = f"{domain}/{gateway_cli.get_launchd_label()}"
 
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
         monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: True)
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 321,
@@ -797,7 +802,9 @@ class TestLaunchdServiceRecovery:
 
         assert calls == [
             ("term", 321, False),
-            ["launchctl", "kickstart", "-k", target],
+            ["launchctl", "bootout", target],
+            ["launchctl", "bootstrap", domain, str(plist_path)],
+            ["launchctl", "kickstart", target],
         ]
 
     def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
@@ -1024,17 +1031,18 @@ class TestLaunchdServiceRecovery:
         assert "Service installed and loaded" not in capsys.readouterr().out
 
     def test_launchd_restart_falls_back_to_detached_on_error_5(self, monkeypatch, capsys):
-        """kickstart -k error 5 (domain unmanageable) should relaunch detached."""
-        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+        """launchctl error 5 (domain unmanageable) should relaunch detached."""
 
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
         monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: True)
+        monkeypatch.setattr(gateway_cli.time, "sleep", lambda seconds: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
 
         def fake_run(cmd, check=False, **kwargs):
-            if cmd == ["launchctl", "kickstart", "-k", target]:
+            if cmd[:2] == ["launchctl", "bootstrap"]:
                 raise gateway_cli.subprocess.CalledProcessError(
                     5, cmd, stderr="Input/output error"
                 )
@@ -1050,6 +1058,81 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_restart()
 
         assert spawned == [True]
+
+    def test_launchd_restart_retries_bootstrap_error_5_once(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        domain = gateway_cli._launchd_domain()
+        target = f"{domain}/{gateway_cli.get_launchd_label()}"
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: True)
+        monkeypatch.setattr(gateway_cli.time, "sleep", lambda seconds: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+
+        calls = []
+        bootstrap_attempts = {"count": 0}
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd[:2] == ["launchctl", "bootstrap"]:
+                bootstrap_attempts["count"] += 1
+                if bootstrap_attempts["count"] == 1:
+                    raise gateway_cli.subprocess.CalledProcessError(
+                        5, cmd, stderr="Input/output error"
+                    )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [
+            ["launchctl", "bootout", target],
+            ["launchctl", "bootstrap", domain, str(plist_path)],
+            ["launchctl", "bootout", target],
+            ["launchctl", "bootstrap", domain, str(plist_path)],
+            ["launchctl", "kickstart", target],
+        ]
+
+    def test_launchd_restart_rewrites_outdated_plist_before_bootstrap(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+        domain = gateway_cli._launchd_domain()
+        target = f"{domain}/{gateway_cli.get_launchd_label()}"
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "generate_launchd_plist",
+            lambda: (
+                "<plist>--replace\n<key>HERMES_HOME</key>"
+                "<string>/Users/alice/.hermes</string></plist>"
+            ),
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        assert "--replace" in plist_path.read_text(encoding="utf-8")
+        assert calls == [
+            ["launchctl", "bootout", target],
+            ["launchctl", "bootstrap", domain, str(plist_path)],
+            ["launchctl", "kickstart", target],
+        ]
 
     def test_launchd_stop_tolerates_domain_unsupported_bootout(self, monkeypatch, capsys):
         """bootout exit 125 (macOS 26) must fall through to PID-based kill, not raise."""
@@ -1609,7 +1692,7 @@ class TestGatewaySystemServiceRouting:
             gateway_cli,
             "launchd_restart",
             lambda: (_ for _ in ()).throw(
-                gateway_cli.subprocess.CalledProcessError(5, ["launchctl", "kickstart", "-k", "gui/501/ai.hermes.gateway"])
+                gateway_cli.subprocess.CalledProcessError(5, ["launchctl", "bootstrap", "gui/501", str(plist_path)])
             ),
         )
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2180,6 +2180,16 @@ class TestProfileArg:
         assert "<string>Aqua</string>" in plist
         assert "<string>Background</string>" in plist
 
+    def test_launchd_plist_raises_file_descriptor_limits(self):
+        """launchd's default open-file limit can be too low for browser-heavy jobs."""
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>SoftResourceLimits</key>" in plist
+        assert "<key>HardResourceLimits</key>" in plist
+        assert "<key>NumberOfFiles</key>" in plist
+        assert "<integer>4096</integer>" in plist
+        assert "<integer>8192</integer>" in plist
+
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"
         profile_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- Add explicit macOS launchd `NumberOfFiles` limits to generated Hermes gateway plists (`4096` soft, `8192` hard).
- Make `launchd_restart()` reload the service definition with `bootout`/`bootstrap` instead of only `kickstart -k`, with a short retry for the macOS bootout/bootstrap unload race.
- Bound Telegram `HTTPXRequest` pools with a larger active default (`64`), disable Telegram keepalive by default to avoid proxy-held stale sockets, and proactively recycle the general Bot API pool after completed sends/edits/typing/startup calls.
- Drain stale polling/general pools after reconnects, sends, media downloads, edits, rich-message calls, typing, and chat-info failures that report pool exhaustion.

## Related Issues
- Fixes #30230
- Refs #31599

## Root Cause
macOS launchd user sessions can start LaunchAgents with a low soft maxfiles limit, observed as `256`. Updating the plist alone is not enough because `kickstart -k` restarts the process without reliably re-reading runtime-only plist keys such as `ResourceLimits`.

In proxy/reconnect-heavy Telegram gateways, PTB's general Bot API request pool can accumulate stale sockets in `CLOSE_WAIT`. Once enough descriptors are consumed, the gateway fails opening session temp files, channel state, terminal pipes, or Telegram sockets with `OSError: [Errno 24] Too many open files`.

Live profiles also showed media download calls (`get_file()` / `download_as_bytearray()`), streamed status edits (`edit_message_text`), and ordinary typing/send traffic could accumulate stale proxy sockets before PTB raised `Pool timeout`. The fix now both drains on explicit pool exhaustion and recycles the general pool after successful Bot API calls so the gateway does not wait until it is wedged to clean itself up.

## Validation
- `/Users/xingqiwu/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/gateway.py plugins/platforms/telegram/adapter.py`
- `/Users/xingqiwu/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py -k "launchd_restart or launchd_plist" -q`
- `/Users/xingqiwu/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_telegram_conflict.py tests/gateway/test_telegram_network_reconnect.py -q`
- `/Users/xingqiwu/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_telegram_documents.py -q`

## Local Runtime Check
- `honglang-poster`: launchd PID `65391`, `maxfiles` soft/hard `4096/8192`, fd count `94`, `CLOSE_WAIT=0` after restart plus 60s observation.
- `qihuo-manager`: launchd PID `65390`, `maxfiles` soft/hard `4096/8192`, fd count `85`, `CLOSE_WAIT=0` after restart plus 60s observation.

## Follow-up Note
- `qihuo-manager` is back online at the gateway/Telegram layer, but its agent logs also show a separate custom model HTTP 401 invalid-token error. That is not caused by the fd/pool exhaustion path and needs credential/provider config cleanup separately.
