### PR TITLE
fix: surface command STT fallback usage

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5856,6 +5856,29 @@ class TurnRunner:
         }
 
 
+class _STTTranscript(str):
+    """Raw transcript text carrying optional user-facing echo metadata.
+
+    The string value deliberately remains the unadorned transcript so consumers
+    such as clarify-choice parsing receive exactly what the user said. Echo paths
+    can inspect the metadata without leaking provider failures into agent input.
+    """
+
+    fallback_from: str | None
+    provider_used: str | None
+
+    def __new__(
+        cls,
+        transcript: str,
+        *,
+        fallback_from: str | None = None,
+        provider_used: str | None = None,
+    ):
+        value = super().__new__(cls, transcript)
+        value.fallback_from = fallback_from
+        value.provider_used = provider_used
+        return value
+
 
 class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
     """
@@ -16635,6 +16658,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _, successful_transcripts = await self._transcribe_pending_audio_event_once(
             event, "",
         )
+        source = getattr(event, "source", None)
+        if successful_transcripts and source is not None:
+            adapter = self._adapter_for_source(source)
+            metadata = self._thread_metadata_for_source(
+                source,
+                self._reply_anchor_for_event(event),
+            )
+            await self._echo_pending_stt_transcripts_once(
+                event,
+                adapter,
+                source,
+                successful_transcripts,
+                metadata=metadata,
+                log_context="Clarify transcript",
+            )
         return "\n\n".join(
             transcript.strip()
             for transcript in successful_transcripts
@@ -22159,8 +22197,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     @staticmethod
     def _format_stt_echo(transcript: str) -> str:
-        """Format a transcript echo once, preserving enriched fallback notices."""
-        return transcript if transcript.startswith("🎙️") else f'🎙️ "{transcript}"'
+        """Format a transcript echo, including safe fallback metadata when present."""
+        fallback_from = getattr(transcript, "fallback_from", None)
+        if fallback_from:
+            provider_used = getattr(transcript, "provider_used", None) or "local"
+            return (
+                f'🎙️ "{transcript}"\n\n'
+                f"⚠️ STT fallback: {fallback_from} failed, so Hermes used "
+                f"{provider_used} / faster-whisper."
+            )
+        return f'🎙️ "{transcript}"'
 
     async def _enrich_message_with_transcription(
         self,
@@ -22257,14 +22303,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     fallback_from = result.get("fallback_from")
                     if fallback_from:
                         provider_used = result.get("provider", "local")
-                        # This payload is echoed to the user when transcript
-                        # echoing is enabled. Do not put the raw command error
-                        # in the echo or the LLM-visible prompt: it can contain
-                        # environment-specific details.
                         successful_transcripts.append(
-                            f'🎙️ "{transcript}"\n\n'
-                            f'⚠️ STT fallback: {fallback_from} failed, so Hermes used '
-                            f'{provider_used} / faster-whisper.'
+                            _STTTranscript(
+                                transcript,
+                                fallback_from=fallback_from,
+                                provider_used=provider_used,
+                            )
                         )
                     else:
                         successful_transcripts.append(transcript)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16357,9 +16357,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _echo_adapter:
                         for _tx in _successful_transcripts:
                             try:
+                                _echo_text = _tx if _tx.startswith("🎙️") else f'🎙️ "{_tx}"'
                                 await _echo_adapter.send(
                                     source.chat_id,
-                                    f'🎙️ "{_tx}"',
+                                    _echo_text,
                                     metadata=_echo_meta,
                                 )
                             except Exception as _echo_exc:
@@ -22248,12 +22249,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "to resend or type it out.]"
                         )
                         continue
-                    successful_transcripts.append(transcript)
-                    # Pass the transcript through as a plain quoted line. The
-                    # earlier wording ("The user sent a voice message~ Here's
-                    # what they said: ...") read as a meta-instruction and made
-                    # the LLM volunteer commentary about voice mode rather than
-                    # reply to the content.
+                    fallback_from = result.get("fallback_from")
+                    if fallback_from:
+                        provider_used = result.get("provider", "local")
+                        # This payload is echoed to the user when transcript
+                        # echoing is enabled. Do not put the raw command error
+                        # in the echo or the LLM-visible prompt: it can contain
+                        # environment-specific details.
+                        successful_transcripts.append(
+                            f'🎙️ "{transcript}"\n\n'
+                            f'⚠️ STT fallback: {fallback_from} failed, so Hermes used '
+                            f'{provider_used} / faster-whisper.'
+                        )
+                    else:
+                        successful_transcripts.append(transcript)
+                    # Keep the agent-facing input as the current upstream
+                    # plain transcript form. Provider failure details belong
+                    # in operational logs, not durable conversation context.
                     enriched_parts.append(f'"{transcript}"')
                 else:
                     error = result.get("error", "unknown error")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16357,7 +16357,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _echo_adapter:
                         for _tx in _successful_transcripts:
                             try:
-                                _echo_text = _tx if _tx.startswith("🎙️") else f'🎙️ "{_tx}"'
+                                _echo_text = self._format_stt_echo(_tx)
                                 await _echo_adapter.send(
                                     source.chat_id,
                                     _echo_text,
@@ -22157,6 +22157,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return prefix
         return user_text
 
+    @staticmethod
+    def _format_stt_echo(transcript: str) -> str:
+        """Format a transcript echo once, preserving enriched fallback notices."""
+        return transcript if transcript.startswith("🎙️") else f'🎙️ "{transcript}"'
+
     async def _enrich_message_with_transcription(
         self,
         user_text: str,
@@ -22382,7 +22387,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 await adapter.send(
                     source.chat_id,
-                    f'🎙️ "{tx}"',
+                    self._format_stt_echo(tx),
                     metadata=metadata,
                 )
             except Exception as echo_exc:

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -126,3 +126,53 @@ async def test_enrich_message_with_transcription_surfaces_stt_fallback_warning()
         "⚠️ STT fallback: parakeet failed, so Hermes used "
         "local / faster-whisper."
     ]
+
+
+def test_format_stt_echo_does_not_double_wrap_fallback_notice():
+    from gateway.run import GatewayRunner
+
+    fallback_notice = (
+        '🎙️ "fallback transcript"\n\n'
+        "⚠️ STT fallback: parakeet failed, so Hermes used local / faster-whisper."
+    )
+
+    assert GatewayRunner._format_stt_echo("plain transcript") == '🎙️ "plain transcript"'
+    assert GatewayRunner._format_stt_echo(fallback_notice) == fallback_notice
+
+
+@pytest.mark.asyncio
+async def test_pending_echo_preserves_fallback_notice():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._should_echo_stt_transcripts = lambda: True
+    fallback_notice = (
+        '🎙️ "queued fallback"\n\n'
+        "⚠️ STT fallback: parakeet failed, so Hermes used local / faster-whisper."
+    )
+    echo_send = AsyncMock()
+    echo_adapter = type("EchoAdapter", (), {"send": echo_send})()
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/queued-voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+    await runner._echo_pending_stt_transcripts_once(
+        event,
+        echo_adapter,
+        source,
+        [fallback_notice],
+        metadata=None,
+        log_context="Voice-interrupt",
+    )
+
+    echo_send.assert_awaited_once_with("123", fallback_notice, metadata=None)

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -121,31 +121,88 @@ async def test_enrich_message_with_transcription_surfaces_stt_fallback_warning()
     assert "fallback transcript" in result
     assert "STT fallback" not in result
     assert "command exited 127" not in result
-    assert transcripts == [
+    assert transcripts == ["fallback transcript"]
+    assert GatewayRunner._format_stt_echo(transcripts[0]) == (
         '🎙️ "fallback transcript"\n\n'
         "⚠️ STT fallback: parakeet failed, so Hermes used "
         "local / faster-whisper."
-    ]
+    )
 
 
-def test_format_stt_echo_does_not_double_wrap_fallback_notice():
-    from gateway.run import GatewayRunner
+def test_format_stt_echo_includes_fallback_notice_without_changing_raw_text():
+    from gateway.run import GatewayRunner, _STTTranscript
 
+    fallback_transcript = _STTTranscript(
+        "fallback transcript",
+        fallback_from="parakeet",
+        provider_used="local",
+    )
     fallback_notice = (
         '🎙️ "fallback transcript"\n\n'
         "⚠️ STT fallback: parakeet failed, so Hermes used local / faster-whisper."
     )
 
+    assert fallback_transcript == "fallback transcript"
     assert GatewayRunner._format_stt_echo("plain transcript") == '🎙️ "plain transcript"'
-    assert GatewayRunner._format_stt_echo(fallback_notice) == fallback_notice
+    assert GatewayRunner._format_stt_echo(fallback_transcript) == fallback_notice
+
+
+@pytest.mark.asyncio
+async def test_clarify_reply_uses_raw_transcript_after_stt_fallback():
+    from gateway.run import GatewayRunner, _STTTranscript
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._pending_event_audio_paths = lambda event: ["/tmp/voice.ogg"]
+    fallback_transcript = _STTTranscript(
+        "2",
+        fallback_from="parakeet",
+        provider_used="local",
+    )
+    runner._transcribe_pending_audio_event_once = AsyncMock(
+        return_value=('"2"', [fallback_transcript])
+    )
+    echo_pending = AsyncMock()
+    runner._echo_pending_stt_transcripts_once = echo_pending
+    runner._adapter_for_source = lambda source: "adapter"
+    runner._thread_metadata_for_source = (
+        lambda source, reply_to_message_id=None: {"thread_id": "thread-1"}
+    )
+    runner._reply_anchor_for_event = lambda event: "message-1"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+    assert await runner._prepare_clarify_reply_text(event) == "2"
+    echo_pending.assert_awaited_once_with(
+        event,
+        "adapter",
+        source,
+        [fallback_transcript],
+        metadata={"thread_id": "thread-1"},
+        log_context="Clarify transcript",
+    )
 
 
 @pytest.mark.asyncio
 async def test_pending_echo_preserves_fallback_notice():
-    from gateway.run import GatewayRunner
+    from gateway.run import GatewayRunner, _STTTranscript
 
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._should_echo_stt_transcripts = lambda: True
+    fallback_transcript = _STTTranscript(
+        "queued fallback",
+        fallback_from="parakeet",
+        provider_used="local",
+    )
     fallback_notice = (
         '🎙️ "queued fallback"\n\n'
         "⚠️ STT fallback: parakeet failed, so Hermes used local / faster-whisper."
@@ -170,7 +227,7 @@ async def test_pending_echo_preserves_fallback_notice():
         event,
         echo_adapter,
         source,
-        [fallback_notice],
+        [fallback_transcript],
         metadata=None,
         log_context="Voice-interrupt",
     )

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -95,3 +95,34 @@ async def test_enrich_message_with_transcription_guards_empty_transcript():
     assert transcripts == []
 
 
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_surfaces_stt_fallback_warning():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "fallback transcript",
+            "provider": "local",
+            "fallback_from": "parakeet",
+            "fallback_reason": "command exited 127",
+        },
+    ):
+        result, transcripts = await runner._enrich_message_with_transcription(
+            "caption",
+            ["/tmp/voice.ogg"],
+        )
+
+    assert "fallback transcript" in result
+    assert "STT fallback" not in result
+    assert "command exited 127" not in result
+    assert transcripts == [
+        '🎙️ "fallback transcript"\n\n'
+        "⚠️ STT fallback: parakeet failed, so Hermes used "
+        "local / faster-whisper."
+    ]

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -619,6 +619,33 @@ class TestTranscribeAudioDispatch:
         assert result["success"] is True
         mock_local.assert_called_once_with(sample_ogg, DEFAULT_LOCAL_MODEL)
 
+    def test_command_provider_model_override_does_not_leak_into_local_fallback(
+        self, sample_ogg
+    ):
+        config = {
+            "provider": "parakeet",
+            "providers": {
+                "parakeet": {
+                    "type": "command",
+                    "command": "parakeet-transcribe {input}",
+                    "fallback_provider": "local",
+                }
+            },
+            "local": {"model": "small"},
+        }
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="parakeet"), \
+             patch("tools.transcription_tools._transcribe_command_stt",
+                   return_value={"success": False, "error": "missing binary"}), \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("tools.transcription_tools._transcribe_local",
+                   return_value={"success": True, "transcript": "fallback text", "provider": "local"}) as mock_local:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg, model="parakeet-mlx-large")
+
+        assert result["success"] is True
+        mock_local.assert_called_once_with(sample_ogg, "small")
+
     def test_command_provider_returns_original_failure_without_fallback(self, sample_ogg):
         config = {
             "provider": "parakeet",

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -594,6 +594,31 @@ class TestTranscribeAudioDispatch:
         assert "fell back to local faster-whisper" in result["warning"]
         mock_local.assert_called_once_with(sample_ogg, "small")
 
+    def test_command_provider_local_fallback_accepts_null_local_config(self, sample_ogg):
+        config = {
+            "provider": "parakeet",
+            "providers": {
+                "parakeet": {
+                    "type": "command",
+                    "command": "parakeet-transcribe {input}",
+                    "fallback_provider": "local",
+                }
+            },
+            "local": None,
+        }
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="parakeet"), \
+             patch("tools.transcription_tools._transcribe_command_stt",
+                   return_value={"success": False, "error": "missing binary"}), \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("tools.transcription_tools._transcribe_local",
+                   return_value={"success": True, "transcript": "fallback text", "provider": "local"}) as mock_local:
+            from tools.transcription_tools import transcribe_audio, DEFAULT_LOCAL_MODEL
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        mock_local.assert_called_once_with(sample_ogg, DEFAULT_LOCAL_MODEL)
+
     def test_command_provider_returns_original_failure_without_fallback(self, sample_ogg):
         config = {
             "provider": "parakeet",

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -565,6 +565,57 @@ class TestTranscribeAudioDispatch:
 
         assert mock_local.call_args[0][1] == "small"
 
+    def test_command_provider_falls_back_to_local_when_configured(self, sample_ogg):
+        config = {
+            "provider": "parakeet",
+            "providers": {
+                "parakeet": {
+                    "type": "command",
+                    "command": "parakeet-transcribe {input}",
+                    "fallback_provider": "local",
+                }
+            },
+            "local": {"model": "small"},
+        }
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="parakeet"), \
+             patch("tools.transcription_tools._transcribe_command_stt",
+                   return_value={"success": False, "error": "missing binary"}), \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("tools.transcription_tools._transcribe_local",
+                   return_value={"success": True, "transcript": "fallback text", "provider": "local"}) as mock_local:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        assert result["transcript"] == "fallback text"
+        assert result["fallback_from"] == "parakeet"
+        assert result["fallback_reason"] == "missing binary"
+        assert "fell back to local faster-whisper" in result["warning"]
+        mock_local.assert_called_once_with(sample_ogg, "small")
+
+    def test_command_provider_returns_original_failure_without_fallback(self, sample_ogg):
+        config = {
+            "provider": "parakeet",
+            "providers": {
+                "parakeet": {
+                    "type": "command",
+                    "command": "parakeet-transcribe {input}",
+                }
+            },
+        }
+        expected = {"success": False, "error": "missing binary"}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="parakeet"), \
+             patch("tools.transcription_tools._transcribe_command_stt", return_value=expected), \
+             patch("tools.transcription_tools._transcribe_local") as mock_local:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result == expected
+        mock_local.assert_not_called()
+
+
 # ============================================================================
 # _transcribe_mistral
 # ============================================================================

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2812,7 +2812,7 @@ def _dispatch_stt_provider(
             if _HAS_FASTER_WHISPER or _try_lazy_install_stt():
                 local_cfg = stt_config.get("local") or {}
                 model_name = _normalize_local_model(
-                    model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+                    local_cfg.get("model", DEFAULT_LOCAL_MODEL)
                 )
                 logger.warning(
                     "STT command provider '%s' failed (%s); falling back to local faster-whisper",

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2810,7 +2810,7 @@ def _dispatch_stt_provider(
         if fallback_provider in {"local", "faster-whisper"}:
             command_error = command_result.get("error", "unknown error")
             if _HAS_FASTER_WHISPER or _try_lazy_install_stt():
-                local_cfg = stt_config.get("local", {})
+                local_cfg = stt_config.get("local") or {}
                 model_name = _normalize_local_model(
                     model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
                 )

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2792,13 +2792,54 @@ def _dispatch_stt_provider(
     # local than a plugin install (same precedence rule as TTS PR #17843).
     command_provider_config = _resolve_command_stt_provider_config(provider, stt_config)
     if command_provider_config is not None:
-        return _transcribe_command_stt(
+        command_result = _transcribe_command_stt(
             file_path,
             provider,
             command_provider_config,
             stt_config,
             model_override=model,
         )
+        if command_result.get("success"):
+            return command_result
+
+        fallback_provider = str(
+            command_provider_config.get("fallback_provider")
+            or command_provider_config.get("fallback")
+            or ""
+        ).strip().lower().replace("_", "-")
+        if fallback_provider in {"local", "faster-whisper"}:
+            command_error = command_result.get("error", "unknown error")
+            if _HAS_FASTER_WHISPER or _try_lazy_install_stt():
+                local_cfg = stt_config.get("local", {})
+                model_name = _normalize_local_model(
+                    model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+                )
+                logger.warning(
+                    "STT command provider '%s' failed (%s); falling back to local faster-whisper",
+                    provider,
+                    command_error,
+                )
+                fallback_result = _transcribe_local(file_path, model_name)
+                fallback_result["fallback_from"] = provider
+                fallback_result["fallback_reason"] = command_error
+                if fallback_result.get("success"):
+                    fallback_result["warning"] = (
+                        f"STT provider '{provider}' failed; fell back to local faster-whisper."
+                    )
+                else:
+                    fallback_error = fallback_result.get("error", "unknown error")
+                    fallback_result["error"] = (
+                        f"STT provider '{provider}' failed ({command_error}); "
+                        f"fallback provider 'local' also failed ({fallback_error})"
+                    )
+                return fallback_result
+            logger.warning(
+                "STT command provider '%s' failed and fallback_provider=local is configured, "
+                "but faster-whisper is unavailable: %s",
+                provider,
+                command_error,
+            )
+        return command_result
 
     # Plugin-registered STT backend (e.g. OpenRouter, SenseAudio,
     # Gemini-STT). Fires only when ``provider`` is neither a built-in

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -591,12 +591,13 @@ For `format: json` / `srt` / `vtt`, Hermes returns the raw file content as the `
 
 #### STT command-provider optional keys
 
-| Key             | Default | Meaning                                                                                              |
-|-----------------|---------|------------------------------------------------------------------------------------------------------|
-| `timeout`       | `300`   | Seconds; the process tree is killed on expiry (Unix `start_new_session`, Windows `taskkill /T`).     |
-| `format`        | `txt`   | One of `txt` / `json` / `srt` / `vtt`. Sets the extension of `{output_path}`.                       |
-| `language`      | `en`    | Forwarded to `{language}`. Defaults to `stt.language` then `en`.                                     |
-| `model`         | empty   | Forwarded to `{model}`. The `model=` argument to `transcribe_audio()` overrides this.                |
+| Key                              | Default | Meaning                                                                                              |
+|----------------------------------|---------|------------------------------------------------------------------------------------------------------|
+| `timeout`                        | `300`   | Seconds; the process tree is killed on expiry (Unix `start_new_session`, Windows `taskkill /T`).     |
+| `format`                         | `txt`   | One of `txt` / `json` / `srt` / `vtt`. Sets the extension of `{output_path}`.                       |
+| `language`                       | `en`    | Forwarded to `{language}`. Defaults to `stt.language` then `en`.                                     |
+| `model`                          | empty   | Forwarded to `{model}`. The `model=` argument to `transcribe_audio()` overrides this.                |
+| `fallback_provider` / `fallback` | empty   | Set to `local` or `faster-whisper` to retry a failed command with the configured local model.        |
 
 #### STT command-provider behavior notes
 


### PR DESCRIPTION
## Summary

- Allows command STT providers to fall back to local/faster-whisper when `fallback_provider: local` (or `fallback: local`) is configured.
- Keeps `stt.local: null` safe and resolves the fallback through its own local-model configuration instead of leaking a command-provider model override.
- Preserves the originating provider in structured fallback metadata and surfaces a concise transcript-echo warning across normal, pending-voice, and pending-clarify paths without placing raw command failures or metadata in LLM-visible or durable conversation context.
- Documents the command-provider fallback settings.

## Validation

Rebased onto `main` at `2b618fe7e5c31ea62a167a40b3b72c52a88047b2` and verified with focused coverage for command-provider fallback, explicit-null local config, model-override isolation, fresh/pending transcript echoes, and raw clarify replies:

```text
uv run --frozen --with pytest --with pytest-asyncio pytest -q \
  tests/tools/test_transcription_tools.py::TestTranscribeAudioDispatch::test_command_provider_falls_back_to_local_when_configured \
  tests/tools/test_transcription_tools.py::TestTranscribeAudioDispatch::test_command_provider_local_fallback_accepts_null_local_config \
  tests/tools/test_transcription_tools.py::TestTranscribeAudioDispatch::test_command_provider_model_override_does_not_leak_into_local_fallback \
  tests/tools/test_transcription_tools.py::TestTranscribeAudioDispatch::test_command_provider_returns_original_failure_without_fallback \
  tests/gateway/test_stt_config.py
12 passed

uv run --frozen --with ruff ruff check gateway/run.py tools/transcription_tools.py tests/gateway/test_stt_config.py tests/tools/test_transcription_tools.py
All checks passed!
```

`git diff --check` also passes. The full transcription-tools file has one unrelated Apple Silicon expectation failure that reproduces unchanged on the rebased `main` commit; the focused PR coverage above is green.

## AI assistance disclosure

This PR was prepared with AI assistance under human direction and reviewed/tested locally before submission.
