### PR TITLE
fix(cli): replace bare asserts with proper guards in hermes_cli/

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4637,7 +4637,8 @@ def _run_with_idle_timeout(
 
     def _reader() -> None:
         nonlocal last_output_ts
-        assert proc.stdout is not None
+        if proc.stdout is None:
+            return
         for line in proc.stdout:
             try:
                 print(f"{indent}{line.rstrip()}", flush=True)

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -374,7 +374,8 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
 def _do_git_install(entry: CatalogEntry) -> Path:
     """Clone the entry's repo into ``~/.hermes/mcp-installs/<name>`` and run
     bootstrap commands. Returns the install directory."""
-    assert entry.install is not None and entry.install.type == "git"
+    if not entry.install or entry.install.type != "git":
+        raise CatalogError("entry must have a git install definition")
     install = entry.install
     dest = _install_root() / entry.name
 

--- a/hermes_cli/mcp_picker.py
+++ b/hermes_cli/mcp_picker.py
@@ -219,7 +219,8 @@ def _handle_row(row: _Row) -> None:
                 print(color(f"  '{row.name}' was not installed", Colors.DIM))
     elif choice == 3:
         try:
-            assert row.entry is not None
+            if row.entry is None:
+                raise CatalogError(f"no catalog entry for '{row.name}'")
             install_entry(row.entry, enable=True)
         except CatalogError as exc:
             print(color(f"  ✗ reinstall failed: {exc}", Colors.RED))


### PR DESCRIPTION
## Summary

`assert` statements are stripped when Python runs with `-O` flag, causing silent failures in production.

Replace 3 bare asserts in `hermes_cli/` with explicit checks:

- **mcp_catalog.py**: `assert entry.install` -> `raise CatalogError`
- **mcp_picker.py**: `assert row.entry` -> `raise CatalogError` (caught by existing except block)
- **main.py**: `assert proc.stdout` -> early `return` in `_reader()`

## Test plan

- [ ] `python -O -c "import hermes_cli.mcp_catalog"` succeeds
- [ ] `python -O -c "import hermes_cli.mcp_picker"` succeeds
- [ ] `python -O -c "import hermes_cli.main"` succeeds
- [ ] CI passes