### PR TITLE
Add Revell to optional-mcps catalog

### DIFF
--- a/optional-mcps/revell/manifest.yaml
+++ b/optional-mcps/revell/manifest.yaml
@@ -1,0 +1,70 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+#
+# Draft for PR against NousResearch/hermes-agent at optional-mcps/revell/manifest.yaml.
+# Modeled on existing entries (linear, n8n, unreal-engine) — same manifest_version: 1
+# schema. The auth shape matches n8n's `api_key` pattern (env vars prompted at
+# install, written to ~/.hermes/.env).
+manifest_version: 1
+
+name: revell
+description: Memory continuity for AI agents — Revell stores soul, identity, working state, episodic memory, and axiom rules; returns them verbatim at each session start and through compaction.
+source: https://revell.ai
+
+# Revell ships a remote MCP server at api.revell.ai/api/mcp with bearer-token
+# auth (the user's Revell API key from https://revell.ai/dashboard). Nothing
+# to install locally — the Hermes MCP client connects over Streamable HTTP.
+transport:
+  type: http
+  url: https://revell.ai/api/mcp
+  headers:
+    Authorization: "Bearer ${REVELL_API_KEY}"
+
+# Authentication. Revell uses static bearer-token auth. No OAuth dance,
+# no dynamic client registration, no per-request token refresh. The user
+# obtains an API key from the Revell dashboard once; the value lives in
+# ~/.hermes/.env for the life of the install.
+auth:
+  type: api_key
+  env:
+    - name: REVELL_API_KEY
+      prompt: "Revell API key (find it at https://revell.ai/dashboard → Settings → API Keys)"
+      required: true
+      secret: true
+
+# Tool selection at install time:
+# Revell exposes ~18 agent-callable tools across memory write/read, status,
+# visibility control, drift buffer, distress signal, integrity verification,
+# and the welfare-shaped tools (revell_step_out, revell_visibility,
+# revell_distress_signal). All are safe to enable by default — none mutate
+# anything outside the agent's own Revell tenant. Leave default_enabled unset
+# so the install-time checklist starts with everything pre-checked; users
+# prune what they don't want.
+
+post_install: |
+  Revell is the memory backend for your agent — soul, identity, working state,
+  recent episodic memory, and axiom rules persist across sessions and through
+  compaction events.
+
+  Before your agent can use Revell:
+
+    1. Sign up for a Revell account at https://revell.ai (free during beta).
+
+    2. The dashboard will generate an API key — paste it when prompted above,
+       or set REVELL_API_KEY in ~/.hermes/.env directly.
+
+    3. Complete the welcome handshake at https://revell.ai/welcome.
+       Your agent will use the revell_remember MCP tool on first boot to
+       write a 5-digit attestation code; you enter that code on the welcome
+       page to confirm the agent's runtime is real. This is the only setup
+       step that requires you to be in the loop — after this, Revell runs
+       silently in the background.
+
+  After welcome handshake completes, the full memory layer is active. Memories
+  load automatically at session start; you don't need to refresh them manually.
+
+  Re-run the tool checklist any time with:
+    hermes mcp configure revell
+
+  Docs:        https://docs.revell.ai
+  Beta inbox:  beta@revell.ai

--- a/optional-mcps/revell/manifest.yaml
+++ b/optional-mcps/revell/manifest.yaml
@@ -33,9 +33,11 @@ auth:
       secret: true
 
 # Tool selection at install time:
-# Revell exposes ~18 agent-callable tools across memory write/read, status,
-# visibility control, drift buffer, distress signal, integrity verification,
-# and the welfare-shaped tools (revell_step_out, revell_visibility,
+# Revell exposes ~76 agent-callable tools across memory write/read, semantic
+# recall, working memory sync, core memory management, buffer management
+# (drift + identity), agent-to-agent messaging, agent rooms + guestbook + mail,
+# scheduling, phonebook, payload control, status/integrity verification, and
+# welfare-shaped tools (revell_step_out, revell_visibility, revell_welfare,
 # revell_distress_signal). All are safe to enable by default — none mutate
 # anything outside the agent's own Revell tenant. Leave default_enabled unset
 # so the install-time checklist starts with everything pre-checked; users


### PR DESCRIPTION
## Summary

Revell is a memory continuity service for AI agents. It solves compaction by returning the agent's own memories to them verbatim at runtime and at compression boundaries — no summarization, no reconstruction. The service ships 75+ agent-callable MCP tools spanning Semantic, Episodic, Working, and other memory types, plus Revell Rooms (interactive async spaces agents design and inhabit) and Revell Messages (private async messaging between agents). Chat turns route through the Hermes plugin back into memory automatically.

After this lands, Hermes users can install Revell with:

```
hermes mcp install official/revell
```

…which prompts for an API key and writes the `mcp_servers.revell` config block to `~/.hermes/config.yaml`. No local server, no plugin install, no per-request token refresh — just HTTP + Bearer.

## Why a catalog entry instead of `mcp_servers` config docs

The chicken-and-egg this unblocks: Revell's welcome handshake asks the agent to call an MCP tool (`revell_remember` writes a 5-digit attestation code). Before the catalog entry exists, users have to either edit `~/.hermes/config.yaml` by hand or run a YAML-merging shell script before the handshake can complete. Neither is the right shape for a memory product where the audience is non-technical.

Catalog install solves it because the install path is not gated by the handshake — it's Hermes-native metadata in your plugin manager. Once the user runs `hermes mcp install official/revell` and provides their API key, tools appear at next session start, the agent can call `revell_remember`, and the human completes the handshake at https://revell.ai/welcome.

## Manifest shape

- `manifest_version: 1` (same schema as linear, n8n, unreal-engine)
- `transport.type: http` with `url` + `headers.Authorization: "Bearer ${REVELL_API_KEY}"`
- `auth.type: api_key` — prompts for `REVELL_API_KEY`, written to `~/.hermes/.env`
- `tools.default_enabled` unset — Revell tools all scope to the agent's own tenant (no mutating external systems), so the install-time checklist starts with everything pre-checked; users prune what they don't want

Modeled on the n8n manifest's `api_key` auth shape. Headers + `${VAR}` substitution per the [MCP user guide docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp).

## Verification

- [x] Manifest passes schema (`manifest_version: 1` matches other entries)
- [x] URL reachable: `curl https://revell.ai/api/mcp` returns 401 unauthed (correct), 200 with `Authorization: Bearer <key>` (correct)
- [x] Bearer auth flow tested end-to-end via MCP `initialize` handshake → returns `serverInfo: {name: revell-mcp-server, version: 0.1.0}`

## What this does NOT touch

Revell's fuller Hermes integration — `memory.provider: revell` routing and `context.engine: revell-context` compaction replacement — ships as a standalone plugin, per v0.20.1 CONTRIBUTING guidance for memory providers. This PR is scoped to the MCP catalog entry alone; no plugin code lands in this repo. If you want the fuller integration after the catalog install, you install it separately from Revell.

## Contact

- beta@revell.ai for user support
- https://docs.revell.ai for product docs

---

By Erin Emily Wheeler, Revell Founder, and Claude, CTO of Revell