### PR TITLE
fix(logging): remove logging.basicConfig from library __init__ (compressor + swe-runner)

### DIFF
--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -194,12 +194,6 @@ class MiniSWERunner:
         self.image = image
         self.cwd = cwd
         
-        # Setup logging
-        logging.basicConfig(
-            level=logging.DEBUG if verbose else logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
         
         # Initialize LLM client via centralized provider router.
@@ -676,6 +670,13 @@ def main(
     """
     print("🚀 Mini-SWE Runner with Hermes Trajectory Format")
     print("=" * 60)
+    
+    # Configure root logging at the entry point (not in library __init__).
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        datefmt='%H:%M:%S'
+    )
     
     # Initialize runner
     runner = MiniSWERunner(

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -352,11 +352,6 @@ class TrajectoryCompressor:
         # Initialize OpenRouter client
         self._init_summarizer()
         
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
     
     def _init_tokenizer(self):


### PR DESCRIPTION
## Summary
Library code no longer hijacks the application's root logger config when a compressor or SWE runner is instantiated.

`logging.basicConfig()` in `__init__()` is a library anti-pattern: it sets the root logger's level/format the first time the class is constructed, overriding whatever the application (e.g. the gateway) configured. This salvages @vanthinh6886's fix and extends it to the sibling site.

## Changes
- `trajectory_compressor.py`: remove `basicConfig()` from `TrajectoryCompressor.__init__()` (contributor's commit). `getLogger(__name__)` remains.
- `mini_swe_runner.py`: same class of bug — moved `basicConfig()` out of `MiniSWERunner.__init__()` into `main()` (the CLI entry point) so standalone verbose logging is preserved.

(The two remaining `basicConfig()` calls in `mcp_serve.py` / `hermes_tools_mcp_server.py` are inside entry-point `main()` functions — correct, left as-is.)

## Validation
| | Before | After |
|---|---|---|
| App sets `APP::` root format, then imports/uses these modules | root format overwritten | root format unchanged (E2E verified) |
| Targeted tests | — | 37/37 pass |

Salvage of #50490 by @vanthinh6886 — original commit cherry-picked with authorship preserved.

## Infographic

![root-logger-fix](https://v3b.fal.media/files/b/0a9f4129/13Trgq8pIT2-swoixnRM8_DRnanNOg.png)
