### PR TITLE
fix(gateway): pass session_db to compress temp agents so persistence works

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9239,6 +9239,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             ]
 
                             if len(_hyg_msgs) >= 4:
+                                _hyg_session_db = getattr(self.session_store, "_db", None)
                                 _hyg_agent = AIAgent(
                                     **_hyg_runtime,
                                     model=_hyg_model,
@@ -9247,6 +9248,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     skip_memory=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
+                                    session_db=_hyg_session_db,
                                 )
                                 try:
                                     # The hygiene agent rotates the session

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2655,6 +2655,12 @@ class GatewaySlashCommandsMixin:
                     partial = False
                     head = msgs
 
+            # Pass session_db so the temp agent can persist its session
+            # rotation to the database. Without it, compress_context computes
+            # the compressed messages in memory but never writes them to the
+            # session store — the next user message reloads the full original
+            # transcript and the apparent compression is lost (#fix/compress-gateway-persistence).
+            _tmp_session_db = getattr(self.session_store, "_db", None)
             tmp_agent = AIAgent(
                 **runtime_kwargs,
                 model=model,
@@ -2663,9 +2669,14 @@ class GatewaySlashCommandsMixin:
                 skip_memory=True,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
+                session_db=_tmp_session_db,
             )
             try:
                 tmp_agent._print_fn = lambda *a, **kw: None
+                # Prevent close() from ending the newly rotated session —
+                # the gateway session entry now points at the new id and
+                # must remain open for the next user turn.
+                tmp_agent._end_session_on_close = False
 
                 # Estimate with system prompt + tool schemas included so the
                 # figure reflects real request pressure, not a transcript-only


### PR DESCRIPTION
## Problem

Both the manual `/compress` handler and the session hygiene auto-compression create temporary AIAgent instances to run context compression. These agents were created **without a `session_db`**, so `compress_context` computed the compressed messages in memory, rotated the session ID, and reported success — but **never wrote to the database**. The next user message reloaded the original full transcript, making compression appear to do nothing.

## Fix

Pass `session_db=self.session_store._db` to both temporary agents so the session rotation is properly persisted. Also set `_end_session_on_close=False` on the `/compress` temp agent (already done in the hygiene path) to prevent cleanup from ending the newly rotated session.

## Files changed

- `gateway/slash_commands.py` — manual `/compress` handler
- `gateway/run.py` — session hygiene auto-compression

## Testing

Tested live on Discord: `/compress` previously showed `Compressed: 970 → 11 messages` followed by immediate context overflow on the next user message. After the fix, the compressed context persists across turns.