### PR TITLE
fix(desktop): seed saved profile before gateway boot

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $gatewayState } from '@/store/session'
 
 import { useGatewayBoot } from './use-gateway-boot'
@@ -122,6 +123,7 @@ beforeEach(() => {
   FakeWebSocket.instances = []
   ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
   ;(window as { hermesDesktop?: unknown }).hermesDesktop = fakeDesktop()
+  $activeGatewayProfile.set('default')
   $gatewayState.set('idle')
   $desktopBoot.set({
     error: null,
@@ -222,6 +224,18 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($desktopBoot.get().error).toBeNull()
     // It is actively retrying, not idle — more sockets were minted.
     expect(FakeWebSocket.instances.length).toBeGreaterThan(1)
+  })
+
+  it('seeds the primary gateway profile from the desktop preference before connecting', async () => {
+    const desktop = fakeDesktop()
+    desktop.profile.get = vi.fn(async () => ({ profile: 'coder' }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($activeGatewayProfile.get()).toBe('coder')
+    expect(desktop.profile.get).toHaveBeenCalled()
   })
 
   it('FIX: after the prolonged drop the hook raises a recoverable boot error (the escape hatch)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -222,6 +222,20 @@ export function useGatewayBoot({
     // Secondary (background-profile) sockets funnel into the same handler.
     configureGatewayRegistry({ onEvent: event => callbacksRef.current.handleGatewayEvent(event) })
 
+    const seedPrimaryProfileFromPreference = async () => {
+      try {
+        const pref = await desktop.profile?.get?.()
+        const profileKey = normalizeProfileKey(pref?.profile)
+
+        $activeGatewayProfile.set(profileKey)
+        setPrimaryGateway(gateway, profileKey)
+
+        return profileKey
+      } catch {
+        return null
+      }
+    }
+
     const offState = gateway.onState(st => {
       // Mirror to the composer only while the primary is the active profile —
       // a background secondary reconnect mustn't flip the foreground state.
@@ -315,6 +329,7 @@ export function useGatewayBoot({
 
     async function boot() {
       try {
+        await seedPrimaryProfileFromPreference()
         const conn = await desktop.getConnection()
 
         if (cancelled) {
@@ -343,10 +358,7 @@ export function useGatewayBoot({
         // same-profile resumes are no-op swaps and any reconnect targets the
         // right backend. Best-effort: a missing preference means "default".
         try {
-          const pref = await desktop.profile?.get?.()
-          const profileKey = (pref?.profile ?? '').trim() || 'default'
-          $activeGatewayProfile.set(profileKey)
-          setPrimaryGateway(gateway, profileKey)
+          const profileKey = (await seedPrimaryProfileFromPreference()) || 'default'
           void ensureGatewayForProfile(profileKey)
         } catch {
           $activeGatewayProfile.set('default')


### PR DESCRIPTION
## Summary
- Seed the Desktop renderer's active gateway profile from the saved Desktop profile preference before the primary connection starts.
- Keep the primary gateway registry aligned with the saved profile so boot-time requests do not briefly assume `default`.
- Add a focused regression test for a saved `coder` Desktop profile.

## Background / Why
When Hermes Desktop is configured to launch a non-default profile, the main process correctly starts the primary backend with `--profile <name>`. The renderer still initializes its active gateway profile as `default` until the connection finishes, which can make boot-time profile-scoped work briefly target the wrong profile.

## Changes
- Read `desktop.profile.get()` at the start of gateway boot and seed `$activeGatewayProfile` plus `setPrimaryGateway` before `desktop.getConnection()`.
- Reuse the same preference seeding after connect so reconnect routing stays aligned.
- Reset and assert `$activeGatewayProfile` in the gateway boot test.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test:ui -- src/app/gateway/hooks/use-gateway-boot.test.tsx -t 'seeds the primary gateway profile'`

## Risks / Rollback
- 想定リスク: malformed or unavailable Desktop profile preference falls back to the existing `default` behavior.
- ロールバック手順: revert this PR.

## Refs
- Related: Desktop non-default profile boot routing
