### PR TITLE
fix(redact): close header-credential leaks #50423 missed (JSON secret headers + Cookie/Set-Cookie)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -142,6 +142,44 @@ _SECRET_HEADER_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Same secret headers serialized in JSON form (``"x-api-key": "<value>"``). The
+# bare-header regex above cannot match this shape — the closing quote sits
+# between the name and the colon — and ``_JSON_FIELD_RE``'s key list omits the
+# hyphenated header names, so opaque custom/local-backend keys (no vendor prefix
+# for ``_PREFIX_RE`` to catch) leak verbatim from serialized request dumps. This
+# mirrors the JSON-field redaction shape, so it is applied under the same
+# ``code_file`` gate.
+_SECRET_HEADER_JSON_RE = re.compile(
+    # ``(?:\\.|[^"\\])`` consumes JSON string contents escape-aware, so a value
+    # containing an escaped quote (``"ab\"cd"``) is masked whole rather than
+    # truncated at the embedded quote (which would leave the tail in cleartext).
+    rf'("{_SECRET_HEADER_NAMES}"\s*:\s*")((?:\\.|[^"\\])+)(")',
+    re.IGNORECASE,
+)
+
+# Cookie: / Set-Cookie: headers carry session, auth and CSRF tokens and were
+# previously unhandled. The full cookie payload is masked while the header name
+# is preserved. A ``name=value`` pair is required so plain prose ("the cookie:
+# …") is left untouched.
+_COOKIE_HEADER_RE = re.compile(
+    r"((?:Set-)?Cookie:\s*)(\S+=[^\r\n]+)",
+    re.IGNORECASE,
+)
+
+# The on-disk request/response dump sink serializes headers as JSON, so cookies
+# also appear as ``"Cookie": "<name=value…>"`` — the bare regex above cannot see
+# that shape. A ``name=value`` pair is required so non-header ``"Cookie"`` values
+# are left untouched. JSON-shaped, so applied under the ``code_file`` gate.
+_COOKIE_HEADER_JSON_RE = re.compile(
+    # Escape-aware single-group value match (see _SECRET_HEADER_JSON_RE): the
+    # whole JSON string value of a "Cookie"/"Set-Cookie" key is masked. A single
+    # unambiguous group (no internal "=" split) avoids superlinear backtracking
+    # on malformed/unterminated JSON. A JSON key literally named Cookie is a
+    # strong-enough header signal that the "name=value" requirement is dropped.
+    r'("(?:Set-)?Cookie"\s*:\s*")((?:\\.|[^"\\])*)(")',
+    re.IGNORECASE,
+)
+
 # Telegram bot tokens: bot<digits>:<token> or <digits>:<token>,
 # where token part is restricted to [-A-Za-z0-9_] and length >= 30
 _TELEGRAM_RE = re.compile(
@@ -390,6 +428,21 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
                 return f'{key}: "{_mask_token(value)}"'
             text = _JSON_FIELD_RE.sub(_redact_json, text)
 
+            # Secret headers serialized as JSON ("x-api-key": "<opaque>"). The
+            # bare _SECRET_HEADER_RE below can't see this shape; without this an
+            # opaque custom/local-backend key leaks from on-disk request dumps.
+            text = _SECRET_HEADER_JSON_RE.sub(
+                lambda m: m.group(1) + _mask_token(m.group(2)) + m.group(3),
+                text,
+            )
+
+            # Cookies serialized as JSON ("Cookie": "sid=<secret>…") in the same
+            # request/response dump sink — the bare cookie regex can't see this.
+            text = _COOKIE_HEADER_JSON_RE.sub(
+                lambda m: m.group(1) + _mask_token(m.group(2)) + m.group(3),
+                text,
+            )
+
     # Authorization headers — _AUTH_HEADER_RE matches any scheme after
     # "[Proxy-]Authorization:" case-insensitively, so "uthorization" is the
     # cheapest substring gate that covers every casing without a casefold().
@@ -403,6 +456,18 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     # colon-separated, so gate on ":" — the regex itself is the precise filter.
     if ":" in text:
         text = _SECRET_HEADER_RE.sub(
+            lambda m: m.group(1) + _mask_token(m.group(2)),
+            text,
+        )
+
+        # Cookie: / Set-Cookie: header values (session/auth/CSRF tokens). The
+        # whole cookie payload is masked; preserving attribute words like
+        # ``HttpOnly`` is not worth a parser, and a redactor erring toward
+        # over-masking is the safe direction. No casefold-free substring gate:
+        # mixed-case headers (``CoOkie:``) must not bypass a security redactor,
+        # and the IGNORECASE regex is itself the precise filter (the ":" gate
+        # above already scopes the scan).
+        text = _COOKIE_HEADER_RE.sub(
             lambda m: m.group(1) + _mask_token(m.group(2)),
             text,
         )

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -4,6 +4,7 @@ Short tokens (< 18 chars) are fully masked; longer ones keep the first 6 and
 last 4 characters for debuggability.
 """
 
+import json
 import logging
 import os
 import re
@@ -281,7 +282,116 @@ _AUTH_HEADER_RE = re.compile(r"((?:Proxy-)?Authorization:\s*)([A-Za-z][\w.+-]*\s
 # API-key style headers (single opaque value, no scheme word): non-vendor-prefix
 # values would otherwise leak when a curl command is echoed into tool output.
 _SECRET_HEADER_NAMES = r"(?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|x-auth-token|x-access-token)"
-_SECRET_HEADER_RE = re.compile(rf"({_SECRET_HEADER_NAMES}\s*:\s*)(\S+)", re.IGNORECASE)
+_SECRET_HEADER_LINE_RE = re.compile(
+    rf"(^[ \t]*(?:[<>][ \t]+)?{_SECRET_HEADER_NAMES}:[ \t]*)([^\r\n]+)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_SECRET_HEADER_INLINE_RE = re.compile(
+    rf"({_SECRET_HEADER_NAMES}:[ \t]*)([^\s\"';&|<>()$`\\]+)",
+    re.IGNORECASE,
+)
+_SECRET_HEADER_DOUBLE_QUOTED_RE = re.compile(
+    rf'((?:^|[ \t])(?:-H(?:(?:[ \t]|\\\r?\n)*|=)'
+    rf'|--header(?:(?:[ \t]|\\\r?\n)+|=))")'
+    rf'({_SECRET_HEADER_NAMES}:[ \t]*)'
+    r'((?:\\\r?\n|\\.|[^"\\\r\n])+)(")',
+    re.IGNORECASE,
+)
+_SECRET_HEADER_SINGLE_QUOTED_RE = re.compile(
+    rf"((?:^|[ \t])(?:-H(?:(?:[ \t]|\\\r?\n)*|=)"
+    rf"|--header(?:(?:[ \t]|\\\r?\n)+|=))')"
+    rf"({_SECRET_HEADER_NAMES}:[ \t]*)([^'\r\n]+)(')",
+    re.IGNORECASE,
+)
+_SECRET_HEADER_UNQUOTED_CURL_RE = re.compile(
+    rf"((?:^|[ \t])(?:-H(?:(?:[ \t]|\\\r?\n)*|=)"
+    rf"|--header(?:(?:[ \t]|\\\r?\n)+|=)){_SECRET_HEADER_NAMES}:)"
+    r"((?:\\[^\r\n]|[^ \t\r\n;&|<>()$`\\])+)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Same secret headers serialized in JSON form (``"x-api-key": "<value>"``). The
+# bare-header regex above cannot match this shape — the closing quote sits
+# between the name and the colon — and ``_JSON_FIELD_RE``'s key list omits the
+# hyphenated header names, so opaque custom/local-backend keys (no vendor prefix
+# for ``_PREFIX_RE`` to catch) leak verbatim from serialized request dumps. This
+# mirrors the JSON-field redaction shape, so it is applied under the same
+# ``code_file`` gate.
+_SECRET_HEADER_JSON_RE = re.compile(
+    # ``(?:\\.|[^"\\])`` consumes JSON string contents escape-aware, so a value
+    # containing an escaped quote (``"ab\"cd"``) is masked whole rather than
+    # truncated at the embedded quote (which would leave the tail in cleartext).
+    rf'("{_SECRET_HEADER_NAMES}"\s*:\s*")((?:\\[^\r\n]|[^"\\\r\n])+)(")',
+    re.IGNORECASE,
+)
+
+# Fail closed for a recognized JSON header whose string value is truncated at
+# a line boundary. The primary regex above handles all valid JSON strings; this
+# fallback is deliberately line-bounded and its alternatives are disjoint so
+# malformed diagnostic output cannot trigger unbounded backtracking.
+_SECRET_HEADER_JSON_UNTERMINATED_RE = re.compile(
+    rf'("{_SECRET_HEADER_NAMES}"\s*:\s*")((?:\\[^\r\n]|[^"\\\r\n])*(?:\\)?)(?=\r?\n|\Z)',
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Cookie: / Set-Cookie: headers carry session, auth and CSRF tokens and were
+# previously unhandled. The full cookie payload is masked while the header name
+# is preserved. A ``name=value`` pair is required so plain prose ("the cookie:
+# …") is left untouched.
+# Restrict raw Cookie matching to an actual header line. A bounded cookie-name
+# class avoids repeatedly scanning whole suffixes for '=' on malformed input.
+_COOKIE_HEADER_LINE_RE = re.compile(
+    r"(^[ \t]*(?:[<>][ \t]+)?(?:Set-)?Cookie:[ \t]*)"
+    r"([!#$%&'*+\-.^_`|~0-9A-Za-z]+=[^\r\n]*)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Shell commands commonly embed a header in a quoted ``-H`` argument. Separate
+# delimiter-specific patterns cannot scan across another candidate opener, so
+# repeated malformed fragments remain linear rather than quadratic.
+_COOKIE_HEADER_DOUBLE_QUOTED_RE = re.compile(
+    r'((?:^|[ \t])(?:-H(?:(?:[ \t]|\\\r?\n)*|=)'
+    r'|--header(?:(?:[ \t]|\\\r?\n)+|=))")'
+    r'((?:Set-)?Cookie:[ \t]*)'
+    r'([!#$%&\'*+\-.^_`|~0-9A-Za-z]+=(?:\\\r?\n|\\.|[^"\\\r\n])*)(")',
+    re.IGNORECASE,
+)
+_COOKIE_HEADER_SINGLE_QUOTED_RE = re.compile(
+    r"((?:^|[ \t])(?:-H(?:(?:[ \t]|\\\r?\n)*|=)"
+    r"|--header(?:(?:[ \t]|\\\r?\n)+|=))')"
+    r"((?:Set-)?Cookie:[ \t]*)([!#$%&'*+\-.^_`|~0-9A-Za-z]+=[^'\r\n]*)(')",
+    re.IGNORECASE,
+)
+
+# An unquoted ``-H Cookie:name=value`` argument cannot contain whitespace, so
+# its token boundary is unambiguous and needs no open-ended delimiter search.
+_COOKIE_HEADER_UNQUOTED_CURL_RE = re.compile(
+    r"((?:^|[ \t])(?:-H(?:(?:[ \t]|\\\r?\n)*|=)"
+    r"|--header(?:(?:[ \t]|\\\r?\n)+|=))"
+    r"(?:Set-)?Cookie:[ \t]*)"
+    r"([!#$%&'*+\-.^_`|~0-9A-Za-z]+="
+    r"(?:\\[^\r\n]|[^ \t\r\n;&|<>()$`\\])*)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# The on-disk request/response dump sink serializes headers as JSON, so cookies
+# also appear as ``"Cookie": "<name=value…>"`` — the bare regex above cannot see
+# that shape. A ``name=value`` pair is required so non-header ``"Cookie"`` values
+# are left untouched. JSON-shaped, so applied under the ``code_file`` gate.
+_COOKIE_HEADER_JSON_RE = re.compile(
+    # Escape-aware single-group value match (see _SECRET_HEADER_JSON_RE): the
+    # whole JSON string value of a "Cookie"/"Set-Cookie" key is masked. A single
+    # unambiguous group (no internal "=" split) avoids superlinear backtracking
+    # on malformed/unterminated JSON. A JSON key literally named Cookie is a
+    # strong-enough header signal that the "name=value" requirement is dropped.
+    r'("(?:Set-)?Cookie"\s*:\s*")((?:\\[^\r\n]|[^"\\\r\n])*)(")',
+    re.IGNORECASE,
+)
+
+_COOKIE_HEADER_JSON_UNTERMINATED_RE = re.compile(
+    r'("(?:Set-)?Cookie"\s*:\s*")((?:\\[^\r\n]|[^"\\\r\n])*(?:\\)?)(?=\r?\n|\Z)',
+    re.IGNORECASE | re.MULTILINE,
+)
 
 # Telegram bot tokens: [bot]<digits>:<token>, token >= 30 chars.
 _TELEGRAM_RE = re.compile(r"(bot)?(\d{8,}):([-A-Za-z0-9_]{30,})")
@@ -489,6 +599,55 @@ def _mask_token_nonreusable(token: str) -> str:
     return f"«redacted:{label}…»" if label else "«redacted-secret»"
 
 
+def _redact_json_string_value(m: re.Match) -> str:
+    """Mask a captured JSON string value without breaking its escapes."""
+    encoded_value = m.group(2)
+    try:
+        value = json.loads(f'"{encoded_value}"')
+    except json.JSONDecodeError:
+        # The regex also accepts malformed escape pairs. Keep redaction
+        # fail-safe while emitting a syntactically valid replacement value.
+        value = encoded_value
+    if _ENV_LOOKUP_VALUE_RE.match(value):
+        return m.group(0)
+    masked = json.dumps(_mask_token(value), ensure_ascii=False)[1:-1]
+    return m.group(1) + masked + m.group(3)
+
+
+def _redact_unterminated_json_string_value(m: re.Match) -> str:
+    """Fail closed on a truncated JSON header value through end-of-line."""
+    encoded_value = m.group(2)
+    try:
+        value = json.loads(f'"{encoded_value}"')
+    except json.JSONDecodeError:
+        value = encoded_value
+    masked = json.dumps(_mask_token(value), ensure_ascii=False)[1:-1]
+    return m.group(1) + masked
+
+
+def _redact_inline_secret_header(m: re.Match) -> str:
+    """Mask an inline header token without stealing an empty curl header's URL."""
+    before = m.string[max(0, m.start() - 32):m.start()]
+    if re.search(r"(?:-H|--header)(?:[ \t]*|=)[\"']?$", before, re.IGNORECASE):
+        return m.group(0)
+    return m.group(1) + "***"
+
+
+def _redact_header_line_value(m: re.Match) -> str:
+    """Mask a header line unless it is the continued argument of curl -H."""
+    line_start = m.string.rfind("\n", 0, m.start()) + 1
+    if line_start:
+        previous_start = m.string.rfind("\n", 0, line_start - 1) + 1
+        previous = m.string[previous_start:line_start - 1].rstrip("\r")
+        if previous.rstrip().endswith("\\") and re.search(
+            r"(?:^|[ \t])(?:-H|--header)(?:[ \t]+|=).*\\[ \t]*$",
+            previous,
+            re.IGNORECASE,
+        ):
+            return m.group(0)
+    return m.group(1) + "***"
+
+
 def _assignment_sub(render, *, check_keyword: bool):
     """re.sub callback: keep the match unless the key/value pair (groups[0], groups[-1]) needs redaction."""
     def _sub(m):
@@ -526,8 +685,14 @@ def _redact_assignments(text: str) -> str:
             text = _CFG_ANCHORED_RE.sub(_redact_env, text)
 
     if ":" in text and '"' in text:
+        for pattern in (_SECRET_HEADER_JSON_RE, _COOKIE_HEADER_JSON_RE):
+            text = pattern.sub(_redact_json_string_value, text)
+        for pattern in (_SECRET_HEADER_JSON_UNTERMINATED_RE, _COOKIE_HEADER_JSON_UNTERMINATED_RE):
+            text = pattern.sub(_redact_unterminated_json_string_value, text)
+        redact_json = _assignment_sub(lambda g: f'{g[0]}: "{_mask_token(g[1])}"', check_keyword=False)
+        # The header pass owns apikey: the legacy capture would split its escapes again.
         text = _JSON_FIELD_RE.sub(
-            _assignment_sub(lambda g: f'{g[0]}: "{_mask_token(g[1])}"', check_keyword=False), text)
+            lambda m: m.group(0) if m.group(1)[1:-1].lower() == "apikey" else redact_json(m), text)
 
     # YAML after JSON: quoted values are handled there (_YAML_ASSIGN_RE skips quotes).
     if ":" in text and "://" not in text:
@@ -604,7 +769,48 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
         text = _AUTH_HEADER_RE.sub(lambda m: m.group(1) + (m.group(2) or "") + _mask_token(m.group(3)), text)
 
     if ":" in text:
-        text = _SECRET_HEADER_RE.sub(lambda m: m.group(1) + _mask_token(m.group(2)), text)
+        text = _SECRET_HEADER_LINE_RE.sub(
+            _redact_header_line_value,
+            text,
+        )
+        for pattern in (
+            _SECRET_HEADER_DOUBLE_QUOTED_RE,
+            _SECRET_HEADER_SINGLE_QUOTED_RE,
+        ):
+            text = pattern.sub(
+                lambda m: m.group(1) + m.group(2) + "***" + m.group(4),
+                text,
+            )
+        text = _SECRET_HEADER_UNQUOTED_CURL_RE.sub(
+            lambda m: m.group(1) + "***",
+            text,
+        )
+        text = _SECRET_HEADER_INLINE_RE.sub(_redact_inline_secret_header, text)
+
+        # Cookie: / Set-Cookie: header values (session/auth/CSRF tokens). The
+        # whole cookie payload is masked; preserving attribute words like
+        # ``HttpOnly`` is not worth a parser, and a redactor erring toward
+        # over-masking is the safe direction. No casefold-free substring gate:
+        # mixed-case headers (``CoOkie:``) must not bypass a security redactor,
+        # and the IGNORECASE regex is itself the precise filter (the ":" gate
+        # above already scopes the scan).
+        if not code_file:
+            text = _COOKIE_HEADER_LINE_RE.sub(
+                _redact_header_line_value,
+                text,
+            )
+            for pattern in (
+                _COOKIE_HEADER_DOUBLE_QUOTED_RE,
+                _COOKIE_HEADER_SINGLE_QUOTED_RE,
+            ):
+                text = pattern.sub(
+                    lambda m: m.group(1) + m.group(2) + "***" + m.group(4),
+                    text,
+                )
+            text = _COOKIE_HEADER_UNQUOTED_CURL_RE.sub(
+                lambda m: m.group(1) + "***",
+                text,
+            )
         text = _TELEGRAM_RE.sub(lambda m: f"{m.group(1) or ''}{m.group(2)}:***", text)
 
     if "BEGIN" in text and "-----" in text:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -189,6 +189,84 @@ class TestApiKeyHeaders:
         result = redact_sensitive_text(text)
         assert "anotherOpaqueSecret" not in result
 
+    def test_x_api_key_json_form_masked(self):
+        # JSON-serialized header (request dumps): the closing quote sits between
+        # the name and the colon, so the bare header regex can't see it, and the
+        # value has no vendor prefix for _PREFIX_RE to catch.
+        text = '{"x-api-key": "opaque-local-backend-key-1234567890"}'
+        result = redact_sensitive_text(text)
+        assert "opaque-local-backend-key" not in result
+        assert '"x-api-key":' in result
+
+    def test_x_api_key_json_form_skipped_for_code_file(self):
+        # Code fixtures must pass through unchanged, like _JSON_FIELD_RE.
+        text = '{"x-api-key": "test-fixture-value-1234567890"}'
+        assert redact_sensitive_text(text, code_file=True) == text
+
+
+class TestCookieHeaders:
+    def test_cookie_header_masked(self):
+        text = "Cookie: session=opaque-session-secret-1234567890"
+        result = redact_sensitive_text(text)
+        assert "opaque-session-secret" not in result
+        assert "Cookie:" in result
+
+    def test_set_cookie_header_masked(self):
+        text = "Set-Cookie: sessionid=opaque-session-secret-123456; HttpOnly; Path=/"
+        result = redact_sensitive_text(text)
+        assert "opaque-session-secret" not in result
+        assert "Set-Cookie:" in result
+
+    def test_cookie_case_insensitive(self):
+        text = "set-cookie: csrftoken=opaque-csrf-secret-1234567890; SameSite=Lax"
+        result = redact_sensitive_text(text)
+        assert "opaque-csrf-secret" not in result
+
+    def test_cookie_mixed_case_not_bypassed(self):
+        # Mixed-case headers must not bypass the redactor (no casing substring gate).
+        text = "CoOkie: sid=opaque-mixedcase-secret-1234567890"
+        result = redact_sensitive_text(text)
+        assert "opaque-mixedcase-secret" not in result
+
+    def test_set_cookie_mixed_case_not_bypassed(self):
+        text = "sEt-CoOkie: sessionid=opaque-mixedcase-secret-123456; HttpOnly"
+        result = redact_sensitive_text(text)
+        assert "opaque-mixedcase-secret" not in result
+
+    def test_cookie_prose_unchanged(self):
+        # "cookie:" with no name=value pair is plain prose, not a header.
+        text = "the cookie: chocolate chip is the best recipe"
+        assert redact_sensitive_text(text) == text
+
+    def test_cookie_json_form_masked(self):
+        text = '{"Cookie": "sessionid=opaque-session-secret-1234567890; HttpOnly"}'
+        result = redact_sensitive_text(text)
+        assert "opaque-session-secret" not in result
+        assert '"Cookie":' in result
+
+    def test_request_dump_headers_block_masked(self):
+        # The real serialize-then-redact sink (agent_runtime_helpers request
+        # dump): both the opaque api key and the cookie must be masked.
+        text = (
+            '{"headers": {"x-api-key": "opaqueCustomBackendKey99887766", '
+            '"Cookie": "sid=opaqueSession5544332211; Path=/"}}'
+        )
+        result = redact_sensitive_text(text, force=True)
+        assert "opaqueCustomBackendKey" not in result
+        assert "opaqueSession5544332211" not in result
+
+    def test_cookie_json_form_with_escaped_quote_masked(self):
+        # A JSON cookie value containing an escaped quote must be masked whole,
+        # not truncated at the embedded quote (which would leak the suffix).
+        text = '{"Cookie": "sid=abc\\"def; csrftoken=opaqueCsrfSecret998877"}'
+        result = redact_sensitive_text(text, force=True)
+        assert "opaqueCsrfSecret" not in result
+
+    def test_secret_header_json_form_with_escaped_quote_masked(self):
+        text = '{"x-api-key": "ab\\"opaqueKeyTail1234567890"}'
+        result = redact_sensitive_text(text, force=True)
+        assert "opaqueKeyTail" not in result
+
 
 class TestTelegramTokens:
     def test_bot_token(self):

--- a/tests/agent/test_redact_headers.py
+++ b/tests/agent/test_redact_headers.py
@@ -1,0 +1,35 @@
+"""Header redaction must preserve the syntax consumed by diagnostic tools."""
+
+import json
+import shlex
+
+from agent.redact import redact_sensitive_text
+
+
+def test_json_headers_remain_parseable_without_exposing_credentials():
+    for name in ("x-api-key", "X-Goog-Api-Key", "apikey", "Cookie", "Set-Cookie"):
+        for value in ('abcd="opaque-session-secret-1234567890"; Path=/',
+                      'short"value', "opaque\\session\\credential1234567890"):
+            payload = {"headers": {name: value}, "model": "example", "messages": []}
+            serialized = json.dumps(payload)
+            redacted = redact_sensitive_text(serialized, force=True)
+            restored = json.loads(redacted)
+            assert restored["headers"][name] != value
+            assert "opaque-session-secret" not in restored["headers"][name]
+            assert restored["model"] == payload["model"]
+            assert restored["messages"] == payload["messages"]
+            assert redact_sensitive_text(serialized, force=True, code_file=True) == serialized
+
+
+def test_raw_headers_mask_all_values_without_consuming_shell_or_next_line():
+    value = "sid=opaque-session-secret-1234567890; second=another-credential"
+    for name in ("Cookie", "sEt-CoOkIe", "x-api-key"):
+        raw = f"{name}: {value}\nX-Trace: unchanged"
+        assert redact_sensitive_text(raw, force=True) == f"{name}: ***\nX-Trace: unchanged"
+        for flag in ("-H", "--header"):
+            for quote in ("'", '"'):
+                command = f"curl {flag} {quote}{name}: {value}{quote} https://example.com/path"
+                output = redact_sensitive_text(command, force=True)
+                assert shlex.split(output) == ["curl", flag, f"{name}: ***", "https://example.com/path"]
+    for benign in ("the cookie: is a browser feature", 'Cookie.set("name", value)'):
+        assert redact_sensitive_text(benign, force=True) == benign


### PR DESCRIPTION
Follow-up to the just-merged #50423 (mask `Authorization` schemes + bare `x-api-key`-style headers). Two sibling shapes of the same header-credential leak class are still uncovered, and both reach the exact sink #50423 targets — the on-disk serialized request/response dumps (`{"headers": {...}}`):

1. **JSON-serialized secret headers** — `_SECRET_HEADER_RE` is anchored on the bare `name: value` form, so it can't see `"x-api-key": "<value>"` (the closing quote sits between the name and the colon), and `_JSON_FIELD_RE`'s key list omits the hyphenated header names. An **opaque custom/local-backend** key (no vendor prefix for `_PREFIX_RE`) leaks verbatim. *(Vendor-prefixed keys like `sk-…`/`AIza…` are already masked.)*
2. **`Cookie:` / `Set-Cookie:` headers** — session/auth/CSRF tokens were not handled at all (`grep -i cookie agent/redact.py` → 0 hits). `Cookie: session=<secret>` / `Set-Cookie: sessionid=<secret>; HttpOnly` leaked verbatim.

Each class is closed in **both** the raw header-line form and the JSON-serialized form.

**Notes**
- JSON-form redaction (`_SECRET_HEADER_JSON_RE`, `_COOKIE_HEADER_JSON_RE`) sits under the existing `code_file` gate alongside `_JSON_FIELD_RE`, so source-code fixtures are left alone (matches existing behavior).
- JSON value regexes are escape-aware (`(?:\\.|[^"\\])`) so an embedded escaped quote can't truncate the match and leak the suffix; the JSON cookie matcher is a single unambiguous group (no ReDoS on malformed input).
- Cookie masking covers the whole payload (attribute words like `HttpOnly` included) — over-masking is the safe direction for a redactor. No casing substring gate, so mixed-case headers (`CoOkie:`) can't bypass it.

Tests added to `tests/agent/test_redact.py` (raw + JSON + escaped-quote + mixed-case + request-dump-sink); full suite passes.

If any of this already landed via a separate patch, please feel free to close.
