### PR TITLE
fix(copilot): resolve empty base URL from the token-exchange endpoint

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6219,7 +6219,31 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
         base_url = _resolve_zai_base_url(api_key, pconfig.inference_base_url, env_url)
     elif env_url:
         base_url = env_url.rstrip("/")
+    elif provider_id == "copilot":
+        # Resolve the Copilot API base URL from the token-exchange response
+        # (endpoints.api), which is authoritative for Enterprise/proxied
+        # accounts. Falls back to the registry default and is guaranteed
+        # non-empty so chat inference never resolves an empty base URL
+        # (#50252).
+        base_url = pconfig.inference_base_url
+        try:
+            from hermes_cli.copilot_auth import (
+                resolve_copilot_token,
+                get_copilot_api_base_url,
+            )
+            raw_token, _ = resolve_copilot_token()
+            resolved = (get_copilot_api_base_url(raw_token) or "").strip()
+            if resolved:
+                base_url = resolved
+        except Exception as exc:
+            logger.debug("Copilot base URL resolution fell back to default: %s", exc)
     else:
+        base_url = pconfig.inference_base_url
+
+    # Last-resort guard: an API-key provider must never hand back an empty
+    # base URL (a set-but-empty COPILOT_API_BASE_URL or similar env override
+    # otherwise wedges chat inference — #50252).
+    if not (isinstance(base_url, str) and base_url.strip()):
         base_url = pconfig.inference_base_url
 
     return {

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -282,6 +282,14 @@ def copilot_device_code_login(
 _jwt_cache: dict[str, tuple[str, float]] = {}
 _JWT_REFRESH_MARGIN_SECONDS = 120  # refresh 2 min before expiry
 
+# Canonical Copilot API base URL. The token-exchange response advertises the
+# real endpoint under ``endpoints.api`` (it can differ for Copilot Enterprise
+# / proxied accounts); we cache it per raw-token fingerprint and fall back to
+# this default when the exchange does not return one.
+DEFAULT_COPILOT_API_BASE_URL = "https://api.githubcopilot.com"
+# Maps raw_token_fingerprint -> resolved api base URL from the exchange.
+_endpoint_cache: dict[str, str] = {}
+
 # Token exchange endpoint and headers (matching VS Code / Copilot CLI)
 _TOKEN_EXCHANGE_URL = "https://api.github.com/copilot_internal/v2/token"
 _EDITOR_VERSION = "vscode/1.104.1"
@@ -343,9 +351,20 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
     expires_at = float(expires_at) if expires_at else time.time() + 1800
 
     _jwt_cache[fp] = (api_token, expires_at)
+    # The exchange response advertises the account-specific API host under
+    # ``endpoints.api``. Cache it so the provider resolver can use the
+    # canonical base URL instead of relying solely on a hardcoded default
+    # (which left the Copilot provider with an empty base URL — #50252).
+    endpoints = data.get("endpoints")
+    api_endpoint = ""
+    if isinstance(endpoints, dict):
+        api_endpoint = str(endpoints.get("api") or "").strip().rstrip("/")
+    if api_endpoint:
+        _endpoint_cache[fp] = api_endpoint
     logger.debug(
-        "Copilot token exchanged, expires_at=%s",
+        "Copilot token exchanged, expires_at=%s, api_endpoint=%s",
         expires_at,
+        api_endpoint or DEFAULT_COPILOT_API_BASE_URL,
     )
     return api_token, expires_at
 
@@ -366,6 +385,28 @@ def get_copilot_api_token(raw_token: str) -> str:
     except Exception as exc:
         logger.debug("Copilot token exchange failed, using raw token: %s", exc)
         return raw_token
+
+
+def get_copilot_api_base_url(raw_token: str) -> str:
+    """Resolve the Copilot API base URL for a raw GitHub token.
+
+    Performs (or reuses the cache of) a token exchange and returns the
+    account-specific ``endpoints.api`` advertised by GitHub. Falls back to
+    :data:`DEFAULT_COPILOT_API_BASE_URL` when the token is empty, the
+    exchange fails, or no endpoint is advertised. The return value is never
+    empty, so the provider resolver always has a usable base URL (#50252).
+    """
+    if not raw_token:
+        return DEFAULT_COPILOT_API_BASE_URL
+    fp = _token_fingerprint(raw_token)
+    cached = _endpoint_cache.get(fp)
+    if cached:
+        return cached
+    try:
+        exchange_copilot_token(raw_token)
+    except Exception as exc:
+        logger.debug("Copilot base URL resolution fell back to default: %s", exc)
+    return _endpoint_cache.get(fp) or DEFAULT_COPILOT_API_BASE_URL
 
 
 # ─── Copilot API Headers ───────────────────────────────────────────────────

--- a/tests/hermes_cli/test_copilot_token_exchange.py
+++ b/tests/hermes_cli/test_copilot_token_exchange.py
@@ -14,8 +14,10 @@ def _clear_jwt_cache():
     """Reset the module-level JWT cache before each test."""
     import hermes_cli.copilot_auth as mod
     mod._jwt_cache.clear()
+    mod._endpoint_cache.clear()
     yield
     mod._jwt_cache.clear()
+    mod._endpoint_cache.clear()
 
 
 class TestExchangeCopilotToken:
@@ -157,3 +159,101 @@ class TestCallerIntegration:
         assert token == "exchanged_jwt"
         assert source == "GH_TOKEN"
         mock_exchange.assert_called_once_with("gho_raw")
+
+
+class TestCopilotApiBaseUrl:
+    """Regression tests for base-URL resolution (#50252).
+
+    The token-exchange response advertises the account-specific API host under
+    ``endpoints.api``. Previously it was dropped, leaving the Copilot provider
+    to rely on a hardcoded default that could end up empty at chat time.
+    """
+
+    def _mock_urlopen(self, *, token="tid=abc", endpoints=None):
+        import json as _json
+        from unittest.mock import MagicMock as _MagicMock
+        payload = {"token": token, "expires_at": time.time() + 1800}
+        if endpoints is not None:
+            payload["endpoints"] = endpoints
+        mock_resp = _MagicMock()
+        mock_resp.read.return_value = _json.dumps(payload).encode()
+        mock_resp.__enter__ = _MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = _MagicMock(return_value=False)
+        return mock_resp
+
+    @patch("urllib.request.urlopen")
+    def test_exchange_caches_advertised_endpoint(self, mock_urlopen):
+        from hermes_cli.copilot_auth import (
+            exchange_copilot_token,
+            _endpoint_cache,
+            _token_fingerprint,
+        )
+
+        mock_urlopen.return_value = self._mock_urlopen(
+            endpoints={"api": "https://copilot-proxy.example.com/"}
+        )
+        exchange_copilot_token("gho_test123")
+
+        fp = _token_fingerprint("gho_test123")
+        assert _endpoint_cache[fp] == "https://copilot-proxy.example.com"
+
+    @patch("urllib.request.urlopen")
+    def test_base_url_uses_advertised_endpoint(self, mock_urlopen):
+        from hermes_cli.copilot_auth import get_copilot_api_base_url
+
+        mock_urlopen.return_value = self._mock_urlopen(
+            endpoints={"api": "https://copilot-proxy.example.com"}
+        )
+        assert get_copilot_api_base_url("gho_test123") == "https://copilot-proxy.example.com"
+
+    @patch("urllib.request.urlopen")
+    def test_base_url_falls_back_to_default_when_no_endpoint(self, mock_urlopen):
+        from hermes_cli.copilot_auth import (
+            get_copilot_api_base_url,
+            DEFAULT_COPILOT_API_BASE_URL,
+        )
+
+        mock_urlopen.return_value = self._mock_urlopen()
+        assert get_copilot_api_base_url("gho_test123") == DEFAULT_COPILOT_API_BASE_URL
+
+    def test_base_url_empty_token_returns_default(self):
+        from hermes_cli.copilot_auth import (
+            get_copilot_api_base_url,
+            DEFAULT_COPILOT_API_BASE_URL,
+        )
+
+        assert get_copilot_api_base_url("") == DEFAULT_COPILOT_API_BASE_URL
+
+    @patch("urllib.request.urlopen", side_effect=Exception("network error"))
+    def test_base_url_exchange_failure_returns_default(self, mock_urlopen):
+        from hermes_cli.copilot_auth import (
+            get_copilot_api_base_url,
+            DEFAULT_COPILOT_API_BASE_URL,
+        )
+
+        assert get_copilot_api_base_url("gho_test123") == DEFAULT_COPILOT_API_BASE_URL
+
+
+class TestResolveCredentialsCopilotBaseUrl:
+    """The provider resolver must always return a non-empty Copilot base URL."""
+
+    @patch("hermes_cli.copilot_auth.resolve_copilot_token", return_value=("gho_raw", "GH_TOKEN"))
+    @patch("hermes_cli.copilot_auth.get_copilot_api_token", return_value="exchanged_jwt")
+    @patch("hermes_cli.copilot_auth.get_copilot_api_base_url", return_value="https://copilot-proxy.example.com")
+    def test_resolver_uses_exchange_endpoint(self, mock_base, mock_tok, mock_resolve, monkeypatch):
+        monkeypatch.delenv("COPILOT_API_BASE_URL", raising=False)
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        creds = resolve_api_key_provider_credentials("copilot")
+        assert creds["base_url"] == "https://copilot-proxy.example.com"
+
+    @patch("hermes_cli.copilot_auth.resolve_copilot_token", return_value=("gho_raw", "GH_TOKEN"))
+    @patch("hermes_cli.copilot_auth.get_copilot_api_token", return_value="exchanged_jwt")
+    @patch("hermes_cli.copilot_auth.get_copilot_api_base_url", return_value="https://api.githubcopilot.com")
+    def test_resolver_never_empty_with_blank_env(self, mock_base, mock_tok, mock_resolve, monkeypatch):
+        monkeypatch.setenv("COPILOT_API_BASE_URL", "   ")
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        creds = resolve_api_key_provider_credentials("copilot")
+        assert creds["base_url"]
+        assert creds["base_url"] == "https://api.githubcopilot.com"


### PR DESCRIPTION
Closes #50252.

The GitHub Copilot provider resolved an empty base URL on every chat inference (setup/catalog worked, chat failed). The token-exchange (`GET /copilot_internal/v2/token`) returns the account's authoritative API host under `endpoints.api`, but `exchange_copilot_token` (`hermes_cli/copilot_auth.py`) extracted only `token`/`expires_at` and **discarded `endpoints.api`**. The provider then relied solely on the hardcoded `inference_base_url` default, and `resolve_api_key_provider_credentials("copilot")` (`hermes_cli/auth.py`) had **no copilot branch and no non-empty guard** — so a set-but-empty `COPILOT_API_BASE_URL` override or a non-default account endpoint wedged chat at the "empty base URL" guard. The catalog path only needs the api_key, which is why setup / `hermes doctor` succeeded while chat failed.

Fix: capture & cache `endpoints.api` per token-fingerprint in `exchange_copilot_token`; add `get_copilot_api_base_url()` that returns the advertised endpoint (cached) and never returns empty (falls back to the default); add a `copilot` branch in `resolve_api_key_provider_credentials` plus a last-resort non-empty guard for all api_key providers.

**Tests:** extended `test_copilot_token_exchange.py` (endpoint caching, advertised-endpoint use, default fallbacks for missing/empty-token/exchange-failure, resolver-never-empty incl. blank env); 57 pass across the 5 copilot test files.