### PR TITLE
feat(telegram): handle Mini App WebApp data

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2105,6 +2105,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 filters.COMMAND,
                 self._handle_command
             ))
+            web_app_data_filter = getattr(getattr(filters, "StatusUpdate", None), "WEB_APP_DATA", None)
+            if web_app_data_filter is not None:
+                self._app.add_handler(TelegramMessageHandler(
+                    web_app_data_filter,
+                    self._handle_web_app_data_message
+                ))
             self._app.add_handler(TelegramMessageHandler(
                 filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
                 self._handle_location_message
@@ -5994,6 +6000,36 @@ class TelegramAdapter(BasePlatformAdapter):
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         await self._cache_replied_media(msg, event)
+        event = self._apply_telegram_group_observe_attribution(event)
+        await self.handle_message(event)
+
+    async def _handle_web_app_data_message(self, update: Any, context: Any) -> None:
+        """Handle Telegram Mini App data sent via WebApp.sendData()."""
+        msg = self._effective_update_message(update)
+        web_app_data = getattr(msg, "web_app_data", None) if msg else None
+        if not msg or web_app_data is None:
+            return
+        if not self._should_process_message(msg):
+            return
+        await self._ensure_forum_commands(msg)
+
+        button_text = getattr(web_app_data, "button_text", None)
+        payload = getattr(web_app_data, "data", "") or ""
+        formatted_payload = payload
+        try:
+            parsed = json.loads(payload)
+            formatted_payload = json.dumps(parsed, ensure_ascii=False, indent=2)
+        except Exception:
+            pass
+
+        parts = ["[Telegram Mini App data]"]
+        if button_text:
+            parts.append(f"Button: {button_text}")
+        parts.append("Payload:")
+        parts.append(formatted_payload)
+
+        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+        event.text = "\n".join(parts)
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)
 

--- a/tests/gateway/test_telegram_web_app_data.py
+++ b/tests/gateway/test_telegram_web_app_data.py
@@ -1,0 +1,82 @@
+"""Tests for Telegram Mini App WebApp data handling."""
+
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType
+
+
+def _make_adapter():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = cast(Any, object.__new__(TelegramAdapter))
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="test-token")
+    adapter._dm_topic_chat_ids = set()
+    adapter._forum_lock = asyncio.Lock()
+    adapter._forum_command_registered = set()
+    adapter._bot = None
+    adapter.handle_message = AsyncMock()
+    adapter._ensure_forum_commands = AsyncMock()
+    adapter._apply_telegram_group_observe_attribution = lambda event: event
+    return adapter
+
+
+def _make_web_app_update(data: str, button_text: str = "Open Mini App"):
+    chat = SimpleNamespace(
+        id=6168627430,
+        type="private",
+        title=None,
+        full_name="Filip Václavík",
+        is_forum=False,
+    )
+    user = SimpleNamespace(id=6168627430, full_name="Filip Václavík")
+    message = SimpleNamespace(
+        chat=chat,
+        from_user=user,
+        text=None,
+        message_id=123,
+        message_thread_id=None,
+        is_topic_message=False,
+        reply_to_message=None,
+        date=datetime.now(timezone.utc),
+        web_app_data=SimpleNamespace(data=data, button_text=button_text),
+    )
+    return SimpleNamespace(update_id=456, effective_message=message, message=message)
+
+
+@pytest.mark.asyncio
+async def test_web_app_data_dispatches_as_text_event_with_pretty_json_payload():
+    adapter = _make_adapter()
+    update = _make_web_app_update('{"type":"budget_summary","spent":2677}')
+
+    await adapter._handle_web_app_data_message(update, SimpleNamespace())
+
+    adapter.handle_message.assert_called_once()
+    event = adapter.handle_message.call_args.args[0]
+    assert event.message_type is MessageType.TEXT
+    assert event.source.chat_id == "6168627430"
+    assert event.source.user_id == "6168627430"
+    assert event.message_id == "123"
+    assert event.platform_update_id == 456
+    assert "[Telegram Mini App data]" in event.text
+    assert "Button: Open Mini App" in event.text
+    assert '"type": "budget_summary"' in event.text
+    assert '"spent": 2677' in event.text
+
+
+@pytest.mark.asyncio
+async def test_web_app_data_uses_raw_payload_when_not_json():
+    adapter = _make_adapter()
+    update = _make_web_app_update("plain payload")
+
+    await adapter._handle_web_app_data_message(update, SimpleNamespace())
+
+    event = adapter.handle_message.call_args.args[0]
+    assert "plain payload" in event.text


### PR DESCRIPTION
## Summary
- add Telegram handler for Mini App `web_app_data` service messages
- convert WebApp `sendData()` payloads into normal inbound text events for the agent
- add tests for JSON pretty-printing and raw payload forwarding

## Why this belongs in the Telegram adapter
Telegram `message.web_app_data` is a standard inbound message shape produced when a KeyboardButton Mini App calls `Telegram.WebApp.sendData()`. Before this change, Telegram could successfully deliver the update to the bot while Hermes ignored it because the adapter only registered text, command, location/media, and callback-query handlers.

This PR intentionally keeps the scope narrow: it does not add Mini App hosting, Telegram initData auth, endpoints, static serving, or a Mini App framework. It only ensures the existing Telegram gateway does not drop a valid Telegram inbound update type.

## User-visible behavior
A Mini App payload like:

```json
{"type":"budget_summary","spent":7837}
```

is surfaced to the agent as a normal text event:

```text
[Telegram Mini App data]
Button: <button text>
Payload:
{
  "type": "budget_summary",
  "spent": 7837
}
```

Non-JSON payloads are forwarded as raw text.

## Related work
- Related to #19863 as a lower-level prerequisite for Mini App-based Telegram UI flows.
- Different from #8419, which proposed Mini App serving/auth endpoints.
- Different from #15974, which targeted phone-gate approvals and mixed in broader changes.

## Verification
- `.venv/bin/python -m pytest tests/gateway/test_telegram_web_app_data.py tests/gateway/test_telegram_text_batching.py -q`
  - `8 passed in 1.52s`
- `roborev wait da211b0aa && roborev show da211b0aa`
  - `No issues found.`

## Notes
This was also manually exercised with a real Telegram KeyboardButton Mini App flow: `Telegram.WebApp.sendData()` produced a `web_app_data` update that Hermes surfaced as an inbound agent message.
