### PR TITLE
fix(api-server): load MCP tools for REST sessions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3732,6 +3732,18 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id or "",
             )
             try:
+                try:
+                    # Session-based REST chat paths construct AIAgent
+                    # directly, so they must initialize configured MCP
+                    # servers just like CLI startup and gateway boot do.
+                    from tools.mcp_tool import discover_mcp_tools
+
+                    discover_mcp_tools()
+                except Exception:
+                    logger.debug(
+                        "MCP tool discovery failed for api_server session run",
+                        exc_info=True,
+                    )
                 agent = self._create_agent(
                     ephemeral_system_prompt=ephemeral_system_prompt,
                     session_id=session_id,

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -438,3 +438,39 @@ async def test_session_header_rejected_without_api_key(adapter, session_db):
         assert resp.status == 403
         data = await resp.json()
         assert "X-Hermes-Session-Key requires API key" in data["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_initializes_mcp_tools_for_session_api(adapter):
+    calls = []
+
+    class _FakeAgent:
+        session_prompt_tokens = 1
+        session_completion_tokens = 2
+        session_total_tokens = 3
+        session_id = "mcp-session"
+
+        def run_conversation(self, **kwargs):
+            calls.append(("run", kwargs["task_id"]))
+            return {"final_response": "ok"}
+
+    def _fake_discover():
+        calls.append("discover")
+        return []
+
+    def _fake_create_agent(**kwargs):
+        calls.append("create")
+        return _FakeAgent()
+
+    with patch("tools.mcp_tool.discover_mcp_tools", side_effect=_fake_discover), \
+         patch.object(adapter, "_create_agent", side_effect=_fake_create_agent):
+        result, usage = await adapter._run_agent(
+            user_message="hello",
+            conversation_history=[],
+            session_id="sess-1",
+        )
+
+    assert result["final_response"] == "ok"
+    assert result["session_id"] == "mcp-session"
+    assert usage == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+    assert calls[:2] == ["discover", "create"]


### PR DESCRIPTION
## What does this PR do?

Fixes API REST session chat paths so they initialize configured MCP servers before constructing `AIAgent`.

Before this change, `POST /api/sessions/{id}/chat`, `POST /api/sessions/{id}/chat/stream`, and the OpenAI-compatible chat path built agents directly without the MCP discovery step that CLI startup and gateway boot already perform. As a result, MCP tools configured in `~/.hermes/config.yaml` could be available in `hermes chat` but missing in API-driven sessions.

## Related Issue

Fixes #50248

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `discover_mcp_tools()` to the executor-backed API session agent run path in `gateway/platforms/api_server.py`.
- Wrapped MCP initialization in the same fail-open pattern used elsewhere so a broken MCP server does not crash unrelated API chat requests.
- Added a regression test in `tests/gateway/test_session_api.py` that proves MCP discovery runs before the REST session agent is created.

## How to Test

1. Configure an MCP server in `~/.hermes/config.yaml`.
2. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/gateway/test_session_api.py -q`.
3. Start the API server and verify an API session chat can see the same MCP tools that appear in `hermes chat`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

```text
13 passed in 1.19s
```
