### PR TITLE
fix(web-server): scope dashboard settings to active profile

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3455,7 +3455,7 @@ async def update_memory_provider_config(name: str, body: MemoryProviderConfigUpd
 
 @app.get("/api/config")
 async def get_config(profile: Optional[str] = None):
-    with _profile_scope(profile):
+    with _profile_scope(_effective_dashboard_settings_profile(profile)):
         config = _normalize_config_for_web(load_config())
     # Strip internal keys that the frontend shouldn't see or send back
     return {k: v for k, v in config.items() if not k.startswith("_")}
@@ -3490,7 +3490,7 @@ def get_model_info(profile: Optional[str] = None):
     Also returns model capabilities (vision, reasoning, tools) when available.
     """
     try:
-        with _profile_scope(profile):
+        with _profile_scope(_effective_dashboard_settings_profile(profile)):
             cfg = load_config()
         model_cfg = cfg.get("model", "")
 
@@ -3614,7 +3614,7 @@ def get_model_options(profile: Optional[str] = None, refresh: bool = False):
         # come back as skeleton rows carrying `authenticated=False` +
         # `auth_type`/`key_env`/`warning` so the GUI can render a setup
         # affordance instead of hiding the provider entirely.
-        with _profile_scope(profile):
+        with _profile_scope(_effective_dashboard_settings_profile(profile)):
             return build_models_payload(
                 load_picker_context(),
                 include_unconfigured=True,
@@ -3721,7 +3721,7 @@ def get_auxiliary_models(profile: Optional[str] = None):
     selected profile's (read/write asymmetry).
     """
     try:
-        with _profile_scope(profile):
+        with _profile_scope(_effective_dashboard_settings_profile(profile)):
             cfg = load_config()
         aux_cfg = cfg.get("auxiliary", {})
         if not isinstance(aux_cfg, dict):
@@ -3802,7 +3802,9 @@ async def set_model_assignment(body: ModelAssignment, profile: Optional[str] = N
                 }
 
         def _apply_assignment():
-            with _profile_scope(body.profile or profile):
+            with _profile_scope(
+                _effective_dashboard_settings_profile(body.profile or profile)
+            ):
                 return _apply_model_assignment_sync(
                     scope, provider, model, task, base_url, api_key
                 )
@@ -4033,7 +4035,9 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
 @app.put("/api/config")
 async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
     try:
-        with _profile_scope(body.profile or profile):
+        with _profile_scope(
+            _effective_dashboard_settings_profile(body.profile or profile)
+        ):
             save_config(_denormalize_config_from_web(body.config))
         return {"ok": True}
     except HTTPException:
@@ -4133,7 +4137,7 @@ def _catalog_provider_env_metadata() -> dict:
 
 @app.get("/api/env")
 async def get_env_vars(profile: Optional[str] = None):
-    with _profile_scope(profile):
+    with _profile_scope(_effective_dashboard_settings_profile(profile)):
         env_on_disk = load_env()
     channel_keys = _channel_managed_env_keys()
     catalog_meta = _catalog_provider_env_metadata()
@@ -4178,7 +4182,9 @@ async def get_env_vars(profile: Optional[str] = None):
 @app.put("/api/env")
 async def set_env_var(body: EnvVarUpdate, profile: Optional[str] = None):
     try:
-        with _profile_scope(body.profile or profile):
+        with _profile_scope(
+            _effective_dashboard_settings_profile(body.profile or profile)
+        ):
             save_env_value(body.key, body.value)
         return {"ok": True, "key": body.key}
     except ValueError as exc:
@@ -4297,7 +4303,9 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
 @app.delete("/api/env")
 async def remove_env_var(body: EnvVarDelete, profile: Optional[str] = None):
     try:
-        with _profile_scope(body.profile or profile):
+        with _profile_scope(
+            _effective_dashboard_settings_profile(body.profile or profile)
+        ):
             removed = remove_env_value(body.key)
         if not removed:
             raise HTTPException(status_code=404, detail=f"{body.key} not found in .env")
@@ -4337,7 +4345,9 @@ async def reveal_env_var(
     _reveal_timestamps.append(now)
 
     # --- Reveal ---
-    with _profile_scope(body.profile or profile):
+    with _profile_scope(
+        _effective_dashboard_settings_profile(body.profile or profile)
+    ):
         env_on_disk = load_env()
     value = env_on_disk.get(body.key)
     if value is None:
@@ -10162,6 +10172,17 @@ async def describe_profile_auto_endpoint(name: str, body: ProfileDescribeAuto):
 _SKILLS_PROFILE_LOCK = threading.RLock()
 
 
+def _effective_dashboard_settings_profile(profile: Optional[str]) -> str:
+    """Return the profile settings routes should read/write by default."""
+    requested = (profile or "").strip()
+    if requested:
+        return requested
+
+    from hermes_cli.profiles import get_active_profile
+
+    return get_active_profile()
+
+
 @contextmanager
 def _profile_scope(profile: Optional[str]):
     """Scope config + skill-directory resolution to ``profile`` for one request.
@@ -10673,7 +10694,7 @@ async def get_config_raw(profile: Optional[str] = None):
     ``config_path`` is machine-global and always reports the dashboard
     process's own profile, which is wrong under the global profile switcher.
     """
-    with _profile_scope(profile):
+    with _profile_scope(_effective_dashboard_settings_profile(profile)):
         path = get_config_path()
     if not path.exists():
         return {"yaml": "", "path": str(path)}
@@ -10686,7 +10707,9 @@ async def update_config_raw(body: RawConfigUpdate, profile: Optional[str] = None
         parsed = yaml.safe_load(body.yaml_text)
         if not isinstance(parsed, dict):
             raise HTTPException(status_code=400, detail="YAML must be a mapping")
-        with _profile_scope(body.profile or profile):
+        with _profile_scope(
+            _effective_dashboard_settings_profile(body.profile or profile)
+        ):
             save_config(parsed)
         return {"ok": True}
     except yaml.YAMLError as e:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.web_server and related config utilities."""
 
 import asyncio
+from contextlib import contextmanager
 import os
 import json
 import shutil
@@ -2823,6 +2824,92 @@ class TestConfigRoundTrip:
             elif expected == "list" and not isinstance(val, list):
                 mismatches.append(f"{key}: expected list, got {type(val).__name__}")
         assert not mismatches, f"Type mismatches:\n" + "\n".join(mismatches)
+
+
+# ---------------------------------------------------------------------------
+# Sticky active-profile settings routing
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardStickyActiveProfileSettings:
+    """Settings routes should follow the sticky active profile by default."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    @staticmethod
+    def _activate_profile(name: str) -> Path:
+        from hermes_cli import profiles as profiles_mod
+
+        home = profiles_mod.get_profile_dir(name)
+        home.mkdir(parents=True, exist_ok=True)
+        profiles_mod.set_active_profile(name)
+        return home
+
+    @staticmethod
+    @contextmanager
+    def _scoped_home(home: Path):
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        token = set_hermes_home_override(str(home))
+        try:
+            yield
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_get_env_vars_defaults_to_sticky_active_profile(self):
+        from hermes_cli.config import save_env_value
+
+        profile_home = self._activate_profile("discord-bot")
+        with self._scoped_home(profile_home):
+            save_env_value("DISCORD_BOT_TOKEN", "profile-secret-ABCDE")
+
+        data = self.client.get("/api/env").json()
+        assert data["DISCORD_BOT_TOKEN"]["is_set"] is True
+        assert data["DISCORD_BOT_TOKEN"]["redacted_value"] == redact_key("profile-secret-ABCDE")
+
+    def test_put_env_var_without_profile_writes_only_sticky_active_profile(self):
+        from hermes_cli.config import load_env
+
+        profile_home = self._activate_profile("discord-bot")
+        resp = self.client.put(
+            "/api/env",
+            json={"key": "DISCORD_BOT_TOKEN", "value": "sticky-profile-token"},
+        )
+        assert resp.status_code == 200
+
+        assert "DISCORD_BOT_TOKEN" not in load_env()
+        with self._scoped_home(profile_home):
+            assert load_env()["DISCORD_BOT_TOKEN"] == "sticky-profile-token"
+
+    def test_put_config_without_profile_writes_only_sticky_active_profile(self):
+        from hermes_cli.config import load_config, save_config
+
+        def model_name(raw):
+            return raw if isinstance(raw, str) else raw.get("default")
+
+        profile_home = self._activate_profile("discord-bot")
+        save_config({"model": "default/model"})
+        with self._scoped_home(profile_home):
+            save_config({"model": "profile/old"})
+
+        resp = self.client.put("/api/config", json={"config": {"model": "profile/new"}})
+        assert resp.status_code == 200
+
+        default_model = model_name(load_config().get("model"))
+        assert default_model == "default/model"
+
+        with self._scoped_home(profile_home):
+            profile_model = model_name(load_config().get("model"))
+        assert profile_model == "profile/new"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes the dashboard settings routes that silently fell back to the dashboard process home when no explicit `profile` parameter was passed.

This makes the default settings flow follow the sticky active profile for config, env, and model settings routes, which stops Discord credentials and related dashboard settings from bleeding across profiles.

## Related Issue

Fixes #50404

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/web_server.py` so dashboard settings endpoints default to the sticky active profile when callers omit `profile`.
- Applied that default to config, env, config raw, and model settings routes that are used by the dashboard settings surfaces.
- Added regression coverage in `tests/hermes_cli/test_web_server.py` for sticky active-profile env reads, env writes, and config writes.

## How to Test

1. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py -k 'StickyActiveProfileSettings' -q`
2. Run `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py -k 'test_get_env_vars or test_get_config_model_is_string or test_round_trip_preserves_model_subkeys or test_config_raw_get or test_config_raw_put_valid' -q`
3. Create a named profile, mark it active, then edit Discord credentials in the dashboard without passing `profile`; the writes should land only in that active profile's `.env` / `config.yaml`.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Python 3.11.14 local macOS worktree

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
3 passed, 313 deselected in 1.08s
11 passed, 305 deselected in 1.22s
git diff --check
```
