### PR TITLE
fix(agent): record cwd for TUI-created sessions

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7899,3 +7899,68 @@ def test_start_agent_build_passes_session_model_override(monkeypatch):
         assert session["agent"].model == "claude-sonnet-4.6"
     finally:
         server._sessions.clear()
+
+
+def _session_create_with_transport(monkeypatch, tmp_path, transport):
+    """Drive session.create with *transport* bound (as dispatch() does) and
+    return the created session dict from server._sessions."""
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    launch_dir = tmp_path / "launchdir"
+    launch_dir.mkdir()
+    monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(launch_dir))
+    token = server.bind_transport(transport)
+    try:
+        resp = server._methods["session.create"]("rcwd", {"cols": 80})
+        assert "result" in resp, resp
+        sid = resp["result"]["session_id"]
+        return sid, server._sessions[sid], str(launch_dir)
+    finally:
+        server.reset_transport(token)
+
+
+def test_tui_stdio_session_records_cwd(monkeypatch, tmp_path):
+    """Regression for #50438: a standalone hermes --tui launch rides the
+    module-level stdio transport and never sends an explicit cwd, yet its launch
+    directory IS the user workspace and must be persisted so the Desktop list
+    can group it instead of dumping every TUI session under No workspace."""
+    for s in list(server._sessions.values()):
+        server._teardown_session(s)
+    server._sessions.clear()
+    try:
+        sid, session, launch_dir = _session_create_with_transport(
+            monkeypatch, tmp_path, server._stdio_transport
+        )
+        assert session["explicit_cwd"] is True
+        assert session["cwd"] == launch_dir
+        assert server._session_cwd(session) == launch_dir
+    finally:
+        for s in list(server._sessions.values()):
+            server._teardown_session(s)
+        server._sessions.clear()
+
+
+def test_desktop_ws_session_without_cwd_stays_unworkspaced(monkeypatch, tmp_path):
+    """The Desktop GUI dispatches over a bound WSTransport and only sends a cwd
+    when the user explicitly picks a workspace. Without that pick the shared
+    launch dir must NOT be stamped onto the row, so explicit_cwd stays False --
+    preserving the #50438 fix narrow scope."""
+
+    class _FakeWS:
+        def write(self, obj):
+            return True
+
+        def close(self):
+            pass
+
+    for s in list(server._sessions.values()):
+        server._teardown_session(s)
+    server._sessions.clear()
+    try:
+        sid, session, _launch_dir = _session_create_with_transport(
+            monkeypatch, tmp_path, _FakeWS()
+        )
+        assert session["explicit_cwd"] is False
+    finally:
+        for s in list(server._sessions.values()):
+            server._teardown_session(s)
+        server._sessions.clear()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4285,6 +4285,19 @@ def _(rid, params: dict) -> dict:
         explicit_cwd = bool(raw_cwd) and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))
     except Exception:
         explicit_cwd = False
+    # A standalone `hermes --tui` launch rides the module-level stdio transport
+    # (dispatch binds _stdio_transport when no per-request transport is given),
+    # whereas the Desktop GUI dispatches over a bound WSTransport. For the former
+    # the gateway process IS the user terminal, so its launch directory (the
+    # resolved cwd below) is the genuine workspace and must be persisted -- without
+    # it the Desktop session list groups every TUI session under No workspace
+    # (#50438). Desktop keeps the explicit-choice-only rule: its launch dir is
+    # shared across sessions and is intentionally not stamped onto the row.
+    if not explicit_cwd:
+        try:
+            explicit_cwd = current_transport() is _stdio_transport
+        except Exception:
+            explicit_cwd = False
     resolved_cwd = _completion_cwd(params)
     source = str(params.get("source") or "tui").strip() or "tui"
     _enable_gateway_prompts()


### PR DESCRIPTION
Closes #50438.

Standalone `hermes --tui` sessions persisted `cwd=NULL`, so the Desktop list (which groups by cwd) collapsed every TUI session under "No workspace". `explicit_cwd` was only set when the client sent a `cwd` param, which a terminal TUI launch never does.

The real discriminator is the transport, not `source` (the Desktop client also defaults `source="tui"`): a standalone terminal TUI rides the module-level `_stdio_transport`; the Desktop GUI dispatches over a bound `WSTransport`. Fix: in `session.create`, when no explicit cwd was sent, set `explicit_cwd = current_transport() is _stdio_transport` — so terminal TUI sessions record their real launch dir while Desktop sessions keep the explicit-choice-only rule (shared launch dir stays null).

(Note: did not apply the maintainer comment's suggested one-liner — it would have stamped the Desktop's *shared* launch dir onto every Desktop session, which the existing docstring deliberately avoids.)

**Tests:** +2 regression tests; 22 pass.