### PR TITLE
fix(gateway): detect FTS write corruption in DB health probe

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1201,6 +1201,46 @@ def run_doctor(args):
             count = cursor.fetchone()[0]
             conn.close()
             check_ok(f"{_DHH}/state.db exists ({count} sessions)")
+
+            # Reads succeeding is not enough: an FTS5 index corrupt only on the
+            # write path lets every read pass while every message INSERT fails
+            # through the triggers, silently dropping conversation history
+            # (#50502). Run the write-aware probe and repair in place on --fix.
+            from hermes_state import _db_opens_cleanly, repair_state_db_schema
+
+            _write_reason = _db_opens_cleanly(state_db_path)
+            if _write_reason is not None:
+                check_warn(
+                    f"{_DHH}/state.db fails a message-write health check "
+                    f"(history may be silently dropped)",
+                    f"({_write_reason})",
+                )
+                if should_fix:
+                    report = repair_state_db_schema(state_db_path)
+                    if report.get("repaired"):
+                        backup_name = (
+                            Path(report["backup_path"]).name
+                            if report.get("backup_path") else "n/a"
+                        )
+                        check_ok(
+                            "Repaired state.db FTS write path",
+                            f"(strategy: {report.get('strategy')}; backup: {backup_name})",
+                        )
+                        fixed_count += 1
+                    else:
+                        check_warn(
+                            "state.db FTS write repair did not recover automatically",
+                            f"({report.get('error')}; backup: {report.get('backup_path')})",
+                        )
+                        issues.append(
+                            "state.db FTS write corruption and auto-repair failed — "
+                            "restore from the backup copy beside state.db"
+                        )
+                else:
+                    issues.append(
+                        "state.db FTS write corruption — run 'hermes doctor --fix' "
+                        "(or 'hermes sessions repair') to rebuild the FTS index"
+                    )
         except Exception as e:
             from hermes_state import is_malformed_db_error, repair_state_db_schema
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -21,6 +21,7 @@ import re
 import sqlite3
 import threading
 import time
+import uuid
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -394,12 +395,55 @@ def _backup_db_file(db_path: Path) -> Optional[Path]:
         return None
 
 
+def _fts_write_probe(conn: sqlite3.Connection) -> Optional[str]:
+    """Drive a rolled-back ``messages`` write through the FTS triggers.
+
+    ``PRAGMA integrity_check`` and ``SELECT`` probes only exercise reads, so an
+    FTS5 index that is corrupt *only on the write path* (the
+    ``messages_fts_insert`` trigger raising ``database disk image is
+    malformed``) reports healthy while every real ``append_message`` silently
+    fails -- the #50502 immediate-history-drop class.
+
+    Insert a sentinel row inside a transaction and ALWAYS roll it back, so the
+    FTS triggers actually fire (proving the index is writable) without
+    persisting anything. Returns ``None`` when the write path is healthy, else
+    the error string. A missing ``messages`` table is treated as healthy here
+    (a fresh/partial DB the caller's read checks already cover).
+    """
+    sentinel = "__hermes_fts_write_probe__" + uuid.uuid4().hex
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+    except sqlite3.DatabaseError as exc:
+        return str(exc)
+    try:
+        conn.execute("SELECT 1 FROM messages LIMIT 0")
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, ?, ?, ?)",
+            (sentinel, "user", sentinel, 0.0),
+        )
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return None
+        return str(exc)
+    except sqlite3.DatabaseError as exc:
+        return str(exc)
+    finally:
+        try:
+            conn.rollback()
+        except sqlite3.DatabaseError:
+            pass
+    return None
+
+
 def _db_opens_cleanly(db_path: Path) -> Optional[str]:
     """Probe a DB on a fresh connection. Returns None if healthy, else a reason.
 
     Runs the same first-statement (``PRAGMA journal_mode``) that trips the
-    malformed-schema parse, then ``PRAGMA integrity_check`` and a canonical
-    ``sessions`` read.
+    malformed-schema parse, then ``PRAGMA integrity_check``, a canonical
+    ``sessions`` read, AND a transactionally rolled-back ``messages`` write so
+    the FTS triggers are exercised (catches the #50502 write-only corruption
+    class that reads alone report as healthy).
     """
     conn = sqlite3.connect(str(db_path), isolation_level=None)
     try:
@@ -409,6 +453,9 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         if problems:
             return "; ".join(problems[:3])
         conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
+        write_reason = _fts_write_probe(conn)
+        if write_reason is not None:
+            return write_reason
         return None
     except sqlite3.DatabaseError as exc:
         return str(exc)

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -21,6 +21,7 @@ import pytest
 import hermes_state
 from hermes_state import (
     SessionDB,
+    _db_opens_cleanly,
     is_malformed_db_error,
     repair_state_db_schema,
 )
@@ -242,3 +243,120 @@ def test_repair_on_clean_db_is_noop(tmp_path):
     assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 10
     assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
     conn.close()
+
+
+# ---------------------------------------------------------------------------
+# #50502 — FTS *write* corruption that reads alone report as healthy.
+#
+# A readable state.db can still be unusable for persistence: when the FTS5
+# index is corrupt only on the write path, every read (integrity_check,
+# COUNT(*) FROM sessions/messages) succeeds while every INSERT INTO messages
+# fails through the messages_fts_insert trigger with
+# "database disk image is malformed". The gateway swallows that write error
+# and the next turn reloads an empty/stale transcript — immediate same-session
+# amnesia. The health probe must therefore also exercise a (rolled-back)
+# write, not just reads.
+#
+# These tests simulate the failure by making the messages_fts_insert trigger
+# raise on insert. That faithfully reproduces "writes fail through the FTS
+# triggers while reads pass" without sqlite_master surgery (which newer SQLite
+# builds block), so the detection contract is exercised on every SQLite.
+# ---------------------------------------------------------------------------
+def _break_fts_insert_trigger(db_path: Path) -> None:
+    """Make the messages_fts_insert trigger fail like a corrupt FTS index.
+
+    Reads of sessions/messages and PRAGMA integrity_check stay healthy; only
+    the trigger-driven write path raises 'database disk image is malformed'.
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("DROP TRIGGER IF EXISTS messages_fts_insert")
+        conn.execute(
+            "CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN "
+            "  SELECT RAISE(ABORT, 'database disk image is malformed'); "
+            "END"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_read_probes_miss_fts_write_corruption(tmp_path):
+    """The old read-only checks all pass on a write-corrupt FTS index."""
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    _break_fts_insert_trigger(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # Every read-only signal the old probe relied on still reports healthy.
+        assert conn.execute("PRAGMA journal_mode").fetchone() is not None
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 10
+    finally:
+        conn.close()
+
+
+def test_db_opens_cleanly_detects_fts_write_corruption(tmp_path):
+    """The write-aware probe flags the corruption the read checks miss."""
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+
+    # Healthy DB: probe reports clean.
+    assert _db_opens_cleanly(db_path) is None
+
+    _break_fts_insert_trigger(db_path)
+
+    # Corrupt write path: probe now returns the failure reason.
+    reason = _db_opens_cleanly(db_path)
+    assert reason is not None
+    assert "malformed" in reason.lower()
+
+
+def test_fts_write_probe_rolls_back_and_corruption_is_real(tmp_path):
+    """The probe must persist nothing, and the simulated corruption must
+    actually block real appends (not just be a synthetic flag)."""
+    db_path = tmp_path / "state.db"
+    sid = _build_healthy_db(db_path)
+    _break_fts_insert_trigger(db_path)
+
+    # The probe ran an INSERT internally; it must have rolled back — no probe
+    # sentinel row leaks into messages.
+    assert _db_opens_cleanly(db_path) is not None
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 10
+        leaked = conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE content LIKE "
+            "'__hermes_fts_write_probe__%'"
+        ).fetchone()[0]
+        assert leaked == 0
+    finally:
+        conn.close()
+
+    # A real append really does fail on this DB (the silent-drop class).
+    db = SessionDB(db_path=db_path)
+    try:
+        with pytest.raises(sqlite3.DatabaseError):
+            db.append_message(sid, role="user", content="next turn")
+    finally:
+        db.close()
+
+
+def test_healthy_db_passes_write_probe(tmp_path):
+    """A healthy DB stays healthy and the write probe leaves no residue."""
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+
+    assert _db_opens_cleanly(db_path) is None
+    # Probe is non-destructive: counts unchanged, no sentinel rows.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 10
+        assert conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE content LIKE "
+            "'__hermes_fts_write_probe__%'"
+        ).fetchone()[0] == 0
+    finally:
+        conn.close()


### PR DESCRIPTION
Closes #50502.

FTS5 write-path corruption silently dropped immediate gateway conversation history. The DB health probe `_db_opens_cleanly()` only validated **reads** (`PRAGMA journal_mode`, `PRAGMA integrity_check`, `SELECT COUNT`), so an FTS index corrupt only on the write path passed every check while each `INSERT INTO messages` failed through the `messages_fts_insert` trigger. `append_to_transcript()` swallowed the write error at debug level, the next turn loaded empty/stale history and seeded the turn from it — same-session amnesia. Because the probe reported healthy, `hermes doctor` and `sessions repair --check-only` all returned false-healthy.

Adds `_fts_write_probe()` (`BEGIN IMMEDIATE` → sentinel insert → always rollback) so the FTS triggers actually fire without persisting anything, and runs it in `_db_opens_cleanly()` and `hermes doctor`. This strengthens the existing repair paths (a write-corrupt index now escalates to the drop-and-rebuild-FTS pass).

**Tests:** +4 regressions in `test_state_db_malformed_repair.py`; `test_hermes_state.py` 278 pass, doctor suites 76 pass. Scoped to detection+repair (the separate cached-agent context change was intentionally left out).