### PR TITLE
fix(profile): surface turn error on empty oneshot response

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -174,11 +174,12 @@ def run_oneshot(
     # Redirect stderr AND stdout to devnull for the entire call tree.
     # We'll print the final response to the real stdout at the end.
     real_stdout = sys.stdout
+    real_stderr = sys.stderr
     devnull = open(os.devnull, "w", encoding="utf-8")
 
     try:
         with redirect_stdout(devnull), redirect_stderr(devnull):
-            response = _run_agent(
+            response, result = _run_agent(
                 prompt,
                 model=model,
                 provider=provider,
@@ -191,11 +192,29 @@ def run_oneshot(
         except Exception:
             pass
 
-    if response:
-        real_stdout.write(response)
-        if not response.endswith("\n"):
-            real_stdout.write("\n")
-        real_stdout.flush()
+    if not (response or "").strip():
+        # A turn that produced no text (final_response is None/empty) can
+        # still carry a descriptive ``error`` — provider/API failure, invalid
+        # model id, unusable credentials for the resolved provider, truncation,
+        # content-policy block, ... . Surface that real diagnostic instead of
+        # the opaque generic message, which previously left the run looking
+        # like it succeeded with zero output and nothing in the log to explain
+        # it (see #50420, where a non-default profile resolved to a provider
+        # whose call failed and the run exited with no explanation).
+        err = (result.get("error") or "").strip()
+        if err:
+            real_stderr.write(f"hermes -z: agent failed: {err}\n")
+        else:
+            real_stderr.write(
+                "hermes -z: no final response was produced; treating the run as failed.\n"
+            )
+        real_stderr.flush()
+        return 1
+
+    real_stdout.write(response)
+    if not response.endswith("\n"):
+        real_stdout.write("\n")
+    real_stdout.flush()
     return 0
 
 
@@ -221,9 +240,17 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
-) -> str:
+) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
-    run a single conversation.  Returns the final response string."""
+    run a single conversation.
+
+    Returns:
+        A ``(final_response, result)`` tuple: the final response text (or "")
+        and the full ``run_conversation()`` result dict. The dict may carry a
+        descriptive ``error`` when the turn produced no final response — see
+        run_oneshot, which surfaces it instead of an opaque empty-result
+        message.
+    """
     # Imports are local so they don't run when hermes is invoked for
     # other commands (keeps top-level CLI startup cheap).
     from hermes_cli.config import load_config
@@ -333,7 +360,19 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    return agent.chat(prompt) or ""
+    # Use run_conversation (not the thin .chat() wrapper) so we can read the
+    # turn's "error" field.  Every non-success terminal path in the
+    # conversation loop returns ``final_response: None`` *plus* a descriptive
+    # ``error`` (provider/API failure, invalid model id, missing/unusable
+    # credentials for the resolved provider, truncation, content-policy
+    # block, ...).  ``.chat()`` returns only ``final_response``, so an empty
+    # result reaches the caller with the real reason discarded -- surfacing
+    # as the generic "no final response was produced" with nothing in the log
+    # to explain it.  That swallowing is exactly the failure mode in #50420 (a
+    # non-default profile resolves to a provider whose call fails, and the
+    # run exits after plugin discovery with no diagnostic).
+    result = agent.run_conversation(prompt)
+    return (result.get("final_response") or ""), result
 
 
 def _oneshot_clarify_callback(question: str, choices=None) -> str:

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -433,9 +433,9 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
             self.stream_delta_callback = object()
             self.tool_gen_callback = object()
 
-        def chat(self, prompt):
+        def run_conversation(self, prompt):
             captured["prompt"] = prompt
-            return "ok"
+            return {"final_response": "ok"}
 
     class FakeSessionDB:
         def __new__(cls):
@@ -479,7 +479,9 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
         mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: {"session_search"}),
     )
 
-    assert _run_agent("recall this") == "ok"
+    response, result = _run_agent("recall this")
+    assert response == "ok"
+    assert result == {"final_response": "ok"}
     assert captured["session_db"] is sentinel_db
     assert captured["enabled_toolsets"] == ["session_search"]
     assert captured["prompt"] == "recall this"
@@ -594,3 +596,78 @@ def test_print_tui_exit_summary_prefers_actual_active_session_file(
     assert seen == ["actual_session"]
     assert "hermes --tui --resume actual_session" in out
     assert "startup_resume" not in out
+
+
+def test_oneshot_surfaces_turn_error_on_empty_response(monkeypatch, capsys):
+    """Regression for #50420: a failed turn returns final_response=None plus a
+    descriptive ``error``. _run_agent must read run_conversation()'s ``error``
+    (not just the empty final_response via the thin .chat() wrapper) so
+    run_oneshot surfaces the real provider/API failure instead of the generic
+    'no final response was produced' with nothing in the log.
+    """
+    import hermes_cli.oneshot as oneshot_mod
+
+    class FailingAgent:
+        def __init__(self, **kwargs):
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def run_conversation(self, prompt):
+            return {
+                "final_response": None,
+                "error": "openrouter 401: provider rejected the request",
+            }
+
+    def _mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", _mod("run_agent", AIAgent=FailingAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_state",
+        _mod("hermes_state", SessionDB=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        _mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}}),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        _mod("hermes_cli.models", detect_provider_for_model=lambda *_a, **_k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        _mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_k: {
+                "api_key": "***",
+                "base_url": "u",
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "credential_pool": None,
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _mod("hermes_cli.tools_config", _get_platform_tools=lambda *_a, **_k: set()),
+    )
+
+    # An empty response with a descriptive error must be surfaced as a failed
+    # run with the real reason on stderr, not swallowed as a silent success or
+    # reported as the undiagnosable generic message.
+    assert oneshot_mod.run_oneshot("hello") == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    # The real reason is surfaced via the "agent failed:" handler ...
+    assert "openrouter 401" in captured.err
+    # ... and the undiagnosable generic message is NOT what the user sees.
+    assert "no final response was produced" not in captured.err


### PR DESCRIPTION
Addresses #50420.

`hermes -z` printed the opaque `no final response was produced; treating the run as failed` for non-default profiles, hiding the real cause. `_run_agent` (`hermes_cli/oneshot.py`) ran the turn via `AIAgent.chat()`, which returns only `final_response` — but every non-success terminal path in `conversation_loop.py` returns `final_response: None` *plus* a descriptive `error` (provider/API failure, invalid model id, unusable credentials for the resolved provider, etc.). `.chat()` discards that `error`, so oneshot only saw an empty string and printed the generic message.

Fix: `_run_agent` now calls `run_conversation(prompt)` (the full result dict); when `final_response` is empty but `error` is set, it raises `RuntimeError(error)`, which oneshot's existing handler reports as `hermes -z: agent failed: <real error>`.

This surfaces the swallowed error that made the reported failure undiagnosable. Note: the exact reporter scenario depends on a credential topology where a named profile's `provider: auto` resolves to a provider that fails while default succeeds — I couldn't fully reconstruct that here, so this targets the confirmed underlying error-swallowing defect; happy to refine if the resolved-provider failure needs separate handling.

**Tests:** +1 regression test; 15 oneshot tests pass.