### PR TITLE
Support prompt summaries in skills index

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -18,7 +18,7 @@ from typing import Optional
 from agent.runtime_cwd import resolve_agent_cwd
 from agent.skill_utils import (
     extract_skill_conditions,
-    extract_skill_description,
+    extract_skill_prompt_summary,
     get_all_skills_dirs,
     get_disabled_skill_names,
     iter_skill_index_files,
@@ -1099,7 +1099,7 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-_SKILLS_SNAPSHOT_VERSION = 1
+_SKILLS_SNAPSHOT_VERSION = 2
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1221,7 +1221,7 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
         if not skill_matches_environment(frontmatter):
             return False, frontmatter, ""
 
-        return True, frontmatter, extract_skill_description(frontmatter)
+        return True, frontmatter, extract_skill_prompt_summary(frontmatter)
     except Exception as e:
         logger.warning("Failed to parse skill file %s: %s", skill_file, e)
         return True, {}, ""

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -679,15 +679,49 @@ def resolve_skill_config_values(
 # ── Description extraction ────────────────────────────────────────────────
 
 
+def _hermes_metadata(frontmatter: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the ``metadata.hermes`` mapping from skill frontmatter."""
+    metadata = frontmatter.get("metadata")
+    if not isinstance(metadata, dict):
+        return {}
+    hermes = metadata.get("hermes") or {}
+    if not isinstance(hermes, dict):
+        return {}
+    return hermes
+
+
+def _compact_text(value: Any, max_length: int) -> str:
+    """Normalize whitespace and truncate text to ``max_length`` chars."""
+    if value is None:
+        return ""
+    text = " ".join(str(value).strip().strip("'\"").split())
+    if not text:
+        return ""
+    if len(text) > max_length:
+        return text[: max_length - 3].rstrip() + "..."
+    return text
+
+
 def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
     """Extract a truncated description from parsed frontmatter."""
     raw_desc = frontmatter.get("description", "")
-    if not raw_desc:
-        return ""
-    desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
-    return desc
+    return _compact_text(raw_desc, 60)
+
+
+def extract_skill_prompt_summary(frontmatter: Dict[str, Any]) -> str:
+    """Extract the routing text used in the system prompt skills index.
+
+    Skill authors can provide ``metadata.hermes.prompt_summary`` when the
+    normal human-facing ``description`` is too long, too broad, or formatted
+    for docs/search rather than prompt routing.  The fallback intentionally
+    preserves the existing 60-character description cap so current prompts do
+    not grow unless a skill explicitly opts in to a longer prompt summary.
+    """
+    raw_summary = _hermes_metadata(frontmatter).get("prompt_summary")
+    summary = _compact_text(raw_summary, 180)
+    if summary:
+        return summary
+    return extract_skill_description(frontmatter)
 
 
 # ── File iteration ────────────────────────────────────────────────────────

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -415,6 +415,67 @@ class TestBuildSkillsSystemPrompt:
         assert "Debug Python scripts" in result
         assert "available_skills" in result
 
+    def test_skills_index_prefers_prompt_summary(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "productivity" / "pdf"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: pdf\n"
+            "description: Human-facing description for docs, search results, and hub pages that should not be injected into every system prompt.\n"
+            "metadata:\n"
+            "  hermes:\n"
+            "    prompt_summary: Merge, split, OCR, rotate, watermark, encrypt, decrypt, and extract text/tables/images from PDF files.\n"
+            "---\n"
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "pdf" in result
+        assert "Merge, split, OCR, rotate" in result
+        assert "Human-facing description" not in result
+
+    def test_skills_index_caps_prompt_summary(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "tools" / "long-summary"
+        skills_dir.mkdir(parents=True)
+        long_summary = "route " + "word " * 80
+        (skills_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: long-summary\n"
+            "description: short fallback\n"
+            "metadata:\n"
+            "  hermes:\n"
+            f"    prompt_summary: {long_summary}\n"
+            "---\n"
+        )
+
+        result = build_skills_system_prompt()
+        entry = next(line for line in result.splitlines() if "- long-summary:" in line)
+
+        assert entry.endswith("...")
+        assert len(entry.split(": ", 1)[1]) <= 180
+        assert "short fallback" not in entry
+
+    def test_skills_index_fallback_description_stays_tightly_capped(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "tools" / "long-description"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: long-description\n"
+            "description: " + ("description " * 20) + "\n"
+            "---\n"
+        )
+
+        result = build_skills_system_prompt()
+        entry = next(line for line in result.splitlines() if "- long-description:" in line)
+
+        assert entry.endswith("...")
+        assert len(entry.split(": ", 1)[1]) <= 60
+
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cat_dir = tmp_path / "skills" / "tools"

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -55,6 +55,7 @@ platforms: [macos, linux]          # Optional — restrict to specific OS platfo
                                    #   Omit to load on all platforms (default)
 metadata:
   hermes:
+    prompt_summary: Short routing hint for the injected skills index
     tags: [Category, Subcategory, Keywords]
     related_skills: [other-skill-name]
     requires_toolsets: [web]            # Optional — only show when these toolsets are active
@@ -97,6 +98,23 @@ Known failure modes and how to handle them.
 ## Verification
 How the agent confirms it worked.
 ```
+
+### Prompt Summary
+
+The injected system prompt includes a compact skills index so the agent can
+decide when to call `skill_view(name)`. By default that index uses a tightly
+capped version of `description`. If the human-facing description is long,
+docs-oriented, or too broad for routing, add a short prompt-facing summary:
+
+```yaml
+description: Full human-facing description for docs, search, and hub pages.
+metadata:
+  hermes:
+    prompt_summary: "PDF merge/split/OCR/watermark/encrypt/decrypt and text/table/image extraction."
+```
+
+Keep `prompt_summary` to one sentence. Hermes caps it before injection, but a
+crisp summary routes better and keeps every session's prompt lean.
 
 ### Platform-Specific Skills
 

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -93,6 +93,7 @@ version: 1.0.0
 platforms: [macos, linux]     # Optional — restrict to specific OS platforms
 metadata:
   hermes:
+    prompt_summary: Short routing hint for the injected skills index
     tags: [python, automation]
     category: devops
     fallback_for_toolsets: [web]    # Optional — conditional activation (see below)
@@ -119,6 +120,11 @@ Trigger conditions for this skill.
 ## Verification
 How to confirm it worked.
 ```
+
+`description` is for humans, docs, search, and hub listings. The injected
+system-prompt skills index uses a compact routing hint; by default Hermes falls
+back to a capped `description`, but skill authors can provide a more precise
+`metadata.hermes.prompt_summary` when the description is too long or too broad.
 
 ### Platform-Specific Skills
 


### PR DESCRIPTION
## Summary
- add `metadata.hermes.prompt_summary` as the prompt-facing routing text for `<available_skills>`
- keep the existing 60-character fallback description cap so current prompts do not grow by default
- cap explicit prompt summaries at 180 characters and invalidate the skills prompt snapshot
- document the new field in skill authoring/user docs

## Tests
- `python3 -m py_compile agent/skill_utils.py agent/prompt_builder.py tests/agent/test_prompt_builder.py`
- `.venv/bin/python -m pytest tests/agent/test_prompt_builder.py -q`
