### PR TITLE
fix(swe-runner): remove logging.basicConfig from library class __init__

### DIFF
--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -194,13 +194,9 @@ class MiniSWERunner:
         self.image = image
         self.cwd = cwd
         
-        # Setup logging
-        logging.basicConfig(
-            level=logging.DEBUG if verbose else logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
+        if verbose:
+            self.logger.setLevel(logging.DEBUG)
         
         # Initialize LLM client via centralized provider router.
         # If explicit api_key/base_url are provided (e.g. from CLI args),


### PR DESCRIPTION
## Summary

Remove `logging.basicConfig()` call from `MiniSWERunner.__init__()`.

**Problem**: `logging.basicConfig()` in library code overrides the root logger configuration every time the class is instantiated. This causes:
- Inconsistent log formatting when the runner is used alongside other logging config
- The runner's format string replaces whatever the application had configured
- `basicConfig()` is a no-op after the first call, but the first call may come from the runner before the app configures logging

**Fix**: Remove the `logging.basicConfig()` call. Use `self.logger.setLevel(logging.DEBUG)` directly when verbose mode is requested. Library code should use `logging.getLogger(__name__)` and let the application entry point configure the root logger.

## Changes
- `mini_swe_runner.py`: Remove `logging.basicConfig(...)` block, add `logger.setLevel()` for verbose mode

## Test plan
- [ ] Verify `MiniSWERunner` still logs correctly when root logger is configured by the application
- [ ] Verify verbose mode still enables debug logging
- [ ] No import errors
- [ ] CI passes