### PR TITLE
fix(vision): transcribe image text verbatim in preprocessing; stop inline-image re-read hallucination

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4321,9 +4321,11 @@ class AIAgent:
             "tool": "tool result",
         }.get(role, "user")
         analysis_prompt = (
-            "Describe everything visible in this image in thorough detail. "
-            "Include any text, code, UI, data, objects, people, layout, colors, "
-            "and any other notable visual information."
+            "First, transcribe ALL text visible in the image VERBATIM — every line, exactly as "
+            "written, including titles, dates, times, locations/addresses, prices, labels, and "
+            "fine print. Do not summarize, paraphrase, or omit any text, even small or low-contrast "
+            "text near the edges or bottom. Then describe the non-text visual content: layout, "
+            "objects, people, colors, UI, charts, and any other notable detail."
         )
 
         vision_source = str(image_url or "")
@@ -4356,6 +4358,16 @@ class AIAgent:
         if vision_source and not str(image_url or "").startswith("data:"):
             note += (
                 f"\n[If you need a closer look, use vision_analyze with image_url: {vision_source}]"
+            )
+        else:
+            # The image was provided inline (no addressable path/URL). Say so explicitly, so the
+            # model doesn't invent a file path or MEDIA handle for vision_analyze — a common
+            # hallucination that fails with "Invalid image source". The transcription above is all
+            # it has to work with.
+            note += (
+                "\n[This image was provided inline and has no file path or URL to re-read. The "
+                "transcription above is the complete extraction — do not call vision_analyze with a "
+                "guessed path; if a needed detail is missing, ask the user.]"
             )
 
         self._anthropic_image_fallback_cache[cache_key] = note

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1208,10 +1208,15 @@ def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         logger.info("vision_analyze: native fast path")
         return _vision_analyze_native(image_url, question)
 
-    # Legacy path: aux LLM describes the image and we return its text.
+    # Legacy path: aux LLM describes the image and we return its text. Ask for a verbatim
+    # transcription of all text FIRST (a plain "describe" prompt tends to summarize and drop
+    # details like an address or fine print on dense images), then the description and answer.
     full_prompt = (
-        "Fully describe and explain everything about this image, then answer the "
-        f"following question:\n\n{question}"
+        "First, transcribe ALL text visible in the image VERBATIM — every line, exactly as "
+        "written, including titles, dates, times, locations/addresses, prices, labels, and fine "
+        "print; do not summarize or omit any text, even small or low-contrast text near the edges "
+        "or bottom. Then fully describe the rest of the image and answer the following "
+        f"question:\n\n{question}"
     )
     model = os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
     return vision_analyze_tool(image_url, full_prompt, model)


### PR DESCRIPTION
## Problem

For non-vision main models, attached images are pre-described via the auxiliary vision path (`AIAgent._describe_image_for_anthropic_fallback`), and the `vision_analyze` tool's legacy path (`_handle_vision_analyze`) does the same. Both prompted the vision model to *"describe everything in thorough detail."*

On dense, text-heavy images (event posters, flyers, receipts, screenshots) that instruction tends to **summarize and silently drop text**. Observed concretely: an event poster's title/date/time were captured but the **venue/address line at the bottom was omitted**, so the main model never received it and couldn't complete the user's request (add the event, with location, to a calendar).

Separately, when an image is provided **inline** (a `data:` URL with no addressable path), models frequently **hallucinate a file path or `MEDIA:` handle** and call `vision_analyze` with it, which fails with `"Invalid image source"`.

## Fix

- **Verbatim-first prompt** in both preprocessing paths: transcribe ALL visible text exactly, line by line (titles, dates, times, addresses, prices, fine print, low-contrast/edge text) *before* describing non-text content. Far more reliable for OCR-style extraction while keeping the general description.
- **Inline-image note**: when the source is a `data:` URL (no path/URL to re-read), the injected note now says so explicitly and tells the model the transcription is the complete extraction — so it asks the user instead of inventing a path for `vision_analyze`.

## Scope

Two prompt/text changes; no behavioral/control-flow changes. Affects only the auxiliary description text fed to non-vision main models (and the legacy `vision_analyze` aux path). Native-vision models are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)