### PR TITLE
fix(model_switch): split volcengine-agent-plan default_model comma list into individual entries

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1768,10 +1768,16 @@ def list_authenticated_providers(
             # custom_providers entries use, so accept either.
             default_model = ep_cfg.get("default_model", "") or ep_cfg.get("model", "")
 
-            # Build models list from both default_model and full models array
+            # Build models list from both default_model and full models array.
+            # ``default_model`` may be a comma-separated fallback chain (e.g.
+            # volcengine-agent-plan: "deepseek-v4-flash,deepseek-v4-pro,...").
+            # Split it into individual selectable entries so the picker offers
+            # each model on its own rather than one comma-joined blob (#50557).
             models_list = []
-            if default_model:
-                models_list.append(default_model)
+            for _dm in str(default_model).split(","):
+                _dm = _dm.strip()
+                if _dm and _dm not in models_list:
+                    models_list.append(_dm)
             # Also include the full models list from config.
             # Hermes writes ``models:`` as a dict keyed by model id
             # (see hermes_cli/main.py::_save_custom_provider); older


### PR DESCRIPTION
Closes #50557.

The model switcher (`hermes_cli/model_switch.py`, `list_authenticated_providers`) appended a provider's `default_model` as a single entry. For `volcengine-agent-plan`, `default_model` is a comma-separated fallback chain, so the picker showed one un-splittable comma-joined row.

This splits `default_model` on commas into individual, stripped, de-duplicated entries (matching the order-preserving dedup already used for the `models:` list just below). A non-comma `default_model` still yields a single entry, so the change is backward compatible.

**Tests:** `test_user_providers_model_switch.py`, `test_custom_provider_model_switch.py`, `test_model_switch_custom_providers.py` — 76 passed; a functional check confirms a 4-model comma chain now yields 4 individual entries.