### PR TITLE
feat: make gateway document types configurable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -546,6 +546,10 @@ class GatewayConfig:
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
 
+    # Shared document attachment allowlist overrides. Shape:
+    # gateway.document_types: {add: {".foo": "application/x-foo"}, remove: [".bar"]}.
+    document_types: Dict[str, Any] = field(default_factory=dict)
+
     # Session store pruning: drop SessionEntry records older than this many
     # days from the in-memory dict and sessions.json.  Keeps the store from
     # growing unbounded in gateways serving many chats/threads/users over
@@ -656,6 +660,7 @@ class GatewayConfig:
             "multiplex_profiles": self.multiplex_profiles,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
+            "document_types": self.document_types,
             "session_store_max_age_days": self.session_store_max_age_days,
         }
     
@@ -701,6 +706,11 @@ class GatewayConfig:
         thread_sessions_per_user = data.get("thread_sessions_per_user")
         multiplex_profiles = data.get("multiplex_profiles")
         nested_gateway = data.get("gateway") if isinstance(data.get("gateway"), dict) else {}
+        document_types = nested_gateway.get("document_types") if isinstance(nested_gateway, dict) else None
+        if "document_types" in data:
+            document_types = data.get("document_types")
+        if not isinstance(document_types, dict):
+            document_types = {}
         if multiplex_profiles is None and isinstance(nested_gateway, dict):
             # Also honor gateway.multiplex_profiles written by
             # ``hermes config set gateway.multiplex_profiles true``.
@@ -745,6 +755,7 @@ class GatewayConfig:
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+            document_types=document_types,
             session_store_max_age_days=session_store_max_age_days,
         )
 
@@ -856,6 +867,10 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["multiplex_profiles"] = yaml_cfg["multiplex_profiles"]
 
             gateway_section = yaml_cfg.get("gateway")
+            if isinstance(gateway_section, dict) and "document_types" in gateway_section:
+                gw_data["document_types"] = gateway_section["document_types"]
+            if "document_types" in yaml_cfg:
+                gw_data["document_types"] = yaml_cfg["document_types"]
             if isinstance(gateway_section, dict) and "max_concurrent_sessions" in gateway_section:
                 gw_data["max_concurrent_sessions"] = gateway_section["max_concurrent_sessions"]
 
@@ -1023,6 +1038,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "document_types" in platform_cfg:
+                    bridged["document_types"] = platform_cfg["document_types"]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue
@@ -1140,11 +1157,22 @@ def load_gateway_config() -> GatewayConfig:
 
     # Override with environment variables
     _apply_env_overrides(config)
+    _propagate_document_type_config(config)
     
     # --- Validate loaded values ---
     _validate_gateway_config(config)
 
     return config
+
+
+def _propagate_document_type_config(config: "GatewayConfig") -> None:
+    """Attach shared gateway.document_types config to every platform extra dict."""
+    if not config.document_types:
+        return
+    for pconfig in config.platforms.values():
+        if not isinstance(pconfig.extra, dict):
+            pconfig.extra = {}
+        pconfig.extra.setdefault("_global_document_types", config.document_types)
 
 
 def _validate_gateway_config(config: "GatewayConfig") -> None:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -9,6 +9,7 @@ import asyncio
 import inspect
 import ipaddress
 import logging
+import mimetypes
 import os
 import random
 import re
@@ -1248,6 +1249,176 @@ SUPPORTED_DOCUMENT_TYPES = {
 }
 
 
+def _normalize_document_extension(ext: Any) -> str:
+    """Return a safe, lowercase extension (including leading dot) or ''."""
+    ext = str(ext or "").strip().lower()
+    if not ext:
+        return ""
+    if not ext.startswith("."):
+        ext = f".{ext}"
+    if ext == "." or any(ch.isspace() for ch in ext) or "/" in ext or "\\" in ext:
+        return ""
+    return ext
+
+
+def _normalize_document_mime(ext: str, mime: Any) -> str:
+    """Return configured MIME, or a safe guess/fallback for extension-only config."""
+    if isinstance(mime, str) and mime.strip():
+        return mime.strip().lower()
+    guessed, _encoding = mimetypes.guess_type(f"file{ext}")
+    return guessed or "application/octet-stream"
+
+
+def _iter_document_type_additions(raw: Any):
+    if not raw:
+        return
+    if isinstance(raw, dict):
+        add = raw.get("add")
+        if add is not None:
+            yield from _iter_document_type_additions(add)
+            return
+        for ext, mime in raw.items():
+            if ext == "remove":
+                continue
+            yield ext, mime
+        return
+    if isinstance(raw, (list, tuple, set)):
+        for item in raw:
+            if isinstance(item, dict):
+                if "extension" in item or "ext" in item:
+                    yield item.get("extension", item.get("ext")), item.get("mime", item.get("mime_type"))
+                elif len(item) == 1:
+                    yield from item.items()
+            elif isinstance(item, str):
+                if "=" in item:
+                    ext, mime = item.split("=", 1)
+                elif ":" in item:
+                    ext, mime = item.split(":", 1)
+                else:
+                    ext, mime = item, None
+                yield ext, mime
+        return
+    if isinstance(raw, str):
+        for item in re.split(r"[\n,]+", raw):
+            item = item.strip()
+            if item:
+                yield from _iter_document_type_additions([item])
+
+
+def _iter_document_type_removals(raw: Any):
+    if not raw:
+        return
+    if isinstance(raw, dict):
+        remove = raw.get("remove")
+        if remove is not None:
+            yield from _iter_document_type_removals(remove)
+        return
+    if isinstance(raw, (list, tuple, set)):
+        for item in raw:
+            yield item
+        return
+    if isinstance(raw, str):
+        for item in re.split(r"[\n,]+", raw):
+            item = item.strip()
+            if item:
+                yield item
+
+
+def _coerce_document_type_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _document_types_allow_unknown(raw_config: Any, default: bool) -> bool:
+    if not isinstance(raw_config, dict):
+        return default
+    if "allow_unknown" in raw_config:
+        return _coerce_document_type_bool(raw_config.get("allow_unknown"), default)
+    if "allow_unknown_document_types" in raw_config:
+        return _coerce_document_type_bool(raw_config.get("allow_unknown_document_types"), default)
+    if "strict" in raw_config:
+        return not _coerce_document_type_bool(raw_config.get("strict"), not default)
+    return default
+
+
+def _apply_document_type_config(
+    document_types: dict[str, str],
+    raw_config: Any,
+    removed: Optional[set[str]] = None,
+) -> None:
+    if not raw_config:
+        return
+    for ext, mime in _iter_document_type_additions(raw_config) or []:
+        normalized_ext = _normalize_document_extension(ext)
+        if normalized_ext:
+            document_types[normalized_ext] = _normalize_document_mime(normalized_ext, mime)
+            if removed is not None:
+                removed.discard(normalized_ext)
+    for ext in _iter_document_type_removals(raw_config) or []:
+        normalized_ext = _normalize_document_extension(ext)
+        if normalized_ext:
+            document_types.pop(normalized_ext, None)
+            if removed is not None:
+                removed.add(normalized_ext)
+
+
+def resolve_document_type_policy(
+    config_extra: Optional[dict[str, Any]] = None,
+) -> tuple[dict[str, str], set[str], bool]:
+    """Return effective document types, explicit removals, and unknown-file policy.
+
+    Defaults come from ``SUPPORTED_DOCUMENT_TYPES``. Operators can add/remove
+    extensions and optionally set ``allow_unknown: false`` (or ``strict: true``)
+    to reject files outside the configured allowlist. Unknown files remain
+    accepted by default to preserve the gateway's broad attachment handling;
+    explicit ``remove`` entries are always rejected.
+    """
+    effective = dict(SUPPORTED_DOCUMENT_TYPES)
+    removed: set[str] = set()
+    allow_unknown = True
+    if isinstance(config_extra, dict):
+        for raw_config in (
+            config_extra.get("_global_document_types"),
+            config_extra.get("document_types"),
+        ):
+            allow_unknown = _document_types_allow_unknown(raw_config, allow_unknown)
+            _apply_document_type_config(effective, raw_config, removed)
+    return effective, removed, allow_unknown
+
+
+def resolve_document_types(config_extra: Optional[dict[str, Any]] = None) -> dict[str, str]:
+    """Return the effective known document MIME map after config overrides.
+
+    ```yaml
+    gateway:
+      document_types:
+        add:
+          .epub: application/epub+zip
+        remove: [.doc]
+
+    telegram:
+      document_types:
+        add:
+          .foo: text/plain
+    ```
+
+    ``gateway.config.load_gateway_config`` injects shared
+    ``gateway.document_types`` into each platform's ``extra`` as
+    ``_global_document_types``. Platform-local ``document_types`` are applied
+    after the global config so a platform can override the shared policy.
+    """
+    return resolve_document_type_policy(config_extra)[0]
+
+
 # ---------------------------------------------------------------------------
 # Text-injection extension allowlist
 #
@@ -1450,7 +1621,7 @@ class CachedMedia:
         return f"[{self.kind} '{self.display_name}' saved at: {self.path}]"
 
 
-def _resolve_media_ext(filename: str, mime_type: str) -> str:
+def _resolve_media_ext(filename: str, mime_type: str, document_types: Optional[dict[str, str]] = None) -> str:
     """Best-effort file extension from filename, then MIME fallback."""
     if filename:
         ext = os.path.splitext(filename)[1].lower()
@@ -1459,10 +1630,11 @@ def _resolve_media_ext(filename: str, mime_type: str) -> str:
     mime = (mime_type or "").lower()
     if not mime:
         return ""
+    document_types = document_types or resolve_document_types()
     for table in (
         SUPPORTED_IMAGE_DOCUMENT_TYPES,
         SUPPORTED_VIDEO_TYPES,
-        SUPPORTED_DOCUMENT_TYPES,
+        document_types,
     ):
         for ext, m in table.items():
             if m == mime:
@@ -1476,6 +1648,8 @@ def cache_media_bytes(
     filename: str = "",
     mime_type: str = "",
     default_kind: Optional[str] = None,
+    document_types: Optional[dict[str, str]] = None,
+    document_type_config: Optional[dict[str, Any]] = None,
 ) -> Optional[CachedMedia]:
     """Classify and cache raw attachment bytes; return a CachedMedia or None.
 
@@ -1488,7 +1662,13 @@ def cache_media_bytes(
     """
     from tools.credential_files import to_agent_visible_cache_path
 
-    ext = _resolve_media_ext(filename, mime_type)
+    if document_type_config is not None:
+        document_types, removed_document_types, allow_unknown_documents = resolve_document_type_policy(document_type_config)
+    else:
+        document_types = document_types or resolve_document_types()
+        removed_document_types = set()
+        allow_unknown_documents = True
+    ext = _resolve_media_ext(filename, mime_type, document_types)
     mime = (mime_type or "").lower()
     display = re.sub(r"[^\w.\- ]", "_", filename) if filename else (ext.lstrip(".") or "file")
 
@@ -1521,16 +1701,17 @@ def cache_media_bytes(
         return CachedMedia(to_agent_visible_cache_path(path), out_mime, "audio", display)
 
     # Any other file type is cached and surfaced to the agent as a local path
-    # so it can be inspected with terminal / read_file / etc. Authorization to
-    # talk to the agent is the gate that matters — once a user is allowed to
-    # message it, the file-extension allowlist must not silently drop their
-    # uploads. Known extensions keep their precise MIME; everything else is
-    # tagged application/octet-stream (or the caller-supplied MIME) so the
-    # agent knows it's an arbitrary file and reaches for terminal tools.
+    # so it can be inspected with terminal / read_file / etc. Known extensions
+    # keep their configured MIME; unknown extensions remain accepted by default
+    # unless document_types.allow_unknown is false. Explicit remove entries are
+    # always rejected.
+    if ext in removed_document_types or (not allow_unknown_documents and ext not in document_types):
+        return None
+
     fallback_name = filename or (f"document{ext}" if ext else "document.bin")
     path = cache_document_from_bytes(data, fallback_name)
-    if ext in SUPPORTED_DOCUMENT_TYPES:
-        out_mime = SUPPORTED_DOCUMENT_TYPES[ext]
+    if ext in document_types:
+        out_mime = document_types[ext]
     else:
         out_mime = mime if mime else "application/octet-stream"
     return CachedMedia(to_agent_visible_cache_path(path), out_mime, "document", display or fallback_name)

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -76,7 +76,6 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
-    SUPPORTED_DOCUMENT_TYPES,
 )
 from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
 from hermes_constants import get_hermes_dir

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2493,12 +2493,23 @@ DEFAULT_CONFIG = {
         # adapter. ``0`` disables the cap. Default 128 MiB.
         "max_inbound_media_bytes": 134217728,
 
+        # Inbound document attachment allowlist overrides. Built-in safe
+        # defaults live in gateway/platforms/base.py; this config lets operators
+        # add or remove extensions without editing Python code. Platform blocks
+        # may also define document_types to override this shared setting.
+        # Example:
+        #   add: {".epub": "application/epub+zip", ".foo": "text/plain"}
+        #   remove: [".doc"]
+        "document_types": {
+            "add": {},
+            "remove": [],
+        },
+
         # When false (default), any file path the agent emits is delivered
         # as a native attachment as long as it isn't under the credential /
         # system-path denylist (/etc, /proc, ~/.ssh, ~/.aws, ~/.hermes/.env,
-        # auth.json, etc.). This matches the symmetry of inbound delivery
-        # — we accept any document type the user uploads, and the agent
-        # can hand back any file that isn't a credential.
+        # auth.json, etc.). This is the outbound delivery policy; inbound
+        # uploads are still governed by the document_types allowlist above.
         #
         # When true, fall back to the older allowlist+recency-window
         # behavior: files must live under the Hermes cache, under

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -115,7 +115,7 @@ from gateway.platforms.base import (
     cache_audio_from_url,
     cache_audio_from_bytes,
     cache_document_from_bytes,
-    SUPPORTED_DOCUMENT_TYPES,
+    resolve_document_type_policy,
     _TEXT_INJECT_EXTENSIONS,
     validate_inbound_media_size,
 )
@@ -4141,12 +4141,11 @@ class DiscordAdapter(BasePlatformAdapter):
         return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in {"false", "0", "no", "off"}
 
     def _discord_allow_any_attachment(self) -> bool:
-        """Return whether Discord attachments bypass the SUPPORTED_DOCUMENT_TYPES allowlist.
+        """Return whether Discord attachments bypass strict document-type policy.
 
-        When True, any uploaded file is cached to disk and surfaced to the
-        agent as a local path so it can be inspected via terminal / read_file
-        / ffprobe / etc. Default False preserves the historical behaviour of
-        dropping unsupported types with a warning log.
+        When True, Discord accepts files even if `document_types.allow_unknown`
+        is disabled. The default remains False; the gateway-level default is to
+        accept unknown attachment types unless operators opt into strict mode.
         """
         configured = self.config.extra.get("allow_any_attachment")
         if configured is not None:
@@ -5392,14 +5391,23 @@ class DiscordAdapter(BasePlatformAdapter):
                 if att.filename:
                     _, ext = os.path.splitext(att.filename)
                     ext = ext.lower()
+                document_types, removed_document_types, allow_unknown_documents = resolve_document_type_policy(self.config.extra)
+                allow_unknown_documents = allow_unknown_documents or self._discord_allow_any_attachment()
                 if not ext and content_type:
-                    mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
+                    mime_to_ext = {v: k for k, v in document_types.items()}
                     ext = mime_to_ext.get(content_type, "")
-                in_allowlist = ext in SUPPORTED_DOCUMENT_TYPES
-                # Any file type is accepted — authorization to message the agent
-                # is the gate, not the file extension. Known types keep their
-                # precise MIME; unknown types fall back to the source content_type
-                # or octet-stream so the agent reaches for terminal tools.
+                in_allowlist = ext in document_types
+                if ext in removed_document_types or (not allow_unknown_documents and not in_allowlist):
+                    logger.warning(
+                        "[Discord] Unsupported document type, skipping: %s (%s)",
+                        att.filename,
+                        ext or content_type,
+                    )
+                    continue
+                # Unknown file types are accepted by default and surfaced to the
+                # agent as cached local paths; known types keep their configured
+                # MIME. Operators can opt into strict allowlist behavior with
+                # document_types.allow_unknown: false.
                 max_doc_bytes = self._discord_max_attachment_bytes()
                 if max_doc_bytes and att.size and att.size > max_doc_bytes:
                     logger.warning(
@@ -5413,7 +5421,7 @@ class DiscordAdapter(BasePlatformAdapter):
                             raw_bytes, att.filename or f"document{ext or '.bin'}"
                         )
                         if in_allowlist:
-                            doc_mime = SUPPORTED_DOCUMENT_TYPES[ext]
+                            doc_mime = document_types[ext]
                         else:
                             # Untyped file. Use the source content_type if
                             # discord gave us one, otherwise fall back to

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -134,7 +134,7 @@ from gateway.platforms.base import (
     MessageType,
     ProcessingOutcome,
     SendResult,
-    SUPPORTED_DOCUMENT_TYPES,
+    resolve_document_types,
     cache_document_from_bytes,
     cache_image_from_url,
     cache_audio_from_bytes,
@@ -170,7 +170,6 @@ _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incor
 _IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
 _AUDIO_EXTENSIONS = {".ogg", ".mp3", ".wav", ".m4a", ".aac", ".flac", ".opus", ".webm"}
 _VIDEO_EXTENSIONS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v", ".3gp"}
-_DOCUMENT_MIME_TO_EXT = {mime: ext for ext, mime in SUPPORTED_DOCUMENT_TYPES.items()}
 _FEISHU_IMAGE_UPLOAD_TYPE = "message"
 _FEISHU_FILE_UPLOAD_TYPE = "stream"
 _FEISHU_OPUS_UPLOAD_EXTENSIONS = {".ogg", ".opus"}
@@ -3303,10 +3302,11 @@ class FeishuAdapter(BasePlatformAdapter):
         cached_path = cache_document_from_bytes(body, filename)
         return cached_path, filename
 
-    @staticmethod
-    def _guess_remote_extension(url: str, *, default: str) -> str:
+    def _guess_remote_extension(self, url: str, *, default: str) -> str:
         ext = Path((url or "").split("?", 1)[0]).suffix.lower()
-        return ext if ext in (_IMAGE_EXTENSIONS | _AUDIO_EXTENSIONS | _VIDEO_EXTENSIONS | set(SUPPORTED_DOCUMENT_TYPES)) else default
+        document_types = resolve_document_types(self.config.extra)
+        allowed = _IMAGE_EXTENSIONS | _AUDIO_EXTENSIONS | _VIDEO_EXTENSIONS | set(document_types)
+        return ext if ext in allowed else default
 
     @staticmethod
     def _derive_remote_filename(file_url: str, *, content_type: str, default_name: str, default_ext: str) -> str:
@@ -3798,8 +3798,11 @@ class FeishuAdapter(BasePlatformAdapter):
                     logger.info("[Feishu] Cached message video resource at %s", cached_path)
                     return cached_path, media_type
 
-                if not Path(filename).suffix and media_type in _DOCUMENT_MIME_TO_EXT:
-                    filename = f"{filename}{_DOCUMENT_MIME_TO_EXT[media_type]}"
+                document_mime_to_ext = {
+                    mime: ext for ext, mime in resolve_document_types(self.config.extra).items()
+                }
+                if not Path(filename).suffix and media_type in document_mime_to_ext:
+                    filename = f"{filename}{document_mime_to_ext[media_type]}"
                 cached_path = cache_document_from_bytes(raw_bytes, filename)
                 logger.info("[Feishu] Cached message document resource at %s", cached_path)
                 return cached_path, (media_type or self._guess_document_media_type(filename))
@@ -3846,10 +3849,10 @@ class FeishuAdapter(BasePlatformAdapter):
         normalized = (content_type or "").split(";", 1)[0].strip().lower()
         return normalized or default
 
-    @staticmethod
-    def _guess_document_media_type(filename: str) -> str:
+    def _guess_document_media_type(self, filename: str) -> str:
         ext = Path(filename or "").suffix.lower()
-        return SUPPORTED_DOCUMENT_TYPES.get(ext, mimetypes.guess_type(filename or "")[0] or "application/octet-stream")
+        document_types = resolve_document_types(self.config.extra)
+        return document_types.get(ext, mimetypes.guess_type(filename or "")[0] or "application/octet-stream")
 
     @staticmethod
     def _display_name_from_cached_path(path: str) -> str:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -44,7 +44,7 @@ from gateway.platforms.base import (
     MessageType,
     ProcessingOutcome,
     SendResult,
-    SUPPORTED_DOCUMENT_TYPES,
+    resolve_document_type_policy,
     SUPPORTED_VIDEO_TYPES,
     _TEXT_INJECT_EXTENSIONS,
     is_host_excluded_by_no_proxy,
@@ -2692,19 +2692,28 @@ class SlackAdapter(BasePlatformAdapter):
                         _, ext = os.path.splitext(original_filename)
                         ext = ext.lower()
 
+                    document_types, removed_document_types, allow_unknown_documents = resolve_document_type_policy(self.config.extra)
+
                     # Fallback: reverse-lookup from MIME type
                     if not ext and mimetype:
                         mime_to_ext = {
-                            v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()
+                            v: k for k, v in document_types.items()
                         }
                         ext = mime_to_ext.get(mimetype, "")
 
-                    # Any file type is accepted — authorization to message the
-                    # agent is the gate, not the file extension. Known types keep
-                    # their precise MIME; unknown types fall back to the source
-                    # mimetype or octet-stream so the agent reaches for terminal
-                    # tools.
-                    in_allowlist = ext in SUPPORTED_DOCUMENT_TYPES
+                    in_allowlist = ext in document_types
+                    if ext in removed_document_types or (not allow_unknown_documents and not in_allowlist):
+                        logger.warning(
+                            "[Slack] Unsupported document type, skipping: %s (%s)",
+                            original_filename,
+                            ext or mimetype,
+                        )
+                        continue
+
+                    # Unknown file types are accepted by default and surfaced to
+                    # the agent as cached local paths; known types keep their
+                    # configured MIME. Operators can opt into strict allowlist
+                    # behavior with document_types.allow_unknown: false.
 
                     # Check file size (Slack limit: 20 MB for bots)
                     file_size = f.get("size", 0)
@@ -2723,7 +2732,7 @@ class SlackAdapter(BasePlatformAdapter):
                         raw_bytes, original_filename or f"document{ext or '.bin'}"
                     )
                     if in_allowlist:
-                        doc_mime = SUPPORTED_DOCUMENT_TYPES[ext]
+                        doc_mime = document_types[ext]
                     else:
                         doc_mime = mimetype or "application/octet-stream"
                     media_urls.append(cached_path)

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -908,7 +908,12 @@ class TeamsAdapter(BasePlatformAdapter):
                 filename = att_name or (f"document.{file_type}" if file_type else "document")
                 try:
                     data = await self._fetch_attachment_bytes(download_url)
-                    cached = cache_media_bytes(data, filename=filename, mime_type="")
+                    cached = cache_media_bytes(
+                        data,
+                        filename=filename,
+                        mime_type="",
+                        document_type_config=self.config.extra,
+                    )
                     if cached:
                         media_urls.append(cached.path)
                         media_types.append(cached.media_type)
@@ -938,7 +943,10 @@ class TeamsAdapter(BasePlatformAdapter):
                 try:
                     data = await self._fetch_attachment_bytes(content_url)
                     cached = cache_media_bytes(
-                        data, filename=att_name, mime_type=content_type
+                        data,
+                        filename=att_name,
+                        mime_type=content_type,
+                        document_type_config=self.config.extra,
                     )
                     if cached:
                         media_urls.append(cached.path)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -79,7 +79,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     resolve_proxy_url,
     SUPPORTED_VIDEO_TYPES,
-    SUPPORTED_DOCUMENT_TYPES,
+    resolve_document_type_policy,
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     _TEXT_INJECT_EXTENSIONS,
     utf16_len,
@@ -5855,7 +5855,13 @@ class TelegramAdapter(BasePlatformAdapter):
             data = bytes(await file_obj.download_as_bytearray())
             if not filename:
                 filename = os.path.basename(getattr(file_obj, "file_path", "") or "")
-            cached = cache_media_bytes(data, filename=filename, mime_type=mime, default_kind=kind)
+            cached = cache_media_bytes(
+                data,
+                filename=filename,
+                mime_type=mime,
+                default_kind=kind,
+                document_type_config=self.config.extra,
+            )
         except Exception as exc:
             logger.warning("[Telegram] Failed to cache observed group media: %s", exc, exc_info=True)
             return
@@ -5903,7 +5909,13 @@ class TelegramAdapter(BasePlatformAdapter):
             data = bytes(await file_obj.download_as_bytearray())
             if not filename:
                 filename = os.path.basename(getattr(file_obj, "file_path", "") or "")
-            cached = cache_media_bytes(data, filename=filename, mime_type=mime, default_kind=kind)
+            cached = cache_media_bytes(
+                data,
+                filename=filename,
+                mime_type=mime,
+                default_kind=kind,
+                document_type_config=self.config.extra,
+            )
         except Exception as exc:
             logger.warning("[Telegram] Failed to cache replied-to media: %s", exc, exc_info=True)
             return
@@ -6451,11 +6463,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 # uppercase like "IMAGE/PNG").
                 doc_mime = (doc.mime_type or "").lower()
 
+                document_types, removed_document_types, allow_unknown_documents = resolve_document_type_policy(self.config.extra)
+
                 # If no extension from filename, reverse-lookup from MIME type
                 if not ext and doc_mime:
                     ext = _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, "")
                     if not ext:
-                        mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
+                        mime_to_ext = {v: k for k, v in document_types.items()}
                         ext = mime_to_ext.get(doc_mime, "")
 
                 # Check file size early so image documents cannot bypass the
@@ -6530,15 +6544,26 @@ class TelegramAdapter(BasePlatformAdapter):
                 # ext-in-SUPPORTED_IMAGE_DOCUMENT_TYPES branch would be dead
                 # code — the extension sets are identical.
 
-                # Download and cache. Any file type is accepted — authorization
-                # to message the agent is the gate, not the file extension.
-                # Known types keep their precise MIME; unknown types are tagged
-                # application/octet-stream so the agent reaches for terminal tools.
+                in_allowlist = ext in document_types
+                if ext in removed_document_types or (not allow_unknown_documents and not in_allowlist):
+                    supported_list = ", ".join(sorted(document_types.keys()))
+                    event.text = (
+                        f"Unsupported document type: {ext or doc_mime or 'unknown'}. "
+                        f"Supported document types: {supported_list}."
+                    )
+                    logger.info("[Telegram] Unsupported document type: %s (%s)", original_filename, ext or doc_mime)
+                    await self.handle_message(event)
+                    return
+
+                # Download and cache. Unknown file types are accepted by default
+                # and surfaced to the agent as cached local paths; known types
+                # keep their configured MIME. Operators can opt into strict
+                # allowlist behavior with document_types.allow_unknown: false.
                 file_obj = await doc.get_file()
                 doc_bytes = await file_obj.download_as_bytearray()
                 raw_bytes = bytes(doc_bytes)
                 cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext or '.bin'}")
-                mime_type = SUPPORTED_DOCUMENT_TYPES.get(ext) or doc.mime_type or "application/octet-stream"
+                mime_type = document_types.get(ext) or doc.mime_type or "application/octet-stream"
                 event.media_urls = [cached_path]
                 event.media_types = [mime_type]
                 logger.info("[Telegram] Cached user document at %s (%s)", cached_path, mime_type)

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -261,7 +261,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
-    SUPPORTED_DOCUMENT_TYPES,
+    resolve_document_types,
     cache_image_from_url,
     cache_audio_from_url,
 )
@@ -1210,7 +1210,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     # Local file path — bridge already downloaded the document
                     cached_urls.append(url)
                     ext = Path(url).suffix.lower()
-                    mime = SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")
+                    document_types = resolve_document_types(self.config.extra)
+                    mime = document_types.get(ext, "application/octet-stream")
                     media_types.append(mime)
                     print(f"[{self.name}] Using bridge-cached document: {url}", flush=True)
                 elif msg_type == MessageType.VIDEO and os.path.isabs(url):

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -278,6 +278,24 @@ class TestIncomingDocumentHandling:
         assert event.message_type == MessageType.DOCUMENT
 
     @pytest.mark.asyncio
+    async def test_configured_custom_document_type_cached(self, adapter):
+        """A document extension added in config should be accepted without allow_any."""
+        adapter.config.extra["document_types"] = {
+            "add": {".epub": "application/epub+zip"}
+        }
+
+        with _mock_aiohttp_download(b"PK\x03\x04 fake epub"):
+            msg = make_message([
+                make_attachment(filename="book.epub", content_type="application/epub+zip")
+            ])
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert len(event.media_urls) == 1
+        assert event.media_types == ["application/epub+zip"]
+        assert event.message_type == MessageType.DOCUMENT
+
+    @pytest.mark.asyncio
     async def test_download_error_handled(self, adapter):
         """If the HTTP download raises, the handler should not crash."""
         resp = AsyncMock()

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -16,6 +16,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     cleanup_document_cache,
     get_document_cache_dir,
+    resolve_document_types,
 )
 
 # ---------------------------------------------------------------------------
@@ -168,6 +169,42 @@ class TestSupportedDocumentTypes:
         assert ext in SUPPORTED_DOCUMENT_TYPES
 
 
+class TestResolveDocumentTypes:
+    def test_defaults_match_builtin_allowlist(self):
+        assert resolve_document_types() == SUPPORTED_DOCUMENT_TYPES
+
+    def test_global_config_can_add_and_remove_extensions(self):
+        effective = resolve_document_types({
+            "_global_document_types": {
+                "add": {".epub": "application/epub+zip", "foo": "text/plain"},
+                "remove": [".doc"],
+            }
+        })
+        assert effective[".epub"] == "application/epub+zip"
+        assert effective[".foo"] == "text/plain"
+        assert ".doc" not in effective
+
+    def test_platform_config_applies_after_global_config(self):
+        effective = resolve_document_types({
+            "_global_document_types": {
+                "add": {".foo": "application/x-global"},
+                "remove": [".pdf"],
+            },
+            "document_types": {
+                "add": {".foo": "application/x-platform", ".pdf": "application/pdf"},
+                "remove": [".doc"],
+            },
+        })
+        assert effective[".foo"] == "application/x-platform"
+        assert effective[".pdf"] == "application/pdf"
+        assert ".doc" not in effective
+
+    def test_invalid_extension_entries_are_ignored(self):
+        effective = resolve_document_types({"document_types": {"add": {"bad/name": "text/plain", ".ok": ""}}})
+        assert "bad/name" not in effective
+        assert effective[".ok"] == "application/octet-stream"
+
+
 # ---------------------------------------------------------------------------
 # TestCacheMediaBytes — the unified, platform-agnostic caching primitive
 # ---------------------------------------------------------------------------
@@ -237,6 +274,28 @@ class TestCacheMediaBytes:
         assert result is not None
         assert result.kind == "document"
         assert result.media_type == "application/octet-stream"
+
+    def test_custom_document_type_routes_to_document(self):
+        from gateway.platforms.base import cache_media_bytes
+        result = cache_media_bytes(
+            b"PK\x03\x04 fake epub",
+            filename="book.epub",
+            mime_type="application/epub+zip",
+            document_type_config={"document_types": {"add": {".epub": "application/epub+zip"}}},
+        )
+        assert result is not None
+        assert result.kind == "document"
+        assert result.media_type == "application/epub+zip"
+
+    def test_removed_document_type_returns_none(self):
+        from gateway.platforms.base import cache_media_bytes
+        result = cache_media_bytes(
+            b"%PDF-1.4 body",
+            filename="report.pdf",
+            mime_type="application/pdf",
+            document_type_config={"document_types": {"remove": [".pdf"]}},
+        )
+        assert result is None
 
     def test_invalid_image_returns_none(self):
         from gateway.platforms.base import cache_media_bytes

--- a/tests/gateway/test_document_type_config.py
+++ b/tests/gateway/test_document_type_config.py
@@ -1,0 +1,66 @@
+"""Tests for config-driven document attachment allowlist overrides."""
+import yaml
+
+from gateway.config import Platform, load_gateway_config
+from gateway.platforms.base import resolve_document_types
+
+
+def test_gateway_document_types_load_and_propagate(tmp_path, monkeypatch):
+    config_yaml = {
+        "gateway": {
+            "document_types": {
+                "add": {".epub": "application/epub+zip"},
+                "remove": [".doc"],
+            }
+        },
+        "platforms": {
+            "telegram": {
+                "enabled": True,
+                "token": "fake-token",
+            }
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(config_yaml), encoding="utf-8")
+    monkeypatch.setattr("gateway.config.get_hermes_home", lambda: tmp_path)
+
+    cfg = load_gateway_config()
+    extra = cfg.platforms[Platform.TELEGRAM].extra
+
+    assert extra["_global_document_types"] == config_yaml["gateway"]["document_types"]
+    effective = resolve_document_types(extra)
+    assert effective[".epub"] == "application/epub+zip"
+    assert ".doc" not in effective
+
+
+def test_platform_document_types_override_global_config(tmp_path, monkeypatch):
+    config_yaml = {
+        "gateway": {
+            "document_types": {
+                "add": {".foo": "application/x-global"},
+                "remove": [".pdf"],
+            }
+        },
+        "platforms": {
+            "telegram": {
+                "enabled": True,
+                "token": "fake-token",
+                "document_types": {
+                    "add": {
+                        ".foo": "application/x-platform",
+                        ".pdf": "application/pdf",
+                    },
+                    "remove": [".doc"],
+                },
+            }
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(config_yaml), encoding="utf-8")
+    monkeypatch.setattr("gateway.config.get_hermes_home", lambda: tmp_path)
+
+    cfg = load_gateway_config()
+    extra = cfg.platforms[Platform.TELEGRAM].extra
+    effective = resolve_document_types(extra)
+
+    assert effective[".foo"] == "application/x-platform"
+    assert effective[".pdf"] == "application/pdf"
+    assert ".doc" not in effective

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -261,6 +261,28 @@ class TestDocumentDownloadBlock:
         assert event.media_types == ["application/zip"]
 
     @pytest.mark.asyncio
+    async def test_configured_custom_document_type_cached(self, adapter):
+        """A document extension added in config should be accepted without code changes."""
+        adapter.config.extra["document_types"] = {
+            "add": {".epub": "application/epub+zip"}
+        }
+        content = b"PK\x03\x04 fake epub"
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name="book.epub",
+            mime_type="application/epub+zip",
+            file_size=len(content),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls and event.media_urls[0].endswith("book.epub")
+        assert event.media_types == ["application/epub+zip"]
+
+    @pytest.mark.asyncio
     async def test_png_document_is_routed_as_image(self, adapter):
         """Telegram documents that are really PNGs should use the image path."""
         file_obj = _make_file_obj(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1573,6 +1573,31 @@ For separate natural mid-turn assistant updates without progressive token editin
 The master `streaming.enabled` switch is `false` by default — nothing streams until you flip it. Once enabled, streaming is decided **per platform**: Telegram ships with `display.platforms.telegram.streaming: true` (streams) and Discord with `display.platforms.discord.streaming: false` (does not). So after enabling streaming, Telegram streams out of the box and Discord stays on whole-message replies until you change its toggle. You can adjust these per-platform switches from the dashboard's **Channels** toggles or directly in `~/.hermes/config.yaml`.
 :::
 
+## Gateway Document Attachment Types
+
+Messaging platforms use a conservative built-in allowlist for inbound document uploads. You can extend or shrink it without editing Hermes source code:
+
+```yaml
+gateway:
+  document_types:
+    add:
+      .epub: application/epub+zip
+      .foo: text/plain
+    remove:
+      - .doc
+```
+
+Platform-specific settings apply after the shared `gateway.document_types` block, so a channel can override the global policy:
+
+```yaml
+telegram:
+  document_types:
+    add:
+      .invoice: application/pdf
+```
+
+Use `add` for extensions that should be accepted and cached as documents. Use `remove` to disable a built-in extension. This is narrower and safer than Discord's `allow_any_attachment`, which bypasses the allowlist entirely.
+
 ## Group Chat Session Isolation
 
 Limit how many chat sessions can actively be open across CLI, TUI/dashboard,


### PR DESCRIPTION
## Goal

Make the gateway's document/file-type handling configurable instead of hardcoding the supported document extension map in code.

The practical use case is: an operator can allow or identify additional document extensions, such as `.epub`, from `config.yaml` without adding source-level one-off support for each file type. The same config can also explicitly block extensions that are otherwise built in.

## What changed

- Add shared `gateway.document_types` config:
  - `add`: register extension → MIME mappings, e.g. `.epub: application/epub+zip`
  - `remove`: explicitly reject extensions from the effective document policy
  - `allow_unknown: false` / `strict: true`: opt into a strict config-defined allowlist
- Propagate the shared gateway policy to platform adapters.
- Add per-platform `document_types` overrides applied after the shared gateway policy, so a platform can diverge when needed.
- Preserve current `main` behavior for broad inbound attachment caching: unknown file extensions are still accepted by default as generic documents unless strict mode is enabled.
- Ensure explicitly removed extensions are rejected even when unknown files are otherwise allowed.
- Wire the effective policy through Telegram, Discord, Slack, Teams, WhatsApp, and Feishu document caching/handling.
- Keep Discord `allow_any_attachment` separate: it remains a broader compatibility bypass, while `document_types` is the narrower configurable document policy.
- Update default config comments, user docs, and focused gateway tests.

## Example config

```yaml
gateway:
  document_types:
    add:
      .epub: application/epub+zip
      .foo: text/plain
    remove:
      - .doc
    # Optional: make configured document types a hard allowlist
    allow_unknown: false

telegram:
  document_types:
    add:
      .invoice: application/pdf
```

## Behavior summary

- By default, `gateway.document_types` customizes the known document-type map, while unknown extensions continue to be cached as generic documents.
- With `allow_unknown: false` or `strict: true`, only configured/built-in effective document types are accepted.
- `remove` always wins for that extension.

## Test plan

- `python -m ruff check gateway/platforms/base.py gateway/config.py hermes_cli/config.py plugins/platforms/telegram/adapter.py plugins/platforms/discord/adapter.py plugins/platforms/slack/adapter.py plugins/platforms/teams/adapter.py plugins/platforms/whatsapp/adapter.py plugins/platforms/feishu/adapter.py gateway/platforms/whatsapp_cloud.py tests/gateway/test_document_cache.py tests/gateway/test_document_type_config.py tests/gateway/test_telegram_documents.py tests/gateway/test_discord_document_handling.py`
- `python -m py_compile gateway/platforms/base.py gateway/config.py hermes_cli/config.py plugins/platforms/telegram/adapter.py plugins/platforms/discord/adapter.py plugins/platforms/slack/adapter.py plugins/platforms/teams/adapter.py plugins/platforms/whatsapp/adapter.py plugins/platforms/feishu/adapter.py gateway/platforms/whatsapp_cloud.py tests/gateway/test_document_cache.py tests/gateway/test_document_type_config.py tests/gateway/test_telegram_documents.py tests/gateway/test_discord_document_handling.py`
- `python -m pytest tests/gateway/test_document_cache.py tests/gateway/test_document_type_config.py tests/gateway/test_telegram_documents.py tests/gateway/test_discord_document_handling.py -q` (`103 passed`)
