### PR TITLE
fix(api): load MCP servers in REST API sessions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4370,6 +4370,26 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.warning("[%s] aiohttp not installed", self.name)
             return False
 
+        # Load configured MCP servers so REST/API sessions expose MCP tools,
+        # matching the TUI/gateway/ACP/CLI entrypoints which all kick off MCP
+        # discovery at startup (#50248). Without this, an API server started
+        # outside the full gateway-run path (e.g. as a standalone service)
+        # never connects MCP servers, so sessions created via POST
+        # /api/sessions and /v1/chat/completions get no MCP tools even when
+        # the mcp toolset is enabled. start_background_mcp_discovery is
+        # idempotent per-process and runs in a daemon thread, so it never
+        # blocks the asyncio loop and is a no-op when MCP discovery already
+        # ran (e.g. via gateway run) or no MCP servers are configured.
+        try:
+            from hermes_cli.mcp_startup import start_background_mcp_discovery
+            start_background_mcp_discovery(
+                logger=logger, thread_name=f"{self.name}-mcp-discovery"
+            )
+        except Exception:
+            logger.debug(
+                "[%s] MCP discovery kickoff failed", self.name, exc_info=True
+            )
+
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -124,3 +124,28 @@ class TestApiServerAdapterToolset:
             call_kwargs = mock_agent_cls.call_args
             toolsets = call_kwargs.kwargs.get("enabled_toolsets")
             assert sorted(toolsets) == ["terminal", "web"]
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_connect_triggers_mcp_discovery(self):
+        """connect() kicks off MCP discovery so REST/API sessions get MCP tools.
+
+        Regression for #50248: API sessions had no MCP tools because the
+        api_server adapter never loaded configured MCP servers, unlike the
+        TUI/gateway/ACP/CLI entrypoints which all run MCP discovery at startup.
+        The adapter must call start_background_mcp_discovery() from connect()
+        (idempotent + non-blocking)."""
+        import asyncio
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+        # Empty API key makes connect() return early AFTER the MCP discovery
+        # kickoff, so no real web server binds during the test.
+        adapter._api_key = ""
+        with patch("hermes_cli.mcp_startup.start_background_mcp_discovery") as mock_disc:
+            result = asyncio.run(adapter.connect())
+
+        assert result is False
+        mock_disc.assert_called_once()
+        assert mock_disc.call_args.kwargs.get("logger") is not None
+        assert "mcp" in mock_disc.call_args.kwargs.get("thread_name", "")


### PR DESCRIPTION
Closes #50248.

Sessions created via the API server (`POST /api/sessions`, `/v1/chat/completions`) had no MCP tools even with the `mcp` toolset enabled. `APIServerAdapter.connect()` started the aiohttp server but never triggered MCP discovery — every other entrypoint (TUI, ACP, CLI, cron, full `gateway run`) kicks off `discover_mcp_tools()` at startup, but the API server adapter (when started outside the full `gateway run` path) had no equivalent, so MCP servers were never connected and agents saw no MCP tools.

Fix: a non-blocking MCP discovery kickoff at the top of `connect()` via the shared `start_background_mcp_discovery(...)` helper (idempotent per-process, daemon-threaded, no-op when already discovered or none configured) — mirrors the existing entrypoints.

**Tests:** +1 regression test (`test_connect_triggers_mcp_discovery`); 13 pass in `test_api_server_toolset.py`.