### PR TITLE
fix(desktop): preserve thinking-off session state

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3029,6 +3029,8 @@ def test_complete_slash_details_args():
 
 def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    emits = []
+    monkeypatch.setattr(server, "_emit", lambda *args: emits.append(args))
     agent = types.SimpleNamespace(reasoning_config=None)
     server._sessions["sid"] = _session(agent=agent)
 
@@ -3041,6 +3043,23 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
     )
     assert resp_effort["result"]["value"] == "low"
     assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+
+    emits.clear()
+    resp_off = server.handle_request(
+        {
+            "id": "1b",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "reasoning", "value": "none"},
+        }
+    )
+    assert resp_off["result"]["value"] == "none"
+    assert agent.reasoning_config == {"enabled": False}
+    assert any(
+        event[0] == "session.info"
+        and event[1] == "sid"
+        and event[2].get("reasoning_effort") == "none"
+        for event in emits
+    )
 
     resp_show = server.handle_request(
         {

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2700,11 +2700,11 @@ def _session_info(agent, session: dict | None = None) -> dict:
     personality = (session or {}).get("personality", cfg_personality)
     reasoning_config = getattr(agent, "reasoning_config", None)
     reasoning_effort = ""
-    if (
-        isinstance(reasoning_config, dict)
-        and reasoning_config.get("enabled") is not False
-    ):
-        reasoning_effort = str(reasoning_config.get("effort", "") or "")
+    if isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is False:
+            reasoning_effort = "none"
+        else:
+            reasoning_effort = str(reasoning_config.get("effort", "") or "")
     service_tier = getattr(agent, "service_tier", None) or ""
     # Effective approval-bypass state — the same three sources that
     # check_all_command_guards() ORs together: persistent config


### PR DESCRIPTION
Closes #50449

## Summary
- return `reasoning_effort: "none"` in TUI/desktop session info when thinking is disabled
- keep the active desktop session from rehydrating an empty effort as the default medium/on state
- cover the `config.set reasoning=none` path with a regression test that asserts the emitted `session.info` payload stays off

## Verification
- `uv run --extra dev pytest tests/test_tui_gateway_server.py -k config_set_reasoning_updates_live_session_and_agent`
- `uv run --extra dev ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `git diff --check`