### PR TITLE
fix(photon): reduce compaction/status noise on iMessage

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -163,6 +163,16 @@ _IMAGE_TOKEN_ESTIMATE = 1600
 _IMAGE_CHAR_EQUIVALENT = _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
 
+# Transient connection blips to the summarizer endpoint (dropped Codex/Envoy
+# stream, brief network hiccup) are common on long-lived gateway sessions.
+# call_llm retries once *immediately*; that does not help a blip lasting longer
+# than an instant, and when the auxiliary model IS the main model there is no
+# distinct fallback target. So _generate_summary retries a bounded number of
+# times WITH backoff for connection errors only, before falling through to the
+# existing fallback/cooldown handling.
+_SUMMARY_CONNECTION_MAX_ATTEMPTS = 3
+_SUMMARY_CONNECTION_BACKOFF_SECONDS = 0.5
+
 # Hard ceiling for the deterministic summary-failure handoff.  The fallback is
 # only meant to preserve continuity anchors from the dropped window, not to
 # become another unbounded transcript copy after the LLM summarizer failed.
@@ -1581,12 +1591,48 @@ This compaction should PRIORITISE preserving all information related to the focu
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
             # Compression is atomic: protect the in-flight summary call from a
-            # mid-turn gateway interrupt. Without this, an incoming user message
-            # aborts the summary and compression falls back to a degraded static
-            # marker, losing the real handoff (#23975). Re-entrant: a main-model
-            # retry (_generate_summary recursion) re-enters harmlessly.
-            with aux_interrupt_protection():
-                response = call_llm(**call_kwargs)
+            # mid-turn gateway interrupt, or an incoming user message would abort
+            # the summary and force a degraded static marker, losing the real
+            # handoff (#23975). Re-entrant: a main-model retry (_generate_summary
+            # recursion) re-enters harmlessly.
+            #
+            # Retry transient connection blips here WITH backoff (see
+            # _SUMMARY_CONNECTION_* above): call_llm only retries once and
+            # immediately, and for aux==main the recovery path below is a no-op,
+            # so without this a single blip drops the turns and shows a
+            # "Compression summary failed" banner. Connection errors only; every
+            # other error (auth, 4xx, model-not-found, empty body) is re-raised
+            # untouched into the existing fallback/cooldown handling.
+            # Only retry-with-backoff here when there is NO distinct fallback
+            # model (aux == main): with a distinct summary_model a connection
+            # error should fall through immediately to the existing main-model
+            # fallback below — switching endpoints beats hammering the same dead
+            # aux endpoint. Mirrors the fallback gate (summary_model and != model).
+            _no_distinct_fallback = (not self.summary_model) or (self.summary_model == self.model)
+            response = None
+            for _conn_attempt in range(_SUMMARY_CONNECTION_MAX_ATTEMPTS):
+                try:
+                    with aux_interrupt_protection():
+                        response = call_llm(**call_kwargs)
+                    break
+                except Exception as _conn_err:
+                    if (
+                        _no_distinct_fallback
+                        and _is_connection_error(_conn_err)
+                        and _conn_attempt < _SUMMARY_CONNECTION_MAX_ATTEMPTS - 1
+                    ):
+                        logger.warning(
+                            "Context compression: transient connection error on "
+                            "summary attempt %d/%d (%s); retrying after backoff.",
+                            _conn_attempt + 1,
+                            _SUMMARY_CONNECTION_MAX_ATTEMPTS,
+                            _conn_err.__class__.__name__,
+                        )
+                        time.sleep(
+                            _SUMMARY_CONNECTION_BACKOFF_SECONDS * (_conn_attempt + 1)
+                        )
+                        continue
+                    raise
             content = response.choices[0].message.content
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -130,6 +130,13 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     # status update as a separate message. Promote to TIER_MEDIUM once
     # Cloud's edit_message lands.
     "whatsapp_cloud":  _TIER_LOW,
+    # Photon (managed iMessage over the gRPC sidecar) and BlueBubbles are both
+    # permanent-message iMessage inboxes with no message-edit support, so both
+    # stay TIER_LOW. This keeps tool progress, interim scratch commentary,
+    # "still working" heartbeats, and busy-ack iteration detail out of the
+    # user's iMessage thread. Without this entry Photon inherited the noisy
+    # global ("all") defaults and compacted/narrated on nearly every turn.
+    "photon":          _TIER_LOW,
     "bluebubbles":     _TIER_LOW,
     "weixin":          _TIER_LOW,
     "wecom":           _TIER_LOW,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -353,16 +353,40 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
     return bool(_GATEWAY_PROVIDER_ERROR_SHAPE_RE.search(body))
 
 
-def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
-    """Sanitize final gateway replies before sending them to high-noise chats.
+def _is_quiet_chat_platform(platform: Any) -> bool:
+    """True for mobile / non-interactive inboxes that should not receive internal
+    status noise (compaction, auxiliary, retry banners) or raw provider error
+    bodies — Telegram plus every TIER_LOW / TIER_MINIMAL platform (Photon/iMessage,
+    BlueBubbles, Signal, WhatsApp Cloud, WeChat, SMS, email, ...). Discord, CLI,
+    and editable team channels (Slack/Mattermost) keep full diagnostics. Driven by
+    the platform's *default* display tier, so any future low-tier platform is
+    covered automatically.
+    """
+    platform_value = _gateway_platform_value(platform)
+    if platform_value == "telegram":
+        return True
+    if not platform_value:
+        return False
+    from gateway.display_config import resolve_display_setting
 
-    Telegram is Bob's mobile inbox, so it should receive concise, safe provider
-    failure categories instead of raw HTTP bodies, request IDs, or policy text.
-    Other platforms keep the existing behaviour for now.
+    return (
+        resolve_display_setting({}, platform_value, "tool_progress") == "off"
+        and resolve_display_setting({}, platform_value, "interim_assistant_messages") is False
+        and resolve_display_setting({}, platform_value, "long_running_notifications") is False
+    )
+
+
+def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
+    """Sanitize final gateway replies before sending them to mobile inboxes.
+
+    Telegram and other low-tier mobile inboxes (Photon/iMessage, BlueBubbles,
+    Signal, ...) should receive concise, safe provider failure categories instead
+    of raw HTTP bodies, request IDs, policy text, or leaked secrets. Discord/CLI
+    and team channels keep the raw behaviour.
     """
     if not text:
         return text
-    if _gateway_platform_value(platform) != "telegram":
+    if not _is_quiet_chat_platform(platform):
         return text
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
@@ -372,11 +396,18 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
 
 
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
-    """Filter/sanitize agent status callbacks before platform delivery."""
+    """Filter/sanitize agent status callbacks before platform delivery.
+
+    On mobile inboxes (Telegram + TIER_LOW/TIER_MINIMAL platforms like
+    Photon/iMessage) internal status noise — compaction / auxiliary / retry
+    banners — is dropped, and raw provider errors are replaced with a safe
+    category. The warning is still emitted to the logs; only the chat delivery is
+    suppressed. Discord/CLI and team channels keep the full status text.
+    """
     text = str(message or "").strip()
     if not text:
         return None
-    if _gateway_platform_value(platform) != "telegram":
+    if not _is_quiet_chat_platform(platform):
         return text
 
     text = _redact_gateway_user_facing_secrets(text)

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2577,3 +2577,75 @@ class TestPreflightSentinelGuard:
         compressor.last_prompt_tokens = 50_000
         result = self._seed(compressor.last_prompt_tokens, 10_000)
         assert result == 50_000
+
+
+class TestSummaryConnectionRetry:
+    """Change C: bounded retry WITH backoff around transient summarizer
+    connection errors. Targets the aux==main case (summary_model is None, so no
+    distinct fallback model), where a single Codex/Envoy stream blip would
+    otherwise drop the turns and surface a 'Compression summary failed' banner.
+    call_llm already retries once *immediately*; the value added here is the
+    backoff that lets a brief blip clear."""
+
+    @staticmethod
+    def _messages():
+        return [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "working on it"},
+            {"role": "user", "content": "and another thing"},
+            {"role": "assistant", "content": "done"},
+        ]
+
+    @staticmethod
+    def _ok_response():
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "[CONTEXT SUMMARY]: the user asked for things."
+        return resp
+
+    def test_retries_transient_connection_error_then_succeeds(self):
+        """A blip that clears within the bounded attempts yields a real summary."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test/model", quiet_mode=True)  # summary_model None => aux==main
+
+        call_llm_mock = MagicMock(side_effect=[
+            ConnectionError("connection reset by peer"),
+            ConnectionError("connection reset by peer"),
+            self._ok_response(),
+        ])
+        with patch("agent.context_compressor.call_llm", call_llm_mock), \
+             patch("agent.context_compressor.time.sleep") as sleep_mock:
+            summary = c._generate_summary(self._messages())
+
+        assert isinstance(summary, str)
+        assert summary.startswith(SUMMARY_PREFIX)
+        assert call_llm_mock.call_count == 3   # 1 initial + 2 backoff retries
+        assert sleep_mock.call_count == 2      # slept between retries (backoff)
+
+    def test_gives_up_after_bounded_attempts(self):
+        """Persistent connection failure stops after the bound (no infinite loop)
+        and degrades gracefully without raising."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test/model", quiet_mode=True)
+
+        call_llm_mock = MagicMock(side_effect=ConnectionError("connection reset by peer"))
+        with patch("agent.context_compressor.call_llm", call_llm_mock), \
+             patch("agent.context_compressor.time.sleep"):
+            summary = c._generate_summary(self._messages())
+
+        assert call_llm_mock.call_count == 3   # == _SUMMARY_CONNECTION_MAX_ATTEMPTS
+        assert summary is None or isinstance(summary, str)  # graceful, never raises
+
+    def test_non_connection_error_is_not_retried(self):
+        """Auth/4xx/etc. must NOT be retried by the connection-blip loop — they
+        fall straight through to the existing fallback/abort handling."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test/model", quiet_mode=True)
+
+        call_llm_mock = MagicMock(side_effect=RuntimeError("Invalid API key provided"))
+        with patch("agent.context_compressor.call_llm", call_llm_mock), \
+             patch("agent.context_compressor.time.sleep") as sleep_mock:
+            c._generate_summary(self._messages())
+
+        assert call_llm_mock.call_count == 1   # not retried by the connection-blip loop
+        assert sleep_mock.call_count == 0

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -207,6 +207,21 @@ class TestPlatformDefaults:
         for plat in ("signal", "bluebubbles", "weixin", "wecom", "dingtalk", "whatsapp_cloud"):
             assert resolve_display_setting({}, plat, "tool_progress") == "off", plat
 
+    def test_photon_defaults_to_low_tier(self):
+        """Photon (managed iMessage) is a permanent-message mobile inbox like
+        BlueBubbles, so it must default to TIER_LOW: tool progress off, no
+        interim scratch commentary, no heartbeats, no busy-ack iteration detail.
+        Regression guard for the Photon launch shipping without a
+        _PLATFORM_DEFAULTS entry, which left it inheriting the noisy global
+        ('all') defaults and spamming the iMessage thread."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "photon", "tool_progress") == "off"
+        assert resolve_display_setting({}, "photon", "interim_assistant_messages") is False
+        assert resolve_display_setting({}, "photon", "long_running_notifications") is False
+        assert resolve_display_setting({}, "photon", "busy_ack_detail") is False
+        assert resolve_display_setting({}, "photon", "streaming") is False
+
     def test_whatsapp_cloud_locked_to_low_tier_until_edit_message_lands(self):
         """Regression guard: ``whatsapp_cloud`` must stay TIER_LOW until the
         adapter implements edit_message. Without an edit endpoint, raising

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -81,3 +81,69 @@ def test_telegram_final_response_keeps_normal_answers():
     answer = "Here is the clean summary you asked for."
 
     assert _sanitize_gateway_final_response(Platform.TELEGRAM, answer) == answer
+
+
+# --- Low-tier mobile inboxes (Photon/iMessage, BlueBubbles, Signal, ...) ---
+# These are permanent-message mobile inboxes, so they get the same quieting as
+# Telegram: internal compaction/auxiliary/retry banners never leak into chat,
+# raw provider error bodies are replaced with a safe category, but normal final
+# replies still pass through untouched. Discord/CLI keep full diagnostics.
+
+
+def test_low_tier_status_suppresses_internal_banners():
+    """Compaction/auxiliary/retry status noise must not reach low-tier inboxes."""
+    noisy_messages = [
+        "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
+        "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
+        "⏳ Retrying in 4.2s (attempt 1/3)...",
+        "⚠️ Max retries (3) exhausted — trying fallback...",
+    ]
+    for platform in ("photon", Platform.BLUEBUBBLES, Platform.SIGNAL):
+        for message in noisy_messages:
+            assert (
+                _prepare_gateway_status_message(platform, "warn", message) is None
+            ), (platform, message)
+
+
+def test_low_tier_status_sanitizes_raw_provider_errors():
+    """Real provider errors still reach low-tier inboxes, as a safe category."""
+    raw = (
+        "❌ API failed after 3 retries — HTTP 400: request blocked because "
+        "Operation contains cybersecurity risk. request_id=req_123"
+    )
+
+    sanitized = _prepare_gateway_status_message("photon", "lifecycle", raw)
+
+    assert sanitized is not None
+    assert "provider rejected" in sanitized.lower()
+    assert "cybersecurity risk" not in sanitized.lower()
+    assert "HTTP 400" not in sanitized
+    assert "req_123" not in sanitized
+
+
+def test_low_tier_final_response_redacts_secrets_and_raw_errors():
+    """Final low-tier replies redact secrets and raw provider error bodies."""
+    raw = (
+        "⚠️ Provider authentication failed: Incorrect API key provided: "
+        "sk-live_abcdefghijklmnopqrstuvwxyz1234567890"
+    )
+
+    sanitized = _sanitize_gateway_final_response("photon", raw)
+
+    assert "authentication failed" in sanitized.lower()
+    assert "sk-live" not in sanitized
+
+
+def test_low_tier_final_response_keeps_normal_answers():
+    """Normal assistant content is never rewritten for low-tier platforms."""
+    answer = "Here is the clean summary you asked for."
+
+    assert _sanitize_gateway_final_response("photon", answer) == answer
+
+
+def test_high_tier_and_cli_still_see_internal_banners():
+    """Regression guard: Discord/CLI keep full diagnostics; banners NOT suppressed."""
+    banner = "⚠ Compression summary failed: upstream error. Inserted a fallback context marker."
+
+    assert _prepare_gateway_status_message(Platform.DISCORD, "warn", banner) == banner
+    assert _prepare_gateway_status_message("local", "warn", banner) == banner


### PR DESCRIPTION
## Summary
- Treat Photon/iMessage as a low-tier display platform by default so chat gateways stay quiet.
- Suppress non-fatal compression/retry status banners on quiet mobile chat platforms while preserving serious errors and final replies.
- Add bounded retry/backoff for transient compression summarizer connection errors when the auxiliary summarizer route is the main model.

## Why
On Photon/iMessage, compaction/retry status banners and transient summarizer failures can leak noisy internal status into the user-facing chat. Combined with a lower compression threshold, long iMessage sessions can churn and surface operational warnings too often. This keeps mobile chat UX quiet without changing richer platforms like Discord.

## Test plan
- Added regression coverage for Photon display defaults.
- Added banner suppression coverage for Photon vs non-quiet platforms.
- Added transient summarizer retry coverage.
- Local validation on Matt's install reported the new targeted tests and broad gateway/runtime sweep passing, with unrelated pre-existing baseline failures reproduced separately.

## Notes
This PR contains only the source/test changes. Matt's local install also has user-specific config changes (`compression.threshold: 0.85`, Photon quiet display block) and a temporary local auto-update carry patch until this lands upstream.