### PR TITLE
fix(config): persist reasoning/thinking toggle

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4434,6 +4434,34 @@ def test_session_info_includes_mcp_servers(monkeypatch):
     assert info["mcp_servers"] == fake_status
 
 
+def test_session_info_reports_none_when_reasoning_disabled():
+    # Regression for #50449: when reasoning is explicitly disabled
+    # ({"enabled": False}), _session_info must report reasoning_effort as
+    # "none" -- the desktop/TUI frontend reads "" as the default (thinking ON)
+    # and would snap the Thinking toggle back on. "none" is the off vocabulary.
+    agent = types.SimpleNamespace(
+        tools=[], model="m", provider="p", reasoning_config={"enabled": False}
+    )
+    info = server._session_info(agent)
+    assert info["reasoning_effort"] == "none"
+
+
+def test_session_info_reports_effort_when_reasoning_enabled():
+    # Enabled reasoning still surfaces its effort level verbatim (#50449).
+    agent = types.SimpleNamespace(
+        tools=[], model="m", provider="p",
+        reasoning_config={"enabled": True, "effort": "high"},
+    )
+    assert server._session_info(agent)["reasoning_effort"] == "high"
+
+
+def test_session_info_reports_empty_when_reasoning_unset():
+    # No reasoning_config at all => "" (unset/default), unchanged by #50449.
+    agent = types.SimpleNamespace(tools=[], model="m", provider="p", reasoning_config=None)
+    assert server._session_info(agent)["reasoning_effort"] == ""
+
+
+
 # ---------------------------------------------------------------------------
 # History-mutating commands must reject while session.running is True.
 # Without these guards, prompt.submit's post-run history write either

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2699,12 +2699,18 @@ def _session_info(agent, session: dict | None = None) -> dict:
     cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
     personality = (session or {}).get("personality", cfg_personality)
     reasoning_config = getattr(agent, "reasoning_config", None)
+    # Report reasoning state in the vocabulary the desktop/TUI frontend reads
+    # back: an *explicitly disabled* config must surface as "none" (the frontend
+    # treats "none" as Thinking-off), NOT "" -- empty means "unset/default"
+    # there, which isThinkingEnabled() reads as ON. Emitting "" for
+    # {"enabled": False} made the desktop Thinking toggle snap back on right
+    # after it was turned off (#50449).
     reasoning_effort = ""
-    if (
-        isinstance(reasoning_config, dict)
-        and reasoning_config.get("enabled") is not False
-    ):
-        reasoning_effort = str(reasoning_config.get("effort", "") or "")
+    if isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is False:
+            reasoning_effort = "none"
+        else:
+            reasoning_effort = str(reasoning_config.get("effort", "") or "")
     service_tier = getattr(agent, "service_tier", None) or ""
     # Effective approval-bypass state — the same three sources that
     # check_all_command_guards() ORs together: persistent config


### PR DESCRIPTION
Closes #50449.

The Desktop/TUI "Thinking" toggle snapped back on after being turned off. The root cause was a readback vocabulary mismatch, not a failed write: when reasoning is explicitly disabled (`reasoning_config == {"enabled": False}`), `_session_info` (`tui_gateway/server.py`) reported `reasoning_effort = ""`, and the frontend treats `""` as *unset* → thinking ON. So the `config.set reasoning` write succeeded, but the `session.info` it emitted carried `""` and the store read it back as ON, snapping the toggle.

Fix: `_session_info` now emits `"none"` (the frontend's "off" vocabulary) when reasoning is explicitly disabled, `""` only when truly unset, and the effort string when enabled.

**Tests:** +3 regression tests in `test_tui_gateway_server.py`; 7 pass (incl. the existing live-session reasoning test).