### PR TITLE
feat: expose explicit runtime event streams

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -164,6 +164,9 @@ def _resolve_restart_drain_timeout() -> float:
 async def _lifespan(app: "FastAPI"):
     app.state.event_channels = {}  # dict[str, set]
     app.state.event_lock = asyncio.Lock()
+    app.state.runtime_global_subscribers = set()
+    app.state.runtime_global_lock = asyncio.Lock()
+    app.state.runtime_channel_registry = {}
     # Serializes chat-argv resolution so concurrent /api/pty connections
     # don't trigger overlapping ``npm install`` / ``npm run build`` work.
     # On app.state (not a module global) so the Lock binds to the running
@@ -229,6 +232,114 @@ def _get_chat_argv_lock(app: "FastAPI") -> asyncio.Lock:
     except AttributeError:
         app.state.chat_argv_lock = asyncio.Lock()
         return app.state.chat_argv_lock
+
+
+def _get_runtime_global_state(app: "FastAPI"):
+    """Return (global_subscribers, global_lock) for observe-only runtime events."""
+    try:
+        return app.state.runtime_global_subscribers, app.state.runtime_global_lock
+    except AttributeError:
+        app.state.runtime_global_subscribers = set()
+        app.state.runtime_global_lock = asyncio.Lock()
+        return app.state.runtime_global_subscribers, app.state.runtime_global_lock
+
+
+def _get_runtime_channel_registry(app: "FastAPI") -> Dict[str, Dict[str, Any]]:
+    try:
+        return app.state.runtime_channel_registry
+    except AttributeError:
+        app.state.runtime_channel_registry = {}
+        return app.state.runtime_channel_registry
+
+
+def _runtime_channel_entry(app: "FastAPI", channel: str) -> Dict[str, Any]:
+    registry = _get_runtime_channel_registry(app)
+    return registry.setdefault(
+        channel,
+        {
+            "publisher_count": 0,
+            "subscriber_count": 0,
+            "profiles": {},
+            "last_seen_at": "",
+        },
+    )
+
+
+def _runtime_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _runtime_channel_connected(
+    app: "FastAPI",
+    channel: str,
+    *,
+    role: str,
+    profile: Optional[str] = None,
+) -> None:
+    entry = _runtime_channel_entry(app, channel)
+    if role == "publisher":
+        entry["publisher_count"] = int(entry.get("publisher_count") or 0) + 1
+        if profile:
+            profiles = entry.setdefault("profiles", {})
+            profiles[profile] = int(profiles.get(profile) or 0) + 1
+    elif role == "subscriber":
+        entry["subscriber_count"] = int(entry.get("subscriber_count") or 0) + 1
+    entry["last_seen_at"] = _runtime_now_iso()
+
+
+def _runtime_channel_disconnected(
+    app: "FastAPI",
+    channel: str,
+    *,
+    role: str,
+    profile: Optional[str] = None,
+) -> None:
+    registry = _get_runtime_channel_registry(app)
+    entry = registry.get(channel)
+    if not entry:
+        return
+    if role == "publisher":
+        entry["publisher_count"] = max(0, int(entry.get("publisher_count") or 0) - 1)
+        if profile:
+            profiles = entry.setdefault("profiles", {})
+            remaining = int(profiles.get(profile) or 0) - 1
+            if remaining > 0:
+                profiles[profile] = remaining
+            else:
+                profiles.pop(profile, None)
+    elif role == "subscriber":
+        entry["subscriber_count"] = max(0, int(entry.get("subscriber_count") or 0) - 1)
+    entry["last_seen_at"] = _runtime_now_iso()
+    if not entry["publisher_count"] and not entry["subscriber_count"]:
+        registry.pop(channel, None)
+
+
+def _runtime_channel_snapshot(app: "FastAPI") -> List[Dict[str, Any]]:
+    out = []
+    for channel, entry in sorted(_get_runtime_channel_registry(app).items()):
+        out.append(
+            {
+                "channel": channel,
+                "publisher_count": int(entry.get("publisher_count") or 0),
+                "subscriber_count": int(entry.get("subscriber_count") or 0),
+                "profiles": sorted((entry.get("profiles") or {}).keys()),
+                "last_seen_at": str(entry.get("last_seen_at") or ""),
+            }
+        )
+    return out
+
+
+def _runtime_frame_for_global(channel: str, payload: str) -> str:
+    try:
+        frame = json.loads(payload)
+    except Exception:
+        return payload
+    if isinstance(frame, dict) and frame.get("method") == "event" and isinstance(frame.get("params"), dict):
+        frame = dict(frame)
+        params = dict(frame["params"])
+        params.setdefault("channel", channel)
+        frame["params"] = params
+    return json.dumps(frame, ensure_ascii=False)
 
 
 app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
@@ -11360,7 +11471,7 @@ async def _resolve_chat_argv_async(
         )
 
 
-def _build_sidecar_url(channel: str) -> Optional[str]:
+def _build_sidecar_url(channel: str, profile: Optional[str] = None) -> Optional[str]:
     """ws:// URL the PTY child should publish events to, or None when unbound.
 
     Loopback / ``--insecure``: uses ``?token=<_SESSION_TOKEN>``.
@@ -11382,25 +11493,35 @@ def _build_sidecar_url(channel: str) -> Optional[str]:
 
     netloc = f"[{host}]:{port}" if ":" in host and not host.startswith("[") else f"{host}:{port}"
 
+    query = {"channel": channel}
+    if profile:
+        query["profile"] = profile
+
     if getattr(app.state, "auth_required", False):
         # Gated mode — use the internal credential so the WS upgrade survives
         # _ws_auth_ok and the child can reconnect.
         from hermes_cli.dashboard_auth.ws_tickets import internal_ws_credential
 
-        qs = urllib.parse.urlencode(
-            {"internal": internal_ws_credential(), "channel": channel}
-        )
+        query["internal"] = internal_ws_credential()
+        qs = urllib.parse.urlencode(query)
     else:
-        qs = urllib.parse.urlencode({"token": _SESSION_TOKEN, "channel": channel})
+        query["token"] = _SESSION_TOKEN
+        qs = urllib.parse.urlencode(query)
 
     return f"ws://{netloc}/api/pub?{qs}"
 
 
 async def _broadcast_event(app: Any, channel: str, payload: str) -> None:
-    """Fan out one publisher frame to every subscriber on `channel`."""
+    """Fan out one publisher frame to channel subscribers and global runtime subscribers."""
     event_channels, event_lock = _get_event_state(app)
     async with event_lock:
         subs = list(event_channels.get(channel, ()))
+
+    global_subscribers, global_lock = _get_runtime_global_state(app)
+    async with global_lock:
+        global_subs = list(global_subscribers)
+    global_payload = _runtime_frame_for_global(channel, payload)
+    _runtime_channel_entry(app, channel)["last_seen_at"] = _runtime_now_iso()
 
     for sub in subs:
         try:
@@ -11409,6 +11530,12 @@ async def _broadcast_event(app: Any, channel: str, payload: str) -> None:
             # Subscriber went away mid-send; the /api/events finally clause
             # will remove it from the registry on its next iteration.
             _log.warning("broadcast send failed for subscriber on %s", channel, exc_info=True)
+
+    for sub in global_subs:
+        try:
+            await sub.send_text(global_payload)
+        except Exception:
+            _log.warning("global runtime broadcast failed for subscriber on %s", channel, exc_info=True)
 
 
 def _channel_or_close_code(ws: WebSocket) -> Optional[str]:
@@ -11487,7 +11614,7 @@ async def pty_ws(ws: WebSocket) -> None:
     resume = ws.query_params.get("resume") or None
     profile = ws.query_params.get("profile") or None
     channel = _channel_or_close_code(ws)
-    sidecar_url = _build_sidecar_url(channel) if channel else None
+    sidecar_url = _build_sidecar_url(channel, profile=profile) if channel else None
 
     try:
         argv, cwd, env = await _resolve_chat_argv_async(
@@ -11632,12 +11759,16 @@ async def pub_ws(ws: WebSocket) -> None:
         return
 
     await ws.accept()
+    profile = ws.query_params.get("profile", "") or None
+    _runtime_channel_connected(ws.app, channel, role="publisher", profile=profile)
 
     try:
         while True:
             await _broadcast_event(ws.app, channel, await ws.receive_text())
     except WebSocketDisconnect:
         pass
+    finally:
+        _runtime_channel_disconnected(ws.app, channel, role="publisher", profile=profile)
 
 
 @app.websocket("/api/events")
@@ -11664,6 +11795,7 @@ async def events_ws(ws: WebSocket) -> None:
     event_channels, event_lock = _get_event_state(ws.app)
     async with event_lock:
         event_channels.setdefault(channel, set()).add(ws)
+    _runtime_channel_connected(ws.app, channel, role="subscriber")
 
     try:
         while True:
@@ -11674,6 +11806,7 @@ async def events_ws(ws: WebSocket) -> None:
     except WebSocketDisconnect:
         pass
     finally:
+        _runtime_channel_disconnected(ws.app, channel, role="subscriber")
         async with event_lock:
             subs = event_channels.get(channel)
 
@@ -11682,6 +11815,41 @@ async def events_ws(ws: WebSocket) -> None:
 
                 if not subs:
                     event_channels.pop(channel, None)
+
+
+@app.get("/api/runtime-channels")
+async def runtime_channels(request: Request):
+    token = request.headers.get(_SESSION_HEADER_NAME, "") or request.query_params.get("token", "")
+    if not hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
+        raise HTTPException(status_code=401, detail="invalid session token")
+    return {"channels": _runtime_channel_snapshot(request.app)}
+
+
+@app.websocket("/api/runtime-events")
+async def runtime_events_ws(ws: WebSocket) -> None:
+    if not _DASHBOARD_EMBEDDED_CHAT_ENABLED:
+        await ws.close(code=4403)
+        return
+    if not _ws_auth_ok(ws):
+        await ws.close(code=4401)
+        return
+    if not _ws_request_is_allowed(ws):
+        await ws.close(code=4403)
+        return
+
+    await ws.accept()
+    global_subscribers, global_lock = _get_runtime_global_state(ws.app)
+    async with global_lock:
+        global_subscribers.add(ws)
+
+    try:
+        while True:
+            await ws.receive_text()
+    except WebSocketDisconnect:
+        pass
+    finally:
+        async with global_lock:
+            global_subscribers.discard(ws)
 
 
 def _normalise_prefix(raw: Optional[str]) -> str:

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -623,31 +623,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -823,21 +816,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/bytes": {
@@ -1052,14 +1030,14 @@
       "license": "MIT"
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -1078,7 +1056,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -1620,24 +1598,23 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1683,9 +1660,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2117,9 +2094,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/tests/hermes_cli/test_runtime_event_bus.py
+++ b/tests/hermes_cli/test_runtime_event_bus.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from hermes_cli import web_server
+
+
+class Recorder:
+    def __init__(self):
+        self.sent: list[str] = []
+
+    async def send_text(self, payload: str) -> None:
+        self.sent.append(payload)
+
+
+def _app():
+    return SimpleNamespace(state=SimpleNamespace())
+
+
+def test_runtime_channel_registry_tracks_active_publishers_subscribers_and_profiles():
+    app = _app()
+
+    web_server._runtime_channel_connected(app, "chan-a", role="publisher", profile="by-nature-cto")
+    web_server._runtime_channel_connected(app, "chan-a", role="subscriber")
+    snapshot = web_server._runtime_channel_snapshot(app)
+
+    assert snapshot == [
+        {
+            "channel": "chan-a",
+            "publisher_count": 1,
+            "subscriber_count": 1,
+            "profiles": ["by-nature-cto"],
+            "last_seen_at": snapshot[0]["last_seen_at"],
+        }
+    ]
+
+    web_server._runtime_channel_disconnected(app, "chan-a", role="publisher", profile="by-nature-cto")
+    after = web_server._runtime_channel_snapshot(app)
+    assert after[0]["publisher_count"] == 0
+    assert after[0]["subscriber_count"] == 1
+    assert after[0]["profiles"] == []
+
+
+def test_runtime_global_bus_receives_every_channel_frame_with_channel_metadata():
+    app = _app()
+    channel_sub = Recorder()
+    global_sub = Recorder()
+    frame = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "tool.start",
+            "session_id": "sid-1",
+            "payload": {"name": "terminal"},
+        },
+    })
+
+    async def run():
+        event_channels, event_lock = web_server._get_event_state(app)
+        async with event_lock:
+            event_channels.setdefault("chan-a", set()).add(channel_sub)
+        global_subs, global_lock = web_server._get_runtime_global_state(app)
+        async with global_lock:
+            global_subs.add(global_sub)
+        await web_server._broadcast_event(app, "chan-a", frame)
+
+    asyncio.run(run())
+
+    assert channel_sub.sent == [frame]
+    assert len(global_sub.sent) == 1
+    relayed = json.loads(global_sub.sent[0])
+    assert relayed["method"] == "event"
+    assert relayed["params"]["type"] == "tool.start"
+    assert relayed["params"]["channel"] == "chan-a"
+    assert relayed["params"]["payload"] == {"name": "terminal"}

--- a/tests/tui_gateway/test_runtime_explicit_events.py
+++ b/tests/tui_gateway/test_runtime_explicit_events.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def server():
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_constants": MagicMock(
+                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_runtime_explicit_events")
+            ),
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+            "hermes_state": MagicMock(),
+        },
+    ):
+        import importlib
+
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+
+
+@pytest.fixture()
+def emits(server, monkeypatch):
+    captured: list[tuple[str, str, dict | None]] = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: captured.append((event, sid, payload)),
+    )
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda sid: True)
+    monkeypatch.setattr(server, "_tool_ctx", lambda name, args: args.get("command", ""))
+    monkeypatch.setattr(
+        server,
+        "_block",
+        lambda event, sid, payload, **_kwargs: captured.append((event, sid, payload)) or None,
+    )
+    return captured
+
+
+def test_tool_callbacks_emit_explicit_agent_and_tool_lifecycle(server, emits):
+    sid = "runtime-sid"
+    server._sessions[sid] = {"tool_started_at": {}, "edit_snapshots": {}}
+
+    server._on_tool_start(sid, "tc-1", "terminal", {"command": "npm test"})
+    server._on_tool_complete(sid, "tc-1", "terminal", {"command": "npm test"}, '{"ok": true}')
+
+    assert [event for event, _, _ in emits] == [
+        "agent.status.changed",
+        "tool_call.started",
+        "tool.start",
+        "agent.status.changed",
+        "tool_call.completed",
+        "tool.complete",
+    ]
+    assert emits[0][2] == {"status": "running_tool", "tool_id": "tc-1", "tool_name": "terminal"}
+    assert emits[1][2]["name"] == "terminal"
+    assert emits[3][2] == {"status": "completed", "tool_id": "tc-1", "tool_name": "terminal"}
+
+
+def test_agent_callbacks_emit_explicit_generation_reasoning_waiting_and_task_events(server, emits):
+    callbacks = server._agent_cbs("sid-2")
+
+    callbacks["thinking_callback"]("thinking")
+    callbacks["reasoning_callback"]("reasoning")
+    callbacks["clarify_callback"]("Need input?", ["yes"])
+    callbacks["notice_callback"](MagicMock(text="Careful", level="warning", kind="warning", ttl_ms=1000, key="k", id="n1"))
+
+    names = [event for event, _, _ in emits]
+    assert "agent.status.changed" in names
+    assert ("agent.status.changed", "sid-2", {"status": "thinking"}) in emits
+    assert ("agent.status.changed", "sid-2", {"status": "reasoning"}) in emits
+    assert ("agent.status.changed", "sid-2", {"status": "waiting_user"}) in emits
+    assert ("warning.emitted", "sid-2", {"text": "Careful", "level": "warning", "kind": "warning", "key": "k", "id": "n1"}) in emits
+
+
+def test_subagent_progress_emits_explicit_handoff_lifecycle(server, emits):
+    server._on_tool_progress(
+        "parent-sid",
+        "subagent.start",
+        preview="Build the parser",
+        child_session_id="child-session",
+        subagent_id="worker-1",
+        parent_id="parent-sid",
+        goal="Build the parser",
+    )
+    server._on_tool_progress(
+        "parent-sid",
+        "subagent.complete",
+        preview="Done",
+        child_session_id="child-session",
+        subagent_id="worker-1",
+        parent_id="parent-sid",
+        summary="Done",
+    )
+
+    assert [event for event, _, _ in emits[:4]] == [
+        "handoff.created",
+        "subagent.start",
+        "handoff.completed",
+        "subagent.complete",
+    ]
+    assert emits[0][2]["confidence"] == "explicit"
+    assert emits[0][2]["target_session_id"] == "child-session"
+    assert emits[2][2]["confidence"] == "explicit"
+    assert emits[2][2]["target_session_id"] == "child-session"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -806,6 +806,11 @@ def _emit(event: str, sid: str, payload: dict | None = None):
     write_json({"jsonrpc": "2.0", "method": "event", "params": params})
 
 
+def _emit_agent_status(sid: str, status: str, **payload):
+    body = {"status": status, **{k: v for k, v in payload.items() if v is not None}}
+    _emit("agent.status.changed", sid, body)
+
+
 def _status_update(sid: str, kind: str, text: str | None = None):
     body = (text if text is not None else kind).strip()
     if not body:
@@ -1040,7 +1045,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 )
 
                 register_gateway_notify(
-                    key, lambda data: _emit("approval.request", sid, data)
+                    key, lambda data: (_emit_agent_status(sid, "waiting_approval"), _emit("approval.request", sid, data))[-1]
                 )
                 notify_registered = True
                 load_permanent_allowlist()
@@ -2554,7 +2559,7 @@ def _sync_session_key_after_compress(
         try:
             register_gateway_notify(
                 new_session_id,
-                lambda data: _emit("approval.request", sid, data),
+                lambda data: (_emit_agent_status(sid, "waiting_approval"), _emit("approval.request", sid, data))[-1],
             )
         except Exception:
             pass
@@ -2949,6 +2954,8 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
                 payload["args_text"] = args_text
         # tool.complete is the source of truth for todos (full list from the
         # tool result). args.todos here may be a partial merge update.
+        _emit_agent_status(sid, "running_tool", tool_id=tool_call_id, tool_name=name)
+        _emit("tool_call.started", sid, payload)
         _emit("tool.start", sid, payload)
 
 
@@ -2996,6 +3003,8 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
     except Exception:
         pass
     if _tool_progress_enabled(sid) or payload.get("inline_diff"):
+        _emit_agent_status(sid, "completed", tool_id=tool_call_id, tool_name=name)
+        _emit("tool_call.completed", sid, payload)
         _emit("tool.complete", sid, payload)
 
 
@@ -3079,6 +3088,33 @@ def _on_tool_progress(
         if preview and event_type == "subagent.tool":
             payload["tool_preview"] = str(preview)
             payload["text"] = str(preview)
+        if event_type == "subagent.start":
+            _emit(
+                "handoff.created",
+                sid,
+                {
+                    "confidence": "explicit",
+                    "source_session_id": sid,
+                    "target_session_id": payload.get("child_session_id"),
+                    "subagent_id": payload.get("subagent_id"),
+                    "parent_id": payload.get("parent_id"),
+                    "goal": payload.get("goal"),
+                    "text": payload.get("text"),
+                },
+            )
+        elif event_type == "subagent.complete":
+            _emit(
+                "handoff.completed",
+                sid,
+                {
+                    "confidence": "explicit",
+                    "source_session_id": sid,
+                    "target_session_id": payload.get("child_session_id"),
+                    "subagent_id": payload.get("subagent_id"),
+                    "parent_id": payload.get("parent_id"),
+                    "summary": payload.get("summary") or payload.get("text"),
+                },
+            )
         # subagent.text is the child's per-token reply, relayed solely to feed a
         # watch window's live mirror. It is meaningless on the parent session
         # (which shows the child via the spawn tree, not its reply body), so
@@ -3190,12 +3226,21 @@ def _agent_cbs(sid: str) -> dict:
             sid, event_type, name, preview, args, **kwargs
         ),
         "tool_gen_callback": lambda name: _tool_progress_enabled(sid)
-        and _emit("tool.generating", sid, {"name": name}),
-        "thinking_callback": lambda text: _emit("thinking.delta", sid, {"text": text}),
-        "reasoning_callback": lambda text: _emit(
-            "reasoning.delta",
-            sid,
-            {"text": text, **({"verbose": True} if _session_verbose(sid) else {})},
+        and (
+            _emit_agent_status(sid, "running_tool", tool_name=name),
+            _emit("tool.generating", sid, {"name": name}),
+        ),
+        "thinking_callback": lambda text: (
+            _emit_agent_status(sid, "thinking"),
+            _emit("thinking.delta", sid, {"text": text}),
+        ),
+        "reasoning_callback": lambda text: (
+            _emit_agent_status(sid, "reasoning"),
+            _emit(
+                "reasoning.delta",
+                sid,
+                {"text": text, **({"verbose": True} if _session_verbose(sid) else {})},
+            ),
         ),
         "status_callback": lambda kind, text=None: _status_update(
             sid, str(kind), None if text is None else str(text)
@@ -3203,24 +3248,39 @@ def _agent_cbs(sid: str) -> dict:
         # Credits/notice spine (L1): an AgentNotice fired by the agent becomes a
         # notification.show WS event; a recovery clear becomes notification.clear.
         # Snake_case payload to match the existing gateway-event convention.
-        "notice_callback": lambda n: _emit(
-            "notification.show",
-            sid,
-            {
-                "text": n.text,
-                "level": n.level,
-                "kind": n.kind,
-                "ttl_ms": n.ttl_ms,
-                "key": n.key,
-                "id": n.id,
-            },
+        "notice_callback": lambda n: (
+            _emit_agent_status(sid, "warning" if n.level == "warning" else "active"),
+            _emit(
+                "warning.emitted" if n.level == "warning" else "notification.emitted",
+                sid,
+                {
+                    "text": n.text,
+                    "level": n.level,
+                    "kind": n.kind,
+                    "key": n.key,
+                    "id": n.id,
+                },
+            ),
+            _emit(
+                "notification.show",
+                sid,
+                {
+                    "text": n.text,
+                    "level": n.level,
+                    "kind": n.kind,
+                    "ttl_ms": n.ttl_ms,
+                    "key": n.key,
+                    "id": n.id,
+                },
+            ),
         ),
         "notice_clear_callback": lambda key: _emit(
             "notification.clear", sid, {"key": key}
         ),
-        "clarify_callback": lambda q, c: _block(
-            "clarify.request", sid, {"question": q, "choices": c}
-        ),
+        "clarify_callback": lambda q, c: (
+            _emit_agent_status(sid, "waiting_user"),
+            _block("clarify.request", sid, {"question": q, "choices": c}),
+        )[-1],
         # read_terminal tool (desktop GUI): same blocking bridge as clarify — the
         # renderer answers terminal.read.respond with the serialized buffer.
         "read_terminal_callback": lambda start=None, count=None: _block(
@@ -3901,7 +3961,7 @@ def _init_session(
     try:
         from tools.approval import register_gateway_notify, load_permanent_allowlist
 
-        register_gateway_notify(key, lambda data: _emit("approval.request", sid, data))
+        register_gateway_notify(key, lambda data: (_emit_agent_status(sid, "waiting_approval"), _emit("approval.request", sid, data))[-1])
         load_permanent_allowlist()
     except Exception:
         pass
@@ -4378,6 +4438,16 @@ def _(rid, params: dict) -> dict:
     build_timer = threading.Timer(0.05, _deferred_build)
     build_timer.daemon = True
     build_timer.start()
+    _emit(
+        "session.started",
+        sid,
+        {
+            "session_id": sid,
+            "stored_session_id": key,
+            "profile_name": _current_profile_name(),
+            "cwd": _sessions[sid]["cwd"],
+        },
+    )
 
     return _ok(
         rid,
@@ -6457,6 +6527,8 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         if not isinstance(session.get("inflight_turn"), dict):
             _start_inflight_turn(session, text)
     agent = session["agent"]
+    _emit_agent_status(sid, "generating")
+    _emit("generation.started", sid, {"session_key": session.get("session_key")})
     _emit("message.start", sid)
 
     def run():
@@ -6670,6 +6742,10 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 payload["rendered"] = rendered
             with session["history_lock"]:
                 _clear_inflight_turn(session)
+            _emit_agent_status(sid, "error" if status == "error" else "completed")
+            _emit("generation.completed", sid, payload)
+            if status == "complete":
+                _emit("task.completed", sid, {"summary": raw, "usage": payload.get("usage")})
             _emit("message.complete", sid, payload)
 
             # ── /goal continuation (Ralph-style loop) ─────────────────


### PR DESCRIPTION
Summary:
- Add runtime channel registry and global runtime event stream for dashboard/TUI observers.
- Emit explicit agent status, tool lifecycle, generation, handoff, notification, and task lifecycle events.
- Refresh WhatsApp bridge lockfile for available transitive security updates.

Validation:
- python -m pytest tests/hermes_cli/test_runtime_event_bus.py tests/tui_gateway/test_runtime_explicit_events.py -q -o 'addopts='
- python -m compileall -q hermes_cli/web_server.py tui_gateway/server.py
- cd scripts/whatsapp-bridge && npm install --package-lock-only && npm audit --audit-level=moderate

Note:
- npm audit still reports the upstream Baileys critical advisory with no fix available.