### PR TITLE
[codex] fix(state): preserve gateway history through FTS corruption

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -816,6 +816,15 @@ def _build_gateway_agent_history(
     return agent_history, observed_context
 
 
+def _select_cached_agent_history(
+    persisted_history: List[Dict[str, Any]],
+    live_history: Any,
+) -> List[Dict[str, Any]]:
+    if isinstance(live_history, list) and len(live_history) > len(persisted_history):
+        return list(live_history)
+    return persisted_history
+
+
 def _wrap_current_message_with_observed_context(message: Any, observed_context: Optional[str]) -> Any:
     """Prepend observed Telegram context to the API-only current user turn."""
 
@@ -15397,6 +15406,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 user_id_alt=getattr(source, "user_id_alt", None),
             )
             agent = None
+            reused_cached_agent = False
             _cache_lock = getattr(self, "_agent_cache_lock", None)
             _cache = getattr(self, "_agent_cache", None)
 
@@ -15441,6 +15451,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 self._cleanup_agent_resources(_ev_agent)
                         else:
                             agent = cached[0]
+                            reused_cached_agent = True
                             # Refresh LRU order so the cap enforcement evicts
                             # truly-oldest entries, not the one we just used.
                             if hasattr(_cache, "move_to_end"):
@@ -15685,6 +15696,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent_holder[0] = agent
             # Capture the full tool definitions for transcript logging
             tools_holder[0] = agent.tools if hasattr(agent, 'tools') else None
+
+            if reused_cached_agent and getattr(agent, "session_id", None) == session_id:
+                selected_history = _select_cached_agent_history(
+                    history,
+                    getattr(agent, "_session_messages", None),
+                )
+                if selected_history is not history:
+                    logger.warning(
+                        "Persisted transcript lagged cached history for session %s "
+                        "(disk=%d, memory=%d); preserving live conversation context",
+                        session_key,
+                        len(history),
+                        len(selected_history),
+                    )
+                    history = selected_history
             
             # Convert history to agent format.
             # Two cases:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1217,6 +1217,11 @@ def run_doctor(args):
     if state_db_path.exists():
         try:
             import sqlite3
+            from hermes_state import _db_opens_cleanly
+
+            health_error = _db_opens_cleanly(state_db_path)
+            if health_error is not None:
+                raise sqlite3.DatabaseError(health_error)
             conn = sqlite3.connect(str(state_db_path))
             cursor = conn.execute("SELECT COUNT(*) FROM sessions")
             count = cursor.fetchone()[0]
@@ -1231,7 +1236,7 @@ def run_doctor(args):
                 # this is NOT a plain FTS-index rebuild. Repair sqlite_master
                 # in place (backup first; sessions/messages preserved).
                 check_warn(
-                    f"{_DHH}/state.db schema is malformed (sessions hidden until repaired)",
+                    f"{_DHH}/state.db is malformed (session reads or writes may fail)",
                     f"({e})",
                 )
                 if should_fix:
@@ -1260,13 +1265,13 @@ def run_doctor(args):
                             f"({report.get('error')}; backup: {report.get('backup_path')})",
                         )
                         issues.append(
-                            "state.db schema malformed and auto-repair failed — "
+                            "state.db malformed and auto-repair failed — "
                             "restore from the backup copy beside state.db"
                         )
                 else:
                     issues.append(
-                        "state.db schema malformed — run 'hermes doctor --fix' "
-                        "(or 'hermes sessions repair') to recover hidden sessions"
+                        "state.db malformed — run 'hermes doctor --fix' "
+                        "(or 'hermes sessions repair') to restore session storage"
                     )
             else:
                 check_warn(f"{_DHH}/state.db exists but has issues: {e}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12307,12 +12307,11 @@ def main():
 
     sessions_repair = sessions_subparsers.add_parser(
         "repair",
-        help="Repair a malformed state.db schema so hidden sessions reappear",
+        help="Repair malformed state.db schema or FTS indexes",
         description=(
-            "Recover a state.db whose schema is malformed (e.g. 'table "
-            "messages_fts already exists'), which makes Desktop/Dashboard show "
-            "no sessions. A backup is made first; sessions and messages are "
-            "preserved and the FTS search index is rebuilt if needed."
+            "Recover a state.db whose schema or FTS indexes are malformed. "
+            "A backup is made first; sessions and messages are preserved and "
+            "the FTS search indexes are rebuilt if needed."
         ),
     )
     sessions_repair.add_argument(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -398,8 +398,8 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
     """Probe a DB on a fresh connection. Returns None if healthy, else a reason.
 
     Runs the same first-statement (``PRAGMA journal_mode``) that trips the
-    malformed-schema parse, then ``PRAGMA integrity_check`` and a canonical
-    ``sessions`` read.
+    malformed-schema parse, then verifies canonical reads and a rolled-back
+    message write so FTS trigger/index corruption cannot pass as healthy.
     """
     conn = sqlite3.connect(str(db_path), isolation_level=None)
     try:
@@ -409,6 +409,18 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         if problems:
             return "; ".join(problems[:3])
         conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
+        probe_session_id = f"_hermes_health_probe_{time.time_ns()}"
+        conn.execute("BEGIN")
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            (probe_session_id, "health_probe", time.time()),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, ?, ?, ?)",
+            (probe_session_id, "user", "health probe", time.time()),
+        )
+        conn.rollback()
         return None
     except sqlite3.DatabaseError as exc:
         return str(exc)
@@ -417,16 +429,17 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
 
 
 def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, Any]:
-    """Repair a state.db whose ``sqlite_master`` schema is malformed.
+    """Repair a state.db whose schema or FTS indexes are malformed.
 
-    Handles the "duplicate object definition" / malformed-schema class where
-    even ``PRAGMA`` statements fail. Tries least-destructive recovery first
-    and escalates:
+    Handles both FTS index corruption that rejects message writes and the
+    "duplicate object definition" schema class where even ``PRAGMA`` statements
+    fail. Tries least-destructive recovery first and escalates:
 
-      1. **De-duplicate** ``sqlite_master`` (keep the lowest rowid per
+      1. **Rebuild FTS indexes in place** from their canonical content rows.
+      2. **De-duplicate** ``sqlite_master`` (keep the lowest rowid per
          ``type``/``name``). Fixes the canonical "table X already exists"
          case and PRESERVES the existing FTS index intact.
-      2. **Drop the FTS schema** (every ``messages_fts*`` object) + ``VACUUM``.
+      3. **Drop the FTS schema** (every ``messages_fts*`` object).
          The next ``SessionDB()`` open rebuilds the FTS indexes from the
          canonical ``messages`` table.
 
@@ -448,9 +461,32 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
         report["error"] = f"{db_path} does not exist"
         return report
 
+    if _db_opens_cleanly(db_path) is None:
+        report["repaired"] = True
+        report["strategy"] = "already_healthy"
+        return report
+
     if backup:
         bpath = _backup_db_file(db_path)
         report["backup_path"] = str(bpath) if bpath else None
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            for table_name in ("messages_fts", "messages_fts_trigram"):
+                conn.execute(
+                    f"INSERT INTO {table_name}({table_name}) VALUES('rebuild')"
+                )
+            conn.commit()
+        finally:
+            conn.close()
+        if _db_opens_cleanly(db_path) is None:
+            report["repaired"] = True
+            report["strategy"] = "rebuild_fts"
+            logger.warning("state.db FTS indexes rebuilt in place: %s", db_path)
+            return report
+    except sqlite3.DatabaseError as exc:
+        logger.warning("state.db FTS rebuild pass failed: %s", exc)
 
     # ── Strategy 1: de-duplicate sqlite_master (keeps FTS index) ──
     try:
@@ -482,15 +518,14 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     except sqlite3.DatabaseError as exc:
         logger.warning("state.db dedup repair pass failed: %s", exc)
 
-    # ── Strategy 2: drop all FTS schema, VACUUM, rebuild on next open ──
+    # ── Strategy 2: drop all FTS schema, rebuild on next open ──
     try:
         conn = sqlite3.connect(str(db_path), isolation_level=None)
         try:
-            conn.execute("PRAGMA writable_schema=ON")
-            conn.execute("DELETE FROM sqlite_master WHERE name LIKE 'messages_fts%'")
-            conn.execute("PRAGMA writable_schema=OFF")
-            conn.commit()
-            conn.execute("VACUUM")
+            for trigger_name in _FTS_TRIGGERS:
+                conn.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+            conn.execute("DROP TABLE IF EXISTS messages_fts")
+            conn.execute("DROP TABLE IF EXISTS messages_fts_trigram")
         finally:
             conn.close()
         reason = _db_opens_cleanly(db_path)
@@ -503,8 +538,25 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
             )
             return report
         report["error"] = reason
-    except sqlite3.DatabaseError as exc:
-        report["error"] = str(exc)
+    except sqlite3.DatabaseError:
+        try:
+            conn = sqlite3.connect(str(db_path), isolation_level=None)
+            try:
+                conn.execute("PRAGMA writable_schema=ON")
+                conn.execute("DELETE FROM sqlite_master WHERE name LIKE 'messages_fts%'")
+                conn.execute("PRAGMA writable_schema=OFF")
+                conn.commit()
+                conn.execute("VACUUM")
+            finally:
+                conn.close()
+            reason = _db_opens_cleanly(db_path)
+            if reason is None:
+                report["repaired"] = True
+                report["strategy"] = "drop_fts_rebuild"
+                return report
+            report["error"] = reason
+        except sqlite3.DatabaseError as exc:
+            report["error"] = str(exc)
 
     if not report["repaired"]:
         logger.error(

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -1706,3 +1706,32 @@ class TestAgentCacheMessageCountRebaseline:
         runner._refresh_agent_cache_message_count("telegram:s1", "s1")
         with runner._agent_cache_lock:
             assert runner._agent_cache["telegram:s1"][2] == 5
+
+
+class TestCachedAgentHistoryFallback:
+    def test_longer_live_history_wins_when_persisted_history_lags(self):
+        from gateway.run import _select_cached_agent_history
+
+        persisted = []
+        live = [
+            {"role": "user", "content": "work in hermes-agent"},
+            {"role": "assistant", "content": "Understood."},
+        ]
+
+        selected = _select_cached_agent_history(persisted, live)
+
+        assert selected == live
+        assert selected is not live
+
+    def test_persisted_history_wins_when_it_is_at_least_as_current(self):
+        from gateway.run import _select_cached_agent_history
+
+        persisted = [
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+        ]
+        live = [{"role": "user", "content": "stale"}]
+
+        selected = _select_cached_agent_history(persisted, live)
+
+        assert selected is persisted

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -53,6 +53,18 @@ def _corrupt_duplicate_fts(db_path: Path) -> None:
     conn.close()
 
 
+def _break_fts_insert_trigger(db_path: Path) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("DROP TRIGGER messages_fts_insert")
+    conn.execute(
+        "CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN "
+        "SELECT RAISE(ABORT, 'database disk image is malformed'); "
+        "END"
+    )
+    conn.commit()
+    conn.close()
+
+
 def test_duplicate_fts_makes_every_statement_fail(tmp_path):
     """Document the failure: not even PRAGMA journal_mode survives."""
     db_path = tmp_path / "state.db"
@@ -64,6 +76,34 @@ def test_duplicate_fts_makes_every_statement_fail(tmp_path):
         conn.execute("PRAGMA journal_mode").fetchone()
     conn.close()
     assert is_malformed_db_error(exc_info.value)
+
+
+def test_health_probe_detects_message_write_failure(tmp_path):
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    _break_fts_insert_trigger(db_path)
+
+    reason = hermes_state._db_opens_cleanly(db_path)
+
+    assert reason is not None
+    assert "database disk image is malformed" in reason
+
+
+def test_repair_restores_message_writes_when_fts_trigger_is_broken(tmp_path):
+    db_path = tmp_path / "state.db"
+    sid = _build_healthy_db(db_path)
+    _break_fts_insert_trigger(db_path)
+
+    report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is True
+    assert report["strategy"] == "drop_fts_rebuild"
+    db = SessionDB(db_path=db_path)
+    try:
+        db.append_message(sid, role="user", content="write works again")
+        assert db.message_count(session_id=sid) == 11
+    finally:
+        db.close()
 
 
 def test_repair_preserves_sessions_and_messages(tmp_path):


### PR DESCRIPTION
Fixes #50502.

Supersedes the narrower draft #30082, which only handled a broken optional trigram virtual table. This PR covers the production failure chain where FTS corruption rejects message writes while ordinary database reads still succeed, causing immediate same-session context loss in messaging gateways.

## Root cause

The gateway reloads its transcript from `state.db` for every inbound message and passes that result explicitly as `conversation_history`. A corrupt FTS index can make every `INSERT INTO messages` fail through the FTS triggers with `database disk image is malformed`, while the existing health probe still passes because it only checks `PRAGMA integrity_check` and a `sessions` read.

On the next Telegram message, persisted history is therefore empty or stale. Even if the same cached `AIAgent` is reused, `run_conversation()` starts from the supplied stale history rather than the agent's live `_session_messages`, so the agent forgets the immediately preceding exchange.

## Changes

- extend the state DB health probe with a transactionally rolled-back session/message write, exercising the real FTS trigger path;
- attempt an in-place FTS5 `rebuild` before escalating to schema recovery;
- make `hermes doctor` and `hermes sessions repair` detect FTS write corruption and describe the broader failure accurately;
- when reusing the same cached agent, prefer its longer live transcript if persisted history lags;
- add regressions for write-health detection, repair, and cached-agent continuity.

Canonical `sessions` and `messages` rows are preserved. The repair command still creates a timestamped backup before mutation.

## Production verification

On the affected macOS installation:

- `hermes sessions repair --check-only` changed from a false healthy result to reporting `database disk image is malformed`;
- `hermes sessions repair` rebuilt both FTS indexes in place and recovered 909 sessions;
- a real `SessionDB` append/delete probe passed afterward;
- the gateway restarted cleanly and Telegram reconnected;
- a follow-up `--check-only` reported the database healthy.

## Tests

- `scripts/run_tests.sh tests/gateway/test_agent_cache.py -- -q` — 70 passed
- focused malformed-state regressions — 5 passed
- `ruff check` on all changed files — passed
- `python -m py_compile` on all changed files — passed
- `git diff --check` — passed

The full pre-existing malformed-schema test file is not clean under this machine's SQLite 3.43 defensive configuration because its older direct `sqlite_master` corruption fixture is rejected before the tested code runs; the new focused regressions pass.