### PR TITLE
fix(title): handle duplicate auto-generated session titles gracefully

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -146,13 +146,24 @@ def auto_title_session(
     try:
         session_db.set_session_title(session_id, title)
         logger.debug("Auto-generated session title: %s", title)
-        if title_callback is not None:
-            try:
-                title_callback(title)
-            except Exception:
-                logger.debug("Auto-title callback failed", exc_info=True)
+    except ValueError:
+        # Title collision — generate a unique variant and retry
+        try:
+            title = session_db.get_next_title_in_lineage(title)
+            session_db.set_session_title(session_id, title)
+            logger.debug("Auto-generated session title (deduplicated): %s", title)
+        except Exception as e:
+            logger.debug("Failed to set auto-generated title after dedup: %s", e)
+            return
     except Exception as e:
         logger.debug("Failed to set auto-generated title: %s", e)
+        return
+
+    if title_callback is not None:
+        try:
+            title_callback(title)
+        except Exception:
+            logger.debug("Auto-title callback failed", exc_info=True)
 
 
 def maybe_auto_title(


### PR DESCRIPTION
## Summary

- When `set_session_title()` raises `ValueError` due to a title collision, use `get_next_title_in_lineage()` to generate a unique variant (e.g. "Debugging Import Errors #2") instead of silently dropping the title
- The `title_callback` is now called with the final title (whether original or deduplicated)
- Fixes #50537

## Changes

In `agent/title_generator.py` → `auto_title_session()`:

**Before:** All exceptions from `set_session_title()` were caught and silently logged as debug, leaving the session with no title.

**After:** `ValueError` (title collision) is caught specifically. When it occurs, `get_next_title_in_lineage()` generates a unique " #N" suffix and retries. Other exceptions are still logged and silently skipped.

## Tests

- Verified that `get_next_title_in_lineage()` is already tested in the existing test suite
- The fix is minimal and follows the exact approach suggested in the issue