### PR TITLE
fix: replace remaining bare asserts in tools and agent modules

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -396,7 +396,8 @@ class CodexAppServerSession:
             # turn re-spawns cleanly.
             result.should_retire = True
             return result
-        assert self._client is not None and self._thread_id is not None
+        if self._client is None or self._thread_id is None:
+            raise RuntimeError("run called before client or thread is initialized")
         result.thread_id = self._thread_id
 
         self._interrupt_event.clear()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4373,7 +4373,8 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
-            assert self._app is not None
+            if self._app is None:
+                raise RuntimeError("Failed to create web.Application")
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -810,7 +810,8 @@ class CDPSupervisor:
 
     async def _read_loop(self) -> None:
         """Continuously dispatch incoming CDP frames."""
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("_read_loop called before websocket is connected")
         try:
             async for raw in self._ws:
                 if self._stop_requested:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -944,7 +944,8 @@ class DockerEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
-        assert self._container_id, "Container not started"
+        if not self._container_id:
+            raise RuntimeError("Cannot exec: container not started")
         cmd = [self._docker_exe, "exec"]
         if stdin_data is not None:
             cmd.append("-i")


### PR DESCRIPTION
## Summary

`assert` statements are stripped when Python runs with `-O` flag, causing silent failures in production.

Replace 4 remaining bare asserts across 4 files:

- **tools/environments/docker.py**: guard `_container_id` in `exec_bash`
- **tools/browser_supervisor.py**: guard `_ws` in `_read_loop`
- **agent/transports/codex_app_server_session.py**: guard `_client`/`_thread_id` in `run`
- **gateway/platforms/api_server.py**: guard `_app` initialization

All replaced with `if X is None: raise RuntimeError(msg)` pattern.

## Test plan

- [ ] `python -O -c "import tools.environments.docker"` succeeds
- [ ] `python -O -c "import tools.browser_supervisor"` succeeds
- [ ] `python -O -c "import agent.transports.codex_app_server_session"` succeeds
- [ ] `python -O -c "import gateway.platforms.api_server"` succeeds
- [ ] CI passes