### PR TITLE
fix(bedrock): route non-Claude Bedrock models off the Anthropic SDK

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1732,7 +1732,10 @@ def resolve_runtime_provider(
         # Dual-path routing: Claude models use AnthropicBedrock SDK for full
         # feature parity (prompt caching, thinking budgets, adaptive thinking).
         # Non-Claude models use the Converse API for multi-model support.
-        _current_model = str(model_cfg.get("default") or "").strip()
+        # Use the runtime model (target_model) when present so a CLI --model
+        # selection (e.g. deepseek.v3.2) is not routed through the Anthropic SDK
+        # just because the config default happens to be a Claude model.
+        _current_model = str(target_model or model_cfg.get("default") or "").strip()
         if is_anthropic_bedrock_model(_current_model):
             # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path
             runtime = {

--- a/tests/hermes_cli/test_bedrock_non_claude_routing.py
+++ b/tests/hermes_cli/test_bedrock_non_claude_routing.py
@@ -1,0 +1,59 @@
+"""Regression test for issue #50292."""
+
+import agent.bedrock_adapter as bedrock_adapter
+from hermes_cli import runtime_provider as rp
+
+
+def _patch_bedrock(monkeypatch, *, config_default, provider="bedrock"):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "bedrock")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": provider, "default": config_default},
+    )
+    monkeypatch.setattr(rp, "load_config", lambda: {"bedrock": {}})
+    monkeypatch.setattr(rp, "_resolve_explicit_runtime", lambda **k: None)
+    monkeypatch.setattr(
+        bedrock_adapter, "resolve_bedrock_region", lambda *a, **k: "us-east-1"
+    )
+    monkeypatch.setattr(
+        bedrock_adapter, "resolve_aws_auth_env_var", lambda *a, **k: "AWS_PROFILE"
+    )
+    monkeypatch.setattr(bedrock_adapter, "has_aws_credentials", lambda *a, **k: True)
+
+
+def test_bedrock_non_claude_runtime_model_uses_converse(monkeypatch):
+    # Config default is Claude, but the runtime --model is a non-Claude model:
+    # it must route through the Converse API, not the Anthropic SDK path.
+    _patch_bedrock(monkeypatch, config_default="global.anthropic.claude-sonnet-4-6")
+
+    resolved = rp.resolve_runtime_provider(
+        requested="bedrock", target_model="deepseek.v3.2"
+    )
+
+    assert resolved["provider"] == "bedrock"
+    assert resolved["api_mode"] == "bedrock_converse"
+    assert resolved.get("bedrock_anthropic") is not True
+
+
+def test_bedrock_claude_runtime_model_uses_anthropic_sdk(monkeypatch):
+    # A Claude runtime model still routes through the AnthropicBedrock SDK.
+    _patch_bedrock(monkeypatch, config_default="deepseek.v3.2")
+
+    resolved = rp.resolve_runtime_provider(
+        requested="bedrock", target_model="global.anthropic.claude-sonnet-4-6"
+    )
+
+    assert resolved["provider"] == "bedrock"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["bedrock_anthropic"] is True
+
+
+def test_bedrock_falls_back_to_config_default_without_target_model(monkeypatch):
+    # No runtime override: the config default still decides routing.
+    _patch_bedrock(monkeypatch, config_default="global.anthropic.claude-sonnet-4-6")
+
+    resolved = rp.resolve_runtime_provider(requested="bedrock")
+
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["bedrock_anthropic"] is True


### PR DESCRIPTION
Closes #50292.

On AWS Bedrock, non-Claude models were routed through the Anthropic SDK path because the routing decision read the config-file default instead of the runtime model. In `hermes_cli/runtime_provider.py` (`resolve_runtime_provider`, bedrock branch), `_current_model` was read from `model_cfg.get("default")` rather than the `target_model` param the rest of the file uses. So with a Claude config default and `--model deepseek.v3.2`, the request went through AnthropicBedrock (`anthropic_messages`) and Bedrock rejected it (HTTP 400).

Fix: `_current_model = str(target_model or model_cfg.get("default") or "").strip()` — non-Claude models now correctly fall to the `bedrock_converse` path (`is_anthropic_bedrock_model` already normalizes regional `us.`/`global.`/`eu.` prefixes).

**Tests:** +3 regression tests (`test_bedrock_non_claude_routing.py`); 306 pass across the bedrock suites.