### PR TITLE
fix(desktop): guard second-instance focus against destroyed mainWindow (#50491)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -6661,7 +6661,7 @@ if (!_gotSingleInstanceLock) {
   app.on('second-instance', (_event, argv) => {
     const url = _extractDeepLink(argv)
     if (url) handleDeepLink(url)
-    else if (mainWindow) {
+    else if (mainWindow && !mainWindow.isDestroyed()) {
       if (mainWindow.isMinimized()) mainWindow.restore()
       mainWindow.focus()
     }

--- a/apps/desktop/electron/single-instance-guard.test.cjs
+++ b/apps/desktop/electron/single-instance-guard.test.cjs
@@ -1,0 +1,44 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const ELECTRON_DIR = __dirname
+
+function readElectronFile(name) {
+  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8').replace(/\r\n/g, '\n')
+}
+
+// Regression guard for #50491: closing the window (Cmd+W) without quitting
+// destroys the BrowserWindow but leaves `mainWindow` set. The 'second-instance'
+// handler (re-focus on a second launch / dock click / hermes:// deep link) used
+// to focus mainWindow after only a truthiness check, so it touched a destroyed
+// native object and crashed the still-running process with an uncaught
+// 'TypeError: Object has been destroyed'. The focus branch must additionally
+// check !mainWindow.isDestroyed() before calling isMinimized()/restore()/focus().
+test("second-instance focus branch guards against a destroyed mainWindow", () => {
+  const source = readElectronFile('main.cjs')
+
+  const handlerIndex = source.indexOf("app.on('second-instance'")
+  assert.notEqual(handlerIndex, -1, "missing 'second-instance' handler")
+
+  const handler = source.slice(handlerIndex, handlerIndex + 400)
+
+  // The branch that focuses an existing window must confirm the window is not
+  // destroyed before touching it, matching the sibling 'activate' handler.
+  assert.match(
+    handler,
+    /else if \(mainWindow && !mainWindow\.isDestroyed\(\)\) \{/,
+    "second-instance focus branch must guard with !mainWindow.isDestroyed()"
+  )
+
+  // A bare truthiness-only guard immediately followed by isMinimized() is the
+  // exact crash shape from #50491 and must not regress.
+  assert.doesNotMatch(
+    handler,
+    /else if \(mainWindow\) \{\s*if \(mainWindow\.isMinimized\(\)\)/,
+    "second-instance focus branch must not call isMinimized() behind an unguarded mainWindow check"
+  )
+})


### PR DESCRIPTION
## Summary

Fixes #50491 — Hermes Desktop crashes with `Object has been destroyed` when the `second-instance` event fires after `mainWindow` has been closed.

The `second-instance` handler in `apps/desktop/electron/main.cjs` re-focuses `mainWindow` after only a truthiness check:

```js
else if (mainWindow) {
  if (mainWindow.isMinimized()) mainWindow.restore()
  mainWindow.focus()
}
```

Closing the window with ⌘W (without quitting) destroys the `BrowserWindow`, but the `mainWindow` variable is never nulled, so the reference survives as a stale handle. A subsequent launch (`open -a Hermes`), dock re-focus, or `hermes://` deep link fires `second-instance`, the `if (mainWindow)` check passes, and `mainWindow.isMinimized()` throws an uncaught `TypeError: Object has been destroyed`, crashing the still-running Electron process.

## Fix

Add the `!mainWindow.isDestroyed()` check that is already used by the sibling `activate` handler (a few lines below) and 10+ other sites in the same file:

```diff
-    else if (mainWindow) {
+    else if (mainWindow && !mainWindow.isDestroyed()) {
       if (mainWindow.isMinimized()) mainWindow.restore()
       mainWindow.focus()
     }
```

When the window is gone, the `activate` handler (dock click) already recreates it via `createWindow()`; the `second-instance` event is now harmlessly absorbed instead of crashing.

## Commits

1. `fix(desktop)` — add the `isDestroyed()` guard to the `second-instance` focus branch.
2. `test(desktop)` — source-text regression test (the established convention for `main.cjs`, which can't be imported because it requires `electron`) asserting the guard is present and the bare-truthiness crash shape does not regress.

## Testing

```
$ node --test apps/desktop/electron/single-instance-guard.test.cjs
# pass 1  # fail 0
```

## Notes

This is the `second-instance` site only — the same "stale reference to a destroyed Electron object" pattern noted in the issue at other call sites (#38468 `getWindowState`, #47826 `readTitle`) is tracked separately and out of scope here, matching the issue author's scoping.
