### PR TITLE
fix(cron): improve cron session title reliability — nonblank titles, pre-close race fix, duplicate suffix hardening

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -112,13 +112,21 @@ def generate_title(
 def _set_generated_title(session_db, session_id: str, title: str) -> str:
     """Persist a generated title, suffixing on collisions when supported."""
     try:
-        session_db.set_session_title(session_id, title)
+        persisted = session_db.set_session_title(session_id, title)
+        if persisted is False:
+            raise RuntimeError(
+                f"Session {session_id} was not found; generated title was not persisted"
+            )
         return title
     except ValueError:
         if not hasattr(session_db, "get_next_title_in_lineage"):
             raise
         unique_title = session_db.get_next_title_in_lineage(title)
-        session_db.set_session_title(session_id, unique_title)
+        persisted = session_db.set_session_title(session_id, unique_title)
+        if persisted is False:
+            raise RuntimeError(
+                f"Session {session_id} was not found; generated title was not persisted"
+            )
         return unique_title
 
 
@@ -131,42 +139,56 @@ def auto_title_session(
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
-) -> None:
+    fallback_title: Optional[str] = None,
+) -> Optional[str]:
     """Generate and set a session title if one doesn't already exist.
 
     Called in a background thread after the first exchange completes.
     Silently skips if:
     - session_db is None
     - session already has a title (user-set or previously auto-generated)
-    - title generation fails
+    - title generation fails and no fallback_title is provided
+
+    When ``fallback_title`` is given and auto-generation yields nothing
+    (or yields the same value as the fallback), the fallback is used
+    instead.  This ensures headless cron sessions always get a title
+    even when the generation model is unavailable.
     """
     if not session_db or not session_id:
-        return
+        return None
 
     # Check if title already exists (user may have set one via /title before first response)
     try:
         existing = session_db.get_session_title(session_id)
         if existing:
-            return
+            return existing
     except Exception:
-        return
+        return None
 
     title = generate_title(
         user_message, assistant_response, failure_callback=failure_callback, main_runtime=main_runtime
     )
-    if not title:
-        return
+    candidates = []
+    if title:
+        candidates.append((title, "auto-generated"))
+    if fallback_title:
+        if not title or fallback_title.strip() != title.strip():
+            candidates.append((fallback_title, "fallback"))
 
-    try:
-        applied_title = _set_generated_title(session_db, session_id, title)
-        logger.debug("Auto-generated session title: %s", applied_title)
-        if title_callback is not None:
-            try:
-                title_callback(applied_title)
-            except Exception:
-                logger.debug("Auto-title callback failed", exc_info=True)
-    except Exception as e:
-        logger.debug("Failed to set auto-generated title: %s", e)
+    for candidate, source in candidates:
+        try:
+            applied_title = _set_generated_title(session_db, session_id, candidate)
+            logger.debug("%s session title: %s", source.capitalize(), applied_title)
+            if title_callback is not None:
+                try:
+                    title_callback(applied_title)
+                except Exception:
+                    logger.debug("Auto-title callback failed", exc_info=True)
+            return applied_title
+        except Exception as e:
+            logger.debug("Failed to set %s session title: %s", source, e)
+
+    return None
 
 
 def maybe_auto_title(
@@ -200,10 +222,11 @@ def maybe_auto_title(
         target=auto_title_session,
         args=(session_db, session_id, user_message, assistant_response),
         kwargs={
-            "failure_callback": failure_callback,
-            "main_runtime": main_runtime,
-            "title_callback": title_callback,
-        },
+                "failure_callback": failure_callback,
+                "main_runtime": main_runtime,
+                "title_callback": title_callback,
+                "fallback_title": None,
+            },
         daemon=True,
         name="auto-title",
     )

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -109,6 +109,20 @@ def generate_title(
         return None
 
 
+def _set_generated_title(session_db, session_id: str, title: str) -> str:
+    """Persist a generated title, suffixing on collisions when supported."""
+    try:
+        session_db.set_session_title(session_id, title)
+        return title
+    except ValueError:
+        if not hasattr(session_db, "get_next_title_in_lineage"):
+            raise
+        unique_title = session_db.get_next_title_in_lineage(title)
+        session_db.set_session_title(session_id, unique_title)
+        return unique_title
+
+
+
 def auto_title_session(
     session_db,
     session_id: str,
@@ -144,11 +158,11 @@ def auto_title_session(
         return
 
     try:
-        session_db.set_session_title(session_id, title)
-        logger.debug("Auto-generated session title: %s", title)
+        applied_title = _set_generated_title(session_db, session_id, title)
+        logger.debug("Auto-generated session title: %s", applied_title)
         if title_callback is not None:
             try:
-                title_callback(title)
+                title_callback(applied_title)
             except Exception:
                 logger.debug("Auto-title callback failed", exc_info=True)
     except Exception as e:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2179,6 +2179,31 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 {logged_response}
 """
         
+        # Auto-generate session title after successful cron run.
+        # Cron sessions bypass the gateway's per-message title-generation
+        # path (gateway/run.py), so we generate the title here before the
+        # session is closed in the finally block below.  Called
+        # synchronously so the title is guaranteed to persist before
+        # _session_db.close() tears down the connection.
+        if final_response and _session_db:
+            try:
+                from agent.title_generator import auto_title_session
+                auto_title_session(
+                    _session_db,
+                    _cron_session_id,
+                    prompt,
+                    final_response,
+                    main_runtime={
+                        "model": model,
+                        "provider": runtime.get("provider"),
+                        "base_url": runtime.get("base_url"),
+                        "api_key": runtime.get("api_key"),
+                        "api_mode": runtime.get("api_mode"),
+                    },
+                )
+            except Exception:
+                pass
+
         logger.info("Job '%s' completed successfully", job_name)
         return True, output, final_response, None
         

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2200,6 +2200,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                         "api_key": runtime.get("api_key"),
                         "api_mode": runtime.get("api_mode"),
                     },
+                    fallback_title=job_name,
                 )
             except Exception:
                 pass


### PR DESCRIPTION
## Summary

Three related fixes to cron session title generation:

1. **Pre-close race fix** — Cron sessions never got auto-generated titles because `run_job()` never called `auto_title_session()`. Unlike CLI/gateway/TUI/ACP paths which invoke `maybe_auto_title()` after the first exchange, the cron path was missing this call entirely. The fix adds a synchronous `auto_title_session()` call after successful job completion, before the session is closed in the `finally` block.

2. **Duplicate suffix hardening** — When two sessions get the same auto-generated title, `set_session_title()` raises `ValueError`. This introduces `_set_generated_title()`, which catches the collision and uses `get_next_title_in_lineage()` to append a unique suffix. It also checks the return value of `set_session_title()`: if it returns `False` (session not found between title gen and storage), a `RuntimeError` is raised.

3. **Nonblank titles via fallback** — When auto-generation fails (model unavailable, timeout, API error), cron sessions end up with blank titles. Adds a `fallback_title` parameter to `auto_title_session()`. When auto-generation produces nothing, the fallback (the cron job name) is used instead, ensuring every cron session has a meaningful title.

## Changes

### `agent/title_generator.py`
- Add `_set_generated_title()` helper that deduplicates via `get_next_title_in_lineage()` on `ValueError`
- Add `fallback_title` parameter to `auto_title_session()` with candidate-loop fallback logic
- Change return type from `None` to `Optional[str]` so callers know what title was applied
- Pass `fallback_title=None` from `maybe_auto_title()` (backward compatible)

### `cron/scheduler.py`
- Add `auto_title_session()` call after successful cron job completion (synchronous, before session close)
- Pass `fallback_title=job_name` to ensure nonblank titles

## Related Issues

- Closes #50535 (nonblank titles)
- Closes #50536 (pre-close race)
- Closes #50537 (duplicate suffix)
