### PR TITLE
fix(matrix): restore nested mention placeholders in reverse order (#50432)

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3801,8 +3801,13 @@ class MatrixAdapter(BasePlatformAdapter):
             protected,
         )
 
-        for idx, original in enumerate(placeholders):
-            linked = linked.replace(f"\x00MENTION_PROTECTED{idx}\x00", original)
+        # Restore in reverse order so that outer placeholders (higher idx)
+        # are unwrapped before inner ones — otherwise the inner placeholder
+        # text is embedded inside the outer's ``original`` string and the
+        # forward loop skips it, leaking ``\x00MENTION_PROTECTED{idx}\x00``
+        # into the HTML output (visible as "MENTION_PROTECTED0" etc.).
+        for idx in range(len(placeholders) - 1, -1, -1):
+            linked = linked.replace(f"\x00MENTION_PROTECTED{idx}\x00", placeholders[idx])
 
         return linked
 

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -810,3 +810,89 @@ class TestMatrixConfigBridge:
             )
 
         assert os.getenv("MATRIX_REQUIRE_MENTION") == "true"
+
+
+class TestOutboundMentionPlaceholderRestoration:
+    """Regression tests for nested placeholder restoration (#50432).
+
+    When ``_protect_outbound_mention_regions`` nests placeholders (inline
+    code inside a markdown link), the restoration loop must process them
+    in reverse order so that outer placeholders are unwrapped before the
+    inner ones they embed.
+    """
+
+    def test_flat_placeholders_restored(self):
+        """Two non-nested placeholders are both restored."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter.__new__(MatrixAdapter)
+        text = "See `code` and [link](https://example.com) here"
+        result = adapter._inject_outbound_mention_links(text)
+        assert "`code`" in result
+        assert "[link](https://example.com)" in result
+        assert "\x00" not in result
+        assert "MENTION_PROTECTED" not in result
+
+    def test_inline_code_inside_markdown_link_restored(self):
+        """Inline code nested inside a markdown link must be fully restored."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter.__new__(MatrixAdapter)
+        text = "Check [this `code` link](https://example.com) for details"
+        result = adapter._inject_outbound_mention_links(text)
+        assert "`code`" in result
+        assert "[this `code` link](https://example.com)" in result
+        assert "\x00" not in result
+        assert "MENTION_PROTECTED" not in result
+
+    def test_triple_backtick_inside_markdown_link_restored(self):
+        """Fenced code nested inside a markdown link must be fully restored."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter.__new__(MatrixAdapter)
+        text = "See [the code ```x=1``` here](https://example.com)"
+        result = adapter._inject_outbound_mention_links(text)
+        assert "```x=1```" in result
+        assert "\x00" not in result
+        assert "MENTION_PROTECTED" not in result
+
+    def test_mention_outside_link_still_wrapped(self):
+        """Mention links should be created for @user:server outside code."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter.__new__(MatrixAdapter)
+        text = "Hey @alice:example.org check [link](https://example.com)"
+        result = adapter._inject_outbound_mention_links(text)
+        assert "matrix.to/#/@alice:example.org" in result
+        assert "[link](https://example.com)" in result
+        assert "\x00" not in result
+        assert "MENTION_PROTECTED" not in result
+
+    def test_mention_inside_code_not_wrapped(self):
+        """@user:server inside inline code should stay literal."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter.__new__(MatrixAdapter)
+        text = "Run `@bot:example.org` to test"
+        result = adapter._inject_outbound_mention_links(text)
+        assert "`@bot:example.org`" in result
+        assert "matrix.to" not in result
+        assert "\x00" not in result
+        assert "MENTION_PROTECTED" not in result
+
+    def test_empty_text_passthrough(self):
+        """Empty/None text returns as-is."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter.__new__(MatrixAdapter)
+        assert adapter._inject_outbound_mention_links("") == ""
+        assert adapter._inject_outbound_mention_links(None) is None
+
+    def test_no_placeholders_text_unchanged(self):
+        """Plain text with no code/links passes through unchanged."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter.__new__(MatrixAdapter)
+        text = "Hello world, no special markup here"
+        result = adapter._inject_outbound_mention_links(text)
+        assert result == text


### PR DESCRIPTION
## What does this PR do?

Fixes nested placeholder restoration in Matrix outbound mention link injection. When inline code or fenced code blocks appear inside markdown links, the placeholder restoration loop processed them in forward order, causing inner placeholders to be skipped — leaking `\x00MENTION_PROTECTED{idx}\x00` into the HTML output, visible as "MENTION_PROTECTED0" etc. in Matrix clients.

## Related Issue

Fixes #50432

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: Changed `_inject_outbound_mention_links` to restore placeholders in reverse order (highest idx first), so outer placeholders are unwrapped before the inner ones they embed
- `tests/gateway/test_matrix_mention.py`: Added 7 regression tests covering flat placeholders, nested inline code, nested fenced code, mention wrapping, code protection, empty input, and plain text passthrough

## How to Test

1. Run `python -m pytest tests/gateway/test_matrix_mention.py::TestOutboundMentionPlaceholderRestoration -v` — all 7 tests should pass
2. Run `python -m pytest tests/gateway/test_matrix_mention.py -v` — all 59 tests should pass (52 existing + 7 new)
3. Reproduce: send a message with inline code inside a markdown link via Matrix (e.g., "Check [this `code` link](https://example.com)") — the link should render correctly instead of showing "MENTION_PROTECTED0"

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_matrix_mention.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_inject_outbound_mention_links`, `_protect_outbound_mention_regions` (callers: 2, flows: outbound message delivery)
- Blast radius: LOW — single method change, 7 regression tests
- Related patterns: placeholder restoration in `_markdown_to_html_fallback` uses similar `\x00PROTECTED{idx}\x00` pattern (not affected — no nesting between the two systems)
