### PR TITLE
fix(gateway): replace bare asserts in bluebubbles and ws_transport

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -216,13 +216,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return text
 
     async def _api_get(self, path: str) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError("_api_get called before client is initialized")
         res = await self.client.get(self._api_url(path))
         res.raise_for_status()
         return res.json()
 
     async def _api_post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        assert self.client is not None
+        if self.client is None:
+            raise RuntimeError("_api_post called before client is initialized")
         res = await self.client.post(self._api_url(path), json=payload)
         res.raise_for_status()
         return res.json()

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -277,7 +277,8 @@ class WebSocketRelayTransport:
         await self._ws.send(json.dumps(frame) + "\n")
 
     async def _read_loop(self) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("_read_loop called before websocket is connected")
         buf = ""
         try:
             async for chunk in self._ws:


### PR DESCRIPTION
## Summary

`assert` statements are stripped when Python runs with `-O` flag, causing silent failures in production.

Replace 3 bare asserts across 2 files:

- **bluebubbles.py** `_api_get`: guard `client` initialization
- **bluebubbles.py** `_api_post`: guard `client` initialization
- **ws_transport.py** `_read_loop`: guard websocket connection state

All replaced with `if X is None: raise RuntimeError(msg)` pattern.

## Test plan

- [ ] `python -O -c "import gateway.platforms.bluebubbles"` succeeds
- [ ] `python -O -c "import gateway.relay.ws_transport"` succeeds
- [ ] CI passes