### PR TITLE
fix(telegram): limit concurrent send operations

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -491,6 +491,31 @@ class TelegramAdapter(BasePlatformAdapter):
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        try:
+            send_concurrency = int(os.getenv("HERMES_TELEGRAM_SEND_CONCURRENCY", "8"))
+        except (TypeError, ValueError):
+            send_concurrency = 8
+        try:
+            typing_concurrency = int(os.getenv("HERMES_TELEGRAM_TYPING_CONCURRENCY", "2"))
+        except (TypeError, ValueError):
+            typing_concurrency = 2
+        send_concurrency = max(1, send_concurrency)
+        typing_concurrency = max(1, typing_concurrency)
+        self._send_semaphore = asyncio.Semaphore(send_concurrency)
+        self._typing_semaphore = asyncio.Semaphore(typing_concurrency)
+        self._telegram_send_queue_timeout_seconds = self._env_float_clamped(
+            "HERMES_TELEGRAM_SEND_QUEUE_TIMEOUT_SECONDS",
+            60.0,
+            min_value=0.1,
+            max_value=600.0,
+        )
+        self._telegram_typing_min_interval_seconds = self._env_float_clamped(
+            "HERMES_TELEGRAM_TYPING_MIN_INTERVAL_SECONDS",
+            4.0,
+            min_value=0.5,
+            max_value=30.0,
+        )
+        self._last_typing_at: Dict[tuple, float] = {}
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -1841,6 +1866,38 @@ class TelegramAdapter(BasePlatformAdapter):
             return chunk_index == 0
 
     async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None
+    ) -> SendResult:
+        """Send a message to a Telegram chat with adapter-level backpressure."""
+        semaphore = getattr(self, "_send_semaphore", None)
+        if semaphore is None:
+            return await self._send_unthrottled(chat_id, content, reply_to=reply_to, metadata=metadata)
+
+        timeout = float(getattr(self, "_telegram_send_queue_timeout_seconds", 60.0))
+        try:
+            await asyncio.wait_for(semaphore.acquire(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[%s] Telegram send queue timed out after %.1fs; dropping to retry path",
+                self.name,
+                timeout,
+            )
+            return SendResult(
+                success=False,
+                error=f"telegram_send_queue_timeout:{timeout:.1f}s",
+                retryable=True,
+            )
+
+        try:
+            return await self._send_unthrottled(chat_id, content, reply_to=reply_to, metadata=metadata)
+        finally:
+            semaphore.release()
+
+    async def _send_unthrottled(
         self,
         chat_id: str,
         content: str,
@@ -4269,10 +4326,31 @@ class TelegramAdapter(BasePlatformAdapter):
         if self._bot:
             _is_dm_topic: bool = False
             message_thread_id: Optional[int] = None
+            acquired_typing_slot = False
             try:
                 _typing_thread = self._metadata_thread_id(metadata)
                 _is_dm_topic = bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
                 message_thread_id = self._message_thread_id_for_typing(_typing_thread)
+                typing_key = (str(chat_id), message_thread_id)
+                loop_time = asyncio.get_running_loop().time()
+                last_typing_at = getattr(self, "_last_typing_at", {}).get(typing_key, 0.0)
+                min_interval = float(getattr(self, "_telegram_typing_min_interval_seconds", 4.0))
+                if loop_time - last_typing_at < min_interval:
+                    return
+
+                typing_semaphore = getattr(self, "_typing_semaphore", None)
+                if typing_semaphore is not None:
+                    if typing_semaphore.locked():
+                        return
+                    try:
+                        await asyncio.wait_for(typing_semaphore.acquire(), timeout=0.05)
+                        acquired_typing_slot = True
+                    except asyncio.TimeoutError:
+                        return
+
+                if not hasattr(self, "_last_typing_at"):
+                    self._last_typing_at = {}
+                self._last_typing_at[typing_key] = loop_time
                 await self._bot.send_chat_action(
                     chat_id=int(chat_id),
                     action="typing",
@@ -4298,6 +4376,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     e,
                     exc_info=True,
                 )
+            finally:
+                if acquired_typing_slot:
+                    self._typing_semaphore.release()
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Get information about a Telegram chat."""

--- a/tests/gateway/test_telegram_send_path_health.py
+++ b/tests/gateway/test_telegram_send_path_health.py
@@ -6,6 +6,7 @@ but nothing reaches the recipient.  ``_send_path_degraded`` short-circuits
 ``send()`` so cron's live-adapter branch falls through to standalone HTTP.
 """
 import sys
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -62,6 +63,69 @@ async def test_send_short_circuits_when_path_degraded():
     assert result.error == "send_path_degraded"
     assert result.retryable is True
     adapter._bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_uses_adapter_backpressure_for_concurrent_calls():
+    """Concurrent sends are gated before they enter python-telegram-bot.
+
+    This protects the shared PTB/httpx pool from digest/status bursts that
+    otherwise create many simultaneous send_message calls.
+    """
+    adapter = _make_adapter()
+    adapter._send_semaphore = asyncio.Semaphore(1)
+    adapter.send_typing = AsyncMock()
+    active = 0
+    max_active = 0
+
+    async def fake_send_message(**_kwargs):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.02)
+        active -= 1
+        return MagicMock(message_id=42)
+
+    adapter._bot.send_message = AsyncMock(side_effect=fake_send_message)
+
+    results = await asyncio.gather(
+        adapter.send("123", "one"),
+        adapter.send("123", "two"),
+        adapter.send("123", "three"),
+    )
+
+    assert [r.success for r in results] == [True, True, True]
+    assert max_active == 1
+    assert adapter._bot.send_message.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_send_queue_timeout_returns_retryable_failure():
+    """A saturated Telegram send queue fails fast instead of wedging Hermes."""
+    adapter = _make_adapter()
+    adapter._send_semaphore = asyncio.Semaphore(1)
+    adapter._telegram_send_queue_timeout_seconds = 0.01
+    adapter.send_typing = AsyncMock()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def fake_send_message(**_kwargs):
+        first_started.set()
+        await release_first.wait()
+        return MagicMock(message_id=42)
+
+    adapter._bot.send_message = AsyncMock(side_effect=fake_send_message)
+
+    first = asyncio.create_task(adapter.send("123", "first"))
+    await first_started.wait()
+    second = await adapter.send("123", "second")
+    release_first.set()
+    first_result = await first
+
+    assert first_result.success is True
+    assert second.success is False
+    assert second.retryable is True
+    assert "telegram_send_queue_timeout" in second.error
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Adds adapter-level backpressure around Telegram sends so bursty gateway traffic does not flood the shared python-telegram-bot/httpx request pool.

In practice, long digest/status bursts and typing refreshes can produce many concurrent Telegram API calls. When the pool is saturated, Hermes may stay healthy locally while Telegram delivery fails with repeated `Pool timeout: All connections in the connection pool are occupied` errors.

This change:

- limits concurrent Telegram `send_message` calls inside `TelegramAdapter.send()`
- returns a retryable failure if the local send queue is saturated for too long
- throttles Telegram typing indicators per chat/thread
- skips excess typing calls when the typing semaphore is already full
- adds focused tests for send-path backpressure and queue timeout behavior

Opening as draft because I ran focused validation, not the full repository test suite.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py`: add send and typing semaphores with environment-tunable defaults.
- `gateway/platforms/telegram.py`: split the existing send implementation behind a throttled wrapper.
- `gateway/platforms/telegram.py`: throttle typing indicators per chat/thread and fail fast when typing slots are saturated.
- `tests/gateway/test_telegram_send_path_health.py`: add tests proving concurrent sends are gated and saturated queues return retryable failures.

## How to Test

1. `uv run --with pytest --with pytest-timeout --with pytest-asyncio pytest tests/gateway/test_telegram_send_path_health.py tests/gateway/test_telegram_status_update.py -q`
2. `uv run --with ruff ruff check gateway/platforms/telegram.py tests/gateway/test_telegram_send_path_health.py`
3. Optional local smoke: start the gateway and verify `/health` plus socket state after Telegram reconnect.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.7.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing docs changed
- [x] I've updated `cli-config.yaml.example` — N/A, no config schema changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — asyncio/httpx/PTB behavior is platform-independent
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Representative failure mode this addresses:

```text
telegram.error.TimedOut: Pool timeout: All connections in the connection pool are occupied. Request was not sent to Telegram.
```
