### PR TITLE
fix: surface BlueBubbles edit and reaction events

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -221,6 +221,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
         self._recent_message_texts: OrderedDict[str, str] = OrderedDict()
+        self._recent_update_event_keys: OrderedDict[
+            tuple[Any, ...], tuple[Any, ...]
+        ] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -937,6 +940,72 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         while len(self._recent_message_texts) > _UPDATED_MESSAGE_CACHE_LIMIT:
             self._recent_message_texts.popitem(last=False)
 
+    def _update_event_key(
+        self,
+        event_type: str,
+        record: Dict[str, Any],
+        message_id: Optional[str],
+        text: str,
+        *,
+        is_tapback: bool,
+    ) -> Optional[tuple[Any, ...]]:
+        """Return a bounded-cache key for a dispatchable update/reaction event."""
+        if not message_id:
+            return None
+        sender = self._value(
+            record.get("handle", {}).get("address")
+            if isinstance(record.get("handle"), dict)
+            else None,
+            record.get("sender"),
+            record.get("from"),
+            record.get("address"),
+        )
+        if is_tapback:
+            return (
+                "tapback",
+                message_id,
+                sender,
+                text,
+            )
+        if event_type != "updated-message":
+            return None
+        if self._is_set(
+            record.get("dateRetracted")
+            or record.get("date_retracted")
+            or record.get("retractedAt")
+            or record.get("retracted_at")
+        ):
+            return ("retraction", message_id, sender)
+        if self._is_set(
+            record.get("dateEdited")
+            or record.get("date_edited")
+            or record.get("editedAt")
+            or record.get("edited_at")
+        ):
+            return ("edit", message_id, sender, text)
+        return None
+
+    def _has_seen_update_event(self, key: Optional[tuple[Any, ...]]) -> bool:
+        if key is None:
+            return False
+        identity = key[:3]
+        if self._recent_update_event_keys.get(identity) != key:
+            return False
+        self._recent_update_event_keys.move_to_end(identity)
+        return True
+
+    def _remember_update_event(self, key: Optional[tuple[Any, ...]]) -> None:
+        if key is None:
+            return
+        # Keep only the latest semantic state for each event identity. This
+        # suppresses webhook retries without hiding legitimate A→B→A edits or
+        # reaction remove/re-add sequences that revisit an earlier state.
+        identity = key[:3]
+        self._recent_update_event_keys[identity] = key
+        self._recent_update_event_keys.move_to_end(identity)
+        while len(self._recent_update_event_keys) > _UPDATED_MESSAGE_CACHE_LIMIT:
+            self._recent_update_event_keys.popitem(last=False)
+
     @staticmethod
     def _canonical_dm_handle(raw: Optional[str]) -> Optional[str]:
         if not raw:
@@ -1020,7 +1089,6 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         )
         if is_retraction:
             if previous:
-                self._recent_message_texts.pop(message_id, None)
                 return f"Message retracted/unsent.\nOriginal text: {previous}"
             return "Message retracted/unsent.\nOriginal text: (unknown)"
 
@@ -1033,9 +1101,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not is_edit or not text or previous == text:
             return None
         if previous:
-            self._remember_message_text(message_id, text)
             return f"Message edited.\nBefore: {previous}\nAfter: {text}"
-        self._remember_message_text(message_id, text)
         return f"Message edited.\nNew text: {text}"
 
     async def _handle_webhook(self, request):
@@ -1090,58 +1156,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             )
             or ""
         )
+        inbound_text = text
 
-        tapback_text = self._classify_tapback_record(record, text)
-        is_tapback = tapback_text is not None
-        if is_tapback:
-            text = tapback_text
-
-        # --- Inbound attachment handling ---
-        attachments = record.get("attachments") or []
-        media_urls: List[str] = []
-        media_types: List[str] = []
-        msg_type = MessageType.TEXT
-
-        for att in attachments:
-            att_guid = att.get("guid", "")
-            if not att_guid:
-                continue
-            cached = await self._download_attachment(att_guid, att)
-            if cached:
-                mime = (att.get("mimeType") or "").lower()
-                media_urls.append(cached)
-                media_types.append(mime)
-                if mime.startswith("image/"):
-                    msg_type = MessageType.PHOTO
-                elif mime.startswith("audio/") or (att.get("uti") or "").endswith(
-                    "caf"
-                ):
-                    msg_type = MessageType.VOICE
-                elif mime.startswith("video/"):
-                    msg_type = MessageType.VIDEO
-                else:
-                    msg_type = MessageType.DOCUMENT
-
-        # With multiple attachments, prefer PHOTO if any images present
-        if len(media_urls) > 1:
-            mime_prefixes = {(m or "").split("/")[0] for m in media_types}
-            if "image" in mime_prefixes:
-                msg_type = MessageType.PHOTO
-
-        if not text and media_urls:
-            text = "(attachment)"
-        # --- End attachment handling ---
-
-        message_id = self._message_id_for_record(record)
-        is_update_notification = False
-        if event_type == "updated-message" and not is_tapback:
-            text = self._classify_updated_message(record, message_id, text) or ""
-            if not text:
-                return web.Response(text="ok")
-            is_update_notification = True
-        elif not is_tapback:
-            self._remember_message_text(message_id, text)
-
+        # Validate routing before update classification mutates semantic state.
+        # A malformed first delivery must not poison the dedupe/text caches and
+        # suppress a later valid webhook retry.
         chat_guid = self._value(
             record.get("chatGuid"),
             payload.get("chatGuid"),
@@ -1153,8 +1172,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         # the chat GUID is nested under data.chats[0].guid instead.
         if not chat_guid:
             _chats = record.get("chats") or []
-            if _chats and isinstance(_chats[0], dict):
-                chat_guid = _chats[0].get("guid") or _chats[0].get("chatGuid")
+            if (
+                isinstance(_chats, list)
+                and _chats
+                and isinstance(_chats[0], dict)
+            ):
+                chat_guid = self._value(
+                    _chats[0].get("guid"),
+                    _chats[0].get("chatGuid"),
+                )
         chat_identifier = self._value(
             record.get("chatIdentifier"),
             record.get("identifier"),
@@ -1180,8 +1206,99 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         session_chat_id = self._canonical_chat_id(
             chat_guid, chat_identifier, sender, is_group
         )
-        if not sender or not session_chat_id or not text:
+        if not sender or not session_chat_id:
             return web.json_response({"error": "missing message fields"}, status=400)
+
+        tapback_text = self._classify_tapback_record(record, text)
+        is_tapback = tapback_text is not None
+        message_id = self._message_id_for_record(record)
+        update_event_key = self._update_event_key(
+            event_type,
+            record,
+            message_id,
+            tapback_text or text,
+            is_tapback=is_tapback,
+        )
+        if self._has_seen_update_event(update_event_key):
+            return web.Response(text="ok")
+
+        if is_tapback:
+            text = tapback_text
+
+        is_update_notification = False
+        if event_type == "updated-message" and not is_tapback:
+            text = self._classify_updated_message(record, message_id, text) or ""
+            if not text:
+                return web.Response(text="ok")
+            is_update_notification = True
+
+        # Routing and classified text are now valid. Commit the semantic key
+        # before the first attachment await so concurrent webhook retries
+        # cannot both pass duplicate suppression and dispatch.
+        if is_update_notification:
+            is_retraction = self._is_set(
+                record.get("dateRetracted")
+                or record.get("date_retracted")
+                or record.get("retractedAt")
+                or record.get("retracted_at")
+            )
+            if is_retraction and message_id:
+                self._recent_message_texts.pop(message_id, None)
+            else:
+                self._remember_message_text(message_id, inbound_text)
+            self._remember_update_event(update_event_key)
+        elif is_tapback:
+            self._remember_update_event(update_event_key)
+
+        # --- Inbound attachment handling ---
+        attachments = record.get("attachments") or []
+        if not isinstance(attachments, list):
+            attachments = []
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        msg_type = MessageType.TEXT
+
+        for att in attachments:
+            if not isinstance(att, dict):
+                continue
+            att_guid = self._value(att.get("guid"))
+            if not att_guid:
+                continue
+            cached = await self._download_attachment(att_guid, att)
+            if cached:
+                raw_mime = att.get("mimeType")
+                mime = raw_mime.lower() if isinstance(raw_mime, str) else ""
+                uti = att.get("uti")
+                media_urls.append(cached)
+                media_types.append(mime)
+                if mime.startswith("image/"):
+                    msg_type = MessageType.PHOTO
+                elif mime.startswith("audio/") or (
+                    isinstance(uti, str) and uti.endswith("caf")
+                ):
+                    msg_type = MessageType.VOICE
+                elif mime.startswith("video/"):
+                    msg_type = MessageType.VIDEO
+                else:
+                    msg_type = MessageType.DOCUMENT
+
+        # With multiple attachments, prefer PHOTO if any images present
+        if len(media_urls) > 1:
+            mime_prefixes = {(m or "").split("/")[0] for m in media_types}
+            if "image" in mime_prefixes:
+                msg_type = MessageType.PHOTO
+
+        if not text and media_urls:
+            text = "(attachment)"
+        # --- End attachment handling ---
+
+        if not text:
+            return web.json_response({"error": "missing message fields"}, status=400)
+
+        # Keep ordinary message text even when mention gating suppresses its
+        # dispatch so a later edit/retraction can still include prior context.
+        if event_type != "updated-message" and not is_tapback:
+            self._remember_message_text(message_id, text)
 
         if (
             is_group

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -946,20 +946,18 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         record: Dict[str, Any],
         message_id: Optional[str],
         text: str,
+        routing_identity: Optional[str],
         *,
         is_tapback: bool,
     ) -> Optional[tuple[Any, ...]]:
         """Return a bounded-cache key for a dispatchable update/reaction event."""
         if not message_id:
             return None
-        sender = self._value(
-            record.get("handle", {}).get("address")
-            if isinstance(record.get("handle"), dict)
-            else None,
-            record.get("sender"),
-            record.get("from"),
-            record.get("address"),
-        )
+        # Use the same canonical identity selected for routing. BlueBubbles can
+        # replay one physical update with the address first in chatIdentifier
+        # and later in handle.address; direct-field extraction would split the
+        # semantic dedupe key even though both route to the same DM.
+        sender = routing_identity
         if is_tapback:
             return (
                 "tapback",
@@ -1217,6 +1215,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             record,
             message_id,
             tapback_text or text,
+            session_chat_id,
             is_tapback=is_tapback,
         )
         if self._has_seen_update_event(update_event_key):

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -1127,10 +1127,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         # --- End attachment handling ---
 
         message_id = self._message_id_for_record(record)
+        is_update_notification = False
         if event_type == "updated-message" and not is_tapback:
             text = self._classify_updated_message(record, message_id, text) or ""
             if not text:
                 return web.Response(text="ok")
+            is_update_notification = True
         elif not is_tapback:
             self._remember_message_text(message_id, text)
 
@@ -1175,7 +1177,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not sender or not session_chat_id or not text:
             return web.json_response({"error": "missing message fields"}, status=400)
 
-        if is_group and self.require_mention:
+        if (
+            is_group
+            and self.require_mention
+            and not (is_tapback or is_update_notification)
+        ):
             if not self._message_matches_mention_patterns(text):
                 logger.debug(
                     "[bluebubbles] ignoring group message (require_mention=true, no mention pattern matched)"

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -220,6 +220,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
         self._recent_message_texts: OrderedDict[str, str] = OrderedDict()
+        self._recent_update_event_keys: OrderedDict[
+            tuple[Any, ...], tuple[Any, ...]
+        ] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -931,6 +934,72 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         while len(self._recent_message_texts) > _UPDATED_MESSAGE_CACHE_LIMIT:
             self._recent_message_texts.popitem(last=False)
 
+    def _update_event_key(
+        self,
+        event_type: str,
+        record: Dict[str, Any],
+        message_id: Optional[str],
+        text: str,
+        *,
+        is_tapback: bool,
+    ) -> Optional[tuple[Any, ...]]:
+        """Return a bounded-cache key for a dispatchable update/reaction event."""
+        if not message_id:
+            return None
+        sender = self._value(
+            record.get("handle", {}).get("address")
+            if isinstance(record.get("handle"), dict)
+            else None,
+            record.get("sender"),
+            record.get("from"),
+            record.get("address"),
+        )
+        if is_tapback:
+            return (
+                "tapback",
+                message_id,
+                sender,
+                text,
+            )
+        if event_type != "updated-message":
+            return None
+        if self._is_set(
+            record.get("dateRetracted")
+            or record.get("date_retracted")
+            or record.get("retractedAt")
+            or record.get("retracted_at")
+        ):
+            return ("retraction", message_id, sender)
+        if self._is_set(
+            record.get("dateEdited")
+            or record.get("date_edited")
+            or record.get("editedAt")
+            or record.get("edited_at")
+        ):
+            return ("edit", message_id, sender, text)
+        return None
+
+    def _has_seen_update_event(self, key: Optional[tuple[Any, ...]]) -> bool:
+        if key is None:
+            return False
+        identity = key[:3]
+        if self._recent_update_event_keys.get(identity) != key:
+            return False
+        self._recent_update_event_keys.move_to_end(identity)
+        return True
+
+    def _remember_update_event(self, key: Optional[tuple[Any, ...]]) -> None:
+        if key is None:
+            return
+        # Keep only the latest semantic state for each event identity. This
+        # suppresses webhook retries without hiding legitimate A→B→A edits or
+        # reaction remove/re-add sequences that revisit an earlier state.
+        identity = key[:3]
+        self._recent_update_event_keys[identity] = key
+        self._recent_update_event_keys.move_to_end(identity)
+        while len(self._recent_update_event_keys) > _UPDATED_MESSAGE_CACHE_LIMIT:
+            self._recent_update_event_keys.popitem(last=False)
+
     @staticmethod
     def _canonical_dm_handle(raw: Optional[str]) -> Optional[str]:
         if not raw:
@@ -1014,7 +1083,6 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         )
         if is_retraction:
             if previous:
-                self._recent_message_texts.pop(message_id, None)
                 return f"Message retracted/unsent.\nOriginal text: {previous}"
             return "Message retracted/unsent.\nOriginal text: (unknown)"
 
@@ -1027,9 +1095,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not is_edit or not text or previous == text:
             return None
         if previous:
-            self._remember_message_text(message_id, text)
             return f"Message edited.\nBefore: {previous}\nAfter: {text}"
-        self._remember_message_text(message_id, text)
         return f"Message edited.\nNew text: {text}"
 
     async def _handle_webhook(self, request):
@@ -1084,58 +1150,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             )
             or ""
         )
+        inbound_text = text
 
-        tapback_text = self._classify_tapback_record(record, text)
-        is_tapback = tapback_text is not None
-        if is_tapback:
-            text = tapback_text
-
-        # --- Inbound attachment handling ---
-        attachments = record.get("attachments") or []
-        media_urls: List[str] = []
-        media_types: List[str] = []
-        msg_type = MessageType.TEXT
-
-        for att in attachments:
-            att_guid = att.get("guid", "")
-            if not att_guid:
-                continue
-            cached = await self._download_attachment(att_guid, att)
-            if cached:
-                mime = (att.get("mimeType") or "").lower()
-                media_urls.append(cached)
-                media_types.append(mime)
-                if mime.startswith("image/"):
-                    msg_type = MessageType.PHOTO
-                elif mime.startswith("audio/") or (att.get("uti") or "").endswith(
-                    "caf"
-                ):
-                    msg_type = MessageType.VOICE
-                elif mime.startswith("video/"):
-                    msg_type = MessageType.VIDEO
-                else:
-                    msg_type = MessageType.DOCUMENT
-
-        # With multiple attachments, prefer PHOTO if any images present
-        if len(media_urls) > 1:
-            mime_prefixes = {(m or "").split("/")[0] for m in media_types}
-            if "image" in mime_prefixes:
-                msg_type = MessageType.PHOTO
-
-        if not text and media_urls:
-            text = "(attachment)"
-        # --- End attachment handling ---
-
-        message_id = self._message_id_for_record(record)
-        is_update_notification = False
-        if event_type == "updated-message" and not is_tapback:
-            text = self._classify_updated_message(record, message_id, text) or ""
-            if not text:
-                return web.Response(text="ok")
-            is_update_notification = True
-        elif not is_tapback:
-            self._remember_message_text(message_id, text)
-
+        # Validate routing before update classification mutates semantic state.
+        # A malformed first delivery must not poison the dedupe/text caches and
+        # suppress a later valid webhook retry.
         chat_guid = self._value(
             record.get("chatGuid"),
             payload.get("chatGuid"),
@@ -1147,8 +1166,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         # the chat GUID is nested under data.chats[0].guid instead.
         if not chat_guid:
             _chats = record.get("chats") or []
-            if _chats and isinstance(_chats[0], dict):
-                chat_guid = _chats[0].get("guid") or _chats[0].get("chatGuid")
+            if (
+                isinstance(_chats, list)
+                and _chats
+                and isinstance(_chats[0], dict)
+            ):
+                chat_guid = self._value(
+                    _chats[0].get("guid"),
+                    _chats[0].get("chatGuid"),
+                )
         chat_identifier = self._value(
             record.get("chatIdentifier"),
             record.get("identifier"),
@@ -1174,8 +1200,99 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         session_chat_id = self._canonical_chat_id(
             chat_guid, chat_identifier, sender, is_group
         )
-        if not sender or not session_chat_id or not text:
+        if not sender or not session_chat_id:
             return web.json_response({"error": "missing message fields"}, status=400)
+
+        tapback_text = self._classify_tapback_record(record, text)
+        is_tapback = tapback_text is not None
+        message_id = self._message_id_for_record(record)
+        update_event_key = self._update_event_key(
+            event_type,
+            record,
+            message_id,
+            tapback_text or text,
+            is_tapback=is_tapback,
+        )
+        if self._has_seen_update_event(update_event_key):
+            return web.Response(text="ok")
+
+        if is_tapback:
+            text = tapback_text
+
+        is_update_notification = False
+        if event_type == "updated-message" and not is_tapback:
+            text = self._classify_updated_message(record, message_id, text) or ""
+            if not text:
+                return web.Response(text="ok")
+            is_update_notification = True
+
+        # Routing and classified text are now valid. Commit the semantic key
+        # before the first attachment await so concurrent webhook retries
+        # cannot both pass duplicate suppression and dispatch.
+        if is_update_notification:
+            is_retraction = self._is_set(
+                record.get("dateRetracted")
+                or record.get("date_retracted")
+                or record.get("retractedAt")
+                or record.get("retracted_at")
+            )
+            if is_retraction and message_id:
+                self._recent_message_texts.pop(message_id, None)
+            else:
+                self._remember_message_text(message_id, inbound_text)
+            self._remember_update_event(update_event_key)
+        elif is_tapback:
+            self._remember_update_event(update_event_key)
+
+        # --- Inbound attachment handling ---
+        attachments = record.get("attachments") or []
+        if not isinstance(attachments, list):
+            attachments = []
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        msg_type = MessageType.TEXT
+
+        for att in attachments:
+            if not isinstance(att, dict):
+                continue
+            att_guid = self._value(att.get("guid"))
+            if not att_guid:
+                continue
+            cached = await self._download_attachment(att_guid, att)
+            if cached:
+                raw_mime = att.get("mimeType")
+                mime = raw_mime.lower() if isinstance(raw_mime, str) else ""
+                uti = att.get("uti")
+                media_urls.append(cached)
+                media_types.append(mime)
+                if mime.startswith("image/"):
+                    msg_type = MessageType.PHOTO
+                elif mime.startswith("audio/") or (
+                    isinstance(uti, str) and uti.endswith("caf")
+                ):
+                    msg_type = MessageType.VOICE
+                elif mime.startswith("video/"):
+                    msg_type = MessageType.VIDEO
+                else:
+                    msg_type = MessageType.DOCUMENT
+
+        # With multiple attachments, prefer PHOTO if any images present
+        if len(media_urls) > 1:
+            mime_prefixes = {(m or "").split("/")[0] for m in media_types}
+            if "image" in mime_prefixes:
+                msg_type = MessageType.PHOTO
+
+        if not text and media_urls:
+            text = "(attachment)"
+        # --- End attachment handling ---
+
+        if not text:
+            return web.json_response({"error": "missing message fields"}, status=400)
+
+        # Keep ordinary message text even when mention gating suppresses its
+        # dispatch so a later edit/retraction can still include prior context.
+        if event_type != "updated-message" and not is_tapback:
+            self._remember_message_text(message_id, text)
 
         if (
             is_group

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -1133,10 +1133,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         # --- End attachment handling ---
 
         message_id = self._message_id_for_record(record)
+        is_update_notification = False
         if event_type == "updated-message" and not is_tapback:
             text = self._classify_updated_message(record, message_id, text) or ""
             if not text:
                 return web.Response(text="ok")
+            is_update_notification = True
         elif not is_tapback:
             self._remember_message_text(message_id, text)
 
@@ -1181,7 +1183,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not sender or not session_chat_id or not text:
             return web.json_response({"error": "missing message fields"}, status=400)
 
-        if is_group and self.require_mention:
+        if (
+            is_group
+            and self.require_mention
+            and not (is_tapback or is_update_notification)
+        ):
             if not self._message_matches_mention_patterns(text):
                 logger.debug(
                     "[bluebubbles] ignoring group message (require_mention=true, no mention pattern matched)"

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -113,9 +113,26 @@ _TAPBACK_REMOVED = {
     3000: "love", 3001: "like", 3002: "dislike",
     3003: "laugh", 3004: "emphasize", 3005: "question",
 }
+_TAPBACK_TEXT_RE = re.compile(
+    r"^(?P<verb>Liked|Loved|Disliked|Laughed at|Emphasized|Questioned)\s+[\"“](?P<target>.*)[\"”]$",
+    re.S,
+)
+_TAPBACK_REMOVED_TEXT_RE = re.compile(
+    r"^Removed an? (?P<reaction>like|love|dislike|laugh|emphasis|question) from\s+[\"“](?P<target>.*)[\"”]$",
+    re.S,
+)
+_TAPBACK_VERBS = {
+    "Liked": "liked",
+    "Loved": "loved",
+    "Disliked": "disliked",
+    "Laughed at": "laughed at",
+    "Emphasized": "emphasized",
+    "Questioned": "questioned",
+}
 
 # Webhook event types that carry user messages
 _MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
+_UPDATED_MESSAGE_CACHE_LIMIT = 500
 
 # Log redaction patterns
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
@@ -202,6 +219,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._recent_message_texts: OrderedDict[str, str] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -893,6 +911,127 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 return candidate.strip()
         return None
 
+    @staticmethod
+    def _is_set(value: Any) -> bool:
+        return value not in (None, "", 0, False)
+
+    def _message_id_for_record(self, record: Dict[str, Any]) -> Optional[str]:
+        return self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("message_guid"),
+            record.get("id"),
+        )
+
+    def _remember_message_text(self, message_id: Optional[str], text: str) -> None:
+        if not message_id or not text:
+            return
+        self._recent_message_texts[message_id] = text
+        self._recent_message_texts.move_to_end(message_id)
+        while len(self._recent_message_texts) > _UPDATED_MESSAGE_CACHE_LIMIT:
+            self._recent_message_texts.popitem(last=False)
+
+    @staticmethod
+    def _canonical_dm_handle(raw: Optional[str]) -> Optional[str]:
+        if not raw:
+            return None
+        value = raw.strip()
+        if ";+;" in value:
+            return None
+        if ";-;" in value:
+            value = value.rsplit(";-;", 1)[-1]
+        return value or None
+
+    def _canonical_chat_id(
+        self,
+        chat_guid: Optional[str],
+        chat_identifier: Optional[str],
+        sender: Optional[str],
+        is_group: bool,
+    ) -> str:
+        if is_group:
+            return chat_guid or chat_identifier or sender or ""
+        return (
+            self._canonical_dm_handle(chat_identifier)
+            or self._canonical_dm_handle(sender)
+            or self._canonical_dm_handle(chat_guid)
+            or chat_guid
+            or chat_identifier
+            or sender
+            or ""
+        )
+
+    @staticmethod
+    def _classify_tapback_text(text: str) -> Optional[str]:
+        stripped = text.strip()
+        removed = _TAPBACK_REMOVED_TEXT_RE.match(stripped)
+        if removed:
+            reaction = removed.group("reaction")
+            target = removed.group("target").strip()
+            return f"Reaction removed: User removed a {reaction} Tapback from: {target}"
+        match = _TAPBACK_TEXT_RE.match(stripped)
+        if not match:
+            return None
+        verb = _TAPBACK_VERBS.get(match.group("verb"), match.group("verb").lower())
+        target = match.group("target").strip()
+        return f"Reaction: User {verb} this message: {target}"
+
+    def _classify_tapback_record(
+        self,
+        record: Dict[str, Any],
+        text: str,
+    ) -> Optional[str]:
+        assoc_type = record.get("associatedMessageType")
+        if isinstance(assoc_type, str) and assoc_type.strip().lstrip("-").isdigit():
+            assoc_type = int(assoc_type)
+        if isinstance(assoc_type, int):
+            if assoc_type in _TAPBACK_ADDED:
+                reaction = _TAPBACK_ADDED[assoc_type]
+                target = text or "(message text unavailable)"
+                return f"Reaction: User added a {reaction} Tapback to: {target}"
+            if assoc_type in _TAPBACK_REMOVED:
+                reaction = _TAPBACK_REMOVED[assoc_type]
+                target = text or "(message text unavailable)"
+                return f"Reaction removed: User removed a {reaction} Tapback from: {target}"
+        return self._classify_tapback_text(text)
+
+    def _classify_updated_message(
+        self,
+        record: Dict[str, Any],
+        message_id: Optional[str],
+        text: str,
+    ) -> Optional[str]:
+        """Return agent-facing text for an updated-message, or None to ACK only."""
+        if not message_id:
+            return None
+
+        previous = self._recent_message_texts.get(message_id)
+        is_retraction = self._is_set(
+            record.get("dateRetracted")
+            or record.get("date_retracted")
+            or record.get("retractedAt")
+            or record.get("retracted_at")
+        )
+        if is_retraction:
+            if previous:
+                self._recent_message_texts.pop(message_id, None)
+                return f"Message retracted/unsent.\nOriginal text: {previous}"
+            return "Message retracted/unsent.\nOriginal text: (unknown)"
+
+        is_edit = self._is_set(
+            record.get("dateEdited")
+            or record.get("date_edited")
+            or record.get("editedAt")
+            or record.get("edited_at")
+        )
+        if not is_edit or not text or previous == text:
+            return None
+        if previous:
+            self._remember_message_text(message_id, text)
+            return f"Message edited.\nBefore: {previous}\nAfter: {text}"
+        self._remember_message_text(message_id, text)
+        return f"Message edited.\nNew text: {text}"
+
     async def _handle_webhook(self, request):
         from aiohttp import web
 
@@ -939,20 +1078,17 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if is_from_me:
             return web.Response(text="ok")
 
-        # Skip tapback reactions delivered as messages
-        assoc_type = record.get("associatedMessageType")
-        if isinstance(assoc_type, int) and assoc_type in {
-            **_TAPBACK_ADDED,
-            **_TAPBACK_REMOVED,
-        }:
-            return web.Response(text="ok")
-
         text = (
             self._value(
                 record.get("text"), record.get("message"), record.get("body")
             )
             or ""
         )
+
+        tapback_text = self._classify_tapback_record(record, text)
+        is_tapback = tapback_text is not None
+        if is_tapback:
+            text = tapback_text
 
         # --- Inbound attachment handling ---
         attachments = record.get("attachments") or []
@@ -990,6 +1126,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             text = "(attachment)"
         # --- End attachment handling ---
 
+        message_id = self._message_id_for_record(record)
+        if event_type == "updated-message" and not is_tapback:
+            text = self._classify_updated_message(record, message_id, text) or ""
+            if not text:
+                return web.Response(text="ok")
+        elif not is_tapback:
+            self._remember_message_text(message_id, text)
+
         chat_guid = self._value(
             record.get("chatGuid"),
             payload.get("chatGuid"),
@@ -1023,11 +1167,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         )
         if not (chat_guid or chat_identifier) and sender:
             chat_identifier = sender
-        if not sender or not (chat_guid or chat_identifier) or not text:
+
+        is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
+        session_chat_id = self._canonical_chat_id(
+            chat_guid, chat_identifier, sender, is_group
+        )
+        if not sender or not session_chat_id or not text:
             return web.json_response({"error": "missing message fields"}, status=400)
 
-        session_chat_id = chat_guid or chat_identifier
-        is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
         if is_group and self.require_mention:
             if not self._message_matches_mention_patterns(text):
                 logger.debug(
@@ -1041,18 +1188,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             chat_type="group" if is_group else "dm",
             user_id=sender,
             user_name=sender,
-            chat_id_alt=chat_identifier,
+            chat_id_alt=chat_guid if chat_guid != session_chat_id else chat_identifier,
         )
         event = MessageEvent(
             text=text,
             message_type=msg_type,
             source=source,
             raw_message=payload,
-            message_id=self._value(
-                record.get("guid"),
-                record.get("messageGuid"),
-                record.get("id"),
-            ),
+            message_id=message_id,
             reply_to_message_id=self._value(
                 record.get("threadOriginatorGuid"),
                 record.get("associatedMessageGuid"),

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -114,9 +114,26 @@ _TAPBACK_REMOVED = {
     3000: "love", 3001: "like", 3002: "dislike",
     3003: "laugh", 3004: "emphasize", 3005: "question",
 }
+_TAPBACK_TEXT_RE = re.compile(
+    r"^(?P<verb>Liked|Loved|Disliked|Laughed at|Emphasized|Questioned)\s+[\"“](?P<target>.*)[\"”]$",
+    re.S,
+)
+_TAPBACK_REMOVED_TEXT_RE = re.compile(
+    r"^Removed an? (?P<reaction>like|love|dislike|laugh|emphasis|question) from\s+[\"“](?P<target>.*)[\"”]$",
+    re.S,
+)
+_TAPBACK_VERBS = {
+    "Liked": "liked",
+    "Loved": "loved",
+    "Disliked": "disliked",
+    "Laughed at": "laughed at",
+    "Emphasized": "emphasized",
+    "Questioned": "questioned",
+}
 
 # Webhook event types that carry user messages
 _MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
+_UPDATED_MESSAGE_CACHE_LIMIT = 500
 
 # Log redaction patterns
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
@@ -203,6 +220,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._recent_message_texts: OrderedDict[str, str] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -899,6 +917,127 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 return candidate.strip()
         return None
 
+    @staticmethod
+    def _is_set(value: Any) -> bool:
+        return value not in (None, "", 0, False)
+
+    def _message_id_for_record(self, record: Dict[str, Any]) -> Optional[str]:
+        return self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("message_guid"),
+            record.get("id"),
+        )
+
+    def _remember_message_text(self, message_id: Optional[str], text: str) -> None:
+        if not message_id or not text:
+            return
+        self._recent_message_texts[message_id] = text
+        self._recent_message_texts.move_to_end(message_id)
+        while len(self._recent_message_texts) > _UPDATED_MESSAGE_CACHE_LIMIT:
+            self._recent_message_texts.popitem(last=False)
+
+    @staticmethod
+    def _canonical_dm_handle(raw: Optional[str]) -> Optional[str]:
+        if not raw:
+            return None
+        value = raw.strip()
+        if ";+;" in value:
+            return None
+        if ";-;" in value:
+            value = value.rsplit(";-;", 1)[-1]
+        return value or None
+
+    def _canonical_chat_id(
+        self,
+        chat_guid: Optional[str],
+        chat_identifier: Optional[str],
+        sender: Optional[str],
+        is_group: bool,
+    ) -> str:
+        if is_group:
+            return chat_guid or chat_identifier or sender or ""
+        return (
+            self._canonical_dm_handle(chat_identifier)
+            or self._canonical_dm_handle(sender)
+            or self._canonical_dm_handle(chat_guid)
+            or chat_guid
+            or chat_identifier
+            or sender
+            or ""
+        )
+
+    @staticmethod
+    def _classify_tapback_text(text: str) -> Optional[str]:
+        stripped = text.strip()
+        removed = _TAPBACK_REMOVED_TEXT_RE.match(stripped)
+        if removed:
+            reaction = removed.group("reaction")
+            target = removed.group("target").strip()
+            return f"Reaction removed: User removed a {reaction} Tapback from: {target}"
+        match = _TAPBACK_TEXT_RE.match(stripped)
+        if not match:
+            return None
+        verb = _TAPBACK_VERBS.get(match.group("verb"), match.group("verb").lower())
+        target = match.group("target").strip()
+        return f"Reaction: User {verb} this message: {target}"
+
+    def _classify_tapback_record(
+        self,
+        record: Dict[str, Any],
+        text: str,
+    ) -> Optional[str]:
+        assoc_type = record.get("associatedMessageType")
+        if isinstance(assoc_type, str) and assoc_type.strip().lstrip("-").isdigit():
+            assoc_type = int(assoc_type)
+        if isinstance(assoc_type, int):
+            if assoc_type in _TAPBACK_ADDED:
+                reaction = _TAPBACK_ADDED[assoc_type]
+                target = text or "(message text unavailable)"
+                return f"Reaction: User added a {reaction} Tapback to: {target}"
+            if assoc_type in _TAPBACK_REMOVED:
+                reaction = _TAPBACK_REMOVED[assoc_type]
+                target = text or "(message text unavailable)"
+                return f"Reaction removed: User removed a {reaction} Tapback from: {target}"
+        return self._classify_tapback_text(text)
+
+    def _classify_updated_message(
+        self,
+        record: Dict[str, Any],
+        message_id: Optional[str],
+        text: str,
+    ) -> Optional[str]:
+        """Return agent-facing text for an updated-message, or None to ACK only."""
+        if not message_id:
+            return None
+
+        previous = self._recent_message_texts.get(message_id)
+        is_retraction = self._is_set(
+            record.get("dateRetracted")
+            or record.get("date_retracted")
+            or record.get("retractedAt")
+            or record.get("retracted_at")
+        )
+        if is_retraction:
+            if previous:
+                self._recent_message_texts.pop(message_id, None)
+                return f"Message retracted/unsent.\nOriginal text: {previous}"
+            return "Message retracted/unsent.\nOriginal text: (unknown)"
+
+        is_edit = self._is_set(
+            record.get("dateEdited")
+            or record.get("date_edited")
+            or record.get("editedAt")
+            or record.get("edited_at")
+        )
+        if not is_edit or not text or previous == text:
+            return None
+        if previous:
+            self._remember_message_text(message_id, text)
+            return f"Message edited.\nBefore: {previous}\nAfter: {text}"
+        self._remember_message_text(message_id, text)
+        return f"Message edited.\nNew text: {text}"
+
     async def _handle_webhook(self, request):
         from aiohttp import web
 
@@ -945,20 +1084,17 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if is_from_me:
             return web.Response(text="ok")
 
-        # Skip tapback reactions delivered as messages
-        assoc_type = record.get("associatedMessageType")
-        if isinstance(assoc_type, int) and assoc_type in {
-            **_TAPBACK_ADDED,
-            **_TAPBACK_REMOVED,
-        }:
-            return web.Response(text="ok")
-
         text = (
             self._value(
                 record.get("text"), record.get("message"), record.get("body")
             )
             or ""
         )
+
+        tapback_text = self._classify_tapback_record(record, text)
+        is_tapback = tapback_text is not None
+        if is_tapback:
+            text = tapback_text
 
         # --- Inbound attachment handling ---
         attachments = record.get("attachments") or []
@@ -996,6 +1132,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             text = "(attachment)"
         # --- End attachment handling ---
 
+        message_id = self._message_id_for_record(record)
+        if event_type == "updated-message" and not is_tapback:
+            text = self._classify_updated_message(record, message_id, text) or ""
+            if not text:
+                return web.Response(text="ok")
+        elif not is_tapback:
+            self._remember_message_text(message_id, text)
+
         chat_guid = self._value(
             record.get("chatGuid"),
             payload.get("chatGuid"),
@@ -1029,11 +1173,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         )
         if not (chat_guid or chat_identifier) and sender:
             chat_identifier = sender
-        if not sender or not (chat_guid or chat_identifier) or not text:
+
+        is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
+        session_chat_id = self._canonical_chat_id(
+            chat_guid, chat_identifier, sender, is_group
+        )
+        if not sender or not session_chat_id or not text:
             return web.json_response({"error": "missing message fields"}, status=400)
 
-        session_chat_id = chat_guid or chat_identifier
-        is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
         if is_group and self.require_mention:
             if not self._message_matches_mention_patterns(text):
                 logger.debug(
@@ -1047,18 +1194,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             chat_type="group" if is_group else "dm",
             user_id=sender,
             user_name=sender,
-            chat_id_alt=chat_identifier,
+            chat_id_alt=chat_guid if chat_guid != session_chat_id else chat_identifier,
         )
         event = MessageEvent(
             text=text,
             message_type=msg_type,
             source=source,
             raw_message=payload,
-            message_id=self._value(
-                record.get("guid"),
-                record.get("messageGuid"),
-                record.get("id"),
-            ),
+            message_id=message_id,
             reply_to_message_id=self._value(
                 record.get("threadOriginatorGuid"),
                 record.get("associatedMessageGuid"),

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -115,6 +115,81 @@ class TestBlueBubblesMentionGating:
         assert response.status == 200
         assert handled == []
 
+    @pytest.mark.asyncio
+    async def test_group_tapback_bypasses_mention_gate(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "group-tapback-1",
+                "text": "Liked “Smoke test passed”",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "isGroup": True,
+                "chats": [{"guid": "iMessage;+;group-chat"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert [event.text for event in handled] == [
+            "Reaction: User liked this message: Smoke test passed"
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("update_fields", "expected_fragment"),
+        [
+            ({"text": "second draft", "dateEdited": 123456789}, "Message edited."),
+            ({"dateRetracted": 123456789}, "Message retracted/unsent."),
+        ],
+    )
+    async def test_group_update_notification_bypasses_mention_gate(
+        self, monkeypatch, update_fields, expected_fragment
+    ):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        base = {
+            "guid": "group-update-1",
+            "handle": {"address": "+155****0100"},
+            "isFromMe": False,
+            "isGroup": True,
+            "chats": [{"guid": "iMessage;+;group-chat"}],
+        }
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {**base, "text": "first draft"},
+        }))
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {**base, **update_fields},
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert len(handled) == 1
+        assert expected_fragment in handled[0].text
+        assert "first draft" in handled[0].text
+
 
 class TestBlueBubblesUpdatedMessageHandling:
     async def _dispatch(self, adapter, payload):

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -1,6 +1,7 @@
 """Tests for the BlueBubbles iMessage gateway adapter."""
 import asyncio
 import json
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -227,6 +228,94 @@ class TestBlueBubblesUpdatedMessageHandling:
         assert handled[0].text == "hello"
 
     @pytest.mark.asyncio
+    async def test_invalid_update_does_not_poison_valid_retry(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", AsyncMock(return_value=False))
+
+        invalid = {
+            "type": "updated-message",
+            "data": {
+                "guid": "MSG-GUID-RETRY",
+                "text": "corrected text",
+                "isFromMe": False,
+                "dateEdited": 123456789,
+                "chats": {"guid": "malformed-chat-container"},
+            },
+        }
+        invalid_response = await self._dispatch(adapter, invalid)
+
+        assert invalid_response.status == 400
+        assert handled == []
+        assert getattr(adapter, "_recent_update_event_keys") == {}
+        assert adapter._recent_message_texts == {}
+
+        valid = {
+            **invalid,
+            "data": {
+                **invalid["data"],
+                "handle": {"address": "user@example.com"},
+                "chats": [{"guid": "any;-;user@example.com"}],
+            },
+        }
+        valid_response = await self._dispatch(adapter, valid)
+
+        assert valid_response.status == 200
+        assert len(handled) == 1
+        assert handled[0].text == "Message edited.\nNew text: corrected text"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_update_retry_is_reserved_before_attachment_download(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def slow_download(att_guid, attachment):
+            await asyncio.sleep(0.01)
+            return "/tmp/update-image.png"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        download_attachment = AsyncMock(side_effect=slow_download)
+        monkeypatch.setattr(adapter, "_download_attachment", download_attachment)
+
+        payload = {
+            "type": "updated-message",
+            "data": {
+                "guid": "MSG-GUID-CONCURRENT",
+                "text": "corrected text",
+                "dateEdited": 123456789,
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
+                "attachments": [
+                    {
+                        "guid": "ATTACHMENT-GUID",
+                        "mimeType": {"malformed": True},
+                        "uti": {"malformed": True},
+                    }
+                ],
+            },
+        }
+        responses = await asyncio.gather(
+            adapter._handle_webhook(_FakeBlueBubblesRequest(payload)),
+            adapter._handle_webhook(_FakeBlueBubblesRequest(payload)),
+        )
+        await asyncio.sleep(0)
+
+        assert [response.status for response in responses] == [200, 200]
+        assert len(handled) == 1
+        download_attachment.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_updated_message_receipt_without_text_is_acknowledged(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         handled = []
@@ -235,6 +324,8 @@ class TestBlueBubblesUpdatedMessageHandling:
             handled.append(event)
 
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        download_attachment = AsyncMock(return_value="/tmp/duplicate-sensitive-media.png")
+        monkeypatch.setattr(adapter, "_download_attachment", download_attachment)
 
         response = await self._dispatch(
             adapter,
@@ -247,12 +338,16 @@ class TestBlueBubblesUpdatedMessageHandling:
                     "chats": [{"guid": "any;-;user@example.com"}],
                     "dateEdited": None,
                     "dateRetracted": None,
+                    "attachments": [
+                        {"guid": "duplicate-attachment", "mimeType": "image/png"}
+                    ],
                 },
             },
         )
 
         assert response.status == 200
         assert handled == []
+        download_attachment.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_updated_message_edit_forwards_before_after_context(self, monkeypatch):
@@ -292,11 +387,22 @@ class TestBlueBubblesUpdatedMessageHandling:
 
         await self._dispatch(adapter, original)
         await self._dispatch(adapter, edited)
+        await self._dispatch(adapter, edited)
 
         assert len(handled) == 2
         assert "edited" in handled[1].text.lower()
         assert "first draft" in handled[1].text
         assert "second draft" in handled[1].text
+
+        edited_back = {
+            **edited,
+            "data": {**edited["data"], "text": "first draft"},
+        }
+        await self._dispatch(adapter, edited_back)
+        await self._dispatch(adapter, edited)
+
+        assert len(handled) == 4
+        assert "second draft" in handled[3].text
 
     @pytest.mark.asyncio
     async def test_updated_message_retraction_notifies_agent_with_cached_text(self, monkeypatch):
@@ -306,11 +412,9 @@ class TestBlueBubblesUpdatedMessageHandling:
         async def fake_handle_message(event):
             handled.append(event)
 
-        async def fake_mark_read(chat_id):
-            return False
-
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
-        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+        mark_read = AsyncMock(return_value=False)
+        monkeypatch.setattr(adapter, "mark_read", mark_read)
 
         await self._dispatch(
             adapter,
@@ -325,23 +429,23 @@ class TestBlueBubblesUpdatedMessageHandling:
                 },
             },
         )
-        await self._dispatch(
-            adapter,
-            {
-                "type": "updated-message",
-                "data": {
-                    "guid": "MSG-GUID-4",
-                    "handle": {"address": "user@example.com"},
-                    "isFromMe": False,
-                    "chats": [{"guid": "any;-;user@example.com"}],
-                    "dateRetracted": 123456789,
-                },
+        retraction = {
+            "type": "updated-message",
+            "data": {
+                "guid": "MSG-GUID-4",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
+                "dateRetracted": 123456789,
             },
-        )
+        }
+        await self._dispatch(adapter, retraction)
+        await self._dispatch(adapter, retraction)
 
         assert len(handled) == 2
         assert "retracted" in handled[1].text.lower() or "unsent" in handled[1].text.lower()
         assert "please unsend me" in handled[1].text
+        assert mark_read.await_count == 2
 
     @pytest.mark.asyncio
     async def test_tapback_text_is_forwarded_as_reaction_event(self, monkeypatch):
@@ -351,29 +455,27 @@ class TestBlueBubblesUpdatedMessageHandling:
         async def fake_handle_message(event):
             handled.append(event)
 
-        async def fake_mark_read(chat_id):
-            return False
-
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
-        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+        mark_read = AsyncMock(return_value=False)
+        monkeypatch.setattr(adapter, "mark_read", mark_read)
 
-        await self._dispatch(
-            adapter,
-            {
-                "type": "new-message",
-                "data": {
-                    "guid": "TAPBACK-GUID-1",
-                    "text": "Liked “Smoke test passed”",
-                    "handle": {"address": "user@example.com"},
-                    "isFromMe": False,
-                    "chats": [{"guid": "any;-;user@example.com"}],
-                },
+        tapback = {
+            "type": "new-message",
+            "data": {
+                "guid": "TAPBACK-GUID-1",
+                "text": "Liked “Smoke test passed”",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
             },
-        )
+        }
+        await self._dispatch(adapter, tapback)
+        await self._dispatch(adapter, tapback)
 
         assert len(handled) == 1
         assert handled[0].text == "Reaction: User liked this message: Smoke test passed"
         assert handled[0].source.chat_id == "user@example.com"
+        mark_read.assert_awaited_once_with("user@example.com")
 
     @pytest.mark.asyncio
     async def test_removed_tapback_text_is_forwarded_as_reaction_removal(self, monkeypatch):
@@ -420,20 +522,23 @@ class TestBlueBubblesUpdatedMessageHandling:
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
         monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
 
-        await self._dispatch(
-            adapter,
-            {
-                "type": "new-message",
-                "data": {
-                    "guid": "TAPBACK-GUID-3",
-                    "text": "Smoke test passed",
-                    "associatedMessageType": "2003",
-                    "handle": {"address": "user@example.com"},
-                    "isFromMe": False,
-                    "chats": [{"guid": "any;-;user@example.com"}],
-                },
+        tapback = {
+            "type": "new-message",
+            "data": {
+                "guid": "TAPBACK-GUID-3",
+                "text": "Smoke test passed",
+                "associatedMessageType": "2003",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
             },
-        )
+        }
+        await self._dispatch(adapter, tapback)
+        numeric_tapback = {
+            **tapback,
+            "data": {**tapback["data"], "associatedMessageType": 2003},
+        }
+        await self._dispatch(adapter, numeric_tapback)
 
         assert len(handled) == 1
         assert handled[0].text == "Reaction: User added a laugh Tapback to: Smoke test passed"

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -448,6 +448,55 @@ class TestBlueBubblesUpdatedMessageHandling:
         assert mark_read.await_count == 2
 
     @pytest.mark.asyncio
+    async def test_retraction_retry_dedupes_across_sender_representations(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", AsyncMock(return_value=False))
+
+        await self._dispatch(
+            adapter,
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "MSG-RETRACTION-ALIAS",
+                    "text": "remove this",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                },
+            },
+        )
+        identifier_retry = {
+            "type": "updated-message",
+            "data": {
+                "guid": "MSG-RETRACTION-ALIAS",
+                "chatIdentifier": "user@example.com",
+                "isFromMe": False,
+                "dateRetracted": 123456789,
+            },
+        }
+        handle_retry = {
+            **identifier_retry,
+            "data": {
+                **identifier_retry["data"],
+                "handle": {"address": "user@example.com"},
+            },
+        }
+
+        await self._dispatch(adapter, identifier_retry)
+        await self._dispatch(adapter, handle_retry)
+
+        assert len(handled) == 2
+        assert "remove this" in handled[1].text
+
+    @pytest.mark.asyncio
     async def test_tapback_text_is_forwarded_as_reaction_event(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         handled = []
@@ -476,6 +525,42 @@ class TestBlueBubblesUpdatedMessageHandling:
         assert handled[0].text == "Reaction: User liked this message: Smoke test passed"
         assert handled[0].source.chat_id == "user@example.com"
         mark_read.assert_awaited_once_with("user@example.com")
+
+    @pytest.mark.asyncio
+    async def test_tapback_retry_dedupes_across_sender_representations(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", AsyncMock(return_value=False))
+
+        identifier_retry = {
+            "type": "new-message",
+            "data": {
+                "guid": "TAPBACK-ALIAS",
+                "text": "Liked “Alias-safe”",
+                "chatIdentifier": "user@example.com",
+                "isFromMe": False,
+            },
+        }
+        handle_retry = {
+            **identifier_retry,
+            "data": {
+                **identifier_retry["data"],
+                "handle": {"address": "user@example.com"},
+            },
+        }
+
+        await self._dispatch(adapter, identifier_retry)
+        await self._dispatch(adapter, handle_retry)
+
+        assert len(handled) == 1
+        assert handled[0].text == "Reaction: User liked this message: Alias-safe"
 
     @pytest.mark.asyncio
     async def test_removed_tapback_text_is_forwarded_as_reaction_removal(self, monkeypatch):

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -114,6 +114,302 @@ class TestBlueBubblesMentionGating:
         assert handled == []
 
 
+class TestBlueBubblesUpdatedMessageHandling:
+    async def _dispatch(self, adapter, payload):
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+        return response
+
+    @pytest.mark.asyncio
+    async def test_updated_message_same_guid_and_text_is_deduped(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        base = {
+            "data": {
+                "guid": "MSG-GUID-1",
+                "text": "hello",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
+            }
+        }
+        await self._dispatch(adapter, {"type": "new-message", **base})
+        await self._dispatch(adapter, {"type": "updated-message", **base})
+
+        assert len(handled) == 1
+        assert handled[0].text == "hello"
+
+    @pytest.mark.asyncio
+    async def test_updated_message_receipt_without_text_is_acknowledged(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        response = await self._dispatch(
+            adapter,
+            {
+                "type": "updated-message",
+                "data": {
+                    "guid": "MSG-GUID-2",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                    "dateEdited": None,
+                    "dateRetracted": None,
+                },
+            },
+        )
+
+        assert response.status == 200
+        assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_updated_message_edit_forwards_before_after_context(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        original = {
+            "type": "new-message",
+            "data": {
+                "guid": "MSG-GUID-3",
+                "text": "first draft",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
+            },
+        }
+        edited = {
+            "type": "updated-message",
+            "data": {
+                "guid": "MSG-GUID-3",
+                "text": "second draft",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
+                "dateEdited": 123456789,
+            },
+        }
+
+        await self._dispatch(adapter, original)
+        await self._dispatch(adapter, edited)
+
+        assert len(handled) == 2
+        assert "edited" in handled[1].text.lower()
+        assert "first draft" in handled[1].text
+        assert "second draft" in handled[1].text
+
+    @pytest.mark.asyncio
+    async def test_updated_message_retraction_notifies_agent_with_cached_text(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        await self._dispatch(
+            adapter,
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "MSG-GUID-4",
+                    "text": "please unsend me",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                },
+            },
+        )
+        await self._dispatch(
+            adapter,
+            {
+                "type": "updated-message",
+                "data": {
+                    "guid": "MSG-GUID-4",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                    "dateRetracted": 123456789,
+                },
+            },
+        )
+
+        assert len(handled) == 2
+        assert "retracted" in handled[1].text.lower() or "unsent" in handled[1].text.lower()
+        assert "please unsend me" in handled[1].text
+
+    @pytest.mark.asyncio
+    async def test_tapback_text_is_forwarded_as_reaction_event(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        await self._dispatch(
+            adapter,
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "TAPBACK-GUID-1",
+                    "text": "Liked “Smoke test passed”",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                },
+            },
+        )
+
+        assert len(handled) == 1
+        assert handled[0].text == "Reaction: User liked this message: Smoke test passed"
+        assert handled[0].source.chat_id == "user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_removed_tapback_text_is_forwarded_as_reaction_removal(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        await self._dispatch(
+            adapter,
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "TAPBACK-GUID-2",
+                    "text": "Removed a like from “Smoke test passed”",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                },
+            },
+        )
+
+        assert len(handled) == 1
+        assert handled[0].text == "Reaction removed: User removed a like Tapback from: Smoke test passed"
+
+    @pytest.mark.asyncio
+    async def test_associated_message_type_string_is_forwarded_as_reaction(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        await self._dispatch(
+            adapter,
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "TAPBACK-GUID-3",
+                    "text": "Smoke test passed",
+                    "associatedMessageType": "2003",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                },
+            },
+        )
+
+        assert len(handled) == 1
+        assert handled[0].text == "Reaction: User added a laugh Tapback to: Smoke test passed"
+
+    @pytest.mark.asyncio
+    async def test_dm_chat_guid_and_plain_identifier_use_same_session(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        await self._dispatch(
+            adapter,
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "MSG-GUID-5",
+                    "text": "first draft",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                },
+            },
+        )
+        await self._dispatch(
+            adapter,
+            {
+                "type": "updated-message",
+                "data": {
+                    "guid": "MSG-GUID-5",
+                    "text": "second draft",
+                    "chatIdentifier": "user@example.com",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "dateEdited": 123456789,
+                },
+            },
+        )
+
+        assert len(handled) == 2
+        assert handled[0].source.chat_id == "user@example.com"
+        assert handled[1].source.chat_id == "user@example.com"
+        assert "first draft" in handled[1].text
+        assert "second draft" in handled[1].text
+
+
 class TestBlueBubblesWebhookParsing:
 
     def test_webhook_can_fall_back_to_sender_when_chat_fields_missing(self, monkeypatch):

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -1,6 +1,7 @@
 """Tests for the BlueBubbles iMessage gateway adapter."""
 import asyncio
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -225,6 +226,94 @@ class TestBlueBubblesUpdatedMessageHandling:
         assert handled[0].text == "hello"
 
     @pytest.mark.asyncio
+    async def test_invalid_update_does_not_poison_valid_retry(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", AsyncMock(return_value=False))
+
+        invalid = {
+            "type": "updated-message",
+            "data": {
+                "guid": "MSG-GUID-RETRY",
+                "text": "corrected text",
+                "isFromMe": False,
+                "dateEdited": 123456789,
+                "chats": {"guid": "malformed-chat-container"},
+            },
+        }
+        invalid_response = await self._dispatch(adapter, invalid)
+
+        assert invalid_response.status == 400
+        assert handled == []
+        assert getattr(adapter, "_recent_update_event_keys") == {}
+        assert adapter._recent_message_texts == {}
+
+        valid = {
+            **invalid,
+            "data": {
+                **invalid["data"],
+                "handle": {"address": "user@example.com"},
+                "chats": [{"guid": "any;-;user@example.com"}],
+            },
+        }
+        valid_response = await self._dispatch(adapter, valid)
+
+        assert valid_response.status == 200
+        assert len(handled) == 1
+        assert handled[0].text == "Message edited.\nNew text: corrected text"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_update_retry_is_reserved_before_attachment_download(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def slow_download(att_guid, attachment):
+            await asyncio.sleep(0.01)
+            return "/tmp/update-image.png"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        download_attachment = AsyncMock(side_effect=slow_download)
+        monkeypatch.setattr(adapter, "_download_attachment", download_attachment)
+
+        payload = {
+            "type": "updated-message",
+            "data": {
+                "guid": "MSG-GUID-CONCURRENT",
+                "text": "corrected text",
+                "dateEdited": 123456789,
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
+                "attachments": [
+                    {
+                        "guid": "ATTACHMENT-GUID",
+                        "mimeType": {"malformed": True},
+                        "uti": {"malformed": True},
+                    }
+                ],
+            },
+        }
+        responses = await asyncio.gather(
+            adapter._handle_webhook(_FakeBlueBubblesRequest(payload)),
+            adapter._handle_webhook(_FakeBlueBubblesRequest(payload)),
+        )
+        await asyncio.sleep(0)
+
+        assert [response.status for response in responses] == [200, 200]
+        assert len(handled) == 1
+        download_attachment.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_updated_message_receipt_without_text_is_acknowledged(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         handled = []
@@ -233,6 +322,8 @@ class TestBlueBubblesUpdatedMessageHandling:
             handled.append(event)
 
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        download_attachment = AsyncMock(return_value="/tmp/duplicate-sensitive-media.png")
+        monkeypatch.setattr(adapter, "_download_attachment", download_attachment)
 
         response = await self._dispatch(
             adapter,
@@ -245,12 +336,16 @@ class TestBlueBubblesUpdatedMessageHandling:
                     "chats": [{"guid": "any;-;user@example.com"}],
                     "dateEdited": None,
                     "dateRetracted": None,
+                    "attachments": [
+                        {"guid": "duplicate-attachment", "mimeType": "image/png"}
+                    ],
                 },
             },
         )
 
         assert response.status == 200
         assert handled == []
+        download_attachment.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_updated_message_edit_forwards_before_after_context(self, monkeypatch):
@@ -290,11 +385,22 @@ class TestBlueBubblesUpdatedMessageHandling:
 
         await self._dispatch(adapter, original)
         await self._dispatch(adapter, edited)
+        await self._dispatch(adapter, edited)
 
         assert len(handled) == 2
         assert "edited" in handled[1].text.lower()
         assert "first draft" in handled[1].text
         assert "second draft" in handled[1].text
+
+        edited_back = {
+            **edited,
+            "data": {**edited["data"], "text": "first draft"},
+        }
+        await self._dispatch(adapter, edited_back)
+        await self._dispatch(adapter, edited)
+
+        assert len(handled) == 4
+        assert "second draft" in handled[3].text
 
     @pytest.mark.asyncio
     async def test_updated_message_retraction_notifies_agent_with_cached_text(self, monkeypatch):
@@ -304,11 +410,9 @@ class TestBlueBubblesUpdatedMessageHandling:
         async def fake_handle_message(event):
             handled.append(event)
 
-        async def fake_mark_read(chat_id):
-            return False
-
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
-        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+        mark_read = AsyncMock(return_value=False)
+        monkeypatch.setattr(adapter, "mark_read", mark_read)
 
         await self._dispatch(
             adapter,
@@ -323,23 +427,23 @@ class TestBlueBubblesUpdatedMessageHandling:
                 },
             },
         )
-        await self._dispatch(
-            adapter,
-            {
-                "type": "updated-message",
-                "data": {
-                    "guid": "MSG-GUID-4",
-                    "handle": {"address": "user@example.com"},
-                    "isFromMe": False,
-                    "chats": [{"guid": "any;-;user@example.com"}],
-                    "dateRetracted": 123456789,
-                },
+        retraction = {
+            "type": "updated-message",
+            "data": {
+                "guid": "MSG-GUID-4",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
+                "dateRetracted": 123456789,
             },
-        )
+        }
+        await self._dispatch(adapter, retraction)
+        await self._dispatch(adapter, retraction)
 
         assert len(handled) == 2
         assert "retracted" in handled[1].text.lower() or "unsent" in handled[1].text.lower()
         assert "please unsend me" in handled[1].text
+        assert mark_read.await_count == 2
 
     @pytest.mark.asyncio
     async def test_tapback_text_is_forwarded_as_reaction_event(self, monkeypatch):
@@ -349,29 +453,27 @@ class TestBlueBubblesUpdatedMessageHandling:
         async def fake_handle_message(event):
             handled.append(event)
 
-        async def fake_mark_read(chat_id):
-            return False
-
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
-        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+        mark_read = AsyncMock(return_value=False)
+        monkeypatch.setattr(adapter, "mark_read", mark_read)
 
-        await self._dispatch(
-            adapter,
-            {
-                "type": "new-message",
-                "data": {
-                    "guid": "TAPBACK-GUID-1",
-                    "text": "Liked “Smoke test passed”",
-                    "handle": {"address": "user@example.com"},
-                    "isFromMe": False,
-                    "chats": [{"guid": "any;-;user@example.com"}],
-                },
+        tapback = {
+            "type": "new-message",
+            "data": {
+                "guid": "TAPBACK-GUID-1",
+                "text": "Liked “Smoke test passed”",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
             },
-        )
+        }
+        await self._dispatch(adapter, tapback)
+        await self._dispatch(adapter, tapback)
 
         assert len(handled) == 1
         assert handled[0].text == "Reaction: User liked this message: Smoke test passed"
         assert handled[0].source.chat_id == "user@example.com"
+        mark_read.assert_awaited_once_with("user@example.com")
 
     @pytest.mark.asyncio
     async def test_removed_tapback_text_is_forwarded_as_reaction_removal(self, monkeypatch):
@@ -418,20 +520,23 @@ class TestBlueBubblesUpdatedMessageHandling:
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
         monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
 
-        await self._dispatch(
-            adapter,
-            {
-                "type": "new-message",
-                "data": {
-                    "guid": "TAPBACK-GUID-3",
-                    "text": "Smoke test passed",
-                    "associatedMessageType": "2003",
-                    "handle": {"address": "user@example.com"},
-                    "isFromMe": False,
-                    "chats": [{"guid": "any;-;user@example.com"}],
-                },
+        tapback = {
+            "type": "new-message",
+            "data": {
+                "guid": "TAPBACK-GUID-3",
+                "text": "Smoke test passed",
+                "associatedMessageType": "2003",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
             },
-        )
+        }
+        await self._dispatch(adapter, tapback)
+        numeric_tapback = {
+            **tapback,
+            "data": {**tapback["data"], "associatedMessageType": 2003},
+        }
+        await self._dispatch(adapter, numeric_tapback)
 
         assert len(handled) == 1
         assert handled[0].text == "Reaction: User added a laugh Tapback to: Smoke test passed"

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -113,6 +113,81 @@ class TestBlueBubblesMentionGating:
         assert response.status == 200
         assert handled == []
 
+    @pytest.mark.asyncio
+    async def test_group_tapback_bypasses_mention_gate(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "group-tapback-1",
+                "text": "Liked “Smoke test passed”",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "isGroup": True,
+                "chats": [{"guid": "iMessage;+;group-chat"}],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert [event.text for event in handled] == [
+            "Reaction: User liked this message: Smoke test passed"
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("update_fields", "expected_fragment"),
+        [
+            ({"text": "second draft", "dateEdited": 123456789}, "Message edited."),
+            ({"dateRetracted": 123456789}, "Message retracted/unsent."),
+        ],
+    )
+    async def test_group_update_notification_bypasses_mention_gate(
+        self, monkeypatch, update_fields, expected_fragment
+    ):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        base = {
+            "guid": "group-update-1",
+            "handle": {"address": "+155****0100"},
+            "isFromMe": False,
+            "isGroup": True,
+            "chats": [{"guid": "iMessage;+;group-chat"}],
+        }
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {**base, "text": "first draft"},
+        }))
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {**base, **update_fields},
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert len(handled) == 1
+        assert expected_fragment in handled[0].text
+        assert "first draft" in handled[0].text
+
 
 class TestBlueBubblesUpdatedMessageHandling:
     async def _dispatch(self, adapter, payload):

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -116,6 +116,302 @@ class TestBlueBubblesMentionGating:
         assert handled == []
 
 
+class TestBlueBubblesUpdatedMessageHandling:
+    async def _dispatch(self, adapter, payload):
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+        return response
+
+    @pytest.mark.asyncio
+    async def test_updated_message_same_guid_and_text_is_deduped(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        base = {
+            "data": {
+                "guid": "MSG-GUID-1",
+                "text": "hello",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
+            }
+        }
+        await self._dispatch(adapter, {"type": "new-message", **base})
+        await self._dispatch(adapter, {"type": "updated-message", **base})
+
+        assert len(handled) == 1
+        assert handled[0].text == "hello"
+
+    @pytest.mark.asyncio
+    async def test_updated_message_receipt_without_text_is_acknowledged(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        response = await self._dispatch(
+            adapter,
+            {
+                "type": "updated-message",
+                "data": {
+                    "guid": "MSG-GUID-2",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                    "dateEdited": None,
+                    "dateRetracted": None,
+                },
+            },
+        )
+
+        assert response.status == 200
+        assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_updated_message_edit_forwards_before_after_context(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        original = {
+            "type": "new-message",
+            "data": {
+                "guid": "MSG-GUID-3",
+                "text": "first draft",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
+            },
+        }
+        edited = {
+            "type": "updated-message",
+            "data": {
+                "guid": "MSG-GUID-3",
+                "text": "second draft",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chats": [{"guid": "any;-;user@example.com"}],
+                "dateEdited": 123456789,
+            },
+        }
+
+        await self._dispatch(adapter, original)
+        await self._dispatch(adapter, edited)
+
+        assert len(handled) == 2
+        assert "edited" in handled[1].text.lower()
+        assert "first draft" in handled[1].text
+        assert "second draft" in handled[1].text
+
+    @pytest.mark.asyncio
+    async def test_updated_message_retraction_notifies_agent_with_cached_text(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        await self._dispatch(
+            adapter,
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "MSG-GUID-4",
+                    "text": "please unsend me",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                },
+            },
+        )
+        await self._dispatch(
+            adapter,
+            {
+                "type": "updated-message",
+                "data": {
+                    "guid": "MSG-GUID-4",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                    "dateRetracted": 123456789,
+                },
+            },
+        )
+
+        assert len(handled) == 2
+        assert "retracted" in handled[1].text.lower() or "unsent" in handled[1].text.lower()
+        assert "please unsend me" in handled[1].text
+
+    @pytest.mark.asyncio
+    async def test_tapback_text_is_forwarded_as_reaction_event(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        await self._dispatch(
+            adapter,
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "TAPBACK-GUID-1",
+                    "text": "Liked “Smoke test passed”",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                },
+            },
+        )
+
+        assert len(handled) == 1
+        assert handled[0].text == "Reaction: User liked this message: Smoke test passed"
+        assert handled[0].source.chat_id == "user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_removed_tapback_text_is_forwarded_as_reaction_removal(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        await self._dispatch(
+            adapter,
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "TAPBACK-GUID-2",
+                    "text": "Removed a like from “Smoke test passed”",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                },
+            },
+        )
+
+        assert len(handled) == 1
+        assert handled[0].text == "Reaction removed: User removed a like Tapback from: Smoke test passed"
+
+    @pytest.mark.asyncio
+    async def test_associated_message_type_string_is_forwarded_as_reaction(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        await self._dispatch(
+            adapter,
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "TAPBACK-GUID-3",
+                    "text": "Smoke test passed",
+                    "associatedMessageType": "2003",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                },
+            },
+        )
+
+        assert len(handled) == 1
+        assert handled[0].text == "Reaction: User added a laugh Tapback to: Smoke test passed"
+
+    @pytest.mark.asyncio
+    async def test_dm_chat_guid_and_plain_identifier_use_same_session(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_mark_read(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+
+        await self._dispatch(
+            adapter,
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "MSG-GUID-5",
+                    "text": "first draft",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "any;-;user@example.com"}],
+                },
+            },
+        )
+        await self._dispatch(
+            adapter,
+            {
+                "type": "updated-message",
+                "data": {
+                    "guid": "MSG-GUID-5",
+                    "text": "second draft",
+                    "chatIdentifier": "user@example.com",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "dateEdited": 123456789,
+                },
+            },
+        )
+
+        assert len(handled) == 2
+        assert handled[0].source.chat_id == "user@example.com"
+        assert handled[1].source.chat_id == "user@example.com"
+        assert "first draft" in handled[1].text
+        assert "second draft" in handled[1].text
+
+
 class TestBlueBubblesWebhookParsing:
 
     def test_webhook_can_fall_back_to_sender_when_chat_fields_missing(self, monkeypatch):


### PR DESCRIPTION
## Summary

- Classifies BlueBubbles `updated-message` webhooks so receipt/no-op updates are ACKed before attachment download or agent dispatch.
- Deduplicates classified retractions, edits, and Tapbacks with a bounded semantic-event cache so webhook retries do not trigger duplicate agent turns or read receipts; malformed updates are rejected before they can mutate that cache.
- Surfaces message edits, retractions/unsends, Tapbacks, and Tapback removals as explicit agent-visible events.
- Lets classified reaction/update notifications bypass group mention gating while ordinary group messages remain gated.
- Canonicalizes one-to-one iMessage chat IDs so raw BlueBubbles GUIDs and plain identifiers share the same session.

## Validation

Refreshed the three scoped commits onto current `main` at `baa344dee76993f0444c18fc59a69738ccb339d0`, preserving authorship. With the inherited webhook host override removed:

```text
python -m pytest tests/gateway/test_bluebubbles.py -q -o 'addopts='
38 passed

ruff check gateway/platforms/bluebubbles.py tests/gateway/test_bluebubbles.py
All checks passed!
```

`git diff --check` passes. The branch changes only `gateway/platforms/bluebubbles.py` and `tests/gateway/test_bluebubbles.py`.

## AI assistance disclosure

This refresh was prepared with AI assistance under human direction and reviewed/tested locally before publication.
