### PR TITLE
fix(agent): use monotonic clock for duration measurement

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -931,7 +931,7 @@ def run_conversation(
             logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
             logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
         
-        api_start_time = time.time()
+        api_start_time = time.monotonic()
         retry_count = 0
         max_retries = agent._api_max_retries
         _retry = TurnRetryState()
@@ -1161,7 +1161,7 @@ def run_conversation(
                     middleware_trace=list(_llm_middleware_trace),
                 )
                 
-                api_duration = time.time() - api_start_time
+                api_duration = time.monotonic() - api_start_time
                 
                 # Stop thinking spinner silently -- the response box or tool
                 # execution messages that follow are more informative.
@@ -1391,9 +1391,9 @@ def run_conversation(
                     logger.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
                     
                     # Sleep in small increments to stay responsive to interrupts
-                    sleep_end = time.time() + wait_time
+                    sleep_end = time.monotonic() + wait_time
                     _backoff_touch_counter = 0
-                    while time.time() < sleep_end:
+                    while time.monotonic() < sleep_end:
                         if agent._interrupt_requested:
                             agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
                             agent._persist_session(messages, conversation_history)
@@ -1412,7 +1412,7 @@ def run_conversation(
                         if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
                             agent._touch_activity(
                                 f"retry backoff ({retry_count}/{max_retries}), "
-                                f"{int(sleep_end - time.time())}s remaining"
+                                f"{int(sleep_end - time.monotonic())}s remaining"
                             )
                     continue  # Retry the API call
 
@@ -1969,7 +1969,7 @@ def run_conversation(
                     thinking_spinner = None
                 if agent.thinking_callback:
                     agent.thinking_callback("")
-                api_elapsed = time.time() - api_start_time
+                api_elapsed = time.monotonic() - api_start_time
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupted during API call.", force=True)
                 agent._persist_session(messages, conversation_history)
                 interrupted = True
@@ -2606,7 +2606,7 @@ def run_conversation(
                     )
 
                 retry_count += 1
-                elapsed_time = time.time() - api_start_time
+                elapsed_time = time.monotonic() - api_start_time
                 agent._touch_activity(
                     f"API error recovery (attempt {retry_count}/{max_retries})"
                 )
@@ -3530,9 +3530,9 @@ def run_conversation(
                 )
                 # Sleep in small increments so we can respond to interrupts quickly
                 # instead of blocking the entire wait_time in one sleep() call
-                sleep_end = time.time() + wait_time
+                sleep_end = time.monotonic() + wait_time
                 _backoff_touch_counter = 0
-                while time.time() < sleep_end:
+                while time.monotonic() < sleep_end:
                     if agent._interrupt_requested:
                         agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
                         agent._persist_session(messages, conversation_history)
@@ -3551,7 +3551,7 @@ def run_conversation(
                     if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
                         agent._touch_activity(
                             f"error retry backoff ({retry_count}/{max_retries}), "
-                            f"{int(sleep_end - time.time())}s remaining"
+                            f"{int(sleep_end - time.monotonic())}s remaining"
                         )
         
         # If the API call was interrupted, skip response processing


### PR DESCRIPTION
## Summary

`time.time()` is affected by system clock adjustments (NTP sync, manual changes) which can cause negative or wildly inaccurate duration measurements.

Replace all 10 instances in `agent/conversation_loop.py` with `time.monotonic()` which provides a stable, monotonically increasing clock ideal for elapsed time.

Affected patterns:
- API call duration tracking (`api_start_time`, `api_elapsed`, `api_duration`)
- Retry backoff sleep timers (`sleep_end` calculations)
- Activity touch messages during backoff waits

## Why this matters

If the system clock jumps backwards during an NTP correction (e.g. by 2 seconds), `time.time() - start` can return negative values or heavily inflated durations. This breaks retry backoff logic and produces misleading performance metrics.

`time.monotonic()` is guaranteed to never go backwards and is not affected by system clock changes.

## Test plan

- [ ] CI passes
- [ ] Retry backoff still works correctly during API errors