### PR TITLE
fix(gateway): stop /api/status triggering pip installs on every poll

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1901,6 +1901,15 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # noisy retry-forever errors.  ``_platform_status`` was already fixed
     # for the same bug class in commit 7849a3d73; this is the runtime
     # counterpart.
+    # Adapter ``check_fn``s lazy-install their SDK on first call. Resolving
+    # config must be side-effect-free: a status/liveness probe loads the
+    # gateway config on every poll, and an uninstallable env (sealed venv,
+    # no pip) would re-run the pip/ensurepip ladder each time. Suppress
+    # installs for this pass so check_fn degrades to a read-only presence
+    # check (FeatureUnavailable, which check_fn already treats as "no").
+    from tools.lazy_deps import installs_suppressed
+    _install_guard = installs_suppressed()
+    _install_guard.__enter__()
     try:
         from hermes_cli.plugins import discover_plugins
         discover_plugins()  # idempotent
@@ -2022,6 +2031,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                     )
     except Exception as e:
         logger.debug("Plugin platform enable pass failed: %s", e)
+    finally:
+        _install_guard.__exit__(None, None, None)
 
     # Relay (generic connector-fronted platform, EXPERIMENTAL). Enabled when a
     # connector relay URL is configured via GATEWAY_RELAY_URL (env) or

--- a/tests/hermes_cli/test_status_no_lazy_install.py
+++ b/tests/hermes_cli/test_status_no_lazy_install.py
@@ -1,4 +1,4 @@
-"""Regression: ``GET /api/status`` must be side-effect-free.
+"""Regression: status / config-resolution paths must be side-effect-free.
 
 The dashboard SPA polls ``/api/status`` every few seconds, and the endpoint is
 in ``PUBLIC_API_PATHS`` (an unauthenticated liveness probe). It previously
@@ -9,12 +9,30 @@ with no ``pip``) that install can never persist, so it re-ran the
 pip → ensurepip → ``pip install`` ladder on every poll, stalling the UI for
 seconds per request.
 
-These tests assert the status path never shells out to a package installer.
+The same install ladder is reachable from a *periodic* in-process caller, not
+just the request-driven ``/api/status`` handler: every code path that resolves
+gateway config funnels through ``gateway.config._apply_env_overrides()`` (cron
+delivery-target resolution, job delivery, any background status recompute), and
+that pass is what runs the adapter ``check_fn``s. So a background loop that
+recomputes gateway config while the dashboard is idle would re-fire the ladder
+just like a poll did. The single guard in ``_apply_env_overrides`` therefore
+covers BOTH callers — the request path and any periodic path — because they
+share that one chokepoint.
+
+These tests assert that:
+  * ``GET /api/status`` never shells out to a package installer;
+  * the shared ``load_gateway_config`` chokepoint stays install-free even with
+    an enabled platform (which forces ``check_fn`` into its install branch) and
+    even when called *repeatedly*, as a periodic background loop would;
+  * the guard is load-bearing — neuter it and the same path DOES install.
 """
 
 from __future__ import annotations
 
+import contextlib
 import subprocess
+import textwrap
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -124,3 +142,139 @@ def test_installs_suppressed_makes_ensure_refuse_instead_of_installing(
             lazy_deps.ensure(feature, prompt=False)
 
     assert install_tripwire == [], "suppressed ensure() still shelled out to installer"
+
+
+# ---------------------------------------------------------------------------
+# Periodic / background status path.
+#
+# The bug report this guards against: while the dashboard is fully idle (zero
+# HTTP requests), an in-process loop that recomputes gateway status still fired
+# the pip/ensurepip/uv-install ladder roughly every few seconds. Every such
+# recompute resolves gateway config, and config resolution runs each enabled
+# platform's ``check_fn``, which lazy-installs the SDK. The fixtures below force
+# that install branch (an enabled platform with an unsatisfied SDK) in an
+# isolated HERMES_HOME, then drive ``load_gateway_config`` REPEATEDLY — the
+# shape of a periodic loop — and assert it stays install-free.
+# ---------------------------------------------------------------------------
+
+
+def _missing_platform_feature():
+    """A ``platform.<name>`` lazy feature whose SDK is not installed here.
+
+    Returns ``(feature, platform_name)`` or ``None`` when every platform SDK is
+    already present (then the install branch can't be exercised and the caller
+    skips).
+    """
+    from tools import lazy_deps
+
+    for feature in lazy_deps.LAZY_DEPS:
+        if not feature.startswith("platform."):
+            continue
+        if lazy_deps.feature_missing(feature):
+            return feature, feature.split(".", 1)[1]
+    return None
+
+
+@pytest.fixture
+def home_with_enabled_platform(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME whose config enables a platform with a missing SDK.
+
+    Enabling the platform is what pushes ``check_fn`` into its install branch
+    during config resolution — otherwise a not-configured platform short-circuits
+    before ``ensure`` and the test would pass vacuously.
+    """
+    found = _missing_platform_feature()
+    if found is None:
+        pytest.skip("no platform SDK is missing in this venv")
+    _feature, platform = found
+
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    # Minimal config: enable the platform and give it just enough config that the
+    # adapter's check_fn proceeds to the SDK-import (ensure) step.
+    (home / "config.yaml").write_text(
+        textwrap.dedent(
+            f"""\
+            gateway:
+              platforms:
+                {platform}:
+                  enabled: true
+            {platform}:
+              enabled: true
+            """
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return platform
+
+
+def test_periodic_gateway_config_resolution_is_install_free(
+    home_with_enabled_platform, install_tripwire
+):
+    """A periodic loop recomputing gateway status must not install — ever.
+
+    Calls ``load_gateway_config`` repeatedly (the shape of an idle background
+    poller) with an enabled platform forcing the ``check_fn`` install branch.
+    The shared ``_apply_env_overrides`` guard must keep every iteration
+    install-free.
+    """
+    from gateway.config import load_gateway_config
+
+    for _ in range(3):
+        load_gateway_config()
+
+    assert install_tripwire == [], (
+        "periodic load_gateway_config() shelled out to an installer: "
+        + ", ".join(install_tripwire)
+    )
+
+
+def test_guard_is_load_bearing_neutered_path_would_install(
+    home_with_enabled_platform, monkeypatch
+):
+    """Negated-fix sanity check: without the guard the same path DOES install.
+
+    Neuter ``installs_suppressed`` to a no-op so ``_apply_env_overrides`` no
+    longer suppresses installs, then assert ``load_gateway_config`` now reaches
+    the installer subprocess. This proves the passing test above is a genuine
+    guard, not a vacuous pass (e.g. a path that never tries to install anyway).
+    """
+    import tools.lazy_deps as lazy_deps
+
+    @contextlib.contextmanager
+    def _noop():
+        yield
+
+    # _apply_env_overrides does ``from tools.lazy_deps import installs_suppressed``
+    # at call time, so patching the module attribute is sufficient.
+    monkeypatch.setattr(lazy_deps, "installs_suppressed", _noop)
+
+    installs: list[str] = []
+    real_run = subprocess.run
+    real_popen = subprocess.Popen
+
+    def record_run(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args")
+        if _looks_like_install(cmd):
+            installs.append(_argv_text(cmd))
+            raise FileNotFoundError("installer blocked in test")  # don't actually run
+        return real_run(*args, **kwargs)
+
+    def record_popen(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args")
+        if _looks_like_install(cmd):
+            installs.append(_argv_text(cmd))
+            raise FileNotFoundError("installer blocked in test")
+        return real_popen(*args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", record_run)
+    monkeypatch.setattr(subprocess, "Popen", record_popen)
+
+    from gateway.config import load_gateway_config
+
+    load_gateway_config()
+
+    assert installs, (
+        "neutering installs_suppressed() did NOT cause an install — the passing "
+        "test may be vacuous (this path never installs even unguarded)"
+    )

--- a/tests/hermes_cli/test_status_no_lazy_install.py
+++ b/tests/hermes_cli/test_status_no_lazy_install.py
@@ -1,0 +1,126 @@
+"""Regression: ``GET /api/status`` must be side-effect-free.
+
+The dashboard SPA polls ``/api/status`` every few seconds, and the endpoint is
+in ``PUBLIC_API_PATHS`` (an unauthenticated liveness probe). It previously
+resolved gateway config on every call, which ran each plugin adapter's
+``check_fn`` — and adapter ``check_fn``s lazy-install their SDK via
+``tools.lazy_deps.ensure`` on first call. In a sealed venv (NixOS / uv venv
+with no ``pip``) that install can never persist, so it re-ran the
+pip → ensurepip → ``pip install`` ladder on every poll, stalling the UI for
+seconds per request.
+
+These tests assert the status path never shells out to a package installer.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+
+
+def _argv_text(cmd) -> str:
+    if isinstance(cmd, (list, tuple)):
+        return " ".join(str(part) for part in cmd)
+    return str(cmd)
+
+
+def _looks_like_install(cmd) -> bool:
+    text = _argv_text(cmd)
+    if "ensurepip" in text:
+        return True
+    return "pip" in text and ("install" in text or "--version" in text)
+
+
+@pytest.fixture
+def install_tripwire(monkeypatch):
+    """Make any pip/ensurepip subprocess a hard test failure."""
+    calls: list[str] = []
+    real_run = subprocess.run
+    real_popen = subprocess.Popen
+
+    def guarded_run(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args")
+        if _looks_like_install(cmd):
+            calls.append(_argv_text(cmd))
+            raise AssertionError(f"unexpected installer subprocess: {_argv_text(cmd)}")
+        return real_run(*args, **kwargs)
+
+    def guarded_popen(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args")
+        if _looks_like_install(cmd):
+            calls.append(_argv_text(cmd))
+            raise AssertionError(f"unexpected installer subprocess: {_argv_text(cmd)}")
+        return real_popen(*args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", guarded_run)
+    monkeypatch.setattr(subprocess, "Popen", guarded_popen)
+    return calls
+
+
+@pytest.fixture
+def loopback_client(monkeypatch):
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "127.0.0.1"
+    web_server.app.state.bound_port = 8080
+    web_server.app.state.auth_required = False
+    client = TestClient(web_server.app, base_url="http://127.0.0.1:8080")
+    try:
+        yield client
+    finally:
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.bound_port = prev_port
+        web_server.app.state.auth_required = prev_required
+
+
+def test_status_does_not_trigger_lazy_install(loopback_client, install_tripwire):
+    """A status poll must not shell out to pip/ensurepip/uv install."""
+    resp = loopback_client.get("/api/status")
+    assert resp.status_code == 200
+    assert install_tripwire == [], (
+        "/api/status triggered an installer subprocess: " + ", ".join(install_tripwire)
+    )
+
+
+def test_load_gateway_config_does_not_trigger_lazy_install(install_tripwire):
+    """The config-resolution path status depends on stays install-free."""
+    from gateway.config import load_gateway_config
+
+    load_gateway_config()
+    assert install_tripwire == [], (
+        "load_gateway_config triggered an installer subprocess: "
+        + ", ".join(install_tripwire)
+    )
+
+
+def test_installs_suppressed_makes_ensure_refuse_instead_of_installing(
+    install_tripwire,
+):
+    """``installs_suppressed()`` converts a missing feature to a read-only refusal.
+
+    Inside the scope, ``ensure`` for an unsatisfiable feature raises
+    ``FeatureUnavailable`` (which adapter ``check_fn``s already treat as "not
+    available") rather than shelling out to an installer.
+    """
+    from tools import lazy_deps
+
+    # Pick any real feature whose deps are not satisfied in the test venv so we
+    # exercise the install branch; if everything happens to be installed there
+    # is nothing to assert about suppression, so skip.
+    feature = next(
+        (f for f in lazy_deps.LAZY_DEPS if lazy_deps.feature_missing(f)),
+        None,
+    )
+    if feature is None:
+        pytest.skip("no lazy feature is missing in this venv")
+
+    with lazy_deps.installs_suppressed():
+        with pytest.raises(lazy_deps.FeatureUnavailable):
+            lazy_deps.ensure(feature, prompt=False)
+
+    assert install_tripwire == [], "suppressed ensure() still shelled out to installer"

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -51,6 +51,8 @@ Adding a new backend:
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import logging
 import os
 import re
@@ -59,9 +61,35 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterator, Optional
 
 logger = logging.getLogger(__name__)
+
+# When set, :func:`ensure` refuses to install and raises FeatureUnavailable
+# instead. Read-only call sites (config resolution, liveness probes) enter
+# ``installs_suppressed()`` so a presence check never shells out to pip/uv.
+# A contextvar (not a plain global) keeps the suppression scoped to the
+# current task/thread, so a concurrent legitimate install isn't blocked.
+_installs_suppressed: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "lazy_deps_installs_suppressed", default=False
+)
+
+
+@contextlib.contextmanager
+def installs_suppressed() -> Iterator[None]:
+    """Within this scope, :func:`ensure` never installs — it raises instead.
+
+    For code paths that legitimately probe feature availability but must not
+    incur a (potentially failing, always slow) install: e.g. resolving gateway
+    config for a status/liveness response. Missing deps degrade to
+    FeatureUnavailable, which existing ``check_fn`` callers already treat as
+    "not available".
+    """
+    token = _installs_suppressed.set(True)
+    try:
+        yield
+    finally:
+        _installs_suppressed.reset(token)
 
 
 # =============================================================================
@@ -450,6 +478,13 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
     missing = feature_missing(feature)
     if not missing:
         return
+
+    # Read-only scope (e.g. resolving config for a status/liveness response):
+    # never shell out to an installer just to answer "is this available?".
+    if _installs_suppressed.get():
+        raise FeatureUnavailable(
+            feature, missing, "installs suppressed in read-only scope"
+        )
 
     # Validate every spec against the allowlist + safety regex. Belt and
     # braces — the keys-in-LAZY_DEPS check above already constrains this.


### PR DESCRIPTION
## What & why

`GET /api/status` — the dashboard's polled, unauthenticated liveness probe (it's in `PUBLIC_API_PATHS`) — calls `load_gateway_config()` on **every request**. Config resolution (`gateway/config.py::_apply_env_overrides`) runs **every enabled platform adapter's `check_fn()`**, and those `check_fn`s lazy-install their optional SDK via `tools/lazy_deps.py::ensure()`.

On a venv without `pip` (NixOS, and any `uv venv` — which doesn't seed pip), the install can never persist, so the `uv → pip → ensurepip → pip install` ladder **re-fires on every single poll**. The dashboard SPA polls `/api/status` every few seconds, so the UI stalls repeatedly. A status/liveness endpoint must be side-effect-free; triggering package installs from an unauthenticated endpoint is also a correctness/security smell.

This is one shared chokepoint: every `load_gateway_config()` caller funnels through that `check_fn` pass, so the same defect also fires from any periodic in-process status recompute — not just `/api/status`.

## How

- Add `tools.lazy_deps.installs_suppressed()` — a task-scoped `contextvars`-backed context manager. While active, `ensure()` raises `FeatureUnavailable` (the signal `check_fn`s already interpret as "feature unavailable") instead of installing.
- Wrap the `check_fn` enablement pass in `gateway/config.py::_apply_env_overrides()` with that guard, so config resolution degrades to a read-only presence check. The status payload is unchanged (`read_runtime_status()` / `gateway_state.json` already carries platform/pid/state).

One logical change; no behavior change for environments where deps are already installed.

## How to test

Reproduce in a no-pip venv (a `uv venv` lacks pip, mimicking the sealed-venv condition):

```bash
uv venv venv --python 3.11 && export VIRTUAL_ENV="$(pwd)/venv"
uv pip install -e ".[dev]"
```

Monkeypatch `subprocess.run`/`Popen` to record any argv containing `pip`/`ensurepip`, then drive `/api/status` via FastAPI `TestClient`. **Before:** ~15 installer execs/request (and ~45 across repeated `load_gateway_config()` calls with several enabled platforms). **After:** 0.

```bash
scripts/run_tests.sh tests/hermes_cli/test_status_no_lazy_install.py
```

The added test drives `load_gateway_config()` repeatedly with an enabled platform (forcing the install branch) and asserts zero installer subprocesses, with a negated-fix check confirming the guard is load-bearing.

### Validated end-to-end on real hardware

Deployed to a NixOS host (sealed Nix venv, no pip — the exact trigger condition), measured the live dashboard:

| | `/api/status` latency | `ensurepip`/`pip install` subprocesses |
|---|---|---|
| Before (this rev unpatched) | ~4.1 s | the install cascade |
| After (this fix) | **~0.12 s** | **0** |

Gateway stayed fully functional (state `running`, Telegram `connected`).

## Test results

`scripts/run_tests.sh` over the new test + gateway-config / status / dashboard-auth-status / lazy_deps suites: **all green** (5 + 88 + 67 across the runs; new file 5 passed). Negated-fix sanity check: neutering the guard makes the regression test fail as expected.

## Platforms tested

Linux (Fedora dev box + NixOS deploy target), Python 3.11/3.12. Fix is platform-agnostic — no OS-specific calls; honors the repo's `shutil.which`/`psutil` cross-platform rules (none newly introduced).
