### PR TITLE
fix: integrate google-antigravity with credential pool for proper rotation

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -124,6 +124,7 @@ _EXTRA_KEYS = frozenset({
     "token_type", "scope", "client_id", "portal_base_url", "obtained_at",
     "expires_in", "agent_key_id", "agent_key_expires_in", "agent_key_reused",
     "agent_key_obtained_at", "tls", "secret_source", "secret_fingerprint",
+    "email", "project_id"
 })
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2264,38 +2264,55 @@ def resolve_antigravity_oauth_runtime_credentials(
 ) -> Dict[str, Any]:
     """Resolve runtime OAuth creds for google-antigravity."""
     try:
-        from agent.antigravity_oauth import (
-            AntigravityOAuthError,
-            _credentials_path,
-            get_valid_access_token,
-            load_credentials,
-        )
+        from agent.credential_pool import load_pool
     except ImportError as exc:
         raise AuthError(
-            f"agent.antigravity_oauth is not importable: {exc}",
+            f"agent.credential_pool is not importable: {exc}",
             provider="google-antigravity",
-            code="antigravity_oauth_module_missing",
+            code="credential_pool_module_missing",
         ) from exc
 
     try:
-        access_token = get_valid_access_token(force_refresh=force_refresh)
-    except AntigravityOAuthError as exc:
+        pool = load_pool("google-antigravity")
+        # Try to select an available credential from the pool
+        selected = pool.select()
+        if not selected:
+            raise AuthError(
+                "No available google-antigravity credentials in the pool",
+                provider="google-antigravity",
+                code="antigravity_oauth_not_logged_in",
+                relogin_required=True,
+            )
+        
+        # Ensure it has a valid access token.
+        access_token = selected.access_token
+        if not access_token:
+            raise AuthError(
+                "Selected credential has no access token",
+                provider="google-antigravity",
+                code="invalid_credential",
+            )
+            
+    except Exception as exc:
+        # Fallback error mapping for tests that might mock load_pool but not catch it correctly
+        if isinstance(exc, AuthError):
+            raise
         raise AuthError(
-            str(exc),
+            f"Credential pool error: {exc}",
             provider="google-antigravity",
-            code=exc.code,
+            code="credential_pool_error",
         ) from exc
 
-    creds = load_credentials()
     return {
         "provider": "google-antigravity",
         "base_url": DEFAULT_ANTIGRAVITY_CLOUDCODE_BASE_URL,
         "api_key": access_token,
-        "source": "antigravity-oauth",
-        "expires_at_ms": (creds.expires_ms if creds else None),
-        "auth_file": str(_credentials_path()),
-        "email": (creds.email if creds else "") or "",
-        "project_id": (creds.project_id if creds else "") or "",
+        "source": getattr(selected, "source", None) or "antigravity-oauth-pool",
+        "credential_pool": pool,
+        "expires_at_ms": None,  # Not strictly needed for runtime resolution if pool handles it
+        "auth_file": str(selected.id), # Traceability
+        "email": getattr(selected, "email", None) or getattr(selected, "label", ""),
+        "project_id": getattr(selected, "project_id", None) or "",
     }
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1646,7 +1646,7 @@ def resolve_runtime_provider(
                 "api_mode": "chat_completions",
                 "base_url": creds.get("base_url", ""),
                 "api_key": creds.get("api_key", ""),
-                "source": creds.get("source", "antigravity-oauth"),
+                "source": creds.get("source", "antigravity-oauth-pool"),
                 "expires_at_ms": creds.get("expires_at_ms"),
                 "email": creds.get("email", ""),
                 "project_id": creds.get("project_id", ""),

--- a/run_agent.py
+++ b/run_agent.py
@@ -4093,8 +4093,9 @@ class AIAgent:
         if pool is None:
             return False
         if (
-            self.provider == "google-gemini-cli"
+            self.provider in ("google-gemini-cli", "google-antigravity")
             or str(getattr(self, "base_url", "")).startswith("cloudcode-pa://")
+            or str(getattr(self, "base_url", "")).startswith("antigravity-pa://")
         ):
             # CloudCode/Gemini quota windows are usually account-level throttles.
             # Prefer the configured fallback immediately instead of waiting out

--- a/tests/agent/test_antigravity_cloudcode.py
+++ b/tests/agent/test_antigravity_cloudcode.py
@@ -357,25 +357,41 @@ class TestAntigravityRegistration:
         assert resolve_provider("google-antigravity-oauth") == "google-antigravity"
         assert resolve_provider("agy") == "google-antigravity"
 
-    def test_runtime_provider_raises_when_not_logged_in(self):
+    def test_runtime_provider_raises_when_not_logged_in(self, monkeypatch):
         from hermes_cli.auth import AuthError
         from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        def mock_load_pool(provider):
+            from agent.credential_pool import CredentialPool
+            return CredentialPool(provider, [])
+
+        # We need to mock it in the module where it's used or where it's imported.
+        # It's used inside resolve_antigravity_oauth_runtime_credentials, imported locally.
+        # The easiest way is to mock agent.credential_pool.load_pool directly.
+        monkeypatch.setattr("agent.credential_pool.load_pool", mock_load_pool)
 
         with pytest.raises(AuthError) as exc_info:
             resolve_runtime_provider(requested="google-antigravity")
         assert exc_info.value.code == "antigravity_oauth_not_logged_in"
 
-    def test_runtime_provider_returns_correct_shape_when_logged_in(self):
-        from agent.antigravity_oauth import AntigravityCredentials, save_credentials
+    def test_runtime_provider_returns_correct_shape_when_logged_in(self, monkeypatch):
         from hermes_cli.runtime_provider import resolve_runtime_provider
-
-        save_credentials(AntigravityCredentials(
-            access_token="live-tok",
-            refresh_token="rt",
-            expires_ms=int((time.time() + 3600) * 1000),
-            project_id="my-proj",
-            email="t@e.com",
-        ))
+        
+        def mock_load_pool(provider):
+            from agent.credential_pool import CredentialPool, PooledCredential
+            entry = PooledCredential(
+                provider=provider,
+                id="fake-id",
+                label="fake-id",
+                auth_type="oauth",
+                priority=1,
+                source="oauth",
+                access_token="live-tok",
+                extra={"email": "t@e.com", "project_id": "my-proj"}
+            )
+            return CredentialPool(provider, [entry])
+            
+        monkeypatch.setattr("agent.credential_pool.load_pool", mock_load_pool)
 
         result = resolve_runtime_provider(requested="google-antigravity")
         assert result["provider"] == "google-antigravity"


### PR DESCRIPTION
Fixes bug where google-antigravity single credential file was used instead of the credential pool, preventing account rotation on 429 errors.