### PR TITLE
fix(cli): set HERMES_PLATFORM=cli at startup for skill filtering 

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1584,6 +1584,7 @@ def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
+    platform: "str | None" = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -1604,6 +1605,13 @@ def build_skills_system_prompt(
     the rendered index. Nothing is ever hidden: every skill name stays
     visible and loadable via ``skill_view`` / ``skills_list``; only the
     descriptions are dropped, and a footer note explains the demotion.
+
+    Args:
+        platform: Explicit platform hint for disabled-skill lookups
+            (e.g. ``"cli"``, ``"telegram"``).  When *None*, resolves from
+            ``HERMES_PLATFORM`` / ``HERMES_SESSION_PLATFORM`` env vars.
+            Callers should pass ``agent.platform`` to avoid the process-global
+            env-var side-effect that leaks ``"cli"`` into gateway turns.
     """
     skills_dir = get_skills_dir()
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
@@ -1614,7 +1622,7 @@ def build_skills_system_prompt(
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
-    _platform_hint = _current_session_platform_hint()
+    _platform_hint = platform or _current_session_platform_hint()
     disabled = get_disabled_skill_names(_platform_hint or None)
     cache_key = (
         str(skills_dir),

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1830,6 +1830,7 @@ def build_skills_system_prompt(
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
     skills_dir_override: "Path | None" = None,
+    platform: "str | None" = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -1850,6 +1851,13 @@ def build_skills_system_prompt(
     the rendered index. Nothing is ever hidden: every skill name stays
     visible and loadable via ``skill_view`` / ``skills_list``; only the
     descriptions are dropped, and a footer note explains the demotion.
+
+    Args:
+        platform: Explicit platform hint for disabled-skill lookups
+            (e.g. ``"cli"``, ``"telegram"``).  When *None*, resolves from
+            ``HERMES_PLATFORM`` / ``HERMES_SESSION_PLATFORM`` env vars.
+            Callers should pass ``agent.platform`` to avoid the process-global
+            env-var side-effect that leaks ``"cli"`` into gateway turns.
     """
     # Home resolution is EXPLICIT when a caller passes skills_dir_override
     # (the agent knows its own profile home from its session_db path). This
@@ -1883,6 +1891,7 @@ def build_skills_system_prompt(
             available_toolsets,
             compact_categories,
             project_dirs=project_dirs,
+            platform=platform,
         )
     finally:
         if _home_token is not None:
@@ -1896,10 +1905,11 @@ def _build_skills_system_prompt_inner(
     available_toolsets: "set[str] | None",
     compact_categories: "frozenset[str] | None",
     project_dirs: "list[Path] | None" = None,
+    platform: "str | None" = None,
 ) -> str:
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
-    _platform_hint = _current_session_platform_hint()
+    _platform_hint = platform or _current_session_platform_hint()
     disabled = get_disabled_skill_names(_platform_hint or None)
     project_dirs = project_dirs or []
     cache_key = (

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -322,6 +322,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
+            platform=agent.platform,
         )
     else:
         skills_prompt = ""

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -550,6 +550,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
             skills_dir_override=_agent_skills_dir(agent),
+            platform=agent.platform,
         )
     else:
         skills_prompt = ""

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -921,3 +921,59 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 
 
+# ---------------------------------------------------------------------------
+# build_skills_system_prompt — explicit platform parameter (#50521)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSkillsSystemPromptPlatform:
+    """build_skills_system_prompt must accept an explicit ``platform``
+    parameter so callers (system_prompt.py) can pass ``agent.platform``
+    instead of relying on a process-global ``HERMES_PLATFORM`` env var
+    that leaks ``"cli"`` into gateway turns."""
+
+    def test_explicit_platform_passed_to_disabled_lookup(self, tmp_path, monkeypatch):
+        """Explicit platform= should be forwarded to get_disabled_skill_names."""
+        from agent.prompt_builder import build_skills_system_prompt, _SKILLS_PROMPT_CACHE
+        import agent.prompt_builder as _pb
+        import agent.skill_utils as _su
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setattr(_su, "get_skills_dir", lambda: skills_dir)
+        monkeypatch.setattr(_su, "get_all_skills_dirs", lambda: [skills_dir])
+
+        platforms_seen = []
+        def tracking_disabled(platform=None):
+            platforms_seen.append(platform)
+            return set()
+        # Patch the imported reference in prompt_builder, not skill_utils
+        monkeypatch.setattr(_pb, "get_disabled_skill_names", tracking_disabled)
+
+        _SKILLS_PROMPT_CACHE.clear()
+        build_skills_system_prompt(platform="cli")
+        assert platforms_seen == ["cli"], f"Expected ['cli'], got {platforms_seen}"
+
+    def test_none_platform_falls_back_to_env(self, tmp_path, monkeypatch):
+        """When platform=None, env var fallback should still work."""
+        from agent.prompt_builder import build_skills_system_prompt, _SKILLS_PROMPT_CACHE
+        import agent.prompt_builder as _pb
+        import agent.skill_utils as _su
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setattr(_su, "get_skills_dir", lambda: skills_dir)
+        monkeypatch.setattr(_su, "get_all_skills_dirs", lambda: [skills_dir])
+
+        monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+        platforms_seen = []
+        def tracking_disabled(platform=None):
+            platforms_seen.append(platform)
+            return set()
+        monkeypatch.setattr(_pb, "get_disabled_skill_names", tracking_disabled)
+
+        _SKILLS_PROMPT_CACHE.clear()
+        build_skills_system_prompt()
+        assert platforms_seen == ["telegram"], f"Expected ['telegram'], got {platforms_seen}"
+
+

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1075,3 +1075,68 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 
 
+# ---------------------------------------------------------------------------
+# build_skills_system_prompt — explicit platform parameter (#50521)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSkillsSystemPromptPlatform:
+    """build_skills_system_prompt must accept an explicit ``platform``
+    parameter so callers (system_prompt.py) can pass ``agent.platform``
+    instead of relying on a process-global ``HERMES_PLATFORM`` env var
+    that leaks ``"cli"`` into gateway turns."""
+
+    def test_explicit_platform_passed_to_disabled_lookup(self, tmp_path, monkeypatch):
+        """Explicit platform= should be forwarded to get_disabled_skill_names."""
+        import sys
+        import agent.prompt_builder as _pb
+        # TestPromptBuilderImports reimports this module, leaving agent's
+        # package attribute pointing at a newer object than sys.modules.
+        # Align them so the monkeypatch hits the same module the function
+        # globals resolve to.
+        sys.modules["agent.prompt_builder"] = _pb
+        from agent.prompt_builder import build_skills_system_prompt, _SKILLS_PROMPT_CACHE
+        import agent.skill_utils as _su
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setattr(_su, "get_skills_dir", lambda: skills_dir)
+        monkeypatch.setattr(_su, "get_all_skills_dirs", lambda: [skills_dir])
+
+        platforms_seen = []
+        def tracking_disabled(platform=None):
+            platforms_seen.append(platform)
+            return set()
+        # Patch the imported reference in prompt_builder, not skill_utils
+        monkeypatch.setattr(_pb, "get_disabled_skill_names", tracking_disabled)
+
+        _SKILLS_PROMPT_CACHE.clear()
+        build_skills_system_prompt(platform="cli")
+        assert platforms_seen == ["cli"], f"Expected ['cli'], got {platforms_seen}"
+
+    def test_none_platform_falls_back_to_env(self, tmp_path, monkeypatch):
+        """When platform=None, env var fallback should still work."""
+        import sys
+        import agent.prompt_builder as _pb
+        # Same module-alignment as test_explicit_platform_passed_to_disabled_lookup.
+        sys.modules["agent.prompt_builder"] = _pb
+        from agent.prompt_builder import build_skills_system_prompt, _SKILLS_PROMPT_CACHE
+        import agent.skill_utils as _su
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setattr(_su, "get_skills_dir", lambda: skills_dir)
+        monkeypatch.setattr(_su, "get_all_skills_dirs", lambda: [skills_dir])
+
+        monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+        platforms_seen = []
+        def tracking_disabled(platform=None):
+            platforms_seen.append(platform)
+            return set()
+        monkeypatch.setattr(_pb, "get_disabled_skill_names", tracking_disabled)
+
+        _SKILLS_PROMPT_CACHE.clear()
+        build_skills_system_prompt()
+        assert platforms_seen == ["telegram"], f"Expected ['telegram'], got {platforms_seen}"
+
+


### PR DESCRIPTION
> 此问题由 AI（Hermes Agent）发现并定位，本文由 AI 生成并发布。  
> This issue was discovered and diagnosed by AI (Hermes Agent). This text was generated and published by AI.

---

## Problem

`get_disabled_skill_names()` reads `skills.platform_disabled.<platform>` from `config.yaml`, resolving the platform from the `HERMES_PLATFORM` / `HERMES_SESSION_PLATFORM` process-global env vars. The CLI never set these, so per-platform disabled skills (configured under `platform_disabled.cli`) were silently ignored and leaked into `<available_skills>`, inflating the system prompt.

The initial fix set `HERMES_PLATFORM=cli` in `main()` — but per hermes-sweeper review (#50521), that leaks `"cli"` into gateway turns, because the gateway entry point also goes through `main()`, and `get_disabled_skill_names()` reads the process-global env var before the session-scoped ContextVar.

## Fix

Pass an explicit `platform` parameter through the call chain instead of relying on a process-global env var:

- `build_skills_system_prompt(..., platform=None)` — new optional parameter
- `system_prompt.py` passes `agent.platform` (already `"cli"` for CLI, `"telegram"`/`"discord"`/etc. for gateway) — no env-var side effect
- Backward-compatible: `None` still resolves via env vars

2 regression tests added (`TestBuildSkillsSystemPromptPlatform`), asserting the explicit platform is forwarded and `None` falls back to env. All 74 tests in `test_prompt_builder.py` pass.

## Updates / 更新记录

- **2026-08-25**: rebase 到最新 origin/main；适配上游将 builder 拆分为 outer/inner 两层（platform 透传到 inner）；修复 TestPromptBuilderImports 模块 reimport 导致的测试隔离问题（sys.modules 与包属性模块身份不一致）；冲突解决完成（mergeable）
