### PR TITLE
fix(web): preserve native dashboard terminal input

### DIFF
--- a/web/src/lib/terminal-native-input.test.ts
+++ b/web/src/lib/terminal-native-input.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveNativeTerminalInputText,
+  shouldDeferToNativeTerminalInput,
+} from "./terminal-native-input";
+
+describe("shouldDeferToNativeTerminalInput", () => {
+  it("defers IME/composition keydown events to the textarea path", () => {
+    expect(
+      shouldDeferToNativeTerminalInput({
+        type: "keydown",
+        key: "Process",
+        ctrlKey: false,
+        altKey: false,
+        metaKey: false,
+        keyCode: 229,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps command shortcuts on the xterm keydown path", () => {
+    expect(
+      shouldDeferToNativeTerminalInput({
+        type: "keydown",
+        key: "c",
+        ctrlKey: true,
+        altKey: false,
+        metaKey: false,
+        keyCode: 67,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats AltGraph text entry as native input instead of a shortcut", () => {
+    expect(
+      shouldDeferToNativeTerminalInput({
+        type: "keydown",
+        key: "@",
+        ctrlKey: true,
+        altKey: true,
+        metaKey: false,
+        altGraph: true,
+        keyCode: 81,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("resolveNativeTerminalInputText", () => {
+  it("returns null while composition is still active", () => {
+    expect(
+      resolveNativeTerminalInputText({
+        armed: true,
+        isComposing: true,
+        value: "й",
+      }),
+    ).toBeNull();
+  });
+
+  it("prefers the textarea value when the browser committed direct-layout text", () => {
+    expect(
+      resolveNativeTerminalInputText({
+        armed: true,
+        isComposing: false,
+        data: null,
+        value: "й",
+      }),
+    ).toBe("й");
+  });
+
+  it("falls back to event.data when the textarea was already cleared", () => {
+    expect(
+      resolveNativeTerminalInputText({
+        armed: true,
+        isComposing: false,
+        data: "é",
+        value: "",
+      }),
+    ).toBe("é");
+  });
+});

--- a/web/src/lib/terminal-native-input.ts
+++ b/web/src/lib/terminal-native-input.ts
@@ -1,0 +1,48 @@
+export type NativeTerminalKeydown = {
+  type: string;
+  key: string;
+  ctrlKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  isComposing?: boolean;
+  keyCode?: number;
+  which?: number;
+  altGraph?: boolean;
+};
+
+export function shouldDeferToNativeTerminalInput(
+  event: NativeTerminalKeydown,
+): boolean {
+  if (event.type !== "keydown") return false;
+
+  const altGraph = event.altGraph === true;
+  const hasCommandModifier = event.metaKey || (event.ctrlKey && !altGraph);
+  if (hasCommandModifier) return false;
+
+  if (event.isComposing || altGraph) return true;
+
+  if (
+    event.key === "Dead" ||
+    event.key === "Process" ||
+    event.key === "Unidentified"
+  ) {
+    return true;
+  }
+
+  return event.keyCode === 229 || event.which === 229;
+}
+
+export function resolveNativeTerminalInputText(args: {
+  armed: boolean;
+  isComposing: boolean;
+  data?: string | null;
+  value?: string | null;
+}): string | null {
+  if (!args.armed || args.isComposing) return null;
+
+  const value = args.value ?? "";
+  if (value) return value;
+
+  const data = args.data ?? "";
+  return data || null;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -36,6 +36,10 @@ import { ChatSessionList } from "@/components/ChatSessionList";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
+import {
+  resolveNativeTerminalInputText,
+  shouldDeferToNativeTerminalInput,
+} from "@/lib/terminal-native-input";
 import { PluginSlot } from "@/plugins";
 import { useTheme } from "@/themes";
 import { useProfileScope } from "@/contexts/useProfileScope";
@@ -406,6 +410,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
     const isMac =
       typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+    let nativeTextareaInputArmed = false;
+    let nativeTextareaCompositionActive = false;
 
     term.attachCustomKeyEventHandler((ev) => {
       if (ev.type !== "keydown") return true;
@@ -450,6 +456,23 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         return false;
       }
 
+      if (
+        shouldDeferToNativeTerminalInput({
+          type: ev.type,
+          key: ev.key,
+          ctrlKey: ev.ctrlKey,
+          altKey: ev.altKey,
+          metaKey: ev.metaKey,
+          isComposing: ev.isComposing,
+          keyCode: ev.keyCode,
+          which: ev.which,
+          altGraph: ev.getModifierState?.("AltGraph") ?? false,
+        })
+      ) {
+        nativeTextareaInputArmed = true;
+        return false;
+      }
+
       return true;
     });
 
@@ -480,6 +503,61 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     term.loadAddon(new WebLinksAddon());
 
     term.open(host);
+
+    let removeNativeTextareaListeners = () => {};
+    const nativeTextarea = host.querySelector("textarea");
+    if (nativeTextarea instanceof HTMLTextAreaElement) {
+      const flushNativeTextareaInput = (
+        event: InputEvent | CompositionEvent,
+      ) => {
+        const text = resolveNativeTerminalInputText({
+          armed: nativeTextareaInputArmed,
+          isComposing:
+            nativeTextareaCompositionActive ||
+            ("isComposing" in event && event.isComposing === true),
+          data: "data" in event ? event.data : null,
+          value: nativeTextarea.value,
+        });
+        if (!text) return;
+
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(text);
+        }
+        nativeTextarea.value = "";
+        nativeTextareaInputArmed = false;
+      };
+
+      const onNativeCompositionStart = () => {
+        nativeTextareaCompositionActive = true;
+        nativeTextareaInputArmed = true;
+      };
+      const onNativeCompositionEnd = (event: CompositionEvent) => {
+        nativeTextareaCompositionActive = false;
+        flushNativeTextareaInput(event);
+      };
+      const onNativeInput = (event: InputEvent) => {
+        flushNativeTextareaInput(event);
+      };
+
+      nativeTextarea.addEventListener(
+        "compositionstart",
+        onNativeCompositionStart,
+      );
+      nativeTextarea.addEventListener("compositionend", onNativeCompositionEnd);
+      nativeTextarea.addEventListener("input", onNativeInput);
+      removeNativeTextareaListeners = () => {
+        nativeTextarea.removeEventListener(
+          "compositionstart",
+          onNativeCompositionStart,
+        );
+        nativeTextarea.removeEventListener(
+          "compositionend",
+          onNativeCompositionEnd,
+        );
+        nativeTextarea.removeEventListener("input", onNativeInput);
+      };
+    }
 
     // WebGL draws from a texture atlas sized with device pixels. On phones and
     // in DevTools device mode that often produces *visually* much larger cells
@@ -744,6 +822,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // effect's top level so it can't reach into that scope — close via
       // the ref instead. ``?.`` covers the race where unmount fires before
       // the ticket fetch resolves and ``wsRef.current`` was never assigned.
+      removeNativeTextareaListeners();
       wsRef.current?.close();
       wsRef.current = null;
       term.dispose();


### PR DESCRIPTION
## Summary
- defer IME/direct-layout keydown events that xterm mis-translates to the browser textarea input path
- flush committed native textarea text into the PTY websocket once composition/input completes
- cover the keydown/input decision logic with targeted vitest cases

Fixes #50330.

## Proof
- `proof SHA`: `aea18b20fa7c4ded4d21b57c68d5d718e34174dc`
- `proof path`: `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-50330-cyrillic-xterm/.paperclip_artifacts/quality-gate/proof-aea18b20fa7c4ded4d21b57c68d5d718e34174dc.json`
- targeted commands:
  - `vitest run src/lib/terminal-native-input.test.ts --config vitest.config.ts`
  - `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
  - `./node_modules/.bin/eslint src/pages/ChatPage.tsx src/lib/terminal-native-input.ts src/lib/terminal-native-input.test.ts`
  - `git diff --check`
- baseline note: existing `react-hooks/exhaustive-deps` warnings in `web/src/pages/ChatPage.tsx:214` and `web/src/pages/ChatPage.tsx:836` were preexisting and unrelated to this diff.
